### PR TITLE
Add install target to Makefile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-.gclient_entries
+/bin
 /out
-/third_party/gecko-dev*
-/third_party/v8/depot_tools
 /fuzz-out
 /emscripten
 *.pyc


### PR DESCRIPTION
This means running `make` will generate a `bin` dir and put all the binaries in there. Similarly, `make clang-debug-asan` will install those binaries to the `bin` dir as well.