### PR TITLE
Don't apply names in name section to globals

### DIFF
--- a/src/apply-names.c
+++ b/src/apply-names.c
@@ -303,7 +303,9 @@ static WasmResult visit_func(Context* ctx,
 static WasmResult visit_export(Context* ctx,
                                uint32_t export_index,
                                WasmExport* export) {
-  use_name_for_func_var(ctx->allocator, ctx->module, &export->var);
+  if (export->kind == WASM_EXTERNAL_KIND_FUNC) {
+    use_name_for_func_var(ctx->allocator, ctx->module, &export->var);
+  }
   return WASM_OK;
 }
 

--- a/test/binary/no-global-names.txt
+++ b/test/binary/no-global-names.txt
@@ -1,0 +1,35 @@
+;;; TOOL: run-gen-wasm
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(GLOBAL) {
+  count[1]
+  type[i32] mut[0] init_expr[i32.const 0 end]
+}
+section(EXPORT) {
+  count[2]
+  str("bar") func_kind func[0]
+  str("d_glob") global_kind global[0]
+}
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    return
+  }
+}
+section("name") {
+  func_count[1]
+  str("bar")
+  local_count[0]
+}
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func bar (type 0)
+    return)
+  (global (;0;) i32 (i32.const 0))
+  (export "bar" (func bar))
+  (export "d_glob" (global 0)))
+;;; STDOUT ;;)


### PR DESCRIPTION
The name section currently only provides names for functions and locals.
This fixes issue #286.