### PR TITLE
binary reader API: pass module/field names to on_import_*

### DIFF
--- a/src/binary-reader-ast.cc
+++ b/src/binary-reader-ast.cc
@@ -191,6 +191,8 @@ static Result on_import(uint32_t index,
 }
 
 static Result on_import_func(uint32_t import_index,
+                             StringSlice module_name,
+                             StringSlice field_name,
                              uint32_t func_index,
                              uint32_t sig_index,
                              void* user_data) {
@@ -213,6 +215,8 @@ static Result on_import_func(uint32_t import_index,
 }
 
 static Result on_import_table(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
                               uint32_t table_index,
                               Type elem_type,
                               const Limits* elem_limits,
@@ -230,6 +234,8 @@ static Result on_import_table(uint32_t import_index,
 }
 
 static Result on_import_memory(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t memory_index,
                                const Limits* page_limits,
                                void* user_data) {
@@ -246,6 +252,8 @@ static Result on_import_memory(uint32_t import_index,
 }
 
 static Result on_import_global(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t global_index,
                                Type type,
                                bool mutable_,

--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -502,6 +502,8 @@ static PrintErrorCallback make_print_error_callback(Context* ctx) {
 }
 
 static Result on_import_func(uint32_t import_index,
+                             StringSlice module_name,
+                             StringSlice field_name,
                              uint32_t func_index,
                              uint32_t sig_index,
                              void* user_data) {
@@ -547,6 +549,8 @@ static Result on_import_func(uint32_t import_index,
 }
 
 static Result on_import_table(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
                               uint32_t table_index,
                               Type elem_type,
                               const Limits* elem_limits,
@@ -586,6 +590,8 @@ static Result on_import_table(uint32_t import_index,
 }
 
 static Result on_import_memory(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t memory_index,
                                const Limits* page_limits,
                                void* user_data) {
@@ -625,6 +631,8 @@ static Result on_import_memory(uint32_t import_index,
 }
 
 static Result on_import_global(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t global_index,
                                Type type,
                                bool mutable_,

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -46,9 +46,6 @@ struct Context {
   uint32_t section_starts[kBinarySectionCount];
   BinarySection reloc_section;
 
-  StringSlice import_module_name;
-  StringSlice import_field_name;
-
   uint32_t next_reloc;
 };
 
@@ -414,13 +411,12 @@ static Result on_import(uint32_t index,
                         StringSlice module_name,
                         StringSlice field_name,
                         void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  ctx->import_module_name = module_name;
-  ctx->import_field_name = field_name;
   return Result::Ok;
 }
 
 static Result on_import_func(uint32_t import_index,
+                             StringSlice module_name,
+                             StringSlice field_name,
                              uint32_t func_index,
                              uint32_t sig_index,
                              void* user_data) {
@@ -428,12 +424,14 @@ static Result on_import_func(uint32_t import_index,
   print_details(ctx,
                 " - func[%d] sig=%d <- " PRIstringslice "." PRIstringslice "\n",
                 func_index, sig_index,
-                WABT_PRINTF_STRING_SLICE_ARG(ctx->import_module_name),
-                WABT_PRINTF_STRING_SLICE_ARG(ctx->import_field_name));
+                WABT_PRINTF_STRING_SLICE_ARG(module_name),
+                WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return Result::Ok;
 }
 
 static Result on_import_table(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
                               uint32_t table_index,
                               Type elem_type,
                               const Limits* elem_limits,
@@ -442,24 +440,28 @@ static Result on_import_table(uint32_t import_index,
   print_details(
       ctx, " - " PRIstringslice "." PRIstringslice
            " -> table elem_type=%s init=%" PRId64 " max=%" PRId64 "\n",
-      WABT_PRINTF_STRING_SLICE_ARG(ctx->import_module_name),
-      WABT_PRINTF_STRING_SLICE_ARG(ctx->import_field_name),
+      WABT_PRINTF_STRING_SLICE_ARG(module_name),
+      WABT_PRINTF_STRING_SLICE_ARG(field_name),
       get_type_name(elem_type), elem_limits->initial, elem_limits->max);
   return Result::Ok;
 }
 
 static Result on_import_memory(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t memory_index,
                                const Limits* page_limits,
                                void* user_data) {
   Context* ctx = static_cast<Context*>(user_data);
   print_details(ctx, " - " PRIstringslice "." PRIstringslice " -> memory\n",
-                WABT_PRINTF_STRING_SLICE_ARG(ctx->import_module_name),
-                WABT_PRINTF_STRING_SLICE_ARG(ctx->import_field_name));
+                WABT_PRINTF_STRING_SLICE_ARG(module_name),
+                WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return Result::Ok;
 }
 
 static Result on_import_global(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t global_index,
                                Type type,
                                bool mutable_,
@@ -468,8 +470,8 @@ static Result on_import_global(uint32_t import_index,
   print_details(ctx, " - global[%d] %s mutable=%d <- " PRIstringslice
                      "." PRIstringslice "\n",
                 global_index, get_type_name(type), mutable_,
-                WABT_PRINTF_STRING_SLICE_ARG(ctx->import_module_name),
-                WABT_PRINTF_STRING_SLICE_ARG(ctx->import_field_name));
+                WABT_PRINTF_STRING_SLICE_ARG(module_name),
+                WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return Result::Ok;
 }
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -407,13 +407,6 @@ static Result begin_function_body(BinaryReaderContext* context,
   return Result::Ok;
 }
 
-static Result on_import(uint32_t index,
-                        StringSlice module_name,
-                        StringSlice field_name,
-                        void* user_data) {
-  return Result::Ok;
-}
-
 static Result on_import_func(uint32_t import_index,
                              StringSlice module_name,
                              StringSlice field_name,
@@ -701,7 +694,6 @@ Result read_binary_objdump(const uint8_t* data,
 
     // Import section
     reader.on_import_count = on_count;
-    reader.on_import = on_import;
     reader.on_import_func = on_import_func;
     reader.on_import_table = on_import_table;
     reader.on_import_memory = on_import_memory;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -79,19 +79,27 @@ struct BinaryReader {
                       StringSlice field_name,
                       void* user_data);
   Result (*on_import_func)(uint32_t import_index,
+                           StringSlice module_name,
+                           StringSlice field_name,
                            uint32_t func_index,
                            uint32_t sig_index,
                            void* user_data);
   Result (*on_import_table)(uint32_t import_index,
+                            StringSlice module_name,
+                            StringSlice field_name,
                             uint32_t table_index,
                             Type elem_type,
                             const Limits* elem_limits,
                             void* user_data);
   Result (*on_import_memory)(uint32_t import_index,
+                             StringSlice module_name,
+                             StringSlice field_name,
                              uint32_t memory_index,
                              const Limits* page_limits,
                              void* user_data);
   Result (*on_import_global)(uint32_t import_index,
+                             StringSlice module_name,
+                             StringSlice field_name,
                              uint32_t global_index,
                              Type type,
                              bool mutable_,


### PR DESCRIPTION
I think our binary reader API can be improved by passing module/field names to the specific on_import_{func,table,...} methods rather than requiring users to store the names in their private context.

There's no real reason to think of a function import, say, as two events: it's a single event, with many parameters, but that's not a problem for the current C++ code. Particularly for simple translating binary readers, saving temporary data in between calls that you're assuming are always paired makes the code slightly less readable.