### PR TITLE
wasmdump: Dump contents of `name` section

### DIFF
--- a/src/binary-reader-objdump.c
+++ b/src/binary-reader-objdump.c
@@ -489,7 +489,8 @@ static WasmResult on_init_expr_i64_const_expr(uint32_t index,
 static WasmResult on_function_name(uint32_t index,
                                    WasmStringSlice name,
                                    void* user_data) {
-  print_details(user_data, " - [%d] " PRIstringslice "\n", index, WASM_PRINTF_STRING_SLICE_ARG(name));
+  print_details(user_data, " - func:%d " PRIstringslice "\n", index,
+                WASM_PRINTF_STRING_SLICE_ARG(name));
   return WASM_OK;
 }
 
@@ -497,7 +498,8 @@ static WasmResult on_local_name(uint32_t func_index,
                                 uint32_t local_index,
                                 WasmStringSlice name,
                                 void* user_data) {
-  print_details(user_data, "  - [%d] " PRIstringslice "\n", local_index, WASM_PRINTF_STRING_SLICE_ARG(name));
+  print_details(user_data, "  - local:%d " PRIstringslice "\n", local_index,
+                WASM_PRINTF_STRING_SLICE_ARG(name));
   return WASM_OK;
 }
 

--- a/src/binary-reader-objdump.c
+++ b/src/binary-reader-objdump.c
@@ -486,6 +486,21 @@ static WasmResult on_init_expr_i64_const_expr(uint32_t index,
   return WASM_OK;
 }
 
+static WasmResult on_function_name(uint32_t index,
+                                   WasmStringSlice name,
+                                   void* user_data) {
+  print_details(user_data, " - [%d] " PRIstringslice "\n", index, WASM_PRINTF_STRING_SLICE_ARG(name));
+  return WASM_OK;
+}
+
+static WasmResult on_local_name(uint32_t func_index,
+                                uint32_t local_index,
+                                WasmStringSlice name,
+                                void* user_data) {
+  print_details(user_data, "  - [%d] " PRIstringslice "\n", local_index, WASM_PRINTF_STRING_SLICE_ARG(name));
+  return WASM_OK;
+}
+
 static void on_error(WasmBinaryReaderContext* ctx, const char* message) {
   wasm_default_binary_error_callback(ctx->offset, message, ctx->user_data);
 }
@@ -559,6 +574,8 @@ static WasmBinaryReader s_binary_reader = {
     // Known "User" sections:
     // - Names section
     .on_function_names_count = on_count,
+    .on_function_name = on_function_name,
+    .on_local_name = on_local_name,
 
     .on_init_expr_i32_const_expr = on_init_expr_i32_const_expr,
     .on_init_expr_i64_const_expr = on_init_expr_i64_const_expr,

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-wasmdump
-;;; FLAGS: -v --debug-names
+;;; FLAGS: -v --debug-names --dump-verbose
 (module
   (func $F1 (param $F1P0 i32)
     (local $F1L1 f32)
@@ -86,6 +86,29 @@
 000005c: 2446 324c 33                             $F2L3  ; local name 3
 000002a: 36                                        ; FIXUP section size
 debug-names.wasm:	file format wasm 0x00000d
+
+Section Details:
+TYPE:
+ - [0] (i32) -> nil
+ - [1] (f32) -> nil
+FUNCTION:
+ - [0] sig=0
+ - [1] sig=1
+CODE:
+ - func 0
+ - func 1
+USER:
+ - name: "name"
+ - [0] $F1
+  - [0] $F1P0
+  - [1] $F1L1
+  - [2] $F1L2
+  - [3] 
+ - [1] $F2
+  - [0] $F2P0
+  - [1] $F2L1
+  - [2] 
+  - [3] $F2L3
 
 Code Disassembly:
 func 0

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -99,16 +99,16 @@ CODE:
  - func 1
 USER:
  - name: "name"
- - [0] $F1
-  - [0] $F1P0
-  - [1] $F1L1
-  - [2] $F1L2
-  - [3] 
- - [1] $F2
-  - [0] $F2P0
-  - [1] $F2L1
-  - [2] 
-  - [3] $F2L3
+ - func:0 $F1
+  - local:0 $F1P0
+  - local:1 $F1L1
+  - local:2 $F1L2
+  - local:3 
+ - func:1 $F2
+  - local:0 $F2P0
+  - local:1 $F2L1
+  - local:2 
+  - local:3 $F2L3
 
 Code Disassembly:
 func 0

--- a/test/run-wasmdump.py
+++ b/test/run-wasmdump.py
@@ -42,6 +42,7 @@ def main(args):
                       action='store_true')
   parser.add_argument('--headers', action='store_true')
   parser.add_argument('--no-check', action='store_true')
+  parser.add_argument('--dump-verbose', action='store_true')
   parser.add_argument('--spec', action='store_true')
   parser.add_argument('--no-canonicalize-leb128s', action='store_true')
   parser.add_argument('--use-libc-allocator', action='store_true')
@@ -66,6 +67,7 @@ def main(args):
       error_cmdline=options.error_cmdline)
   wasmdump.AppendOptionalArgs({
     '-h': options.headers,
+    '-v': options.dump_verbose,
   })
 
   wast2wasm.verbose = options.print_cmd


### PR DESCRIPTION
Also add `--dump-verbose` flag to `run-wasmdump.py` in order to
be able test the output of `wasmdump -v`