### PR TITLE
fix bug defining a global by an imported global

### DIFF
--- a/src/wasm-ast-checker.c
+++ b/src/wasm-ast-checker.c
@@ -1121,6 +1121,7 @@ static void check_import(Context* ctx,
       break;
     case WASM_EXTERNAL_KIND_GLOBAL:
       check_global(ctx, loc, &import->global);
+      ctx->current_global_index++;
       break;
     case WASM_NUM_EXTERNAL_KINDS:
       assert(0);

--- a/test/parse/module/import-global-getglobal.txt
+++ b/test/parse/module/import-global-getglobal.txt
@@ -1,0 +1,3 @@
+(module
+  (import "a" "global" (global i32))
+  (global i32 (get_global 0)))


### PR DESCRIPTION
Because the index space of globals merges imported and defined locals,
the checker's Context::current_global_index must be incremented for when
checking both.

Fixes #143.