### PR TITLE
Use wabt_snprintf instead of calling snprintf directly

### DIFF
--- a/src/ast-parser-lexer-shared.cc
+++ b/src/ast-parser-lexer-shared.cc
@@ -43,10 +43,10 @@ void ast_format_error(SourceErrorHandler* error_handler,
   va_copy(args_copy, args);
   char fixed_buf[WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE];
   char* buffer = fixed_buf;
-  size_t len = vsnprintf(fixed_buf, sizeof(fixed_buf), format, args);
+  size_t len = wabt_vsnprintf(fixed_buf, sizeof(fixed_buf), format, args);
   if (len + 1 > sizeof(fixed_buf)) {
     buffer = static_cast<char*>(alloca(len + 1));
-    len = vsnprintf(buffer, len + 1, format, args_copy);
+    len = wabt_vsnprintf(buffer, len + 1, format, args_copy);
   }
 
   char* source_line = nullptr;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -642,10 +642,10 @@ LOGGING_UINT32_UINT32(on_init_expr_get_global_expr, "index", "global_index")
 static void sprint_limits(char* dst, size_t size, const Limits* limits) {
   int result;
   if (limits->has_max) {
-    result = snprintf(dst, size, "initial: %" PRIu64 ", max: %" PRIu64,
+    result = wabt_snprintf(dst, size, "initial: %" PRIu64 ", max: %" PRIu64,
                       limits->initial, limits->max);
   } else {
-    result = snprintf(dst, size, "initial: %" PRIu64, limits->initial);
+    result = wabt_snprintf(dst, size, "initial: %" PRIu64, limits->initial);
   }
   WABT_USE(result);
   assert(static_cast<size_t>(result) < size);

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -100,7 +100,7 @@ static char* get_module_filename(Context* ctx) {
   size_t buflen = ctx->module_filename_noext.length + 20;
   char* str = new char[buflen];
   size_t length =
-      snprintf(str, buflen, PRIstringslice ".%" PRIzd ".wasm",
+      wabt_snprintf(str, buflen, PRIstringslice ".%" PRIzd ".wasm",
                WABT_PRINTF_STRING_SLICE_ARG(ctx->module_filename_noext),
                ctx->num_modules);
   convert_backslash_to_slash(str, length);

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -268,7 +268,7 @@ static void begin_known_section(Context* ctx,
                                 size_t leb_size_guess) {
   assert(ctx->last_section_leb_size_guess == 0);
   char desc[100];
-  snprintf(desc, sizeof(desc), "section \"%s\" (%u)",
+  wabt_snprintf(desc, sizeof(desc), "section \"%s\" (%u)",
            get_section_name(section_code), static_cast<unsigned>(section_code));
   write_header(ctx, desc, PRINT_HEADER_NO_INDEX);
   write_u8_enum(&ctx->stream, section_code, "section code");
@@ -284,7 +284,7 @@ static void begin_custom_section(Context* ctx,
                                  size_t leb_size_guess) {
   assert(ctx->last_section_leb_size_guess == 0);
   char desc[100];
-  snprintf(desc, sizeof(desc), "section \"%s\"", name);
+  wabt_snprintf(desc, sizeof(desc), "section \"%s\"", name);
   write_header(ctx, desc, PRINT_HEADER_NO_INDEX);
   write_u8_enum(&ctx->stream, BinarySection::Custom, "custom section code");
   ctx->last_section_type = BinarySection::Custom;
@@ -627,7 +627,7 @@ static void write_global_header(Context* ctx, const Global* global) {
 
 static void write_reloc_section(Context* ctx, RelocSection* reloc_section) {
   char section_name[128];
-  snprintf(section_name, sizeof(section_name), "%s.%s",
+  wabt_snprintf(section_name, sizeof(section_name), "%s.%s",
            WABT_BINARY_SECTION_RELOC, reloc_section->name);
   begin_custom_section(ctx, section_name, LEB_SECTION_SIZE_GUESS);
   write_u32_leb128_enum(&ctx->stream, reloc_section->section_code,
@@ -715,7 +715,7 @@ static Result write_module(Context* ctx, const Module* module) {
     for (i = 0; i < num_funcs; ++i) {
       const Func* func = module->funcs.data[i + module->num_func_imports];
       char desc[100];
-      snprintf(desc, sizeof(desc), "function %" PRIzd " signature index", i);
+      wabt_snprintf(desc, sizeof(desc), "function %" PRIzd " signature index", i);
       write_u32_leb128(&ctx->stream,
                        get_func_type_index_by_decl(module, &func->decl), desc);
     }
@@ -879,7 +879,7 @@ static Result write_module(Context* ctx, const Module* module) {
     for (i = 0; i < module->funcs.size; ++i) {
       const Func* func = module->funcs.data[i];
       write_u32_leb128(&ctx->stream, i, "function index");
-      snprintf(desc, sizeof(desc), "func name %" PRIzd, i);
+      wabt_snprintf(desc, sizeof(desc), "func name %" PRIzd, i);
       write_str(&ctx->stream, func->name.start, func->name.length,
                 PrintChars::Yes, desc);
     }
@@ -903,7 +903,7 @@ static Result write_module(Context* ctx, const Module* module) {
       size_t j;
       for (j = 0; j < num_params; ++j) {
         StringSlice name = index_to_name.data[j];
-        snprintf(desc, sizeof(desc), "local name %" PRIzd, j);
+        wabt_snprintf(desc, sizeof(desc), "local name %" PRIzd, j);
         write_u32_leb128(&ctx->stream, j, "local index");
         write_str(&ctx->stream, name.start, name.length, PrintChars::Yes,
                   desc);
@@ -913,7 +913,7 @@ static Result write_module(Context* ctx, const Module* module) {
         &func->local_types, &func->local_bindings, &index_to_name);
       for (j = 0; j < num_locals; ++j) {
         StringSlice name = index_to_name.data[j];
-        snprintf(desc, sizeof(desc), "local name %" PRIzd, num_params + j);
+        wabt_snprintf(desc, sizeof(desc), "local name %" PRIzd, num_params + j);
         write_u32_leb128(&ctx->stream, num_params + j, "local index");
         write_str(&ctx->stream, name.start, name.length, PrintChars::Yes,
                   desc);

--- a/src/common.cc
+++ b/src/common.cc
@@ -122,7 +122,7 @@ Result read_file(const char* filename, char** out_data, size_t* out_size) {
   if (!infile) {
     const char* format = "unable to read file %s";
     char msg[PATH_MAX + sizeof(format)];
-    snprintf(msg, sizeof(msg), format, filename);
+    wabt_snprintf(msg, sizeof(msg), format, filename);
     perror(msg);
     return Result::Error;
   }

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -46,7 +46,7 @@ static void generate_name(const char* prefix,
   size_t prefix_len = strlen(prefix);
   size_t buffer_len = prefix_len + 20; /* add space for the number */
   char* buffer = static_cast<char*>(alloca(buffer_len));
-  int actual_len = snprintf(buffer, buffer_len, "%s%u", prefix, index);
+  int actual_len = wabt_snprintf(buffer, buffer_len, "%s%u", prefix, index);
 
   StringSlice buf;
   buf.length = actual_len;


### PR DESCRIPTION
I tried to use a compiler without `snprintf` and it was causing me some problems.
When I realized that there was a version in wabt, I figured the wabt version was supposed to be used everywhere, but since most compilers has snprintf it hasn't been an issue before.
