### PR TITLE
Use perror to output error messages when reading files

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -623,8 +623,8 @@ static void write_global_header(Context* ctx, const WabtGlobal* global) {
 
 static void write_reloc_section(Context* ctx, RelocSection* reloc_section) {
   char section_name[128];
-  sprintf(section_name, "%s.%s", WABT_BINARY_SECTION_RELOC,
-          reloc_section->name);
+  wabt_snprintf(section_name, sizeof(section_name), "%s.%s",
+                WABT_BINARY_SECTION_RELOC, reloc_section->name);
   begin_custom_section(ctx, section_name, LEB_SECTION_SIZE_GUESS);
   wabt_write_u32_leb128(&ctx->stream, reloc_section->section_code,
                         "reloc section type");


### PR DESCRIPTION
Example: `unable to read file /path/to/file: No such file or directory`
Modified it locally when debugging an issue on my end, figured I might as well PR..

Also changed the single sprintf usage to wabt_snprintf