### PR TITLE
Remove known failures related to `call_indirect with no table`

### DIFF
--- a/s2wasm_known_gcc_test_failures.txt
+++ b/s2wasm_known_gcc_test_failures.txt
@@ -3,9 +3,3 @@
 
 # too few parameters to function in call. got 8, expected 9
 pr44942.c.s.wast
-
-# New in 0xc:
-# call_indirect with no table
-20021118-2.c.s.wast
-921208-1.c.s.wast
-930513-1.c.s.wast


### PR DESCRIPTION
These are now passing on the waterfall.