### PR TITLE
Convert WasmType into an enum

### DIFF
--- a/src/wasm-binary-reader.c
+++ b/src/wasm-binary-reader.c
@@ -783,7 +783,7 @@ static WasmResult logging_begin_global(uint32_t index,
   LoggingContext* ctx = user_data;
   LOGF("begin_global(index: %u, type: %s, mutable: %s)\n", index,
        wasm_get_type_name(type), mutable_ ? "true" : "false");
-  FORWARD(begin_global, index, mutable_, type);
+  FORWARD(begin_global, index, type, mutable_);
 }
 
 static WasmResult logging_on_export(uint32_t index,

--- a/src/wasm-common.h
+++ b/src/wasm-common.h
@@ -128,7 +128,7 @@ typedef struct WasmBinaryErrorHandler {
   { wasm_default_binary_error_callback, NULL }
 
 /* matches binary format, do not change */
-enum {
+typedef enum WasmType {
   WASM_TYPE_I32 = -0x01,
   WASM_TYPE_I64 = -0x02,
   WASM_TYPE_F32 = -0x03,
@@ -138,8 +138,7 @@ enum {
   WASM_TYPE_VOID = -0x40,
   WASM_TYPE____ = WASM_TYPE_VOID, /* convenient for the opcode table below */
   WASM_TYPE_ANY = 0, /* Not actually specified, but useful for type-checking */
-};
-typedef int32_t WasmType;
+} WasmType;
 
 /* matches binary format, do not change */
 typedef enum WasmExternalKind {


### PR DESCRIPTION
Fix the bug in logging_begin_global that was exposed by the
using an explictly type here.