### PR TITLE
Fix the export spec test

### DIFF
--- a/src/prebuilt/wasm-ast-parser-gen.c
+++ b/src/prebuilt/wasm-ast-parser-gen.c
@@ -690,7 +690,7 @@ static const yytype_uint16 yyrline[] =
     1078,  1081,  1092,  1096,  1103,  1107,  1110,  1118,  1126,  1143,
     1159,  1170,  1177,  1184,  1190,  1230,  1240,  1262,  1272,  1298,
     1303,  1311,  1319,  1329,  1335,  1341,  1347,  1353,  1358,  1367,
-    1372,  1373,  1379,  1387,  1388,  1396,  1408,  1409,  1416,  1474
+    1372,  1373,  1379,  1387,  1388,  1396,  1408,  1409,  1416,  1479
 };
 #endif
 
@@ -3986,18 +3986,23 @@ yyreduce:
       int last_module_index = -1;
       size_t i;
       for (i = 0; i < (yyval.script).commands.size; ++i) {
-        WasmCommand* command = &(yyval.script).commands.data[0];
+        WasmCommand* command = &(yyval.script).commands.data[i];
         WasmAction* action = NULL;
         switch (command->type) {
           case WASM_COMMAND_TYPE_MODULE: {
+            last_module_index = i;
+
             /* Wire up module name bindings. */
             WasmModule* module = &command->module;
             if (module->name.length == 0)
               continue;
+
             WasmStringSlice module_name =
                 wasm_dup_string_slice(parser->allocator, module->name);
-            INSERT_BINDING(&(yyval.script), module, commands, module->loc, module_name);
-            last_module_index = i;
+            WasmBinding* binding = wasm_insert_binding(
+                parser->allocator, &(yyval.script).module_bindings, &module_name);
+            binding->loc = module->loc;
+            binding->index = i;
             break;
           }
 
@@ -4031,11 +4036,11 @@ yyreduce:
       }
       parser->script = (yyval.script);
     }
-#line 4035 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 4040 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
 
-#line 4039 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
+#line 4044 "src/prebuilt/wasm-ast-parser-gen.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4270,7 +4275,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1477 "src/wasm-ast-parser.y" /* yacc.c:1906  */
+#line 1482 "src/wasm-ast-parser.y" /* yacc.c:1906  */
 
 
 static void append_expr_list(WasmExprList* expr_list, WasmExprList* expr) {

--- a/src/wasm-ast-parser.y
+++ b/src/wasm-ast-parser.y
@@ -1421,18 +1421,23 @@ script :
       int last_module_index = -1;
       size_t i;
       for (i = 0; i < $$.commands.size; ++i) {
-        WasmCommand* command = &$$.commands.data[0];
+        WasmCommand* command = &$$.commands.data[i];
         WasmAction* action = NULL;
         switch (command->type) {
           case WASM_COMMAND_TYPE_MODULE: {
+            last_module_index = i;
+
             /* Wire up module name bindings. */
             WasmModule* module = &command->module;
             if (module->name.length == 0)
               continue;
+
             WasmStringSlice module_name =
                 wasm_dup_string_slice(parser->allocator, module->name);
-            INSERT_BINDING(&$$, module, commands, module->loc, module_name);
-            last_module_index = i;
+            WasmBinding* binding = wasm_insert_binding(
+                parser->allocator, &$$.module_bindings, &module_name);
+            binding->loc = module->loc;
+            binding->index = i;
             break;
           }
 

--- a/src/wasm-interpreter.h
+++ b/src/wasm-interpreter.h
@@ -57,8 +57,10 @@ struct WasmStream;
   /* we attempted to call a function with the an argument list that doesn't    \
    * match the function signature */                                           \
   V(ARGUMENT_TYPE_MISMATCH, "argument type mismatch")                          \
-  /* we tried to call an exported function by name that doesn't exist */       \
-  V(UNKNOWN_EXPORTED_FUNCTION, "unknown exported function")
+  /* we tried to get an export by name that doesn't exist */                   \
+  V(UNKNOWN_EXPORT, "unknown export")                                          \
+  /* the expected export kind doesn't match. */                                \
+  V(EXPORT_KIND_MISMATCH, "export kind mismatch")
 
 typedef enum WasmInterpreterResult {
 #define V(name, str) WASM_INTERPRETER_##name,

--- a/test/parse/assert/bad-assert-before-module.txt
+++ b/test/parse/assert/bad-assert-before-module.txt
@@ -2,7 +2,7 @@
 ;;; ERROR: 1
 (assert_return (invoke "f") (i32.const 0))
 (;; STDERR ;;;
-parse/assert/bad-assert-before-module.txt:3:17: invoke must occur after a module definition
+parse/assert/bad-assert-before-module.txt:3:17: unknown module
 (assert_return (invoke "f") (i32.const 0))
                 ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/assert/bad-invoke-no-module.txt
+++ b/test/parse/assert/bad-invoke-no-module.txt
@@ -2,7 +2,7 @@
 ;;; FLAGS: --spec
 (invoke "foo")
 (;; STDERR ;;;
-parse/assert/bad-invoke-no-module.txt:3:2: invoke must occur after a module definition
+parse/assert/bad-invoke-no-module.txt:3:2: unknown module
 (invoke "foo")
  ^^^^^^
 ;;; STDERR ;;)

--- a/test/spec/exports.txt
+++ b/test/spec/exports.txt
@@ -1,22 +1,93 @@
-;;; SKIP: exports not working properly in interpreter yet
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/exports.wast
 (;; STDOUT ;;;
 assert_invalid error:
-  third_party/testsuite/exports.wast:6:30: function variable out of range (max 1)
-  (module (func) (export "a" 1))
-                             ^
+  third_party/testsuite/exports.wast:27:36: function variable out of range (max 1)
+  (module (func) (export "a" (func 1)))
+                                   ^
 assert_invalid error:
-  third_party/testsuite/exports.wast:10:40: redefinition of export "a"
-  (module (func) (func) (export "a" 0) (export "a" 1))
-                                       ^^^^^^^^^^^^^^
+  third_party/testsuite/exports.wast:31:40: redefinition of export "a"
+  (module (func) (export "a" (func 0)) (export "a" (func 0)))
+                                       ^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  third_party/testsuite/exports.wast:14:33: redefinition of export "a"
-  (module (func) (export "a" 0) (export "a" 0))
-                                ^^^^^^^^^^^^^^
+  third_party/testsuite/exports.wast:35:47: redefinition of export "a"
+  (module (func) (func) (export "a" (func 0)) (export "a" (func 1)))
+                                              ^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  third_party/testsuite/exports.wast:31:25: no memory to export
-(assert_invalid (module (export "a" memory)) "no memory")
-                        ^^^^^^^^^^^^^^^^^^^
-1/1 tests passed.
+  third_party/testsuite/exports.wast:39:67: redefinition of export "a"
+...nc) (global i32 (i32.const 0)) (export "a" (func 0)) (export "a" (global 0)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:43:58: redefinition of export "a"
+  (module (func) (table 0 anyfunc) (export "a" (func 0)) (export "a" (table 0)))
+                                                         ^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:47:51: redefinition of export "a"
+  (module (func) (memory 0) (export "a" (func 0)) (export "a" (memory 0)))
+                                                  ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:76:58: global variable out of range (max 1)
+  (module (global i32 (i32.const 0)) (export "a" (global 1)))
+                                                         ^
+assert_invalid error:
+  third_party/testsuite/exports.wast:80:62: redefinition of export "a"
+...e (global i32 (i32.const 0)) (export "a" (global 0)) (export "a" (global 0)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:84:89: redefinition of export "a"
+...) (global i32 (i32.const 0)) (export "a" (global 0)) (export "a" (global 1)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:88:69: redefinition of export "a"
+...obal i32 (i32.const 0)) (func) (export "a" (global 0)) (export "a" (func 0)))
+                                                          ^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:92:80: redefinition of export "a"
+...2.const 0)) (table 0 anyfunc) (export "a" (global 0)) (export "a" (table 0)))
+                                                         ^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:96:73: redefinition of export "a"
+...32 (i32.const 0)) (memory 0) (export "a" (global 0)) (export "a" (memory 0)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:124:48: table variable out of range (max 1)
+  (module (table 0 anyfunc) (export "a" (table 1)))
+                                               ^
+assert_invalid error:
+  third_party/testsuite/exports.wast:128:52: redefinition of export "a"
+  (module (table 0 anyfunc) (export "a" (table 0)) (export "a" (table 0)))
+                                                   ^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:137:59: redefinition of export "a"
+  (module (table 0 anyfunc) (func) (export "a" (table 0)) (export "a" (func 0)))
+                                                          ^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:141:79: redefinition of export "a"
+...c) (global i32 (i32.const 0)) (export "a" (table 0)) (export "a" (global 0)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:145:63: redefinition of export "a"
+... (table 0 anyfunc) (memory 0) (export "a" (table 0)) (export "a" (memory 0)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:173:42: memory variable out of range (max 1)
+  (module (memory 0) (export "a" (memory 1)))
+                                         ^
+assert_invalid error:
+  third_party/testsuite/exports.wast:177:46: redefinition of export "a"
+  (module (memory 0) (export "a" (memory 0)) (export "a" (memory 0)))
+                                             ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:186:53: redefinition of export "a"
+  (module (memory 0) (func) (export "a" (memory 0)) (export "a" (func 0)))
+                                                    ^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:190:73: redefinition of export "a"
+...) (global i32 (i32.const 0)) (export "a" (memory 0)) (export "a" (global 0)))
+                                                        ^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/exports.wast:194:64: redefinition of export "a"
+... (memory 0) (table 0 anyfunc) (export "a" (memory 0)) (export "a" (table 0)))
+                                                         ^^^^^^^^^^^^^^^^^^^^^^
+6/6 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
* Implement the "get" action, for reading exported globals
* Fix invoke/get checking when given action has a named module
* Fix module name binding when parsing wast