### PR TITLE
Roll back to previous MSYS2

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 ---
 
+# TODO(binji): roll back to previous image because MSYS2 6.3.0 seems to be
+# broken.
+os: Previous Visual Studio 2015
+
 init:
   - set PATH=C:\Python27\Scripts;%PATH%             # while python's bin is already in PATH, but pip.exe in Scripts\ dir isn't
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%


### PR DESCRIPTION
Looks like MSYS was rev'd from 5.3.0 -> 6.3.0 recently, breaking the appveyor bots, see https://ci.appveyor.com/project/WebAssembly/wabt/build/1.0.610/job/o0ad22qnjcjg1x62 for example.

This change uses the old image for now. We should figure out what's wrong w/ the errors there though.