### PR TITLE
Fix crash bug when -d specified without -v

### DIFF
--- a/src/wast2wasm.c
+++ b/src/wast2wasm.c
@@ -124,8 +124,6 @@ static void on_option(struct WasmOptionParser* parser,
   switch (option->id) {
     case FLAG_VERBOSE:
       s_verbose++;
-      wasm_init_file_writer_existing(&s_log_stream_writer, stdout);
-      wasm_init_stream(&s_log_stream, &s_log_stream_writer.base, NULL);
       s_write_binary_options.log_stream = &s_log_stream;
       break;
 
@@ -387,6 +385,9 @@ int main(int argc, char** argv) {
   WasmAllocator* allocator;
 
   wasm_init_stdio();
+
+  wasm_init_file_writer_existing(&s_log_stream_writer, stdout);
+  wasm_init_stream(&s_log_stream, &s_log_stream_writer.base, NULL);
   parse_options(argc, argv);
 
   if (s_use_libc_allocator) {

--- a/test/dump/basic_dump_only.txt
+++ b/test/dump/basic_dump_only.txt
@@ -1,0 +1,13 @@
+;;; FLAGS: -d
+(module
+  (memory 1)
+  (func $f (param i32 i32) (result i32)
+    (i32.store (i32.const 0) (i32.add (i32.load (i32.const 0)) (i32.const 1)))
+    (i32.add (get_local 0) (get_local 1)))
+  (export "f" (func $f)))
+(;; STDOUT ;;;
+0000000: 0061 736d 0c00 0000 0107 0140 0201 0101  
+0000010: 0103 0201 0005 0301 0001 0705 0101 6600  
+0000020: 000a 1601 1400 1000 1000 2a02 0010 0140  
+0000030: 3302 0014 0014 0140 0f                   
+;;; STDOUT ;;)


### PR DESCRIPTION
Initialize the s_log_stream in all cases since its
used with -v and -d both.

Add a test for -d on its own.