### PR TITLE
Pass --bindir to test helpers rather than full path to each tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -319,10 +319,7 @@ if (NOT EMSCRIPTEN)
   find_package(PythonInterp 2.7 REQUIRED)
   set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
   add_custom_target(run-tests
-    COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY}
-        --wast2wasm $<TARGET_FILE:wast2wasm>
-        --wasm2wast $<TARGET_FILE:wasm2wast>
-        --wasm-interp $<TARGET_FILE:wasm-interp>
+    COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir ${CMAKE_BINARY_DIR}
     DEPENDS wast2wasm wasm2wast wasm-interp
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}
   )

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -35,8 +35,7 @@ set_run_test_args() {
   local BUILD_TYPE=$2
   local CONFIG=${3:-}
 
-  local EXE_DIR=out/${COMPILER}/${BUILD_TYPE}/${CONFIG}
-  RUN_TEST_ARGS="--exe-dir ${EXE_DIR}"
+  RUN_TEST_ARGS="--bindir out/${COMPILER}/${BUILD_TYPE}/${CONFIG}"
 }
 
 if [ ${CC} = "gcc" ]; then

--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -29,8 +29,12 @@ EXECUTABLES = [
 ]
 
 
+def GetDefaultPath():
+  return os.path.join(REPO_ROOT_DIR, 'out')
+
+
 def GetDefaultExe(basename):
-  result = os.path.join(REPO_ROOT_DIR, 'out', basename)
+  result = os.path.join(GetDefaultPath(), basename)
   if IS_WINDOWS:
     result += '.exe'
   return result
@@ -39,6 +43,8 @@ def GetDefaultExe(basename):
 def FindExeWithFallback(name, default_exe_list, override_exe=None):
   result = override_exe
   if result is not None:
+    if os.path.isdir(result):
+      result = os.path.join(result, name)
     if IS_WINDOWS and os.path.splitext(result)[1] != '.exe':
       result += '.exe'
     if os.path.exists(result):

--- a/test/gen-spec-js.py
+++ b/test/gen-spec-js.py
@@ -27,7 +27,7 @@ import re
 import struct
 import sys
 
-from find_exe import GetWast2WasmExecutable, GetWasm2WastExecutable
+import find_exe
 from utils import ChangeDir, ChangeExt, Error, Executable
 import utils
 
@@ -421,10 +421,9 @@ def main(args):
   parser.add_argument('-o', '--output', metavar='PATH', help='output file.')
   parser.add_argument('-P', '--prefix', metavar='PATH', help='prefix file.',
                       default=os.path.join(SCRIPT_DIR, 'gen-spec-prefix.js'))
-  parser.add_argument('--wast2wasm', metavar='PATH',
-                      help='set the wast2wasm executable to use.')
-  parser.add_argument('--wasm2wast', metavar='PATH',
-                      help='set the wasm2wast executable to use.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--temp-dir', metavar='PATH',
                       help='set the directory that temporary wasm/wast'
                            ' files are written.')
@@ -438,9 +437,9 @@ def main(args):
   parser.add_argument('file', help='spec json file.')
   options = parser.parse_args(args)
 
-  wast2wasm = Executable(GetWast2WasmExecutable(options.wast2wasm),
+  wast2wasm = Executable(find_exe.GetWast2WasmExecutable(options.bindir),
                          error_cmdline=options.error_cmdline)
-  wasm2wast = Executable(GetWasm2WastExecutable(options.wasm2wast),
+  wasm2wast = Executable(find_exe.GetWasm2WastExecutable(options.bindir),
                          error_cmdline=options.error_cmdline)
 
   wast2wasm.verbose = options.print_cmd

--- a/test/run-gen-spec-js.py
+++ b/test/run-gen-spec-js.py
@@ -32,10 +32,9 @@ def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wast2wasm', metavar='PATH',
-                      help='override wast2wasm executable.')
-  parser.add_argument('--wasm2wast', metavar='PATH',
-                      help='override wasm2wast executable.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--js-engine', metavar='PATH',
                       help='the path to the JavaScript engine with which to run'
                       ' the generated JavaScript. If not specified, JavaScript'
@@ -59,7 +58,7 @@ def main(args):
 
   with utils.TempDirectory(options.out_dir, 'run-gen-spec-js-') as out_dir:
     wast2wasm = utils.Executable(
-        find_exe.GetWast2WasmExecutable(options.wast2wasm),
+        find_exe.GetWast2WasmExecutable(options.bindir),
         '--spec',
         '--no-check-assert-invalid',
         error_cmdline=options.error_cmdline)
@@ -73,8 +72,7 @@ def main(args):
         '--temp-dir', out_dir,
         error_cmdline=options.error_cmdline)
     gen_spec_js.AppendOptionalArgs({
-      '--wast2wasm': options.wast2wasm,
-      '--wasm2wast': options.wasm2wast,
+      '--bindir': options.bindir,
       '--prefix': options.prefix_js,
     })
     gen_spec_js.verbose = options.print_cmd

--- a/test/run-gen-wasm-interp.py
+++ b/test/run-gen-wasm-interp.py
@@ -32,10 +32,11 @@ def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wasm-interp-executable', metavar='PATH',
-                      help='override wasm-interp executable.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
@@ -52,7 +53,7 @@ def main(args):
       sys.executable, GEN_WASM_PY, error_cmdline=options.error_cmdline)
 
   wasm_interp = utils.Executable(find_exe.GetWasmInterpExecutable(
-      options.wasm_interp_executable),
+      options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_interp.AppendOptionalArgs({
     '--run-all-exports': options.run_all_exports,

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -36,8 +36,9 @@ def main(args):
                       action='store_true')
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wasm2wast', metavar='PATH',
-                      help='set the wasm2wast executable to use.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
@@ -54,7 +55,7 @@ def main(args):
       sys.executable, GEN_WASM_PY, error_cmdline=options.error_cmdline)
 
   wasm2wast = utils.Executable(
-      find_exe.GetWasm2WastExecutable(options.wasm2wast),
+      find_exe.GetWasm2WastExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm2wast.AppendOptionalArgs({
     '--no-debug-names': options.no_debug_names,

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -31,14 +31,11 @@ def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wast2wasm', metavar='PATH',
-                      help='override wast2wasm executable.')
-  parser.add_argument('--wasmdump', metavar='PATH',
-                      help='override wast2wasm executable.')
-  parser.add_argument('--wasm-interp', metavar='PATH',
-                      help='override wasm-interp executable.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
@@ -52,7 +49,7 @@ def main(args):
   options = parser.parse_args(args)
 
   wast2wasm = utils.Executable(
-      find_exe.GetWast2WasmExecutable(options.wast2wasm),
+      find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
     '-v': options.verbose,
@@ -61,11 +58,11 @@ def main(args):
   })
 
   wasmdump = utils.Executable(
-      find_exe.GetWasmdumpExecutable(options.wasmdump),
+      find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
 
   wasm_interp = utils.Executable(find_exe.GetWasmInterpExecutable(
-      options.wasm_interp),
+      options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_interp.AppendOptionalArgs({
     '--run-all-exports': options.run_all_exports,

--- a/test/run-opcodecnt.py
+++ b/test/run-opcodecnt.py
@@ -31,10 +31,9 @@ def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wast2wasm-executable', metavar='PATH',
-                      help='override wast2wasm executable.')
-  parser.add_argument('--wasmopcodecnt-executable', metavar='PATH',
-                      help='override wasmopcodecnt executable.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
   parser.add_argument('--no-error-cmdline',
@@ -48,7 +47,7 @@ def main(args):
   options = parser.parse_args(args)
 
   wast2wasm = utils.Executable(
-      find_exe.GetWast2WasmExecutable(options.wast2wasm_executable),
+      find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
     '-v': options.verbose,
@@ -56,7 +55,7 @@ def main(args):
   })
 
   wasmopcodecnt = utils.Executable(find_exe.GetWasmOpcodeCntExecutable(
-      options.wasmopcodecnt_executable),
+      options.bindir),
       error_cmdline=options.error_cmdline)
   wasmopcodecnt.AppendOptionalArgs({
     '--use-libc-allocator': options.use_libc_allocator

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -101,10 +101,9 @@ def main(args):
                       action='store_true')
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wast2wasm', metavar='PATH',
-                      help='set the wast2wasm executable to use.')
-  parser.add_argument('--wasm2wast', metavar='PATH',
-                      help='set the wasm2wast executable to use.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--stdout', action='store_true',
                       help='do one roundtrip and write wast output to stdout')
   parser.add_argument('--no-error-cmdline',
@@ -121,7 +120,7 @@ def main(args):
   options = parser.parse_args(args)
 
   wast2wasm = utils.Executable(
-      find_exe.GetWast2WasmExecutable(options.wast2wasm),
+      find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
     '--debug-names': options.debug_names,
@@ -130,7 +129,7 @@ def main(args):
   })
 
   wasm2wast = utils.Executable(
-      find_exe.GetWasm2WastExecutable(options.wasm2wast),
+      find_exe.GetWasm2WastExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm2wast.AppendOptionalArgs({
     '--no-debug-names': not options.debug_names,

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -59,17 +59,14 @@ TOOLS = {
   'run-wasmdump': {
     'EXE': 'test/run-wasmdump.py',
     'FLAGS': ' '.join([
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasmdump=%(wasmdump)s',
+      '--bindir=%(bindir)s',
     ]),
     'VERBOSE-FLAGS': ['-v']
   },
   'run-wasm-link': {
     'EXE': 'test/run-wasm-link.py',
     'FLAGS': ' '.join([
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasm-link=%(wasm-link)s',
-      '--wasmdump=%(wasmdump)s',
+      '--bindir=%(bindir)s',
     ]),
     'VERBOSE-FLAGS': ['-v']
   },
@@ -77,8 +74,7 @@ TOOLS = {
     'EXE': 'test/run-roundtrip.py',
     'FLAGS': ' '.join([
       '-v',
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasm2wast=%(wasm2wast)s',
+      '--bindir=%(bindir)s',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
     ]),
@@ -92,9 +88,7 @@ TOOLS = {
   'run-interp': {
     'EXE': 'test/run-interp.py',
     'FLAGS': ' '.join([
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasmdump=%(wasmdump)s',
-      '--wasm-interp=%(wasm-interp)s',
+      '--bindir=%(bindir)s',
       '--run-all-exports',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
@@ -109,9 +103,7 @@ TOOLS = {
   'run-interp-spec': {
     'EXE': 'test/run-interp.py',
     'FLAGS': ' '.join([
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasmdump=%(wasmdump)s',
-      '--wasm-interp=%(wasm-interp)s',
+      '--bindir=%(bindir)s',
       '--spec',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
@@ -126,7 +118,7 @@ TOOLS = {
   'run-gen-wasm': {
     'EXE': 'test/run-gen-wasm.py',
     'FLAGS': ' '.join([
-      '--wasm2wast=%(wasm2wast)s',
+      '--bindir=%(bindir)s',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
     ]),
@@ -140,7 +132,7 @@ TOOLS = {
   'run-gen-wasm-interp': {
     'EXE': 'test/run-gen-wasm-interp.py',
     'FLAGS': ' '.join([
-      '--wasm-interp=%(wasm-interp)s',
+      '--bindir=%(bindir)s',
       '--run-all-exports',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
@@ -155,8 +147,7 @@ TOOLS = {
   'run-opcodecnt': {
     'EXE': 'test/run-opcodecnt.py',
     'FLAGS': ' '.join([
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasmopcodecnt=%(wasmopcodecnt)s',
+      '--bindir=%(bindir)s',
       '--no-error-cmdline',
     ]),
     'VERBOSE-FLAGS': [
@@ -169,8 +160,7 @@ TOOLS = {
   'run-gen-spec-js': {
     'EXE': 'test/run-gen-spec-js.py',
     'FLAGS': ' '.join([
-      '--wast2wasm=%(wast2wasm)s',
-      '--wasm2wast=%(wasm2wast)s',
+      '--bindir=%(bindir)s',
       '--no-error-cmdline',
       '-o', '%(out_dir)s',
     ]),
@@ -290,8 +280,7 @@ class TestInfo(object):
     result.expected_stderr = ''
     result.tool = 'run-roundtrip'
     result.exe = ROUNDTRIP_PY
-    result.flags = ['--wast2wasm', '%(wast2wasm)s', '--wasm2wast',
-                    '%(wasm2wast)s', '-v']
+    result.flags = ['--bindir', '%(bindir)s', '-v']
     result.expected_error = 0
     result.slow = self.slow
     result.skip = self.skip
@@ -753,13 +742,9 @@ def main(args):
   parser.add_argument('-a', '--arg',
                       help='additional args to pass to executable',
                       action='append')
-  parser.add_argument('--exe-dir', metavar='PATH',
-                      help='directory to search for all executables. '
-                          'This can be overridden by the other executable '
-                          'flags.')
-  for exe_basename in find_exe.EXECUTABLES:
-    parser.add_argument('--%s' % exe_basename, metavar='PATH',
-                        help='override %s executable.' % exe_basename)
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
   parser.add_argument('-f', '--fail-fast',
@@ -810,15 +795,9 @@ def main(args):
 
   variables = {}
   variables['test_dir'] = os.path.abspath(TEST_DIR)
-
+  variables['bindir'] = options.bindir
   for exe_basename in find_exe.EXECUTABLES:
-    attr_name = exe_basename.replace('-', '_')
-    exe_override = getattr(options, attr_name)
-    if options.exe_dir:
-      if not exe_override:
-        exe_override = os.path.join(options.exe_dir, exe_basename)
-        setattr(options, attr_name, exe_override)
-
+    exe_override = os.path.join(options.bindir, exe_basename)
     variables[exe_basename] = find_exe.FindExecutable(exe_basename,
                                                       exe_override)
 

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -30,12 +30,9 @@ def main(args):
                       action='store_true')
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wast2wasm', metavar='PATH',
-                      help='set the wast2wasm executable to use.')
-  parser.add_argument('--wasm-link', metavar='PATH',
-                      help='set the wasm-link executable to use.')
-  parser.add_argument('--wasmdump', metavar='PATH',
-                      help='set the wasmdump executable to use.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
@@ -51,7 +48,7 @@ def main(args):
   options = parser.parse_args(args)
 
   wast2wasm = utils.Executable(
-      find_exe.GetWast2WasmExecutable(options.wast2wasm),
+      find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
     '--debug-names': options.debug_names,
@@ -60,14 +57,14 @@ def main(args):
   })
 
   wasm_link = utils.Executable(
-      find_exe.GetWasmlinkExecutable(options.wasm_link),
+      find_exe.GetWasmlinkExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_link.AppendOptionalArgs({
     '-v': options.verbose,
   })
 
   wasmdump = utils.Executable(
-      find_exe.GetWasmdumpExecutable(options.wasmdump),
+      find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasmdump.AppendOptionalArgs({
   })

--- a/test/run-wasmdump.py
+++ b/test/run-wasmdump.py
@@ -30,10 +30,9 @@ def main(args):
                       action='store_true')
   parser.add_argument('-o', '--out-dir', metavar='PATH',
                       help='output directory for files.')
-  parser.add_argument('--wast2wasm', metavar='PATH',
-                      help='set the wast2wasm executable to use.')
-  parser.add_argument('--wasmdump', metavar='PATH',
-                      help='set the wasmdump executable to use.')
+  parser.add_argument('--bindir', metavar='PATH',
+                      default=find_exe.GetDefaultPath(),
+                      help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
                           ' an error occurs', dest='error_cmdline',
@@ -52,7 +51,7 @@ def main(args):
   options = parser.parse_args(args)
 
   wast2wasm = utils.Executable(
-      find_exe.GetWast2WasmExecutable(options.wast2wasm),
+      find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
     '--debug-names': options.debug_names,
@@ -65,7 +64,7 @@ def main(args):
   })
 
   wasmdump = utils.Executable(
-      find_exe.GetWasmdumpExecutable(options.wasmdump),
+      find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasmdump.AppendOptionalArgs({
     '-h': options.headers,


### PR DESCRIPTION
This simplifies the invocations and aids maintainability.