### PR TITLE
Adjust asserts to allow writing invalid modules

### DIFF
--- a/src/binary-writer.c
+++ b/src/binary-writer.c
@@ -305,7 +305,7 @@ static void write_expr(Context* ctx,
     }
     case WASM_EXPR_TYPE_CALL: {
       int index = wasm_get_func_index_by_var(module, &expr->call.var);
-      assert(index >= 0 && (size_t)index < module->funcs.size);
+      assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->funcs.size));
       write_opcode(&ctx->stream, WASM_OPCODE_CALL);
       write_u32_leb128(&ctx->stream, index, "func index");
       break;
@@ -313,7 +313,7 @@ static void write_expr(Context* ctx,
     case WASM_EXPR_TYPE_CALL_INDIRECT: {
       int index =
           wasm_get_func_type_index_by_var(module, &expr->call_indirect.var);
-      assert(index >= 0 && (size_t)index < module->func_types.size);
+      assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->func_types.size));
       write_opcode(&ctx->stream, WASM_OPCODE_CALL_INDIRECT);
       write_u32_leb128(&ctx->stream, index, "signature index");
       write_u32_leb128(&ctx->stream, 0, "call_indirect reserved");
@@ -679,25 +679,25 @@ static void write_module(Context* ctx, const WasmModule* module) {
       switch (export->kind) {
         case WASM_EXTERNAL_KIND_FUNC: {
           int index = wasm_get_func_index_by_var(module, &export->var);
-          assert(index >= 0 && (size_t)index < module->funcs.size);
+          assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->funcs.size));
           write_u32_leb128(&ctx->stream, index, "export func index");
           break;
         }
         case WASM_EXTERNAL_KIND_TABLE: {
           int index = wasm_get_table_index_by_var(module, &export->var);
-          assert(index >= 0 && (size_t)index < module->tables.size);
+          assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->tables.size));
           write_u32_leb128(&ctx->stream, index, "export table index");
           break;
         }
         case WASM_EXTERNAL_KIND_MEMORY: {
           int index = wasm_get_memory_index_by_var(module, &export->var);
-          assert(index >= 0 && (size_t)index < module->memories.size);
+          assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->memories.size));
           write_u32_leb128(&ctx->stream, index, "export memory index");
           break;
         }
         case WASM_EXTERNAL_KIND_GLOBAL: {
           int index = wasm_get_global_index_by_var(module, &export->var);
-          assert(index >= 0 && (size_t)index < module->globals.size);
+          assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->globals.size));
           write_u32_leb128(&ctx->stream, index, "export global index");
           break;
         }
@@ -734,7 +734,7 @@ static void write_module(Context* ctx, const WasmModule* module) {
       size_t j;
       for (j = 0; j < segment->vars.size; ++j) {
         int index = wasm_get_func_index_by_var(module, &segment->vars.data[j]);
-        assert(index >= 0 && (size_t)index < module->funcs.size);
+        assert(ctx->options->is_invalid || (index >= 0 && (size_t)index < module->funcs.size));
         write_u32_leb128(&ctx->stream, index, "function index");
       }
     }

--- a/src/binary-writer.h
+++ b/src/binary-writer.h
@@ -26,12 +26,13 @@ struct WasmWriter;
 struct WasmStream;
 
 #define WASM_WRITE_BINARY_OPTIONS_DEFAULT \
-  { NULL, WASM_TRUE, WASM_FALSE }
+  { NULL, WASM_TRUE, WASM_FALSE, WASM_FALSE }
 
 typedef struct WasmWriteBinaryOptions {
   struct WasmStream* log_stream;
   WasmBool canonicalize_lebs;
   WasmBool write_debug_names;
+  WasmBool is_invalid;
 } WasmWriteBinaryOptions;
 
 WASM_EXTERN_C_BEGIN


### PR DESCRIPTION
I was able to convert all assert_invalid tests in the spec repository using this change