### PR TITLE
Disable print checking on mingw64, roll appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 ---
 
-# TODO(binji): roll back to previous image because MSYS2 6.3.0 seems to be
-# broken.
-os: Previous Visual Studio 2015
-
 init:
   - set PATH=C:\Python27\Scripts;%PATH%             # while python's bin is already in PATH, but pip.exe in Scripts\ dir isn't
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -66,8 +66,14 @@
 #define WABT_INLINE inline
 #define WABT_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #define WABT_LIKELY(x) __builtin_expect(!!(x), 1)
+
+// Mingw64 seems to be confused about printf formats: see issue #324.
+#if !defined(__MINGW64__)
 #define WABT_PRINTF_FORMAT(format_arg, first_arg) \
   __attribute__((format(printf, (format_arg), (first_arg))))
+#else
+#define WABT_PRINTF_FORMAT(format_arg, first_arg)
+#endif
 
 #ifdef __cplusplus
 #if __cplusplus >= 201103L


### PR DESCRIPTION
It's not clear why, but it appears that the printf format checking isn't
correct on mingw64, see issue #324.