### PR TITLE
implement assert_malformed

### DIFF
--- a/src/wasm-ast-checker.h
+++ b/src/wasm-ast-checker.h
@@ -39,13 +39,17 @@ WasmResult wasm_check_ast(struct WasmAllocator*,
                           const struct WasmScript*,
                           WasmSourceErrorHandler*);
 
-/* Run the assert_invalid spec tests. These always contain an invalid module.
- * This function succeeds if and only if the contained module is invalid. */
-WasmResult wasm_check_assert_invalid(
+/* Run the assert_invalid and assert_malformed spec tests. A module is
+ * "malformed" if it cannot be read from the binary format. A module is
+ * "invalid" if either it is malformed, or if it does not pass the standard
+ * checks (as done by wasm_check_ast). This function succeeds if and only if
+ * all assert_invalid and assert_malformed tests pass. */
+WasmResult wasm_check_assert_invalid_and_malformed(
     struct WasmAllocator*,
     WasmAstLexer*,
     const struct WasmScript*,
     WasmSourceErrorHandler* assert_invalid_error_handler,
+    WasmSourceErrorHandler* assert_malformed_error_handler,
     WasmSourceErrorHandler* error_handler);
 WASM_EXTERN_C_END
 

--- a/src/wasm-common.c
+++ b/src/wasm-common.c
@@ -154,6 +154,18 @@ void wasm_default_assert_invalid_source_error_callback(
                      source_line_column_offset);
 }
 
+void wasm_default_assert_malformed_source_error_callback(
+    const WasmLocation* loc,
+    const char* error,
+    const char* source_line,
+    size_t source_line_length,
+    size_t source_line_column_offset,
+    void* user_data) {
+  fprintf(stdout, "assert_malformed error:\n  ");
+  print_source_error(stdout, loc, error, source_line, source_line_length,
+                     source_line_column_offset);
+}
+
 void wasm_default_binary_error_callback(uint32_t offset,
                                         const char* error,
                                         void* user_data) {

--- a/src/wasm-common.h
+++ b/src/wasm-common.h
@@ -111,6 +111,9 @@ typedef struct WasmSourceErrorHandler {
 #define WASM_ASSERT_INVALID_SOURCE_ERROR_HANDLER_DEFAULT \
   { wasm_default_assert_invalid_source_error_callback, 80, NULL }
 
+#define WASM_ASSERT_MALFORMED_SOURCE_ERROR_HANDLER_DEFAULT \
+  { wasm_default_assert_malformed_source_error_callback, 80, NULL }
+
 typedef void (*WasmBinaryErrorCallback)(uint32_t offset,
                                         const char* error,
                                         void* user_data);
@@ -386,6 +389,13 @@ void wasm_default_source_error_callback(const WasmLocation*,
                                         size_t source_line_column_offset,
                                         void* user_data);
 void wasm_default_assert_invalid_source_error_callback(
+    const WasmLocation*,
+    const char* error,
+    const char* source_line,
+    size_t source_line_length,
+    size_t source_line_column_offset,
+    void* user_data);
+void wasm_default_assert_malformed_source_error_callback(
     const WasmLocation*,
     const char* error,
     const char* source_line,

--- a/test/help/sexpr-wasm.txt
+++ b/test/help/sexpr-wasm.txt
@@ -22,14 +22,14 @@ examples:
   $ wast2wasm spec-test.wast --spec -o spec-test.json
 
 options:
-  -v, --verbose                        use multiple times for more info
-  -h, --help                           print this help message
-  -d, --dump-module                    print a hexdump of the module to stdout
-  -o, --output=FILE                    output file for the generated binary format
-      --spec                           parse a file with multiple modules and assertions, like the spec tests
-      --use-libc-allocator             use malloc, free, etc. instead of stack allocator
-      --no-canonicalize-leb128s        Write all LEB128 sizes as 5-bytes instead of their minimal size
-      --debug-names                    Write debug names to the generated binary file
-      --no-check                       Don't check for invalid modules
-      --no-check-assert-invalid        Don't run the assert_invalid checks
+  -v, --verbose                                      use multiple times for more info
+  -h, --help                                         print this help message
+  -d, --dump-module                                  print a hexdump of the module to stdout
+  -o, --output=FILE                                  output file for the generated binary format
+      --spec                                         parse a file with multiple modules and assertions, like the spec tests
+      --use-libc-allocator                           use malloc, free, etc. instead of stack allocator
+      --no-canonicalize-leb128s                      Write all LEB128 sizes as 5-bytes instead of their minimal size
+      --debug-names                                  Write debug names to the generated binary file
+      --no-check                                     Don't check for invalid modules
+      --no-check-assert-invalid-and-malformed        Don't run the assert_invalid or assert_malformed checks
 ;;; STDOUT ;;)

--- a/test/parse/assert/assertmalformed.txt
+++ b/test/parse/assert/assertmalformed.txt
@@ -1,0 +1,11 @@
+;;; FLAGS: --spec
+(assert_malformed
+  (module
+    "\00asm\bc\0a\00\00")
+  "unknown binary version")
+(;; STDOUT ;;;
+assert_malformed error:
+  parse/assert/assertmalformed.txt:3:4: error in binary module: @0x00000008: bad wasm file version: 0xabc (expected 0xc)
+  (module
+   ^^^^^^
+;;; STDOUT ;;)

--- a/test/parse/assert/bad-assertmalformed-succeeds.txt
+++ b/test/parse/assert/bad-assertmalformed-succeeds.txt
@@ -1,0 +1,11 @@
+;;; ERROR: 1
+;;; FLAGS: --spec
+(assert_malformed
+  (module
+    "\00asm\0c\00\00\00")
+  "???")
+(;; STDERR ;;;
+parse/assert/bad-assertmalformed-succeeds.txt:4:4: expected module to be malformed
+  (module
+   ^^^^^^
+;;; STDERR ;;)

--- a/test/parse/assert/nocheck-assertmalformed.txt
+++ b/test/parse/assert/nocheck-assertmalformed.txt
@@ -1,0 +1,11 @@
+;;; FLAGS: --spec --no-check-assert-invalid
+
+;; normally would fail because the module is well-formed.
+(assert_malformed
+  (module "\00asm\0c\00\00\00")
+  "???")
+
+;; normally would print a message displaying why the module was malformed.
+(assert_malformed
+  (module "\00asm\ab\cd\ef\01")
+  "???")


### PR DESCRIPTION
Checking for malformed modules is almost the same as checking for
invalid modules, the difference being that assert_malformed only tries
to decode the binary format, but doesn't do any other validation.

* Renamed check_assert_invalid -> check_assert_invalid_and_malformed
* Add wasm_default_assert_malformed_source_error_callback, which is the
  same as the assert_invalid one, but prints out "assert_malformed"
  instead
* Add some basic tests for assert_malformed