### PR TITLE
fix displayed index when writing out wast files

### DIFF
--- a/src/wasm-binary-reader-ast.c
+++ b/src/wasm-binary-reader-ast.c
@@ -390,10 +390,10 @@ static WasmResult begin_global(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult begin_global_init_expr(uint32_t index,
-                                               void* user_data) {
+static WasmResult begin_global_init_expr(uint32_t index, void* user_data) {
   Context* ctx = user_data;
-  assert(index == ctx->module->globals.size - 1);
+  assert(ctx->module->num_global_imports + index ==
+         ctx->module->globals.size - 1);
   WasmGlobal* global =
       ctx->module->globals.data[index + ctx->module->num_global_imports];
   ctx->current_init_expr = &global->init_expr;

--- a/test/roundtrip/func-index.txt
+++ b/test/roundtrip/func-index.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout
+(module
+  (import "a" "b" (func (result i32)))
+  (func (param f32)))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (result i32)))
+  (type (;1;) (func (param f32)))
+  (import "a" "b" (func (;0;) (type 0)))
+  (func (;1;) (type 1) (param f32)))
+;;; STDOUT ;;)

--- a/test/roundtrip/generate-global-names.txt
+++ b/test/roundtrip/generate-global-names.txt
@@ -10,9 +10,9 @@
 (module
   (type $t0 (func (result i32)))
   (func $f0 (type $t0) (result i32)
-    f32.const 0x1.8p+1
+    f32.const 0x1.8p+1 (;=3;)
     set_global $g1
     get_global $g0)
   (global $g0 i32 (i32.const 42))
-  (global $g1 f32 (f32.const -0x1.8p+0)))
+  (global $g1 f32 (f32.const -0x1.8p+0 (;=-1.5;))))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-import-names.txt
+++ b/test/roundtrip/generate-import-names.txt
@@ -16,6 +16,6 @@
   (func $f2 (type $t2)
     i32.const 0
     call $f0
-    f32.const 0x0p+0
+    f32.const 0x0p+0 (;=0;)
     call $f1))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-local-names.txt
+++ b/test/roundtrip/generate-local-names.txt
@@ -27,9 +27,9 @@
     drop
     i32.const 1
     set_local $p0
-    f32.const 0x1p+0
+    f32.const 0x1p+0 (;=1;)
     set_local $p1
-    f64.const 0x1p+0
+    f64.const 0x1p+0 (;=1;)
     set_local $l0
     i64.const 1
     set_local $l1))

--- a/test/roundtrip/generate-some-names.txt
+++ b/test/roundtrip/generate-some-names.txt
@@ -27,7 +27,7 @@
   (type $t2 (func (param i32 i64)))
   (import "foo" "bar" (func $import (type $t1)))
   (func $func0 (type $t0) (param $p0 i32) (result f32)
-    f32.const 0x1p+0)
+    f32.const 0x1p+0 (;=1;))
   (func $f2 (type $t2) (param $p0 i32) (param $param1 i64)
     (local $l0 f32) (local $local1 f64)
     call $import
@@ -41,7 +41,7 @@
     drop
     get_local $param1
     drop
-    f32.const 0x0p+0
+    f32.const 0x0p+0 (;=0;)
     set_local $l0)
   (table $T0 1 1 anyfunc)
   (export "baz" (func $import))

--- a/test/roundtrip/global-index.txt
+++ b/test/roundtrip/global-index.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout
+(module
+  (import "a" "b" (global i32))
+  (global f32 (f32.const 12345.625)))
+(;; STDOUT ;;;
+(module
+  (import "a" "b" (global (;0;) i32))
+  (global (;1;) f32 (f32.const 0x1.81cdp+13 (;=12345.6;))))
+;;; STDOUT ;;)

--- a/test/roundtrip/label.txt
+++ b/test/roundtrip/label.txt
@@ -1,0 +1,25 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout
+(module
+  (func (param i32) (result f32)
+    block f32
+      f32.const 1
+      get_local 0
+      i32.eqz
+      br_if 0
+      drop
+      f32.const 2
+    end))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (param i32) (result f32)))
+  (func (;0;) (type 0) (param i32) (result f32)
+    block f32  ;; label = @1
+      f32.const 0x1p+0 (;=1;)
+      get_local 0
+      i32.eqz
+      br_if 0 (;@1;)
+      drop
+      f32.const 0x1p+1 (;=2;)
+    end))
+;;; STDOUT ;;)

--- a/test/roundtrip/memory-index.txt
+++ b/test/roundtrip/memory-index.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout
+(module
+  (import "a" "b" (memory 1))
+  (memory 2 3))
+(;; STDOUT ;;;
+(module
+  (import "a" "b" (memory (;0;) 1))
+  (memory (;1;) 2 3))
+;;; STDOUT ;;)

--- a/test/roundtrip/table-index.txt
+++ b/test/roundtrip/table-index.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout
+(module
+  (import "a" "b" (table 2 anyfunc))
+  (table 3 anyfunc))
+(;; STDOUT ;;;
+(module
+  (import "a" "b" (table (;0;) 2 anyfunc))
+  (table (;1;) 3 anyfunc))
+;;; STDOUT ;;)


### PR DESCRIPTION
Also:

* change block comment to "label" instead of "exit"
* remove text parameter to write_end_block, it's always "end"
* write decimal float values for float constants (it's easier to read
  than hex floats)
* fix assertion in begin_global_init_expr, it wasn't taking into account
  imported globals
* add some new tests that show the correct indexing behavior when
  importing funcs, tables, memories and globals