### PR TITLE
Fix spec/linking test

### DIFF
--- a/src/binary-writer-spec.c
+++ b/src/binary-writer-spec.c
@@ -303,6 +303,7 @@ static void write_commands(Context* ctx, WasmScript* script) {
               ctx->source_filename);
   wasm_writef(&ctx->json_stream, " \"commands\": [\n");
   size_t i;
+  int last_module_index = -1;
   for (i = 0; i < script->commands.size; ++i) {
     WasmCommand* command = &script->commands.data[i];
 
@@ -326,6 +327,7 @@ static void write_commands(Context* ctx, WasmScript* script) {
         write_module(ctx, filename, module);
         wasm_free(ctx->allocator, filename);
         ctx->num_modules++;
+        last_module_index = (int)i;
         break;
       }
 
@@ -345,7 +347,8 @@ static void write_commands(Context* ctx, WasmScript* script) {
         } else {
           /* If we're not registering by name, then we should only be
            * registering the last module. */
-          assert(command->register_.var.index == (int)ctx->num_modules - 1);
+          WASM_USE(last_module_index);
+          assert(command->register_.var.index == last_module_index);
         }
         write_key(ctx, "as");
         write_escaped_string_slice(ctx, command->register_.module_name);

--- a/src/interpreter.c
+++ b/src/interpreter.c
@@ -189,47 +189,22 @@ WasmInterpreterModule* wasm_append_host_module(WasmAllocator* allocator,
   return module;
 }
 
-WasmResult wasm_init_interpreter_thread(WasmAllocator* allocator,
-                                        WasmInterpreterEnvironment* env,
-                                        WasmInterpreterModule* module,
-                                        WasmInterpreterThread* thread,
-                                        WasmInterpreterThreadOptions* options) {
-  assert(!module->is_host);
+void wasm_init_interpreter_thread(WasmAllocator* allocator,
+                                  WasmInterpreterEnvironment* env,
+                                  WasmInterpreterThread* thread,
+                                  WasmInterpreterThreadOptions* options) {
   WASM_ZERO_MEMORY(*thread);
   wasm_new_interpreter_value_array(allocator, &thread->value_stack,
                                    options->value_stack_size);
   wasm_new_uint32_array(allocator, &thread->call_stack,
                         options->call_stack_size);
+  thread->allocator = allocator;
   thread->env = env;
-  thread->module = module;
   thread->value_stack_top = thread->value_stack.data;
   thread->value_stack_end = thread->value_stack.data + thread->value_stack.size;
   thread->call_stack_top = thread->call_stack.data;
   thread->call_stack_end = thread->call_stack.data + thread->call_stack.size;
   thread->pc = options->pc;
-
-  /* cache this module's memory and table, for convenience */
-  if (module->memory_index != WASM_INVALID_INDEX)
-    thread->memory = &env->memories.data[module->memory_index];
-  if (module->table_index != WASM_INVALID_INDEX)
-    thread->table = &env->tables.data[module->table_index];
-
-  /* allocate host_args based on the signature with the most params */
-  /* TODO(binji): move this elsewhere? */
-  uint32_t i;
-  uint32_t max_host_params = 0;
-  for (i = 0; i < env->funcs.size; ++i) {
-    WasmInterpreterFunc* func = &env->funcs.data[i];
-    if (!func->is_host)
-      continue;
-    assert(func->sig_index < env->sigs.size);
-    WasmInterpreterFuncSignature* sig = &env->sigs.data[func->sig_index];
-    if (sig->param_types.size > max_host_params)
-      max_host_params = sig->param_types.size;
-  }
-  wasm_new_interpreter_typed_value_array(allocator, &thread->host_args,
-                                         max_host_params);
-  return WASM_OK;
 }
 
 WasmInterpreterResult wasm_push_thread_value(WasmInterpreterThread* thread,
@@ -255,7 +230,7 @@ void wasm_destroy_interpreter_thread(WasmAllocator* allocator,
                                      WasmInterpreterThread* thread) {
   wasm_destroy_interpreter_value_array(allocator, &thread->value_stack);
   wasm_destroy_uint32_array(allocator, &thread->call_stack);
-  wasm_destroy_interpreter_typed_value_array(allocator, &thread->host_args);
+  wasm_destroy_interpreter_typed_value_vector(allocator, &thread->host_args);
 }
 
 /* 3 32222222 222...00
@@ -549,26 +524,33 @@ DEFINE_BITCAST(bitcast_u64_to_f64, uint64_t, double)
 
 #define POP_CALL() (*--thread->call_stack_top)
 
-#define LOAD(type, mem_type)                                                \
-  do {                                                                      \
-    uint64_t offset = (uint64_t)POP_I32() + read_u32(&pc);                  \
-    MEM_TYPE_##mem_type value;                                              \
-    TRAP_IF(offset + sizeof(value) > thread->memory->byte_size,             \
-            MEMORY_ACCESS_OUT_OF_BOUNDS);                                   \
-    void* src = (void*)((intptr_t)thread->memory->data + (uint32_t)offset); \
-    memcpy(&value, src, sizeof(MEM_TYPE_##mem_type));                       \
-    PUSH_##type((MEM_TYPE_EXTEND_##type##_##mem_type)value);                \
+#define GET_MEMORY(var)                      \
+  uint32_t memory_index = read_u32(&pc);     \
+  assert(memory_index < env->memories.size); \
+  WasmInterpreterMemory* var = &env->memories.data[memory_index]
+
+#define LOAD(type, mem_type)                                        \
+  do {                                                              \
+    GET_MEMORY(memory);                                             \
+    uint64_t offset = (uint64_t)POP_I32() + read_u32(&pc);          \
+    MEM_TYPE_##mem_type value;                                      \
+    TRAP_IF(offset + sizeof(value) > memory->byte_size,             \
+            MEMORY_ACCESS_OUT_OF_BOUNDS);                           \
+    void* src = (void*)((intptr_t)memory->data + (uint32_t)offset); \
+    memcpy(&value, src, sizeof(MEM_TYPE_##mem_type));               \
+    PUSH_##type((MEM_TYPE_EXTEND_##type##_##mem_type)value);        \
   } while (0)
 
-#define STORE(type, mem_type)                                               \
-  do {                                                                      \
-    VALUE_TYPE_##type value = POP_##type();                                 \
-    uint64_t offset = (uint64_t)POP_I32() + read_u32(&pc);                  \
-    MEM_TYPE_##mem_type src = (MEM_TYPE_##mem_type)value;                   \
-    TRAP_IF(offset + sizeof(src) > thread->memory->byte_size,               \
-            MEMORY_ACCESS_OUT_OF_BOUNDS);                                   \
-    void* dst = (void*)((intptr_t)thread->memory->data + (uint32_t)offset); \
-    memcpy(dst, &src, sizeof(MEM_TYPE_##mem_type));                         \
+#define STORE(type, mem_type)                                       \
+  do {                                                              \
+    GET_MEMORY(memory);                                             \
+    VALUE_TYPE_##type value = POP_##type();                         \
+    uint64_t offset = (uint64_t)POP_I32() + read_u32(&pc);          \
+    MEM_TYPE_##mem_type src = (MEM_TYPE_##mem_type)value;           \
+    TRAP_IF(offset + sizeof(src) > memory->byte_size,               \
+            MEMORY_ACCESS_OUT_OF_BOUNDS);                           \
+    void* dst = (void*)((intptr_t)memory->data + (uint32_t)offset); \
+    memcpy(dst, &src, sizeof(MEM_TYPE_##mem_type));                 \
   } while (0)
 
 #define BINOP(rtype, type, op)            \
@@ -773,8 +755,12 @@ WasmInterpreterResult wasm_call_host(WasmInterpreterThread* thread,
   WasmInterpreterFuncSignature* sig = &thread->env->sigs.data[func->sig_index];
 
   uint32_t num_args = sig->param_types.size;
+  if (thread->host_args.size < num_args) {
+    wasm_resize_interpreter_typed_value_vector(thread->allocator,
+                                               &thread->host_args, num_args);
+  }
+
   uint32_t i;
-  assert(num_args <= thread->host_args.size);
   for (i = num_args; i > 0; --i) {
     WasmInterpreterValue value = POP();
     WasmInterpreterTypedValue* arg = &thread->host_args.data[i - 1];
@@ -807,7 +793,6 @@ WasmInterpreterResult wasm_run_interpreter(WasmInterpreterThread* thread,
   assert(call_stack_return_top < thread->call_stack_end);
 
   WasmInterpreterEnvironment* env = thread->env;
-  WasmInterpreterModule* module = thread->module;
 
   const uint8_t* istream = env->istream.start;
   const uint8_t* pc = &istream[thread->pc];
@@ -916,7 +901,9 @@ WasmInterpreterResult wasm_run_interpreter(WasmInterpreterThread* thread,
       }
 
       case WASM_OPCODE_CALL_INDIRECT: {
-        WasmInterpreterTable* table = &env->tables.data[module->table_index];
+        uint32_t table_index = read_u32(&pc);
+        assert(table_index < env->tables.size);
+        WasmInterpreterTable* table = &env->tables.data[table_index];
         uint32_t sig_index = read_u32(&pc);
         assert(sig_index < env->sigs.size);
         VALUE_TYPE_I32 entry_index = POP_I32();
@@ -1036,31 +1023,34 @@ WasmInterpreterResult wasm_run_interpreter(WasmInterpreterThread* thread,
         STORE(F64, F64);
         break;
 
-      case WASM_OPCODE_CURRENT_MEMORY:
-        PUSH_I32(thread->memory->page_limits.initial);
+      case WASM_OPCODE_CURRENT_MEMORY: {
+        GET_MEMORY(memory);
+        PUSH_I32(memory->page_limits.initial);
         break;
+      }
 
       case WASM_OPCODE_GROW_MEMORY: {
-        uint32_t old_page_size = thread->memory->page_limits.initial;
-        uint32_t old_byte_size = thread->memory->byte_size;
+        GET_MEMORY(memory);
+        uint32_t old_page_size = memory->page_limits.initial;
+        uint32_t old_byte_size = memory->byte_size;
         VALUE_TYPE_I32 grow_pages = POP_I32();
         uint32_t new_page_size = old_page_size + grow_pages;
-        uint32_t max_page_size = thread->memory->page_limits.has_max
-                                     ? thread->memory->page_limits.max
+        uint32_t max_page_size = memory->page_limits.has_max
+                                     ? memory->page_limits.max
                                      : WASM_MAX_PAGES;
         PUSH_NEG_1_AND_BREAK_IF(new_page_size > max_page_size);
         PUSH_NEG_1_AND_BREAK_IF((uint64_t)new_page_size * WASM_PAGE_SIZE >
                                 UINT32_MAX);
         uint32_t new_byte_size = new_page_size * WASM_PAGE_SIZE;
-        WasmAllocator* allocator = thread->memory->allocator;
-        void* new_data = wasm_realloc(allocator, thread->memory->data,
-                                      new_byte_size, WASM_DEFAULT_ALIGN);
+        WasmAllocator* allocator = memory->allocator;
+        void* new_data = wasm_realloc(allocator, memory->data, new_byte_size,
+                                      WASM_DEFAULT_ALIGN);
         PUSH_NEG_1_AND_BREAK_IF(new_data == NULL);
         memset((void*)((intptr_t)new_data + old_byte_size), 0,
                new_byte_size - old_byte_size);
-        thread->memory->data = new_data;
-        thread->memory->page_limits.initial = new_page_size;
-        thread->memory->byte_size = new_byte_size;
+        memory->data = new_data;
+        memory->page_limits.initial = new_page_size;
+        memory->byte_size = new_byte_size;
         PUSH_I32(old_page_size);
         break;
       }
@@ -1748,10 +1738,16 @@ void wasm_trace_pc(WasmInterpreterThread* thread, WasmStream* stream) {
     case WASM_OPCODE_NOP:
     case WASM_OPCODE_RETURN:
     case WASM_OPCODE_UNREACHABLE:
-    case WASM_OPCODE_CURRENT_MEMORY:
     case WASM_OPCODE_DROP:
       wasm_writef(stream, "%s\n", wasm_get_interpreter_opcode_name(opcode));
       break;
+
+    case WASM_OPCODE_CURRENT_MEMORY: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u\n", wasm_get_interpreter_opcode_name(opcode),
+                  memory_index);
+      break;
+    }
 
     case WASM_OPCODE_I32_CONST:
       wasm_writef(stream, "%s $%u\n", wasm_get_interpreter_opcode_name(opcode),
@@ -1816,45 +1812,60 @@ void wasm_trace_pc(WasmInterpreterThread* thread, WasmStream* stream) {
     case WASM_OPCODE_I32_LOAD:
     case WASM_OPCODE_I64_LOAD:
     case WASM_OPCODE_F32_LOAD:
-    case WASM_OPCODE_F64_LOAD:
-      wasm_writef(stream, "%s %u+$%u\n",
-                  wasm_get_interpreter_opcode_name(opcode), TOP().i32,
-                  read_u32_at(pc));
+    case WASM_OPCODE_F64_LOAD: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u:%u+$%u\n",
+                  wasm_get_interpreter_opcode_name(opcode), memory_index,
+                  TOP().i32, read_u32_at(pc));
       break;
+    }
 
     case WASM_OPCODE_I32_STORE8:
     case WASM_OPCODE_I32_STORE16:
-    case WASM_OPCODE_I32_STORE:
-      wasm_writef(stream, "%s %u+$%u, %u\n",
-                  wasm_get_interpreter_opcode_name(opcode), PICK(2).i32,
-                  read_u32_at(pc), PICK(1).i32);
+    case WASM_OPCODE_I32_STORE: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u:%u+$%u, %u\n",
+                  wasm_get_interpreter_opcode_name(opcode), memory_index,
+                  PICK(2).i32, read_u32_at(pc), PICK(1).i32);
       break;
+    }
 
     case WASM_OPCODE_I64_STORE8:
     case WASM_OPCODE_I64_STORE16:
     case WASM_OPCODE_I64_STORE32:
-    case WASM_OPCODE_I64_STORE:
-      wasm_writef(stream, "%s %u+$%u, %" PRIu64 "\n",
-                  wasm_get_interpreter_opcode_name(opcode), PICK(2).i32,
-                  read_u32_at(pc), PICK(1).i64);
+    case WASM_OPCODE_I64_STORE: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u:%u+$%u, %" PRIu64 "\n",
+                  wasm_get_interpreter_opcode_name(opcode), memory_index,
+                  PICK(2).i32, read_u32_at(pc), PICK(1).i64);
       break;
+    }
 
-    case WASM_OPCODE_F32_STORE:
-      wasm_writef(stream, "%s %u+$%u, %g\n",
-                  wasm_get_interpreter_opcode_name(opcode), PICK(2).i32,
-                  read_u32_at(pc), bitcast_u32_to_f32(PICK(1).f32_bits));
+    case WASM_OPCODE_F32_STORE: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u:%u+$%u, %g\n",
+                  wasm_get_interpreter_opcode_name(opcode), memory_index,
+                  PICK(2).i32, read_u32_at(pc),
+                  bitcast_u32_to_f32(PICK(1).f32_bits));
       break;
+    }
 
-    case WASM_OPCODE_F64_STORE:
-      wasm_writef(stream, "%s %u+$%u, %g\n",
-                  wasm_get_interpreter_opcode_name(opcode), PICK(2).i32,
-                  read_u32_at(pc), bitcast_u64_to_f64(PICK(1).f64_bits));
+    case WASM_OPCODE_F64_STORE: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u:%u+$%u, %g\n",
+                  wasm_get_interpreter_opcode_name(opcode), memory_index,
+                  PICK(2).i32, read_u32_at(pc),
+                  bitcast_u64_to_f64(PICK(1).f64_bits));
       break;
+    }
 
-    case WASM_OPCODE_GROW_MEMORY:
-      wasm_writef(stream, "%s %u\n", wasm_get_interpreter_opcode_name(opcode),
+    case WASM_OPCODE_GROW_MEMORY: {
+      uint32_t memory_index = read_u32(&pc);
+      wasm_writef(stream, "%s $%u:%u\n",
+                  wasm_get_interpreter_opcode_name(opcode), memory_index,
                   TOP().i32);
       break;
+    }
 
     case WASM_OPCODE_I32_ADD:
     case WASM_OPCODE_I32_SUB:
@@ -2104,10 +2115,16 @@ void wasm_disassemble(WasmInterpreterEnvironment* env,
       case WASM_OPCODE_NOP:
       case WASM_OPCODE_RETURN:
       case WASM_OPCODE_UNREACHABLE:
-      case WASM_OPCODE_CURRENT_MEMORY:
       case WASM_OPCODE_DROP:
         wasm_writef(stream, "%s\n", wasm_get_interpreter_opcode_name(opcode));
         break;
+
+      case WASM_OPCODE_CURRENT_MEMORY: {
+        uint32_t memory_index = read_u32(&pc);
+        wasm_writef(stream, "%s $%u\n",
+                    wasm_get_interpreter_opcode_name(opcode), memory_index);
+        break;
+      }
 
       case WASM_OPCODE_I32_CONST:
         wasm_writef(stream, "%s $%u\n",
@@ -2149,10 +2166,13 @@ void wasm_disassemble(WasmInterpreterEnvironment* env,
                     wasm_get_interpreter_opcode_name(opcode), read_u32(&pc));
         break;
 
-      case WASM_OPCODE_CALL_INDIRECT:
-        wasm_writef(stream, "%s $%u, %%[-1]\n",
-                    wasm_get_interpreter_opcode_name(opcode), read_u32(&pc));
+      case WASM_OPCODE_CALL_INDIRECT: {
+        uint32_t table_index = read_u32(&pc);
+        wasm_writef(stream, "%s $%u:%u, %%[-1]\n",
+                    wasm_get_interpreter_opcode_name(opcode), table_index,
+                    read_u32(&pc));
         break;
+      }
 
       case WASM_OPCODE_CALL_HOST:
         wasm_writef(stream, "%s $%u\n",
@@ -2172,10 +2192,13 @@ void wasm_disassemble(WasmInterpreterEnvironment* env,
       case WASM_OPCODE_I32_LOAD:
       case WASM_OPCODE_I64_LOAD:
       case WASM_OPCODE_F32_LOAD:
-      case WASM_OPCODE_F64_LOAD:
-        wasm_writef(stream, "%s %%[-1]+$%u\n",
-                    wasm_get_interpreter_opcode_name(opcode), read_u32(&pc));
+      case WASM_OPCODE_F64_LOAD: {
+        uint32_t memory_index = read_u32(&pc);
+        wasm_writef(stream, "%s $%u:%%[-1]+$%u\n",
+                    wasm_get_interpreter_opcode_name(opcode), memory_index,
+                    read_u32(&pc));
         break;
+      }
 
       case WASM_OPCODE_I32_STORE8:
       case WASM_OPCODE_I32_STORE16:
@@ -2185,10 +2208,13 @@ void wasm_disassemble(WasmInterpreterEnvironment* env,
       case WASM_OPCODE_I64_STORE32:
       case WASM_OPCODE_I64_STORE:
       case WASM_OPCODE_F32_STORE:
-      case WASM_OPCODE_F64_STORE:
-        wasm_writef(stream, "%s %%[-2]+$%u, %%[-1]\n",
-                    wasm_get_interpreter_opcode_name(opcode), read_u32(&pc));
+      case WASM_OPCODE_F64_STORE: {
+        uint32_t memory_index = read_u32(&pc);
+        wasm_writef(stream, "%s %%[-2]+$%u, $%u:%%[-1]\n",
+                    wasm_get_interpreter_opcode_name(opcode), memory_index,
+                    read_u32(&pc));
         break;
+      }
 
       case WASM_OPCODE_I32_ADD:
       case WASM_OPCODE_I32_SUB:
@@ -2317,10 +2343,16 @@ void wasm_disassemble(WasmInterpreterEnvironment* env,
       case WASM_OPCODE_F32_REINTERPRET_I32:
       case WASM_OPCODE_F64_CONVERT_S_I32:
       case WASM_OPCODE_F64_CONVERT_U_I32:
-      case WASM_OPCODE_GROW_MEMORY:
         wasm_writef(stream, "%s %%[-1]\n",
                     wasm_get_interpreter_opcode_name(opcode));
         break;
+
+      case WASM_OPCODE_GROW_MEMORY: {
+        uint32_t memory_index = read_u32(&pc);
+        wasm_writef(stream, "%s $%u:%%[-1]\n",
+                    wasm_get_interpreter_opcode_name(opcode), memory_index);
+        break;
+      }
 
       case WASM_OPCODE_ALLOCA:
         wasm_writef(stream, "%s $%u\n",

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -124,7 +124,6 @@ typedef struct WasmInterpreterTypedValue {
   WasmType type;
   WasmInterpreterValue value;
 } WasmInterpreterTypedValue;
-WASM_DEFINE_ARRAY(interpreter_typed_value, WasmInterpreterTypedValue);
 WASM_DEFINE_VECTOR(interpreter_typed_value, WasmInterpreterTypedValue);
 
 typedef struct WasmInterpreterGlobal {
@@ -262,10 +261,8 @@ typedef struct WasmInterpreterEnvironment {
 } WasmInterpreterEnvironment;
 
 typedef struct WasmInterpreterThread {
+  WasmAllocator* allocator;
   WasmInterpreterEnvironment* env;
-  WasmInterpreterModule* module;
-  WasmInterpreterTable* table;
-  WasmInterpreterMemory* memory;
   WasmInterpreterValueArray value_stack;
   WasmUint32Array call_stack;
   WasmInterpreterValue* value_stack_top;
@@ -275,7 +272,7 @@ typedef struct WasmInterpreterThread {
   uint32_t pc;
 
   /* a temporary buffer that is for passing args to host functions */
-  WasmInterpreterTypedValueArray host_args;
+  WasmInterpreterTypedValueVector host_args;
 } WasmInterpreterThread;
 
 #define WASM_INTERPRETER_THREAD_OPTIONS_DEFAULT \
@@ -307,11 +304,10 @@ void wasm_reset_interpreter_environment_to_mark(
 WasmInterpreterModule* wasm_append_host_module(WasmAllocator* allocator,
                                                WasmInterpreterEnvironment* env,
                                                WasmStringSlice name);
-WasmResult wasm_init_interpreter_thread(WasmAllocator* allocator,
-                                        WasmInterpreterEnvironment* env,
-                                        WasmInterpreterModule* module,
-                                        WasmInterpreterThread* thread,
-                                        WasmInterpreterThreadOptions* options);
+void wasm_init_interpreter_thread(WasmAllocator* allocator,
+                                  WasmInterpreterEnvironment* env,
+                                  WasmInterpreterThread* thread,
+                                  WasmInterpreterThreadOptions* options);
 WasmInterpreterResult wasm_push_thread_value(WasmInterpreterThread* thread,
                                              WasmInterpreterValue value);
 void wasm_destroy_interpreter_thread(WasmAllocator* allocator,

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -1,3 +1,17 @@
-;;; SKIP: linking not working yet
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/linking.wast
+(;; STDOUT ;;;
+third_party/testsuite/linking.wast:28: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000025: on_import_func callback failed
+third_party/testsuite/linking.wast:32: assert_unlinkable error:
+  error: import signature mismatch
+  error: @0x00000026: on_import_func callback failed
+third_party/testsuite/linking.wast:160: assert_unlinkable error:
+  error: unknown module field "mem"
+  error: @0x00000038: on_import callback failed
+third_party/testsuite/linking.wast:233: assert_unlinkable error:
+  error: unknown module field "tab"
+  error: @0x00000033: on_import callback failed
+69/69 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
* The func_fixups table is specified in the "defined" index-space, not
  module
* Always fill function tables with the unitialized value when created
* The global_index_mapping table should include imported globals
* Use the "defined" global index space when initializing module globals
* Write table_index to istream for call_indirect
* Write memory_index to istream for all memory ops
* WasmInterpreterThread should not be tied to a particular module;
  originally this was to match it to a given module's memory or table,
  but now those values are in the instruction stream
* Use just one WasmInterpreterThread now in wasm-interp
* Lazily allocate thread's host_args vector, rather than trying to
  determine the maximum size from all signatures