### PR TITLE
Fix potential one-definition-rule breaking structs

### DIFF
--- a/src/ast-writer.cc
+++ b/src/ast-writer.cc
@@ -33,6 +33,8 @@
 
 namespace wabt {
 
+namespace {
+
 static const uint8_t s_is_char_escaped[] = {
     1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
     1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
@@ -68,6 +70,8 @@ struct Context {
   int memory_index;
   int func_type_index;
 };
+
+}  // namespace
 
 static void indent(Context* ctx) {
   ctx->indent += INDENT_SIZE;

--- a/src/binary-reader-ast.cc
+++ b/src/binary-reader-ast.cc
@@ -34,6 +34,8 @@
 
 namespace wabt {
 
+namespace {
+
 struct LabelNode {
   LabelType label_type;
   Expr** first;
@@ -50,6 +52,8 @@ struct Context {
   uint32_t max_depth;
   Expr** current_init_expr;
 };
+
+}  // namespace
 
 static bool handle_error(Context* ctx, uint32_t offset, const char* message);
 

--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -55,6 +55,8 @@
 
 namespace wabt {
 
+namespace {
+
 typedef uint32_t Uint32;
 WABT_DEFINE_VECTOR(uint32, Uint32);
 WABT_DEFINE_VECTOR(uint32_vector, Uint32Vector);
@@ -93,6 +95,8 @@ struct Context {
   HostInterpreterModule* host_import_module;
   uint32_t import_env_index;
 };
+
+}  // namespace
 
 static Label* get_label(Context* ctx, uint32_t depth) {
   assert(depth < ctx->label_stack.size);

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -22,6 +22,9 @@
 #define RELOC_SIZE 5
 
 namespace wabt {
+namespace link {
+
+namespace {
 
 struct Context {
   LinkerInputBinary* binary;
@@ -29,6 +32,8 @@ struct Context {
   Section* reloc_section;
   Section* current_section;
 };
+
+}  // namespace
 
 static Result on_reloc_count(uint32_t count,
                              BinarySection section_code,
@@ -334,4 +339,5 @@ Result read_binary_linker(LinkerInputBinary* input_info,
                      &read_options);
 }
 
+}  // namespace link
 }  // namespace wabt

--- a/src/binary-reader-linker.h
+++ b/src/binary-reader-linker.h
@@ -23,6 +23,9 @@
 namespace wabt {
 
 struct Stream;
+
+namespace link {
+
 struct LinkerInputBinary;
 
 struct LinkOptions {
@@ -32,6 +35,7 @@ struct LinkOptions {
 Result read_binary_linker(struct LinkerInputBinary* input_info,
                           struct LinkOptions* options);
 
+} // namespace link
 }  // namespace wabt
 
 #endif /* WABT_BINARY_READER_LINKER_H_ */

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -27,6 +27,8 @@
 
 namespace wabt {
 
+namespace {
+
 typedef uint32_t Uint32;
 WABT_DEFINE_VECTOR(uint32, Uint32);
 
@@ -48,6 +50,8 @@ struct Context {
 
   uint32_t next_reloc;
 };
+
+}  // namespace
 
 static bool should_print_details(Context* ctx) {
   if (ctx->options->mode != ObjdumpMode::Details)

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -27,9 +27,13 @@
 
 namespace wabt {
 
+namespace {
+
 struct Context {
   OpcntData* opcnt_data;
 };
+
+}  // namespace
 
 static Result add_int_counter_value(IntCounterVector* vec,
                                         intmax_t value) {

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -40,6 +40,8 @@
 
 namespace wabt {
 
+namespace {
+
 typedef uint32_t Uint32;
 WABT_DEFINE_VECTOR(type, Type)
 WABT_DEFINE_VECTOR(uint32, Uint32);
@@ -137,6 +139,8 @@ struct LoggingContext {
   BinaryReader* reader;
   int indent;
 };
+
+}  // namespace
 
 static BinaryReaderContext* get_user_context(Context* ctx) {
   ctx->user_ctx.user_data = ctx->reader->user_data;

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -28,6 +28,8 @@
 
 namespace wabt {
 
+namespace {
+
 struct Context {
   MemoryWriter json_writer;
   Stream json_stream;
@@ -38,6 +40,8 @@ struct Context {
   Result result;
   size_t num_modules;
 };
+
+}  // namespace
 
 static void convert_backslash_to_slash(char* s, size_t length) {
   for (size_t i = 0; i < length; ++i)

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -35,6 +35,8 @@
 
 namespace wabt {
 
+namespace {
+
 /* TODO(binji): better leb size guess. Some sections we know will only be 1
  byte, but others we can be fairly certain will be larger. */
 static const size_t LEB_SECTION_SIZE_GUESS = 1;
@@ -68,6 +70,8 @@ struct Context {
   size_t last_subsection_leb_size_guess;
   size_t last_subsection_payload_offset;
 };
+
+}  // namespace
 
 void destroy_reloc_section(RelocSection* reloc_section) {
   destroy_reloc_vector(&reloc_section->relocations);

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -29,12 +29,16 @@
 
 namespace wabt {
 
+namespace {
+
 struct Context {
   Module* module;
   ExprVisitor visitor;
   StringSliceVector index_to_name;
   uint32_t label_count;
 };
+
+}  // namespace
 
 static bool has_name(StringSlice* str) {
   return str->length > 0;

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -24,6 +24,8 @@
 
 namespace wabt {
 
+namespace {
+
 typedef Label* LabelPtr;
 WABT_DEFINE_VECTOR(label_ptr, LabelPtr);
 
@@ -37,6 +39,8 @@ struct Context {
   LabelPtrVector labels;
   Result result;
 };
+
+}  // namespace
 
 static void WABT_PRINTF_FORMAT(3, 4)
     print_error(Context* ctx, const Location* loc, const char* fmt, ...) {

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -31,6 +31,7 @@
 #define FIRST_KNOWN_SECTION static_cast<size_t>(BinarySection::Type)
 
 using namespace wabt;
+using namespace wabt::link;
 
 enum { FLAG_DEBUG, FLAG_OUTPUT, FLAG_RELOCATABLE, FLAG_HELP, NUM_FLAGS };
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -30,6 +30,8 @@
 
 namespace wabt {
 
+namespace {
+
 enum class ActionResultKind {
   Error,
   Types,
@@ -58,6 +60,8 @@ struct Context {
   const Location* expr_loc; /* Cached for access by on_typechecker_error */
   Result result;
 };
+
+}  // namespace
 
 static void WABT_PRINTF_FORMAT(3, 4)
     print_error(Context* ctx, const Location* loc, const char* fmt, ...) {

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -24,6 +24,7 @@
 #define WABT_LINK_MODULE_NAME "__extern"
 
 namespace wabt {
+namespace link {
 
 struct LinkerInputBinary;
 
@@ -128,6 +129,7 @@ struct LinkerInputBinary {
 };
 WABT_DEFINE_VECTOR(binary, LinkerInputBinary);
 
+}  // namespace link
 }  // namespace wabt
 
 #endif /* WABT_LINK_H_ */


### PR DESCRIPTION
Context is the most common potential problem here, but I noticed that
wasm-link.h had some others too (DataSegment and Export).

These probably aren't an issue yet, since they all have trivial
constructors. As soon as we add non-trivial types to these they break
though.