### PR TITLE
Fix reading of custom section relocations

### DIFF
--- a/src/binary-reader.c
+++ b/src/binary-reader.c
@@ -1712,10 +1712,10 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
     CALLBACK_SECTION(begin_reloc_section, section_size);
     uint32_t i, num_relocs, section;
     in_u32_leb128(ctx, &section, "section");
-    in_u32_leb128(ctx, &num_relocs, "relocation count count");
     WASM_ZERO_MEMORY(section_name);
     if (section == WASM_BINARY_SECTION_CUSTOM)
       in_str(ctx, &section_name, "section name");
+    in_u32_leb128(ctx, &num_relocs, "relocation count");
     CALLBACK(on_reloc_count, num_relocs, section, section_name);
     for (i = 0; i < num_relocs; ++i) {
       uint32_t reloc_type, offset;

--- a/src/tools/wasm-link.c
+++ b/src/tools/wasm-link.c
@@ -278,13 +278,6 @@ static void write_export_section(Context* ctx) {
   for (i = 0; i < ctx->inputs.size; i++) {
     WasmLinkerInputBinary* binary = &ctx->inputs.data[i];
     total_exports += binary->exports.size;
-    /*
-    for (j = 0; j < binary->exports.size; j++) {
-      WasmExport* export = &binary->exports.data[j];
-      if (exports) {
-      }
-    }
-    */
   }
 
   WasmStream* stream = &ctx->stream;

--- a/test/binary/relocs.txt
+++ b/test/binary/relocs.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-gen-wasm
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section("name") {
+  func_count[0]
+}
+section("reloc.TYPE") {
+  reloc_section[1]
+  reloc_count[0]
+}
+section("reloc.name") {
+  reloc_section[0]
+  str("name")
+  reloc_count[0]
+}
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (result i32))))
+;;; STDOUT ;;)


### PR DESCRIPTION
The string name of the target section comes before
the relocation count.

This was not tested because we don't currently generate
any relocations for custom sections, so I also added
a binary/relocs.txt test to generate a binary that
does.