### PR TITLE
don't try to evaluate imported globals

### DIFF
--- a/test/parse/module/data-offset.txt
+++ b/test/parse/module/data-offset.txt
@@ -1,0 +1,6 @@
+(module
+  (memory 1)
+  (import "foo" "bar" (global i32))
+  (global i32 (i32.const 1))
+  (data (get_global 0) "hi")
+  (data (get_global 1) "world"))

--- a/test/parse/module/elem-offset.txt
+++ b/test/parse/module/elem-offset.txt
@@ -1,0 +1,7 @@
+(module
+  (import "foo" "bar" (global i32))
+  (global i32 (i32.const 1))
+  (func)
+  (table 2 anyfunc)
+  (elem (get_global 0) 0)
+  (elem (get_global 1) 0))


### PR DESCRIPTION
Imported globals don't have an initializer expression until they're
linked, so they can't be evaluated in the normal check pass.