### PR TITLE
Parse arbitrary user sections

### DIFF
--- a/src/binary-reader-objdump.c
+++ b/src/binary-reader-objdump.c
@@ -365,7 +365,7 @@ static WasmResult on_import(uint32_t index,
 static WasmResult on_import_func(uint32_t index,
                                  uint32_t sig_index,
                                  void* user_data) {
-  print_details(user_data, "  - func sig=%d\n", sig_index);
+  print_details(user_data, " - func sig=%d\n", sig_index);
   return WASM_OK;
 }
 
@@ -374,7 +374,7 @@ static WasmResult on_import_table(uint32_t index,
                                   const WasmLimits* elem_limits,
                                   void* user_data) {
   print_details(user_data,
-      "  - table elem_type=%s init=%" PRId64 " max=%" PRId64 "\n",
+      " - table elem_type=%s init=%" PRId64 " max=%" PRId64 "\n",
       wasm_get_type_name(elem_type),
       elem_limits->initial,
       elem_limits->max);
@@ -384,7 +384,7 @@ static WasmResult on_import_table(uint32_t index,
 static WasmResult on_import_memory(uint32_t index,
                                    const WasmLimits* page_limits,
                                    void* user_data) {
-  print_details(user_data, "  - memory\n");
+  print_details(user_data, " - memory\n");
   return WASM_OK;
 }
 
@@ -392,14 +392,14 @@ static WasmResult on_import_global(uint32_t index,
                                    WasmType type,
                                    WasmBool mutable_,
                                    void* user_data) {
-  print_details(user_data, "- global\n");
+  print_details(user_data, " - global\n");
   return WASM_OK;
 }
 
 static WasmResult on_memory(uint32_t index,
                             const WasmLimits* page_limits,
                             void* user_data) {
-  print_details(user_data, "- memory %d\n", index);
+  print_details(user_data, " - memory %d\n", index);
   return WASM_OK;
 }
 
@@ -408,7 +408,7 @@ static WasmResult on_table(uint32_t index,
                            const WasmLimits* elem_limits,
                            void* user_data) {
   print_details(user_data,
-      "  - [%d] type=%#x init=%" PRId64 " max=%" PRId64 " \n",
+      " - [%d] type=%#x init=%" PRId64 " max=%" PRId64 " \n",
       index,
       elem_type,
       elem_limits->initial,

--- a/src/binary-reader-objdump.c
+++ b/src/binary-reader-objdump.c
@@ -90,6 +90,17 @@ static WasmResult begin_section(Context* ctx,
   return WASM_OK;
 }
 
+static WasmResult begin_user_section(WasmBinaryReaderContext* ctx,
+                                     uint32_t size,
+                                     WasmStringSlice section_name) {
+  Context* context = ctx->user_data;
+  if (begin_section(context, "USER", ctx->offset, size))
+    return WASM_ERROR;
+  if (context->options->mode == WASM_DUMP_DETAILS)
+    printf(" - name: \"" PRIstringslice "\"\n", WASM_PRINTF_STRING_SLICE_ARG(section_name));
+  return WASM_OK;
+}
+
 SEGSTART(signature, "TYPE")
 SEGSTART(import, "IMPORT")
 SEGSTART(function_signatures, "FUNCTION")
@@ -101,7 +112,6 @@ SEGSTART(start, "START")
 SEGSTART(function_bodies, "CODE")
 SEGSTART(elem, "ELEM")
 SEGSTART(data, "DATA")
-SEGSTART(names, "NAMES")
 
 static WasmResult on_count(uint32_t count, void* user_data) {
   Context* ctx = user_data;
@@ -487,7 +497,10 @@ static WasmBinaryReader s_binary_reader = {
     .end_module = end_module,
     .on_error = on_error,
 
-    // Signature sections
+    // User section
+    .begin_user_section = begin_user_section,
+
+    // Signature section
     .begin_signature_section = begin_signature_section,
     .on_signature_count = on_count,
     .on_signature = on_signature,
@@ -543,8 +556,8 @@ static WasmBinaryReader s_binary_reader = {
     .begin_data_section = begin_data_section,
     .on_data_segment_count = on_count,
 
-    // Names section
-    .begin_names_section = begin_names_section,
+    // Known "User" sections:
+    // - Names section
     .on_function_names_count = on_count,
 
     .on_init_expr_i32_const_expr = on_init_expr_i32_const_expr,

--- a/src/binary-reader.c
+++ b/src/binary-reader.c
@@ -543,7 +543,8 @@ static WasmResult logging_begin_user_section(WasmBinaryReaderContext* context,
                                              uint32_t size,
                                              WasmStringSlice section_name) {
   LoggingContext* ctx = context->user_data;
-  LOGF("begin_user_section: " PRIstringslice "\n", WASM_PRINTF_STRING_SLICE_ARG(section_name));
+  LOGF("begin_user_section: '" PRIstringslice "' size=%d\n",
+       WASM_PRINTF_STRING_SLICE_ARG(section_name), size);
   indent(ctx);
   FORWARD_CTX(begin_user_section, size, section_name);
 }

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -49,6 +49,12 @@ typedef struct WasmBinaryReader {
   WasmResult (*begin_module)(uint32_t version, void* user_data);
   WasmResult (*end_module)(void* user_data);
 
+  /* user section */
+  WasmResult (*begin_user_section)(WasmBinaryReaderContext* ctx,
+                                   uint32_t size,
+                                   WasmStringSlice section_name);
+  WasmResult (*end_user_section)(WasmBinaryReaderContext* ctx);
+
   /* signatures section */
   /* TODO(binji): rename to "type" section */
   WasmResult (*begin_signature_section)(WasmBinaryReaderContext* ctx,

--- a/src/binary-writer.c
+++ b/src/binary-writer.c
@@ -243,7 +243,7 @@ static void begin_user_section(Context* ctx,
   char desc[100];
   wasm_snprintf(desc, sizeof(desc), "section \"%s\"", name);
   write_header(ctx, desc, PRINT_HEADER_NO_INDEX);
-  wasm_write_u8(&ctx->stream, WASM_BINARY_SECTION_UNKNOWN, "user section code");
+  wasm_write_u8(&ctx->stream, WASM_BINARY_SECTION_USER, "user section code");
   ctx->last_section_leb_size_guess = leb_size_guess;
   ctx->last_section_offset =
       write_u32_leb128_space(ctx, leb_size_guess, "section size (guess)");

--- a/src/binary.h
+++ b/src/binary.h
@@ -24,7 +24,7 @@
 #define WASM_BINARY_SECTION_NAME "name"
 
 #define WASM_FOREACH_BINARY_SECTION(V) \
-  V(UNKNOWN, 0)                        \
+  V(USER, 0)                           \
   V(TYPE, 1)                           \
   V(IMPORT, 2)                         \
   V(FUNCTION, 3)                       \

--- a/test/binary/user-section.txt
+++ b/test/binary/user-section.txt
@@ -1,0 +1,24 @@
+;;; TOOL: run-gen-wasm
+;;; FLAGS: -v
+magic
+version
+section("foo") { count[4] }
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section("bar") { count[5] }
+section("foo") { count[6] }
+(;; STDOUT ;;;
+begin_module(13)
+begin_user_section: foo
+end_user_section
+begin_signature_section
+  on_signature_count(1)
+  on_signature(index: 0, params: [], results: [i32])
+end_signature_section
+begin_user_section: bar
+end_user_section
+begin_user_section: foo
+end_user_section
+end_module
+(module
+  (type (;0;) (func (result i32))))
+;;; STDOUT ;;)

--- a/test/binary/user-section.txt
+++ b/test/binary/user-section.txt
@@ -8,15 +8,15 @@ section("bar") { count[5] }
 section("foo") { count[6] }
 (;; STDOUT ;;;
 begin_module(13)
-begin_user_section: foo
+begin_user_section: 'foo' size=5
 end_user_section
 begin_signature_section
   on_signature_count(1)
   on_signature(index: 0, params: [], results: [i32])
 end_signature_section
-begin_user_section: bar
+begin_user_section: 'bar' size=5
 end_user_section
-begin_user_section: foo
+begin_user_section: 'foo' size=5
 end_user_section
 end_module
 (module

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -41,7 +41,7 @@ debug-import-names.wasm:	file format wasm 0x00000d
 Sections:
      TYPE start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    IMPORT start=0x00000010 end=0x0000001b (size=0x0000000b) count: 1
-    NAMES start=0x00000022 end=0x0000002e (size=0x0000000c) count: 1
+     USER start=0x00000022 end=0x0000002e (size=0x0000000c) count: 1
 
 Code Disassembly:
 ;;; STDOUT ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -50,7 +50,7 @@ NAMED_VALUES = {
   'version': (0xd, 0, 0, 0),
 
   # section codes
-  'UNKNOWN': 0,
+  'USER': 0,
   'TYPE': 1,
   'IMPORT': 2,
   'FUNCTION': 3,
@@ -401,7 +401,7 @@ def p_data_user_section(p):
   p[0] = p[1]
   name = p[4]
   section_data = p[7]
-  p[0].append(0)  # 0 is the section code for "unknown"
+  p[0].append(0)  # 0 is the section code for "user"
   section_name_data = []
   WriteLebU32(section_name_data, len(name))
   WriteString(section_name_data, name)

--- a/test/parse/module/bad-global-invalid-expr.txt
+++ b/test/parse/module/bad-global-invalid-expr.txt
@@ -8,5 +8,4 @@
 parse/module/bad-global-invalid-expr.txt:3:3: invalid global initializer expression, must be a constant expression; either *.const or get_global.
   (global i32 
   ^^^^^^^^^^
-
 ;;; STDERR ;;)

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -64,6 +64,9 @@ def main(args):
 
   gen_wasm.verbose = options.print_cmd
   wasm2wast.verbose = options.print_cmd
+  wasm2wast.AppendOptionalArgs({
+    '--verbose': options.verbose,
+  })
 
   with utils.TempDirectory(options.out_dir, 'run-gen-wasm-') as out_dir:
     out_file = utils.ChangeDir(utils.ChangeExt(options.file, '.wasm'), out_dir)


### PR DESCRIPTION
Handle user sections interspersed with other section
types and add tests from these.

Switch from calling these sections "Unknown" to
"User".

Fixes #214 