### PR TITLE
Win32 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,7 +81,7 @@ if (COMPILER_IS_MSVC)
   # disable warning C4018: signed/unsigned mismatch
   # disable warning C4056, C4756: overflow in floating-point constant arithmetic
   #   seems to not like float compare w/ HUGE_VALF; bug?
-  add_definitions(-W3 -WX -wd4018 -wd4056 -wd4756 -D_CRT_SECURE_NO_WARNINGS)
+  add_definitions(-W3 -wd4018 -wd4056 -wd4756 -D_CRT_SECURE_NO_WARNINGS)
 else ()
   # disable -Wunused-parameter: this is really common when implementing
   #   interfaces, etc.

--- a/src/wasm-config.h.in
+++ b/src/wasm-config.h.in
@@ -104,7 +104,7 @@
 #define WASM_LIKELY(x) (x)
 #define WASM_PRINTF_FORMAT(format_arg, first_arg)
 
-#define WABT_UNREACHABLE __assume(false)
+#define WABT_UNREACHABLE __assume(0)
 
 __inline unsigned long wasm_clz_u32(unsigned long mask) {
   unsigned long index;


### PR DESCRIPTION
Do not treat warning as errors on Windows. Fix WABT_UNREACHABLE to use __assume(0) on Windows