### PR TITLE
Fix mingw build by defining _POSIX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,9 +95,9 @@ else ()
 
   if (MINGW)
     # Mingw won't define format (e.g. PRIu64) or limit (e.g. UINT32_MAX) macros
-    # in C++ without these.
-    # See issue:324 and PR:344 for -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS=1
-    add_definitions(-D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1 -D_GLIBCXX_INCLUDE_NEXT_C_HEADERS=1)
+    # in C++ without these. Also, _POSIX is needed to ensure we use mingw
+    # printf instead of the VC runtime one.
+    add_definitions(-D_POSIX -D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1)
   endif ()
 
   if (COMPILER_IS_GNU)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -66,8 +66,17 @@
 #define WABT_INLINE inline
 #define WABT_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #define WABT_LIKELY(x) __builtin_expect(!!(x), 1)
+
+#if __MINGW32__
+// mingw defaults to printf format specifier being ms_printf (which doesn't
+// understand 'llu', etc.) We always want gnu_printf, and force mingw to always
+// use mingw_printf, mingw_vprintf, etc.
+#define WABT_PRINTF_FORMAT(format_arg, first_arg) \
+  __attribute__((format(gnu_printf, (format_arg), (first_arg))))
+#else
 #define WABT_PRINTF_FORMAT(format_arg, first_arg) \
   __attribute__((format(printf, (format_arg), (first_arg))))
+#endif
 
 #ifdef __cplusplus
 #if __cplusplus >= 201103L
@@ -201,8 +210,7 @@ __inline unsigned __int64 __popcnt64(unsigned __int64 value) {
 #endif
 
 
-/* Check For MINGW first, because it is also a GNU compiler */
-#if COMPILER_IS_MSVC || __MINGW32__
+#if COMPILER_IS_MSVC
 
 /* print format specifier for size_t */
 #if SIZEOF_SIZE_T == 4


### PR DESCRIPTION
mingw32 tries to support both VC runtime printf and a POSIX-compliant
printf. It seems to randomly choose between the two, depending on
arbitrary factors like header include order. This change forces us to
always use the POSIX-compliant printf on mingw, and also changes the
WABT_PRINTF_FORMAT attribute to use the POSIX-compliant tag too
(gnu_printf, since printf defaults to ms_printf).

This seems to resolve the issues for #324, as well as the ones I found
in #342 as well.