### PR TITLE
fix interp tests

### DIFF
--- a/src/wasm-vector.c
+++ b/src/wasm-vector.c
@@ -56,7 +56,9 @@ void* wasm_append_element(WasmAllocator* allocator,
                           size_t* capacity,
                           size_t elt_byte_size) {
   wasm_ensure_capacity(allocator, data, capacity, *size + 1, elt_byte_size);
-  return (void*)((size_t)*data + (*size)++ * elt_byte_size);
+  void* p = (void*)((size_t)*data + (*size)++ * elt_byte_size);
+  memset(p, 0, elt_byte_size);
+  return p;
 }
 
 void wasm_extend_elements(WasmAllocator* allocator,

--- a/test/interp/callimport-zero-args.txt
+++ b/test/interp/callimport-zero-args.txt
@@ -7,6 +7,6 @@
       (i32.const 13)
       (call $imported))))
 (;; STDOUT ;;;
-called import foo.bar() => i32:0
+called import foo.bar() => (i32:0)
 f() => i32:13
 ;;; STDOUT ;;)

--- a/test/interp/import.txt
+++ b/test/interp/import.txt
@@ -1,16 +1,14 @@
 ;;; TOOL: run-interp
 (module
-  ;; stdio is ignored
-  (import $print_i32 "stdio" "print" (param i32))
-  (import $print_i32_i32 "stdio" "print" (param i32 i32))
-  (func $test (result i32)
-    (call_import $print_i32 (i32.const 100))
-    (call_import $print_i32_i32 (i32.const 200) (i32.const 300))
+  (import "stdio" "print" (func $print_i32 (param i32)))
+  (import "stdio" "print" (func $print_i32_i32 (param i32 i32)))
+  (func (export "test") (result i32)
+    (call $print_i32 (i32.const 100))
+    (call $print_i32_i32 (i32.const 200) (i32.const 300))
     (return (i32.const 1)))
-  (export "test" $test)
 )
 (;; STDOUT ;;;
-called import stdio.print(i32:100)
-called import stdio.print(i32:200, i32:300)
+called import stdio.print(i32:100) => ()
+called import stdio.print(i32:200, i32:300) => ()
 test() => i32:1
 ;;; STDOUT ;;)

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -712,7 +712,7 @@ def main(args):
 
   # HACK(binji): exclude interp/ and spec/ tests
   test_names = [test_name for test_name in test_names
-                if not test_name.startswith(('interp', 'spec'))]
+                if not test_name.startswith('spec')]
   # HACK(binji)
 
   if options.list:


### PR DESCRIPTION
* elem segment entries should be func_index not sig_index
* change the call_stack and value_stack tops to pointers instead of
  integers; this is more convenient for the interpreter, and means we
  don't have to convert back and forth between the two when calling to
  helper functions (e.g. `call_import`)
* pass dummy results `WasmInterpreterTypedValueVector` to
  `run_export_wrapper`, it's required now
* rename all uses of `vs_` -> `value_stack_`, `cs_` -> `call_stack_`
* destroy the func_imports array when destroying the
  `WasmInterpreterModule`.