### PR TITLE
Fix crash using binary reader logging with error

### DIFF
--- a/src/ast-parser.y
+++ b/src/ast-parser.y
@@ -177,7 +177,7 @@ struct BinaryErrorCallbackData {
   AstParser* parser;
 };
 
-static void on_read_binary_error(uint32_t offset, const char* error,
+static bool on_read_binary_error(uint32_t offset, const char* error,
                                  void* user_data);
 
 #define wabt_ast_parser_lex ast_lexer_lex
@@ -1674,7 +1674,7 @@ Result parse_ast(AstLexer * lexer, struct Script * out_script,
   return result == 0 && parser.errors == 0 ? Result::Ok : Result::Error;
 }
 
-void on_read_binary_error(uint32_t offset, const char* error, void* user_data) {
+bool on_read_binary_error(uint32_t offset, const char* error, void* user_data) {
   BinaryErrorCallbackData* data = (BinaryErrorCallbackData*)user_data;
   if (offset == WABT_UNKNOWN_OFFSET) {
     ast_parser_error(data->loc, data->lexer, data->parser,
@@ -1683,6 +1683,7 @@ void on_read_binary_error(uint32_t offset, const char* error, void* user_data) {
     ast_parser_error(data->loc, data->lexer, data->parser,
                      "error in binary module: @0x%08x: %s", offset, error);
   }
+  return true;
 }
 
 }  // namespace wabt

--- a/src/binary-reader-ast.cc
+++ b/src/binary-reader-ast.cc
@@ -51,7 +51,7 @@ struct Context {
   Expr** current_init_expr;
 };
 
-static void handle_error(Context* ctx, uint32_t offset, const char* message);
+static bool handle_error(Context* ctx, uint32_t offset, const char* message);
 
 static void WABT_PRINTF_FORMAT(2, 3)
     print_error(Context* ctx, const char* format, ...) {
@@ -117,16 +117,17 @@ static Result append_expr(Context* ctx, Expr* expr) {
   return Result::Ok;
 }
 
-static void handle_error(Context* ctx, uint32_t offset, const char* message) {
+static bool handle_error(Context* ctx, uint32_t offset, const char* message) {
   if (ctx->error_handler->on_error) {
-    ctx->error_handler->on_error(offset, message,
-                                 ctx->error_handler->user_data);
+    return ctx->error_handler->on_error(offset, message,
+                                        ctx->error_handler->user_data);
   }
+  return false;
 }
 
-static void on_error(BinaryReaderContext* reader_context, const char* message) {
+static bool on_error(BinaryReaderContext* reader_context, const char* message) {
   Context* ctx = static_cast<Context*>(reader_context->user_data);
-  handle_error(ctx, reader_context->offset, message);
+  return handle_error(ctx, reader_context->offset, message);
 }
 
 static Result on_signature_count(uint32_t count, void* user_data) {

--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -103,11 +103,12 @@ static Label* top_label(Context* ctx) {
   return get_label(ctx, 0);
 }
 
-static void handle_error(uint32_t offset, const char* message, Context* ctx) {
+static bool handle_error(uint32_t offset, const char* message, Context* ctx) {
   if (ctx->error_handler->on_error) {
-    ctx->error_handler->on_error(offset, message,
-                                 ctx->error_handler->user_data);
+    return ctx->error_handler->on_error(offset, message,
+                                        ctx->error_handler->user_data);
   }
+  return false;
 }
 
 static void WABT_PRINTF_FORMAT(2, 3)
@@ -344,8 +345,9 @@ static Result emit_func_offset(Context* ctx,
   return Result::Ok;
 }
 
-static void on_error(BinaryReaderContext* ctx, const char* message) {
-  handle_error(ctx->offset, message, static_cast<Context*>(ctx->user_data));
+static bool on_error(BinaryReaderContext* ctx, const char* message) {
+  return handle_error(ctx->offset, message,
+                      static_cast<Context*>(ctx->user_data));
 }
 
 static Result on_signature_count(uint32_t count, void* user_data) {

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -631,14 +631,6 @@ Result on_reloc(RelocType type, uint32_t offset, void* user_data) {
   return Result::Ok;
 }
 
-static void on_error(BinaryReaderContext* ctx, const char* message) {
-  DefaultErrorHandlerInfo info;
-  info.header = "error reading binary";
-  info.out_file = stdout;
-  info.print_header = PrintErrorHeader::Once;
-  default_binary_error_callback(ctx->offset, message, &info);
-}
-
 static Result begin_data_segment(uint32_t index,
                                  uint32_t memory_index,
                                  void* user_data) {
@@ -681,7 +673,6 @@ Result read_binary_objdump(const uint8_t* data,
   } else {
     reader.begin_module = begin_module;
     reader.end_module = end_module;
-    reader.on_error = on_error;
 
     reader.begin_section = begin_section;
 

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -120,14 +120,6 @@ static  Result on_store_expr(Opcode opcode,
   return Result::Ok;
 }
 
-static void on_error(BinaryReaderContext* ctx, const char* message) {
-  DefaultErrorHandlerInfo info;
-  info.header = "error reading binary";
-  info.out_file = stdout;
-  info.print_header = PrintErrorHeader::Once;
-  default_binary_error_callback(ctx->offset, message, &info);
-}
-
 void init_opcnt_data(OpcntData* data) {
   WABT_ZERO_MEMORY(*data);
 }
@@ -150,7 +142,6 @@ Result read_binary_opcnt(const void* data,
   BinaryReader reader;
   WABT_ZERO_MEMORY(reader);
   reader.user_data = &ctx;
-  reader.on_error = on_error;
   reader.on_opcode = on_opcode;
   reader.on_i32_const_expr = on_i32_const_expr;
   reader.on_get_local_expr = on_get_local_expr;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -43,7 +43,7 @@ struct BinaryReaderContext {
 struct BinaryReader {
   void* user_data;
 
-  void (*on_error)(BinaryReaderContext* ctx, const char* message);
+  bool (*on_error)(BinaryReaderContext* ctx, const char* message);
 
   /* module */
   Result (*begin_module)(uint32_t version, void* user_data);

--- a/src/common.cc
+++ b/src/common.cc
@@ -211,7 +211,7 @@ static FILE* get_default_error_handler_info_output_file(
   return info && info->out_file ? info->out_file : stderr;
 }
 
-void default_source_error_callback(const Location* loc,
+bool default_source_error_callback(const Location* loc,
                                    const char* error,
                                    const char* source_line,
                                    size_t source_line_length,
@@ -223,9 +223,10 @@ void default_source_error_callback(const Location* loc,
   print_error_header(out, info);
   print_source_error(out, loc, error, source_line, source_line_length,
                      source_line_column_offset);
+  return true;
 }
 
-void default_binary_error_callback(uint32_t offset,
+bool default_binary_error_callback(uint32_t offset,
                                    const char* error,
                                    void* user_data) {
   DefaultErrorHandlerInfo* info =
@@ -237,6 +238,7 @@ void default_binary_error_callback(uint32_t offset,
   else
     fprintf(out, "error: @0x%08x: %s\n", offset, error);
   fflush(out);
+  return true;
 }
 
 void init_stdio() {

--- a/src/common.h
+++ b/src/common.h
@@ -95,7 +95,8 @@ struct Location {
   int last_column;
 };
 
-typedef void (*SourceErrorCallback)(const Location*,
+/* Returns true if the error was handled. */
+typedef bool (*SourceErrorCallback)(const Location*,
                                     const char* error,
                                     const char* source_line,
                                     size_t source_line_length,
@@ -116,7 +117,8 @@ struct SourceErrorHandler {
         nullptr                                                         \
   }
 
-typedef void (*BinaryErrorCallback)(uint32_t offset,
+/* Returns true if the error was handled. */
+typedef bool (*BinaryErrorCallback)(uint32_t offset,
                                     const char* error,
                                     void* user_data);
 
@@ -446,14 +448,14 @@ bool string_slices_are_equal(const StringSlice*, const StringSlice*);
 void destroy_string_slice(StringSlice*);
 Result read_file(const char* filename, char** out_data, size_t* out_size);
 
-void default_source_error_callback(const Location*,
+bool default_source_error_callback(const Location*,
                                    const char* error,
                                    const char* source_line,
                                    size_t source_line_length,
                                    size_t source_line_column_offset,
                                    void* user_data);
 
-void default_binary_error_callback(uint32_t offset,
+bool default_binary_error_callback(uint32_t offset,
                                    const char* error,
                                    void* user_data);
 

--- a/src/prebuilt/ast-parser-gen.cc
+++ b/src/prebuilt/ast-parser-gen.cc
@@ -234,7 +234,7 @@ struct BinaryErrorCallbackData {
   AstParser* parser;
 };
 
-static void on_read_binary_error(uint32_t offset, const char* error,
+static bool on_read_binary_error(uint32_t offset, const char* error,
                                  void* user_data);
 
 #define wabt_ast_parser_lex ast_lexer_lex
@@ -708,10 +708,10 @@ static const yytype_uint16 yyrline[] =
      965,   972,   985,   992,   998,  1004,  1010,  1018,  1023,  1030,
     1036,  1042,  1048,  1057,  1065,  1070,  1075,  1080,  1087,  1094,
     1098,  1101,  1112,  1116,  1123,  1127,  1130,  1138,  1146,  1163,
-    1179,  1189,  1196,  1203,  1209,  1245,  1255,  1277,  1287,  1313,
-    1318,  1326,  1334,  1344,  1350,  1356,  1362,  1368,  1374,  1379,
-    1385,  1394,  1399,  1400,  1406,  1415,  1416,  1424,  1436,  1437,
-    1444,  1508
+    1179,  1189,  1196,  1203,  1209,  1245,  1255,  1276,  1286,  1312,
+    1317,  1325,  1333,  1343,  1349,  1355,  1361,  1367,  1373,  1378,
+    1384,  1393,  1398,  1399,  1405,  1414,  1415,  1423,  1435,  1436,
+    1443,  1506
 };
 #endif
 
@@ -3766,8 +3766,7 @@ yyreduce:
 
       /* resolve func type variables where the signature was not specified
        * explicitly */
-      size_t i;
-      for (i = 0; i < (yyvsp[-1].module)->funcs.size; ++i) {
+      for (size_t i = 0; i < (yyvsp[-1].module)->funcs.size; ++i) {
         Func* func = (yyvsp[-1].module)->funcs.data[i];
         if (decl_has_func_type(&func->decl) &&
             is_empty_signature(&func->decl.sig)) {
@@ -3780,11 +3779,11 @@ yyreduce:
         }
       }
     }
-#line 3784 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3783 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1277 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1276 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = RawModuleType::Binary;
       (yyval.raw_module).binary.name = (yyvsp[-2].text);
@@ -3792,11 +3791,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.raw_module).binary.data, &(yyval.raw_module).binary.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3796 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3795 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1287 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1286 "src/ast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].raw_module).type == RawModuleType::Text) {
         (yyval.module) = (yyvsp[0].raw_module).text;
@@ -3818,31 +3817,31 @@ yyreduce:
         (yyval.module)->loc = (yyvsp[0].raw_module).binary.loc;
       }
     }
-#line 3822 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3821 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1313 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1312 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Index;
       (yyval.var).index = INVALID_VAR_INDEX;
     }
-#line 3832 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3831 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1318 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1317 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Name;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 3842 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3841 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1326 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1325 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.action));
       (yyval.action).loc = (yylsp[-4]);
@@ -3851,11 +3850,11 @@ yyreduce:
       (yyval.action).invoke.name = (yyvsp[-2].text);
       (yyval.action).invoke.args = (yyvsp[-1].consts);
     }
-#line 3855 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3854 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1334 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1333 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.action));
       (yyval.action).loc = (yylsp[-3]);
@@ -3863,119 +3862,119 @@ yyreduce:
       (yyval.action).type = ActionType::Get;
       (yyval.action).invoke.name = (yyvsp[-1].text);
     }
-#line 3867 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3866 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1344 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1343 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertMalformed;
       (yyval.command)->assert_malformed.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_malformed.text = (yyvsp[-1].text);
     }
-#line 3878 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3877 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1350 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1349 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertInvalid;
       (yyval.command)->assert_invalid.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_invalid.text = (yyvsp[-1].text);
     }
-#line 3889 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3888 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1356 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1355 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertUnlinkable;
       (yyval.command)->assert_unlinkable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_unlinkable.text = (yyvsp[-1].text);
     }
-#line 3900 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3899 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1362 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1361 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertUninstantiable;
       (yyval.command)->assert_uninstantiable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_uninstantiable.text = (yyvsp[-1].text);
     }
-#line 3911 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3910 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1368 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1367 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertReturn;
       (yyval.command)->assert_return.action = (yyvsp[-2].action);
       (yyval.command)->assert_return.expected = (yyvsp[-1].consts);
     }
-#line 3922 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3921 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1374 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1373 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertReturnNan;
       (yyval.command)->assert_return_nan.action = (yyvsp[-1].action);
     }
-#line 3932 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3931 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1379 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1378 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertTrap;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3943 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3942 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1385 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1384 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertExhaustion;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3954 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3953 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1394 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1393 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Action;
       (yyval.command)->action = (yyvsp[0].action);
     }
-#line 3964 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3963 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 163:
-#line 1400 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1399 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Module;
       (yyval.command)->module = *(yyvsp[0].module);
       delete (yyvsp[0].module);
     }
-#line 3975 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3974 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1406 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1405 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Register;
@@ -3983,27 +3982,27 @@ yyreduce:
       (yyval.command)->register_.var = (yyvsp[-1].var);
       (yyval.command)->register_.var.loc = (yylsp[-1]);
     }
-#line 3987 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3986 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1414 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.commands)); }
-#line 3993 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3992 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1416 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       append_command_value(&(yyval.commands), (yyvsp[0].command));
       delete (yyvsp[0].command);
     }
-#line 4003 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4002 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1424 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1423 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WABT_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -4014,33 +4013,32 @@ yyreduce:
       }
       delete [] (yyvsp[-1].literal).text.start;
     }
-#line 4018 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4017 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1436 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1435 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.consts)); }
-#line 4024 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4023 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1437 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1436 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       append_const_value(&(yyval.consts), &(yyvsp[0].const_));
     }
-#line 4033 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4032 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1444 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1443 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.script));
       (yyval.script).commands = (yyvsp[0].commands);
 
       int last_module_index = -1;
-      size_t i;
-      for (i = 0; i < (yyval.script).commands.size; ++i) {
+      for (size_t i = 0; i < (yyval.script).commands.size; ++i) {
         Command* command = &(yyval.script).commands.data[i];
         Var* module_var = nullptr;
         switch (command->type) {
@@ -4093,11 +4091,11 @@ yyreduce:
       }
       parser->script = (yyval.script);
     }
-#line 4097 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4095 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4101 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4099 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4332,7 +4330,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1511 "src/ast-parser.y" /* yacc.c:1906  */
+#line 1509 "src/ast-parser.y" /* yacc.c:1906  */
 
 
 void append_expr_list(ExprList* expr_list, ExprList* expr) {
@@ -4446,8 +4444,7 @@ size_t copy_string_contents(StringSlice* text, char* dest) {
 void dup_text_list(TextList* text_list, char** out_data, size_t* out_size) {
   /* walk the linked list to see how much total space is needed */
   size_t total_size = 0;
-  TextListNode* node;
-  for (node = text_list->first; node; node = node->next) {
+  for (TextListNode* node = text_list->first; node; node = node->next) {
     /* Always allocate enough space for the entire string including the escape
      * characters. It will only get shorter, and this way we only have to
      * iterate through the string once. */
@@ -4458,7 +4455,7 @@ void dup_text_list(TextList* text_list, char** out_data, size_t* out_size) {
   }
   char* result = new char [total_size];
   char* dest = result;
-  for (node = text_list->first; node; node = node->next) {
+  for (TextListNode* node = text_list->first; node; node = node->next) {
     size_t actual_size = copy_string_contents(&node->text, dest);
     dest += actual_size;
   }
@@ -4502,7 +4499,7 @@ Result parse_ast(AstLexer * lexer, struct Script * out_script,
   return result == 0 && parser.errors == 0 ? Result::Ok : Result::Error;
 }
 
-void on_read_binary_error(uint32_t offset, const char* error, void* user_data) {
+bool on_read_binary_error(uint32_t offset, const char* error, void* user_data) {
   BinaryErrorCallbackData* data = (BinaryErrorCallbackData*)user_data;
   if (offset == WABT_UNKNOWN_OFFSET) {
     ast_parser_error(data->loc, data->lexer, data->parser,
@@ -4511,6 +4508,7 @@ void on_read_binary_error(uint32_t offset, const char* error, void* user_data) {
     ast_parser_error(data->loc, data->lexer, data->parser,
                      "error in binary module: @0x%08x: %s", offset, error);
   }
+  return true;
 }
 
 }  // namespace wabt

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -334,12 +334,14 @@ static void visit_raw_module(Context* ctx, RawModule* raw_module) {
     visit_module(ctx, raw_module->text);
 }
 
-static void dummy_source_error_callback(const Location* loc,
+static bool dummy_source_error_callback(const Location* loc,
                                         const char* error,
                                         const char* source_line,
                                         size_t source_line_length,
                                         size_t source_line_column_offset,
-                                        void* user_data) {}
+                                        void* user_data) {
+  return false;
+}
 
 static void visit_command(Context* ctx, Command* command) {
   switch (command->type) {

--- a/test/binary/bad-logging-basic.txt
+++ b/test/binary/bad-logging-basic.txt
@@ -1,0 +1,30 @@
+;;; TOOL: run-gen-wasm-interp
+;;; FLAGS: -v
+;;; ERROR: 1
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[0]
+  func {  ;; error
+    return
+  }
+}
+(;; STDERR ;;;
+Error running "wasm-interp":
+error: @0x00000015: function signature count != function body count
+
+;;; STDERR ;;)
+(;; STDOUT ;;;
+begin_module(1)
+begin_signature_section(4)
+  on_signature_count(1)
+  on_signature(index: 0, params: [], results: [])
+end_signature_section
+begin_function_signatures_section(2)
+  on_function_signatures_count(1)
+  on_function_signature(index: 0, sig_index: 0)
+end_function_signatures_section
+begin_function_bodies_section(4)
+;;; STDOUT ;;)

--- a/test/dump/bad-version-logging.txt
+++ b/test/dump/bad-version-logging.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-wasmdump
+;;; FLAGS: --gen-wasm --dump-debug
+magic
+0xe 0 0 0
+(;; STDERR ;;;
+Error running "wasmdump":
+*ERROR*: @0x00000008: bad wasm file version: 0xe (expected 0x1)
+
+;;; STDERR ;;)

--- a/test/dump/bad-version.txt
+++ b/test/dump/bad-version.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+;;; TOOL: run-wasmdump
+;;; FLAGS: --gen-wasm
+magic
+0xe 0 0 0
+(;; STDERR ;;;
+Error running "wasmdump":
+*ERROR*: @0x00000008: bad wasm file version: 0xe (expected 0x1)
+
+;;; STDERR ;;)

--- a/test/interp/basic-logging.txt
+++ b/test/interp/basic-logging.txt
@@ -1,0 +1,96 @@
+;;; TOOL: run-interp
+;;; FLAGS: -v
+(module
+  (func (export "main") (result i32)
+    i32.const 42
+    return))
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Export" (7)
+0000013: 07                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num exports
+0000016: 04                                        ; string length
+0000017: 6d61 696e                                main  ; export name
+000001b: 00                                        ; export kind
+000001c: 00                                        ; export func index
+0000014: 08                                        ; FIXUP section size
+; section "Code" (10)
+000001d: 0a                                        ; section code
+000001e: 00                                        ; section size (guess)
+000001f: 01                                        ; num functions
+; function body 0
+0000020: 00                                        ; func body size (guess)
+0000021: 00                                        ; local decl count
+0000022: 41                                        ; i32.const
+0000023: 2a                                        ; i32 literal
+0000024: 0f                                        ; return
+0000025: 0b                                        ; end
+0000020: 05                                        ; FIXUP func body size
+000001e: 07                                        ; FIXUP section size
+begin_module(1)
+begin_signature_section(5)
+  on_signature_count(1)
+  on_signature(index: 0, params: [], results: [i32])
+end_signature_section
+begin_function_signatures_section(2)
+  on_function_signatures_count(1)
+  on_function_signature(index: 0, sig_index: 0)
+end_function_signatures_section
+begin_export_section(8)
+  on_export_count(1)
+  on_export(index: 0, kind: func, item_index: 0, name: "main")
+end_export_section
+begin_function_bodies_section(7)
+  on_function_bodies_count(1)
+  begin_function_body(0)
+  on_local_decl_count(0)
+  on_i32_const_expr(42 (0x2a))
+  on_return_expr
+  end_function_body(0)
+end_function_bodies_section
+end_module
+begin_module(1)
+begin_signature_section(5)
+  on_signature_count(1)
+  on_signature(index: 0, params: [], results: [i32])
+end_signature_section
+begin_function_signatures_section(2)
+  on_function_signatures_count(1)
+  on_function_signature(index: 0, sig_index: 0)
+end_function_signatures_section
+begin_export_section(8)
+  on_export_count(1)
+  on_export(index: 0, kind: func, item_index: 0, name: "main")
+end_export_section
+begin_function_bodies_section(7)
+  on_function_bodies_count(1)
+  begin_function_body(0)
+  on_local_decl_count(0)
+  on_i32_const_expr(42 (0x2a))
+  on_return_expr
+  end_function_body(0)
+end_function_bodies_section
+end_module
+   0| i32.const $42
+   5| return
+   6| return
+main() => i32:42
+;;; STDOUT ;;)

--- a/test/interp/basic-tracing.txt
+++ b/test/interp/basic-tracing.txt
@@ -1,0 +1,60 @@
+;;; TOOL: run-interp
+;;; FLAGS: --trace
+(module
+  (func $fib (param $n i32) (result i32)
+    get_local $n
+    i32.const 1
+    i32.le_s
+    if i32
+      i32.const 1
+    else
+      get_local $n
+      i32.const 1
+      i32.sub
+      call $fib
+      get_local $n
+      i32.mul
+    end)
+
+  (func (export "main") (result i32)
+    i32.const 3
+    call $fib))
+(;; STDOUT ;;;
+>>> running export "main":
+#0.   55: V:0  | i32.const $3
+#0.   60: V:1  | call @0
+#1.    0: V:1  | get_local $1
+#1.    5: V:2  | i32.const $1
+#1.   10: V:3  | i32.le_s 3, 1
+#1.   11: V:2  | br_unless @26, 0
+#1.   26: V:1  | get_local $1
+#1.   31: V:2  | i32.const $1
+#1.   36: V:3  | i32.sub 3, 1
+#1.   37: V:2  | call @0
+#2.    0: V:2  | get_local $1
+#2.    5: V:3  | i32.const $1
+#2.   10: V:4  | i32.le_s 2, 1
+#2.   11: V:3  | br_unless @26, 0
+#2.   26: V:2  | get_local $1
+#2.   31: V:3  | i32.const $1
+#2.   36: V:4  | i32.sub 2, 1
+#2.   37: V:3  | call @0
+#3.    0: V:3  | get_local $1
+#3.    5: V:4  | i32.const $1
+#3.   10: V:5  | i32.le_s 1, 1
+#3.   11: V:4  | br_unless @26, 1
+#3.   16: V:3  | i32.const $1
+#3.   21: V:4  | br @48
+#3.   48: V:4  | drop_keep $1 $1
+#3.   54: V:3  | return
+#2.   42: V:3  | get_local $2
+#2.   47: V:4  | i32.mul 1, 2
+#2.   48: V:3  | drop_keep $1 $1
+#2.   54: V:2  | return
+#1.   42: V:2  | get_local $2
+#1.   47: V:3  | i32.mul 2, 3
+#1.   48: V:2  | drop_keep $1 $1
+#1.   54: V:1  | return
+#0.   65: V:1  | return
+main() => i32:6
+;;; STDOUT ;;)

--- a/test/run-gen-wasm-interp.py
+++ b/test/run-gen-wasm-interp.py
@@ -43,6 +43,7 @@ def main(args):
                       action='store_false')
   parser.add_argument('--run-all-exports', action='store_true')
   parser.add_argument('--spec', action='store_true')
+  parser.add_argument('-t', '--trace', action='store_true')
   parser.add_argument('--print-cmd', help='print the commands that are run.',
                       action='store_true')
   parser.add_argument('file', help='test file.')
@@ -55,9 +56,10 @@ def main(args):
       find_exe.GetWasmInterpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_interp.AppendOptionalArgs({
+      '-v': options.verbose,
       '--run-all-exports': options.run_all_exports,
       '--spec': options.spec,
-      '--trace': options.verbose,
+      '--trace': options.trace,
   })
 
   gen_wasm.verbose = options.print_cmd

--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -45,6 +45,7 @@ def main(args):
                       action='store_true')
   parser.add_argument('--run-all-exports', action='store_true')
   parser.add_argument('--spec', action='store_true')
+  parser.add_argument('-t', '--trace', action='store_true')
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
 
@@ -60,9 +61,10 @@ def main(args):
       find_exe.GetWasmInterpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_interp.AppendOptionalArgs({
+      '-v': options.verbose,
       '--run-all-exports': options.run_all_exports,
       '--spec': options.spec,
-      '--trace': options.verbose,
+      '--trace': options.trace,
   })
 
   wast2wasm.verbose = options.print_cmd

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -51,7 +51,7 @@ TOOLS = {
     },
     'run-wasmdump': {
         'EXE': 'test/run-wasmdump.py',
-        'FLAGS': ' '.join(['--bindir=%(bindir)s',]),
+        'FLAGS': ' '.join(['--bindir=%(bindir)s', '--no-error-cmdline']),
         'VERBOSE-FLAGS': ['-v']
     },
     'run-wasm-link': {


### PR DESCRIPTION
When the binary logging is turned on, it can't use the
`reader->on_error` directly since that function expects that the
user_data is the BinaryReaderInterpreter context (for example), but it
is actually the LoggingContext.

Some additional changes:

* Add a test that uses logging and succeeds
* Add a test that uses logging and has an error
* Change the `run-*-interp.py` scripts to use `-t` for tracing and `-v`
  for logging