### PR TITLE
Update relocation encoding to latest "spec"

### DIFF
--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -52,7 +52,11 @@ static Result on_reloc_count(uint32_t count,
   return Result::Error;
 }
 
-static Result on_reloc(RelocType type, uint32_t offset, void* user_data) {
+static Result on_reloc(RelocType type,
+                       uint32_t offset,
+                       uint32_t index,
+                       int32_t addend,
+                       void* user_data) {
   Context* ctx = static_cast<Context*>(user_data);
 
   if (offset + RELOC_SIZE > ctx->reloc_section->size) {
@@ -62,6 +66,8 @@ static Result on_reloc(RelocType type, uint32_t offset, void* user_data) {
   Reloc* reloc = append_reloc(&ctx->reloc_section->relocations);
   reloc->type = type;
   reloc->offset = offset;
+  reloc->index = index;
+  reloc->addend = addend;
 
   return Result::Ok;
 }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -249,8 +249,8 @@ static void log_opcode(Context* ctx,
           ctx->section_starts[static_cast<size_t>(BinarySection::Code)];
       size_t abs_offset = code_start + reloc->offset;
       if (ctx->last_opcode_end > abs_offset) {
-        printf("           %06" PRIzx ": %s\n", abs_offset,
-               get_reloc_type_name(reloc->type));
+        printf("           %06" PRIzx ": %s\t%d\n", abs_offset,
+               get_reloc_type_name(reloc->type), reloc->index);
         ctx->next_reloc++;
       }
     }
@@ -615,7 +615,11 @@ Result on_reloc_count(uint32_t count,
   return Result::Ok;
 }
 
-Result on_reloc(RelocType type, uint32_t offset, void* user_data) {
+Result on_reloc(RelocType type,
+                uint32_t offset,
+                uint32_t index,
+                int32_t addend,
+                void* user_data) {
   Context* ctx = static_cast<Context*>(user_data);
   uint32_t total_offset =
       ctx->section_starts[static_cast<size_t>(ctx->reloc_section)] + offset;
@@ -626,6 +630,8 @@ Result on_reloc(RelocType type, uint32_t offset, void* user_data) {
     Reloc reloc;
     reloc.offset = offset;
     reloc.type = type;
+    reloc.index = index;
+    reloc.addend = addend;
     append_reloc_value(&ctx->options->code_relocations, &reloc);
   }
   return Result::Ok;

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -26,10 +26,6 @@ namespace wabt {
 struct Module;
 struct ReadBinaryOptions;
 
-struct Reloc {
-  RelocType type;
-  size_t offset;
-};
 WABT_DEFINE_VECTOR(reloc, Reloc);
 
 WABT_DEFINE_VECTOR(string_slice, StringSlice);

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1661,9 +1661,9 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
       in_u32_leb128(ctx, &index, "index");
       RelocType type = static_cast<RelocType>(reloc_type);
       switch (type) {
-        case RelocType::GlobalAddressLEB:
-        case RelocType::GlobalAddressSLEB:
-        case RelocType::GlobalAddressI32:
+        case RelocType::MemoryAddressLEB:
+        case RelocType::MemoryAddressSLEB:
+        case RelocType::MemoryAddressI32:
           in_u32_leb128(ctx, &addend, "addend");
           break;
         default:

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -299,7 +299,11 @@ struct BinaryReader {
                            BinarySection section_code,
                            StringSlice section_name,
                            void* user_data);
-  Result (*on_reloc)(RelocType type, uint32_t offset, void* user_data);
+  Result (*on_reloc)(RelocType type,
+                     uint32_t offset,
+                     uint32_t index,
+                     int32_t addend,
+                     void* user_data);
   Result (*end_reloc_section)(BinaryReaderContext* ctx);
 
   /* init_expr - used by elem, data and global sections; these functions are

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -635,9 +635,9 @@ static void write_reloc_section(Context* ctx, RelocSection* reloc_section) {
     write_u32_leb128(&ctx->stream, relocs->data[i].offset, "reloc offset");
     write_u32_leb128(&ctx->stream, relocs->data[i].index, "reloc index");
     switch (relocs->data[i].type) {
-      case RelocType::GlobalAddressLEB:
-      case RelocType::GlobalAddressSLEB:
-      case RelocType::GlobalAddressI32:
+      case RelocType::MemoryAddressLEB:
+      case RelocType::MemoryAddressSLEB:
+      case RelocType::MemoryAddressI32:
         write_u32_leb128(&ctx->stream, relocs->data[i].addend, "reloc addend");
         break;
       default:

--- a/src/common.cc
+++ b/src/common.cc
@@ -58,9 +58,10 @@ WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(g_kind_name) == kExternalKindCount);
 const char* g_reloc_type_name[] = {"R_FUNC_INDEX_LEB",
                                    "R_TABLE_INDEX_SLEB",
                                    "R_TABLE_INDEX_I32",
-                                   "R_GLOBAL_ADDR_LEB",
-                                   "R_GLOBAL_ADDR_SLEB",
-                                   "R_GLOBAL_ADDR_I32",
+                                   "R_MEMORY_ADDR_LEB",
+                                   "R_MEMORY_ADDR_SLEB",
+                                   "R_MEMORY_ADDR_I32",
+                                   "R_TYPE_INDEX_LEB",
                                    "R_GLOBAL_INDEX_LEB",
                                    };
 WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(g_reloc_type_name) == kRelocTypeCount);

--- a/src/common.cc
+++ b/src/common.cc
@@ -55,9 +55,14 @@ void init_opcode_info(void) {
 const char* g_kind_name[] = {"func", "table", "memory", "global"};
 WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(g_kind_name) == kExternalKindCount);
 
-const char* g_reloc_type_name[] = {"R_FUNC_INDEX_LEB", "R_TABLE_INDEX_SLEB",
-                                   "R_TABLE_INDEX_I32", "R_GLOBAL_INDEX_LEB",
-                                   "R_DATA"};
+const char* g_reloc_type_name[] = {"R_FUNC_INDEX_LEB",
+                                   "R_TABLE_INDEX_SLEB",
+                                   "R_TABLE_INDEX_I32",
+                                   "R_GLOBAL_ADDR_LEB",
+                                   "R_GLOBAL_ADDR_SLEB",
+                                   "R_GLOBAL_ADDR_I32",
+                                   "R_GLOBAL_INDEX_LEB",
+                                   };
 WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(g_reloc_type_name) == kRelocTypeCount);
 
 bool is_naturally_aligned(Opcode opcode, uint32_t alignment) {

--- a/src/common.h
+++ b/src/common.h
@@ -159,10 +159,11 @@ enum class RelocType {
   FuncIndexLEB = 0,   /* e.g. immediate of call instruction */
   TableIndexSLEB = 1, /* e.g. loading address of function */
   TableIndexI32 = 2,  /* e.g. function address in DATA */
-  GlobalAddressLEB = 3,
-  GlobalAddressSLEB = 4,
-  GlobalAddressI32 = 5,
-  GlobalIndexLEB = 6, /* e.g immediate of get_global inst */
+  MemoryAddressLEB = 3,
+  MemoryAddressSLEB = 4,
+  MemoryAddressI32 = 5,
+  TypeIndexLEB = 6, /* e.g immediate type in call_indirect */
+  GlobalIndexLEB = 7, /* e.g immediate of get_global inst */
 
   First = FuncIndexLEB,
   Last = GlobalIndexLEB,

--- a/src/common.h
+++ b/src/common.h
@@ -156,16 +156,25 @@ enum class Type {
 };
 
 enum class RelocType {
-  FuncIndexLeb = 0,   /* e.g. immediate of call instruction */
-  TableIndexSleb = 1, /* e.g. loading address of function */
+  FuncIndexLEB = 0,   /* e.g. immediate of call instruction */
+  TableIndexSLEB = 1, /* e.g. loading address of function */
   TableIndexI32 = 2,  /* e.g. function address in DATA */
-  GlobalIndexLeb = 3, /* e.g immediate of get_global inst */
-  Data = 4,
+  GlobalAddressLEB = 3,
+  GlobalAddressSLEB = 4,
+  GlobalAddressI32 = 5,
+  GlobalIndexLEB = 6, /* e.g immediate of get_global inst */
 
-  First = FuncIndexLeb,
-  Last = Data,
+  First = FuncIndexLEB,
+  Last = GlobalIndexLEB,
 };
 static const int kRelocTypeCount = WABT_ENUM_COUNT(RelocType);
+
+struct Reloc {
+  RelocType type;
+  size_t offset;
+  uint32_t index;
+  int32_t addend;
+};
 
 /* matches binary format, do not change */
 enum class ExternalKind {

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -170,16 +170,16 @@ static void apply_relocation(Section* section, Reloc* r) {
 
   uint32_t offset = 0;
   switch (r->type) {
-    case RelocType::FuncIndexLeb:
+    case RelocType::FuncIndexLEB:
       new_value = relocate_func_index(binary, cur_value);
       break;
-    case RelocType::TableIndexSleb:
+    case RelocType::TableIndexSLEB:
       printf("%s: table index reloc: %d offset=%d\n", binary->filename,
              cur_value, binary->table_index_offset);
       offset = binary->table_index_offset;
       new_value = cur_value + offset;
       break;
-    case RelocType::GlobalIndexLeb:
+    case RelocType::GlobalIndexLEB:
       if (cur_value >= binary->global_imports.size) {
         offset = binary->global_index_offset;
       } else {
@@ -529,6 +529,7 @@ static void write_reloc_section(Context* ctx,
       write_u32_leb128_enum(&ctx->stream, relocs->data[j].type, "reloc type");
       uint32_t new_offset = relocs->data[j].offset + sec->output_payload_offset;
       write_u32_leb128(&ctx->stream, new_offset, "reloc offset");
+      write_u32_leb128(&ctx->stream, relocs->data[j].index, "reloc index");
     }
   }
 

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -51,10 +51,6 @@ struct DataSegment {
 };
 WABT_DEFINE_VECTOR(data_segment, DataSegment);
 
-struct Reloc {
-  RelocType type;
-  size_t offset;
-};
 WABT_DEFINE_VECTOR(reloc, Reloc);
 
 struct Export {

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -21,7 +21,7 @@ Sections:
  Function start=0x00000019 end=0x0000001c (size=0x00000003) count: 2
    Export start=0x00000022 end=0x0000002f (size=0x0000000d) count: 2
      Code start=0x00000031 end=0x00000048 (size=0x00000017) count: 2
-   Custom start=0x0000004e end=0x0000005f (size=0x00000011) "reloc.Code"
+   Custom start=0x0000004e end=0x00000061 (size=0x00000013) "reloc.Code"
 
 Section Details:
 
@@ -45,9 +45,9 @@ Code Disassembly:
 000032 func[0]:
  000034: 41 01                      | i32.const 0x1
  000036: 10 80 80 80 80 00          | call 0
-           000037: R_FUNC_INDEX_LEB
+           000037: R_FUNC_INDEX_LEB	0
 00003d func[1]:
  00003f: 41 02                      | i32.const 0x2
  000041: 10 81 80 80 80 00          | call 0x1
-           000042: R_FUNC_INDEX_LEB
+           000042: R_FUNC_INDEX_LEB	0
 ;;; STDOUT ;;)

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -24,7 +24,7 @@ Sections:
    Import start=0x00000022 end=0x00000041 (size=0x0000001f) count: 2
  Function start=0x00000047 end=0x0000004a (size=0x00000003) count: 2
      Code start=0x0000004c end=0x00000078 (size=0x0000002c) count: 2
-   Custom start=0x0000007e end=0x00000093 (size=0x00000015) "reloc.Code"
+   Custom start=0x0000007e end=0x00000097 (size=0x00000019) "reloc.Code"
 
 Section Details:
 
@@ -52,14 +52,14 @@ Code Disassembly:
 00004d func[2]:
  00004f: 20 00                      | get_local 0
  000051: 10 80 80 80 80 00          | call 0
-           000052: R_FUNC_INDEX_LEB
+           000052: R_FUNC_INDEX_LEB	0
  000057: 10 82 80 80 80 00          | call 0x2
-           000058: R_FUNC_INDEX_LEB
+           000058: R_FUNC_INDEX_LEB	1
 00005e func[3]:
  000060: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000069: 10 81 80 80 80 00          | call 0x1
-           00006a: R_FUNC_INDEX_LEB
+           00006a: R_FUNC_INDEX_LEB	0
  00006f: 42 0a                      | i64.const 10
  000071: 10 83 80 80 80 00          | call 0x3
-           000072: R_FUNC_INDEX_LEB
+           000072: R_FUNC_INDEX_LEB	1
 ;;; STDOUT ;;)

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -32,7 +32,7 @@ Sections:
    Import start=0x0000002a end=0x00000069 (size=0x0000003f) count: 3
  Function start=0x0000006f end=0x00000073 (size=0x00000004) count: 3
      Code start=0x00000075 end=0x000000b7 (size=0x00000042) count: 3
-   Custom start=0x000000bd end=0x000000d6 (size=0x00000019) "reloc.Code"
+   Custom start=0x000000bd end=0x000000dc (size=0x0000001f) "reloc.Code"
 
 Section Details:
 
@@ -66,21 +66,21 @@ Code Disassembly:
 000076 func[3]:
  000078: 20 00                      | get_local 0
  00007a: 10 80 80 80 80 00          | call 0
-           00007b: R_FUNC_INDEX_LEB
+           00007b: R_FUNC_INDEX_LEB	0
  000080: 10 83 80 80 80 00          | call 0x3
-           000081: R_FUNC_INDEX_LEB
+           000081: R_FUNC_INDEX_LEB	1
 000087 func[4]:
  000089: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000092: 10 81 80 80 80 00          | call 0x1
-           000093: R_FUNC_INDEX_LEB
+           000093: R_FUNC_INDEX_LEB	0
  000098: 42 0a                      | i64.const 10
  00009a: 10 84 80 80 80 00          | call 0x4
-           00009b: R_FUNC_INDEX_LEB
+           00009b: R_FUNC_INDEX_LEB	1
 0000a1 func[5]:
  0000a3: 43 00 00 80 3f             | f32.const 0x1p+0
  0000a8: 10 82 80 80 80 00          | call 0x2
-           0000a9: R_FUNC_INDEX_LEB
+           0000a9: R_FUNC_INDEX_LEB	0
  0000ae: 41 0a                      | i32.const 0xa
  0000b0: 10 85 80 80 80 00          | call 0x5
-           0000b1: R_FUNC_INDEX_LEB
+           0000b1: R_FUNC_INDEX_LEB	1
 ;;; STDOUT ;;)

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -30,7 +30,7 @@ Sections:
  Function start=0x00000041 end=0x00000044 (size=0x00000003) count: 2
    Global start=0x00000046 end=0x00000056 (size=0x00000010) count: 3
      Code start=0x00000058 end=0x0000008b (size=0x00000033) count: 2
-   Custom start=0x00000091 end=0x000000ac (size=0x0000001b) "reloc.Code"
+   Custom start=0x00000091 end=0x000000b3 (size=0x00000022) "reloc.Code"
 
 Section Details:
 
@@ -62,20 +62,20 @@ Code Disassembly:
 
 000059 func[0]:
  00005b: 23 83 80 80 80 00          | get_global 0x3
-           00005c: R_GLOBAL_INDEX_LEB
+           00005c: R_GLOBAL_INDEX_LEB	2
  000061: 23 82 80 80 80 00          | get_global 0x2
-           000062: R_GLOBAL_INDEX_LEB
+           000062: R_GLOBAL_INDEX_LEB	1
  000067: 6a                         | i32.add
  000068: 23 80 80 80 80 00          | get_global 0
-           000069: R_GLOBAL_INDEX_LEB
+           000069: R_GLOBAL_INDEX_LEB	0
  00006e: 6a                         | i32.add
  00006f: 10 80 80 80 80 00          | call 0
-           000070: R_FUNC_INDEX_LEB
+           000070: R_FUNC_INDEX_LEB	0
 000076 func[1]:
  000078: 23 81 80 80 80 00          | get_global 0x1
-           000079: R_GLOBAL_INDEX_LEB
+           000079: R_GLOBAL_INDEX_LEB	0
  00007e: 23 84 80 80 80 00          | get_global 0x4
-           00007f: R_GLOBAL_INDEX_LEB
+           00007f: R_GLOBAL_INDEX_LEB	1
  000084: 10 81 80 80 80 00          | call 0x1
-           000085: R_FUNC_INDEX_LEB
+           000085: R_FUNC_INDEX_LEB	0
 ;;; STDOUT ;;)

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -37,8 +37,8 @@ Sections:
     Table start=0x00000079 end=0x0000007e (size=0x00000005) count: 1
      Elem start=0x00000084 end=0x000000ad (size=0x00000029) count: 1
      Code start=0x000000af end=0x000000f1 (size=0x00000042) count: 3
-   Custom start=0x000000f7 end=0x00000112 (size=0x0000001b) "reloc.Elem"
-   Custom start=0x00000118 end=0x00000131 (size=0x00000019) "reloc.Code"
+   Custom start=0x000000f7 end=0x00000119 (size=0x00000022) "reloc.Elem"
+   Custom start=0x0000011f end=0x0000013e (size=0x0000001f) "reloc.Code"
 
 Section Details:
 
@@ -94,21 +94,21 @@ Code Disassembly:
 0000b0 func[3]:
  0000b2: 20 00                      | get_local 0
  0000b4: 10 80 80 80 80 00          | call 0
-           0000b5: R_FUNC_INDEX_LEB
+           0000b5: R_FUNC_INDEX_LEB	0
  0000ba: 10 83 80 80 80 00          | call 0x3
-           0000bb: R_FUNC_INDEX_LEB
+           0000bb: R_FUNC_INDEX_LEB	1
 0000c1 func[4]:
  0000c3: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  0000cc: 10 81 80 80 80 00          | call 0x1
-           0000cd: R_FUNC_INDEX_LEB
+           0000cd: R_FUNC_INDEX_LEB	0
  0000d2: 42 0a                      | i64.const 10
  0000d4: 10 84 80 80 80 00          | call 0x4
-           0000d5: R_FUNC_INDEX_LEB
+           0000d5: R_FUNC_INDEX_LEB	1
 0000db func[5]:
  0000dd: 43 00 00 80 3f             | f32.const 0x1p+0
  0000e2: 10 82 80 80 80 00          | call 0x2
-           0000e3: R_FUNC_INDEX_LEB
+           0000e3: R_FUNC_INDEX_LEB	0
  0000e8: 41 0a                      | i32.const 0xa
  0000ea: 10 85 80 80 80 00          | call 0x5
-           0000eb: R_FUNC_INDEX_LEB
+           0000eb: R_FUNC_INDEX_LEB	1
 ;;; STDOUT ;;)

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -50,7 +50,7 @@ Sections:
  Function start=0x0000002c end=0x00000032 (size=0x00000006) count: 5
    Export start=0x00000038 end=0x00000075 (size=0x0000003d) count: 5
      Code start=0x00000077 end=0x000000a2 (size=0x0000002b) count: 5
-   Custom start=0x000000a8 end=0x000000b9 (size=0x00000011) "reloc.Code"
+   Custom start=0x000000a8 end=0x000000bb (size=0x00000013) "reloc.Code"
 
 Section Details:
 
@@ -86,11 +86,11 @@ Code Disassembly:
  00007f: 0f                         | return
 000081 func[1]:
  000083: 10 83 80 80 80 00          | call 0x3
-           000084: R_FUNC_INDEX_LEB
+           000084: R_FUNC_INDEX_LEB	0
  000089: 0f                         | return
 00008b func[2]:
  00008d: 10 84 80 80 80 00          | call 0x4
-           00008e: R_FUNC_INDEX_LEB
+           00008e: R_FUNC_INDEX_LEB	1
  000093: 0f                         | return
 000095 func[3]:
  000097: 41 2a                      | i32.const 0x2a

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -28,7 +28,7 @@ Sections:
    Export start=0x00000044 end=0x00000051 (size=0x0000000d) count: 2
      Code start=0x00000053 end=0x00000075 (size=0x00000022) count: 3
    Custom start=0x0000007b end=0x000000ae (size=0x00000033) "name"
-   Custom start=0x000000b4 end=0x000000c7 (size=0x00000013) "reloc.Code"
+   Custom start=0x000000b4 end=0x000000ca (size=0x00000016) "reloc.Code"
 
 Section Details:
 
@@ -64,13 +64,13 @@ Code Disassembly:
 000054 <$name1>:
  000056: 41 01                      | i32.const 0x1
  000058: 10 83 80 80 80 00          | call 0x3
-           000059: R_FUNC_INDEX_LEB
+           000059: R_FUNC_INDEX_LEB	0
 00005f <$name2>:
  000061: 42 01                      | i64.const 1
  000063: 10 81 80 80 80 00          | call 0x1
-           000064: R_FUNC_INDEX_LEB
+           000064: R_FUNC_INDEX_LEB	1
 00006a <$name3>:
  00006c: 41 02                      | i32.const 0x2
  00006e: 10 83 80 80 80 00          | call 0x3
-           00006f: R_FUNC_INDEX_LEB
+           00006f: R_FUNC_INDEX_LEB	0
 ;;; STDOUT ;;)

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -19,7 +19,7 @@ Sections:
     Table start=0x00000027 end=0x0000002c (size=0x00000005) count: 1
      Elem start=0x00000032 end=0x00000051 (size=0x0000001f) count: 1
      Code start=0x00000053 end=0x0000005d (size=0x0000000a) count: 3
-   Custom start=0x00000063 end=0x0000007a (size=0x00000017) "reloc.Elem"
+   Custom start=0x00000063 end=0x0000007f (size=0x0000001c) "reloc.Elem"
 
 Section Details:
 


### PR DESCRIPTION
This brings wabt into line with what llvm is now
producing and what is soon that land in the
tool-conventions "spec" for static linking.

Adds 'index' and (options) 'addend' to relocations.

Define Relec in common.h rather than once for each
tool.