### PR TITLE
Remove index assertions in binary-writer.c

### DIFF
--- a/src/binary-writer-spec.c
+++ b/src/binary-writer-spec.c
@@ -290,8 +290,7 @@ static void write_action_result_type(Context* ctx,
 
 static void write_module(Context* ctx,
                          char* filename,
-                         const WasmModule* module,
-                         WasmBool is_invalid) {
+                         const WasmModule* module) {
   if (!ctx->write_modules)
     return;
 
@@ -299,7 +298,6 @@ static void write_module(Context* ctx,
   WasmResult result = wasm_init_mem_writer(ctx->allocator, &writer);
   if (WASM_SUCCEEDED(result)) {
     WasmWriteBinaryOptions options = ctx->spec_options->write_binary_options;
-    options.is_invalid = is_invalid;
     result = wasm_write_binary_module(ctx->allocator, &writer.base, module,
                                       &options);
     if (WASM_SUCCEEDED(result))
@@ -312,13 +310,12 @@ static void write_module(Context* ctx,
 
 static void write_raw_module(Context* ctx,
                              char* filename,
-                             const WasmRawModule* raw_module,
-                             WasmBool is_invalid) {
+                             const WasmRawModule* raw_module) {
   if (!ctx->write_modules)
     return;
 
   if (raw_module->type == WASM_RAW_MODULE_TYPE_TEXT) {
-    write_module(ctx, filename, raw_module->text, is_invalid);
+    write_module(ctx, filename, raw_module->text);
   } else {
     WasmFileStream stream;
     WasmResult result = wasm_init_file_writer(&stream.writer, filename);
@@ -343,7 +340,7 @@ static void write_invalid_module(Context* ctx,
   write_separator(ctx);
   write_key(ctx, "text");
   write_escaped_string_slice(ctx, text);
-  write_raw_module(ctx, filename, module, WASM_TRUE);
+  write_raw_module(ctx, filename, module);
   wasm_free(ctx->allocator, filename);
 }
 
@@ -373,7 +370,7 @@ static void write_commands(Context* ctx, WasmScript* script) {
         }
         write_key(ctx, "filename");
         write_escaped_string_slice(ctx, get_basename(filename));
-        write_module(ctx, filename, module, WASM_FALSE);
+        write_module(ctx, filename, module);
         wasm_free(ctx->allocator, filename);
         ctx->num_modules++;
         last_module_index = (int)i;

--- a/src/binary-writer.c
+++ b/src/binary-writer.c
@@ -393,8 +393,6 @@ static void write_expr(Context* ctx,
     }
     case WASM_EXPR_TYPE_CALL: {
       int index = wasm_get_func_index_by_var(module, &expr->call.var);
-      assert(ctx->options->is_invalid ||
-             (index >= 0 && (size_t)index < module->funcs.size));
       wasm_write_opcode(&ctx->stream, WASM_OPCODE_CALL);
       write_u32_leb128_with_reloc(ctx, index, "function index",
                                   WASM_RELOC_FUNC_INDEX_LEB);
@@ -403,8 +401,6 @@ static void write_expr(Context* ctx,
     case WASM_EXPR_TYPE_CALL_INDIRECT: {
       int index =
           wasm_get_func_type_index_by_var(module, &expr->call_indirect.var);
-      assert(ctx->options->is_invalid ||
-             (index >= 0 && (size_t)index < module->func_types.size));
       wasm_write_opcode(&ctx->stream, WASM_OPCODE_CALL_INDIRECT);
       wasm_write_u32_leb128(&ctx->stream, index, "signature index");
       wasm_write_u32_leb128(&ctx->stream, 0, "call_indirect reserved");
@@ -790,29 +786,21 @@ static WasmResult write_module(Context* ctx, const WasmModule* module) {
       switch (export->kind) {
         case WASM_EXTERNAL_KIND_FUNC: {
           int index = wasm_get_func_index_by_var(module, &export->var);
-          assert(ctx->options->is_invalid ||
-                 (index >= 0 && (size_t)index < module->funcs.size));
           wasm_write_u32_leb128(&ctx->stream, index, "export func index");
           break;
         }
         case WASM_EXTERNAL_KIND_TABLE: {
           int index = wasm_get_table_index_by_var(module, &export->var);
-          assert(ctx->options->is_invalid ||
-                 (index >= 0 && (size_t)index < module->tables.size));
           wasm_write_u32_leb128(&ctx->stream, index, "export table index");
           break;
         }
         case WASM_EXTERNAL_KIND_MEMORY: {
           int index = wasm_get_memory_index_by_var(module, &export->var);
-          assert(ctx->options->is_invalid ||
-                 (index >= 0 && (size_t)index < module->memories.size));
           wasm_write_u32_leb128(&ctx->stream, index, "export memory index");
           break;
         }
         case WASM_EXTERNAL_KIND_GLOBAL: {
           int index = wasm_get_global_index_by_var(module, &export->var);
-          assert(ctx->options->is_invalid ||
-                 (index >= 0 && (size_t)index < module->globals.size));
           wasm_write_u32_leb128(&ctx->stream, index, "export global index");
           break;
         }
@@ -850,8 +838,6 @@ static WasmResult write_module(Context* ctx, const WasmModule* module) {
       size_t j;
       for (j = 0; j < segment->vars.size; ++j) {
         int index = wasm_get_func_index_by_var(module, &segment->vars.data[j]);
-        assert(ctx->options->is_invalid ||
-               (index >= 0 && (size_t)index < module->funcs.size));
         write_u32_leb128_with_reloc(ctx, index, "function index",
                                     WASM_RELOC_FUNC_INDEX_LEB);
       }

--- a/src/binary-writer.h
+++ b/src/binary-writer.h
@@ -27,14 +27,13 @@ struct WasmStream;
 enum WasmPrintChars;
 
 #define WASM_WRITE_BINARY_OPTIONS_DEFAULT \
-  { NULL, WASM_TRUE, WASM_FALSE, WASM_FALSE, WASM_FALSE }
+  { NULL, WASM_TRUE, WASM_FALSE, WASM_FALSE }
 
 typedef struct WasmWriteBinaryOptions {
   struct WasmStream* log_stream;
   WasmBool canonicalize_lebs;
   WasmBool relocatable;
   WasmBool write_debug_names;
-  WasmBool is_invalid;
 } WasmWriteBinaryOptions;
 
 WASM_EXTERN_C_BEGIN


### PR DESCRIPTION
These assertions aren't useful if we allow writing invalid modules. I
asked @Cellule to pipe through `is_invalid` instead, but now I think
it's better to just remove the assertions.