### PR TITLE
Update CMake and Makefile to use .hh instead of .h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,7 +174,7 @@ if (RUN_BISON AND BISON_FOUND)
   BISON_TARGET(AST_PARSER_GEN_C
     ${WABT_SOURCE_DIR}/src/ast-parser.y
     ${AST_PARSER_GEN_C}
-    COMPILE_FLAGS --defines=${WABT_BINARY_DIR}/ast-parser-gen.h
+    COMPILE_FLAGS --defines=${WABT_BINARY_DIR}/ast-parser-gen.hh
   )
 else ()
   set(AST_PARSER_GEN_C src/prebuilt/ast-parser-gen.cc)

--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ update-bison: src/prebuilt/ast-parser-gen.cc
 update-re2c: src/prebuilt/ast-lexer-gen.cc
 
 src/prebuilt/ast-parser-gen.cc: src/ast-parser.y
-	bison -o $@ $< --defines=src/prebuilt/ast-parser-gen.h --report=state
+	bison -o $@ $< --defines=src/prebuilt/ast-parser-gen.hh --report=state
 
 src/prebuilt/ast-lexer-gen.cc: src/ast-lexer.cc
 	re2c --no-generation-date -bc -o $@ $<

--- a/src/ast-lexer.cc
+++ b/src/ast-lexer.cc
@@ -26,7 +26,7 @@
 #include "vector.h"
 
 /* must be included after so some typedefs will be defined */
-#include "ast-parser-gen.h"
+#include "ast-parser-gen.hh"
 
 /*!max:re2c */
 

--- a/src/prebuilt/ast-lexer-gen.cc
+++ b/src/prebuilt/ast-lexer-gen.cc
@@ -28,7 +28,7 @@
 #include "vector.h"
 
 /* must be included after so some typedefs will be defined */
-#include "ast-parser-gen.h"
+#include "ast-parser-gen.hh"
 
 #define YYMAXFILL 20
 

--- a/src/prebuilt/ast-parser-gen.cc
+++ b/src/prebuilt/ast-parser-gen.cc
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.0.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -269,9 +269,9 @@ static void on_read_binary_error(uint32_t offset, const char* error,
 #endif
 
 /* In a future release of Bison, this section will be replaced
-   by #include "ast-parser-gen.h".  */
-#ifndef YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_H_INCLUDED
-# define YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_H_INCLUDED
+   by #include "ast-parser-gen.hh".  */
+#ifndef YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_HH_INCLUDED
+# define YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_HH_INCLUDED
 /* Debug traces.  */
 #ifndef WABT_AST_PARSER_DEBUG
 # if defined YYDEBUG
@@ -393,7 +393,7 @@ struct WABT_AST_PARSER_LTYPE
 
 int wabt_ast_parser_parse (WabtAstLexer* lexer, WabtAstParser* parser);
 
-#endif /* !YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_H_INCLUDED  */
+#endif /* !YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_HH_INCLUDED  */
 
 /* Copy the second part of user declarations.  */
 

--- a/src/prebuilt/ast-parser-gen.hh
+++ b/src/prebuilt/ast-parser-gen.hh
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -30,8 +30,8 @@
    This special exception was added by the Free Software Foundation in
    version 2.2 of Bison.  */
 
-#ifndef YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_H_INCLUDED
-# define YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_H_INCLUDED
+#ifndef YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_HH_INCLUDED
+# define YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_HH_INCLUDED
 /* Debug traces.  */
 #ifndef WABT_AST_PARSER_DEBUG
 # if defined YYDEBUG
@@ -153,4 +153,4 @@ struct WABT_AST_PARSER_LTYPE
 
 int wabt_ast_parser_parse (WabtAstLexer* lexer, WabtAstParser* parser);
 
-#endif /* !YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_H_INCLUDED  */
+#endif /* !YY_WABT_AST_PARSER_SRC_PREBUILT_AST_PARSER_GEN_HH_INCLUDED  */


### PR DESCRIPTION
The built-in CMake rules look for an .hh file instead of a .h when
building for C++. Without it, the build will always think that the
generated parser is stale and rebuild it.