### PR TITLE
Update README now that wasm2wast defaults to including debug names

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Some examples:
 # parse binary file test.wasm and write s-expression file test.wast
 $ out/wasm2wast test.wasm -o test.wast
 
-# parse test.wasm and write test.wast, using the debug names, if any
-$ out/wasm2wast test.wasm --debug-names -o test.wast
+# parse test.wasm and write test.wast
+$ out/wasm2wast test.wasm -o test.wast
 ```
 
 You can use `-h` to get additional help:


### PR DESCRIPTION
As of #253, wasm2wast now includes debug-names by default, letting you opt-out via `--no-debug-names`.

I also noticed that now wasm2wast and wast2wasm are inconsistent in that regard. The later still defaulting to excluding debug names. Is that intentional? Happy to PR if it too should be reversed. There's mostly a tradition of toolchains requiring opt-in for optimizations like excluding debug names, but I'm new around here 🤓 