### PR TITLE
fix a bug when checking whether a segment is valid

### DIFF
--- a/src/wasm-ast-checker.c
+++ b/src/wasm-ast-checker.c
@@ -1059,12 +1059,10 @@ static void check_elem_segments(Context* ctx, const WasmModule* module) {
             offset, last_end);
       }
 
-      uint64_t max =
-          table->elem_limits.has_max ? table->elem_limits.initial : UINT32_MAX;
-
-      if (offset + elem_segment->vars.size > max) {
+      uint64_t max = table->elem_limits.initial;
+      if ((uint64_t)offset + elem_segment->vars.size > max) {
         print_error(ctx, CHECK_STYLE_FULL, &field->loc,
-                    "segment ends past the end of table max size (%" PRIu64 ")",
+                    "segment ends past the end of the table (%" PRIu64 ")",
                     max);
       }
 
@@ -1102,14 +1100,12 @@ static void check_data_segments(Context* ctx, const WasmModule* module) {
             offset, last_end);
       }
 
-      uint32_t max = memory->page_limits.has_max ? memory->page_limits.initial
-                                                 : WASM_MAX_PAGES;
-      const uint64_t memory_max_size = max * WASM_PAGE_SIZE;
-      if (offset + data_segment->size > memory_max_size) {
+      uint32_t max = memory->page_limits.initial;
+      const uint64_t memory_initial_size = (uint64_t)max * WASM_PAGE_SIZE;
+      if ((uint64_t)offset + data_segment->size > memory_initial_size) {
         print_error(ctx, CHECK_STYLE_FULL, &field->loc,
-                    "segment ends past the end of memory max size (%" PRIu64
-                    ")",
-                    memory_max_size);
+                    "segment ends past the end of memory (%" PRIu64 ")",
+                    memory_initial_size);
       }
 
       last_end = offset + data_segment->size;

--- a/test/parse/module/bad-memory-segment-address-negative.txt
+++ b/test/parse/module/bad-memory-segment-address-negative.txt
@@ -3,7 +3,7 @@
   (memory 100)
   (data (i32.const -1) "foo"))
 (;; STDERR ;;;
-parse/module/bad-memory-segment-address-negative.txt:4:3: segment ends past the end of memory max size (4294901760)
+parse/module/bad-memory-segment-address-negative.txt:4:3: segment ends past the end of memory (6553600)
   (data (i32.const -1) "foo"))
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-segment-address-oob.txt
+++ b/test/parse/module/bad-memory-segment-address-oob.txt
@@ -3,7 +3,7 @@
   (memory 1 1)
   (data (i32.const 80000) "hi"))
 (;; STDERR ;;;
-parse/module/bad-memory-segment-address-oob.txt:4:3: segment ends past the end of memory max size (65536)
+parse/module/bad-memory-segment-address-oob.txt:4:3: segment ends past the end of memory (65536)
   (data (i32.const 80000) "hi"))
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-segment-end-oob.txt
+++ b/test/parse/module/bad-memory-segment-end-oob.txt
@@ -3,7 +3,7 @@
   (memory 1 1)
   (data (i32.const 65531) "56789a"))
 (;; STDERR ;;;
-parse/module/bad-memory-segment-end-oob.txt:4:3: segment ends past the end of memory max size (65536)
+parse/module/bad-memory-segment-end-oob.txt:4:3: segment ends past the end of memory (65536)
   (data (i32.const 65531) "56789a"))
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
A segment has to fit in the initial size, not the max size. Also, when
building on a 32-bit arch, the offset must be cast to a 64-bit int so
the overflow check works properly.