### PR TITLE
Add function names and relocations to wasmdump disassembly

### DIFF
--- a/src/binary-reader-ast.c
+++ b/src/binary-reader-ast.c
@@ -479,8 +479,9 @@ static WasmResult on_function_bodies_count(uint32_t count, void* user_data) {
   return WASM_OK;
 }
 
-static WasmResult begin_function_body(uint32_t index, void* user_data) {
-  Context* ctx = user_data;
+static WasmResult begin_function_body(WasmBinaryReaderContext* context,
+                                      uint32_t index) {
+  Context* ctx = context->user_data;
   assert(index < ctx->module->funcs.size);
   ctx->current_func = ctx->module->funcs.data[index];
   push_label(ctx, LABEL_TYPE_FUNC, &ctx->current_func->first_expr);

--- a/src/binary-reader-interpreter.c
+++ b/src/binary-reader-interpreter.c
@@ -1131,8 +1131,9 @@ static WasmResult drop_types_for_return(Context* ctx, uint32_t arity) {
   return WASM_OK;
 }
 
-static WasmResult begin_function_body(uint32_t index, void* user_data) {
-  Context* ctx = user_data;
+static WasmResult begin_function_body(WasmBinaryReaderContext* context,
+                                      uint32_t index) {
+  Context* ctx = context->user_data;
   WasmInterpreterFunc* func = get_func_by_module_index(ctx, index);
   WasmInterpreterFuncSignature* sig =
       get_signature_by_env_index(ctx, func->sig_index);

--- a/src/binary-reader-objdump.c
+++ b/src/binary-reader-objdump.c
@@ -399,11 +399,11 @@ static WasmResult begin_function_body(WasmBinaryReaderContext* context,
 
   if (ctx->options->mode == WASM_DUMP_DISASSEMBLE) {
     if (index < ctx->options->function_names.size)
-      printf("%06" PRIx64 " <" PRIstringslice ">:\n", context->offset,
+      printf("%06" PRIzx " <" PRIstringslice ">:\n", context->offset,
              WASM_PRINTF_STRING_SLICE_ARG(
                  ctx->options->function_names.data[index]));
     else
-      printf("%06" PRIx64 " func[%d]:\n", context->offset, index);
+      printf("%06" PRIzx " func[%d]:\n", context->offset, index);
   }
 
   ctx->last_opcode_end = 0;

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -19,12 +19,22 @@
 
 #include "common.h"
 #include "stream.h"
+#include "vector.h"
 
 struct WasmAllocator;
 struct WasmModule;
 struct WasmReadBinaryOptions;
 
+typedef struct WasmReloc {
+  WasmRelocType type;
+  size_t offset;
+} WasmReloc;
+WASM_DEFINE_VECTOR(reloc, WasmReloc);
+
+WASM_DEFINE_VECTOR(string_slice, WasmStringSlice);
+
 typedef enum WasmObjdumpMode {
+  WASM_DUMP_PREPASS,
   WASM_DUMP_HEADERS,
   WASM_DUMP_DETAILS,
   WASM_DUMP_DISASSEMBLE,
@@ -37,10 +47,13 @@ typedef struct WasmObjdumpOptions {
   WasmBool raw;
   WasmBool disassemble;
   WasmBool debug;
+  WasmBool relocs;
   WasmObjdumpMode mode;
   const char* infile;
   const char* section_name;
   WasmBool print_header;
+  WasmStringSliceVector function_names;
+  WasmRelocVector code_relocations;
 } WasmObjdumpOptions;
 
 WASM_EXTERN_C_BEGIN
@@ -48,7 +61,7 @@ WASM_EXTERN_C_BEGIN
 WasmResult wasm_read_binary_objdump(struct WasmAllocator* allocator,
                                     const uint8_t* data,
                                     size_t size,
-                                    const WasmObjdumpOptions* options);
+                                    WasmObjdumpOptions* options);
 
 WASM_EXTERN_C_END
 

--- a/src/binary-reader.c
+++ b/src/binary-reader.c
@@ -507,6 +507,14 @@ static WasmResult logging_begin_custom_section(WasmBinaryReaderContext* context,
     FORWARD(name, value);                                             \
   }
 
+#define LOGGING_UINT32_CTX(name)                                     \
+  static WasmResult logging_##name(WasmBinaryReaderContext* context, \
+                                   uint32_t value) {                 \
+    LoggingContext* ctx = context->user_data;                        \
+    LOGF(#name "(%u)\n", value);                                     \
+    FORWARD_CTX(name, value);                                        \
+  }
+
 #define LOGGING_UINT32_DESC(name, desc)                               \
   static WasmResult logging_##name(uint32_t value, void* user_data) { \
     LoggingContext* ctx = user_data;                                  \
@@ -577,7 +585,7 @@ LOGGING_UINT32(on_start_function)
 LOGGING_END(start_section)
 LOGGING_BEGIN(function_bodies_section)
 LOGGING_UINT32(on_function_bodies_count)
-LOGGING_UINT32(begin_function_body)
+LOGGING_UINT32_CTX(begin_function_body)
 LOGGING_UINT32(end_function_body)
 LOGGING_UINT32(on_local_decl_count)
 LOGGING_OPCODE(on_binary_expr)
@@ -1985,7 +1993,7 @@ static void read_code_section(Context* ctx, uint32_t section_size) {
     uint32_t func_index = ctx->num_func_imports + i;
     uint32_t func_offset = ctx->offset;
     ctx->offset = func_offset;
-    CALLBACK(begin_function_body, func_index);
+    CALLBACK_CTX(begin_function_body, func_index);
     uint32_t body_size;
     in_u32_leb128(ctx, &body_size, "function body size");
     uint32_t body_start_offset = ctx->offset;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -167,7 +167,8 @@ typedef struct WasmBinaryReader {
   WasmResult (*begin_function_body_pass)(uint32_t index,
                                          uint32_t pass,
                                          void* user_data);
-  WasmResult (*begin_function_body)(uint32_t index, void* user_data);
+  WasmResult (*begin_function_body)(WasmBinaryReaderContext* ctx,
+                                    uint32_t index);
   WasmResult (*on_local_decl_count)(uint32_t count, void* user_data);
   WasmResult (*on_local_decl)(uint32_t decl_index,
                               uint32_t count,

--- a/src/tools/wasmdump.c
+++ b/src/tools/wasmdump.c
@@ -38,6 +38,7 @@ enum {
   FLAG_DISASSEMBLE,
   FLAG_DEBUG,
   FLAG_DETAILS,
+  FLAG_RELOCS,
   FLAG_HELP,
   NUM_FLAGS
 };
@@ -56,6 +57,8 @@ static WasmOption s_options[] = {
      "disassemble function bodies"},
     {FLAG_DEBUG, '\0', "debug", NULL, NOPE, "disassemble function bodies"},
     {FLAG_DETAILS, 'x', "details", NULL, NOPE, "Show section details"},
+    {FLAG_RELOCS, 'r', "reloc", NULL, NOPE,
+     "show relocations inline with disassembly"},
     {FLAG_HELP, 'h', "help", NULL, NOPE, "print this help message"},
 };
 
@@ -88,6 +91,10 @@ static void on_option(struct WasmOptionParser* parser,
 
     case FLAG_DETAILS:
       s_objdump_options.details = WASM_TRUE;
+      break;
+
+    case FLAG_RELOCS:
+      s_objdump_options.relocs = WASM_TRUE;
       break;
 
     case FLAG_SECTION:
@@ -156,6 +163,11 @@ int main(int argc, char** argv) {
     printf(" -s/--full-contents\n");
     return 1;
   }
+
+  s_objdump_options.mode = WASM_DUMP_PREPASS;
+  result = wasm_read_binary_objdump(allocator, data, size, &s_objdump_options);
+  if (WASM_FAILED(result))
+    goto done;
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -82,6 +82,7 @@
 basic.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x00000011 (size=0x00000007) count: 1
  FUNCTION start=0x00000013 end=0x00000015 (size=0x00000002) count: 1
    MEMORY start=0x00000017 end=0x0000001a (size=0x00000003) count: 1
@@ -89,7 +90,8 @@ Sections:
      CODE start=0x00000023 end=0x00000039 (size=0x00000016) count: 1
 
 Code Disassembly:
-func 0
+
+000024 func[0]:
  000026: 41 00                      | i32.const 0
  000028: 41 00                      | i32.const 0
  00002a: 28 02 00                   | i32.load 2 0

--- a/test/dump/basic_dump_only.txt
+++ b/test/dump/basic_dump_only.txt
@@ -16,7 +16,8 @@
 basic_dump_only.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000024 func[0]:
  000026: 41 00                      | i32.const 0
  000028: 41 00                      | i32.const 0
  00002a: 28 02 00                   | i32.load 2 0

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -278,7 +278,8 @@
 binary.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 41 00                      | i32.const 0
  00001b: 41 00                      | i32.const 0
  00001d: 78                         | i32.rotr

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -343,7 +343,8 @@
 block-257-exprs-br.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 02 40                      | block
  00001b: 01                         |   nop
  00001c: 01                         |   nop

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -339,7 +339,8 @@
 block-257-exprs.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 02 40                      | block
  00001b: 01                         |   nop
  00001c: 01                         |   nop

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -65,13 +65,14 @@
 block.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001a func[0]:
  00001c: 02 40                      | block
  00001e: 01                         |   nop
  00001f: 01                         |   nop
  000020: 01                         |   nop
  000021: 0b                         | end
-func 1
+000023 func[1]:
  000025: 02 7f                      | block i32
  000027: 41 01                      |   i32.const 0x1
  000029: 0b                         | end

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -64,7 +64,8 @@
 br-block-named.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 02 40                      | block
  000019: 03 40                      |   loop
  00001b: 02 40                      |     block

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -70,7 +70,8 @@
 br-block.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 02 40                      | block
  000019: 03 40                      |   loop
  00001b: 02 40                      |     block

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -72,7 +72,8 @@
 br-loop-inner-expr.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000018: 02 7f                      | block i32
  00001a: 03 7f                      |   loop i32
  00001c: 41 01                      |     i32.const 0x1

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -58,7 +58,8 @@
 br-loop-inner.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 02 40                      | block
  000019: 03 40                      |   loop
  00001b: 41 01                      |     i32.const 0x1

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -49,7 +49,8 @@
 br-loop.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 03 40                      | loop
  000019: 41 01                      |   i32.const 0x1
  00001b: 04 40                      |   if

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -44,7 +44,8 @@
 brif-loop.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 03 40                      | loop
  000019: 41 00                      |   i32.const 0
  00001b: 0d 00                      |   br_if 0

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -44,7 +44,8 @@
 brif.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 02 40                      | block
  000019: 41 01                      |   i32.const 0x1
  00001b: 0d 00                      |   br_if 0

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -45,7 +45,8 @@
 brtable-empty.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 02 40                      | block
  000019: 41 00                      |   i32.const 0
  00001b: 0e 00 00                   |   br_table

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -78,7 +78,8 @@
 brtable.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 02 40                      | block
  000019: 02 40                      |   block
  00001b: 02 40                      |     block

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -40,7 +40,8 @@
 call.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000018: 41 01                      | i32.const 0x1
  00001a: 10 00                      | call 0
 ;;; STDOUT ;;)

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -70,7 +70,8 @@
 callimport.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 1
+
+000029 func[1]:
  00002b: 41 01                      | i32.const 0x1
  00002d: 43 00 00 00 40             | f32.const 0x1p+1
  000032: 10 00                      | call 0

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -68,7 +68,8 @@
 callindirect.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000026 func[0]:
  000028: 41 00                      | i32.const 0
  00002a: 41 00                      | i32.const 0
  00002c: 11 00 00                   | call_indirect 0 0

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -61,7 +61,8 @@
 cast.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 00                      | i32.const 0
  000019: be                         | f32.reinterpret/i32
  00001a: 1a                         | drop

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -313,7 +313,8 @@
 compare.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 41 00                      | i32.const 0
  00001b: 41 00                      | i32.const 0
  00001d: 4f                         | i32.ge_u

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -225,7 +225,8 @@
 const.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 41 00                      | i32.const 0
  00001b: 1a                         | drop
  00001c: 41 80 80 80 80 78          | i32.const 0x80000000

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -92,7 +92,8 @@
 convert.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 00                      | i32.const 0
  000019: b8                         | f64.convert_u/i32
  00001a: ab                         | i32.trunc_u/f64

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -46,6 +46,7 @@
 current-memory.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001b func[0]:
  00001d: 3f 00                      | current_memory 0
 ;;; STDOUT ;;)

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -39,11 +39,13 @@
 debug-import-names.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    IMPORT start=0x00000010 end=0x0000001b (size=0x0000000b) count: 1
    CUSTOM start=0x0000001d end=0x00000029 (size=0x0000000c) "name"
 
 Section Details:
+
 TYPE:
  - [0] () -> nil
 IMPORT:
@@ -53,4 +55,5 @@ CUSTOM:
  - func[0] $foo
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -88,15 +88,13 @@
 debug-names.wasm:	file format wasm 0x00000d
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> nil
  - [1] (f32) -> nil
 FUNCTION:
  - func[0] sig=0
  - func[1] sig=1
-CODE:
- - func 0
- - func 1
 CUSTOM:
  - name: "name"
  - func[0] $F1
@@ -109,6 +107,7 @@ CUSTOM:
   - local[3] $F2L3
 
 Code Disassembly:
-func 0
-func 1
+
+00001b <$F1>:
+000022 <$F2>:
 ;;; STDOUT ;;)

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -52,6 +52,7 @@
 dedupe-sig.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 1
+
+000024 func[1]:
  000026: 42 00                      | i64.const 0
 ;;; STDOUT ;;)

--- a/test/dump/drop.txt
+++ b/test/dump/drop.txt
@@ -38,7 +38,8 @@
 drop.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 00                      | i32.const 0
  000019: 1a                         | drop
 ;;; STDOUT ;;)

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -49,6 +49,7 @@
 export-multi.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000020 func[0]:
  000022: 01                         | nop
 ;;; STDOUT ;;)

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -46,7 +46,8 @@
 expr-br.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000018: 02 7f                      | block i32
  00001a: 41 01                      |   i32.const 0x1
  00001c: 0c 00                      |   br 0

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -53,7 +53,8 @@
 expr-brif.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000018: 02 7f                      | block i32
  00001a: 41 2a                      |   i32.const 0x2a
  00001c: 41 00                      |   i32.const 0

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -43,5 +43,6 @@
 func-exported.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001e func[0]:
 ;;; STDOUT ;;)

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -47,7 +47,8 @@
 func-multi.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
-func 1
-func 2
+
+000017 func[0]:
+00001a func[1]:
+00001d func[2]:
 ;;; STDOUT ;;)

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -33,5 +33,6 @@
 func-named.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
 ;;; STDOUT ;;)

--- a/test/dump/getglobal.txt
+++ b/test/dump/getglobal.txt
@@ -48,6 +48,7 @@
 getglobal.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001e func[0]:
  000020: 23 00                      | get_global 0
 ;;; STDOUT ;;)

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -74,7 +74,8 @@
 getlocal-param.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000017 func[0]:
  000021: 20 00                      | get_local 0
  000023: 1a                         | drop
  000024: 20 01                      | get_local 0x1

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -88,7 +88,8 @@
 getlocal.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000025: 20 00                      | get_local 0
  000027: 1a                         | drop
  000028: 20 01                      | get_local 0x1

--- a/test/dump/global.txt
+++ b/test/dump/global.txt
@@ -103,6 +103,7 @@
 global.wasm:	file format wasm 0x00000d
 
 Section Details:
+
 IMPORT:
  - global[0] i32 mutable=0 <- foo.i32_global
  - global[1] i64 mutable=0 <- foo.i64_global
@@ -119,4 +120,5 @@ GLOBAL:
  - global[11] f64 mutable=0 - init global=3
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -52,7 +52,8 @@
 grow-memory.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001c func[0]:
  00001e: 20 00                      | get_local 0
  000020: 40 00                      | grow_memory 0
  000022: 1a                         | drop

--- a/test/dump/hexfloat_f32.txt
+++ b/test/dump/hexfloat_f32.txt
@@ -120,7 +120,8 @@
 hexfloat_f32.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 43 00 00 00 00             | f32.const 0x0p+0
  00001c: 1a                         | drop
  00001d: 43 80 a2 91 48             | f32.const 0x1.2345p+18

--- a/test/dump/hexfloat_f64.txt
+++ b/test/dump/hexfloat_f64.txt
@@ -122,7 +122,8 @@
 hexfloat_f64.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
  000022: 1a                         | drop
  000023: 44 00 00 00 00 50 34 12 41 | f64.const 0x1.2345p+18

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -63,7 +63,8 @@
 if-then-else-list.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 01                      | i32.const 0x1
  000019: 04 40                      | if
  00001b: 41 02                      |   i32.const 0x2

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -45,7 +45,8 @@
 if-then-list.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 01                      | i32.const 0x1
  000019: 04 40                      | if
  00001b: 01                         |   nop

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -82,7 +82,8 @@
 if.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000018: 41 01                      | i32.const 0x1
  00001a: 04 40                      | if
  00001c: 01                         |   nop
@@ -94,7 +95,7 @@ func 0
  000028: 43 00 00 00 40             |   f32.const 0x1p+1
  00002d: 0b                         | end
  00002e: 1a                         | drop
-func 1
+000030 func[1]:
  000032: 41 01                      | i32.const 0x1
  000034: 04 40                      | if
  000036: 0f                         |   return

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -47,6 +47,7 @@
 import.wasm:	file format wasm 0x00000d
 
 Section Details:
+
 TYPE:
  - [0] (i32, i64, f32, f64) -> nil
  - [1] (i32) -> i32
@@ -55,4 +56,5 @@ IMPORT:
  - func[1] sig=1 <- ignored.test2
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -186,7 +186,8 @@
 load-aligned.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001a func[0]:
  00001c: 41 00                      | i32.const 0
  00001e: 2c 00 00                   | i32.load8_s 0 0
  000021: 1a                         | drop

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -168,7 +168,8 @@
 load.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001a func[0]:
  00001c: 41 00                      | i32.const 0
  00001e: 28 02 00                   | i32.load 2 0
  000021: 1a                         | drop

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -41,5 +41,6 @@
 locals.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -356,7 +356,8 @@
 loop-257-exprs-br.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 02 40                      | block
  00001b: 03 40                      |   loop
  00001d: 01                         |     nop

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -339,7 +339,8 @@
 loop-257-exprs.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000016 func[0]:
  000019: 03 40                      | loop
  00001b: 01                         |   nop
  00001c: 01                         |   nop

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -42,7 +42,8 @@
 loop.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 03 40                      | loop
  000019: 01                         |   nop
  00001a: 01                         |   nop

--- a/test/dump/memory-1-byte.txt
+++ b/test/dump/memory-1-byte.txt
@@ -15,4 +15,5 @@
 memory-1-byte.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/memory-data-size.txt
+++ b/test/dump/memory-data-size.txt
@@ -48,13 +48,17 @@
 memory-data-size.0.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 memory-data-size.1.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 memory-data-size.2.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 memory-data-size.3.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/memory-hex.txt
+++ b/test/dump/memory-hex.txt
@@ -31,4 +31,5 @@
 memory-hex.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -41,6 +41,7 @@
 memory.wasm:	file format wasm 0x00000d
 
 Section Details:
+
 MEMORY:
  - memory[0] pages: initial=1
 DATA:
@@ -52,4 +53,5 @@ DATA:
   - 0000020: 6d65 742c 2063 6f6e 7365 6374 6574 7572  met, consectetur
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -149,17 +149,18 @@
 no-canonicalize.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 1
+
+000071 func[1]:
  000077: 20 00                      | get_local 0
  000079: 20 01                      | get_local 0x1
  00007b: 11 01 00                   | call_indirect 1 0
  00007e: 1a                         | drop
-func 2
+000080 func[2]:
  000086: 20 00                      | get_local 0
  000088: 41 01                      | i32.const 0x1
  00008a: 6a                         | i32.add
  00008b: 1a                         | drop
-func 3
+00008d func[3]:
  000093: 20 00                      | get_local 0
  000095: 41 02                      | i32.const 0x2
  000097: 6c                         | i32.mul

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -52,7 +52,8 @@
 nocheck.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001f func[0]:
  000021: 43 00 00 80 3f             | f32.const 0x1p+0
  000026: 44 00 00 00 00 00 00 00 40 | f64.const 0x1p+1
  00002f: 6a                         | i32.add

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -35,6 +35,7 @@
 nop.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 01                         | nop
 ;;; STDOUT ;;)

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -37,5 +37,6 @@
 param-multi.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000019 func[0]:
 ;;; STDOUT ;;)

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -82,12 +82,13 @@
 result.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000025 func[0]:
  000027: 41 00                      | i32.const 0
-func 1
+00002a func[1]:
  00002c: 42 00                      | i64.const 0
-func 2
+00002f func[2]:
  000031: 43 00 00 00 00             | f32.const 0x0p+0
-func 3
+000037 func[3]:
  000039: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
 ;;; STDOUT ;;)

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -52,9 +52,10 @@
 return.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001a func[0]:
  00001c: 41 2a                      | i32.const 0x2a
  00001e: 0f                         | return
-func 1
+000020 func[1]:
  000022: 0f                         | return
 ;;; STDOUT ;;)

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -85,7 +85,8 @@
 select.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 02                      | i32.const 0x2
  000019: 41 03                      | i32.const 0x3
  00001b: 41 01                      | i32.const 0x1

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -50,7 +50,8 @@
 setglobal.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000020 func[0]:
  000022: 43 00 00 00 40             | f32.const 0x1p+1
  000027: 24 00                      | set_global 0
 ;;; STDOUT ;;)

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -84,7 +84,8 @@
 setlocal-param.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000017 func[0]:
  000021: 41 00                      | i32.const 0
  000023: 21 00                      | set_local 0
  000025: 43 00 00 00 00             | f32.const 0x0p+0

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -100,7 +100,8 @@
 setlocal.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000025: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
  00002e: 21 00                      | set_local 0
  000030: 43 00 00 00 00             | f32.const 0x0p+0

--- a/test/dump/signatures.txt
+++ b/test/dump/signatures.txt
@@ -69,4 +69,5 @@
 signatures.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -202,7 +202,8 @@
 store-aligned.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001a func[0]:
  00001c: 41 00                      | i32.const 0
  00001e: 41 00                      | i32.const 0
  000020: 3a 00 00                   | i32.store8 0 0

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -132,7 +132,8 @@
 store.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+00001a func[0]:
  00001c: 41 00                      | i32.const 0
  00001e: 41 00                      | i32.const 0
  000020: 3a 00 00                   | i32.store8 0 0

--- a/test/dump/string-escape.txt
+++ b/test/dump/string-escape.txt
@@ -43,5 +43,6 @@
 string-escape.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000043 func[0]:
 ;;; STDOUT ;;)

--- a/test/dump/string-hex.txt
+++ b/test/dump/string-hex.txt
@@ -41,5 +41,6 @@
 string-hex.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000022 func[0]:
 ;;; STDOUT ;;)

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -89,6 +89,7 @@
 table.wasm:	file format wasm 0x00000d
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> nil
  - [1] (i32, i64) -> nil
@@ -106,14 +107,11 @@ ELEM:
   - func[0]
   - func[1]
   - func[2]
-CODE:
- - func 0
- - func 1
- - func 2
 
 Code Disassembly:
-func 0
-func 1
-func 2
+
+000034 func[0]:
+000037 func[1]:
+00003a func[2]:
  00003c: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
 ;;; STDOUT ;;)

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -44,7 +44,8 @@
 tee_local.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000019: 41 00                      | i32.const 0
  00001b: 22 00                      | tee_local 0
  00001d: 1a                         | drop

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -98,7 +98,8 @@
 unary.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 41 00                      | i32.const 0
  000019: 69                         | i32.popcnt
  00001a: 68                         | i32.ctz

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -35,6 +35,7 @@
 unreachable.wasm:	file format wasm 0x00000d
 
 Code Disassembly:
-func 0
+
+000015 func[0]:
  000017: 00                         | unreachable
 ;;; STDOUT ;;)

--- a/test/link/data.txt
+++ b/test/link/data.txt
@@ -14,10 +14,12 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
    MEMORY start=0x0000000e end=0x00000012 (size=0x00000004) count: 1
      DATA start=0x00000018 end=0x00000041 (size=0x00000029) count: 4
 
 Section Details:
+
 MEMORY:
  - memory[0] pages: initial=2 max=2
 DATA:
@@ -31,4 +33,5 @@ DATA:
   - 0000000: 776f 726c 64                             world
 
 Code Disassembly:
+
 ;;; STDOUT ;;)

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -16,6 +16,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x00000013 (size=0x00000009) count: 2
  FUNCTION start=0x00000019 end=0x0000001c (size=0x00000003) count: 2
    EXPORT start=0x00000022 end=0x0000002f (size=0x0000000d) count: 2
@@ -23,6 +24,7 @@ Sections:
    CUSTOM start=0x0000004e end=0x0000005f (size=0x00000011) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> nil
  - [1] (i32) -> nil
@@ -32,9 +34,6 @@ FUNCTION:
 EXPORT:
  - func[0] foo
  - func[1] bar
-CODE:
- - func 0
- - func 1
 CUSTOM:
  - name: "reloc.CODE"
   - section: CODE
@@ -42,10 +41,13 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0x42 (0x11)
 
 Code Disassembly:
-func 0
+
+000032 func[0]:
  000034: 41 01                      | i32.const 0x1
  000036: 10 80 80 80 80 00          | call 0
-func 1
+           000037: R_FUNC_INDEX_LEB
+00003d func[1]:
  00003f: 41 02                      | i32.const 0x2
  000041: 10 81 80 80 80 00          | call 0x1
+           000042: R_FUNC_INDEX_LEB
 ;;; STDOUT ;;)

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -19,6 +19,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x0000001c (size=0x00000012) count: 4
    IMPORT start=0x00000022 end=0x00000041 (size=0x0000001f) count: 2
  FUNCTION start=0x00000047 end=0x0000004a (size=0x00000003) count: 2
@@ -26,6 +27,7 @@ Sections:
    CUSTOM start=0x0000007e end=0x00000093 (size=0x00000015) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> i32
  - [1] (i32) -> nil
@@ -37,9 +39,6 @@ IMPORT:
 FUNCTION:
  - func[2] sig=1
  - func[3] sig=3
-CODE:
- - func 2
- - func 3
 CUSTOM:
  - name: "reloc.CODE"
   - section: CODE
@@ -49,13 +48,18 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0x72 (0x26)
 
 Code Disassembly:
-func 2
+
+00004d func[2]:
  00004f: 20 00                      | get_local 0
  000051: 10 80 80 80 80 00          | call 0
+           000052: R_FUNC_INDEX_LEB
  000057: 10 82 80 80 80 00          | call 0x2
-func 3
+           000058: R_FUNC_INDEX_LEB
+00005e func[3]:
  000060: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000069: 10 81 80 80 80 00          | call 0x1
+           00006a: R_FUNC_INDEX_LEB
  00006f: 42 0a                      | i64.const 10
  000071: 10 83 80 80 80 00          | call 0x3
+           000072: R_FUNC_INDEX_LEB
 ;;; STDOUT ;;)

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -27,6 +27,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x00000024 (size=0x0000001a) count: 6
    IMPORT start=0x0000002a end=0x00000069 (size=0x0000003f) count: 3
  FUNCTION start=0x0000006f end=0x00000073 (size=0x00000004) count: 3
@@ -34,6 +35,7 @@ Sections:
    CUSTOM start=0x000000bd end=0x000000d6 (size=0x00000019) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> i32
  - [1] (i32) -> nil
@@ -49,10 +51,6 @@ FUNCTION:
  - func[3] sig=1
  - func[4] sig=3
  - func[5] sig=5
-CODE:
- - func 3
- - func 4
- - func 5
 CUSTOM:
  - name: "reloc.CODE"
   - section: CODE
@@ -64,18 +62,25 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0xb1 (0x3c)
 
 Code Disassembly:
-func 3
+
+000076 func[3]:
  000078: 20 00                      | get_local 0
  00007a: 10 80 80 80 80 00          | call 0
+           00007b: R_FUNC_INDEX_LEB
  000080: 10 83 80 80 80 00          | call 0x3
-func 4
+           000081: R_FUNC_INDEX_LEB
+000087 func[4]:
  000089: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000092: 10 81 80 80 80 00          | call 0x1
+           000093: R_FUNC_INDEX_LEB
  000098: 42 0a                      | i64.const 10
  00009a: 10 84 80 80 80 00          | call 0x4
-func 5
+           00009b: R_FUNC_INDEX_LEB
+0000a1 func[5]:
  0000a3: 43 00 00 80 3f             | f32.const 0x1p+0
  0000a8: 10 82 80 80 80 00          | call 0x2
+           0000a9: R_FUNC_INDEX_LEB
  0000ae: 41 0a                      | i32.const 0xa
  0000b0: 10 85 80 80 80 00          | call 0x5
+           0000b1: R_FUNC_INDEX_LEB
 ;;; STDOUT ;;)

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -24,6 +24,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x00000014 (size=0x0000000a) count: 2
    IMPORT start=0x0000001a end=0x0000003b (size=0x00000021) count: 2
  FUNCTION start=0x00000041 end=0x00000044 (size=0x00000003) count: 2
@@ -32,6 +33,7 @@ Sections:
    CUSTOM start=0x00000091 end=0x000000ac (size=0x0000001b) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> nil
  - [1] (i64, i64) -> nil
@@ -45,9 +47,6 @@ GLOBAL:
  - global[2] i32 mutable=0 - init i32=1
  - global[3] i32 mutable=0 - init i32=2
  - global[4] i64 mutable=0 - init i64=2
-CODE:
- - func 0
- - func 1
 CUSTOM:
  - name: "reloc.CODE"
   - section: CODE
@@ -60,15 +59,23 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0x85 (0x2d)
 
 Code Disassembly:
-func 0
+
+000059 func[0]:
  00005b: 23 83 80 80 80 00          | get_global 0x3
+           00005c: R_GLOBAL_INDEX_LEB
  000061: 23 82 80 80 80 00          | get_global 0x2
+           000062: R_GLOBAL_INDEX_LEB
  000067: 6a                         | i32.add
  000068: 23 80 80 80 80 00          | get_global 0
+           000069: R_GLOBAL_INDEX_LEB
  00006e: 6a                         | i32.add
  00006f: 10 80 80 80 80 00          | call 0
-func 1
+           000070: R_FUNC_INDEX_LEB
+000076 func[1]:
  000078: 23 81 80 80 80 00          | get_global 0x1
+           000079: R_GLOBAL_INDEX_LEB
  00007e: 23 84 80 80 80 00          | get_global 0x4
+           00007f: R_GLOBAL_INDEX_LEB
  000084: 10 81 80 80 80 00          | call 0x1
+           000085: R_FUNC_INDEX_LEB
 ;;; STDOUT ;;)

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -30,6 +30,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x00000024 (size=0x0000001a) count: 6
    IMPORT start=0x0000002a end=0x00000069 (size=0x0000003f) count: 3
  FUNCTION start=0x0000006f end=0x00000073 (size=0x00000004) count: 3
@@ -40,6 +41,7 @@ Sections:
    CUSTOM start=0x00000118 end=0x00000131 (size=0x00000019) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> i32
  - [1] (i32) -> nil
@@ -67,10 +69,6 @@ ELEM:
   - func[4]
   - func[5]
   - func[5]
-CODE:
- - func 3
- - func 4
- - func 5
 CUSTOM:
  - name: "reloc.ELEM"
   - section: ELEM
@@ -92,18 +90,25 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0xeb (0x3c)
 
 Code Disassembly:
-func 3
+
+0000b0 func[3]:
  0000b2: 20 00                      | get_local 0
  0000b4: 10 80 80 80 80 00          | call 0
+           0000b5: R_FUNC_INDEX_LEB
  0000ba: 10 83 80 80 80 00          | call 0x3
-func 4
+           0000bb: R_FUNC_INDEX_LEB
+0000c1 func[4]:
  0000c3: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  0000cc: 10 81 80 80 80 00          | call 0x1
+           0000cd: R_FUNC_INDEX_LEB
  0000d2: 42 0a                      | i64.const 10
  0000d4: 10 84 80 80 80 00          | call 0x4
-func 5
+           0000d5: R_FUNC_INDEX_LEB
+0000db func[5]:
  0000dd: 43 00 00 80 3f             | f32.const 0x1p+0
  0000e2: 10 82 80 80 80 00          | call 0x2
+           0000e3: R_FUNC_INDEX_LEB
  0000e8: 41 0a                      | i32.const 0xa
  0000ea: 10 85 80 80 80 00          | call 0x5
+           0000eb: R_FUNC_INDEX_LEB
 ;;; STDOUT ;;)

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -44,6 +44,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x0000001f (size=0x00000015) count: 5
    IMPORT start=0x00000025 end=0x00000026 (size=0x00000001) count: 0
  FUNCTION start=0x0000002c end=0x00000032 (size=0x00000006) count: 5
@@ -52,6 +53,7 @@ Sections:
    CUSTOM start=0x000000a8 end=0x000000b9 (size=0x00000011) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] () -> i32
  - [1] () -> i64
@@ -71,12 +73,6 @@ EXPORT:
  - func[2] call_import2
  - func[3] export2
  - func[4] export3
-CODE:
- - func 0
- - func 1
- - func 2
- - func 3
- - func 4
 CUSTOM:
  - name: "reloc.CODE"
   - section: CODE
@@ -84,19 +80,22 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0x8e (0x17)
 
 Code Disassembly:
-func 0
+
+000078 func[0]:
  00007a: 43 00 00 80 3f             | f32.const 0x1p+0
  00007f: 0f                         | return
-func 1
+000081 func[1]:
  000083: 10 83 80 80 80 00          | call 0x3
+           000084: R_FUNC_INDEX_LEB
  000089: 0f                         | return
-func 2
+00008b func[2]:
  00008d: 10 84 80 80 80 00          | call 0x4
+           00008e: R_FUNC_INDEX_LEB
  000093: 0f                         | return
-func 3
+000095 func[3]:
  000097: 41 2a                      | i32.const 0x2a
  000099: 0f                         | return
-func 4
+00009b func[4]:
  00009d: 42 e3 00                   | i64.const 99
  0000a0: 0f                         | return
 5/5 tests passed.

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -21,6 +21,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x0000001a (size=0x00000010) count: 4
    IMPORT start=0x00000020 end=0x00000034 (size=0x00000014) count: 1
  FUNCTION start=0x0000003a end=0x0000003e (size=0x00000004) count: 3
@@ -30,6 +31,7 @@ Sections:
    CUSTOM start=0x000000ae end=0x000000c1 (size=0x00000013) "reloc.CODE"
 
 Section Details:
+
 TYPE:
  - [0] () -> nil
  - [1] (i32) -> nil
@@ -44,10 +46,6 @@ FUNCTION:
 EXPORT:
  - func[1] foo
  - func[3] baz
-CODE:
- - func 1
- - func 2
- - func 3
 CUSTOM:
  - name: "name"
  - func[0] $import_func2
@@ -62,13 +60,17 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0x6f (0x1c)
 
 Code Disassembly:
-func 1
+
+000054 <$name1>:
  000056: 41 01                      | i32.const 0x1
  000058: 10 83 80 80 80 00          | call 0x3
-func 2
+           000059: R_FUNC_INDEX_LEB
+00005f <$name2>:
  000061: 42 01                      | i64.const 1
  000063: 10 81 80 80 80 00          | call 0x1
-func 3
+           000064: R_FUNC_INDEX_LEB
+00006a <$name3>:
  00006c: 41 02                      | i32.const 0x2
  00006e: 10 83 80 80 80 00          | call 0x3
+           00006f: R_FUNC_INDEX_LEB
 ;;; STDOUT ;;)

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -13,6 +13,7 @@
 linked.wasm:	file format wasm 0x00000d
 
 Sections:
+
      TYPE start=0x0000000a end=0x00000017 (size=0x0000000d) count: 3
  FUNCTION start=0x0000001d end=0x00000021 (size=0x00000004) count: 3
     TABLE start=0x00000027 end=0x0000002c (size=0x00000005) count: 1
@@ -21,6 +22,7 @@ Sections:
    CUSTOM start=0x00000063 end=0x0000007a (size=0x00000017) "reloc.ELEM"
 
 Section Details:
+
 TYPE:
  - [0] (i32) -> nil
  - [1] (i64) -> nil
@@ -39,10 +41,6 @@ ELEM:
   - func[2]
   - func[1]
   - func[1]
-CODE:
- - func 0
- - func 1
- - func 2
 CUSTOM:
  - name: "reloc.ELEM"
   - section: ELEM
@@ -53,7 +51,8 @@ CUSTOM:
    - R_FUNC_INDEX_LEB   offset=0x4c (0x1a)
 
 Code Disassembly:
-func 0
-func 1
-func 2
+
+000054 func[0]:
+000057 func[1]:
+00005a func[2]:
 ;;; STDOUT ;;)

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -105,10 +105,10 @@ def main(args):
           os.rename(output, partialy_linked)
           wasm_link.RunWithArgs('-r', '-o', output, partialy_linked, f)
         #wasmdump.RunWithArgs('-d', '-h', output)
-      wasmdump.RunWithArgs('-d', '-x', '-h', output)
+      wasmdump.RunWithArgs('-d', '-x', '-r', '-h', output)
     else:
       wasm_link.RunWithArgs('-o', output, *wasm_files)
-      wasmdump.RunWithArgs('-d', '-x', '-h', output)
+      wasmdump.RunWithArgs('-d', '-x', '-r', '-h', output)
 
     if options.spec:
       with open(out_file) as json_file:


### PR DESCRIPTION
Relocations are only shown if -r is passed.