### PR TITLE
Add support for yapf python formatting tool

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,4 @@
 [style]
 split_before_named_assigns = False
 based_on_style = chromium
+column_limit = 79

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,3 @@
+[style]
+split_before_named_assigns = False
+based_on_style = chromium

--- a/scripts/gen-emscripten-exported-json.py
+++ b/scripts/gen-emscripten-exported-json.py
@@ -78,8 +78,7 @@ def ProcessFile(nm, file_):
 def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--output', metavar='PATH', help='output file.')
-  parser.add_argument('-v', '--verbose',
-                      help='print more diagnostic messages.',
+  parser.add_argument('-v', '--verbose', help='print more diagnostic messages.',
                       action='store_true')
   parser.add_argument('--emscripten-dir', metavar='PATH',
                       help='emscripten directory',

--- a/scripts/gen-emscripten-exported-json.py
+++ b/scripts/gen-emscripten-exported-json.py
@@ -78,7 +78,8 @@ def ProcessFile(nm, file_):
 def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('-o', '--output', metavar='PATH', help='output file.')
-  parser.add_argument('-v', '--verbose', help='print more diagnostic messages.',
+  parser.add_argument('-v', '--verbose',
+                      help='print more diagnostic messages.',
                       action='store_true')
   parser.add_argument('--emscripten-dir', metavar='PATH',
                       help='emscripten directory',

--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -55,9 +55,9 @@ def FindExeWithFallback(name, default_exe_list, override_exe=None):
     if os.path.exists(result):
       return os.path.abspath(result)
 
-  raise Error('%s executable not found.\n%s\n' % (
-      name,
-      '\n'.join('search path: %s' % path for path in default_exe_list)))
+  raise Error('%s executable not found.\n%s\n' %
+              (name, '\n'.join('search path: %s' % path
+                               for path in default_exe_list)))
 
 
 def FindExecutable(basename, override=None):

--- a/test/gen-spec-js.py
+++ b/test/gen-spec-js.py
@@ -199,8 +199,8 @@ def CollectInvalidModuleCommands(commands):
       module_name = command.get('name')
       if module_name:
         module_map[module_name] = pair
-    elif command['type'] in ('assert_return', 'assert_return_nan', 'assert_trap'
-                            ):
+    elif command['type'] in ('assert_return', 'assert_return_nan',
+                             'assert_trap'):
       if IsValidJSCommand(command):
         continue
 
@@ -447,8 +447,8 @@ def main(args):
                       help='set the directory that temporary wasm/wast'
                       ' files are written.')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd',
                       help='print the commands that are run.',

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -511,7 +511,8 @@ def Run(input_file_name):
 
 def main(args):
   arg_parser = argparse.ArgumentParser()
-  arg_parser.add_argument('-o', '--output', metavar='PATH', help='output file.')
+  arg_parser.add_argument('-o', '--output', metavar='PATH',
+                          help='output file.')
   arg_parser.add_argument('-v', '--verbose',
                           help='print more diagnotic messages.',
                           action='store_true')

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -36,240 +36,237 @@ try:
 except ImportError:
   raise Error('Unable to import ply. Did you run "git submodule update"?')
 
-
 ## ply stuff ###################################################################
 NAMED_VALUES = {
-  'i32': 0x7f, # -1
-  'i64': 0x7e, # -2
-  'f32': 0x7d, # -3
-  'f64': 0x7c, # -4
-  'anyfunc': 0x70, # -0x10
-  'function': 0x60, # -0x20
-  'void': 0x40, # -0x40
-  'magic': (0, 0x61, 0x73, 0x6d),
-  'version': (0xd, 0, 0, 0),
+    'i32': 0x7f,  # -1
+    'i64': 0x7e,  # -2
+    'f32': 0x7d,  # -3
+    'f64': 0x7c,  # -4
+    'anyfunc': 0x70,  # -0x10
+    'function': 0x60,  # -0x20
+    'void': 0x40,  # -0x40
+    'magic': (0, 0x61, 0x73, 0x6d),
+    'version': (0xd, 0, 0, 0),
 
-  # section codes
-  'USER': 0,
-  'TYPE': 1,
-  'IMPORT': 2,
-  'FUNCTION': 3,
-  'TABLE': 4,
-  'MEMORY': 5,
-  'GLOBAL': 6,
-  'EXPORT': 7,
-  'START': 8,
-  'ELEM': 9,
-  'CODE': 10,
-  'DATA': 11,
+    # section codes
+    'USER': 0,
+    'TYPE': 1,
+    'IMPORT': 2,
+    'FUNCTION': 3,
+    'TABLE': 4,
+    'MEMORY': 5,
+    'GLOBAL': 6,
+    'EXPORT': 7,
+    'START': 8,
+    'ELEM': 9,
+    'CODE': 10,
+    'DATA': 11,
 
-  # external kinds
-  'func_kind': 0,
-  'table_kind': 1,
-  'memory_kind': 2,
-  'global_kind': 3,
-
-  "unreachable": 0x00,
-  "nop": 0x01,
-  "block": 0x02,
-  "loop": 0x03,
-  "if": 0x04,
-  "else": 0x05,
-  "end": 0x0b,
-  "br": 0x0c,
-  "br_if": 0x0d,
-  "br_table": 0x0e,
-  "return": 0x0f,
-  "call": 0x10,
-  "call_indirect": 0x11,
-  "drop": 0x1a,
-  "select": 0x1b,
-  "get_local": 0x20,
-  "set_local": 0x21,
-  "tee_local": 0x22,
-  "get_global": 0x23,
-  "set_global": 0x24,
-  "i32.load": 0x28,
-  "i64.load": 0x29,
-  "f32.load": 0x2a,
-  "f64.load": 0x2b,
-  "i32.load8_s": 0x2c,
-  "i32.load8_u": 0x2d,
-  "i32.load16_s": 0x2e,
-  "i32.load16_u": 0x2f,
-  "i64.load8_s": 0x30,
-  "i64.load8_u": 0x31,
-  "i64.load16_s": 0x32,
-  "i64.load16_u": 0x33,
-  "i64.load32_s": 0x34,
-  "i64.load32_u": 0x35,
-  "i32.store": 0x36,
-  "i64.store": 0x37,
-  "f32.store": 0x38,
-  "f64.store": 0x39,
-  "i32.store8": 0x3a,
-  "i32.store16": 0x3b,
-  "i64.store8": 0x3c,
-  "i64.store16": 0x3d,
-  "i64.store32": 0x3e,
-  "current_memory": 0x3f,
-  "grow_memory": 0x40,
-  "i32.const": 0x41,
-  "i64.const": 0x42,
-  "f32.const": 0x43,
-  "f64.const": 0x44,
-  "i32.eqz": 0x45,
-  "i32.eq": 0x46,
-  "i32.ne": 0x47,
-  "i32.lt_s": 0x48,
-  "i32.lt_u": 0x49,
-  "i32.gt_s": 0x4a,
-  "i32.gt_u": 0x4b,
-  "i32.le_s": 0x4c,
-  "i32.le_u": 0x4d,
-  "i32.ge_s": 0x4e,
-  "i32.ge_u": 0x4f,
-  'i64.eqz': 0x50,
-  "i64.eq": 0x51,
-  "i64.ne": 0x52,
-  "i64.lt_s": 0x53,
-  "i64.lt_u": 0x54,
-  "i64.gt_s": 0x55,
-  "i64.gt_u": 0x56,
-  "i64.le_s": 0x57,
-  "i64.le_u": 0x58,
-  "i64.ge_s": 0x59,
-  "i64.ge_u": 0x5a,
-  "f32.eq": 0x5b,
-  "f32.ne": 0x5c,
-  "f32.lt": 0x5d,
-  "f32.gt": 0x5e,
-  "f32.le": 0x5f,
-  "f32.ge": 0x60,
-  "f64.eq": 0x61,
-  "f64.ne": 0x62,
-  "f64.lt": 0x63,
-  "f64.gt": 0x64,
-  "f64.le": 0x65,
-  "f64.ge": 0x66,
-  "i32.clz": 0x67,
-  "i32.ctz": 0x68,
-  "i32.popcnt": 0x69,
-  "i32.add": 0x6a,
-  "i32.sub": 0x6b,
-  "i32.mul": 0x6c,
-  "i32.div_s": 0x6d,
-  "i32.div_u": 0x6e,
-  "i32.rem_s": 0x6f,
-  "i32.rem_u": 0x70,
-  "i32.and": 0x71,
-  "i32.or": 0x72,
-  "i32.xor": 0x73,
-  "i32.shl": 0x74,
-  "i32.shr_s": 0x75,
-  "i32.shr_u": 0x76,
-  "i32.rotl": 0x77,
-  "i32.rotr": 0x78,
-  "i64.clz": 0x79,
-  "i64.ctz": 0x7a,
-  "i64.popcnt": 0x7b,
-  "i64.add": 0x7c,
-  "i64.sub": 0x7d,
-  "i64.mul": 0x7e,
-  "i64.div_s": 0x7f,
-  "i64.div_u": 0x80,
-  "i64.rem_s": 0x81,
-  "i64.rem_u": 0x82,
-  "i64.and": 0x83,
-  "i64.or": 0x84,
-  "i64.xor": 0x85,
-  "i64.shl": 0x86,
-  "i64.shr_s": 0x87,
-  "i64.shr_u": 0x88,
-  "i64.rotl": 0x89,
-  "i64.rotr": 0x8a,
-  "f32.abs": 0x8b,
-  "f32.neg": 0x8c,
-  "f32.copysign": 0x8d,
-  "f32.ceil": 0x8e,
-  "f32.floor": 0x8f,
-  "f32.trunc": 0x90,
-  "f32.nearest": 0x91,
-  "f32.sqrt": 0x92,
-  "f32.add": 0x93,
-  "f32.sub": 0x94,
-  "f32.mul": 0x95,
-  "f32.div": 0x96,
-  "f32.min": 0x97,
-  "f32.max": 0x98,
-  "f64.abs": 0x99,
-  "f64.neg": 0x9a,
-  "f64.copysign": 0x9b,
-  "f64.ceil": 0x9c,
-  "f64.floor": 0x9d,
-  "f64.trunc": 0x9e,
-  "f64.nearest": 0x9f,
-  "f64.sqrt": 0xa0,
-  "f64.add": 0xa1,
-  "f64.sub": 0xa2,
-  "f64.mul": 0xa3,
-  "f64.div": 0xa4,
-  "f64.min": 0xa5,
-  "f64.max": 0xa6,
-  "i32.wrap/i64": 0xa7,
-  "i32.trunc_s/f32": 0xa8,
-  "i32.trunc_u/f32": 0xa9,
-  "i32.trunc_s/f64": 0xaa,
-  "i32.trunc_u/f64": 0xab,
-  "i64.extend_s/i32": 0xac,
-  "i64.extend_u/i32": 0xad,
-  "i64.trunc_s/f32": 0xae,
-  "i64.trunc_u/f32": 0xaf,
-  "i64.trunc_s/f64": 0xb0,
-  "i64.trunc_u/f64": 0xb1,
-  "f32.convert_s/i32": 0xb2,
-  "f32.convert_u/i32": 0xb3,
-  "f32.convert_s/i64": 0xb4,
-  "f32.convert_u/i64": 0xb5,
-  "f32.demote/f64": 0xb6,
-  "f64.convert_s/i32": 0xb7,
-  "f64.convert_u/i32": 0xb8,
-  "f64.convert_s/i64": 0xb9,
-  "f64.convert_u/i64": 0xba,
-  "f64.promote/f32": 0xbb,
-  "i32.reinterpret/f32": 0xbc,
-  "i64.reinterpret/f64": 0xbd,
-  "f32.reinterpret/i32": 0xbe,
-  "f64.reinterpret/i64": 0xbf,
+    # external kinds
+    'func_kind': 0,
+    'table_kind': 1,
+    'memory_kind': 2,
+    'global_kind': 3,
+    "unreachable": 0x00,
+    "nop": 0x01,
+    "block": 0x02,
+    "loop": 0x03,
+    "if": 0x04,
+    "else": 0x05,
+    "end": 0x0b,
+    "br": 0x0c,
+    "br_if": 0x0d,
+    "br_table": 0x0e,
+    "return": 0x0f,
+    "call": 0x10,
+    "call_indirect": 0x11,
+    "drop": 0x1a,
+    "select": 0x1b,
+    "get_local": 0x20,
+    "set_local": 0x21,
+    "tee_local": 0x22,
+    "get_global": 0x23,
+    "set_global": 0x24,
+    "i32.load": 0x28,
+    "i64.load": 0x29,
+    "f32.load": 0x2a,
+    "f64.load": 0x2b,
+    "i32.load8_s": 0x2c,
+    "i32.load8_u": 0x2d,
+    "i32.load16_s": 0x2e,
+    "i32.load16_u": 0x2f,
+    "i64.load8_s": 0x30,
+    "i64.load8_u": 0x31,
+    "i64.load16_s": 0x32,
+    "i64.load16_u": 0x33,
+    "i64.load32_s": 0x34,
+    "i64.load32_u": 0x35,
+    "i32.store": 0x36,
+    "i64.store": 0x37,
+    "f32.store": 0x38,
+    "f64.store": 0x39,
+    "i32.store8": 0x3a,
+    "i32.store16": 0x3b,
+    "i64.store8": 0x3c,
+    "i64.store16": 0x3d,
+    "i64.store32": 0x3e,
+    "current_memory": 0x3f,
+    "grow_memory": 0x40,
+    "i32.const": 0x41,
+    "i64.const": 0x42,
+    "f32.const": 0x43,
+    "f64.const": 0x44,
+    "i32.eqz": 0x45,
+    "i32.eq": 0x46,
+    "i32.ne": 0x47,
+    "i32.lt_s": 0x48,
+    "i32.lt_u": 0x49,
+    "i32.gt_s": 0x4a,
+    "i32.gt_u": 0x4b,
+    "i32.le_s": 0x4c,
+    "i32.le_u": 0x4d,
+    "i32.ge_s": 0x4e,
+    "i32.ge_u": 0x4f,
+    'i64.eqz': 0x50,
+    "i64.eq": 0x51,
+    "i64.ne": 0x52,
+    "i64.lt_s": 0x53,
+    "i64.lt_u": 0x54,
+    "i64.gt_s": 0x55,
+    "i64.gt_u": 0x56,
+    "i64.le_s": 0x57,
+    "i64.le_u": 0x58,
+    "i64.ge_s": 0x59,
+    "i64.ge_u": 0x5a,
+    "f32.eq": 0x5b,
+    "f32.ne": 0x5c,
+    "f32.lt": 0x5d,
+    "f32.gt": 0x5e,
+    "f32.le": 0x5f,
+    "f32.ge": 0x60,
+    "f64.eq": 0x61,
+    "f64.ne": 0x62,
+    "f64.lt": 0x63,
+    "f64.gt": 0x64,
+    "f64.le": 0x65,
+    "f64.ge": 0x66,
+    "i32.clz": 0x67,
+    "i32.ctz": 0x68,
+    "i32.popcnt": 0x69,
+    "i32.add": 0x6a,
+    "i32.sub": 0x6b,
+    "i32.mul": 0x6c,
+    "i32.div_s": 0x6d,
+    "i32.div_u": 0x6e,
+    "i32.rem_s": 0x6f,
+    "i32.rem_u": 0x70,
+    "i32.and": 0x71,
+    "i32.or": 0x72,
+    "i32.xor": 0x73,
+    "i32.shl": 0x74,
+    "i32.shr_s": 0x75,
+    "i32.shr_u": 0x76,
+    "i32.rotl": 0x77,
+    "i32.rotr": 0x78,
+    "i64.clz": 0x79,
+    "i64.ctz": 0x7a,
+    "i64.popcnt": 0x7b,
+    "i64.add": 0x7c,
+    "i64.sub": 0x7d,
+    "i64.mul": 0x7e,
+    "i64.div_s": 0x7f,
+    "i64.div_u": 0x80,
+    "i64.rem_s": 0x81,
+    "i64.rem_u": 0x82,
+    "i64.and": 0x83,
+    "i64.or": 0x84,
+    "i64.xor": 0x85,
+    "i64.shl": 0x86,
+    "i64.shr_s": 0x87,
+    "i64.shr_u": 0x88,
+    "i64.rotl": 0x89,
+    "i64.rotr": 0x8a,
+    "f32.abs": 0x8b,
+    "f32.neg": 0x8c,
+    "f32.copysign": 0x8d,
+    "f32.ceil": 0x8e,
+    "f32.floor": 0x8f,
+    "f32.trunc": 0x90,
+    "f32.nearest": 0x91,
+    "f32.sqrt": 0x92,
+    "f32.add": 0x93,
+    "f32.sub": 0x94,
+    "f32.mul": 0x95,
+    "f32.div": 0x96,
+    "f32.min": 0x97,
+    "f32.max": 0x98,
+    "f64.abs": 0x99,
+    "f64.neg": 0x9a,
+    "f64.copysign": 0x9b,
+    "f64.ceil": 0x9c,
+    "f64.floor": 0x9d,
+    "f64.trunc": 0x9e,
+    "f64.nearest": 0x9f,
+    "f64.sqrt": 0xa0,
+    "f64.add": 0xa1,
+    "f64.sub": 0xa2,
+    "f64.mul": 0xa3,
+    "f64.div": 0xa4,
+    "f64.min": 0xa5,
+    "f64.max": 0xa6,
+    "i32.wrap/i64": 0xa7,
+    "i32.trunc_s/f32": 0xa8,
+    "i32.trunc_u/f32": 0xa9,
+    "i32.trunc_s/f64": 0xaa,
+    "i32.trunc_u/f64": 0xab,
+    "i64.extend_s/i32": 0xac,
+    "i64.extend_u/i32": 0xad,
+    "i64.trunc_s/f32": 0xae,
+    "i64.trunc_u/f32": 0xaf,
+    "i64.trunc_s/f64": 0xb0,
+    "i64.trunc_u/f64": 0xb1,
+    "f32.convert_s/i32": 0xb2,
+    "f32.convert_u/i32": 0xb3,
+    "f32.convert_s/i64": 0xb4,
+    "f32.convert_u/i64": 0xb5,
+    "f32.demote/f64": 0xb6,
+    "f64.convert_s/i32": 0xb7,
+    "f64.convert_u/i32": 0xb8,
+    "f64.convert_s/i64": 0xb9,
+    "f64.convert_u/i64": 0xba,
+    "f64.promote/f32": 0xbb,
+    "i32.reinterpret/f32": 0xbc,
+    "i64.reinterpret/f64": 0xbd,
+    "f32.reinterpret/i32": 0xbe,
+    "f64.reinterpret/i64": 0xbf,
 }
 
 keywords = {
-  'func': 'FUNC',
-  'section': 'SECTION',
-  'leb_i32': 'LEB_I32',
-  'leb_i64': 'LEB_I64',
-  'leb_u32': 'LEB_U32',
-  'f32': 'F32',
-  'f64': 'F64',
-  'str': 'STR',
+    'func': 'FUNC',
+    'section': 'SECTION',
+    'leb_i32': 'LEB_I32',
+    'leb_i64': 'LEB_I64',
+    'leb_u32': 'LEB_U32',
+    'f32': 'F32',
+    'f64': 'F64',
+    'str': 'STR',
 }
 
 ## lexer ###
 
 tokens = tuple(keywords.values()) + (
-  'BYTE',
-  'INT',
-  'FLOAT',
-  'STRING',
-  'NAME',
-  'NAMED_VALUE',
-  'LPAREN',
-  'RPAREN',
-  'LBRACE',
-  'RBRACE',
-  'LBRACKET',
-  'RBRACKET',
-)
+    'BYTE',
+    'INT',
+    'FLOAT',
+    'STRING',
+    'NAME',
+    'NAMED_VALUE',
+    'LPAREN',
+    'RPAREN',
+    'LBRACE',
+    'RBRACE',
+    'LBRACKET',
+    'RBRACKET',)
 
 t_LPAREN = r'\('
 t_RPAREN = r'\)'
@@ -277,11 +274,13 @@ t_LBRACE = r'{'
 t_RBRACE = r'}'
 t_LBRACKET = r'\['
 t_RBRACKET = r'\]'
-t_ignore  = ' \t'
+t_ignore = ' \t'
+
 
 def t_COMMENT(t):
   r';;.*'
   pass
+
 
 def t_INT(t):
   r'\-?(0[xX][0-9a-fA-F]+|[0-9]+)'
@@ -294,15 +293,18 @@ def t_INT(t):
     t.type = 'BYTE'
   return t
 
+
 def t_FLOAT(t):
   r'\-?([0-9]*\.?[0-9]+|[0-9]+\.?[0-9]*)([eE][0-9]+)?'
   t.value = float(t.value)
   return t
 
+
 def t_STRING(t):
   r'\'[^\']*\'|\"[^\"]*\"'
   t.value = t.value[1:-1]
   return t
+
 
 def t_NAME(t):
   r'[a-zA-Z][a-zA-Z0-9_\.\/]*'
@@ -313,17 +315,21 @@ def t_NAME(t):
     t.type = keywords[t.value]
   return t
 
+
 def t_newline(t):
   r'\n+'
   t.lexer.lineno += len(t.value)
+
 
 def t_error(t):
   print("Illegal character '%s'" % t.value[0])
   t.lexer.skip(1)
 
+
 lexer = lex.lex()
 
 ## parser ###
+
 
 def LebLoop(data, v, cond):
   while True:
@@ -335,14 +341,17 @@ def LebLoop(data, v, cond):
     else:
       data.append(byte | 0x80)
 
+
 def WriteUnsignedLeb(data, v, max_size):
   result = []
   LebLoop(result, v, lambda v, byte: v == 0)
   assert len(result) <= max_size
   data.extend(result)
 
+
 def WriteLebU32(data, v):
   WriteUnsignedLeb(data, v, 5)
+
 
 def WriteSignedLeb(data, v, max_size):
   result = []
@@ -353,25 +362,32 @@ def WriteSignedLeb(data, v, max_size):
   assert len(result) <= max_size
   data.extend(result)
 
+
 def WriteLebI32(data, v):
   WriteSignedLeb(data, v, 5)
+
 
 def WriteLebI64(data, v):
   WriteSignedLeb(data, v, 10)
 
+
 def WriteF32(data, v):
   data.extend(ord(b) for b in struct.pack('<f', v))
+
 
 def WriteF64(data, v):
   data.extend(ord(b) for b in struct.pack('<d', v))
 
+
 def WriteString(data, s):
   data.extend(ord(c) for c in s)
+
 
 def p_data_byte(p):
   'data : data BYTE'
   p[0] = p[1]
   p[0].append(p[2])
+
 
 def p_data_name(p):
   '''data : data NAME LBRACKET data RBRACKET
@@ -379,6 +395,7 @@ def p_data_name(p):
   p[0] = p[1]
   # name is only used for documentation
   p[0].extend(p[4])
+
 
 def p_data_named_value(p):
   'data : data NAMED_VALUE'
@@ -388,6 +405,7 @@ def p_data_named_value(p):
   else:
     p[0].append(p[2])
 
+
 def p_data_section(p):
   'data : data SECTION LPAREN NAMED_VALUE RPAREN LBRACE data RBRACE'
   p[0] = p[1]
@@ -395,6 +413,7 @@ def p_data_section(p):
   p[0].append(p[4])
   WriteLebU32(p[0], len(section_data))
   p[0].extend(section_data)
+
 
 def p_data_user_section(p):
   'data : data SECTION LPAREN STRING RPAREN LBRACE data RBRACE'
@@ -409,13 +428,15 @@ def p_data_user_section(p):
   p[0].extend(section_name_data)
   p[0].extend(section_data)
 
+
 def p_data_func(p):
   'data : data FUNC LBRACE data RBRACE'
   p[0] = p[1]
   func_data = p[4]
-  func_data.append(0xb) # end opcode
+  func_data.append(0xb)  # end opcode
   WriteLebU32(p[0], len(func_data))
   p[0].extend(func_data)
+
 
 def p_data_str(p):
   'data : data STR LPAREN STRING RPAREN'
@@ -424,11 +445,13 @@ def p_data_str(p):
   WriteLebU32(p[0], len(s))
   WriteString(p[0], s)
 
+
 def p_data_leb_i32(p):
   '''data : data LEB_I32 LPAREN INT RPAREN
           | data LEB_I32 LPAREN BYTE RPAREN'''
   p[0] = p[1]
   WriteLebI32(p[0], p[4])
+
 
 def p_data_leb_i64(p):
   '''data : data LEB_I64 LPAREN INT RPAREN
@@ -436,38 +459,46 @@ def p_data_leb_i64(p):
   p[0] = p[1]
   WriteLebI64(p[0], p[4])
 
+
 def p_data_leb_u32(p):
   '''data : data LEB_U32 LPAREN INT RPAREN
           | data LEB_U32 LPAREN BYTE RPAREN'''
   p[0] = p[1]
   WriteLebU32(p[0], p[4])
 
+
 def p_data_f32(p):
   'data : data F32 LPAREN FLOAT RPAREN'
   p[0] = p[1]
   WriteF32(p[0], p[4])
+
 
 def p_data_f64(p):
   'data : data F64 LPAREN FLOAT RPAREN'
   p[0] = p[1]
   WriteF64(p[0], p[4])
 
+
 def p_data_string(p):
   'data : data STRING'
   p[0] = p[1]
   WriteString(p[0], p[2])
 
+
 def p_data_empty(p):
   'data :'
   p[0] = []
 
+
 def p_error(p):
   print('%d: syntax error, %s' % (p.lineno, p))
+
 
 parser = yacc.yacc(tabmodule='gen_wasm', debugfile='gen_wasm_debug.txt',
                    outputdir=OUT_DIR)
 
 ################################################################################
+
 
 def Run(input_file_name):
   with open(input_file_name) as input_file:
@@ -476,6 +507,7 @@ def Run(input_file_name):
   # convert to bytes
   data = bytearray(data)
   return data
+
 
 def main(args):
   arg_parser = argparse.ArgumentParser()

--- a/test/run-gen-spec-js.py
+++ b/test/run-gen-spec-js.py
@@ -35,10 +35,11 @@ def main(args):
   parser.add_argument('--bindir', metavar='PATH',
                       default=find_exe.GetDefaultPath(),
                       help='directory to search for all executables.')
-  parser.add_argument('--js-engine', metavar='PATH',
-                      help='the path to the JavaScript engine with which to run'
-                      ' the generated JavaScript. If not specified, JavaScript'
-                      ' output will be written to stdout.')
+  parser.add_argument(
+      '--js-engine', metavar='PATH',
+      help='the path to the JavaScript engine with which to run'
+      ' the generated JavaScript. If not specified, JavaScript'
+      ' output will be written to stdout.')
   parser.add_argument('--js-engine-flags', metavar='FLAGS',
                       help='additional flags for JavaScript engine.',
                       action='append', default=[])
@@ -47,8 +48,8 @@ def main(args):
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd',
                       help='print the commands that are run.',
@@ -66,15 +67,17 @@ def main(args):
         '--use-libc-allocator': options.use_libc_allocator
     })
 
-    gen_spec_js = utils.Executable(sys.executable, GEN_SPEC_JS_PY, '--temp-dir',
-                                   out_dir, error_cmdline=options.error_cmdline)
+    gen_spec_js = utils.Executable(sys.executable, GEN_SPEC_JS_PY,
+                                   '--temp-dir', out_dir,
+                                   error_cmdline=options.error_cmdline)
     gen_spec_js.AppendOptionalArgs({
         '--bindir': options.bindir,
         '--prefix': options.prefix_js,
     })
     gen_spec_js.verbose = options.print_cmd
 
-    json_file = utils.ChangeDir(utils.ChangeExt(options.file, '.json'), out_dir)
+    json_file = utils.ChangeDir(
+        utils.ChangeExt(options.file, '.json'), out_dir)
     js_file = utils.ChangeExt(json_file, '.js')
     wast2wasm.RunWithArgs(options.file, '-o', json_file)
 

--- a/test/run-gen-spec-js.py
+++ b/test/run-gen-spec-js.py
@@ -48,9 +48,10 @@ def main(args):
                       action='store_true')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
-  parser.add_argument('-p', '--print-cmd', help='print the commands that are run.',
+  parser.add_argument('-p', '--print-cmd',
+                      help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('--use-libc-allocator', action='store_true')
   parser.add_argument('file', help='wast file.')
@@ -58,22 +59,18 @@ def main(args):
 
   with utils.TempDirectory(options.out_dir, 'run-gen-spec-js-') as out_dir:
     wast2wasm = utils.Executable(
-        find_exe.GetWast2WasmExecutable(options.bindir),
-        '--spec',
-        '--no-check-assert-invalid',
-        error_cmdline=options.error_cmdline)
+        find_exe.GetWast2WasmExecutable(options.bindir), '--spec',
+        '--no-check-assert-invalid', error_cmdline=options.error_cmdline)
     wast2wasm.AppendOptionalArgs({
-      '-v': options.verbose,
-      '--use-libc-allocator': options.use_libc_allocator
+        '-v': options.verbose,
+        '--use-libc-allocator': options.use_libc_allocator
     })
 
-    gen_spec_js = utils.Executable(
-        sys.executable, GEN_SPEC_JS_PY,
-        '--temp-dir', out_dir,
-        error_cmdline=options.error_cmdline)
+    gen_spec_js = utils.Executable(sys.executable, GEN_SPEC_JS_PY, '--temp-dir',
+                                   out_dir, error_cmdline=options.error_cmdline)
     gen_spec_js.AppendOptionalArgs({
-      '--bindir': options.bindir,
-      '--prefix': options.prefix_js,
+        '--bindir': options.bindir,
+        '--prefix': options.prefix_js,
     })
     gen_spec_js.verbose = options.print_cmd
 
@@ -88,6 +85,7 @@ def main(args):
     else:
       # Write JavaScript output to stdout
       gen_spec_js.RunWithArgs(json_file)
+
 
 if __name__ == '__main__':
   try:

--- a/test/run-gen-wasm-interp.py
+++ b/test/run-gen-wasm-interp.py
@@ -38,8 +38,8 @@ def main(args):
                       default=find_exe.GetDefaultPath(),
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('--run-all-exports', action='store_true')
   parser.add_argument('--spec', action='store_true')

--- a/test/run-gen-wasm-interp.py
+++ b/test/run-gen-wasm-interp.py
@@ -39,7 +39,7 @@ def main(args):
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('--run-all-exports', action='store_true')
   parser.add_argument('--spec', action='store_true')
@@ -49,17 +49,17 @@ def main(args):
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
 
-  gen_wasm = utils.Executable(
-      sys.executable, GEN_WASM_PY, error_cmdline=options.error_cmdline)
+  gen_wasm = utils.Executable(sys.executable, GEN_WASM_PY,
+                              error_cmdline=options.error_cmdline)
 
-  wasm_interp = utils.Executable(find_exe.GetWasmInterpExecutable(
-      options.bindir),
+  wasm_interp = utils.Executable(
+      find_exe.GetWasmInterpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_interp.AppendOptionalArgs({
-    '--run-all-exports': options.run_all_exports,
-    '--spec': options.spec,
-    '--trace': options.verbose,
-    '--use-libc-allocator': options.use_libc_allocator
+      '--run-all-exports': options.run_all_exports,
+      '--spec': options.spec,
+      '--trace': options.verbose,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   gen_wasm.verbose = options.print_cmd
@@ -79,4 +79,3 @@ if __name__ == '__main__':
   except Error as e:
     sys.stderr.write(str(e) + '\n')
     sys.exit(1)
-

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -40,8 +40,8 @@ def main(args):
                       default=find_exe.GetDefaultPath(),
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd', action='store_true',
                       help='print the commands that are run.')

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -41,7 +41,7 @@ def main(args):
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd', action='store_true',
                       help='print the commands that are run.')
@@ -51,28 +51,27 @@ def main(args):
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
 
-  gen_wasm = utils.Executable(
-      sys.executable, GEN_WASM_PY, error_cmdline=options.error_cmdline)
+  gen_wasm = utils.Executable(sys.executable, GEN_WASM_PY,
+                              error_cmdline=options.error_cmdline)
 
   wasm2wast = utils.Executable(
       find_exe.GetWasm2WastExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm2wast.AppendOptionalArgs({
-    '--no-debug-names': options.no_debug_names,
-    '--generate-names': options.generate_names,
-    '--use-libc-allocator': options.use_libc_allocator
+      '--no-debug-names': options.no_debug_names,
+      '--generate-names': options.generate_names,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   gen_wasm.verbose = options.print_cmd
   wasm2wast.verbose = options.print_cmd
-  wasm2wast.AppendOptionalArgs({
-    '--verbose': options.verbose,
-  })
+  wasm2wast.AppendOptionalArgs({'--verbose': options.verbose,})
 
   with utils.TempDirectory(options.out_dir, 'run-gen-wasm-') as out_dir:
     out_file = utils.ChangeDir(utils.ChangeExt(options.file, '.wasm'), out_dir)
     gen_wasm.RunWithArgs(options.file, '-o', out_file)
     wasm2wast.RunWithArgs(out_file)
+
 
 if __name__ == '__main__':
   try:

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -38,9 +38,10 @@ def main(args):
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
-  parser.add_argument('-p', '--print-cmd', help='print the commands that are run.',
+  parser.add_argument('-p', '--print-cmd',
+                      help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('--run-all-exports', action='store_true')
   parser.add_argument('--spec', action='store_true')
@@ -52,23 +53,23 @@ def main(args):
       find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
-    '-v': options.verbose,
-    '--spec': options.spec,
-    '--use-libc-allocator': options.use_libc_allocator
+      '-v': options.verbose,
+      '--spec': options.spec,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   wasmdump = utils.Executable(
       find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
 
-  wasm_interp = utils.Executable(find_exe.GetWasmInterpExecutable(
-      options.bindir),
+  wasm_interp = utils.Executable(
+      find_exe.GetWasmInterpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_interp.AppendOptionalArgs({
-    '--run-all-exports': options.run_all_exports,
-    '--spec': options.spec,
-    '--trace': options.verbose,
-    '--use-libc-allocator': options.use_libc_allocator
+      '--run-all-exports': options.run_all_exports,
+      '--spec': options.spec,
+      '--trace': options.verbose,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   wast2wasm.verbose = options.print_cmd
@@ -96,4 +97,3 @@ if __name__ == '__main__':
   except Error as e:
     sys.stderr.write(str(e) + '\n')
     sys.exit(1)
-

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -37,8 +37,8 @@ def main(args):
                       default=find_exe.GetDefaultPath(),
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd',
                       help='print the commands that are run.',

--- a/test/run-opcodecnt.py
+++ b/test/run-opcodecnt.py
@@ -38,7 +38,7 @@ def main(args):
                       action='store_true')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('--print-cmd', help='print the commands that are run.',
                       action='store_true')
@@ -50,15 +50,15 @@ def main(args):
       find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
-    '-v': options.verbose,
-    '--use-libc-allocator': options.use_libc_allocator
+      '-v': options.verbose,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
-  wasmopcodecnt = utils.Executable(find_exe.GetWasmOpcodeCntExecutable(
-      options.bindir),
+  wasmopcodecnt = utils.Executable(
+      find_exe.GetWasmOpcodeCntExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasmopcodecnt.AppendOptionalArgs({
-    '--use-libc-allocator': options.use_libc_allocator
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   wast2wasm.verbose = options.print_cmd
@@ -78,5 +78,3 @@ if __name__ == '__main__':
   except Error as e:
     sys.stderr.write(str(e) + '\n')
     sys.exit(1)
-
-

--- a/test/run-opcodecnt.py
+++ b/test/run-opcodecnt.py
@@ -37,8 +37,8 @@ def main(args):
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('--print-cmd', help='print the commands that are run.',
                       action='store_true')

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -106,8 +106,8 @@ def main(args):
   parser.add_argument('--stdout', action='store_true',
                       help='do one roundtrip and write wast output to stdout')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd',
                       help='print the commands that are run.',

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -48,8 +48,8 @@ def FilesAreEqual(filename1, filename2, verbose=False):
       hexdump1 = utils.Hexdump(data1)
       hexdump2 = utils.Hexdump(data2)
       diff_lines = []
-      for line in (difflib.unified_diff(
-          hexdump1, hexdump2, fromfile=filename1, tofile=filename2)):
+      for line in (difflib.unified_diff(hexdump1, hexdump2, fromfile=filename1,
+                                        tofile=filename2)):
         diff_lines.append(line)
       msg += ''.join(diff_lines)
     msg += '\n'
@@ -77,8 +77,7 @@ def TwoRoundtrips(wast2wasm, wasm2wast, out_dir, filename, verbose):
   return FilesAreEqual(wasm1_file, wasm3_file, verbose)
 
 
-def OneRoundtripToStdout(wast2wasm, wasm2wast, out_dir, filename,
-                         verbose):
+def OneRoundtripToStdout(wast2wasm, wasm2wast, out_dir, filename, verbose):
   basename = os.path.basename(filename)
   basename_noext = os.path.splitext(basename)[0]
   wasm_file = os.path.join(out_dir, basename_noext + '.wasm')
@@ -108,9 +107,10 @@ def main(args):
                       help='do one roundtrip and write wast output to stdout')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
-  parser.add_argument('-p', '--print-cmd', help='print the commands that are run.',
+  parser.add_argument('-p', '--print-cmd',
+                      help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('--use-libc-allocator', action='store_true')
   parser.add_argument('--no-check', action='store_true')
@@ -123,18 +123,18 @@ def main(args):
       find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
-    '--debug-names': options.debug_names,
-    '--no-check': options.no_check,
-    '--use-libc-allocator': options.use_libc_allocator
+      '--debug-names': options.debug_names,
+      '--no-check': options.no_check,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   wasm2wast = utils.Executable(
       find_exe.GetWasm2WastExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm2wast.AppendOptionalArgs({
-    '--no-debug-names': not options.debug_names,
-    '--generate-names': options.generate_names,
-    '--use-libc-allocator': options.use_libc_allocator
+      '--no-debug-names': not options.debug_names,
+      '--generate-names': options.generate_names,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   wast2wasm.verbose = options.print_cmd
@@ -150,8 +150,8 @@ def main(args):
       result, msg = OneRoundtripToStdout(wast2wasm, wasm2wast, out_dir,
                                          filename, options.verbose)
     else:
-      result, msg = TwoRoundtrips(wast2wasm, wasm2wast, out_dir,
-                                  filename, options.verbose)
+      result, msg = TwoRoundtrips(wast2wasm, wasm2wast, out_dir, filename,
+                                  options.verbose)
     if result == ERROR:
       sys.stderr.write(msg)
     return result

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -207,9 +207,9 @@ def RunCommandWithTimeout(command, cwd, timeout, console_out=False):
 
     # http://stackoverflow.com/a/10012262: subprocess with a timeout
     # http://stackoverflow.com/a/22582602: kill subprocess and children
-    process = subprocess.Popen(command, cwd=cwd, stdout=None if console_out else
-                               subprocess.PIPE, stderr=None if console_out else
-                               subprocess.PIPE, universal_newlines=True,
+    process = subprocess.Popen(command, cwd=cwd, stdout=None if console_out
+                               else subprocess.PIPE, stderr=None if console_out
+                               else subprocess.PIPE, universal_newlines=True,
                                **kwargs)
     timer = threading.Timer(timeout, KillProcess)
     try:
@@ -503,8 +503,8 @@ class Status(object):
       percent = 100 * (self.passed + self.failed) / (self.total - self.skipped)
     else:
       percent = 100
-    status = '[+%d|-%d|%%%d] (%.2fs) %s\r' % (self.passed, self.failed, percent,
-                                              total_duration, name)
+    status = '[+%d|-%d|%%%d] (%.2fs) %s\r' % (self.passed, self.failed,
+                                              percent, total_duration, name)
     self.last_length = len(status)
     self.last_finished = info
     sys.stderr.write(status)
@@ -735,8 +735,9 @@ def main(args):
   parser.add_argument('-r', '--rebase',
                       help='rebase a test to its current output.',
                       action='store_true')
-  parser.add_argument('-j', '--jobs', help='number of jobs to use to run tests',
-                      type=int, default=GetDefaultJobCount())
+  parser.add_argument('-j', '--jobs',
+                      help='number of jobs to use to run tests', type=int,
+                      default=GetDefaultJobCount())
   parser.add_argument('-t', '--timeout', type=float, default=DEFAULT_TIMEOUT,
                       help='per test timeout in seconds')
   parser.add_argument('--no-roundtrip',

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -37,155 +37,132 @@ import time
 import find_exe
 from utils import Error
 
-
 IS_WINDOWS = sys.platform == 'win32'
 TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT_DIR = os.path.dirname(TEST_DIR)
 OUT_DIR = os.path.join(REPO_ROOT_DIR, 'out')
 ROUNDTRIP_PY = os.path.join(TEST_DIR, 'run-roundtrip.py')
-DEFAULT_TIMEOUT = 10 # seconds
+DEFAULT_TIMEOUT = 10  # seconds
 SLOW_TIMEOUT_MULTIPLIER = 2
-
 
 # default configurations for tests
 TOOLS = {
-  'wast2wasm': {
-    'EXE': '%(wast2wasm)s',
-    'VERBOSE-FLAGS': ['-v']
-  },
-  'wast-desugar': {
-    'EXE': '%(wast-desugar)s'
-  },
-  'run-wasmdump': {
-    'EXE': 'test/run-wasmdump.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-    ]),
-    'VERBOSE-FLAGS': ['-v']
-  },
-  'run-wasm-link': {
-    'EXE': 'test/run-wasm-link.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-    ]),
-    'VERBOSE-FLAGS': ['-v']
-  },
-  'run-roundtrip': {
-    'EXE': 'test/run-roundtrip.py',
-    'FLAGS': ' '.join([
-      '-v',
-      '--bindir=%(bindir)s',
-      '--no-error-cmdline',
-      '-o', '%(out_dir)s',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
-  'run-interp': {
-    'EXE': 'test/run-interp.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-      '--run-all-exports',
-      '--no-error-cmdline',
-      '-o', '%(out_dir)s',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
-  'run-interp-spec': {
-    'EXE': 'test/run-interp.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-      '--spec',
-      '--no-error-cmdline',
-      '-o', '%(out_dir)s',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
-  'run-gen-wasm': {
-    'EXE': 'test/run-gen-wasm.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-      '--no-error-cmdline',
-      '-o', '%(out_dir)s',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
-  'run-gen-wasm-interp': {
-    'EXE': 'test/run-gen-wasm-interp.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-      '--run-all-exports',
-      '--no-error-cmdline',
-      '-o', '%(out_dir)s',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
-  'run-opcodecnt': {
-    'EXE': 'test/run-opcodecnt.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-      '--no-error-cmdline',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
-  'run-gen-spec-js': {
-    'EXE': 'test/run-gen-spec-js.py',
-    'FLAGS': ' '.join([
-      '--bindir=%(bindir)s',
-      '--no-error-cmdline',
-      '-o', '%(out_dir)s',
-    ]),
-    'VERBOSE-FLAGS': [
-      ' '.join([
-        '--print-cmd',
-      ]),
-      '-v'
-    ]
-  },
+    'wast2wasm': {
+        'EXE': '%(wast2wasm)s',
+        'VERBOSE-FLAGS': ['-v']
+    },
+    'wast-desugar': {
+        'EXE': '%(wast-desugar)s'
+    },
+    'run-wasmdump': {
+        'EXE': 'test/run-wasmdump.py',
+        'FLAGS': ' '.join(['--bindir=%(bindir)s',]),
+        'VERBOSE-FLAGS': ['-v']
+    },
+    'run-wasm-link': {
+        'EXE': 'test/run-wasm-link.py',
+        'FLAGS': ' '.join(['--bindir=%(bindir)s',]),
+        'VERBOSE-FLAGS': ['-v']
+    },
+    'run-roundtrip': {
+        'EXE':
+            'test/run-roundtrip.py',
+        'FLAGS':
+            ' '.join([
+                '-v',
+                '--bindir=%(bindir)s',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+            ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
+    'run-interp': {
+        'EXE':
+            'test/run-interp.py',
+        'FLAGS':
+            ' '.join([
+                '--bindir=%(bindir)s',
+                '--run-all-exports',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+            ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
+    'run-interp-spec': {
+        'EXE':
+            'test/run-interp.py',
+        'FLAGS':
+            ' '.join([
+                '--bindir=%(bindir)s',
+                '--spec',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+            ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
+    'run-gen-wasm': {
+        'EXE':
+            'test/run-gen-wasm.py',
+        'FLAGS':
+            ' '.join([
+                '--bindir=%(bindir)s',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+            ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
+    'run-gen-wasm-interp': {
+        'EXE':
+            'test/run-gen-wasm-interp.py',
+        'FLAGS':
+            ' '.join([
+                '--bindir=%(bindir)s',
+                '--run-all-exports',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+            ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
+    'run-opcodecnt': {
+        'EXE': 'test/run-opcodecnt.py',
+        'FLAGS': ' '.join([
+            '--bindir=%(bindir)s',
+            '--no-error-cmdline',
+        ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
+    'run-gen-spec-js': {
+        'EXE':
+            'test/run-gen-spec-js.py',
+        'FLAGS':
+            ' '.join([
+                '--bindir=%(bindir)s',
+                '--no-error-cmdline',
+                '-o',
+                '%(out_dir)s',
+            ]),
+        'VERBOSE-FLAGS': [' '.join(['--print-cmd',]), '-v']
+    },
 }
 
 ROUNDTRIP_TOOLS = ('wast2wasm',)
 
 
 def Indent(s, spaces):
-  return ''.join(' '*spaces + l for l in s.splitlines(1))
+  return ''.join(' ' * spaces + l for l in s.splitlines(1))
 
 
 def DiffLines(expected, actual):
   expected_lines = [line for line in expected.splitlines() if line]
   actual_lines = [line for line in actual.splitlines() if line]
-  return list(difflib.unified_diff(expected_lines, actual_lines,
-                                   fromfile='expected', tofile='actual',
-                                   lineterm=''))
+  return list(
+      difflib.unified_diff(expected_lines, actual_lines, fromfile='expected',
+                           tofile='actual', lineterm=''))
 
 
 def AppendBeforeExt(file_path, suffix):
@@ -194,6 +171,7 @@ def AppendBeforeExt(file_path, suffix):
 
 
 class Cell(object):
+
   def __init__(self, value):
     self.value = [value]
 
@@ -207,6 +185,7 @@ class Cell(object):
 def RunCommandWithTimeout(command, cwd, timeout, console_out=False):
   process = None
   is_timeout = Cell(False)
+
   def KillProcess(timeout=True):
     if process:
       try:
@@ -228,11 +207,9 @@ def RunCommandWithTimeout(command, cwd, timeout, console_out=False):
 
     # http://stackoverflow.com/a/10012262: subprocess with a timeout
     # http://stackoverflow.com/a/22582602: kill subprocess and children
-    process = subprocess.Popen(command,
-                               cwd=cwd,
-                               stdout=None if console_out else subprocess.PIPE,
-                               stderr=None if console_out else subprocess.PIPE,
-                               universal_newlines=True,
+    process = subprocess.Popen(command, cwd=cwd, stdout=None if console_out else
+                               subprocess.PIPE, stderr=None if console_out else
+                               subprocess.PIPE, universal_newlines=True,
                                **kwargs)
     timer = threading.Timer(timeout, KillProcess)
     try:
@@ -254,6 +231,7 @@ def RunCommandWithTimeout(command, cwd, timeout, console_out=False):
 
 
 class TestInfo(object):
+
   def __init__(self):
     self.filename = ''
     self.header = []
@@ -372,8 +350,8 @@ class TestInfo(object):
               self.ParseDirective(key, value)
             elif state in ('stdout', 'stderr'):
               if not re.match(r'%s ;;\)$' % state.upper(), directive):
-                raise Error('Bad directive in %s block: %s' % (
-                    state, directive))
+                raise Error('Bad directive in %s block: %s' % (state,
+                                                               directive))
               state = 'none'
             else:
               raise Error('Unexpected directive: %s' % directive)
@@ -474,6 +452,7 @@ class TestInfo(object):
 
 
 class Status(object):
+
   def __init__(self, verbose):
     self.verbose = verbose
     self.start_time = None
@@ -524,8 +503,8 @@ class Status(object):
       percent = 100 * (self.passed + self.failed) / (self.total - self.skipped)
     else:
       percent = 100
-    status = '[+%d|-%d|%%%d] (%.2fs) %s\r' % (self.passed, self.failed,
-                                              percent, total_duration, name)
+    status = '[+%d|-%d|%%%d] (%.2fs) %s\r' % (self.passed, self.failed, percent,
+                                              total_duration, name)
     self.last_length = len(status)
     self.last_finished = info
     sys.stderr.write(status)
@@ -558,7 +537,7 @@ def GetAllTestInfo(test_names, status):
   return infos
 
 
-def RunTest(info, options, variables, verbose_level = 0):
+def RunTest(info, options, variables, verbose_level=0):
   timeout = options.timeout
   if info.slow:
     timeout *= SLOW_TIMEOUT_MULTIPLIER
@@ -640,8 +619,7 @@ def YesNoPrompt(question, default='yes'):
 
   The "answer" return value is True for "yes" or False for "no".
   """
-  valid = {'yes': True, 'y': True, 'ye': True,
-           'no': False, 'n': False}
+  valid = {'yes': True, 'y': True, 'ye': True, 'no': False, 'n': False}
   if default is None:
     prompt = ' [y/n] '
   elif default == 'yes':
@@ -747,14 +725,11 @@ def main(args):
                       help='directory to search for all executables.')
   parser.add_argument('-v', '--verbose', help='print more diagnotic messages.',
                       action='store_true')
-  parser.add_argument('-f', '--fail-fast',
-                      help='Exit on first failure. '
-                           'Extra options with \'--jobs 1\'',
-                      action='store_true')
+  parser.add_argument('-f', '--fail-fast', help='Exit on first failure. '
+                      'Extra options with \'--jobs 1\'', action='store_true')
   parser.add_argument('--stop-interactive',
                       help='Enter interactive mode on errors. '
-                           'Extra options with \'--jobs 1\'',
-                      action='store_true')
+                      'Extra options with \'--jobs 1\'', action='store_true')
   parser.add_argument('-l', '--list', help='list all tests.',
                       action='store_true')
   parser.add_argument('-r', '--rebase',
@@ -778,8 +753,8 @@ def main(args):
       parser.error('--stop-interactive only works with -j1')
 
   if options.patterns:
-    pattern_re = '|'.join(fnmatch.translate('*%s*' % p)
-                          for p in options.patterns)
+    pattern_re = '|'.join(
+        fnmatch.translate('*%s*' % p) for p in options.patterns)
   else:
     pattern_re = '.*'
 

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -34,8 +34,8 @@ def main(args):
                       default=find_exe.GetDefaultPath(),
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd',
                       help='print the commands that are run.',

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -35,12 +35,13 @@ def main(args):
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
-  parser.add_argument('-p', '--print-cmd', help='print the commands that are run.',
+  parser.add_argument('-p', '--print-cmd',
+                      help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('--incremental', help='incremenatly link one object at' +
-                          ' a time to produce the final linked binary.',
+                      ' a time to produce the final linked binary.',
                       action='store_true')
   parser.add_argument('--debug-names', action='store_true')
   parser.add_argument('--use-libc-allocator', action='store_true')
@@ -51,23 +52,20 @@ def main(args):
       find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
-    '--debug-names': options.debug_names,
-    '--use-libc-allocator': options.use_libc_allocator,
-    '-v': options.verbose,
+      '--debug-names': options.debug_names,
+      '--use-libc-allocator': options.use_libc_allocator,
+      '-v': options.verbose,
   })
 
   wasm_link = utils.Executable(
       find_exe.GetWasmlinkExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
-  wasm_link.AppendOptionalArgs({
-    '-v': options.verbose,
-  })
+  wasm_link.AppendOptionalArgs({'-v': options.verbose,})
 
   wasmdump = utils.Executable(
       find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
-  wasmdump.AppendOptionalArgs({
-  })
+  wasmdump.AppendOptionalArgs({})
 
   wast2wasm.verbose = options.print_cmd
   wasm_link.verbose = options.print_cmd

--- a/test/run-wasmdump.py
+++ b/test/run-wasmdump.py
@@ -34,8 +34,8 @@ def main(args):
                       default=find_exe.GetDefaultPath(),
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
-                      help='don\'t display the subprocess\'s commandline when' +
-                      ' an error occurs', dest='error_cmdline',
+                      help='don\'t display the subprocess\'s commandline when'
+                      + ' an error occurs', dest='error_cmdline',
                       action='store_false')
   parser.add_argument('-p', '--print-cmd',
                       help='print the commands that are run.',

--- a/test/run-wasmdump.py
+++ b/test/run-wasmdump.py
@@ -35,9 +35,10 @@ def main(args):
                       help='directory to search for all executables.')
   parser.add_argument('--no-error-cmdline',
                       help='don\'t display the subprocess\'s commandline when' +
-                          ' an error occurs', dest='error_cmdline',
+                      ' an error occurs', dest='error_cmdline',
                       action='store_false')
-  parser.add_argument('-p', '--print-cmd', help='print the commands that are run.',
+  parser.add_argument('-p', '--print-cmd',
+                      help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('--headers', action='store_true')
   parser.add_argument('--no-check', action='store_true')
@@ -54,21 +55,21 @@ def main(args):
       find_exe.GetWast2WasmExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
-    '--debug-names': options.debug_names,
-    '--no-check': options.no_check,
-    '--no-canonicalize-leb128s': options.no_canonicalize_leb128s,
-    '--spec': options.spec,
-    '-v': options.verbose,
-    '-c': options.compile_only,
-    '--use-libc-allocator': options.use_libc_allocator
+      '--debug-names': options.debug_names,
+      '--no-check': options.no_check,
+      '--no-canonicalize-leb128s': options.no_canonicalize_leb128s,
+      '--spec': options.spec,
+      '-v': options.verbose,
+      '-c': options.compile_only,
+      '--use-libc-allocator': options.use_libc_allocator
   })
 
   wasmdump = utils.Executable(
       find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasmdump.AppendOptionalArgs({
-    '-h': options.headers,
-    '-v': options.dump_verbose,
+      '-h': options.headers,
+      '-v': options.dump_verbose,
   })
 
   wast2wasm.verbose = options.print_cmd

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -52,8 +52,9 @@ def main(args):
     os.remove(test_filename)
 
   for added_test_name in testsuite_tests - spec_tests:
-    wast_filename = os.path.join(os.path.relpath(TESTSUITE_DIR, REPO_ROOT_DIR),
-                                 added_test_name + '.wast')
+    wast_filename = os.path.join(
+        os.path.relpath(TESTSUITE_DIR, REPO_ROOT_DIR),
+        added_test_name + '.wast')
     test_filename = os.path.join(SPEC_TEST_DIR, added_test_name + '.txt')
     if options.verbose:
       print('Adding %s' % test_filename)
@@ -64,6 +65,7 @@ def main(args):
       f.write(';;; STDIN_FILE: %s\n' % wast_filename)
 
   return 0
+
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv[1:]))

--- a/test/utils.py
+++ b/test/utils.py
@@ -28,13 +28,15 @@ import tempfile
 # Get signal names from numbers in Python
 # http://stackoverflow.com/a/2549950
 SIGNAMES = dict((k, v) for v, k in reversed(sorted(signal.__dict__.items()))
-                       if v.startswith('SIG') and not v.startswith('SIG_'))
+                if v.startswith('SIG') and not v.startswith('SIG_'))
+
 
 class Error(Exception):
   pass
 
 
 class Executable(object):
+
   def __init__(self, exe, *before_args, **kwargs):
     self.exe = exe
     self.before_args = list(before_args)
@@ -61,8 +63,7 @@ class Executable(object):
     error = None
     try:
       process = subprocess.Popen(cmd, stdout=subprocess.PIPE,
-                                      stderr=subprocess.PIPE,
-                                 **kwargs)
+                                 stderr=subprocess.PIPE, **kwargs)
       stdout, stderr = process.communicate()
       stdout = stdout.decode('ascii')
       stderr = stderr.decode('ascii')
@@ -73,8 +74,8 @@ class Executable(object):
       if process.returncode < 0:
         # Terminated by signal
         signame = SIGNAMES.get(-process.returncode, '<unknown>')
-        error = Error('Signal raised running "%s": %s\n%s' % (
-                      err_cmd_str, signame, stderr))
+        error = Error('Signal raised running "%s": %s\n%s' % (err_cmd_str,
+                                                              signame, stderr))
       elif process.returncode > 0:
         error = Error('Error running "%s":\n%s' % (err_cmd_str, stderr))
     except OSError as e:
@@ -142,7 +143,7 @@ def Hexdump(data):
   lines = []
   while p < end:
     line_start = p
-    line_end = p +  DUMP_OCTETS_PER_LINE
+    line_end = p + DUMP_OCTETS_PER_LINE
     line = '%07x: ' % p
     while p < line_end:
       for i in xrange(DUMP_OCTETS_PER_GROUP):


### PR DESCRIPTION
This changs adds .style.yapf to define the python style
we are using.

I also ran yapf over all the python files:
 $ yapf -i `git ls-files *.py`

Going forward, we should probably add a travis test to
prevent regressions.  We should probably also switch to
more conventional 4-space indentation, which is used by
almost everybody outside of Google.