### PR TITLE
Add WasmBinaryReaderContext type which is passed to reader callback

### DIFF
--- a/src/wasm-binary-reader-ast.c
+++ b/src/wasm-binary-reader-ast.c
@@ -59,12 +59,12 @@ typedef struct Context {
   WasmExpr** current_init_expr;
 } Context;
 
-static void on_error(uint32_t offset, const char* message, void* user_data);
+static void handle_error(Context* ctx, uint32_t offset, const char* message);
 
 static void WASM_PRINTF_FORMAT(2, 3)
     print_error(Context* ctx, const char* format, ...) {
   WASM_SNPRINTF_ALLOCA(buffer, length, format);
-  on_error(WASM_UNKNOWN_OFFSET, buffer, ctx);
+  handle_error(ctx, WASM_UNKNOWN_OFFSET, buffer);
 }
 
 static void push_label(Context* ctx, LabelType label_type, WasmExpr** first) {
@@ -126,12 +126,16 @@ static WasmResult append_expr(Context* ctx, WasmExpr* expr) {
   return WASM_OK;
 }
 
-static void on_error(uint32_t offset, const char* message, void* user_data) {
-  Context* ctx = user_data;
+static void handle_error(Context* ctx, uint32_t offset, const char* message) {
   if (ctx->error_handler->on_error) {
-    ctx->error_handler->on_error(offset, message,
-                                 ctx->error_handler->user_data);
+    ctx->error_handler->on_error(offset, message, ctx->error_handler->user_data);
   }
+}
+
+static void on_error(WasmBinaryReaderContext* reader_context,
+                     const char* message) {
+  Context* ctx = reader_context->user_data;
+  handle_error(ctx, reader_context->offset, message);
 }
 
 static WasmResult on_signature_count(uint32_t count, void* user_data) {

--- a/src/wasm-binary-reader-opcnt.h
+++ b/src/wasm-binary-reader-opcnt.h
@@ -60,7 +60,6 @@ WasmResult wasm_read_binary_opcnt(struct WasmAllocator* allocator,
                                   const void* data,
                                   size_t size,
                                   const struct WasmReadBinaryOptions* options,
-                                  WasmBinaryErrorHandler*,
                                   WasmOpcntData* opcnt_data);
 
 WASM_EXTERN_C_END

--- a/src/wasm-binary-reader.h
+++ b/src/wasm-binary-reader.h
@@ -33,10 +33,17 @@ typedef struct WasmReadBinaryOptions {
   WasmBool read_debug_names;
 } WasmReadBinaryOptions;
 
+typedef struct WasmBinaryReaderContext {
+  const uint8_t* data;
+  size_t size;
+  size_t offset;
+  void* user_data;
+} WasmBinaryReaderContext;
+
 typedef struct WasmBinaryReader {
   void* user_data;
 
-  void (*on_error)(uint32_t offset, const char* message, void* user_data);
+  void (*on_error)(WasmBinaryReaderContext* ctx, const char* message);
 
   /* module */
   WasmResult (*begin_module)(void* user_data);
@@ -44,7 +51,7 @@ typedef struct WasmBinaryReader {
 
   /* signatures section */
   /* TODO(binji): rename to "type" section */
-  WasmResult (*begin_signature_section)(void* user_data);
+  WasmResult (*begin_signature_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_signature_count)(uint32_t count, void* user_data);
   WasmResult (*on_signature)(uint32_t index,
                              uint32_t param_count,
@@ -52,10 +59,10 @@ typedef struct WasmBinaryReader {
                              uint32_t result_count,
                              WasmType* result_types,
                              void* user_data);
-  WasmResult (*end_signature_section)(void* user_data);
+  WasmResult (*end_signature_section)(WasmBinaryReaderContext* ctx);
 
   /* import section */
-  WasmResult (*begin_import_section)(void* user_data);
+  WasmResult (*begin_import_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_import_count)(uint32_t count, void* user_data);
   WasmResult (*on_import)(uint32_t index,
                           WasmStringSlice module_name,
@@ -75,36 +82,36 @@ typedef struct WasmBinaryReader {
                                  WasmType type,
                                  WasmBool mutable_,
                                  void* user_data);
-  WasmResult (*end_import_section)(void* user_data);
+  WasmResult (*end_import_section)(WasmBinaryReaderContext* ctx);
 
   /* function signatures section */
   /* TODO(binji): rename to "function" section */
-  WasmResult (*begin_function_signatures_section)(void* user_data);
+  WasmResult (*begin_function_signatures_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_function_signatures_count)(uint32_t count, void* user_data);
   WasmResult (*on_function_signature)(uint32_t index,
                                       uint32_t sig_index,
                                       void* user_data);
-  WasmResult (*end_function_signatures_section)(void* user_data);
+  WasmResult (*end_function_signatures_section)(WasmBinaryReaderContext* ctx);
 
   /* table section */
-  WasmResult (*begin_table_section)(void* user_data);
+  WasmResult (*begin_table_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_table_count)(uint32_t count, void* user_data);
   WasmResult (*on_table)(uint32_t index,
                          uint32_t elem_type,
                          const WasmLimits* elem_limits,
                          void* user_data);
-  WasmResult (*end_table_section)(void* user_data);
+  WasmResult (*end_table_section)(WasmBinaryReaderContext* ctx);
 
   /* memory section */
-  WasmResult (*begin_memory_section)(void* user_data);
+  WasmResult (*begin_memory_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_memory_count)(uint32_t count, void* user_data);
   WasmResult (*on_memory)(uint32_t index,
                           const WasmLimits* limits,
                           void* user_data);
-  WasmResult (*end_memory_section)(void* user_data);
+  WasmResult (*end_memory_section)(WasmBinaryReaderContext* ctx);
 
   /* global section */
-  WasmResult (*begin_global_section)(void* user_data);
+  WasmResult (*begin_global_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_global_count)(uint32_t count, void* user_data);
   WasmResult (*begin_global)(uint32_t index,
                              WasmType type,
@@ -113,26 +120,26 @@ typedef struct WasmBinaryReader {
   WasmResult (*begin_global_init_expr)(uint32_t index, void* user_data);
   WasmResult (*end_global_init_expr)(uint32_t index, void* user_data);
   WasmResult (*end_global)(uint32_t index, void* user_data);
-  WasmResult (*end_global_section)(void* user_data);
+  WasmResult (*end_global_section)(WasmBinaryReaderContext* ctx);
 
   /* exports section */
-  WasmResult (*begin_export_section)(void* user_data);
+  WasmResult (*begin_export_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_export_count)(uint32_t count, void* user_data);
   WasmResult (*on_export)(uint32_t index,
                           WasmExternalKind kind,
                           uint32_t item_index,
                           WasmStringSlice name,
                           void* user_data);
-  WasmResult (*end_export_section)(void* user_data);
+  WasmResult (*end_export_section)(WasmBinaryReaderContext* ctx);
 
   /* start section */
-  WasmResult (*begin_start_section)(void* user_data);
+  WasmResult (*begin_start_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_start_function)(uint32_t func_index, void* user_data);
-  WasmResult (*end_start_section)(void* user_data);
+  WasmResult (*end_start_section)(WasmBinaryReaderContext* ctx);
 
   /* function bodies section */
   /* TODO(binji): rename to code section */
-  WasmResult (*begin_function_bodies_section)(void* user_data);
+  WasmResult (*begin_function_bodies_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_function_bodies_count)(uint32_t count, void* user_data);
   WasmResult (*begin_function_body_pass)(uint32_t index,
                                          uint32_t pass,
@@ -146,7 +153,7 @@ typedef struct WasmBinaryReader {
 
   /* function expressions; called between begin_function_body and
    end_function_body */
-  WasmResult (*on_opcode)(WasmOpcode Opcode, void* user_data);
+  WasmResult (*on_opcode)(WasmBinaryReaderContext* ctx, WasmOpcode Opcode);
   WasmResult (*on_binary_expr)(WasmOpcode opcode, void* user_data);
   WasmResult (*on_block_expr)(uint32_t num_types,
                               WasmType* sig_types,
@@ -199,10 +206,10 @@ typedef struct WasmBinaryReader {
   WasmResult (*end_function_body_pass)(uint32_t index,
                                        uint32_t pass,
                                        void* user_data);
-  WasmResult (*end_function_bodies_section)(void* user_data);
+  WasmResult (*end_function_bodies_section)(WasmBinaryReaderContext* ctx);
 
   /* elem section */
-  WasmResult (*begin_elem_section)(void* user_data);
+  WasmResult (*begin_elem_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_elem_segment_count)(uint32_t count, void* user_data);
   WasmResult (*begin_elem_segment)(uint32_t index,
                                    uint32_t table_index,
@@ -216,10 +223,10 @@ typedef struct WasmBinaryReader {
                                                uint32_t func_index,
                                                void* user_data);
   WasmResult (*end_elem_segment)(uint32_t index, void* user_data);
-  WasmResult (*end_elem_section)(void* user_data);
+  WasmResult (*end_elem_section)(WasmBinaryReaderContext* ctx);
 
   /* data section */
-  WasmResult (*begin_data_section)(void* user_data);
+  WasmResult (*begin_data_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_data_segment_count)(uint32_t count, void* user_data);
   WasmResult (*begin_data_segment)(uint32_t index,
                                    uint32_t memory_index,
@@ -231,10 +238,10 @@ typedef struct WasmBinaryReader {
                                      uint32_t size,
                                      void* user_data);
   WasmResult (*end_data_segment)(uint32_t index, void* user_data);
-  WasmResult (*end_data_section)(void* user_data);
+  WasmResult (*end_data_section)(WasmBinaryReaderContext* ctx);
 
   /* names section */
-  WasmResult (*begin_names_section)(void* user_data);
+  WasmResult (*begin_names_section)(WasmBinaryReaderContext* ctx, uint32_t size);
   WasmResult (*on_function_names_count)(uint32_t count, void* user_data);
   WasmResult (*on_function_name)(uint32_t index,
                                  WasmStringSlice name,
@@ -246,7 +253,7 @@ typedef struct WasmBinaryReader {
                               uint32_t local_index,
                               WasmStringSlice name,
                               void* user_data);
-  WasmResult (*end_names_section)(void* user_data);
+  WasmResult (*end_names_section)(WasmBinaryReaderContext* ctx);
 
   /* init_expr - used by elem, data and global sections; these functions are
    * only called between calls to begin_*_init_expr and end_*_init_expr */

--- a/src/wasmopcodecnt.c
+++ b/src/wasmopcodecnt.c
@@ -44,9 +44,6 @@ static WasmReadBinaryOptions s_read_binary_options =
 
 static WasmBool s_use_libc_allocator;
 
-static WasmBinaryErrorHandler s_error_handler =
-    WASM_BINARY_ERROR_HANDLER_DEFAULT;
-
 static WasmFileWriter s_log_stream_writer;
 static WasmStream s_log_stream;
 
@@ -394,8 +391,7 @@ int main(int argc, char** argv) {
     WasmOpcntData opcnt_data;
     wasm_init_opcnt_data(allocator, &opcnt_data);
     result = wasm_read_binary_opcnt(
-        allocator, data, size, &s_read_binary_options, &s_error_handler,
-        &opcnt_data);
+        allocator, data, size, &s_read_binary_options, &opcnt_data);
     if (WASM_SUCCEEDED(result)) {
       display_sorted_int_counter_vector(
           out, "Opcode counts:", allocator, &opcnt_data.opcode_vec,

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -41,7 +41,7 @@ def main(args):
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
                       action='store_false')
-  parser.add_argument('--print-cmd', help='print the commands that are run.',
+  parser.add_argument('-p', '--print-cmd', help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('--run-all-exports', action='store_true')
   parser.add_argument('--spec', action='store_true')


### PR DESCRIPTION
This includes the user_data pointer that was previously
passed but also includes information about the current
reader context such as the offset with in the binary.