### PR TITLE
Update testsuite

### DIFF
--- a/src/tools/wasm-interp.c
+++ b/src/tools/wasm-interp.c
@@ -1484,12 +1484,13 @@ static WasmResult on_assert_exhaustion_command(Context* ctx,
     ctx->total++;
     WasmResult result = run_action(ctx, action, &iresult, &results, RUN_QUIET);
     if (WASM_SUCCEEDED(result)) {
-        if (iresult == WASM_INTERPRETER_TRAP_CALL_STACK_EXHAUSTED) {
-            ctx->passed++;
-        } else {
-            print_command_error(ctx, "expected call stack exhaustion");
-            result = WASM_ERROR;
-        }
+      if (iresult == WASM_INTERPRETER_TRAP_CALL_STACK_EXHAUSTED ||
+          iresult == WASM_INTERPRETER_TRAP_VALUE_STACK_EXHAUSTED) {
+        ctx->passed++;
+      } else {
+        print_command_error(ctx, "expected call stack exhaustion");
+        result = WASM_ERROR;
+      }
     }
 
     wasm_destroy_interpreter_typed_value_vector(ctx->allocator, &results);

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -85,5 +85,13 @@ assert_invalid error:
   out/third_party/testsuite/call_indirect.wast:359:5: type stack at end of function is 1. expected 0
     (func $large-type (call_indirect 1012321300 (i32.const 0)))
     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+assert_invalid error:
+  out/third_party/testsuite/call_indirect.wast:366:32: function variable out of range (max 0)
+  (module (table anyfunc (elem 0 0)))
+                               ^
+assert_invalid error:
+  out/third_party/testsuite/call_indirect.wast:366:34: function variable out of range (max 0)
+  (module (table anyfunc (elem 0 0)))
+                                 ^
 48/48 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -42,28 +42,28 @@ assert_invalid error:
   (module (global i32 (get_global 1)) (global i32 (i32.const 0)))
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 assert_malformed error:
-  out/third_party/testsuite/globals.wast:102:20: error in binary module: @0x00000022: global mutability must be 0 or 1
-(assert_malformed (module "\00asm\0d\00\00\00\02\94\80\80\80\00\01\08\73\70\6...
-                   ^^^^^^
+  out/third_party/testsuite/globals.wast:103:4: error in binary module: @0x00000022: global mutability must be 0 or 1
+  (module
+   ^^^^^^
 assert_malformed error:
-  out/third_party/testsuite/globals.wast:107:20: error in binary module: @0x00000011: global mutability must be 0 or 1
-(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\ff\41\0...
-                   ^^^^^^
+  out/third_party/testsuite/globals.wast:116:4: error in binary module: @0x00000022: global mutability must be 0 or 1
+  (module
+   ^^^^^^
 assert_malformed error:
-  out/third_party/testsuite/globals.wast:108:20: error in binary module: @0x00000011: global mutability must be 0 or 1
-(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\d4\41\0...
-                   ^^^^^^
+  out/third_party/testsuite/globals.wast:133:4: error in binary module: @0x00000011: global mutability must be 0 or 1
+  (module
+   ^^^^^^
 assert_malformed error:
-  out/third_party/testsuite/globals.wast:109:20: error in binary module: @0x00000011: global mutability must be 0 or 1
-(assert_malformed (module "\00asm\0d\00\00\00\06\86\80\80\80\00\01\7f\02\41\0...
-                   ^^^^^^
-out/third_party/testsuite/globals.wast:102: assert_malformed passed:
+  out/third_party/testsuite/globals.wast:145:4: error in binary module: @0x00000011: global mutability must be 0 or 1
+  (module
+   ^^^^^^
+out/third_party/testsuite/globals.wast:103: assert_malformed passed:
   error: @0x00000022: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:107: assert_malformed passed:
+out/third_party/testsuite/globals.wast:116: assert_malformed passed:
+  error: @0x00000022: global mutability must be 0 or 1
+out/third_party/testsuite/globals.wast:133: assert_malformed passed:
   error: @0x00000011: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:108: assert_malformed passed:
-  error: @0x00000011: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:109: assert_malformed passed:
+out/third_party/testsuite/globals.wast:145: assert_malformed passed:
   error: @0x00000011: global mutability must be 0 or 1
 20/20 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -2,27 +2,27 @@
 ;;; STDIN_FILE: third_party/testsuite/imports.wast
 (;; STDOUT ;;;
 assert_invalid error:
-  out/third_party/testsuite/imports.wast:284:45: only one table allowed
+  out/third_party/testsuite/imports.wast:288:45: only one table allowed
   (module (import "" "" (table 10 anyfunc)) (import "" "" (table 10 anyfunc)))
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/imports.wast:288:45: only one table allowed
+  out/third_party/testsuite/imports.wast:292:45: only one table allowed
   (module (import "" "" (table 10 anyfunc)) (table 10 anyfunc))
                                             ^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/imports.wast:292:30: only one table allowed
+  out/third_party/testsuite/imports.wast:296:30: only one table allowed
   (module (table 10 anyfunc) (table 10 anyfunc))
                              ^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/imports.wast:379:37: only one memory block allowed
+  out/third_party/testsuite/imports.wast:383:37: only one memory block allowed
   (module (import "" "" (memory 1)) (import "" "" (memory 1)))
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/imports.wast:383:37: only one memory block allowed
+  out/third_party/testsuite/imports.wast:387:37: only one memory block allowed
   (module (import "" "" (memory 1)) (memory 0))
                                     ^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/imports.wast:387:22: only one memory block allowed
+  out/third_party/testsuite/imports.wast:391:22: only one memory block allowed
   (module (memory 0) (memory 0))
                      ^^^^^^^^^^
 called host spectest.print(i32:13) =>
@@ -31,177 +31,176 @@ called host spectest.print(i32:13) =>
 called host spectest.print(i32:13) =>
 called host spectest.print(f32:13) =>
 called host spectest.print(i32:13) =>
-called host spectest.print(i64:24) =>
 called host spectest.print(f64:25, f64:53) =>
 called host spectest.print(f64:24) =>
 called host spectest.print(f64:24) =>
 called host spectest.print(f64:24) =>
-out/third_party/testsuite/imports.wast:86: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:89: assert_unlinkable passed:
   error: unknown module field "unknown"
   error: @0x0000001e: on_import callback failed
-out/third_party/testsuite/imports.wast:90: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:93: assert_unlinkable passed:
   error: unknown host function import "spectest.unknown"
   error: @0x00000024: on_import_func callback failed
-out/third_party/testsuite/imports.wast:95: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:98: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x0000001e: on_import_func callback failed
-out/third_party/testsuite/imports.wast:99: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:102: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x0000001e: on_import_func callback failed
-out/third_party/testsuite/imports.wast:103: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:106: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x0000001f: on_import_func callback failed
-out/third_party/testsuite/imports.wast:107: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:110: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000021: on_import_func callback failed
-out/third_party/testsuite/imports.wast:111: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:114: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000022: on_import_func callback failed
-out/third_party/testsuite/imports.wast:115: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:118: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000022: on_import_func callback failed
-out/third_party/testsuite/imports.wast:119: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:122: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000022: on_import_func callback failed
-out/third_party/testsuite/imports.wast:123: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:126: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000023: on_import_func callback failed
-out/third_party/testsuite/imports.wast:127: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:130: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000022: on_import_func callback failed
-out/third_party/testsuite/imports.wast:131: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:134: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000023: on_import_func callback failed
-out/third_party/testsuite/imports.wast:135: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:138: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000023: on_import_func callback failed
-out/third_party/testsuite/imports.wast:139: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:142: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000023: on_import_func callback failed
-out/third_party/testsuite/imports.wast:143: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:146: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000024: on_import_func callback failed
-out/third_party/testsuite/imports.wast:147: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:150: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000026: on_import_func callback failed
-out/third_party/testsuite/imports.wast:151: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:154: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000027: on_import_func callback failed
-out/third_party/testsuite/imports.wast:155: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:158: assert_unlinkable passed:
   error: import signature mismatch
   error: @0x00000027: on_import_func callback failed
-out/third_party/testsuite/imports.wast:160: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:163: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind func, not global
   error: @0x00000024: on_import_func callback failed
-out/third_party/testsuite/imports.wast:164: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:167: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind func, not table
   error: @0x00000025: on_import_func callback failed
-out/third_party/testsuite/imports.wast:168: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:171: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind func, not memory
   error: @0x00000025: on_import_func callback failed
-out/third_party/testsuite/imports.wast:172: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:175: assert_unlinkable passed:
   error: unknown host function import "spectest.global"
   error: @0x00000023: on_import_func callback failed
-out/third_party/testsuite/imports.wast:176: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:179: assert_unlinkable passed:
   error: unknown host function import "spectest.table"
   error: @0x00000022: on_import_func callback failed
-out/third_party/testsuite/imports.wast:180: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:183: assert_unlinkable passed:
   error: unknown host function import "spectest.memory"
   error: @0x00000023: on_import_func callback failed
-out/third_party/testsuite/imports.wast:213: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:217: assert_unlinkable passed:
   error: unknown module field "unknown"
   error: @0x00000018: on_import callback failed
-out/third_party/testsuite/imports.wast:217: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:221: assert_unlinkable passed:
   error: unknown host global import "spectest.unknown"
   error: @0x0000001f: on_import_global callback failed
-out/third_party/testsuite/imports.wast:222: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:226: assert_unlinkable passed:
   error: expected import "test.func" to have kind global, not func
   error: @0x00000018: on_import_global callback failed
-out/third_party/testsuite/imports.wast:226: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:230: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind global, not table
   error: @0x00000020: on_import_global callback failed
-out/third_party/testsuite/imports.wast:230: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:234: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind global, not memory
   error: @0x00000020: on_import_global callback failed
-out/third_party/testsuite/imports.wast:234: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:238: assert_unlinkable passed:
   error: unknown host global import "spectest.print"
   error: @0x0000001d: on_import_global callback failed
-out/third_party/testsuite/imports.wast:238: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:242: assert_unlinkable passed:
   error: unknown host global import "spectest.table"
   error: @0x0000001d: on_import_global callback failed
-out/third_party/testsuite/imports.wast:242: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:246: assert_unlinkable passed:
   error: unknown host global import "spectest.memory"
   error: @0x0000001e: on_import_global callback failed
-out/third_party/testsuite/imports.wast:309: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:313: assert_unlinkable passed:
   error: unknown module field "unknown"
   error: @0x00000018: on_import callback failed
-out/third_party/testsuite/imports.wast:313: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:317: assert_unlinkable passed:
   error: unknown host table import "spectest.unknown"
   error: @0x00000020: on_import_table callback failed
-out/third_party/testsuite/imports.wast:318: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:322: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
   error: @0x00000021: on_import_table callback failed
-out/third_party/testsuite/imports.wast:322: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:326: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (20)
   error: @0x00000022: on_import_table callback failed
-out/third_party/testsuite/imports.wast:326: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:330: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
   error: @0x0000001e: on_import_table callback failed
-out/third_party/testsuite/imports.wast:330: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:334: assert_unlinkable passed:
   error: max size (20) larger than declared (15)
   error: @0x0000001f: on_import_table callback failed
-out/third_party/testsuite/imports.wast:335: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:339: assert_unlinkable passed:
   error: expected import "test.func" to have kind table, not func
   error: @0x00000019: on_import_table callback failed
-out/third_party/testsuite/imports.wast:339: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:343: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind table, not global
   error: @0x0000001f: on_import_table callback failed
-out/third_party/testsuite/imports.wast:343: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:347: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind table, not memory
   error: @0x00000021: on_import_table callback failed
-out/third_party/testsuite/imports.wast:347: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:351: assert_unlinkable passed:
   error: unknown host table import "spectest.print"
   error: @0x0000001e: on_import_table callback failed
-out/third_party/testsuite/imports.wast:402: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:406: assert_unlinkable passed:
   error: unknown module field "unknown"
   error: @0x00000018: on_import callback failed
-out/third_party/testsuite/imports.wast:406: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:410: assert_unlinkable passed:
   error: unknown host memory import "spectest.unknown"
   error: @0x0000001f: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:411: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:415: assert_unlinkable passed:
   error: actual size (2) smaller than declared (3)
   error: @0x00000020: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:415: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:419: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (3)
   error: @0x00000021: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:419: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:423: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
   error: @0x0000001e: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:423: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:427: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
   error: @0x0000001f: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:428: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:432: assert_unlinkable passed:
   error: expected import "test.func-i32" to have kind memory, not func
   error: @0x0000001c: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:432: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:436: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind memory, not global
   error: @0x0000001e: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:436: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:440: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind memory, not table
   error: @0x00000020: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:440: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:444: assert_unlinkable passed:
   error: unknown host memory import "spectest.print"
   error: @0x0000001d: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:444: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:448: assert_unlinkable passed:
   error: unknown host memory import "spectest.global"
   error: @0x0000001e: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:448: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:452: assert_unlinkable passed:
   error: unknown host memory import "spectest.table"
   error: @0x0000001d: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:453: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:457: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
   error: @0x0000001e: on_import_memory callback failed
-out/third_party/testsuite/imports.wast:457: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:461: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
   error: @0x0000001f: on_import_memory callback failed
 85/85 tests passed.

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -9,9 +9,21 @@ out/third_party/testsuite/linking.wast:32: assert_unlinkable passed:
   error: @0x00000026: on_import_func callback failed
 out/third_party/testsuite/linking.wast:160: assert_unlinkable passed:
   error: unknown module field "mem"
-  error: @0x00000038: on_import callback failed
-out/third_party/testsuite/linking.wast:233: assert_unlinkable passed:
+  error: @0x00000024: on_import callback failed
+out/third_party/testsuite/linking.wast:172: assert_unlinkable passed:
+  error: elem segment offset is out of bounds: 12 >= max value 10
+  error: @0x00000030: on_elem_segment_function_index callback failed
+out/third_party/testsuite/linking.wast:183: assert_unlinkable passed:
+  error: data segment is out of bounds: [65536, 65537) >= max value 65536
+  error: @0x00000042: on_data_segment_data callback failed
+out/third_party/testsuite/linking.wast:255: assert_unlinkable passed:
   error: unknown module field "tab"
   error: @0x00000033: on_import callback failed
-69/69 tests passed.
+out/third_party/testsuite/linking.wast:266: assert_unlinkable passed:
+  error: data segment is out of bounds: [327680, 327681) >= max value 327680
+  error: @0x00000028: on_data_segment_data callback failed
+out/third_party/testsuite/linking.wast:276: assert_unlinkable passed:
+  error: elem segment offset is out of bounds: 0 >= max value 0
+  error: @0x0000002e: on_elem_segment_function_index callback failed
+77/77 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -66,85 +66,94 @@ assert_invalid error:
   (module (memory 1) (data (nop)))
                      ^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:104:11: max pages (0) must be >= initial pages (1)
+  out/third_party/testsuite/memory.wast:116:11: max pages (0) must be >= initial pages (1)
   (module (memory 1 0))
           ^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:108:11: initial pages (65537) must be <= (65536)
+  out/third_party/testsuite/memory.wast:120:11: initial pages (65537) must be <= (65536)
   (module (memory 65537))
           ^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:112:11: initial pages (2147483648) must be <= (65536)
+  out/third_party/testsuite/memory.wast:124:11: initial pages (2147483648) must be <= (65536)
   (module (memory 2147483648))
           ^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:116:11: initial pages (4294967295) must be <= (65536)
+  out/third_party/testsuite/memory.wast:128:11: initial pages (4294967295) must be <= (65536)
   (module (memory 4294967295))
           ^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:120:11: max pages (65537) must be <= (65536)
+  out/third_party/testsuite/memory.wast:132:11: max pages (65537) must be <= (65536)
   (module (memory 0 65537))
           ^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:124:11: max pages (2147483648) must be <= (65536)
+  out/third_party/testsuite/memory.wast:136:11: max pages (2147483648) must be <= (65536)
   (module (memory 0 2147483648))
           ^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:128:11: max pages (4294967295) must be <= (65536)
+  out/third_party/testsuite/memory.wast:140:11: max pages (4294967295) must be <= (65536)
   (module (memory 0 4294967295))
           ^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:139:35: alignment must not be larger than natural alignment (8)
+  out/third_party/testsuite/memory.wast:151:35: alignment must not be larger than natural alignment (8)
   (module (memory 0) (func (drop (i64.load align=16 (i32.const 0)))))
                                   ^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:143:35: alignment must not be larger than natural alignment (8)
+  out/third_party/testsuite/memory.wast:155:35: alignment must not be larger than natural alignment (8)
   (module (memory 0) (func (drop (i64.load align=32 (i32.const 0)))))
                                   ^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:147:35: alignment must not be larger than natural alignment (4)
+  out/third_party/testsuite/memory.wast:159:35: alignment must not be larger than natural alignment (4)
   (module (memory 0) (func (drop (i32.load align=8 (i32.const 0)))))
                                   ^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:151:35: alignment must not be larger than natural alignment (2)
+  out/third_party/testsuite/memory.wast:163:35: alignment must not be larger than natural alignment (2)
   (module (memory 0) (func (drop (i32.load16_u align=4 (i32.const 0)))))
                                   ^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:155:35: alignment must not be larger than natural alignment (1)
+  out/third_party/testsuite/memory.wast:167:35: alignment must not be larger than natural alignment (1)
   (module (memory 0) (func (drop (i32.load8_u align=2 (i32.const 0)))))
                                   ^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:159:29: alignment must not be larger than natural alignment (1)
+  out/third_party/testsuite/memory.wast:171:29: alignment must not be larger than natural alignment (1)
   (module (memory 0) (func (i32.store8 align=2 (i32.const 0) (i32.const 0))))
                             ^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:163:29: alignment must not be larger than natural alignment (2)
+  out/third_party/testsuite/memory.wast:175:29: alignment must not be larger than natural alignment (2)
   (module (memory 0) (func (i32.load16_u align=4 (i32.const 0))))
                             ^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:163:22: type stack at end of function is 1. expected 0
+  out/third_party/testsuite/memory.wast:175:22: type stack at end of function is 1. expected 0
   (module (memory 0) (func (i32.load16_u align=4 (i32.const 0))))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:167:29: alignment must not be larger than natural alignment (1)
+  out/third_party/testsuite/memory.wast:179:29: alignment must not be larger than natural alignment (1)
   (module (memory 0) (func (i32.load8_u align=2 (i32.const 0))))
                             ^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:167:22: type stack at end of function is 1. expected 0
+  out/third_party/testsuite/memory.wast:179:22: type stack at end of function is 1. expected 0
   (module (memory 0) (func (i32.load8_u align=2 (i32.const 0))))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 assert_invalid error:
-  out/third_party/testsuite/memory.wast:171:29: alignment must not be larger than natural alignment (1)
+  out/third_party/testsuite/memory.wast:183:29: alignment must not be larger than natural alignment (1)
   (module (memory 0) (func (i32.store8 align=2 (i32.const 0) (i32.const 0))))
                             ^^^^^^^^^^^^^^^^^^
 out/third_party/testsuite/memory.wast:77: assert_unlinkable passed:
   error: data segment is out of bounds: [0, 1) >= max value 0
   error: @0x00000017: on_data_segment_data callback failed
 out/third_party/testsuite/memory.wast:81: assert_unlinkable passed:
+  error: data segment is out of bounds: [0, 1) >= max value 0
+  error: @0x00000017: on_data_segment_data callback failed
+out/third_party/testsuite/memory.wast:85: assert_unlinkable passed:
   error: data segment is out of bounds: [98304, 98305) >= max value 65536
   error: @0x0000001f: on_data_segment_data callback failed
-out/third_party/testsuite/memory.wast:90: assert_unlinkable passed:
+out/third_party/testsuite/memory.wast:89: assert_unlinkable passed:
+  error: data segment is out of bounds: [1, 1) >= max value 0
+  error: @0x00000016: on_data_segment_data callback failed
+out/third_party/testsuite/memory.wast:93: assert_unlinkable passed:
+  error: data segment is out of bounds: [73728, 73728) >= max value 65536
+  error: @0x00000017: on_data_segment_data callback failed
+out/third_party/testsuite/memory.wast:102: assert_unlinkable passed:
   error: data segment is out of bounds: [666, 667) >= max value 0
   error: @0x0000002c: on_data_segment_data callback failed
-30/30 tests passed.
+33/33 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
Also:
* Check all data/elem segments before updating memory/tables
* assert_exhaustion should check for call stack or value stack
  exhaustion.
* Don't allow out-of-bound size 0 data segments