### PR TITLE
wasmdump improvments

### DIFF
--- a/src/tools/wasmdump.c
+++ b/src/tools/wasmdump.c
@@ -141,30 +141,30 @@ int main(int argc, char** argv) {
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {
-    s_objdump_options.mode = DUMP_HEADERS;
+    s_objdump_options.mode = WASM_DUMP_HEADERS;
     result = wasm_read_binary_objdump(allocator, data, size, &s_objdump_options);
-    if (result)
+    if (WASM_FAILED(result))
       goto done;
     s_objdump_options.print_header = 0;
   }
   // Pass 2: Print extra information based on section type
   if (s_objdump_options.verbose || s_objdump_options.section_name) {
-    s_objdump_options.mode = DUMP_DETAILS;
+    s_objdump_options.mode = WASM_DUMP_DETAILS;
     result = wasm_read_binary_objdump(allocator, data, size, &s_objdump_options);
-    if (result)
+    if (WASM_FAILED(result))
       goto done;
     s_objdump_options.print_header = 0;
   }
   if (s_objdump_options.disassemble) {
-    s_objdump_options.mode = DUMP_DISASSEMBLE;
+    s_objdump_options.mode = WASM_DUMP_DISASSEMBLE;
     result = wasm_read_binary_objdump(allocator, data, size, &s_objdump_options);
-    if (result)
+    if (WASM_FAILED(result))
       goto done;
     s_objdump_options.print_header = 0;
   }
   // Pass 3: Dump to raw contents of the sections
   if (s_objdump_options.raw) {
-    s_objdump_options.mode = DUMP_RAW_DATA;
+    s_objdump_options.mode = WASM_DUMP_RAW_DATA;
     result = wasm_read_binary_objdump(allocator, data, size, &s_objdump_options);
   }
 

--- a/src/wasm-binary-reader-objdump.c
+++ b/src/wasm-binary-reader-objdump.c
@@ -374,7 +374,7 @@ static WasmResult on_import_table(uint32_t index,
                                   const WasmLimits* elem_limits,
                                   void* user_data) {
   print_details(user_data,
-      "  - table elem_type=%s init=%" PRIzx " max=%" PRIzx "\n",
+      "  - table elem_type=%s init=%" PRIzx " max=%" PRId64 "\n",
       wasm_get_type_name(elem_type),
       elem_limits->initial,
       elem_limits->max);
@@ -408,7 +408,7 @@ static WasmResult on_table(uint32_t index,
                            const WasmLimits* elem_limits,
                            void* user_data) {
   print_details(user_data,
-      "  - [%d] type=%#x init=%" PRIzx " max=%" PRIzx" \n",
+      "  - [%d] type=%#x init=%" PRId64 " max=%" PRId64 " \n",
       index,
       elem_type,
       elem_limits->initial,

--- a/src/wasm-binary-reader-objdump.c
+++ b/src/wasm-binary-reader-objdump.c
@@ -374,7 +374,7 @@ static WasmResult on_import_table(uint32_t index,
                                   const WasmLimits* elem_limits,
                                   void* user_data) {
   print_details(user_data,
-      "  - table elem_type=%s init=%" PRIzx " max=%" PRId64 "\n",
+      "  - table elem_type=%s init=%" PRId64 " max=%" PRId64 "\n",
       wasm_get_type_name(elem_type),
       elem_limits->initial,
       elem_limits->max);

--- a/src/wasm-binary-reader-objdump.c
+++ b/src/wasm-binary-reader-objdump.c
@@ -17,6 +17,7 @@
 #include "wasm-binary-reader-objdump.h"
 
 #include <assert.h>
+#include <inttypes.h>
 #include <string.h>
 #include <stdio.h>
 
@@ -113,7 +114,12 @@ static WasmResult on_count(uint32_t count, void* user_data) {
 static WasmResult begin_module(uint32_t version, void* user_data) {
   Context* ctx = user_data;
   if (ctx->options->print_header) {
-    printf("%s:\tfile format wasm %#08x\n", ctx->options->infile, version);
+    const char *basename = strrchr(ctx->options->infile, '/');
+    if (basename)
+      basename++;
+    else
+      basename = ctx->options->infile;
+    printf("%s:\tfile format wasm %#08x\n", basename, version);
     ctx->header_printed = 1;
   }
 
@@ -371,7 +377,7 @@ static WasmResult on_import_table(uint32_t index,
       "  - table elem_type=%s init=%" PRIzx " max=%" PRIzx "\n",
       wasm_get_type_name(elem_type),
       elem_limits->initial,
-      elem_limits->has_max ? elem_limits->max : 0);
+      elem_limits->max);
   return WASM_OK;
 }
 
@@ -445,7 +451,7 @@ static WasmResult on_init_expr_f32_const_expr(uint32_t index,
 static WasmResult on_init_expr_f64_const_expr(uint32_t index,
                                               uint64_t value,
                                               void* user_data) {
-  print_details(user_data, " - init f64=%ld\n", value);
+  print_details(user_data, " - init f64=%" PRId64 "\n", value);
   return WASM_OK;
 }
 
@@ -466,7 +472,7 @@ static WasmResult on_init_expr_i32_const_expr(uint32_t index,
 static WasmResult on_init_expr_i64_const_expr(uint32_t index,
                                               uint64_t value,
                                               void* user_data) {
-  print_details(user_data, " - init i64=%ld\n", value);
+  print_details(user_data, " - init i64=%" PRId64 "\n", value);
   return WASM_OK;
 }
 

--- a/src/wasm-binary-reader-objdump.h
+++ b/src/wasm-binary-reader-objdump.h
@@ -25,10 +25,10 @@ struct WasmModule;
 struct WasmReadBinaryOptions;
 
 typedef enum WasmObjdumpMode {
-  DUMP_HEADERS,
-  DUMP_DETAILS,
-  DUMP_DISASSEMBLE,
-  DUMP_RAW_DATA,
+  WASM_DUMP_HEADERS,
+  WASM_DUMP_DETAILS,
+  WASM_DUMP_DISASSEMBLE,
+  WASM_DUMP_RAW_DATA,
 } WasmObjdumpMode;
 
 typedef struct WasmObjdumpOptions {
@@ -40,7 +40,7 @@ typedef struct WasmObjdumpOptions {
   WasmObjdumpMode mode;
   const char* infile;
   const char* section_name;
-  int print_header;
+  WasmBool print_header;
 } WasmObjdumpOptions;
 
 WASM_EXTERN_C_BEGIN

--- a/src/wasm-binary-reader-objdump.h
+++ b/src/wasm-binary-reader-objdump.h
@@ -24,15 +24,27 @@ struct WasmAllocator;
 struct WasmModule;
 struct WasmReadBinaryOptions;
 
+typedef enum WasmObjdumpMode {
+  DUMP_HEADERS,
+  DUMP_DETAILS,
+  DUMP_DISASSEMBLE,
+  DUMP_RAW_DATA,
+} WasmObjdumpMode;
+
 typedef struct WasmObjdumpOptions {
   WasmBool headers;
   WasmBool verbose;
   WasmBool raw;
   WasmBool disassemble;
   WasmBool debug;
+  WasmObjdumpMode mode;
+  const char* infile;
+  const char* section_name;
+  int print_header;
 } WasmObjdumpOptions;
 
 WASM_EXTERN_C_BEGIN
+
 WasmResult wasm_read_binary_objdump(struct WasmAllocator* allocator,
                                     const uint8_t* data,
                                     size_t size,

--- a/src/wasm-binary-reader.c
+++ b/src/wasm-binary-reader.c
@@ -589,7 +589,7 @@ static void logging_on_error(WasmBinaryReaderContext* ctx,
     FORWARD0(name);                                   \
   }
 
-LOGGING0(begin_module)
+LOGGING_UINT32(begin_module)
 LOGGING0(end_module)
 LOGGING_BEGIN(signature_section)
 LOGGING_UINT32(on_signature_count)
@@ -1706,8 +1706,6 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
   wasm_reserve_uint32s(allocator, &ctx->target_depths,
                        INITIAL_BR_TABLE_TARGET_CAPACITY);
 
-  CALLBACK0(begin_module);
-
   uint32_t magic;
   in_u32(ctx, &magic, "magic");
   RAISE_ERROR_UNLESS(magic == WASM_BINARY_MAGIC, "bad magic value");
@@ -1716,6 +1714,8 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
   RAISE_ERROR_UNLESS(version == WASM_BINARY_VERSION,
                      "bad wasm file version: %#x (expected %#x)", version,
                      WASM_BINARY_VERSION);
+
+  CALLBACK(begin_module, version);
 
   /* type */
   uint32_t section_size;

--- a/src/wasm-binary-reader.h
+++ b/src/wasm-binary-reader.h
@@ -46,7 +46,7 @@ typedef struct WasmBinaryReader {
   void (*on_error)(WasmBinaryReaderContext* ctx, const char* message);
 
   /* module */
-  WasmResult (*begin_module)(void* user_data);
+  WasmResult (*begin_module)(uint32_t version, void* user_data);
   WasmResult (*end_module)(void* user_data);
 
   /* signatures section */

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -79,6 +79,9 @@
 0000038: 0b                                        ; end
 0000024: 14                                        ; FIXUP func body size
 0000022: 16                                        ; FIXUP section size
+basic.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000026: 41 00                      | i32.const 0
  000028: 41 00                      | i32.const 0

--- a/test/dump/basic_dump_only.txt
+++ b/test/dump/basic_dump_only.txt
@@ -13,6 +13,9 @@
     i32.add)
   (export "f" (func $f)))
 (;; STDOUT ;;;
+basic_dump_only.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000026: 41 00                      | i32.const 0
  000028: 41 00                      | i32.const 0

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -275,6 +275,9 @@
 0000015: e201                                      ; FIXUP func body size
 ; move data: [14, f9) -> [15, fa)
 0000013: e501                                      ; FIXUP section size
+binary.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 41 00                      | i32.const 0
  00001b: 41 00                      | i32.const 0

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -340,6 +340,9 @@
 0000015: 8902                                      ; FIXUP func body size
 ; move data: [14, 120) -> [15, 121)
 0000013: 8c02                                      ; FIXUP section size
+block-257-exprs-br.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 02 40                      | block
  00001b: 01                         |   nop

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -336,6 +336,9 @@
 0000015: 8602                                      ; FIXUP func body size
 ; move data: [14, 11d) -> [15, 11e)
 0000013: 8902                                      ; FIXUP section size
+block-257-exprs.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 02 40                      | block
  00001b: 01                         |   nop

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -62,6 +62,9 @@
 000002a: 0b                                        ; end
 0000023: 07                                        ; FIXUP func body size
 0000018: 12                                        ; FIXUP section size
+block.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  00001c: 02 40                      | block
  00001e: 01                         |   nop

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -61,6 +61,9 @@
 000002a: 0b                                        ; end
 0000015: 15                                        ; FIXUP func body size
 0000013: 17                                        ; FIXUP section size
+br-block-named.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 02 40                      | block
  000019: 03 40                      |   loop

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -67,6 +67,9 @@
 000002e: 0b                                        ; end
 0000015: 19                                        ; FIXUP func body size
 0000013: 1b                                        ; FIXUP section size
+br-block.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 02 40                      | block
  000019: 03 40                      |   loop

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -69,6 +69,9 @@
 0000030: 0b                                        ; end
 0000016: 1a                                        ; FIXUP func body size
 0000014: 1c                                        ; FIXUP section size
+br-loop-inner-expr.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000018: 02 7f                      | block i32
  00001a: 03 7f                      |   loop i32

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -55,6 +55,9 @@
 000002b: 0b                                        ; end
 0000015: 16                                        ; FIXUP func body size
 0000013: 18                                        ; FIXUP section size
+br-loop-inner.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 02 40                      | block
  000019: 03 40                      |   loop

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -46,6 +46,9 @@
 0000021: 0b                                        ; end
 0000015: 0c                                        ; FIXUP func body size
 0000013: 0e                                        ; FIXUP section size
+br-loop.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 03 40                      | loop
  000019: 41 01                      |   i32.const 0x1

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -41,6 +41,9 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+brif-loop.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 03 40                      | loop
  000019: 41 00                      |   i32.const 0

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -41,6 +41,9 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+brif.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 02 40                      | block
  000019: 41 01                      |   i32.const 0x1

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -42,6 +42,9 @@
 000001f: 0b                                        ; end
 0000015: 0a                                        ; FIXUP func body size
 0000013: 0c                                        ; FIXUP section size
+brtable-empty.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 02 40                      | block
  000019: 41 00                      |   i32.const 0

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -75,6 +75,9 @@
 0000032: 0b                                        ; end
 0000015: 1d                                        ; FIXUP func body size
 0000013: 1f                                        ; FIXUP section size
+brtable.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 02 40                      | block
  000019: 02 40                      |   block

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -37,6 +37,9 @@
 000001c: 0b                                        ; end
 0000016: 06                                        ; FIXUP func body size
 0000014: 08                                        ; FIXUP section size
+call.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000018: 41 01                      | i32.const 0x1
  00001a: 10 00                      | call 0

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -67,6 +67,9 @@
 0000037: 0b                                        ; end
 0000029: 0e                                        ; FIXUP func body size
 0000027: 10                                        ; FIXUP section size
+callimport.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  00002b: 41 01                      | i32.const 0x1
  00002d: 43 00 00 00 40             | f32.const 0x40000000

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -65,6 +65,9 @@
 000002f: 0b                                        ; end
 0000026: 09                                        ; FIXUP func body size
 0000024: 0b                                        ; FIXUP section size
+callindirect.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000028: 41 00                      | i32.const 0
  00002a: 41 00                      | i32.const 0

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -58,6 +58,9 @@
 0000031: 0b                                        ; end
 0000015: 1c                                        ; FIXUP func body size
 0000013: 1e                                        ; FIXUP section size
+cast.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: be                         | f32.reinterpret/i32

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -310,6 +310,9 @@
 0000015: 9f02                                      ; FIXUP func body size
 ; move data: [14, 136) -> [15, 137)
 0000013: a202                                      ; FIXUP section size
+compare.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 41 00                      | i32.const 0
  00001b: 41 00                      | i32.const 0

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -222,6 +222,9 @@
 0000015: 9a02                                      ; FIXUP func body size
 ; move data: [14, 131) -> [15, 132)
 0000013: 9d02                                      ; FIXUP section size
+const.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 41 00                      | i32.const 0
  00001b: 1a                         | drop

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -89,6 +89,9 @@
 0000038: 0b                                        ; end
 0000015: 23                                        ; FIXUP func body size
 0000013: 25                                        ; FIXUP section size
+convert.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: b8                         | f64.convert_u/i32

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -43,6 +43,9 @@
 000001f: 0b                                        ; end
 000001b: 04                                        ; FIXUP func body size
 0000019: 06                                        ; FIXUP section size
+current-memory.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  00001d: 3f 00                      | current_memory 0
 ;;; STDOUT ;;)

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -85,6 +85,9 @@
 000005b: 05                                        ; string length
 000005c: 2446 324c 33                             $F2L3  ; local name 3
 000002a: 36                                        ; FIXUP section size
+debug-names.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 func 1
 ;;; STDOUT ;;)

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -49,6 +49,9 @@
 0000028: 0b                                        ; end
 0000024: 04                                        ; FIXUP func body size
 0000022: 06                                        ; FIXUP section size
+dedupe-sig.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000026: 42 00                      | i64.const 0
 ;;; STDOUT ;;)

--- a/test/dump/drop.txt
+++ b/test/dump/drop.txt
@@ -35,6 +35,9 @@
 000001a: 0b                                        ; end
 0000015: 05                                        ; FIXUP func body size
 0000013: 07                                        ; FIXUP section size
+drop.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: 1a                         | drop

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -46,6 +46,9 @@
 0000023: 0b                                        ; end
 0000020: 03                                        ; FIXUP func body size
 000001e: 05                                        ; FIXUP section size
+export-multi.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000022: 01                         | nop
 ;;; STDOUT ;;)

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -43,6 +43,9 @@
 000001f: 0b                                        ; end
 0000016: 09                                        ; FIXUP func body size
 0000014: 0b                                        ; FIXUP section size
+expr-br.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000018: 02 7f                      | block i32
  00001a: 41 01                      |   i32.const 0x1

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -50,6 +50,9 @@
 0000024: 0b                                        ; end
 0000016: 0e                                        ; FIXUP func body size
 0000014: 10                                        ; FIXUP section size
+expr-brif.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000018: 02 7f                      | block i32
  00001a: 41 2a                      |   i32.const 0x2a

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -40,5 +40,8 @@
 0000020: 0b                                        ; end
 000001e: 02                                        ; FIXUP func body size
 000001c: 04                                        ; FIXUP section size
+func-exported.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 ;;; STDOUT ;;)

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -44,6 +44,9 @@
 000001f: 0b                                        ; end
 000001d: 02                                        ; FIXUP func body size
 0000015: 0a                                        ; FIXUP section size
+func-multi.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 func 1
 func 2

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -30,5 +30,8 @@
 0000017: 0b                                        ; end
 0000015: 02                                        ; FIXUP func body size
 0000013: 04                                        ; FIXUP section size
+func-named.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 ;;; STDOUT ;;)

--- a/test/dump/getglobal.txt
+++ b/test/dump/getglobal.txt
@@ -45,6 +45,9 @@
 0000022: 0b                                        ; end
 000001e: 04                                        ; FIXUP func body size
 000001c: 06                                        ; FIXUP section size
+getglobal.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000020: 23 00                      | get_global 0
 ;;; STDOUT ;;)

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -78,6 +78,9 @@
 0000033: 0b                                        ; end
 0000017: 1c                                        ; FIXUP func body size
 0000015: 1e                                        ; FIXUP section size
+getlocal-param.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000021: 20 00                      | get_local 0
  000023: 1a                         | drop

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -91,6 +91,9 @@
 000003d: 0b                                        ; end
 0000015: 28                                        ; FIXUP func body size
 0000013: 2a                                        ; FIXUP section size
+getlocal.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000025: 20 00                      | get_local 0
  000027: 1a                         | drop

--- a/test/dump/global.txt
+++ b/test/dump/global.txt
@@ -58,4 +58,7 @@
 000003b: 03                                        ; global index
 000003c: 0b                                        ; end
 0000009: 33                                        ; FIXUP section size
+global.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -49,6 +49,9 @@
 0000023: 0b                                        ; end
 000001c: 07                                        ; FIXUP func body size
 000001a: 09                                        ; FIXUP section size
+grow-memory.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  00001e: 20 00                      | get_local 0
  000020: 40 00                      | grow_memory 0

--- a/test/dump/hexfloat_f32.txt
+++ b/test/dump/hexfloat_f32.txt
@@ -117,6 +117,9 @@
 000007d: 0b                                        ; end
 0000015: 68                                        ; FIXUP func body size
 0000013: 6a                                        ; FIXUP section size
+hexfloat_f32.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 43 00 00 00 00             | f32.const 0
  00001c: 1a                         | drop

--- a/test/dump/hexfloat_f64.txt
+++ b/test/dump/hexfloat_f64.txt
@@ -119,6 +119,9 @@
 0000015: ac01                                      ; FIXUP func body size
 ; move data: [14, c3) -> [15, c4)
 0000013: af01                                      ; FIXUP section size
+hexfloat_f64.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 44 00 00 00 00 00 00 00 00 | f64.const 0
  000022: 1a                         | drop

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -60,6 +60,9 @@
 0000029: 0b                                        ; end
 0000015: 14                                        ; FIXUP func body size
 0000013: 16                                        ; FIXUP section size
+if-then-else-list.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 01                      | i32.const 0x1
  000019: 04 40                      | if

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -42,6 +42,9 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+if-then-list.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 01                      | i32.const 0x1
  000019: 04 40                      | if

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -79,6 +79,9 @@
 000003a: 0b                                        ; end
 0000030: 0a                                        ; FIXUP func body size
 0000014: 26                                        ; FIXUP section size
+if.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000018: 41 01                      | i32.const 0x1
  00001a: 04 40                      | if

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -44,4 +44,7 @@
 0000037: 00                                        ; import kind
 0000038: 01                                        ; import signature index
 0000018: 20                                        ; FIXUP section size
+import.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -174,6 +174,9 @@
 0000077: 0b                                        ; end
 0000015: 62                                        ; FIXUP func body size
 0000013: 64                                        ; FIXUP section size
+load-aligned.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: 2c 00 00                   | i32.load8_s 0 0

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -156,6 +156,9 @@
 000006b: 0b                                        ; end
 0000015: 56                                        ; FIXUP func body size
 0000013: 58                                        ; FIXUP section size
+load.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: 28 02 00                   | i32.load 2 0

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -38,5 +38,8 @@
 000001f: 0b                                        ; end
 0000015: 0a                                        ; FIXUP func body size
 0000013: 0c                                        ; FIXUP section size
+locals.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -353,6 +353,9 @@
 0000015: 9002                                      ; FIXUP func body size
 ; move data: [14, 127) -> [15, 128)
 0000013: 9302                                      ; FIXUP section size
+loop-257-exprs-br.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 02 40                      | block
  00001b: 03 40                      |   loop

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -336,6 +336,9 @@
 0000015: 8602                                      ; FIXUP func body size
 ; move data: [14, 11d) -> [15, 11e)
 0000013: 8902                                      ; FIXUP section size
+loop-257-exprs.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000019: 03 40                      | loop
  00001b: 01                         |   nop

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -39,6 +39,9 @@
 000001c: 0b                                        ; end
 0000015: 07                                        ; FIXUP func body size
 0000013: 09                                        ; FIXUP section size
+loop.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 03 40                      | loop
  000019: 01                         |   nop

--- a/test/dump/memory-1-byte.txt
+++ b/test/dump/memory-1-byte.txt
@@ -12,4 +12,7 @@
 000000b: 00                                        ; memory flags
 000000c: 01                                        ; memory initial pages
 0000009: 03                                        ; FIXUP section size
+memory-1-byte.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/memory-data-size.txt
+++ b/test/dump/memory-data-size.txt
@@ -45,4 +45,16 @@
 000000b: 00                                        ; memory flags
 000000c: 05                                        ; memory initial pages
 0000009: 03                                        ; FIXUP section size
+memory-data-size.0.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
+memory-data-size.1.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
+memory-data-size.2.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
+memory-data-size.3.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/memory-hex.txt
+++ b/test/dump/memory-hex.txt
@@ -28,4 +28,7 @@
 ; data segment data 0
 0000016: 0001 0203 0405 0607 0809 0a               ; data segment data
 000000f: 11                                        ; FIXUP section size
+memory-hex.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -36,4 +36,7 @@
 ; data segment data 1
 000001f: 676f 6f64 6279 65                         ; data segment data
 000000e: 17                                        ; FIXUP section size
+memory.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -146,6 +146,9 @@
 0000099: 0b                                        ; end
 000008d: 8880 8080 00                              ; FIXUP func body size
 000006b: aa80 8080 00                              ; FIXUP section size
+no-canonicalize.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000077: 20 00                      | get_local 0
  000079: 20 01                      | get_local 0x1

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -49,6 +49,9 @@
 0000030: 0b                                        ; end
 000001f: 11                                        ; FIXUP func body size
 000001d: 13                                        ; FIXUP section size
+nocheck.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000021: 43 00 00 80 3f             | f32.const 0x3f800000
  000026: 44 00 00 00 00 00 00 00 40 | f64.const 0

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -32,6 +32,9 @@
 0000018: 0b                                        ; end
 0000015: 03                                        ; FIXUP func body size
 0000013: 05                                        ; FIXUP section size
+nop.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 01                         | nop
 ;;; STDOUT ;;)

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -34,5 +34,8 @@
 000001b: 0b                                        ; end
 0000019: 02                                        ; FIXUP func body size
 0000017: 04                                        ; FIXUP section size
+param-multi.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 ;;; STDOUT ;;)

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -79,6 +79,9 @@
 0000042: 0b                                        ; end
 0000037: 0b                                        ; FIXUP func body size
 0000023: 1f                                        ; FIXUP section size
+result.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000027: 41 00                      | i32.const 0
 func 1

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -49,6 +49,9 @@
 0000023: 0b                                        ; end
 0000020: 03                                        ; FIXUP func body size
 0000018: 0b                                        ; FIXUP section size
+return.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  00001c: 41 2a                      | i32.const 0x2a
  00001e: 0f                         | return

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -82,6 +82,9 @@
 000004b: 0b                                        ; end
 0000015: 36                                        ; FIXUP func body size
 0000013: 38                                        ; FIXUP section size
+select.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 02                      | i32.const 0x2
  000019: 41 03                      | i32.const 0x3

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -47,6 +47,9 @@
 0000029: 0b                                        ; end
 0000020: 09                                        ; FIXUP func body size
 000001e: 0b                                        ; FIXUP section size
+setglobal.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000022: 43 00 00 00 40             | f32.const 0x40000000
  000027: 24 00                      | set_global 0

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -81,6 +81,9 @@
 0000042: 0b                                        ; end
 0000017: 2b                                        ; FIXUP func body size
 0000015: 2d                                        ; FIXUP section size
+setlocal-param.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000021: 41 00                      | i32.const 0
  000023: 21 00                      | set_local 0

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -97,6 +97,9 @@
 0000059: 0b                                        ; end
 0000015: 44                                        ; FIXUP func body size
 0000013: 46                                        ; FIXUP section size
+setlocal.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000025: 44 00 00 00 00 00 00 00 00 | f64.const 0
  00002e: 21 00                      | set_local 0

--- a/test/dump/signatures.txt
+++ b/test/dump/signatures.txt
@@ -66,4 +66,7 @@
 000002e: 01                                        ; num results
 000002f: 7c                                        ; f64
 0000009: 26                                        ; FIXUP section size
+signatures.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -190,6 +190,9 @@
 0000087: 0b                                        ; end
 0000015: 72                                        ; FIXUP func body size
 0000013: 74                                        ; FIXUP section size
+store-aligned.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: 41 00                      | i32.const 0

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -120,6 +120,9 @@
 0000060: 0b                                        ; end
 0000015: 4b                                        ; FIXUP func body size
 0000013: 4d                                        ; FIXUP section size
+store.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: 41 00                      | i32.const 0

--- a/test/dump/string-escape.txt
+++ b/test/dump/string-escape.txt
@@ -40,5 +40,8 @@
 0000045: 0b                                        ; end
 0000043: 02                                        ; FIXUP func body size
 0000041: 04                                        ; FIXUP section size
+string-escape.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 ;;; STDOUT ;;)

--- a/test/dump/string-hex.txt
+++ b/test/dump/string-hex.txt
@@ -38,5 +38,8 @@
 0000024: 0b                                        ; end
 0000022: 02                                        ; FIXUP func body size
 0000020: 04                                        ; FIXUP section size
+string-hex.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 ;;; STDOUT ;;)

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -86,6 +86,9 @@
 0000045: 0b                                        ; end
 000003a: 0b                                        ; FIXUP func body size
 0000032: 13                                        ; FIXUP section size
+table.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
 func 1
 func 2

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -41,6 +41,8 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+tee_local.wasm:	file format wasm 0x00000d
+
 Code Disassembly:
 func 0
  000019: 41 00                      | i32.const 0

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -41,6 +41,7 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+Code Disassembly:
 func 0
  000019: 41 00                      | i32.const 0
  00001b: 22 00                      | tee_local 0

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -95,6 +95,9 @@
 0000042: 0b                                        ; end
 0000015: 2d                                        ; FIXUP func body size
 0000013: 2f                                        ; FIXUP section size
+unary.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 41 00                      | i32.const 0
  000019: 69                         | i32.popcnt

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -32,6 +32,9 @@
 0000018: 0b                                        ; end
 0000015: 03                                        ; FIXUP func body size
 0000013: 05                                        ; FIXUP section size
+unreachable.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
 func 0
  000017: 00                         | unreachable
 ;;; STDOUT ;;)


### PR DESCRIPTION
- Split into three different passes: headers, details, and raw
- Nest imports correctly
- Show element count as part of section header rather than on its
  own line
