### PR TITLE
Allow more names than function in binary-reader

### DIFF
--- a/src/binary-reader.c
+++ b/src/binary-reader.c
@@ -1653,8 +1653,6 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
     CALLBACK_SECTION(begin_names_section, section_size);
     uint32_t i, num_functions;
     in_u32_leb128(ctx, &num_functions, "function name count");
-    RAISE_ERROR_UNLESS(num_functions <= num_total_funcs(ctx),
-                       "function name count > function signature count");
     CALLBACK(on_function_names_count, num_functions);
     for (i = 0; i < num_functions; ++i) {
       WasmStringSlice function_name;

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -12,6 +12,7 @@ section("name") {
 }
 (;; STDERR ;;;
 Error running "wasm2wast":
-error: @0x00000021: function name count > function signature count
+error: expected function name count (2) <= function count (1)
+error: @0x00000021: on_function_names_count callback failed
 
 ;;; STDERR ;;)


### PR DESCRIPTION
ast-binary-reader will still fail if there are too
many names but the binary-reader itself will allow this
since the spec allows it.