### PR TITLE
Allow failures on the OSX build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,3 +41,10 @@ matrix:
       env: SANITIZER=ubsan
     - os: osx
       compiler: clang
+
+  # Allow failures on the Mac bots. We'd rather not, but they are quite slow.
+  allow_failures:
+    - os: osx
+      compiler: clang
+
+  fast_finish: true


### PR DESCRIPTION
They OSX builds are very slow to run; it's good to test them, but
they're unlikely to differ from the Linux builds significantly.