### PR TITLE
Rewrite the binary section reader code

### DIFF
--- a/src/binary.c
+++ b/src/binary.c
@@ -17,7 +17,7 @@
 #include "binary.h"
 
 const char* g_wasm_section_name[] = {
-#define V(NAME, code) #NAME,
+#define V(NAME, name, code) #NAME,
   WASM_FOREACH_BINARY_SECTION(V)
 #undef V
 };

--- a/src/binary.h
+++ b/src/binary.h
@@ -27,22 +27,22 @@
 #define WASM_BINARY_SECTION_RELOC "reloc"
 
 #define WASM_FOREACH_BINARY_SECTION(V) \
-  V(CUSTOM, 0)                         \
-  V(TYPE, 1)                           \
-  V(IMPORT, 2)                         \
-  V(FUNCTION, 3)                       \
-  V(TABLE, 4)                          \
-  V(MEMORY, 5)                         \
-  V(GLOBAL, 6)                         \
-  V(EXPORT, 7)                         \
-  V(START, 8)                          \
-  V(ELEM, 9)                           \
-  V(CODE, 10)                          \
-  V(DATA, 11)
+  V(CUSTOM, custom, 0)                 \
+  V(TYPE, type, 1)                     \
+  V(IMPORT, import, 2)                 \
+  V(FUNCTION, function, 3)             \
+  V(TABLE, table, 4)                   \
+  V(MEMORY, memory, 5)                 \
+  V(GLOBAL, global, 6)                 \
+  V(EXPORT, export, 7)                 \
+  V(START, start, 8)                   \
+  V(ELEM, elem, 9)                     \
+  V(CODE, code, 10)                    \
+  V(DATA, data, 11)
 
 /* clang-format off */
 typedef enum WasmBinarySection {
-#define V(NAME, code) WASM_BINARY_SECTION_##NAME = code,
+#define V(NAME, name, code) WASM_BINARY_SECTION_##NAME = code,
   WASM_FOREACH_BINARY_SECTION(V)
 #undef V
   WASM_NUM_BINARY_SECTIONS


### PR DESCRIPTION
The previous way took advantage of the fact that WebAssembly sections
have a required order, but ultimately it made the code more complicated
and fragile.

This change makes parsing more natural; read each section and dispatch
to a function that knows how to parse it.