### PR TITLE
Don't allow defined globals without an init expr

### DIFF
--- a/test/parse/module/export-global.txt
+++ b/test/parse/module/export-global.txt
@@ -1,4 +1,4 @@
 (module
-  (global i32)
-  (global (mut f32))
+  (global i32 (i32.const 0))
+  (global (mut f32) (f32.const 0))
   (export "global0" (global 0)))

--- a/test/parse/module/global.txt
+++ b/test/parse/module/global.txt
@@ -1,9 +1,4 @@
 (module
-  (global i32)
-  (global i64)
-  (global f32)
-  (global f64)
-
   (global i32 (i32.const 1))
   (global i64 (i64.const 2))
   (global f32 (f32.const 3))

--- a/test/typecheck/bad-global-no-init-expr.txt
+++ b/test/typecheck/bad-global-no-init-expr.txt
@@ -1,0 +1,12 @@
+;;; ERROR: 1
+(module
+  (global i32)
+  (global (mut f32)))
+(;; STDERR ;;;
+typecheck/bad-global-no-init-expr.txt:3:3: type mismatch at global initializer expression. got void, expected i32
+  (global i32)
+  ^^^^^^^^^^^^
+typecheck/bad-global-no-init-expr.txt:4:3: type mismatch at global initializer expression. got void, expected f32
+  (global (mut f32)))
+  ^^^^^^^^^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
This fixes issue #188.