### PR TITLE
fix typechecking bug in `check_n_types`

### DIFF
--- a/src/wasm-ast-checker.c
+++ b/src/wasm-ast-checker.c
@@ -568,9 +568,9 @@ static void check_n_types(Context* ctx,
   if (WASM_SUCCEEDED(check_type_stack_limit(ctx, loc, expected->size, desc))) {
     size_t i;
     for (i = 0; i < expected->size; ++i) {
-      WasmType actual = ctx->type_stack.data[i];
-      check_type(ctx, loc, actual, expected->data[expected->size - i - 1],
-                 desc);
+      WasmType actual =
+          ctx->type_stack.data[ctx->type_stack.size - expected->size + i];
+      check_type(ctx, loc, actual, expected->data[i], desc);
     }
   }
 }

--- a/test/regress/regress-6.txt
+++ b/test/regress/regress-6.txt
@@ -1,0 +1,7 @@
+(module
+  (func (result i32)
+    block i32
+      f32.const 1
+      i32.const 1
+      br 0
+    end))


### PR DESCRIPTION
Given a type stack and a block signature , check_n_types should check
that the signature is at the top of the stack. For example:

type stack:       [... , i32, f32, i32]
block signature:  [f32, i32]

A block signature with > 1 types is not currently allowed, but is
supported in the code.

The previous code was wrong, and only checked that the signature was at
the bottom of the type stack, in reverse.