### PR TITLE
Write modules w/ invalid segments

### DIFF
--- a/src/binary-writer.c
+++ b/src/binary-writer.c
@@ -478,7 +478,7 @@ static void write_init_expr(Context* ctx,
                             const WasmModule* module,
                             const WasmExpr* expr) {
   if (expr)
-    write_expr(ctx, module, NULL, expr);
+    write_expr_list(ctx, module, NULL, expr);
   wasm_write_opcode(&ctx->stream, WASM_OPCODE_END);
 }
 
@@ -742,7 +742,7 @@ static void write_module(Context* ctx, const WasmModule* module) {
     }
   }
 
-  if (module->tables.size && module->elem_segments.size) {
+  if (module->elem_segments.size) {
     begin_known_section(ctx, WASM_BINARY_SECTION_ELEM, leb_size_guess);
     wasm_write_u32_leb128(&ctx->stream, module->elem_segments.size,
                           "num elem segments");
@@ -785,7 +785,7 @@ static void write_module(Context* ctx, const WasmModule* module) {
     end_section(ctx);
   }
 
-  if (module->memories.size && module->data_segments.size) {
+  if (module->data_segments.size) {
     begin_known_section(ctx, WASM_BINARY_SECTION_DATA, leb_size_guess);
     wasm_write_u32_leb128(&ctx->stream, module->data_segments.size,
                           "num data segments");

--- a/test/dump/invalid-data-segment-no-memory.txt
+++ b/test/dump/invalid-data-segment-no-memory.txt
@@ -1,0 +1,20 @@
+;;; FLAGS: -v --no-check
+(module
+  (data (i32.const 0) "hello"))
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0d00 0000                                 ; WASM_BINARY_VERSION
+; section "DATA" (11)
+0000008: 0b                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num data segments
+; data segment header 0
+000000b: 00                                        ; memory index
+000000c: 41                                        ; i32.const
+000000d: 00                                        ; i32 literal
+000000e: 0b                                        ; end
+000000f: 05                                        ; data segment size
+; data segment data 0
+0000010: 6865 6c6c 6f                              ; data segment data
+0000009: 0b                                        ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/dump/invalid-data-segment-offset.txt
+++ b/test/dump/invalid-data-segment-offset.txt
@@ -1,0 +1,32 @@
+;;; FLAGS: -v --no-check
+(module
+  (memory 1)
+  (data (i32.add (i32.const 1) (i32.const 2)) "foo"))
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0d00 0000                                 ; WASM_BINARY_VERSION
+; section "MEMORY" (5)
+0000008: 05                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num memories
+; memory 0
+000000b: 00                                        ; limits: flags
+000000c: 01                                        ; limits: initial
+0000009: 03                                        ; FIXUP section size
+; section "DATA" (11)
+000000d: 0b                                        ; section code
+000000e: 00                                        ; section size (guess)
+000000f: 01                                        ; num data segments
+; data segment header 0
+0000010: 00                                        ; memory index
+0000011: 41                                        ; i32.const
+0000012: 01                                        ; i32 literal
+0000013: 41                                        ; i32.const
+0000014: 02                                        ; i32 literal
+0000015: 6a                                        ; i32.add
+0000016: 0b                                        ; end
+0000017: 03                                        ; data segment size
+; data segment data 0
+0000018: 666f 6f                                   ; data segment data
+000000e: 0c                                        ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/dump/invalid-elem-segment-no-table.txt
+++ b/test/dump/invalid-elem-segment-no-table.txt
@@ -1,0 +1,53 @@
+;;; FLAGS: -v --no-check
+(module
+  (func)
+  (func)
+  (elem (i32.const 0) 0 1))
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0d00 0000                                 ; WASM_BINARY_VERSION
+; section "TYPE" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 00                                        ; num results
+0000009: 04                                        ; FIXUP section size
+; section "FUNCTION" (3)
+000000e: 03                                        ; section code
+000000f: 00                                        ; section size (guess)
+0000010: 02                                        ; num functions
+0000011: 00                                        ; function 0 signature index
+0000012: 00                                        ; function 1 signature index
+000000f: 03                                        ; FIXUP section size
+; section "ELEM" (9)
+0000013: 09                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num elem segments
+; elem segment header 0
+0000016: 00                                        ; table index
+0000017: 41                                        ; i32.const
+0000018: 00                                        ; i32 literal
+0000019: 0b                                        ; end
+000001a: 02                                        ; num function indices
+000001b: 00                                        ; function index
+000001c: 01                                        ; function index
+0000014: 08                                        ; FIXUP section size
+; section "CODE" (10)
+000001d: 0a                                        ; section code
+000001e: 00                                        ; section size (guess)
+000001f: 02                                        ; num functions
+; function body 0
+0000020: 00                                        ; func body size (guess)
+0000021: 00                                        ; local decl count
+0000022: 0b                                        ; end
+0000020: 02                                        ; FIXUP func body size
+; function body 1
+0000023: 00                                        ; func body size (guess)
+0000024: 00                                        ; local decl count
+0000025: 0b                                        ; end
+0000023: 02                                        ; FIXUP func body size
+000001e: 07                                        ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/dump/invalid-elem-segment-offset.txt
+++ b/test/dump/invalid-elem-segment-offset.txt
@@ -1,0 +1,56 @@
+;;; FLAGS: -v --no-check
+(module
+  (table 1 anyfunc)
+  (func)
+  (elem (i32.eqz (i32.const 1)) 0))
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0d00 0000                                 ; WASM_BINARY_VERSION
+; section "TYPE" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 00                                        ; num results
+0000009: 04                                        ; FIXUP section size
+; section "FUNCTION" (3)
+000000e: 03                                        ; section code
+000000f: 00                                        ; section size (guess)
+0000010: 01                                        ; num functions
+0000011: 00                                        ; function 0 signature index
+000000f: 02                                        ; FIXUP section size
+; section "TABLE" (4)
+0000012: 04                                        ; section code
+0000013: 00                                        ; section size (guess)
+0000014: 01                                        ; num tables
+; table 0
+0000015: 70                                        ; anyfunc
+0000016: 00                                        ; limits: flags
+0000017: 01                                        ; limits: initial
+0000013: 04                                        ; FIXUP section size
+; section "ELEM" (9)
+0000018: 09                                        ; section code
+0000019: 00                                        ; section size (guess)
+000001a: 01                                        ; num elem segments
+; elem segment header 0
+000001b: 00                                        ; table index
+000001c: 41                                        ; i32.const
+000001d: 01                                        ; i32 literal
+000001e: 45                                        ; i32.eqz
+000001f: 0b                                        ; end
+0000020: 01                                        ; num function indices
+0000021: 00                                        ; function index
+0000019: 08                                        ; FIXUP section size
+; section "CODE" (10)
+0000022: 0a                                        ; section code
+0000023: 00                                        ; section size (guess)
+0000024: 01                                        ; num functions
+; function body 0
+0000025: 00                                        ; func body size (guess)
+0000026: 00                                        ; local decl count
+0000027: 0b                                        ; end
+0000025: 02                                        ; FIXUP func body size
+0000023: 04                                        ; FIXUP section size
+;;; STDOUT ;;)


### PR DESCRIPTION
The binary writer should write invalid modules. This change allows
writing data/element segments if there is no memory/table segment,
respectively. It also writes the full init_expr, even if that would be
invalid.

Fixes issue #256.