### PR TITLE
[Mingw64] fix print format warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ else ()
   if (MINGW)
     # Mingw won't define format (e.g. PRIu64) or limit (e.g. UINT32_MAX) macros
     # in C++ without these.
+    # See issue:324 and PR:344 for -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS=1
     add_definitions(-D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1 -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS=1)
   endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ else ()
   if (MINGW)
     # Mingw won't define format (e.g. PRIu64) or limit (e.g. UINT32_MAX) macros
     # in C++ without these.
-    add_definitions(-D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1)
+    add_definitions(-D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1 -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS=1)
   endif ()
 
   if (COMPILER_IS_GNU)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,5 @@
 ---
 
-# TODO(binji): roll back to previous image because MSYS2 6.3.0 seems to be
-# broken.
-os: Previous Visual Studio 2015
-
 init:
   - set PATH=C:\Python27\Scripts;%PATH%             # while python's bin is already in PATH, but pip.exe in Scripts\ dir isn't
   - set PATH=C:\msys64\mingw64\bin;C:\msys64\usr\bin;%PATH%


### PR DESCRIPTION
Partial fix for #324 

In my previous `test.cpp` example in #324:

- Change both or just one of `stdio.h` and `stdint.h` to `cstdio` and `cstdint`: warnings.
- Add `stdlib.h`: warnings.

After checking `stdlib.h`, I found out that it includes `cstdlib` for C++ code and this (for some reason I do not know) is the culprit of the print format warnings. Adding `-D_GLIBCXX_INCLUDE_NEXT_C_HEADERS=1` solves this issue.

This only fixes print format warnings `-Wformat=`.