### PR TITLE
Pass import_index to binary reader import callbacks

### DIFF
--- a/src/binary-reader-ast.c
+++ b/src/binary-reader-ast.c
@@ -208,13 +208,14 @@ static WasmResult on_import(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_func(uint32_t index,
+static WasmResult on_import_func(uint32_t import_index,
+                                 uint32_t func_index,
                                  uint32_t sig_index,
                                  void* user_data) {
   Context* ctx = user_data;
-  assert(index == ctx->module->imports.size - 1);
+  assert(import_index == ctx->module->imports.size - 1);
   assert(sig_index < ctx->module->func_types.size);
-  WasmImport* import = ctx->module->imports.data[index];
+  WasmImport* import = ctx->module->imports.data[import_index];
 
   import->kind = WASM_EXTERNAL_KIND_FUNC;
   import->func.decl.flags = WASM_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE |
@@ -229,13 +230,14 @@ static WasmResult on_import_func(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_table(uint32_t index,
+static WasmResult on_import_table(uint32_t import_index,
+                                  uint32_t table_index,
                                   WasmType elem_type,
                                   const WasmLimits* elem_limits,
                                   void* user_data) {
   Context* ctx = user_data;
-  assert(index == ctx->module->imports.size - 1);
-  WasmImport* import = ctx->module->imports.data[index];
+  assert(import_index == ctx->module->imports.size - 1);
+  WasmImport* import = ctx->module->imports.data[import_index];
   import->kind = WASM_EXTERNAL_KIND_TABLE;
   import->table.elem_limits = *elem_limits;
 
@@ -245,12 +247,13 @@ static WasmResult on_import_table(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_memory(uint32_t index,
+static WasmResult on_import_memory(uint32_t import_index,
+                                   uint32_t memory_index,
                                    const WasmLimits* page_limits,
                                    void* user_data) {
   Context* ctx = user_data;
-  assert(index == ctx->module->imports.size - 1);
-  WasmImport* import = ctx->module->imports.data[index];
+  assert(import_index == ctx->module->imports.size - 1);
+  WasmImport* import = ctx->module->imports.data[import_index];
   import->kind = WASM_EXTERNAL_KIND_MEMORY;
   import->memory.page_limits = *page_limits;
 
@@ -261,13 +264,14 @@ static WasmResult on_import_memory(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_global(uint32_t index,
+static WasmResult on_import_global(uint32_t import_index,
+                                   uint32_t global_index,
                                    WasmType type,
                                    WasmBool mutable_,
                                    void* user_data) {
   Context* ctx = user_data;
-  assert(index == ctx->module->imports.size - 1);
-  WasmImport* import = ctx->module->imports.data[index];
+  assert(import_index == ctx->module->imports.size - 1);
+  WasmImport* import = ctx->module->imports.data[import_index];
   import->kind = WASM_EXTERNAL_KIND_GLOBAL;
   import->global.type = type;
   import->global.mutable_ = mutable_;

--- a/src/binary-reader-objdump.c
+++ b/src/binary-reader-objdump.c
@@ -393,19 +393,21 @@ static WasmResult on_import(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_func(uint32_t index,
+static WasmResult on_import_func(uint32_t import_index,
+                                 uint32_t func_index,
                                  uint32_t sig_index,
                                  void* user_data) {
   Context* ctx = user_data;
   print_details(user_data,
                 " - func[%d] sig=%d <- " PRIstringslice "." PRIstringslice "\n",
-                index, sig_index,
+                func_index, sig_index,
                 WASM_PRINTF_STRING_SLICE_ARG(ctx->import_module_name),
                 WASM_PRINTF_STRING_SLICE_ARG(ctx->import_field_name));
   return WASM_OK;
 }
 
-static WasmResult on_import_table(uint32_t index,
+static WasmResult on_import_table(uint32_t import_index,
+                                  uint32_t table_index,
                                   WasmType elem_type,
                                   const WasmLimits* elem_limits,
                                   void* user_data) {
@@ -419,7 +421,8 @@ static WasmResult on_import_table(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_memory(uint32_t index,
+static WasmResult on_import_memory(uint32_t import_index,
+                                   uint32_t memory_index,
                                    const WasmLimits* page_limits,
                                    void* user_data) {
   Context* ctx = user_data;
@@ -430,14 +433,15 @@ static WasmResult on_import_memory(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_global(uint32_t index,
+static WasmResult on_import_global(uint32_t import_index,
+                                   uint32_t global_index,
                                    WasmType type,
                                    WasmBool mutable_,
                                    void* user_data) {
   Context* ctx = user_data;
   print_details(user_data, " - global[%d] %s mutable=%d <- " PRIstringslice
                            "." PRIstringslice "\n",
-                index, wasm_get_type_name(type), mutable_,
+                global_index, wasm_get_type_name(type), mutable_,
                 WASM_PRINTF_STRING_SLICE_ARG(ctx->import_module_name),
                 WASM_PRINTF_STRING_SLICE_ARG(ctx->import_field_name));
   return WASM_OK;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -80,17 +80,21 @@ typedef struct WasmBinaryReader {
                           WasmStringSlice module_name,
                           WasmStringSlice field_name,
                           void* user_data);
-  WasmResult (*on_import_func)(uint32_t index,
+  WasmResult (*on_import_func)(uint32_t import_index,
+                               uint32_t func_index,
                                uint32_t sig_index,
                                void* user_data);
-  WasmResult (*on_import_table)(uint32_t index,
+  WasmResult (*on_import_table)(uint32_t import_index,
+                                uint32_t table_index,
                                 WasmType elem_type,
                                 const WasmLimits* elem_limits,
                                 void* user_data);
-  WasmResult (*on_import_memory)(uint32_t index,
+  WasmResult (*on_import_memory)(uint32_t import_index,
+                                 uint32_t memory_index,
                                  const WasmLimits* page_limits,
                                  void* user_data);
-  WasmResult (*on_import_global)(uint32_t index,
+  WasmResult (*on_import_global)(uint32_t import_index,
+                                 uint32_t global_index,
                                  WasmType type,
                                  WasmBool mutable_,
                                  void* user_data);

--- a/src/tools/wasm-link.c
+++ b/src/tools/wasm-link.c
@@ -219,7 +219,8 @@ static WasmResult on_reloc(WasmRelocType type,
   return WASM_OK;
 }
 
-static WasmResult on_import_func(uint32_t index,
+static WasmResult on_import_func(uint32_t import_index,
+                                 uint32_t func_index,
                                  uint32_t sig_index,
                                  void* user_data) {
   InputBinary* binary = user_data;
@@ -227,7 +228,8 @@ static WasmResult on_import_func(uint32_t index,
   return WASM_OK;
 }
 
-static WasmResult on_import_global(uint32_t index,
+static WasmResult on_import_global(uint32_t import_index,
+                                   uint32_t global_index,
                                    WasmType type,
                                    WasmBool mutable,
                                    void* user_data) {


### PR DESCRIPTION
It was being passed before as "index", which is confusing because the
other callbacks have recently been changed to pass the
func/global/memory/table index instead.