### PR TITLE
Add --debug flag to wasmdump and wasm-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,18 +6,19 @@ WABT (we pronounce it "wabbit") is suite of tools for WebAssembly, including:
 
  - **wast2wasm**: translate from [s-expressions](https://github.com/WebAssembly/spec) to the WebAssembly [binary-encoding](https://github.com/WebAssembly/design/blob/master/BinaryEncoding.md)
  - **wasm2wast**: the inverse of wast2wasm, translate from the binary encoding back to an s-expression source file (also known as a .wast)
+ - **wasmdump**: print information about a wasm binary. Similiar to objdump.
  - **wasm-interp**: decode and run a WebAssembly binary file using a stack-based interpreter
  - **wast-desugar**: parse .wast text form as supported by the spec interpreter (s-expressions, flat syntax, or mixed) and print "canonical" flat format
+ - **wasm-link**: simple linker for merging multiple wasm files.
 
 These tools are intended for use in (or for development of) toolchains or other
 systems that want to manipulate WebAssembly files. Unlike the WebAssembly spec
 interpreter (which is written to be as simple, declarative and "speccy" as
-possible), they are written in C (possibly C++ in the future) and designed for
-easier integration into other systems. Unlike
-[Binaryen](https://github.com/WebAssembly/binaryen) these tools do not aim to
-provide an optimization platform or a higher-level compiler target; instead
-they aim for full fidelity and compliance with the spec (e.g. 1:1 round-trips
-with no changes to instructions).
+possible), they are written in C/C++ and designed for easier integration into
+other systems. Unlike [Binaryen](https://github.com/WebAssembly/binaryen) these
+tools do not aim to provide an optimization platform or a higher-level compiler
+target; instead they aim for full fidelity and compliance with the spec (e.g.
+1:1 round-trips with no changes to instructions).
 
 ## Cloning
 

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -265,7 +265,8 @@ static Result on_function_name(uint32_t index,
   return Result::Ok;
 }
 
-Result read_binary_linker(LinkerInputBinary* input_info) {
+Result read_binary_linker(LinkerInputBinary* input_info,
+                          LinkOptions* options) {
   Context context;
   WABT_ZERO_MEMORY(context);
   context.binary = input_info;
@@ -300,6 +301,7 @@ Result read_binary_linker(LinkerInputBinary* input_info) {
 
   ReadBinaryOptions read_options = WABT_READ_BINARY_OPTIONS_DEFAULT;
   read_options.read_debug_names = true;
+  read_options.log_stream = options->log_stream;
   return read_binary(input_info->data, input_info->size, &reader, 1,
                      &read_options);
 }

--- a/src/binary-reader-linker.h
+++ b/src/binary-reader-linker.h
@@ -22,9 +22,15 @@
 
 namespace wabt {
 
+struct Stream;
 struct LinkerInputBinary;
 
-Result read_binary_linker(struct LinkerInputBinary* input_info);
+struct LinkOptions {
+  struct Stream* log_stream;
+};
+
+Result read_binary_linker(struct LinkerInputBinary* input_info,
+                          struct LinkOptions* options);
 
 }  // namespace wabt
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -765,6 +765,7 @@ Result read_binary_objdump(const uint8_t* data,
 
   ReadBinaryOptions read_options = WABT_READ_BINARY_OPTIONS_DEFAULT;
   read_options.read_debug_names = true;
+  read_options.log_stream = options->log_stream;
   return read_binary(data, size, &reader, 1, &read_options);
 }
 

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -43,6 +43,7 @@ enum class ObjdumpMode {
 };
 
 struct ObjdumpOptions {
+  Stream* log_stream;
   bool headers;
   bool details;
   bool raw;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -466,15 +466,6 @@ static void write_indent(LoggingContext* ctx) {
     LOGF_NOINDENT(__VA_ARGS__); \
   } while (0)
 
-static void logging_on_error(BinaryReaderContext* ctx, const char* message) {
-  LoggingContext* logging_ctx = static_cast<LoggingContext*>(ctx->user_data);
-  if (logging_ctx->reader->on_error) {
-    BinaryReaderContext new_ctx = *ctx;
-    new_ctx.user_data = logging_ctx->reader->user_data;
-    logging_ctx->reader->on_error(&new_ctx, message);
-  }
-}
-
 static Result logging_begin_section(BinaryReaderContext* context,
                                     BinarySection section_type,
                                     uint32_t size) {
@@ -1979,7 +1970,7 @@ Result read_binary(const void* data,
   WABT_ZERO_MEMORY(logging_reader);
   logging_reader.user_data = &logging_context;
 
-  logging_reader.on_error = logging_on_error;
+  logging_reader.on_error = reader->on_error;
   logging_reader.begin_section = logging_begin_section;
   logging_reader.begin_module = logging_begin_module;
   logging_reader.end_module = logging_end_module;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -475,6 +475,13 @@ static void logging_on_error(BinaryReaderContext* ctx, const char* message) {
   }
 }
 
+static Result logging_begin_section(BinaryReaderContext* context,
+                                    BinarySection section_type,
+                                    uint32_t size) {
+  LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);
+  FORWARD_CTX(begin_section, section_type, size);
+}
+
 static Result logging_begin_custom_section(BinaryReaderContext* context,
                                            uint32_t size,
                                            StringSlice section_name) {
@@ -1973,6 +1980,7 @@ Result read_binary(const void* data,
   logging_reader.user_data = &logging_context;
 
   logging_reader.on_error = logging_on_error;
+  logging_reader.begin_section = logging_begin_section;
   logging_reader.begin_module = logging_begin_module;
   logging_reader.end_module = logging_end_module;
 

--- a/src/tools/wasmdump.cc
+++ b/src/tools/wasmdump.cc
@@ -57,7 +57,7 @@ static Option s_options[] = {
      "print raw section contents"},
     {FLAG_DISASSEMBLE, 'd', "disassemble", nullptr, NOPE,
      "disassemble function bodies"},
-    {FLAG_DEBUG, '\0', "debug", nullptr, NOPE, "disassemble function bodies"},
+    {FLAG_DEBUG, '\0', "debug", nullptr, NOPE, "print extra debug information"},
     {FLAG_DETAILS, 'x', "details", nullptr, NOPE, "Show section details"},
     {FLAG_RELOCS, 'r', "reloc", nullptr, NOPE,
      "show relocations inline with disassembly"},
@@ -67,6 +67,8 @@ static Option s_options[] = {
 WABT_STATIC_ASSERT(NUM_FLAGS == WABT_ARRAY_SIZE(s_options));
 
 static ObjdumpOptions s_objdump_options;
+static FileWriter s_log_stream_writer;
+static Stream s_log_stream;
 
 static void on_argument(struct OptionParser* parser, const char* argument) {
   s_objdump_options.infile = argument;
@@ -86,6 +88,10 @@ static void on_option(struct OptionParser* parser,
 
     case FLAG_DEBUG:
       s_objdump_options.debug = true;
+      init_file_writer_existing(&s_log_stream_writer, stdout);
+      init_stream(&s_log_stream, &s_log_stream_writer.base, nullptr);
+      s_objdump_options.log_stream = &s_log_stream;
+      break;
 
     case FLAG_DISASSEMBLE:
       s_objdump_options.disassemble = true;
@@ -155,7 +161,7 @@ int main(int argc, char** argv) {
 
   // Perform serveral passed over the binary in order to print out different
   // types of information.
-  s_objdump_options.print_header = 1;
+  s_objdump_options.print_header = true;
   if (!s_objdump_options.headers && !s_objdump_options.details &&
       !s_objdump_options.disassemble && !s_objdump_options.raw) {
     printf("At least one of the following switches must be given:\n");
@@ -177,7 +183,8 @@ int main(int argc, char** argv) {
     result = read_binary_objdump(data, size, &s_objdump_options);
     if (WABT_FAILED(result))
       goto done;
-    s_objdump_options.print_header = 0;
+    s_objdump_options.print_header = false;
+    s_objdump_options.log_stream = nullptr;
   }
   // Pass 2: Print extra information based on section type
   if (s_objdump_options.details) {
@@ -185,14 +192,16 @@ int main(int argc, char** argv) {
     result = read_binary_objdump(data, size, &s_objdump_options);
     if (WABT_FAILED(result))
       goto done;
-    s_objdump_options.print_header = 0;
+    s_objdump_options.print_header = false;
+    s_objdump_options.log_stream = nullptr;
   }
   if (s_objdump_options.disassemble) {
     s_objdump_options.mode = ObjdumpMode::Disassemble;
     result = read_binary_objdump(data, size, &s_objdump_options);
     if (WABT_FAILED(result))
       goto done;
-    s_objdump_options.print_header = 0;
+    s_objdump_options.print_header = false;
+    s_objdump_options.log_stream = nullptr;
   }
   // Pass 3: Dump to raw contents of the sections
   if (s_objdump_options.raw) {


### PR DESCRIPTION
Enable logging in the binary reader when the --debug
flag is passed to wasmdump and wasm-link.

Also don't wrap on_error when logging is enabled otherwise
tools that don't set on_error such as wasmdump won't see
any errors (since the reader will think a handler is installed).