### PR TITLE
Extensible name section support

### DIFF
--- a/src/binary-reader-ast.cc
+++ b/src/binary-reader-ast.cc
@@ -906,9 +906,9 @@ static Result on_function_name(uint32_t index,
   return Result::Ok;
 }
 
-static Result on_local_names_count(uint32_t index,
-                                   uint32_t count,
-                                   void* user_data) {
+static Result on_local_name_local_count(uint32_t index,
+                                        uint32_t count,
+                                        void* user_data) {
   Context* ctx = static_cast<Context*>(user_data);
   Module* module = ctx->module;
   assert(index < module->funcs.size);
@@ -1106,7 +1106,7 @@ Result read_binary_ast(const void* data,
 
   reader.on_function_names_count = on_function_names_count;
   reader.on_function_name = on_function_name;
-  reader.on_local_names_count = on_local_names_count;
+  reader.on_local_name_local_count = on_local_name_local_count;
   reader.on_local_name = on_local_name;
 
   reader.on_init_expr_f32_const_expr = on_init_expr_f32_const_expr;

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -166,10 +166,6 @@ static Result begin_custom_section(BinaryReaderContext* ctx,
     bytes_read = read_u32_leb128(
         &binary->data[sec->offset], &binary->data[binary->size], &subsection_size);
 
-    if (static_cast<NameSectionSubsection>(name_type) != NameSectionSubsection::Function) {
-      WABT_FATAL("no function name section");
-    }
-
     sec->payload_offset += bytes_read;
     sec->payload_size -= bytes_read;
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -593,7 +593,9 @@ static Result on_function_name(uint32_t index,
       StringSlice empty = empty_string_slice();
       append_string_slice_value(&ctx->options->function_names, &empty);
     }
-    append_string_slice_value(&ctx->options->function_names, &name);
+    if (ctx->options->function_names.size == index) {
+      append_string_slice_value(&ctx->options->function_names, &name);
+    }
   }
   return Result::Ok;
 }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -399,7 +399,8 @@ static Result begin_function_body(BinaryReaderContext* context,
   Context* ctx = static_cast<Context*>(context->user_data);
 
   if (ctx->options->mode == ObjdumpMode::Disassemble) {
-    if (index < ctx->options->function_names.size)
+    if (index < ctx->options->function_names.size &&
+        !string_slice_is_empty(&ctx->options->function_names.data[index]))
       printf("%06" PRIzx " <" PRIstringslice ">:\n", context->offset,
              WABT_PRINTF_STRING_SLICE_ARG(
                  ctx->options->function_names.data[index]));
@@ -587,8 +588,13 @@ static Result on_function_name(uint32_t index,
   Context* ctx = static_cast<Context*>(user_data);
   print_details(ctx, " - func[%d] " PRIstringslice "\n", index,
                 WABT_PRINTF_STRING_SLICE_ARG(name));
-  if (ctx->options->mode == ObjdumpMode::Prepass)
+  if (ctx->options->mode == ObjdumpMode::Prepass) {
+    while (ctx->options->function_names.size < index) {
+      StringSlice empty = empty_string_slice();
+      append_string_slice_value(&ctx->options->function_names, &empty);
+    }
     append_string_slice_value(&ctx->options->function_names, &name);
+  }
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1576,8 +1576,8 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
       in_u32_leb128(ctx, &name_type, "name type");
       in_u32_leb128(ctx, &subsection_size, "subsection size");
 
-      switch (name_type) {
-      case 1:
+      switch (static_cast<NameSectionSubsection>(name_type)) {
+      case NameSectionSubsection::Function:
         CALLBACK(on_function_name_subsection, i, name_type, subsection_size);
         if (subsection_size) {
           uint32_t num_names;
@@ -1595,7 +1595,7 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
         }
         ++i;
         break;
-      case 2:
+      case NameSectionSubsection::Local:
         CALLBACK(on_local_name_subsection, i, name_type, subsection_size);
         if (subsection_size) {
           uint32_t num_funcs;
@@ -1620,6 +1620,10 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
           }
         }
         ++i;
+        break;
+      default:
+        /* unknown subsection, skip rest of section */
+        ctx->offset = ctx->read_end;
         break;
       }
     }

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -261,14 +261,27 @@ struct BinaryReader {
 
   /* names section */
   Result (*begin_names_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_function_names_count)(uint32_t count, void* user_data);
-  Result (*on_function_name)(uint32_t index, StringSlice name, void* user_data);
-  Result (*on_local_names_count)(uint32_t index,
-                                 uint32_t count,
-                                 void* user_data);
-  Result (*on_local_name)(uint32_t func_index,
+  Result (*on_function_name_subsection)(uint32_t index,
+                                        uint32_t name_type,
+                                        uint32_t subsection_size,
+                                        void* user_data);
+  Result (*on_function_names_count)(uint32_t num_functions,
+                                    void* user_data);
+  Result (*on_function_name)(uint32_t function_index,
+                             StringSlice function_name,
+                             void* user_data);
+  Result (*on_local_name_subsection)(uint32_t index,
+                                     uint32_t name_type,
+                                     uint32_t subsection_size,
+                                     void* user_data);
+  Result (*on_local_name_function_count)(uint32_t num_functions,
+                                         void* user_data);
+  Result (*on_local_name_local_count)(uint32_t function_index,
+                                      uint32_t num_locals,
+                                      void* user_data);
+  Result (*on_local_name)(uint32_t function_index,
                           uint32_t local_index,
-                          StringSlice name,
+                          StringSlice local_name,
                           void* user_data);
   Result (*end_names_section)(BinaryReaderContext* ctx);
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -874,19 +874,6 @@ static Result write_module(Context* ctx, const Module* module) {
     char desc[100];
     begin_custom_section(ctx, WABT_BINARY_SECTION_NAME, LEB_SECTION_SIZE_GUESS);
     write_u32_leb128(&ctx->stream, 1, "function name type");
-
-    begin_subsection(ctx, "function name subsection", LEB_SECTION_SIZE_GUESS);
-    write_u32_leb128(&ctx->stream, module->funcs.size, "num functions");
-    for (i = 0; i < module->funcs.size; ++i) {
-      const Func* func = module->funcs.data[i];
-      write_u32_leb128(&ctx->stream, i, "function index");
-      snprintf(desc, sizeof(desc), "func name %" PRIzd, i);
-      write_str(&ctx->stream, func->name.start, func->name.length,
-                PrintChars::Yes, desc);
-    }
-    end_subsection(ctx);
-    write_u32_leb128(&ctx->stream, 1, "function name type");
-
     begin_subsection(ctx, "function name subsection", LEB_SECTION_SIZE_GUESS);
     write_u32_leb128(&ctx->stream, module->funcs.size, "num functions");
     for (i = 0; i < module->funcs.size; ++i) {

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -309,7 +309,7 @@ static void begin_subsection(Context* ctx,
                              size_t leb_size_guess) {
   assert(ctx->last_subsection_leb_size_guess == 0);
   char desc[100];
-  snprintf(desc, sizeof(desc), "subsection \"%s\"", name);
+  wabt_snprintf(desc, sizeof(desc), "subsection \"%s\"", name);
   ctx->last_subsection_leb_size_guess = leb_size_guess;
   ctx->last_subsection_offset =
       write_u32_leb128_space(ctx, leb_size_guess, "subsection size (guess)");

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -67,6 +67,10 @@ struct Context {
   size_t last_section_leb_size_guess;
   BinarySection last_section_type;
   size_t last_section_payload_offset;
+
+  size_t last_subsection_offset;
+  size_t last_subsection_leb_size_guess;
+  size_t last_subsection_payload_offset;
 };
 
 void destroy_reloc_section(RelocSection* reloc_section) {
@@ -298,6 +302,26 @@ static void end_section(Context* ctx) {
                               ctx->last_section_leb_size_guess,
                               "FIXUP section size");
   ctx->last_section_leb_size_guess = 0;
+}
+
+static void begin_subsection(Context* ctx,
+                             const char* name,
+                             size_t leb_size_guess) {
+  assert(ctx->last_subsection_leb_size_guess == 0);
+  char desc[100];
+  snprintf(desc, sizeof(desc), "subsection \"%s\"", name);
+  ctx->last_subsection_leb_size_guess = leb_size_guess;
+  ctx->last_subsection_offset =
+      write_u32_leb128_space(ctx, leb_size_guess, "subsection size (guess)");
+  ctx->last_subsection_payload_offset = ctx->stream.offset;
+}
+
+static void end_subsection(Context* ctx) {
+  assert(ctx->last_subsection_leb_size_guess != 0);
+  write_fixup_u32_leb128_size(ctx, ctx->last_subsection_offset,
+                              ctx->last_subsection_leb_size_guess,
+                              "FIXUP subsection size");
+  ctx->last_subsection_leb_size_guess = 0;
 }
 
 static uint32_t get_label_var_depth(Context* ctx, const Var* var) {
@@ -849,6 +873,34 @@ static Result write_module(Context* ctx, const Module* module) {
 
     char desc[100];
     begin_custom_section(ctx, WABT_BINARY_SECTION_NAME, LEB_SECTION_SIZE_GUESS);
+    write_u32_leb128(&ctx->stream, 1, "function name type");
+
+    begin_subsection(ctx, "function name subsection", LEB_SECTION_SIZE_GUESS);
+    write_u32_leb128(&ctx->stream, module->funcs.size, "num functions");
+    for (i = 0; i < module->funcs.size; ++i) {
+      const Func* func = module->funcs.data[i];
+      write_u32_leb128(&ctx->stream, i, "function index");
+      snprintf(desc, sizeof(desc), "func name %" PRIzd, i);
+      write_str(&ctx->stream, func->name.start, func->name.length,
+                PrintChars::Yes, desc);
+    }
+    end_subsection(ctx);
+    write_u32_leb128(&ctx->stream, 1, "function name type");
+
+    begin_subsection(ctx, "function name subsection", LEB_SECTION_SIZE_GUESS);
+    write_u32_leb128(&ctx->stream, module->funcs.size, "num functions");
+    for (i = 0; i < module->funcs.size; ++i) {
+      const Func* func = module->funcs.data[i];
+      write_u32_leb128(&ctx->stream, i, "function index");
+      snprintf(desc, sizeof(desc), "func name %" PRIzd, i);
+      write_str(&ctx->stream, func->name.start, func->name.length,
+                PrintChars::Yes, desc);
+    }
+    end_subsection(ctx);
+
+    write_u32_leb128(&ctx->stream, 2, "local name type");
+
+    begin_subsection(ctx, "local name subsection", LEB_SECTION_SIZE_GUESS);
     write_u32_leb128(&ctx->stream, module->funcs.size, "num functions");
     for (i = 0; i < module->funcs.size; ++i) {
       const Func* func = module->funcs.data[i];
@@ -856,32 +908,34 @@ static Result write_module(Context* ctx, const Module* module) {
       uint32_t num_locals = func->local_types.size;
       uint32_t num_params_and_locals = get_num_params_and_locals(func);
 
-      snprintf(desc, sizeof(desc), "func name %" PRIzd, i);
-      write_str(&ctx->stream, func->name.start, func->name.length,
-                PrintChars::Yes, desc);
+      if (!num_params_and_locals)
+        continue;
+
+      write_u32_leb128(&ctx->stream, i, "function index");
       write_u32_leb128(&ctx->stream, num_params_and_locals, "num locals");
 
-      if (num_params_and_locals) {
-        make_type_binding_reverse_mapping(
-            &func->decl.sig.param_types, &func->param_bindings, &index_to_name);
-        size_t j;
-        for (j = 0; j < num_params; ++j) {
-          StringSlice name = index_to_name.data[j];
-          snprintf(desc, sizeof(desc), "local name %" PRIzd, j);
-          write_str(&ctx->stream, name.start, name.length, PrintChars::Yes,
-                    desc);
-        }
+      make_type_binding_reverse_mapping(
+        &func->decl.sig.param_types, &func->param_bindings, &index_to_name);
+      size_t j;
+      for (j = 0; j < num_params; ++j) {
+        StringSlice name = index_to_name.data[j];
+        snprintf(desc, sizeof(desc), "local name %" PRIzd, j);
+        write_u32_leb128(&ctx->stream, j, "local index");
+        write_str(&ctx->stream, name.start, name.length, PrintChars::Yes,
+                  desc);
+      }
 
-        make_type_binding_reverse_mapping(
-            &func->local_types, &func->local_bindings, &index_to_name);
-        for (j = 0; j < num_locals; ++j) {
-          StringSlice name = index_to_name.data[j];
-          snprintf(desc, sizeof(desc), "local name %" PRIzd, num_params + j);
-          write_str(&ctx->stream, name.start, name.length, PrintChars::Yes,
-                    desc);
-        }
+      make_type_binding_reverse_mapping(
+        &func->local_types, &func->local_bindings, &index_to_name);
+      for (j = 0; j < num_locals; ++j) {
+        StringSlice name = index_to_name.data[j];
+        snprintf(desc, sizeof(desc), "local name %" PRIzd, num_params + j);
+        write_u32_leb128(&ctx->stream, num_params + j, "local index");
+        write_str(&ctx->stream, name.start, name.length, PrintChars::Yes,
+                  desc);
       }
     }
+    end_subsection(ctx);
     end_section(ctx);
 
     destroy_string_slice_vector(&index_to_name);

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -895,9 +895,6 @@ static Result write_module(Context* ctx, const Module* module) {
       uint32_t num_locals = func->local_types.size;
       uint32_t num_params_and_locals = get_num_params_and_locals(func);
 
-      if (!num_params_and_locals)
-        continue;
-
       write_u32_leb128(&ctx->stream, i, "function index");
       write_u32_leb128(&ctx->stream, num_params_and_locals, "num locals");
 

--- a/src/common.h
+++ b/src/common.h
@@ -403,6 +403,11 @@ struct Literal {
   StringSlice text;
 };
 
+enum class NameSectionSubsection {
+  Function = 1,
+  Local = 2,
+};
+
 static WABT_INLINE void* wabt_alloc(size_t size) {
   return malloc(size);
 }

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -6,13 +6,17 @@ section(TYPE) { count[1] function params[0] results[0] }
 section(FUNCTION) { count[1] sig[0] }
 section(CODE) { count[1] func { locals[0] nop } }
 section("name") {
+  subsection[1]
+  length[1]
   count[2]
-  str("f") locals[0]
-  str("g") locals[0]
+  index[0]
+  str("f")
+  index[1]
+  str("g")
 }
 (;; STDERR ;;;
 Error running "wasm2wast":
 error: expected function name count (2) <= function count (1)
-error: @0x00000021: on_function_names_count callback failed
+error: @0x00000023: on_function_names_count callback failed
 
 ;;; STDERR ;;)

--- a/test/binary/names.txt
+++ b/test/binary/names.txt
@@ -11,9 +11,17 @@ section(CODE) {
   }
 }
 section("name") {
+  subsection[1]
+  length[1]
   func_count[1]
+  index[0]
   str("$F0")
+  subsection[2]
+  length[1]
+  func_count[1]
+  index[0]
   local_count[1]
+  index[0]
   str("$L0")
 }
 (;; STDOUT ;;;

--- a/test/binary/no-global-names.txt
+++ b/test/binary/no-global-names.txt
@@ -20,9 +20,11 @@ section(CODE) {
   }
 }
 section("name") {
+  subsection[1]
+  length[1]
   func_count[1]
+  index[0]
   str("bar")
-  local_count[0]
 }
 (;; STDOUT ;;;
 (module

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -31,18 +31,27 @@
 000001c: 00                                        ; section size (guess)
 000001d: 04                                        ; string length
 000001e: 6e61 6d65                                name  ; custom section name
-0000022: 01                                        ; num functions
-0000023: 04                                        ; string length
-0000024: 2466 6f6f                                $foo  ; func name 0
-0000028: 00                                        ; num locals
-000001c: 0c                                        ; FIXUP section size
+0000022: 01                                        ; function name type
+0000023: 00                                        ; subsection size (guess)
+0000024: 01                                        ; num functions
+0000025: 00                                        ; function index
+0000026: 04                                        ; string length
+0000027: 2466 6f6f                                $foo  ; func name 0
+0000023: 07                                        ; FIXUP subsection size
+000002b: 02                                        ; local name type
+000002c: 00                                        ; subsection size (guess)
+000002d: 01                                        ; num functions
+000002e: 00                                        ; function index
+000002f: 00                                        ; num locals
+000002c: 03                                        ; FIXUP subsection size
+000001c: 13                                        ; FIXUP section size
 debug-import-names.wasm:	file format wasm 0x000001
 
 Sections:
 
      Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    Import start=0x00000010 end=0x0000001b (size=0x0000000b) count: 1
-   Custom start=0x0000001d end=0x00000029 (size=0x0000000c) "name"
+   Custom start=0x0000001d end=0x00000030 (size=0x00000013) "name"
 
 Section Details:
 

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -63,28 +63,47 @@
 000002a: 00                                        ; section size (guess)
 000002b: 04                                        ; string length
 000002c: 6e61 6d65                                name  ; custom section name
-0000030: 02                                        ; num functions
-0000031: 03                                        ; string length
-0000032: 2446 31                                  $F1  ; func name 0
-0000035: 04                                        ; num locals
-0000036: 05                                        ; string length
-0000037: 2446 3150 30                             $F1P0  ; local name 0
-000003c: 05                                        ; string length
-000003d: 2446 314c 31                             $F1L1  ; local name 1
-0000042: 05                                        ; string length
-0000043: 2446 314c 32                             $F1L2  ; local name 2
-0000048: 00                                        ; string length
-0000049: 03                                        ; string length
-000004a: 2446 32                                  $F2  ; func name 1
-000004d: 04                                        ; num locals
-000004e: 05                                        ; string length
-000004f: 2446 3250 30                             $F2P0  ; local name 0
-0000054: 05                                        ; string length
-0000055: 2446 324c 31                             $F2L1  ; local name 1
-000005a: 00                                        ; string length
-000005b: 05                                        ; string length
-000005c: 2446 324c 33                             $F2L3  ; local name 3
-000002a: 36                                        ; FIXUP section size
+0000030: 01                                        ; function name type
+0000031: 00                                        ; subsection size (guess)
+0000032: 02                                        ; num functions
+0000033: 00                                        ; function index
+0000034: 03                                        ; string length
+0000035: 2446 31                                  $F1  ; func name 0
+0000038: 01                                        ; function index
+0000039: 03                                        ; string length
+000003a: 2446 32                                  $F2  ; func name 1
+0000031: 0b                                        ; FIXUP subsection size
+000003d: 02                                        ; local name type
+000003e: 00                                        ; subsection size (guess)
+000003f: 02                                        ; num functions
+0000040: 00                                        ; function index
+0000041: 04                                        ; num locals
+0000042: 00                                        ; local index
+0000043: 05                                        ; string length
+0000044: 2446 3150 30                             $F1P0  ; local name 0
+0000049: 01                                        ; local index
+000004a: 05                                        ; string length
+000004b: 2446 314c 31                             $F1L1  ; local name 1
+0000050: 02                                        ; local index
+0000051: 05                                        ; string length
+0000052: 2446 314c 32                             $F1L2  ; local name 2
+0000057: 03                                        ; local index
+0000058: 00                                        ; string length
+0000059: 01                                        ; function index
+000005a: 04                                        ; num locals
+000005b: 00                                        ; local index
+000005c: 05                                        ; string length
+000005d: 2446 3250 30                             $F2P0  ; local name 0
+0000062: 01                                        ; local index
+0000063: 05                                        ; string length
+0000064: 2446 324c 31                             $F2L1  ; local name 1
+0000069: 02                                        ; local index
+000006a: 00                                        ; string length
+000006b: 03                                        ; local index
+000006c: 05                                        ; string length
+000006d: 2446 324c 33                             $F2L3  ; local name 3
+000003e: 33                                        ; FIXUP subsection size
+000002a: 47                                        ; FIXUP section size
 debug-names.wasm:	file format wasm 0x000001
 
 Section Details:
@@ -98,10 +117,10 @@ Function:
 Custom:
  - name: "name"
  - func[0] $F1
+ - func[1] $F2
   - local[0] $F1P0
   - local[1] $F1L1
   - local[2] $F1L2
- - func[1] $F2
   - local[0] $F2P0
   - local[1] $F2L1
   - local[3] $F2L3

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -27,8 +27,8 @@ Sections:
  Function start=0x0000003a end=0x0000003e (size=0x00000004) count: 3
    Export start=0x00000044 end=0x00000051 (size=0x0000000d) count: 2
      Code start=0x00000053 end=0x00000075 (size=0x00000022) count: 3
-   Custom start=0x0000007b end=0x000000a8 (size=0x0000002d) "name"
-   Custom start=0x000000ae end=0x000000c1 (size=0x00000013) "reloc.Code"
+   Custom start=0x0000007b end=0x000000ae (size=0x00000033) "name"
+   Custom start=0x000000b4 end=0x000000c7 (size=0x00000013) "reloc.Code"
 
 Section Details:
 


### PR DESCRIPTION
This PR should change the code to support the new extensible name section rather than the previous now-obsolete layout.

However, I've so far been unable to find any code (except for my own) that produces or reads the new format, so it's not as well-tested as it should be; it might be worth waiting for adoption in other tools, in any case.

See https://github.com/WebAssembly/wabt/issues/334.