### PR TITLE
wasm2wast: parse the name section by default

### DIFF
--- a/src/tools/wasm2wast.c
+++ b/src/tools/wasm2wast.c
@@ -36,8 +36,7 @@
 static int s_verbose;
 static const char* s_infile;
 static const char* s_outfile;
-static WasmReadBinaryOptions s_read_binary_options =
-    WASM_READ_BINARY_OPTIONS_DEFAULT;
+static WasmReadBinaryOptions s_read_binary_options = {NULL, WASM_TRUE};
 static WasmBool s_use_libc_allocator;
 static WasmBool s_generate_names;
 
@@ -55,7 +54,7 @@ enum {
   FLAG_HELP,
   FLAG_OUTPUT,
   FLAG_USE_LIBC_ALLOCATOR,
-  FLAG_DEBUG_NAMES,
+  FLAG_NO_DEBUG_NAMES,
   FLAG_GENERATE_NAMES,
   NUM_FLAGS
 };
@@ -68,8 +67,8 @@ static const char s_description[] =
     "  # parse binary file test.wasm and write s-expression file test.wast\n"
     "  $ wasm2wast test.wasm -o test.wast\n"
     "\n"
-    "  # parse test.wasm and write test.wast, using the debug names, if any\n"
-    "  $ wasm2wast test.wasm --debug-names -o test.wast\n";
+    "  # parse test.wasm, write test.wast, but ignore the debug names, if any\n"
+    "  $ wasm2wast test.wasm --no-debug-names -o test.wast\n";
 
 static WasmOption s_options[] = {
     {FLAG_VERBOSE, 'v', "verbose", NULL, NOPE,
@@ -79,8 +78,8 @@ static WasmOption s_options[] = {
      "output file for the generated wast file, by default use stdout"},
     {FLAG_USE_LIBC_ALLOCATOR, 0, "use-libc-allocator", NULL, NOPE,
      "use malloc, free, etc. instead of stack allocator"},
-    {FLAG_DEBUG_NAMES, 0, "debug-names", NULL, NOPE,
-     "Read debug names from the binary file"},
+    {FLAG_NO_DEBUG_NAMES, 0, "no-debug-names", NULL, NOPE,
+     "Ignore debug names in the binary file"},
     {FLAG_GENERATE_NAMES, 0, "generate-names", NULL, NOPE,
      "Give auto-generated names to non-named functions, types, etc."},
 };
@@ -110,8 +109,8 @@ static void on_option(struct WasmOptionParser* parser,
       s_use_libc_allocator = WASM_TRUE;
       break;
 
-    case FLAG_DEBUG_NAMES:
-      s_read_binary_options.read_debug_names = WASM_TRUE;
+    case FLAG_NO_DEBUG_NAMES:
+      s_read_binary_options.read_debug_names = WASM_FALSE;
       break;
 
     case FLAG_GENERATE_NAMES:

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -1,6 +1,5 @@
 ;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
-;;; FLAGS: --debug-names
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/names.txt
+++ b/test/binary/names.txt
@@ -1,0 +1,25 @@
+;;; TOOL: run-gen-wasm
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[1] i32]
+    get_local 0
+  }
+}
+section("name") {
+  func_count[1]
+  str("$F0")
+  local_count[1]
+  str("$L0")
+}
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (result i32)))
+  (func $F0 (type 0) (result i32)
+    (local $L0 i32)
+    get_local $L0))
+;;; STDOUT ;;)

--- a/test/binary/no-names.txt
+++ b/test/binary/no-names.txt
@@ -1,0 +1,26 @@
+;;; TOOL: run-gen-wasm
+;;; FLAGS: --no-debug-names
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[1] i32]
+    get_local 0
+  }
+}
+section("name") {
+  func_count[1]
+  str("$F0")
+  local_count[1]
+  str("$L0")
+}
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (result i32)))
+  (func (;0;) (type 0) (result i32)
+    (local i32)
+    get_local 0))
+;;; STDOUT ;;)

--- a/test/help/wasm-wast.txt
+++ b/test/help/wasm-wast.txt
@@ -10,14 +10,14 @@ examples:
   # parse binary file test.wasm and write s-expression file test.wast
   $ wasm2wast test.wasm -o test.wast
 
-  # parse test.wasm and write test.wast, using the debug names, if any
-  $ wasm2wast test.wasm --debug-names -o test.wast
+  # parse test.wasm, write test.wast, but ignore the debug names, if any
+  $ wasm2wast test.wasm --no-debug-names -o test.wast
 
 options:
   -v, --verbose                   use multiple times for more info
   -h, --help                      print this help message
   -o, --output=FILENAME           output file for the generated wast file, by default use stdout
       --use-libc-allocator        use malloc, free, etc. instead of stack allocator
-      --debug-names               Read debug names from the binary file
+      --no-debug-names            Ignore debug names in the binary file
       --generate-names            Give auto-generated names to non-named functions, types, etc.
 ;;; STDOUT ;;)

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -45,7 +45,7 @@ def main(args):
   parser.add_argument('-p', '--print-cmd', action='store_true',
                       help='print the commands that are run.')
   parser.add_argument('--use-libc-allocator', action='store_true')
-  parser.add_argument('--debug-names', action='store_true')
+  parser.add_argument('--no-debug-names', action='store_true')
   parser.add_argument('--generate-names', action='store_true')
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
@@ -57,7 +57,7 @@ def main(args):
       find_exe.GetWasm2WastExecutable(options.wasm2wast),
       error_cmdline=options.error_cmdline)
   wasm2wast.AppendOptionalArgs({
-    '--debug-names': options.debug_names,
+    '--no-debug-names': options.no_debug_names,
     '--generate-names': options.generate_names,
     '--use-libc-allocator': options.use_libc_allocator
   })

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -132,7 +132,7 @@ def main(args):
       find_exe.GetWasm2WastExecutable(options.wasm2wast),
       error_cmdline=options.error_cmdline)
   wasm2wast.AppendOptionalArgs({
-    '--debug-names': options.debug_names,
+    '--no-debug-names': not options.debug_names,
     '--generate-names': options.generate_names,
     '--use-libc-allocator': options.use_libc_allocator
   })


### PR DESCRIPTION
You can now disable this behavior by passing `--no-debug-names`.