### PR TITLE
Allow named imports in the names section

### DIFF
--- a/src/binary-reader.c
+++ b/src/binary-reader.c
@@ -1827,6 +1827,9 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
     CALLBACK_CTX0(end_import_section);
   }
 
+  /* Allow the name section to come after the imports have been specified. */
+  ctx->name_section_ok = WASM_TRUE;
+
   /* function */
   if (skip_until_section(ctx, WASM_BINARY_SECTION_FUNCTION, &section_size)) {
     CALLBACK_SECTION(begin_function_signatures_section);
@@ -1843,10 +1846,6 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
     }
     CALLBACK_CTX0(end_function_signatures_section);
   }
-
-  /* only allow the name section to come after the function signatures have
-   * been specified */
-  ctx->name_section_ok = WASM_TRUE;
 
   /* table */
   if (skip_until_section(ctx, WASM_BINARY_SECTION_TABLE, &section_size)) {
@@ -2049,6 +2048,9 @@ WasmResult wasm_read_binary(WasmAllocator* allocator,
     }
     CALLBACK_CTX0(end_data_section);
   }
+
+  /* Handle supported unnamed sections at the end. */
+  skip_until_section(ctx, WASM_BINARY_SECTION_UNKNOWN, &section_size);
 
   CALLBACK0(end_module);
   destroy_context(allocator, ctx);

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -1,0 +1,42 @@
+;;; TOOL: run-wasmdump
+;;; FLAGS: -v --debug-names
+(module
+  (import "bar" "foo" (func $foo)))
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0d00 0000                                 ; WASM_BINARY_VERSION
+; section "TYPE" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 00                                        ; num results
+0000009: 04                                        ; FIXUP section size
+; section "IMPORT" (2)
+000000e: 02                                        ; section code
+000000f: 00                                        ; section size (guess)
+0000010: 01                                        ; num imports
+; import header 0
+0000011: 03                                        ; string length
+0000012: 6261 72                                  bar  ; import module name
+0000015: 03                                        ; string length
+0000016: 666f 6f                                  foo  ; import field name
+0000019: 00                                        ; import kind
+000001a: 00                                        ; import signature index
+000000f: 0b                                        ; FIXUP section size
+; section "name"
+000001b: 00                                        ; user section code
+000001c: 00                                        ; section size (guess)
+000001d: 04                                        ; string length
+000001e: 6e61 6d65                                name  ; user section name
+0000022: 01                                        ; num functions
+0000023: 04                                        ; string length
+0000024: 2466 6f6f                                $foo  ; func name 0
+0000028: 00                                        ; num locals
+000001c: 0c                                        ; FIXUP section size
+debug-import-names.wasm:	file format wasm 0x00000d
+
+Code Disassembly:
+;;; STDOUT ;;)

--- a/test/roundtrip/debug-import-names.txt
+++ b/test/roundtrip/debug-import-names.txt
@@ -1,0 +1,4 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --debug-names
+(module
+  (import "bar" "foo" (func $foo)))

--- a/test/roundtrip/debug-names-after-data.txt
+++ b/test/roundtrip/debug-names-after-data.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --debug-names
+(module
+  (memory 1)
+  (data (i32.const 0) "hi")
+  (func $foo))


### PR DESCRIPTION
This worked before, but only if there was a defined function as well.

I believe this should fix #214 and #215.