### PR TITLE
Refactor interpreter for linking support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -205,9 +205,10 @@ add_library(libwasm STATIC
   src/wasm-binary-writer.c
   src/wasm-binary-writer-spec.c
   src/wasm-binary-reader-ast.c
+  src/wasm-binding-hash.c
   src/wasm-ast-writer.c
-  src/wasm-binary-reader-interpreter.c
   src/wasm-interpreter.c
+  src/wasm-binary-reader-interpreter.c
   src/wasm-apply-names.c
   src/wasm-generate-names.c
 

--- a/src/tools/wasm-interp.c
+++ b/src/tools/wasm-interp.c
@@ -231,41 +231,7 @@ static void print_typed_value(WasmInterpreterTypedValue* tv) {
   }
 }
 
-static void print_typed_values(WasmInterpreterTypedValue* values,
-                               size_t num_values) {
-  uint32_t i;
-  for (i = 0; i < num_values; ++i) {
-    print_typed_value(&values[i]);
-    if (i != num_values - 1)
-      printf(", ");
-  }
-}
-
-static WasmResult default_host_callback(const WasmInterpreterFuncSignature* sig,
-                                        const WasmStringSlice* module_name,
-                                        const WasmStringSlice* field_name,
-                                        uint32_t num_args,
-                                        WasmInterpreterTypedValue* args,
-                                        uint32_t num_results,
-                                        WasmInterpreterTypedValue* out_results,
-                                        void* user_data) {
-  memset(out_results, 0, sizeof(WasmInterpreterTypedValue) * num_results);
-  uint32_t i;
-  for (i = 0; i < num_results; ++i)
-    out_results[i].type = sig->result_types.data[i];
-
-  printf("called host " PRIstringslice "." PRIstringslice "(",
-         WASM_PRINTF_STRING_SLICE_ARG(*module_name),
-         WASM_PRINTF_STRING_SLICE_ARG(*field_name));
-  print_typed_values(args, num_args);
-  printf(") => (");
-  print_typed_values(out_results, num_results);
-  printf(")\n");
-  return WASM_OK;
-}
-
-static WasmInterpreterResult run_defined_function(WasmInterpreterModule* module,
-                                                  WasmInterpreterThread* thread,
+static WasmInterpreterResult run_defined_function(WasmInterpreterThread* thread,
                                                   uint32_t offset) {
   thread->pc = offset;
   WasmInterpreterResult iresult = WASM_INTERPRETER_OK;
@@ -273,9 +239,8 @@ static WasmInterpreterResult run_defined_function(WasmInterpreterModule* module,
   uint32_t* call_stack_return_top = thread->call_stack_top;
   while (iresult == WASM_INTERPRETER_OK) {
     if (s_trace)
-      wasm_trace_pc(module, thread, s_stdout_stream);
-    iresult =
-        wasm_run_interpreter(module, thread, quantum, call_stack_return_top);
+      wasm_trace_pc(thread, s_stdout_stream);
+    iresult = wasm_run_interpreter(thread, quantum, call_stack_return_top);
   }
   if (iresult != WASM_INTERPRETER_RETURNED) {
     if (s_trace)
@@ -286,27 +251,23 @@ static WasmInterpreterResult run_defined_function(WasmInterpreterModule* module,
   return WASM_INTERPRETER_OK;
 }
 
-static WasmInterpreterResult run_function(WasmInterpreterModule* module,
-                                          WasmInterpreterThread* thread,
+static WasmInterpreterResult run_function(WasmInterpreterThread* thread,
                                           uint32_t func_index) {
-  assert(func_index < module->funcs.size);
-  WasmInterpreterFunc* func = &module->funcs.data[func_index];
-  if (func->is_host) {
-    WasmInterpreterImport* import = &module->imports.data[func->import_index];
-    return wasm_call_host(module, thread, import);
-  } else {
-    return run_defined_function(module, thread, func->offset);
-  }
+  assert(func_index < thread->env->funcs.size);
+  WasmInterpreterFunc* func = &thread->env->funcs.data[func_index];
+  if (func->is_host)
+    return wasm_call_host(thread, func);
+  else
+    return run_defined_function(thread, func->defined.offset);
 }
 
-static WasmResult run_start_function(WasmInterpreterModule* module,
-                                     WasmInterpreterThread* thread) {
+static WasmResult run_start_function(WasmInterpreterThread* thread) {
   WasmResult result = WASM_OK;
-  if (module->start_func_index != WASM_INVALID_FUNC_INDEX) {
+  if (thread->module->defined.start_func_index != WASM_INVALID_INDEX) {
     if (s_trace)
       printf(">>> running start function:\n");
     WasmInterpreterResult iresult =
-        run_function(module, thread, module->start_func_index);
+        run_function(thread, thread->module->defined.start_func_index);
     if (iresult != WASM_INTERPRETER_OK) {
       /* trap */
       fprintf(stderr, "error: %s\n", s_trap_strings[iresult]);
@@ -317,22 +278,22 @@ static WasmResult run_start_function(WasmInterpreterModule* module,
 }
 
 static WasmInterpreterFuncSignature* get_export_signature(
-    WasmInterpreterModule* module,
+    WasmInterpreterEnvironment* env,
     WasmInterpreterExport* export) {
+  assert(export->kind == WASM_EXTERNAL_KIND_FUNC);
   uint32_t func_index = export->index;
-  uint32_t sig_index = module->funcs.data[func_index].sig_index;
-  assert(sig_index < module->sigs.size);
-  return &module->sigs.data[sig_index];
+  uint32_t sig_index = env->funcs.data[func_index].sig_index;
+  assert(sig_index < env->sigs.size);
+  return &env->sigs.data[sig_index];
 }
 
 static WasmInterpreterResult run_export(
     WasmAllocator* allocator,
-    WasmInterpreterModule* module,
     WasmInterpreterThread* thread,
     WasmInterpreterExport* export,
-    WasmInterpreterFuncSignature* sig,
     WasmInterpreterTypedValueVector* out_results) {
   assert(export->kind == WASM_EXTERNAL_KIND_FUNC);
+  WasmInterpreterFuncSignature* sig = get_export_signature(thread->env, export);
 
   /* push all 0 values as arguments */
   assert(sig->param_types.size < thread->value_stack.size);
@@ -340,7 +301,7 @@ static WasmInterpreterResult run_export(
   thread->value_stack_top = &thread->value_stack.data[num_args];
   memset(thread->value_stack.data, 0, num_args * sizeof(WasmInterpreterValue));
 
-  WasmInterpreterResult result = run_function(module, thread, export->index);
+  WasmInterpreterResult result = run_function(thread, export->index);
 
   if (result == WASM_INTERPRETER_OK) {
     size_t expected_results = sig->result_types.size;
@@ -374,7 +335,6 @@ static WasmInterpreterResult run_export(
 
 static WasmInterpreterResult run_export_wrapper(
     WasmAllocator* allocator,
-    WasmInterpreterModule* module,
     WasmInterpreterThread* thread,
     WasmInterpreterExport* export,
     WasmInterpreterTypedValueVector* out_results,
@@ -384,11 +344,12 @@ static WasmInterpreterResult run_export_wrapper(
            WASM_PRINTF_STRING_SLICE_ARG(export->name));
   }
 
-  WasmInterpreterFuncSignature* sig = get_export_signature(module, export);
   WasmInterpreterResult result =
-      run_export(allocator, module, thread, export, sig, out_results);
+      run_export(allocator, thread, export, out_results);
 
   if (verbose) {
+    WasmInterpreterFuncSignature* sig =
+        get_export_signature(thread->env, export);
     printf(PRIstringslice "(", WASM_PRINTF_STRING_SLICE_ARG(export->name));
     size_t i;
     for (i = 0; i < sig->param_types.size; ++i) {
@@ -416,19 +377,18 @@ static WasmInterpreterResult run_export_wrapper(
 
 static WasmResult run_export_by_name(
     WasmAllocator* allocator,
-    WasmInterpreterModule* module,
     WasmInterpreterThread* thread,
     WasmStringSlice* name,
     WasmInterpreterResult* out_iresult,
     WasmInterpreterTypedValueVector* out_results,
     RunVerbosity verbose) {
   WasmInterpreterExport* export =
-      wasm_get_interpreter_export_by_name(module, name);
+      wasm_get_interpreter_export_by_name(thread->module, name);
   if (!export)
     return WASM_ERROR;
 
-  *out_iresult = run_export_wrapper(allocator, module, thread, export,
-                                    out_results, verbose);
+  *out_iresult =
+      run_export_wrapper(allocator, thread, export, out_results, verbose);
   return WASM_OK;
 }
 
@@ -441,85 +401,147 @@ static void run_all_exports(WasmAllocator* allocator,
   uint32_t i;
   for (i = 0; i < module->exports.size; ++i) {
     WasmInterpreterExport* export = &module->exports.data[i];
-    run_export_wrapper(allocator, module, thread, export, &results, verbose);
+    run_export_wrapper(allocator, thread, export, &results, verbose);
   }
   wasm_destroy_interpreter_typed_value_vector(allocator, &results);
 }
 
 static WasmResult read_module(WasmAllocator* allocator,
                               const char* module_filename,
-                              WasmInterpreterModule* out_module,
+                              WasmInterpreterEnvironment* env,
+                              WasmInterpreterModule** out_module,
                               WasmInterpreterThread* out_thread) {
   WasmResult result;
   void* data;
   size_t size;
-  WASM_ZERO_MEMORY(*out_module);
   WASM_ZERO_MEMORY(*out_thread);
   result = wasm_read_file(allocator, module_filename, &data, &size);
   if (WASM_SUCCEEDED(result)) {
     WasmAllocator* memory_allocator = &g_wasm_libc_allocator;
-    result = wasm_read_binary_interpreter(allocator, memory_allocator, data,
-                                          size, &s_read_binary_options,
+    result = wasm_read_binary_interpreter(allocator, memory_allocator, env,
+                                          data, size, &s_read_binary_options,
                                           &s_error_handler, out_module);
 
     if (WASM_SUCCEEDED(result)) {
-      if (s_verbose) {
-        wasm_disassemble_module(out_module, s_stdout_stream, 0,
-                                out_module->istream.size);
-      }
+      if (s_verbose)
+        wasm_disassemble_module(env, s_stdout_stream, *out_module);
 
-      result = wasm_init_interpreter_thread(allocator, out_module, out_thread,
-                                            &s_thread_options);
-      out_thread->host_func.callback = default_host_callback;
-      out_thread->host_func.user_data = NULL;
+      result = wasm_init_interpreter_thread(allocator, env, *out_module,
+                                            out_thread, &s_thread_options);
     }
     wasm_free(allocator, data);
   }
   return result;
 }
 
-static void destroy_module_and_thread(WasmAllocator* allocator,
-                                      WasmInterpreterModule* module,
-                                      WasmInterpreterThread* thread) {
-  wasm_destroy_interpreter_thread(allocator, thread);
-  wasm_destroy_interpreter_module(allocator, module);
+static void print_typed_values(WasmInterpreterTypedValue* values,
+                               size_t num_values) {
+  uint32_t i;
+  for (i = 0; i < num_values; ++i) {
+    print_typed_value(&values[i]);
+    if (i != num_values - 1)
+      printf(", ");
+  }
+}
+
+static WasmResult default_host_callback(const WasmInterpreterFunc* func,
+                                        const WasmInterpreterFuncSignature* sig,
+                                        uint32_t num_args,
+                                        WasmInterpreterTypedValue* args,
+                                        uint32_t num_results,
+                                        WasmInterpreterTypedValue* out_results,
+                                        void* user_data) {
+  memset(out_results, 0, sizeof(WasmInterpreterTypedValue) * num_results);
+  uint32_t i;
+  for (i = 0; i < num_results; ++i)
+    out_results[i].type = sig->result_types.data[i];
+
+  printf("called host " PRIstringslice "." PRIstringslice "(",
+         WASM_PRINTF_STRING_SLICE_ARG(func->host.module_name),
+         WASM_PRINTF_STRING_SLICE_ARG(func->host.field_name));
+  print_typed_values(args, num_args);
+  printf(") => (");
+  print_typed_values(out_results, num_results);
+  printf(")\n");
+  return WASM_OK;
+}
+
+static WasmResult spectest_import_func(WasmInterpreterImport* import,
+                                       WasmInterpreterFunc* func,
+                                       WasmInterpreterFuncSignature* sig,
+                                       void* user_data) {
+  func->host.callback = default_host_callback;
+  return WASM_OK;
+}
+
+static WasmResult spectest_import_table(WasmInterpreterImport* import,
+                                        WasmInterpreterTable* table,
+                                        void* user_data) {
+  return WASM_ERROR;
+}
+
+static WasmResult spectest_import_memory(WasmInterpreterImport* import,
+                                         WasmInterpreterMemory* memory,
+                                         void* user_data) {
+  return WASM_ERROR;
+}
+
+static WasmResult spectest_import_global(WasmInterpreterImport* import,
+                                         WasmInterpreterGlobal* global,
+                                         void* user_data) {
+  return WASM_ERROR;
+}
+
+static void init_environment(WasmAllocator* allocator,
+                             WasmInterpreterEnvironment* env) {
+  wasm_init_interpreter_environment(allocator, env);
+  WasmInterpreterModule* host_module = wasm_append_host_module(
+      allocator, env, wasm_string_slice_from_cstr("spectest"));
+  host_module->host.import_delegate.import_func = spectest_import_func;
+  host_module->host.import_delegate.import_table = spectest_import_table;
+  host_module->host.import_delegate.import_memory = spectest_import_memory;
+  host_module->host.import_delegate.import_global = spectest_import_global;
 }
 
 static WasmResult read_and_run_module(WasmAllocator* allocator,
                                       const char* module_filename) {
   WasmResult result;
-  WasmInterpreterModule module;
+  WasmInterpreterEnvironment env;
+  WasmInterpreterModule* module = NULL;
   WasmInterpreterThread thread;
-  result = read_module(allocator, module_filename, &module, &thread);
-  if (WASM_SUCCEEDED(result))
-    result = run_start_function(&module, &thread);
 
-  if (WASM_SUCCEEDED(result) && s_run_all_exports)
-    run_all_exports(allocator, &module, &thread, RUN_VERBOSE);
-  destroy_module_and_thread(allocator, &module, &thread);
+  init_environment(allocator, &env);
+  result = read_module(allocator, module_filename, &env, &module, &thread);
+  if (WASM_SUCCEEDED(result)) {
+    result = run_start_function(&thread);
+    if (s_run_all_exports)
+      run_all_exports(allocator, module, &thread, RUN_VERBOSE);
+  }
+  wasm_destroy_interpreter_thread(allocator, &thread);
+  wasm_destroy_interpreter_environment(allocator, &env);
   return result;
 }
 
 static WasmResult read_and_run_spec_json(WasmAllocator* allocator,
                                          const char* spec_json_filename) {
   WasmResult result = WASM_OK;
-  WasmInterpreterModule module;
+  WasmInterpreterEnvironment env;
+  WasmInterpreterModule* module = NULL;
   WasmInterpreterThread thread;
   WasmStringSlice command_file;
   WasmStringSlice command_name;
-  WasmAllocatorMark module_mark;
   WasmInterpreterTypedValueVector result_values;
   uint32_t command_line_no;
-  WasmBool has_module = WASM_FALSE;
+  WasmBool has_thread = WASM_FALSE;
   uint32_t passed = 0;
   uint32_t failed = 0;
 
-  WASM_ZERO_MEMORY(module);
   WASM_ZERO_MEMORY(thread);
   WASM_ZERO_MEMORY(command_file);
   WASM_ZERO_MEMORY(command_name);
-  WASM_ZERO_MEMORY(module_mark);
   WASM_ZERO_MEMORY(result_values);
+
+  init_environment(allocator, &env);
 
   void* data;
   size_t size;
@@ -653,9 +675,9 @@ static WasmResult read_and_run_spec_json(WasmAllocator* allocator,
       case END_MODULE_OBJECT:
         EXPECT('}');
         MAYBE_CONTINUE(MODULES_ARRAY);
-        destroy_module_and_thread(allocator, &module, &thread);
-        wasm_reset_to_mark(allocator, module_mark);
-        has_module = WASM_FALSE;
+        assert(has_thread);
+        wasm_destroy_interpreter_thread(allocator, &thread);
+        has_thread = WASM_FALSE;
         break;
 
       case MODULE_FILENAME: {
@@ -673,14 +695,13 @@ static WasmResult read_and_run_spec_json(WasmAllocator* allocator,
                         WASM_PRINTF_STRING_SLICE_ARG(module_filename));
         }
 
-        module_mark = wasm_mark(allocator);
-        result = read_module(allocator, path, &module, &thread);
+        result = read_module(allocator, path, &env, &module, &thread);
         if (WASM_FAILED(result))
           goto fail;
 
-        has_module = WASM_TRUE;
+        has_thread = WASM_TRUE;
 
-        result = run_start_function(&module, &thread);
+        result = run_start_function(&thread);
         if (WASM_FAILED(result))
           goto fail;
 
@@ -727,8 +748,8 @@ static WasmResult read_and_run_spec_json(WasmAllocator* allocator,
         WasmInterpreterResult iresult;
         EXPECT('}');
         RunVerbosity verbose = command_type == ACTION ? RUN_VERBOSE : RUN_QUIET;
-        result = run_export_by_name(allocator, &module, &thread, &command_name,
-                                    &iresult, &result_values, verbose);
+        result = run_export_by_name(allocator, &thread, &command_name, &iresult,
+                                    &result_values, verbose);
         if (WASM_FAILED(result)) {
           FAILED("unknown export");
           failed++;
@@ -837,8 +858,9 @@ fail:
   result = WASM_ERROR;
 
 done:
-  if (has_module)
-    destroy_module_and_thread(allocator, &module, &thread);
+  if (has_thread)
+    wasm_destroy_interpreter_thread(allocator, &thread);
+  wasm_destroy_interpreter_environment(allocator, &env);
   wasm_destroy_interpreter_typed_value_vector(allocator, &result_values);
   wasm_free(allocator, data);
   return result;

--- a/src/wasm-ast.c
+++ b/src/wasm-ast.c
@@ -21,158 +21,15 @@
 
 #include "wasm-allocator.h"
 
-#define INITIAL_HASH_CAPACITY 8
-
-static size_t hash_name(const WasmStringSlice* name) {
-  // FNV-1a hash
-  const uint32_t fnv_prime = 0x01000193;
-  const uint8_t* bp = (const uint8_t*)name->start;
-  const uint8_t* be = bp + name->length;
-  uint32_t hval = 0x811c9dc5;
-  while (bp < be) {
-    hval ^= (uint32_t)*bp++;
-    hval *= fnv_prime;
-  }
-  return hval;
-}
-
-static WasmBindingHashEntry* hash_main_entry(const WasmBindingHash* hash,
-                                             const WasmStringSlice* name) {
-  return &hash->entries.data[hash_name(name) % hash->entries.capacity];
-}
-
-WasmBool wasm_hash_entry_is_free(const WasmBindingHashEntry* entry) {
-  return !entry->binding.name.start;
-}
-
-static WasmBindingHashEntry* hash_new_entry(WasmBindingHash* hash,
-                                            const WasmStringSlice* name) {
-  WasmBindingHashEntry* entry = hash_main_entry(hash, name);
-  if (!wasm_hash_entry_is_free(entry)) {
-    assert(hash->free_head);
-    WasmBindingHashEntry* free_entry = hash->free_head;
-    hash->free_head = free_entry->next;
-    if (free_entry->next)
-      free_entry->next->prev = NULL;
-
-    /* our main position is already claimed. Check to see if the entry in that
-     * position is in its main position */
-    WasmBindingHashEntry* other_entry =
-        hash_main_entry(hash, &entry->binding.name);
-    if (other_entry == entry) {
-      /* yes, so add this new entry to the chain, even if it is already there */
-      /* add as the second entry in the chain */
-      free_entry->next = entry->next;
-      entry->next = free_entry;
-      entry = free_entry;
-    } else {
-      /* no, move the entry to the free entry */
-      assert(!wasm_hash_entry_is_free(other_entry));
-      while (other_entry->next != entry)
-        other_entry = other_entry->next;
-
-      other_entry->next = free_entry;
-      *free_entry = *entry;
-      entry->next = NULL;
-    }
-  } else {
-    /* remove from the free list */
-    if (entry->next)
-      entry->next->prev = entry->prev;
-    if (entry->prev)
-      entry->prev->next = entry->next;
-    else
-      hash->free_head = entry->next;
-    entry->next = NULL;
-  }
-
-  WASM_ZERO_MEMORY(entry->binding);
-  entry->binding.name = *name;
-  entry->prev = NULL;
-  /* entry->next is set above */
-  return entry;
-}
-
-static void hash_resize(WasmAllocator* allocator,
-                        WasmBindingHash* hash,
-                        size_t desired_capacity) {
-  WasmBindingHash new_hash;
-  WASM_ZERO_MEMORY(new_hash);
-  /* TODO(binji): better plural */
-  wasm_reserve_binding_hash_entrys(allocator, &new_hash.entries,
-                                   desired_capacity);
-
-  /* update the free list */
-  size_t i;
-  for (i = 0; i < new_hash.entries.capacity; ++i) {
-    WasmBindingHashEntry* entry = &new_hash.entries.data[i];
-    if (new_hash.free_head)
-      new_hash.free_head->prev = entry;
-
-    WASM_ZERO_MEMORY(entry->binding.name);
-    entry->next = new_hash.free_head;
-    new_hash.free_head = entry;
-  }
-  new_hash.free_head->prev = NULL;
-
-  /* copy from the old hash to the new hash */
-  for (i = 0; i < hash->entries.capacity; ++i) {
-    WasmBindingHashEntry* old_entry = &hash->entries.data[i];
-    if (wasm_hash_entry_is_free(old_entry))
-      continue;
-
-    WasmStringSlice* name = &old_entry->binding.name;
-    WasmBindingHashEntry* new_entry = hash_new_entry(&new_hash, name);
-    new_entry->binding = old_entry->binding;
-  }
-
-  /* we are sharing the WasmStringSlices, so we only need to destroy the old
-   * binding vector */
-  wasm_destroy_binding_hash_entry_vector(allocator, &hash->entries);
-  *hash = new_hash;
-}
-
-WasmBinding* wasm_insert_binding(WasmAllocator* allocator,
-                                 WasmBindingHash* hash,
-                                 const WasmStringSlice* name) {
-  if (hash->entries.size == 0)
-    hash_resize(allocator, hash, INITIAL_HASH_CAPACITY);
-
-  if (!hash->free_head) {
-    /* no more free space, allocate more */
-    hash_resize(allocator, hash, hash->entries.capacity * 2);
-  }
-
-  WasmBindingHashEntry* entry = hash_new_entry(hash, name);
-  assert(entry);
-  hash->entries.size++;
-  return &entry->binding;
-}
-
-static int find_binding_index_by_name(const WasmBindingHash* hash,
-                                      const WasmStringSlice* name) {
-  if (hash->entries.capacity == 0)
-    return -1;
-
-  WasmBindingHashEntry* entry = hash_main_entry(hash, name);
-  do {
-    if (wasm_string_slices_are_equal(&entry->binding.name, name))
-      return entry->binding.index;
-
-    entry = entry->next;
-  } while (entry && !wasm_hash_entry_is_free(entry));
-  return -1;
-}
-
 int wasm_get_index_from_var(const WasmBindingHash* hash, const WasmVar* var) {
   if (var->type == WASM_VAR_TYPE_NAME)
-    return find_binding_index_by_name(hash, &var->name);
+    return wasm_find_binding_index_by_name(hash, &var->name);
   return (int)var->index;
 }
 
 WasmExportPtr wasm_get_export_by_name(const WasmModule* module,
                                       const WasmStringSlice* name) {
-  int index = find_binding_index_by_name(&module->export_bindings, name);
+  int index = wasm_find_binding_index_by_name(&module->export_bindings, name);
   if (index == -1)
     return NULL;
   return module->exports.data[index];
@@ -203,11 +60,12 @@ int wasm_get_local_index_by_var(const WasmFunc* func, const WasmVar* var) {
   if (var->type == WASM_VAR_TYPE_INDEX)
     return (int)var->index;
 
-  int result = find_binding_index_by_name(&func->param_bindings, &var->name);
+  int result =
+      wasm_find_binding_index_by_name(&func->param_bindings, &var->name);
   if (result != -1)
     return result;
 
-  result = find_binding_index_by_name(&func->local_bindings, &var->name);
+  result = wasm_find_binding_index_by_name(&func->local_bindings, &var->name);
   if (result == -1)
     return result;
 
@@ -393,21 +251,6 @@ WasmExpr* wasm_new_empty_expr(struct WasmAllocator* allocator,
   return result;
 }
 
-static void destroy_binding_hash_entry(WasmAllocator* allocator,
-                                       WasmBindingHashEntry* entry) {
-  wasm_destroy_string_slice(allocator, &entry->binding.name);
-}
-
-static void destroy_binding_hash(WasmAllocator* allocator,
-                                 WasmBindingHash* hash) {
-  /* Can't use WASM_DESTROY_VECTOR_AND_ELEMENTS, because it loops over size, not
-   * capacity. */
-  size_t i;
-  for (i = 0; i < hash->entries.capacity; ++i)
-    destroy_binding_hash_entry(allocator, &hash->entries.data[i]);
-  wasm_destroy_binding_hash_entry_vector(allocator, &hash->entries);
-}
-
 void wasm_destroy_var(WasmAllocator* allocator, WasmVar* var) {
   if (var->type == WASM_VAR_TYPE_NAME)
     wasm_destroy_string_slice(allocator, &var->name);
@@ -513,8 +356,8 @@ void wasm_destroy_func(WasmAllocator* allocator, WasmFunc* func) {
   wasm_destroy_string_slice(allocator, &func->name);
   wasm_destroy_func_declaration(allocator, &func->decl);
   wasm_destroy_type_vector(allocator, &func->local_types);
-  destroy_binding_hash(allocator, &func->param_bindings);
-  destroy_binding_hash(allocator, &func->local_bindings);
+  wasm_destroy_binding_hash(allocator, &func->param_bindings);
+  wasm_destroy_binding_hash(allocator, &func->local_bindings);
   wasm_destroy_expr_list(allocator, func->first_expr);
 }
 

--- a/src/wasm-ast.h
+++ b/src/wasm-ast.h
@@ -21,6 +21,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "wasm-binding-hash.h"
 #include "wasm-common.h"
 #include "wasm-type-vector.h"
 #include "wasm-vector.h"
@@ -84,24 +85,6 @@ typedef enum WasmExprType {
   WASM_EXPR_TYPE_UNARY,
   WASM_EXPR_TYPE_UNREACHABLE,
 } WasmExprType;
-
-typedef struct WasmBinding {
-  WasmLocation loc;
-  WasmStringSlice name;
-  int index;
-} WasmBinding;
-
-typedef struct WasmBindingHashEntry {
-  WasmBinding binding;
-  struct WasmBindingHashEntry* next;
-  struct WasmBindingHashEntry* prev; /* only valid when this entry is unused */
-} WasmBindingHashEntry;
-WASM_DEFINE_VECTOR(binding_hash_entry, WasmBindingHashEntry);
-
-typedef struct WasmBindingHash {
-  WasmBindingHashEntryVector entries;
-  WasmBindingHashEntry* free_head;
-} WasmBindingHash;
 
 typedef WasmTypeVector WasmBlockSignature;
 
@@ -411,12 +394,6 @@ typedef struct WasmExprVisitor {
 } WasmExprVisitor;
 
 WASM_EXTERN_C_BEGIN
-WasmBinding* wasm_insert_binding(struct WasmAllocator*,
-                                 WasmBindingHash*,
-                                 const WasmStringSlice*);
-
-WasmBool wasm_hash_entry_is_free(const WasmBindingHashEntry*);
-
 WasmModuleField* wasm_append_module_field(struct WasmAllocator*, WasmModule*);
 /* ownership of the function signature is passed to the module */
 WasmFuncType* wasm_append_implicit_func_type(struct WasmAllocator*,

--- a/src/wasm-binary-reader-interpreter.h
+++ b/src/wasm-binary-reader-interpreter.h
@@ -20,6 +20,7 @@
 #include "wasm-common.h"
 
 struct WasmAllocator;
+struct WasmInterpreterEnvironment;
 struct WasmInterpreterModule;
 struct WasmReadBinaryOptions;
 
@@ -27,11 +28,12 @@ WASM_EXTERN_C_BEGIN
 WasmResult wasm_read_binary_interpreter(
     struct WasmAllocator* allocator,
     struct WasmAllocator* memory_allocator,
+    struct WasmInterpreterEnvironment* env,
     const void* data,
     size_t size,
     const struct WasmReadBinaryOptions* options,
     WasmBinaryErrorHandler*,
-    struct WasmInterpreterModule* out_module);
+    struct WasmInterpreterModule** out_module);
 WASM_EXTERN_C_END
 
 #endif /* WASM_BINARY_READER_INTERPRETER_H_ */

--- a/src/wasm-binary-reader.c
+++ b/src/wasm-binary-reader.c
@@ -2015,7 +2015,7 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
     CALLBACK_CTX0(end_data_section);
   }
 
-  CALLBACK_CTX0(end_module);
+  CALLBACK0(end_module);
   destroy_context(allocator, ctx);
   return WASM_OK;
 }

--- a/src/wasm-binding-hash.c
+++ b/src/wasm-binding-hash.c
@@ -1,0 +1,175 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "wasm-binding-hash.h"
+
+#define INITIAL_HASH_CAPACITY 8
+
+static size_t hash_name(const WasmStringSlice* name) {
+  // FNV-1a hash
+  const uint32_t fnv_prime = 0x01000193;
+  const uint8_t* bp = (const uint8_t*)name->start;
+  const uint8_t* be = bp + name->length;
+  uint32_t hval = 0x811c9dc5;
+  while (bp < be) {
+    hval ^= (uint32_t)*bp++;
+    hval *= fnv_prime;
+  }
+  return hval;
+}
+
+static WasmBindingHashEntry* hash_main_entry(const WasmBindingHash* hash,
+                                             const WasmStringSlice* name) {
+  return &hash->entries.data[hash_name(name) % hash->entries.capacity];
+}
+
+WasmBool wasm_hash_entry_is_free(const WasmBindingHashEntry* entry) {
+  return !entry->binding.name.start;
+}
+
+static WasmBindingHashEntry* hash_new_entry(WasmBindingHash* hash,
+                                            const WasmStringSlice* name) {
+  WasmBindingHashEntry* entry = hash_main_entry(hash, name);
+  if (!wasm_hash_entry_is_free(entry)) {
+    assert(hash->free_head);
+    WasmBindingHashEntry* free_entry = hash->free_head;
+    hash->free_head = free_entry->next;
+    if (free_entry->next)
+      free_entry->next->prev = NULL;
+
+    /* our main position is already claimed. Check to see if the entry in that
+     * position is in its main position */
+    WasmBindingHashEntry* other_entry =
+        hash_main_entry(hash, &entry->binding.name);
+    if (other_entry == entry) {
+      /* yes, so add this new entry to the chain, even if it is already there */
+      /* add as the second entry in the chain */
+      free_entry->next = entry->next;
+      entry->next = free_entry;
+      entry = free_entry;
+    } else {
+      /* no, move the entry to the free entry */
+      assert(!wasm_hash_entry_is_free(other_entry));
+      while (other_entry->next != entry)
+        other_entry = other_entry->next;
+
+      other_entry->next = free_entry;
+      *free_entry = *entry;
+      entry->next = NULL;
+    }
+  } else {
+    /* remove from the free list */
+    if (entry->next)
+      entry->next->prev = entry->prev;
+    if (entry->prev)
+      entry->prev->next = entry->next;
+    else
+      hash->free_head = entry->next;
+    entry->next = NULL;
+  }
+
+  WASM_ZERO_MEMORY(entry->binding);
+  entry->binding.name = *name;
+  entry->prev = NULL;
+  /* entry->next is set above */
+  return entry;
+}
+
+static void hash_resize(WasmAllocator* allocator,
+                        WasmBindingHash* hash,
+                        size_t desired_capacity) {
+  WasmBindingHash new_hash;
+  WASM_ZERO_MEMORY(new_hash);
+  /* TODO(binji): better plural */
+  wasm_reserve_binding_hash_entrys(allocator, &new_hash.entries,
+                                   desired_capacity);
+
+  /* update the free list */
+  size_t i;
+  for (i = 0; i < new_hash.entries.capacity; ++i) {
+    WasmBindingHashEntry* entry = &new_hash.entries.data[i];
+    if (new_hash.free_head)
+      new_hash.free_head->prev = entry;
+
+    WASM_ZERO_MEMORY(entry->binding.name);
+    entry->next = new_hash.free_head;
+    new_hash.free_head = entry;
+  }
+  new_hash.free_head->prev = NULL;
+
+  /* copy from the old hash to the new hash */
+  for (i = 0; i < hash->entries.capacity; ++i) {
+    WasmBindingHashEntry* old_entry = &hash->entries.data[i];
+    if (wasm_hash_entry_is_free(old_entry))
+      continue;
+
+    WasmStringSlice* name = &old_entry->binding.name;
+    WasmBindingHashEntry* new_entry = hash_new_entry(&new_hash, name);
+    new_entry->binding = old_entry->binding;
+  }
+
+  /* we are sharing the WasmStringSlices, so we only need to destroy the old
+   * binding vector */
+  wasm_destroy_binding_hash_entry_vector(allocator, &hash->entries);
+  *hash = new_hash;
+}
+
+WasmBinding* wasm_insert_binding(WasmAllocator* allocator,
+                                 WasmBindingHash* hash,
+                                 const WasmStringSlice* name) {
+  if (hash->entries.size == 0)
+    hash_resize(allocator, hash, INITIAL_HASH_CAPACITY);
+
+  if (!hash->free_head) {
+    /* no more free space, allocate more */
+    hash_resize(allocator, hash, hash->entries.capacity * 2);
+  }
+
+  WasmBindingHashEntry* entry = hash_new_entry(hash, name);
+  assert(entry);
+  hash->entries.size++;
+  return &entry->binding;
+}
+
+int wasm_find_binding_index_by_name(const WasmBindingHash* hash,
+                                    const WasmStringSlice* name) {
+  if (hash->entries.capacity == 0)
+    return -1;
+
+  WasmBindingHashEntry* entry = hash_main_entry(hash, name);
+  do {
+    if (wasm_string_slices_are_equal(&entry->binding.name, name))
+      return entry->binding.index;
+
+    entry = entry->next;
+  } while (entry && !wasm_hash_entry_is_free(entry));
+  return -1;
+}
+
+static void destroy_binding_hash_entry(WasmAllocator* allocator,
+                                       WasmBindingHashEntry* entry) {
+  wasm_destroy_string_slice(allocator, &entry->binding.name);
+}
+
+void wasm_destroy_binding_hash(WasmAllocator* allocator,
+                               WasmBindingHash* hash) {
+  /* Can't use WASM_DESTROY_VECTOR_AND_ELEMENTS, because it loops over size, not
+   * capacity. */
+  size_t i;
+  for (i = 0; i < hash->entries.capacity; ++i)
+    destroy_binding_hash_entry(allocator, &hash->entries.data[i]);
+  wasm_destroy_binding_hash_entry_vector(allocator, &hash->entries);
+}

--- a/src/wasm-binding-hash.h
+++ b/src/wasm-binding-hash.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WASM_BINDING_HASH_H_
+#define WASM_BINDING_HASH_H_
+
+#include "wasm-common.h"
+#include "wasm-vector.h"
+
+struct WasmAllocator;
+
+typedef struct WasmBinding {
+  WasmLocation loc;
+  WasmStringSlice name;
+  int index;
+} WasmBinding;
+
+typedef struct WasmBindingHashEntry {
+  WasmBinding binding;
+  struct WasmBindingHashEntry* next;
+  struct WasmBindingHashEntry* prev; /* only valid when this entry is unused */
+} WasmBindingHashEntry;
+WASM_DEFINE_VECTOR(binding_hash_entry, WasmBindingHashEntry);
+
+typedef struct WasmBindingHash {
+  WasmBindingHashEntryVector entries;
+  WasmBindingHashEntry* free_head;
+} WasmBindingHash;
+
+WASM_EXTERN_C_BEGIN
+WasmBinding* wasm_insert_binding(struct WasmAllocator*,
+                                 WasmBindingHash*,
+                                 const WasmStringSlice*);
+WasmBool wasm_hash_entry_is_free(const WasmBindingHashEntry*);
+/* returns -1 if the name is not in the hash */
+int wasm_find_binding_index_by_name(const WasmBindingHash*,
+                                    const WasmStringSlice* name);
+void wasm_destroy_binding_hash(struct WasmAllocator*, WasmBindingHash*);
+WASM_EXTERN_C_END
+
+#endif /* WASM_BINDING_HASH_H_ */

--- a/src/wasm-common.c
+++ b/src/wasm-common.c
@@ -56,6 +56,13 @@ WasmStringSlice wasm_empty_string_slice(void) {
   return result;
 }
 
+WasmStringSlice wasm_string_slice_from_cstr(const char* string) {
+  WasmStringSlice result;
+  result.start = string;
+  result.length = strlen(string);
+  return result;
+}
+
 WasmBool wasm_string_slices_are_equal(const WasmStringSlice* a,
                                       const WasmStringSlice* b) {
   return a->start && b->start && a->length == b->length &&

--- a/src/wasm-common.h
+++ b/src/wasm-common.h
@@ -151,13 +151,6 @@ typedef enum WasmExternalKind {
   WASM_NUM_EXTERNAL_KINDS,
 } WasmExternalKind;
 
-extern const char* g_wasm_kind_name[];
-
-static WASM_INLINE const char* wasm_get_kind_name(WasmExternalKind kind) {
-  assert(kind < WASM_NUM_EXTERNAL_KINDS);
-  return g_wasm_kind_name[kind];
-}
-
 typedef struct WasmLimits {
   uint64_t initial;
   uint64_t max;
@@ -390,6 +383,7 @@ WasmBool wasm_is_naturally_aligned(WasmOpcode opcode, uint32_t alignment);
 uint32_t wasm_get_opcode_alignment(WasmOpcode opcode, uint32_t alignment);
 
 WasmStringSlice wasm_empty_string_slice(void);
+WasmStringSlice wasm_string_slice_from_cstr(const char* string);
 WasmBool wasm_string_slices_are_equal(const WasmStringSlice*,
                                       const WasmStringSlice*);
 void wasm_destroy_string_slice(struct WasmAllocator*, WasmStringSlice*);
@@ -450,6 +444,15 @@ static WASM_INLINE WasmType wasm_get_opcode_param_type_2(WasmOpcode opcode) {
 static WASM_INLINE int wasm_get_opcode_memory_size(WasmOpcode opcode) {
   assert(opcode < WASM_NUM_OPCODES);
   return g_wasm_opcode_info[opcode].memory_size;
+}
+
+/* external kind */
+
+extern const char* g_wasm_kind_name[];
+
+static WASM_INLINE const char* wasm_get_kind_name(WasmExternalKind kind) {
+  assert(kind < WASM_NUM_EXTERNAL_KINDS);
+  return g_wasm_kind_name[kind];
 }
 
 WASM_EXTERN_C_END

--- a/src/wasm-writer.h
+++ b/src/wasm-writer.h
@@ -62,11 +62,17 @@ void wasm_close_file_writer(WasmFileWriter* writer);
 /* WasmMemoryWriter */
 WasmResult wasm_init_mem_writer(WasmAllocator* allocator,
                                 WasmMemoryWriter* writer);
+/* Passes ownership of the buffer to writer */
+WasmResult wasm_init_mem_writer_existing(WasmMemoryWriter* writer,
+                                         WasmOutputBuffer* buf);
 void wasm_steal_mem_writer_output_buffer(WasmMemoryWriter* writer,
                                          WasmOutputBuffer* out_buf);
 void wasm_close_mem_writer(WasmMemoryWriter* writer);
 
 /* WasmOutputBuffer */
+void wasm_init_output_buffer(WasmAllocator* allocator,
+                             WasmOutputBuffer* buf,
+                             size_t initial_capacity);
 WasmResult wasm_write_output_buffer_to_file(WasmOutputBuffer* buf,
                                             const char* filename);
 void wasm_destroy_output_buffer(WasmOutputBuffer* buf);

--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -15,6 +15,7 @@ section(DATA) {
 }
 (;; STDERR ;;;
 Error running "wasm-interp":
+error: data segment is out of bounds: [0, 8) >= max value 0
 error: @0x0000001d: on_data_segment_data callback failed
 
 ;;; STDERR ;;)

--- a/test/interp/callimport-zero-args.txt
+++ b/test/interp/callimport-zero-args.txt
@@ -1,12 +1,12 @@
 ;;; TOOL: run-interp
 (module
-  (import "foo" "bar" (func $imported (result i32)))
+  (import "spectest" "print" (func $imported (result i32)))
 
   (func (export "f") (result i32)
     (i32.add
       (i32.const 13)
       (call $imported))))
 (;; STDOUT ;;;
-called host foo.bar() => (i32:0)
+called host spectest.print() => (i32:0)
 f() => i32:13
 ;;; STDOUT ;;)

--- a/test/interp/import.txt
+++ b/test/interp/import.txt
@@ -1,14 +1,14 @@
 ;;; TOOL: run-interp
 (module
-  (import "stdio" "print" (func $print_i32 (param i32)))
-  (import "stdio" "print" (func $print_i32_i32 (param i32 i32)))
+  (import "spectest" "print" (func $print_i32 (param i32)))
+  (import "spectest" "print" (func $print_i32_i32 (param i32 i32)))
   (func (export "test") (result i32)
     (call $print_i32 (i32.const 100))
     (call $print_i32_i32 (i32.const 200) (i32.const 300))
     (return (i32.const 1)))
 )
 (;; STDOUT ;;;
-called host stdio.print(i32:100) => ()
-called host stdio.print(i32:200, i32:300) => ()
+called host spectest.print(i32:100) => ()
+called host spectest.print(i32:200, i32:300) => ()
 test() => i32:1
 ;;; STDOUT ;;)


### PR DESCRIPTION
* Create WasmInterpreterEnvironment to hold all modules, functions,
  globals, tables and memories
* There are now three index spaces: "module", "environment" and
  "defined".
  - The "module" index space matches up w/ the normal WebAssembly index
    space, which is distinct for functions, globals, tables, etc.
  - The "environment" index space is a combined index space for all loaded
    modules.
  - The "defined" index space only includes defined objects, not
    imported objects. This is used, for example, when iterating over the
    code section; the function bodies are only specified for defined
    functions.
* A thread is implicitly associated with a module and environment, so
  simplify many function signatures to remove those additional arguments
* Any importable kind can be imported from a host module. Unfortunately,
  since the spec tests require polymorphic imports, the importing
  mechanism must be callback-based
* When interpreting spec tests, the environment and all modules must be
  retained throughout
* Move the binding hash code out of wasm-ast.{c,h} =>
  wasm-binding-hash.{c,h}
* Add wasm_init_output_buffer, for initializing the environment's
  instruction stream independently from a WasmMemoryWriter
* Add wasm_init_mem_writer_existing for initializing a WasmMemoryWriter
  given an existing WasmOutputBuffer
* Add predefined "spectest" module, with a generic function import.
  Still need to implement the spectest table, memory and global imports