### PR TITLE
Fix spec imports test

### DIFF
--- a/src/binary-writer-spec.c
+++ b/src/binary-writer-spec.c
@@ -338,9 +338,15 @@ static void write_commands(Context* ctx, WasmScript* script) {
       case WASM_COMMAND_TYPE_REGISTER:
         write_location(ctx, &command->register_.var.loc);
         write_separator(ctx);
-        write_key(ctx, "name");
-        write_var(ctx, &command->register_.var);
-        write_separator(ctx);
+        if (command->register_.var.type == WASM_VAR_TYPE_NAME) {
+          write_key(ctx, "name");
+          write_var(ctx, &command->register_.var);
+          write_separator(ctx);
+        } else {
+          /* If we're not registering by name, then we should only be
+           * registering the last module. */
+          assert(command->register_.var.index == (int)ctx->num_modules - 1);
+        }
         write_key(ctx, "as");
         write_escaped_string_slice(ctx, command->register_.module_name);
         break;

--- a/src/binding-hash.c
+++ b/src/binding-hash.c
@@ -159,6 +159,18 @@ int wasm_find_binding_index_by_name(const WasmBindingHash* hash,
   return -1;
 }
 
+void wasm_remove_binding(struct WasmAllocator* allocator,
+                         WasmBindingHash* hash,
+                         const WasmStringSlice* name) {
+  int index = wasm_find_binding_index_by_name(hash, name);
+  if (index == -1)
+    return;
+
+  WasmBindingHashEntry* entry = &hash->entries.data[index];
+  wasm_destroy_string_slice(allocator, &entry->binding.name);
+  WASM_ZERO_MEMORY(*entry);
+}
+
 static void destroy_binding_hash_entry(WasmAllocator* allocator,
                                        WasmBindingHashEntry* entry) {
   wasm_destroy_string_slice(allocator, &entry->binding.name);

--- a/src/binding-hash.h
+++ b/src/binding-hash.h
@@ -44,6 +44,9 @@ WASM_EXTERN_C_BEGIN
 WasmBinding* wasm_insert_binding(struct WasmAllocator*,
                                  WasmBindingHash*,
                                  const WasmStringSlice*);
+void wasm_remove_binding(struct WasmAllocator*,
+                         WasmBindingHash*,
+                         const WasmStringSlice*);
 WasmBool wasm_hash_entry_is_free(const WasmBindingHashEntry*);
 /* returns -1 if the name is not in the hash */
 int wasm_find_binding_index_by_name(const WasmBindingHash*,

--- a/src/common.c
+++ b/src/common.c
@@ -63,13 +63,20 @@ WasmStringSlice wasm_string_slice_from_cstr(const char* string) {
   return result;
 }
 
+WasmBool wasm_string_slice_is_empty(const WasmStringSlice* str) {
+  assert(str);
+  return str->start == NULL || str->length == 0;
+}
+
 WasmBool wasm_string_slices_are_equal(const WasmStringSlice* a,
                                       const WasmStringSlice* b) {
+  assert(a && b);
   return a->start && b->start && a->length == b->length &&
          memcmp(a->start, b->start, a->length) == 0;
 }
 
 void wasm_destroy_string_slice(WasmAllocator* allocator, WasmStringSlice* str) {
+  assert(str);
   wasm_free(allocator, (void*)str->start);
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -395,6 +395,7 @@ uint32_t wasm_get_opcode_alignment(WasmOpcode opcode, uint32_t alignment);
 
 WasmStringSlice wasm_empty_string_slice(void);
 WasmStringSlice wasm_string_slice_from_cstr(const char* string);
+WasmBool wasm_string_slice_is_empty(const WasmStringSlice*);
 WasmBool wasm_string_slices_are_equal(const WasmStringSlice*,
                                       const WasmStringSlice*);
 void wasm_destroy_string_slice(struct WasmAllocator*, WasmStringSlice*);

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -41,6 +41,8 @@ struct WasmStream;
   V(TRAP_INVALID_CONVERSION_TO_INTEGER, "invalid conversion to integer")       \
   /* function table index is out of bounds */                                  \
   V(TRAP_UNDEFINED_TABLE_INDEX, "undefined table index")                       \
+  /* function table element is uninitialized */                                \
+  V(TRAP_UNINITIALIZED_TABLE_ELEMENT, "uninitialized table element")           \
   /* unreachable instruction executed */                                       \
   V(TRAP_UNREACHABLE, "unreachable executed")                                  \
   /* call indirect signature doesn't match function table signature */         \
@@ -105,9 +107,8 @@ WASM_DEFINE_VECTOR(interpreter_table, WasmInterpreterTable);
 typedef struct WasmInterpreterMemory {
   WasmAllocator* allocator;
   void* data;
-  uint32_t page_size;
-  uint32_t byte_size;
-  uint32_t max_page_size;
+  WasmLimits page_limits;
+  uint32_t byte_size; /* Cached from page_limits. */
 } WasmInterpreterMemory;
 WASM_DEFINE_VECTOR(interpreter_memory, WasmInterpreterMemory);
 
@@ -190,20 +191,29 @@ typedef struct WasmInterpreterExport {
 } WasmInterpreterExport;
 WASM_DEFINE_VECTOR(interpreter_export, WasmInterpreterExport);
 
+typedef struct WasmPrintErrorCallback {
+  void* user_data;
+  void (*print_error)(const char* msg, void* user_data);
+} WasmPrintErrorCallback;
+
 typedef struct WasmInterpreterHostImportDelegate {
   void *user_data;
   WasmResult (*import_func)(WasmInterpreterImport*,
                             WasmInterpreterFunc*,
                             WasmInterpreterFuncSignature*,
+                            WasmPrintErrorCallback,
                             void* user_data);
   WasmResult (*import_table)(WasmInterpreterImport*,
                              WasmInterpreterTable*,
+                             WasmPrintErrorCallback,
                              void* user_data);
   WasmResult (*import_memory)(WasmInterpreterImport*,
                               WasmInterpreterMemory*,
+                              WasmPrintErrorCallback,
                               void* user_data);
   WasmResult (*import_global)(WasmInterpreterImport*,
                               WasmInterpreterGlobal*,
+                              WasmPrintErrorCallback,
                               void* user_data);
 } WasmInterpreterHostImportDelegate;
 
@@ -228,6 +238,17 @@ typedef struct WasmInterpreterModule {
 } WasmInterpreterModule;
 WASM_DEFINE_VECTOR(interpreter_module, WasmInterpreterModule);
 
+/* Used to track and reset the state of the environment. */
+typedef struct WasmInterpreterEnvironmentMark {
+  size_t modules_size;
+  size_t sigs_size;
+  size_t funcs_size;
+  size_t memories_size;
+  size_t tables_size;
+  size_t globals_size;
+  size_t istream_size;
+} WasmInterpreterEnvironmentMark;
+
 typedef struct WasmInterpreterEnvironment {
   WasmInterpreterModuleVector modules;
   WasmInterpreterFuncSignatureVector sigs;
@@ -237,6 +258,7 @@ typedef struct WasmInterpreterEnvironment {
   WasmInterpreterGlobalVector globals;
   WasmOutputBuffer istream;
   WasmBindingHash module_bindings;
+  WasmBindingHash registered_module_bindings;
 } WasmInterpreterEnvironment;
 
 typedef struct WasmInterpreterThread {
@@ -268,11 +290,20 @@ typedef struct WasmInterpreterThreadOptions {
 WASM_EXTERN_C_BEGIN
 WasmBool is_nan_f32(uint32_t f32_bits);
 WasmBool is_nan_f64(uint64_t f64_bits);
+WasmBool wasm_func_signatures_are_equal(WasmInterpreterEnvironment* env,
+                                        uint32_t sig_index_0,
+                                        uint32_t sig_index_1);
 
 void wasm_init_interpreter_environment(WasmAllocator* allocator,
                                        WasmInterpreterEnvironment* env);
 void wasm_destroy_interpreter_environment(WasmAllocator* allocator,
                                           WasmInterpreterEnvironment* env);
+WasmInterpreterEnvironmentMark wasm_mark_interpreter_environment(
+    WasmInterpreterEnvironment* env);
+void wasm_reset_interpreter_environment_to_mark(
+    WasmAllocator* allocator,
+    WasmInterpreterEnvironment* env,
+    WasmInterpreterEnvironmentMark mark);
 WasmInterpreterModule* wasm_append_host_module(WasmAllocator* allocator,
                                                WasmInterpreterEnvironment* env,
                                                WasmStringSlice name);

--- a/src/prebuilt/ast-parser-gen.c
+++ b/src/prebuilt/ast-parser-gen.c
@@ -690,8 +690,8 @@ static const yytype_uint16 yyrline[] =
     1078,  1081,  1092,  1096,  1103,  1107,  1110,  1118,  1126,  1143,
     1159,  1170,  1177,  1184,  1190,  1230,  1240,  1262,  1272,  1298,
     1303,  1311,  1319,  1329,  1335,  1341,  1347,  1353,  1359,  1364,
-    1373,  1378,  1379,  1385,  1393,  1394,  1402,  1414,  1415,  1422,
-    1485
+    1373,  1378,  1379,  1385,  1394,  1395,  1403,  1415,  1416,  1423,
+    1488
 };
 #endif
 
@@ -3943,28 +3943,29 @@ yyreduce:
       (yyval.command)->type = WASM_COMMAND_TYPE_REGISTER;
       (yyval.command)->register_.module_name = (yyvsp[-2].text);
       (yyval.command)->register_.var = (yyvsp[-1].var);
+      (yyval.command)->register_.var.loc = (yylsp[-1]);
     }
-#line 3948 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 3949 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1393 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1394 "src/ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.commands)); }
-#line 3954 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 3955 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1394 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1395 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       wasm_append_command_value(parser->allocator, &(yyval.commands), (yyvsp[0].command));
       wasm_free(parser->allocator, (yyvsp[0].command));
     }
-#line 3964 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 3965 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1402 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1403 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WASM_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -3975,26 +3976,26 @@ yyreduce:
       }
       wasm_free(parser->allocator, (char*)(yyvsp[-1].literal).text.start);
     }
-#line 3979 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 3980 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1414 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
     { WASM_ZERO_MEMORY((yyval.consts)); }
-#line 3985 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 3986 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1416 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       wasm_append_const_value(parser->allocator, &(yyval.consts), &(yyvsp[0].const_));
     }
-#line 3994 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 3995 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1422 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1423 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WASM_ZERO_MEMORY((yyval.script));
       (yyval.script).allocator = parser->allocator;
@@ -4004,7 +4005,7 @@ yyreduce:
       size_t i;
       for (i = 0; i < (yyval.script).commands.size; ++i) {
         WasmCommand* command = &(yyval.script).commands.data[i];
-        WasmAction* action = NULL;
+        WasmVar* module_var = NULL;
         switch (command->type) {
           case WASM_COMMAND_TYPE_MODULE: {
             last_module_index = i;
@@ -4024,25 +4025,27 @@ yyreduce:
           }
 
           case WASM_COMMAND_TYPE_ASSERT_RETURN:
-            action = &command->assert_return.action;
-            goto has_action;
+            module_var = &command->assert_return.action.module_var;
+            goto has_module_var;
           case WASM_COMMAND_TYPE_ASSERT_RETURN_NAN:
-            action = &command->assert_return_nan.action;
-            goto has_action;
+            module_var = &command->assert_return_nan.action.module_var;
+            goto has_module_var;
           case WASM_COMMAND_TYPE_ASSERT_TRAP:
-            action = &command->assert_trap.action;
-            goto has_action;
+            module_var = &command->assert_trap.action.module_var;
+            goto has_module_var;
           case WASM_COMMAND_TYPE_ACTION:
-            action = &command->action;
-            goto has_action;
+            module_var = &command->action.module_var;
+            goto has_module_var;
+          case WASM_COMMAND_TYPE_REGISTER:
+            module_var = &command->register_.var;
+            goto has_module_var;
 
-          has_action: {
+          has_module_var: {
             /* Resolve actions with an invalid index to use the preceding
              * module. */
-            WasmVar* var = &action->module_var;
-            if (var->type == WASM_VAR_TYPE_INDEX &&
-                var->index == INVALID_VAR_INDEX) {
-              var->index = last_module_index;
+            if (module_var->type == WASM_VAR_TYPE_INDEX &&
+                module_var->index == INVALID_VAR_INDEX) {
+              module_var->index = last_module_index;
             }
             break;
           }
@@ -4053,11 +4056,11 @@ yyreduce:
       }
       parser->script = (yyval.script);
     }
-#line 4057 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 4060 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
     break;
 
 
-#line 4061 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
+#line 4064 "src/prebuilt/ast-parser-gen.c" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4292,7 +4295,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1488 "src/ast-parser.y" /* yacc.c:1906  */
+#line 1491 "src/ast-parser.y" /* yacc.c:1906  */
 
 
 static void append_expr_list(WasmExprList* expr_list, WasmExprList* expr) {

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -1,10 +1,207 @@
-;;; SKIP: imports not working properly in interpreter yet
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/imports.wast
 (;; STDOUT ;;;
-called import spectest.print(i32:14, f32:42)
-called import spectest.print(i32:13)
-called import spectest.print(i64:25, f64:53)
-called import spectest.print(i64:24)
-2/2 tests passed.
+assert_invalid error:
+  third_party/testsuite/imports.wast:270:45: only one table allowed
+  (module (import "" "" (table 10 anyfunc)) (import "" "" (table 10 anyfunc)))
+                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/imports.wast:274:45: only one table allowed
+  (module (import "" "" (table 10 anyfunc)) (table 10 anyfunc))
+                                            ^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/imports.wast:278:30: only one table allowed
+  (module (table 10 anyfunc) (table 10 anyfunc))
+                             ^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/imports.wast:365:37: only one memory block allowed
+  (module (import "" "" (memory 1)) (import "" "" (memory 1)))
+                                    ^^^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/imports.wast:369:37: only one memory block allowed
+  (module (import "" "" (memory 1)) (memory 0))
+                                    ^^^^^^^^^^
+assert_invalid error:
+  third_party/testsuite/imports.wast:373:22: only one memory block allowed
+  (module (memory 0) (memory 0))
+                     ^^^^^^^^^^
+called host spectest.print(i32:13) =>
+called host spectest.print(i32:14, f32:42) =>
+called host spectest.print(i32:13) =>
+called host spectest.print(i32:13) =>
+called host spectest.print(i32:13) =>
+called host spectest.print(i64:24) =>
+called host spectest.print(i64:25, f64:53) =>
+called host spectest.print(i64:24) =>
+called host spectest.print(i64:24) =>
+called host spectest.print(i64:24) =>
+third_party/testsuite/imports.wast:72: assert_unlinkable error:
+  error: unknown module field "unknown"
+  error: @0x0000001e: on_import callback failed
+third_party/testsuite/imports.wast:76: assert_unlinkable error:
+  error: unknown host function import "spectest.unknown"
+  error: @0x00000024: on_import_func callback failed
+third_party/testsuite/imports.wast:81: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x0000001e: on_import_func callback failed
+third_party/testsuite/imports.wast:85: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x0000001e: on_import_func callback failed
+third_party/testsuite/imports.wast:89: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x0000001f: on_import_func callback failed
+third_party/testsuite/imports.wast:93: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000021: on_import_func callback failed
+third_party/testsuite/imports.wast:97: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000022: on_import_func callback failed
+third_party/testsuite/imports.wast:101: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000022: on_import_func callback failed
+third_party/testsuite/imports.wast:105: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000022: on_import_func callback failed
+third_party/testsuite/imports.wast:109: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000023: on_import_func callback failed
+third_party/testsuite/imports.wast:113: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000022: on_import_func callback failed
+third_party/testsuite/imports.wast:117: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000023: on_import_func callback failed
+third_party/testsuite/imports.wast:121: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000023: on_import_func callback failed
+third_party/testsuite/imports.wast:125: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000023: on_import_func callback failed
+third_party/testsuite/imports.wast:129: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000024: on_import_func callback failed
+third_party/testsuite/imports.wast:133: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000026: on_import_func callback failed
+third_party/testsuite/imports.wast:137: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000027: on_import_func callback failed
+third_party/testsuite/imports.wast:141: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000027: on_import_func callback failed
+third_party/testsuite/imports.wast:146: assert_unlinkable error:
+  error: expected import "test.global-i32" to have kind func, not global
+  error: @0x00000024: on_import_func callback failed
+third_party/testsuite/imports.wast:150: assert_unlinkable error:
+  error: expected import "test.table-10-inf" to have kind func, not table
+  error: @0x00000025: on_import_func callback failed
+third_party/testsuite/imports.wast:154: assert_unlinkable error:
+  error: expected import "test.memory-2-inf" to have kind func, not memory
+  error: @0x00000025: on_import_func callback failed
+third_party/testsuite/imports.wast:158: assert_unlinkable error:
+  error: unknown host function import "spectest.global"
+  error: @0x00000023: on_import_func callback failed
+third_party/testsuite/imports.wast:162: assert_unlinkable error:
+  error: unknown host function import "spectest.table"
+  error: @0x00000022: on_import_func callback failed
+third_party/testsuite/imports.wast:166: assert_unlinkable error:
+  error: unknown host function import "spectest.memory"
+  error: @0x00000023: on_import_func callback failed
+third_party/testsuite/imports.wast:199: assert_unlinkable error:
+  error: unknown module field "unknown"
+  error: @0x00000018: on_import callback failed
+third_party/testsuite/imports.wast:203: assert_unlinkable error:
+  error: unknown host global import "spectest.unknown"
+  error: @0x0000001f: on_import_global callback failed
+third_party/testsuite/imports.wast:208: assert_unlinkable error:
+  error: expected import "test.func" to have kind global, not func
+  error: @0x00000018: on_import_global callback failed
+third_party/testsuite/imports.wast:212: assert_unlinkable error:
+  error: expected import "test.table-10-inf" to have kind global, not table
+  error: @0x00000020: on_import_global callback failed
+third_party/testsuite/imports.wast:216: assert_unlinkable error:
+  error: expected import "test.memory-2-inf" to have kind global, not memory
+  error: @0x00000020: on_import_global callback failed
+third_party/testsuite/imports.wast:220: assert_unlinkable error:
+  error: unknown host global import "spectest.print"
+  error: @0x0000001d: on_import_global callback failed
+third_party/testsuite/imports.wast:224: assert_unlinkable error:
+  error: unknown host global import "spectest.table"
+  error: @0x0000001d: on_import_global callback failed
+third_party/testsuite/imports.wast:228: assert_unlinkable error:
+  error: unknown host global import "spectest.memory"
+  error: @0x0000001e: on_import_global callback failed
+third_party/testsuite/imports.wast:295: assert_unlinkable error:
+  error: unknown module field "unknown"
+  error: @0x00000018: on_import callback failed
+third_party/testsuite/imports.wast:299: assert_unlinkable error:
+  error: unknown host table import "spectest.unknown"
+  error: @0x00000020: on_import_table callback failed
+third_party/testsuite/imports.wast:304: assert_unlinkable error:
+  error: actual size (10) smaller than declared (12)
+  error: @0x00000021: on_import_table callback failed
+third_party/testsuite/imports.wast:308: assert_unlinkable error:
+  error: max size (unspecified) larger than declared (20)
+  error: @0x00000022: on_import_table callback failed
+third_party/testsuite/imports.wast:312: assert_unlinkable error:
+  error: actual size (10) smaller than declared (12)
+  error: @0x0000001e: on_import_table callback failed
+third_party/testsuite/imports.wast:316: assert_unlinkable error:
+  error: max size (20) larger than declared (15)
+  error: @0x0000001f: on_import_table callback failed
+third_party/testsuite/imports.wast:321: assert_unlinkable error:
+  error: expected import "test.func" to have kind table, not func
+  error: @0x00000019: on_import_table callback failed
+third_party/testsuite/imports.wast:325: assert_unlinkable error:
+  error: expected import "test.global-i32" to have kind table, not global
+  error: @0x0000001f: on_import_table callback failed
+third_party/testsuite/imports.wast:329: assert_unlinkable error:
+  error: expected import "test.memory-2-inf" to have kind table, not memory
+  error: @0x00000021: on_import_table callback failed
+third_party/testsuite/imports.wast:333: assert_unlinkable error:
+  error: unknown host table import "spectest.print"
+  error: @0x0000001e: on_import_table callback failed
+third_party/testsuite/imports.wast:388: assert_unlinkable error:
+  error: unknown module field "unknown"
+  error: @0x00000018: on_import callback failed
+third_party/testsuite/imports.wast:392: assert_unlinkable error:
+  error: unknown host memory import "spectest.unknown"
+  error: @0x0000001f: on_import_memory callback failed
+third_party/testsuite/imports.wast:397: assert_unlinkable error:
+  error: actual size (2) smaller than declared (3)
+  error: @0x00000020: on_import_memory callback failed
+third_party/testsuite/imports.wast:401: assert_unlinkable error:
+  error: max size (unspecified) larger than declared (3)
+  error: @0x00000021: on_import_memory callback failed
+third_party/testsuite/imports.wast:405: assert_unlinkable error:
+  error: actual size (1) smaller than declared (2)
+  error: @0x0000001e: on_import_memory callback failed
+third_party/testsuite/imports.wast:409: assert_unlinkable error:
+  error: max size (2) larger than declared (1)
+  error: @0x0000001f: on_import_memory callback failed
+third_party/testsuite/imports.wast:414: assert_unlinkable error:
+  error: expected import "test.func-i32" to have kind memory, not func
+  error: @0x0000001c: on_import_memory callback failed
+third_party/testsuite/imports.wast:418: assert_unlinkable error:
+  error: expected import "test.global-i32" to have kind memory, not global
+  error: @0x0000001e: on_import_memory callback failed
+third_party/testsuite/imports.wast:422: assert_unlinkable error:
+  error: expected import "test.table-10-inf" to have kind memory, not table
+  error: @0x00000020: on_import_memory callback failed
+third_party/testsuite/imports.wast:426: assert_unlinkable error:
+  error: unknown host memory import "spectest.print"
+  error: @0x0000001d: on_import_memory callback failed
+third_party/testsuite/imports.wast:430: assert_unlinkable error:
+  error: unknown host memory import "spectest.global"
+  error: @0x0000001e: on_import_memory callback failed
+third_party/testsuite/imports.wast:434: assert_unlinkable error:
+  error: unknown host memory import "spectest.table"
+  error: @0x0000001d: on_import_memory callback failed
+third_party/testsuite/imports.wast:439: assert_unlinkable error:
+  error: actual size (1) smaller than declared (2)
+  error: @0x0000001e: on_import_memory callback failed
+third_party/testsuite/imports.wast:443: assert_unlinkable error:
+  error: max size (2) larger than declared (1)
+  error: @0x0000001f: on_import_memory callback failed
+85/85 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -121,5 +121,14 @@ assert_invalid error:
   third_party/testsuite/memory.wast:162:29: alignment must not be larger than natural alignment (1)
   (module (memory 0) (func (i32.store8 align=2 (i32.const 0) (i32.const 0))))
                             ^^^^^^^^^^^^^^^^^^
-27/27 tests passed.
+third_party/testsuite/memory.wast:47: assert_unlinkable error:
+  error: data segment is out of bounds: [0, 1) >= max value 0
+  error: @0x00000017: on_data_segment_data callback failed
+third_party/testsuite/memory.wast:51: assert_unlinkable error:
+  error: data segment is out of bounds: [98304, 98305) >= max value 65536
+  error: @0x0000001f: on_data_segment_data callback failed
+third_party/testsuite/memory.wast:60: assert_unlinkable error:
+  error: data segment is out of bounds: [65536, 65537) >= max value 65536
+  error: @0x00000020: on_data_segment_data callback failed
+30/30 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
* Properly handle registering an unnamed module (most recently read) in
  AST parser
* register command has optional name in spec JSON format
* Implement spectest_import_{table,memory,global}
* Implement on_register_command in wasm-interp (wires up module binding)
* Implement assert_unlinkable
* Set module's table_index and memory_index when importing table/memory
* Translate {get,set}_global index from module -> environment index
  space
* Don't close the environment's istream writer if the module read fails;
  this will destroy the output buffer. Just leave it as is, with extra
  unused data in the environment
* Add registered_module_bindings hash; this has the registered name of
  the module (not to be confused with the module name, which is internal
  only)
* Add {GET,SET}_GLOBAL opcodes to wasm_trace_pc and wasm_disassemble
* Add new trap when calling a function via call_indirect, when the table
  element hasn't been initialized (via an elem segment)
* Check the limits of tables + memories when importing
* Check the function signature when importing
* Use callback for printing errors from a host import; this lets us
  redirect the output the same way other errors are
* Add environment "marks". Similar to allocator marks, allows you to
  backup to a previous state when an operation fails (such as
  successfully reading a module that was supposed to fail)