### PR TITLE
Add reserved immediate to three operators

### DIFF
--- a/src/wasm-binary-reader.c
+++ b/src/wasm-binary-reader.c
@@ -1445,8 +1445,12 @@ static void read_function_body(Context* ctx,
         in_u32_leb128(ctx, &sig_index, "call_indirect signature index");
         RAISE_ERROR_UNLESS(sig_index < ctx->num_signatures,
                            "invalid call_indirect signature index");
+        uint32_t reserved;
+        in_u32_leb128(ctx, &reserved, "call_indirect reserved");
+        RAISE_ERROR_UNLESS(reserved == 0,
+                           "call_indirect reserved value must be 0");
         CALLBACK(on_call_indirect_expr, sig_index);
-        CALLBACK_CTX(on_opcode_uint32, sig_index);
+        CALLBACK_CTX(on_opcode_uint32_uint32, sig_index, reserved);
         break;
       }
 
@@ -1501,15 +1505,25 @@ static void read_function_body(Context* ctx,
         break;
       }
 
-      case WASM_OPCODE_CURRENT_MEMORY:
+      case WASM_OPCODE_CURRENT_MEMORY: {
+        uint32_t reserved;
+        in_u32_leb128(ctx, &reserved, "current_memory reserved");
+        RAISE_ERROR_UNLESS(reserved == 0,
+                           "current_memory reserved value must be 0");
         CALLBACK0(on_current_memory_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK_CTX(on_opcode_uint32, reserved);
         break;
+      }
 
-      case WASM_OPCODE_GROW_MEMORY:
+      case WASM_OPCODE_GROW_MEMORY: {
+        uint32_t reserved;
+        in_u32_leb128(ctx, &reserved, "grow_memory reserved");
+        RAISE_ERROR_UNLESS(reserved == 0,
+                           "grow_memory reserved value must be 0");
         CALLBACK0(on_grow_memory_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK_CTX(on_opcode_uint32, reserved);
         break;
+      }
 
       case WASM_OPCODE_I32_ADD:
       case WASM_OPCODE_I32_SUB:

--- a/src/wasm-binary-writer.c
+++ b/src/wasm-binary-writer.c
@@ -378,6 +378,7 @@ static void write_expr(Context* ctx,
       assert(index >= 0 && (size_t)index < module->func_types.size);
       write_opcode(&ctx->stream, WASM_OPCODE_CALL_INDIRECT);
       write_u32_leb128(&ctx->stream, index, "signature index");
+      write_u32_leb128(&ctx->stream, 0, "call_indirect reserved");
       break;
     }
     case WASM_EXPR_TYPE_COMPARE:
@@ -413,6 +414,7 @@ static void write_expr(Context* ctx,
       break;
     case WASM_EXPR_TYPE_CURRENT_MEMORY:
       write_opcode(&ctx->stream, WASM_OPCODE_CURRENT_MEMORY);
+      write_u32_leb128(&ctx->stream, 0, "current_memory reserved");
       break;
     case WASM_EXPR_TYPE_DROP:
       write_opcode(&ctx->stream, WASM_OPCODE_DROP);
@@ -431,6 +433,7 @@ static void write_expr(Context* ctx,
     }
     case WASM_EXPR_TYPE_GROW_MEMORY:
       write_opcode(&ctx->stream, WASM_OPCODE_GROW_MEMORY);
+      write_u32_leb128(&ctx->stream, 0, "grow_memory reserved");
       break;
     case WASM_EXPR_TYPE_IF: {
       WasmLabelNode node;

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -61,11 +61,12 @@
 000002b: 00                                        ; i32 literal
 000002c: 11                                        ; call_indirect
 000002d: 00                                        ; signature index
-000002e: 0b                                        ; end
-0000026: 08                                        ; FIXUP func body size
-0000024: 0a                                        ; FIXUP section size
+000002e: 00                                        ; call_indirect reserved
+000002f: 0b                                        ; end
+0000026: 09                                        ; FIXUP func body size
+0000024: 0b                                        ; FIXUP section size
 func 0
  000028: 41 00                      | i32.const 0
  00002a: 41 00                      | i32.const 0
- 00002c: 11 00                      | call_indirect 0
+ 00002c: 11 00 00                   | call_indirect 0 0
 ;;; STDOUT ;;)

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -39,9 +39,10 @@
 000001b: 00                                        ; func body size (guess)
 000001c: 00                                        ; local decl count
 000001d: 3f                                        ; current_memory
-000001e: 0b                                        ; end
-000001b: 03                                        ; FIXUP func body size
-0000019: 05                                        ; FIXUP section size
+000001e: 00                                        ; current_memory reserved
+000001f: 0b                                        ; end
+000001b: 04                                        ; FIXUP func body size
+0000019: 06                                        ; FIXUP section size
 func 0
- 00001d: 3f                         | current_memory
+ 00001d: 3f 00                      | current_memory 0
 ;;; STDOUT ;;)

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -44,12 +44,13 @@
 000001e: 20                                        ; get_local
 000001f: 00                                        ; local index
 0000020: 40                                        ; grow_memory
-0000021: 1a                                        ; drop
-0000022: 0b                                        ; end
-000001c: 06                                        ; FIXUP func body size
-000001a: 08                                        ; FIXUP section size
+0000021: 00                                        ; grow_memory reserved
+0000022: 1a                                        ; drop
+0000023: 0b                                        ; end
+000001c: 07                                        ; FIXUP func body size
+000001a: 09                                        ; FIXUP section size
 func 0
  00001e: 20 00                      | get_local 0
- 000020: 40                         | grow_memory
- 000021: 1a                         | drop
+ 000020: 40 00                      | grow_memory 0
+ 000022: 1a                         | drop
 ;;; STDOUT ;;)

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -119,45 +119,46 @@
 000007a: 01                                        ; local index
 000007b: 11                                        ; call_indirect
 000007c: 01                                        ; signature index
-000007d: 1a                                        ; drop
-000007e: 0b                                        ; end
-0000071: 8980 8080 00                              ; FIXUP func body size
+000007d: 00                                        ; call_indirect reserved
+000007e: 1a                                        ; drop
+000007f: 0b                                        ; end
+0000071: 8a80 8080 00                              ; FIXUP func body size
 ; function body 1
-000007f: 0000 0000 00                              ; func body size (guess)
-0000084: 00                                        ; local decl count
-0000085: 20                                        ; get_local
-0000086: 00                                        ; local index
-0000087: 41                                        ; i32.const
-0000088: 01                                        ; i32 literal
-0000089: 6a                                        ; i32.add
-000008a: 1a                                        ; drop
-000008b: 0b                                        ; end
-000007f: 8880 8080 00                              ; FIXUP func body size
+0000080: 0000 0000 00                              ; func body size (guess)
+0000085: 00                                        ; local decl count
+0000086: 20                                        ; get_local
+0000087: 00                                        ; local index
+0000088: 41                                        ; i32.const
+0000089: 01                                        ; i32 literal
+000008a: 6a                                        ; i32.add
+000008b: 1a                                        ; drop
+000008c: 0b                                        ; end
+0000080: 8880 8080 00                              ; FIXUP func body size
 ; function body 2
-000008c: 0000 0000 00                              ; func body size (guess)
-0000091: 00                                        ; local decl count
-0000092: 20                                        ; get_local
-0000093: 00                                        ; local index
-0000094: 41                                        ; i32.const
-0000095: 02                                        ; i32 literal
-0000096: 6c                                        ; i32.mul
-0000097: 1a                                        ; drop
-0000098: 0b                                        ; end
-000008c: 8880 8080 00                              ; FIXUP func body size
-000006b: a980 8080 00                              ; FIXUP section size
+000008d: 0000 0000 00                              ; func body size (guess)
+0000092: 00                                        ; local decl count
+0000093: 20                                        ; get_local
+0000094: 00                                        ; local index
+0000095: 41                                        ; i32.const
+0000096: 02                                        ; i32 literal
+0000097: 6c                                        ; i32.mul
+0000098: 1a                                        ; drop
+0000099: 0b                                        ; end
+000008d: 8880 8080 00                              ; FIXUP func body size
+000006b: aa80 8080 00                              ; FIXUP section size
 func 0
  000077: 20 00                      | get_local 0
  000079: 20 01                      | get_local 0x1
- 00007b: 11 01                      | call_indirect 0x1
- 00007d: 1a                         | drop
+ 00007b: 11 01 00                   | call_indirect 1 0
+ 00007e: 1a                         | drop
 func 1
- 000085: 20 00                      | get_local 0
- 000087: 41 01                      | i32.const 0x1
- 000089: 6a                         | i32.add
- 00008a: 1a                         | drop
+ 000086: 20 00                      | get_local 0
+ 000088: 41 01                      | i32.const 0x1
+ 00008a: 6a                         | i32.add
+ 00008b: 1a                         | drop
 func 2
- 000092: 20 00                      | get_local 0
- 000094: 41 02                      | i32.const 0x2
- 000096: 6c                         | i32.mul
- 000097: 1a                         | drop
+ 000093: 20 00                      | get_local 0
+ 000095: 41 02                      | i32.const 0x2
+ 000097: 6c                         | i32.mul
+ 000098: 1a                         | drop
 ;;; STDOUT ;;)


### PR DESCRIPTION
`call_indirect`, `grow_memory` and `current_memory` all take an additional
immediate which must be zero. After the MVP, this will be used to allow
specifying a table or memory index.