### PR TITLE
Improve wasmdump command line options

### DIFF
--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -33,7 +33,7 @@ typedef enum WasmObjdumpMode {
 
 typedef struct WasmObjdumpOptions {
   WasmBool headers;
-  WasmBool verbose;
+  WasmBool details;
   WasmBool raw;
   WasmBool disassemble;
   WasmBool debug;

--- a/src/tools/wasmdump.c
+++ b/src/tools/wasmdump.c
@@ -127,6 +127,15 @@ int main(int argc, char** argv) {
   wasm_init_stdio();
 
   parse_options(argc, argv);
+  if (!s_objdump_options.headers && !s_objdump_options.details && !s_objdump_options.disassemble && !s_objdump_options.raw) {
+    fprintf(stderr, "At least one of the following switches must be given:\n");
+    fprintf(stderr, " -d/--disassemble\n");
+    fprintf(stderr, " -h/--headers\n");
+    fprintf(stderr, " -x/--details\n");
+    fprintf(stderr, " -s/--full-contents\n");
+    return 1;
+  }
+
   WasmAllocator* allocator = &g_wasm_libc_allocator;
 
   void* data;
@@ -137,16 +146,7 @@ int main(int argc, char** argv) {
 
   // Perform serveral passed over the binary in order to print out different
   // types of information.
-
   s_objdump_options.print_header = 1;
-  if (!s_objdump_options.headers && !s_objdump_options.details && !s_objdump_options.disassemble && !s_objdump_options.raw) {
-    printf("At least one of the following switches must be given:\n");
-    printf(" -d/--disassemble\n");
-    printf(" -h/--headers\n");
-    printf(" -x/--details\n");
-    printf(" -s/--full-contents\n");
-    return 1;
-  }
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {

--- a/src/tools/wasmdump.c
+++ b/src/tools/wasmdump.c
@@ -33,11 +33,11 @@
 
 enum {
   FLAG_HEADERS,
-  FLAG_RAW,
   FLAG_SECTION,
+  FLAG_RAW,
   FLAG_DISASSEMBLE,
-  FLAG_VERBOSE,
   FLAG_DEBUG,
+  FLAG_DETAILS,
   FLAG_HELP,
   NUM_FLAGS
 };
@@ -51,11 +51,11 @@ static const char s_description[] =
 static WasmOption s_options[] = {
     {FLAG_HEADERS, 'h', "headers", NULL, NOPE, "print headers"},
     {FLAG_SECTION, 'j', "section", NULL, YEP, "select just one section"},
-    {FLAG_RAW, 'r', "raw", NULL, NOPE, "print raw section contents"},
+    {FLAG_RAW, 's', "full-contents", NULL, NOPE, "print raw section contents"},
     {FLAG_DISASSEMBLE, 'd', "disassemble", NULL, NOPE,
      "disassemble function bodies"},
     {FLAG_DEBUG, '\0', "debug", NULL, NOPE, "disassemble function bodies"},
-    {FLAG_VERBOSE, 'v', "verbose", NULL, NOPE, "Verbose output"},
+    {FLAG_DETAILS, 'x', "details", NULL, NOPE, "Show section details"},
     {FLAG_HELP, 'h', "help", NULL, NOPE, "print this help message"},
 };
 
@@ -86,8 +86,8 @@ static void on_option(struct WasmOptionParser* parser,
       s_objdump_options.disassemble = WASM_TRUE;
       break;
 
-    case FLAG_VERBOSE:
-      s_objdump_options.verbose = WASM_TRUE;
+    case FLAG_DETAILS:
+      s_objdump_options.details = WASM_TRUE;
       break;
 
     case FLAG_SECTION:
@@ -139,6 +139,14 @@ int main(int argc, char** argv) {
   // types of information.
 
   s_objdump_options.print_header = 1;
+  if (!s_objdump_options.headers && !s_objdump_options.details && !s_objdump_options.disassemble && !s_objdump_options.raw) {
+    printf("At least one of the following switches must be given:\n");
+    printf(" -d/--disassemble\n");
+    printf(" -h/--headers\n");
+    printf(" -x/--details\n");
+    printf(" -s/--full-contents\n");
+    return 1;
+  }
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {
@@ -149,7 +157,7 @@ int main(int argc, char** argv) {
     s_objdump_options.print_header = 0;
   }
   // Pass 2: Print extra information based on section type
-  if (s_objdump_options.verbose) {
+  if (s_objdump_options.details) {
     s_objdump_options.mode = WASM_DUMP_DETAILS;
     result = wasm_read_binary_objdump(allocator, data, size, &s_objdump_options);
     if (WASM_FAILED(result))

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -58,10 +58,6 @@ def main(args):
       '--use-libc-allocator': options.use_libc_allocator
   })
 
-  wasmdump = utils.Executable(
-      find_exe.GetWasmdumpExecutable(options.bindir),
-      error_cmdline=options.error_cmdline)
-
   wasm_interp = utils.Executable(
       find_exe.GetWasmInterpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
@@ -79,13 +75,6 @@ def main(args):
     new_ext = '.json' if options.spec else '.wasm'
     out_file = utils.ChangeDir(utils.ChangeExt(options.file, new_ext), out_dir)
     wast2wasm.RunWithArgs(options.file, '-o', out_file)
-    if options.spec:
-      wasm_files = utils.GetModuleFilenamesFromSpecJSON(out_file)
-      wasm_files = [utils.ChangeDir(f, out_dir) for f in wasm_files]
-    else:
-      wasm_files = [out_file]
-    for wasm_file in wasm_files:
-      wasmdump.RunWithArgs(wasm_file)
     wasm_interp.RunWithArgs(out_file)
 
   return 0

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -92,10 +92,10 @@ def main(args):
           os.rename(output, partialy_linked)
           wasm_link.RunWithArgs('-o', output, partialy_linked, f)
         #wasmdump.RunWithArgs('-d', '-h', output)
-      wasmdump.RunWithArgs('-d', '-v', '-h', output)
+      wasmdump.RunWithArgs('-d', '-x', '-h', output)
     else:
       wasm_link.RunWithArgs('-o', output, *wasm_files)
-      wasmdump.RunWithArgs('-d', '-h', '-v', output)
+      wasmdump.RunWithArgs('-d', '-x', '-h', output)
 
 
 if __name__ == '__main__':

--- a/test/run-wasmdump.py
+++ b/test/run-wasmdump.py
@@ -69,7 +69,7 @@ def main(args):
       error_cmdline=options.error_cmdline)
   wasmdump.AppendOptionalArgs({
       '-h': options.headers,
-      '-v': options.dump_verbose,
+      '-x': options.dump_verbose,
   })
 
   wast2wasm.verbose = options.print_cmd


### PR DESCRIPTION
These changes make wasmdump more closely match objdump.
Change -v/--verbose to -x/--details.  Change -r/--raw to
-s/--full-contents.  Error out unless on of -x/-d/-r/-h is
specified.  Previously wasmdump would simply print nothing
at all which was confusing.
