### PR TITLE
Use std::unordered_multimap for BindingHash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ else ()
   endif ()
 
   if (COMPILER_IS_CLANG)
-    add_definitions(-fcolor-diagnostics)
+    # add_definitions(-fcolor-diagnostics)
   endif ()
 
   if (NOT EMSCRIPTEN)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ else ()
   endif ()
 
   if (COMPILER_IS_CLANG)
-    # add_definitions(-fcolor-diagnostics)
+    add_definitions(-fcolor-diagnostics)
   endif ()
 
   if (NOT EMSCRIPTEN)

--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -35,14 +35,21 @@ typedef Label* LabelPtr;
 WABT_DEFINE_VECTOR(label_ptr, LabelPtr);
 
 struct Context {
-  Module* module;
-  Func* current_func;
+  Context();
+
+  Module* module = nullptr;
+  Func* current_func = nullptr;
   ExprVisitor visitor;
   /* mapping from param index to its name, if any, for the current func */
   std::vector<std::string> param_index_to_name;
   std::vector<std::string> local_index_to_name;
   LabelPtrVector labels;
 };
+
+Context::Context() {
+  WABT_ZERO_MEMORY(visitor);
+  WABT_ZERO_MEMORY(labels);
+}
 
 void push_label(Context* ctx, Label* label) {
   append_label_ptr_value(&ctx->labels, &label);
@@ -319,7 +326,6 @@ Result visit_module(Context* ctx, Module* module) {
 
 Result apply_names(Module* module) {
   Context ctx;
-  WABT_ZERO_MEMORY(ctx);
   ctx.module = module;
   ctx.visitor.user_data = &ctx;
   ctx.visitor.begin_block_expr = begin_block_expr;

--- a/src/ast-parser-lexer-shared.cc
+++ b/src/ast-parser-lexer-shared.cc
@@ -80,7 +80,6 @@ void destroy_optional_export(OptionalExport* export_) {
 
 void destroy_exported_func(ExportedFunc* exported_func) {
   destroy_optional_export(&exported_func->export_);
-  destroy_func(exported_func->func);
   delete exported_func->func;
 }
 

--- a/src/ast-parser-lexer-shared.h
+++ b/src/ast-parser-lexer-shared.h
@@ -138,7 +138,7 @@ union Token {
   Memory memory;
   Module* module;
   RawModule raw_module;
-  Script script;
+  Script* script;
   Table table;
   TextList text_list;
   TypeVector types;
@@ -149,7 +149,7 @@ union Token {
 };
 
 struct AstParser {
-  Script script;
+  Script* script;
   SourceErrorHandler* error_handler;
   int errors;
   /* Cached pointers to reallocated parser buffers, so they don't leak. */

--- a/src/ast-parser.h
+++ b/src/ast-parser.h
@@ -25,7 +25,7 @@ namespace wabt {
 struct Script;
 
 Result parse_ast(AstLexer* lexer,
-                 struct Script* out_script,
+                 struct Script** out_script,
                  SourceErrorHandler*);
 
 }  // namespace wabt

--- a/src/ast-parser.y
+++ b/src/ast-parser.y
@@ -87,13 +87,13 @@
     append_##kind##_ptr_value(&(module)->kinds, &dummy);           \
   } while (0)
 
-#define INSERT_BINDING(module, kind, kinds, loc_, name)                       \
-  do                                                                          \
-    if ((name).start) {                                                       \
-      Binding* binding = insert_binding(&(module)->kind##_bindings, &(name)); \
-      binding->loc = loc_;                                                    \
-      binding->index = (module)->kinds.size - 1;                              \
-    }                                                                         \
+#define INSERT_BINDING(module, kind, kinds, loc_, name) \
+  do                                                    \
+    if ((name).start) {                                 \
+      (module)->kind##_bindings.emplace(                \
+          string_slice_to_string(name),                 \
+          Binding(loc_, (module)->kinds.size - 1));     \
+    }                                                   \
   while (0)
 
 #define APPEND_INLINE_EXPORT(module, Kind, loc_, value, index_)         \
@@ -277,7 +277,7 @@ static bool on_read_binary_error(uint32_t offset, const char* error,
 %destructor { destroy_module($$); delete $$; } <module>
 %destructor { destroy_raw_module(&$$); } <raw_module>
 %destructor { destroy_string_slice(&$$.text); } <literal>
-%destructor { destroy_script(&$$); } <script>
+%destructor { delete $$; } <script>
 %destructor { destroy_string_slice(&$$); } <text>
 %destructor { destroy_text_list(&$$); } <text_list>
 %destructor { destroy_type_vector(&$$); } <types>
@@ -792,10 +792,9 @@ func_info :
             }
 
             append_type_value(types, &field->bound_type.type);
-            Binding* binding =
-                insert_binding(bindings, &field->bound_type.name);
-            binding->loc = field->bound_type.loc;
-            binding->index = types->size - 1;
+            bindings->emplace(string_slice_to_string(field->bound_type.name),
+                              Binding(field->bound_type.loc, types->size - 1));
+            destroy_string_slice(&field->bound_type.name);
             break;
           }
 
@@ -805,7 +804,7 @@ func_info :
         }
 
         /* we steal memory from the func field, but not the linked list nodes */
-        delete (field);
+        delete field;
         field = next;
       }
     }
@@ -985,15 +984,17 @@ import_kind :
     LPAR FUNC bind_var_opt type_use RPAR {
       $$ = new_import();
       $$->kind = ExternalKind::Func;
-      $$->func.name = $3;
-      $$->func.decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
-      $$->func.decl.type_var = $4;
+      $$->func = new Func();
+      $$->func->name = $3;
+      $$->func->decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
+      $$->func->decl.type_var = $4;
     }
   | LPAR FUNC bind_var_opt func_sig RPAR {
       $$ = new_import();
       $$->kind = ExternalKind::Func;
-      $$->func.name = $3;
-      $$->func.decl.sig = $4;
+      $$->func = new Func();
+      $$->func->name = $3;
+      $$->func->decl.sig = $4;
     }
   | LPAR TABLE bind_var_opt table_sig RPAR {
       $$ = new_import();
@@ -1023,15 +1024,17 @@ import :
   | LPAR FUNC bind_var_opt inline_import type_use RPAR {
       $$ = $4;
       $$->kind = ExternalKind::Func;
-      $$->func.name = $3;
-      $$->func.decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
-      $$->func.decl.type_var = $5;
+      $$->func = new Func();
+      $$->func->name = $3;
+      $$->func->decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
+      $$->func->decl.type_var = $5;
     }
   | LPAR FUNC bind_var_opt inline_import func_sig RPAR {
       $$ = $4;
       $$->kind = ExternalKind::Func;
-      $$->func.name = $3;
-      $$->func.decl.sig = $5;
+      $$->func = new Func();
+      $$->func->name = $3;
+      $$->func->decl.sig = $5;
     }
   | LPAR TABLE bind_var_opt inline_import table_sig RPAR {
       $$ = $4;
@@ -1179,12 +1182,11 @@ module_fields :
   | module_fields func {
       $$ = $1;
       ModuleField* field;
-      APPEND_FIELD_TO_LIST($$, field, Func, func, @2, *$2.func);
-      append_implicit_func_declaration(&@2, $$, &field->func.decl);
-      APPEND_ITEM_TO_VECTOR($$, Func, func, funcs, &field->func);
+      APPEND_FIELD_TO_LIST($$, field, Func, func, @2, $2.func);
+      append_implicit_func_declaration(&@2, $$, &field->func->decl);
+      APPEND_ITEM_TO_VECTOR($$, Func, func, funcs, field->func);
       INSERT_BINDING($$, func, funcs, @2, $2.func->name);
       APPEND_INLINE_EXPORT($$, Func, @2, $2, $$->funcs.size - 1);
-      delete $2.func;
     }
   | module_fields elem {
       $$ = $1;
@@ -1209,42 +1211,42 @@ module_fields :
   | module_fields import {
       $$ = $1;
       ModuleField* field;
-      APPEND_FIELD_TO_LIST($$, field, Import, import, @2, *$2);
+      APPEND_FIELD_TO_LIST($$, field, Import, import, @2, $2);
       CHECK_IMPORT_ORDERING($$, func, funcs, @2);
       CHECK_IMPORT_ORDERING($$, table, tables, @2);
       CHECK_IMPORT_ORDERING($$, memory, memories, @2);
       CHECK_IMPORT_ORDERING($$, global, globals, @2);
       switch ($2->kind) {
         case ExternalKind::Func:
-          append_implicit_func_declaration(&@2, $$, &field->import.func.decl);
-          APPEND_ITEM_TO_VECTOR($$, Func, func, funcs, &field->import.func);
-          INSERT_BINDING($$, func, funcs, @2, field->import.func.name);
+          append_implicit_func_declaration(&@2, $$, &field->import->func->decl);
+          APPEND_ITEM_TO_VECTOR($$, Func, func, funcs, field->import->func);
+          INSERT_BINDING($$, func, funcs, @2, field->import->func->name);
           $$->num_func_imports++;
           break;
         case ExternalKind::Table:
-          APPEND_ITEM_TO_VECTOR($$, Table, table, tables, &field->import.table);
-          INSERT_BINDING($$, table, tables, @2, field->import.table.name);
+          APPEND_ITEM_TO_VECTOR($$, Table, table, tables,
+                                &field->import->table);
+          INSERT_BINDING($$, table, tables, @2, field->import->table.name);
           $$->num_table_imports++;
           break;
         case ExternalKind::Memory:
           APPEND_ITEM_TO_VECTOR($$, Memory, memory, memories,
-                                &field->import.memory);
-          INSERT_BINDING($$, memory, memories, @2, field->import.memory.name);
+                                &field->import->memory);
+          INSERT_BINDING($$, memory, memories, @2, field->import->memory.name);
           $$->num_memory_imports++;
           break;
         case ExternalKind::Global:
           APPEND_ITEM_TO_VECTOR($$, Global, global, globals,
-                                &field->import.global);
-          INSERT_BINDING($$, global, globals, @2, field->import.global.name);
+                                &field->import->global);
+          INSERT_BINDING($$, global, globals, @2, field->import->global.name);
           $$->num_global_imports++;
           break;
       }
-      delete $2;
-      APPEND_ITEM_TO_VECTOR($$, Import, import, imports, &field->import);
+      APPEND_ITEM_TO_VECTOR($$, Import, import, imports, field->import);
     }
   | module_fields export {
       $$ = $1;
-      ModuleField* field = append_module_field($$);
+      ModuleField* field;
       APPEND_FIELD_TO_LIST($$, field, Export, export_, @2, $2);
       APPEND_ITEM_TO_VECTOR($$, Export, export, exports, &field->export_);
       INSERT_BINDING($$, export, exports, @2, $2.name);
@@ -1399,8 +1401,7 @@ cmd :
   | module {
       $$ = new_command();
       $$->type = CommandType::Module;
-      $$->module = *$1;
-      delete $1;
+      $$->module = $1;
     }
   | LPAR REGISTER quoted_text script_var_opt RPAR {
       $$ = new_command();
@@ -1441,27 +1442,24 @@ const_list :
 
 script :
     cmd_list {
-      WABT_ZERO_MEMORY($$);
-      $$.commands = $1;
+      $$ = new Script();
+      $$->commands = $1;
 
       int last_module_index = -1;
-      for (size_t i = 0; i < $$.commands.size; ++i) {
-        Command* command = &$$.commands.data[i];
+      for (size_t i = 0; i < $$->commands.size; ++i) {
+        Command* command = &$$->commands.data[i];
         Var* module_var = nullptr;
         switch (command->type) {
           case CommandType::Module: {
             last_module_index = i;
 
             /* Wire up module name bindings. */
-            Module* module = &command->module;
+            Module* module = command->module;
             if (module->name.length == 0)
               continue;
 
-            StringSlice module_name = dup_string_slice(module->name);
-            Binding* binding =
-                insert_binding(&$$.module_bindings, &module_name);
-            binding->loc = module->loc;
-            binding->index = i;
+            $$->module_bindings.emplace(string_slice_to_string(module->name),
+                                        Binding(module->loc, i));
             break;
           }
 
@@ -1661,8 +1659,8 @@ void append_implicit_func_declaration(Location* loc,
   decl->flags |= WABT_FUNC_DECLARATION_FLAG_SHARED_SIGNATURE;
 }
 
-Result parse_ast(AstLexer * lexer, struct Script * out_script,
-                 SourceErrorHandler * error_handler) {
+Result parse_ast(AstLexer* lexer, Script** out_script,
+                 SourceErrorHandler* error_handler) {
   AstParser parser;
   WABT_ZERO_MEMORY(parser);
   parser.error_handler = error_handler;

--- a/src/ast-parser.y
+++ b/src/ast-parser.y
@@ -152,7 +152,6 @@ ExprList join_exprs2(Location* loc,
                          Expr* expr2);
 
 FuncField* new_func_field(void) { return new FuncField(); }
-Func* new_func(void) { return new Func(); }
 Command* new_command(void) { return new Command(); }
 Module* new_module(void) { return new Module(); }
 Import* new_import(void) { return new Import(); }
@@ -269,12 +268,12 @@ static bool on_read_binary_error(uint32_t offset, const char* error,
 %destructor { destroy_expr($$); } <expr>
 %destructor { destroy_expr_list($$.first); } <expr_list>
 %destructor { destroy_func_fields($$); } <func_fields>
-%destructor { destroy_func($$); delete $$; } <func>
+%destructor { delete $$; } <func>
 %destructor { destroy_func_signature(&$$); } <func_sig>
 %destructor { destroy_func_type(&$$); } <func_type>
 %destructor { destroy_import($$); delete $$; } <import>
 %destructor { destroy_data_segment(&$$); } <data_segment>
-%destructor { destroy_module($$); delete $$; } <module>
+%destructor { delete $$; } <module>
 %destructor { destroy_raw_module(&$$); } <raw_module>
 %destructor { destroy_string_slice(&$$.text); } <literal>
 %destructor { delete $$; } <script>
@@ -759,7 +758,7 @@ func_body :
 ;
 func_info :
     func_fields {
-      $$ = new_func();
+      $$ = new Func();
       FuncField* field = $1;
 
       while (field) {

--- a/src/ast-writer.cc
+++ b/src/ast-writer.cc
@@ -61,7 +61,7 @@ struct Context {
   int indent;
   NextChar next_char;
   int depth;
-  StringSliceVector index_to_name;
+  std::vector<std::string> index_to_name;
 
   int func_index;
   int global_index;
@@ -181,6 +181,12 @@ static void write_close_newline(Context* ctx) {
 
 static void write_close_space(Context* ctx) {
   write_close(ctx, NextChar::Space);
+}
+
+static void write_string(Context* ctx,
+                         const std::string& str,
+                         NextChar next_char) {
+  write_puts(ctx, str.c_str(), next_char);
 }
 
 static void write_string_slice(Context* ctx,
@@ -521,7 +527,7 @@ static void write_type_bindings(Context* ctx,
                                 const Func* func,
                                 const TypeVector* types,
                                 const BindingHash* bindings) {
-  make_type_binding_reverse_mapping(types, bindings, &ctx->index_to_name);
+  make_type_binding_reverse_mapping(*types, *bindings, &ctx->index_to_name);
 
   /* named params/locals must be specified by themselves, but nameless
    * params/locals can be compressed, e.g.:
@@ -535,12 +541,11 @@ static void write_type_bindings(Context* ctx,
       is_open = true;
     }
 
-    const StringSlice* name = &ctx->index_to_name.data[i];
-    bool has_name = !!name->start;
-    if (has_name)
-      write_string_slice(ctx, name, NextChar::Space);
+    const std::string& name = ctx->index_to_name[i];
+    if (!name.empty())
+      write_string(ctx, name, NextChar::Space);
     write_type(ctx, types->data[i], NextChar::Space);
-    if (has_name) {
+    if (!name.empty()) {
       write_close_space(ctx);
       is_open = false;
     }
@@ -636,14 +641,14 @@ static void write_import(Context* ctx, const Import* import) {
   switch (import->kind) {
     case ExternalKind::Func:
       write_open_space(ctx, "func");
-      write_string_slice_or_index(ctx, &import->func.name, ctx->func_index++,
+      write_string_slice_or_index(ctx, &import->func->name, ctx->func_index++,
                                   NextChar::Space);
-      if (decl_has_func_type(&import->func.decl)) {
+      if (decl_has_func_type(&import->func->decl)) {
         write_open_space(ctx, "type");
-        write_var(ctx, &import->func.decl.type_var, NextChar::None);
+        write_var(ctx, &import->func->decl.type_var, NextChar::None);
         write_close_space(ctx);
       } else {
-        write_func_sig_space(ctx, &import->func.decl.sig);
+        write_func_sig_space(ctx, &import->func->decl.sig);
       }
       write_close_space(ctx);
       break;
@@ -698,13 +703,13 @@ static void write_module(Context* ctx, const Module* module) {
        field = field->next) {
     switch (field->type) {
       case ModuleFieldType::Func:
-        write_func(ctx, module, &field->func);
+        write_func(ctx, module, field->func);
         break;
       case ModuleFieldType::Global:
         write_global(ctx, &field->global);
         break;
       case ModuleFieldType::Import:
-        write_import(ctx, &field->import);
+        write_import(ctx, field->import);
         break;
       case ModuleFieldType::Export:
         write_export(ctx, &field->export_);
@@ -740,9 +745,6 @@ Result write_ast(Writer* writer, const Module* module) {
   ctx.result = Result::Ok;
   init_stream(&ctx.stream, writer, nullptr);
   write_module(&ctx, module);
-  /* the memory for the actual string slice is shared with the module, so we
-   * only need to free the vector */
-  destroy_string_slice_vector(&ctx.index_to_name);
   return ctx.result;
 }
 

--- a/src/ast-writer.cc
+++ b/src/ast-writer.cc
@@ -56,19 +56,21 @@ enum class NextChar {
 };
 
 struct Context {
+  Context() { WABT_ZERO_MEMORY(stream); }
+
   Stream stream;
-  Result result;
-  int indent;
-  NextChar next_char;
-  int depth;
+  Result result = Result::Ok;
+  int indent = 0;
+  NextChar next_char = NextChar::None;
+  int depth = 0;
   std::vector<std::string> index_to_name;
 
-  int func_index;
-  int global_index;
-  int export_index;
-  int table_index;
-  int memory_index;
-  int func_type_index;
+  int func_index = 0;
+  int global_index = 0;
+  int export_index = 0;
+  int table_index = 0;
+  int memory_index = 0;
+  int func_type_index = 0;
 };
 
 }  // namespace
@@ -741,8 +743,6 @@ static void write_module(Context* ctx, const Module* module) {
 
 Result write_ast(Writer* writer, const Module* module) {
   Context ctx;
-  WABT_ZERO_MEMORY(ctx);
-  ctx.result = Result::Ok;
   init_stream(&ctx.stream, writer, nullptr);
   write_module(&ctx, module);
   return ctx.result;

--- a/src/ast.cc
+++ b/src/ast.cc
@@ -23,12 +23,12 @@ namespace wabt {
 
 int get_index_from_var(const BindingHash* hash, const Var* var) {
   if (var->type == VarType::Name)
-    return find_binding_index_by_name(hash, &var->name);
+    return find_binding_index_by_name(*hash, var->name);
   return static_cast<int>(var->index);
 }
 
 ExportPtr get_export_by_name(const Module* module, const StringSlice* name) {
-  int index = find_binding_index_by_name(&module->export_bindings, name);
+  int index = find_binding_index_by_name(module->export_bindings, *name);
   if (index == -1)
     return nullptr;
   return module->exports.data[index];
@@ -58,11 +58,11 @@ int get_local_index_by_var(const Func* func, const Var* var) {
   if (var->type == VarType::Index)
     return static_cast<int>(var->index);
 
-  int result = find_binding_index_by_name(&func->param_bindings, &var->name);
+  int result = find_binding_index_by_name(func->param_bindings, var->name);
   if (result != -1)
     return result;
 
-  result = find_binding_index_by_name(&func->local_bindings, &var->name);
+  result = find_binding_index_by_name(func->local_bindings, var->name);
   if (result == -1)
     return result;
 
@@ -129,7 +129,7 @@ Module* get_first_module(const Script* script) {
   for (size_t i = 0; i < script->commands.size; ++i) {
     Command* command = &script->commands.data[i];
     if (command->type == CommandType::Module)
-      return &command->module;
+      return command->module;
   }
   return nullptr;
 }
@@ -140,47 +140,19 @@ Module* get_module_by_var(const Script* script, const Var* var) {
     return nullptr;
   Command* command = &script->commands.data[index];
   assert(command->type == CommandType::Module);
-  return &command->module;
+  return command->module;
 }
 
-void make_type_binding_reverse_mapping(const TypeVector* types,
-                                       const BindingHash* bindings,
-                                       StringSliceVector* out_reverse_mapping) {
-  uint32_t num_names = types->size;
-  reserve_string_slices(out_reverse_mapping, num_names);
-  out_reverse_mapping->size = num_names;
-  memset(out_reverse_mapping->data, 0, num_names * sizeof(StringSlice));
-
-  /* map index to name */
-  for (size_t i = 0; i < bindings->entries.capacity; ++i) {
-    const BindingHashEntry* entry = &bindings->entries.data[i];
-    if (hash_entry_is_free(entry))
-      continue;
-
-    uint32_t index = entry->binding.index;
-    assert(index < out_reverse_mapping->size);
-    out_reverse_mapping->data[index] = entry->binding.name;
-  }
-}
-
-void find_duplicate_bindings(const BindingHash* bindings,
-                             DuplicateBindingCallback callback,
-                             void* user_data) {
-  for (size_t i = 0; i < bindings->entries.capacity; ++i) {
-    BindingHashEntry* entry = &bindings->entries.data[i];
-    if (hash_entry_is_free(entry))
-      continue;
-
-    /* only follow the chain if this is the first entry in the chain */
-    if (entry->prev)
-      continue;
-
-    for (BindingHashEntry* a = entry; a; a = a->next) {
-      for (BindingHashEntry* b = a->next; b; b = b->next) {
-        if (string_slices_are_equal(&a->binding.name, &b->binding.name))
-          callback(a, b, user_data);
-      }
-    }
+void make_type_binding_reverse_mapping(
+    const TypeVector& types,
+    const BindingHash& bindings,
+    std::vector<std::string>* out_reverse_mapping) {
+  out_reverse_mapping->clear();
+  out_reverse_mapping->resize(types.size);
+  for (auto iter: bindings) {
+    assert(static_cast<size_t>(iter.second.index) <
+           out_reverse_mapping->size());
+    (*out_reverse_mapping)[iter.second.index] = iter.first;
   }
 }
 
@@ -343,12 +315,16 @@ void destroy_func_declaration(FuncDeclaration* decl) {
     destroy_func_signature(&decl->sig);
 }
 
+Func::Func() : first_expr(nullptr) {
+  WABT_ZERO_MEMORY(name);
+  WABT_ZERO_MEMORY(decl);
+  WABT_ZERO_MEMORY(local_types);
+}
+
 void destroy_func(Func* func) {
   destroy_string_slice(&func->name);
   destroy_func_declaration(&func->decl);
   destroy_type_vector(&func->local_types);
-  destroy_binding_hash(&func->param_bindings);
-  destroy_binding_hash(&func->local_bindings);
   destroy_expr_list(func->first_expr);
 }
 
@@ -362,7 +338,8 @@ void destroy_import(Import* import) {
   destroy_string_slice(&import->field_name);
   switch (import->kind) {
     case ExternalKind::Func:
-      destroy_func(&import->func);
+      destroy_func(import->func);
+      delete import->func;
       break;
     case ExternalKind::Table:
       destroy_table(&import->table);
@@ -403,13 +380,15 @@ void destroy_table(Table* table) {
 static void destroy_module_field(ModuleField* field) {
   switch (field->type) {
     case ModuleFieldType::Func:
-      destroy_func(&field->func);
+      destroy_func(field->func);
+      delete field->func;
       break;
     case ModuleFieldType::Global:
       destroy_global(&field->global);
       break;
     case ModuleFieldType::Import:
-      destroy_import(&field->import);
+      destroy_import(field->import);
+      delete field->import;
       break;
     case ModuleFieldType::Export:
       destroy_export(&field->export_);
@@ -435,6 +414,27 @@ static void destroy_module_field(ModuleField* field) {
   }
 }
 
+Module::Module()
+    : first_field(nullptr),
+      last_field(nullptr),
+      num_func_imports(0),
+      num_table_imports(0),
+      num_memory_imports(0),
+      num_global_imports(0),
+      start(0) {
+  WABT_ZERO_MEMORY(loc);
+  WABT_ZERO_MEMORY(name);
+  WABT_ZERO_MEMORY(funcs);
+  WABT_ZERO_MEMORY(globals);
+  WABT_ZERO_MEMORY(imports);
+  WABT_ZERO_MEMORY(exports);
+  WABT_ZERO_MEMORY(func_types);
+  WABT_ZERO_MEMORY(tables);
+  WABT_ZERO_MEMORY(elem_segments);
+  WABT_ZERO_MEMORY(memories);
+  WABT_ZERO_MEMORY(data_segments);
+}
+
 void destroy_module(Module* module) {
   destroy_string_slice(&module->name);
 
@@ -457,12 +457,6 @@ void destroy_module(Module* module) {
   destroy_elem_segment_ptr_vector(&module->elem_segments);
   destroy_memory_ptr_vector(&module->memories);
   destroy_data_segment_ptr_vector(&module->data_segments);
-  destroy_binding_hash_entry_vector(&module->func_bindings.entries);
-  destroy_binding_hash_entry_vector(&module->global_bindings.entries);
-  destroy_binding_hash_entry_vector(&module->export_bindings.entries);
-  destroy_binding_hash_entry_vector(&module->func_type_bindings.entries);
-  destroy_binding_hash_entry_vector(&module->table_bindings.entries);
-  destroy_binding_hash_entry_vector(&module->memory_bindings.entries);
 }
 
 void destroy_raw_module(RawModule* raw) {
@@ -491,7 +485,8 @@ void destroy_action(Action* action) {
 void destroy_command(Command* command) {
   switch (command->type) {
     case CommandType::Module:
-      destroy_module(&command->module);
+      destroy_module(command->module);
+      delete command->module;
       break;
     case CommandType::Action:
       destroy_action(&command->action);
@@ -542,9 +537,8 @@ void destroy_elem_segment(ElemSegment* elem) {
   WABT_DESTROY_VECTOR_AND_ELEMENTS(elem->vars, var);
 }
 
-void destroy_script(Script* script) {
-  WABT_DESTROY_VECTOR_AND_ELEMENTS(script->commands, command);
-  destroy_binding_hash(&script->module_bindings);
+Script::~Script() {
+  WABT_DESTROY_VECTOR_AND_ELEMENTS(commands, command);
 }
 
 #define CHECK_RESULT(expr)   \

--- a/src/ast.h
+++ b/src/ast.h
@@ -144,7 +144,9 @@ struct FuncDeclaration {
 };
 
 struct Func {
+  WABT_DISALLOW_COPY_AND_ASSIGN(Func);
   Func();
+  ~Func();
 
   StringSlice name;
   FuncDeclaration decl;
@@ -253,7 +255,9 @@ struct ModuleField {
 };
 
 struct Module {
+  WABT_DISALLOW_COPY_AND_ASSIGN(Module);
   Module();
+  ~Module();
 
   Location loc;
   StringSlice name;
@@ -373,6 +377,8 @@ struct Command {
 WABT_DEFINE_VECTOR(command, Command);
 
 struct Script {
+  WABT_DISALLOW_COPY_AND_ASSIGN(Script);
+  Script();
   ~Script();
 
   CommandVector commands;
@@ -449,7 +455,6 @@ Expr* new_unreachable_expr(void);
 
 /* destruction functions. not needed unless you're creating your own AST
  elements */
-void destroy_script(struct Script*);
 void destroy_action(struct Action*);
 void destroy_block(struct Block*);
 void destroy_command_vector_and_elements(CommandVector*);
@@ -462,10 +467,8 @@ void destroy_expr_list(Expr*);
 void destroy_func_declaration(FuncDeclaration*);
 void destroy_func_signature(FuncSignature*);
 void destroy_func_type(FuncType*);
-void destroy_func(Func*);
 void destroy_import(Import*);
 void destroy_memory(Memory*);
-void destroy_module(Module*);
 void destroy_raw_module(RawModule*);
 void destroy_table(Table*);
 void destroy_var_vector_and_elements(VarVector*);

--- a/src/binary-reader-ast.cc
+++ b/src/binary-reader-ast.cc
@@ -1118,8 +1118,6 @@ Result read_binary_ast(const void* data,
 
   Result result = read_binary(data, size, &reader, 1, options);
   WABT_DESTROY_VECTOR_AND_ELEMENTS(ctx.label_stack, label_node);
-  if (WABT_FAILED(result))
-    destroy_module(out_module);
   return result;
 }
 

--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -393,7 +393,7 @@ static Result on_import(uint32_t index,
   import->module_name = dup_string_slice(module_name);
   import->field_name = dup_string_slice(field_name);
   int module_index = find_binding_index_by_name(
-      &ctx->env->registered_module_bindings, &import->module_name);
+      ctx->env->registered_module_bindings, import->module_name);
   if (module_index < 0) {
     print_error(ctx, "unknown import module \"" PRIstringslice "\"",
                 WABT_PRINTF_STRING_SLICE_ARG(import->module_name));
@@ -469,7 +469,7 @@ static Result append_export(Context* ctx,
                             ExternalKind kind,
                             uint32_t item_index,
                             StringSlice name) {
-  if (find_binding_index_by_name(&module->export_bindings, &name) != -1) {
+  if (find_binding_index_by_name(module->export_bindings, name) != -1) {
     print_error(ctx, "duplicate export \"" PRIstringslice "\"",
                 WABT_PRINTF_STRING_SLICE_ARG(name));
     return Result::Error;
@@ -478,8 +478,8 @@ static Result append_export(Context* ctx,
   module->exports.emplace_back(dup_string_slice(name), kind, item_index);
   InterpreterExport* export_ = &module->exports.back();
 
-  Binding* binding = insert_binding(&module->export_bindings, &export_->name);
-  binding->index = module->exports.size() - 1;
+  module->export_bindings.emplace(string_slice_to_string(export_->name),
+                                  Binding(module->exports.size() - 1));
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1750,7 +1750,6 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
     in_str(ctx, &module_name, "import module name");
     StringSlice field_name;
     in_str(ctx, &field_name, "import field name");
-    CALLBACK(on_import, i, module_name, field_name);
 
     uint32_t kind;
     in_u32_leb128(ctx, &kind, "import kind");
@@ -1760,6 +1759,7 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         in_u32_leb128(ctx, &sig_index, "import signature index");
         RAISE_ERROR_UNLESS(sig_index < ctx->num_signatures,
                            "invalid import signature index");
+        CALLBACK(on_import, i, module_name, field_name);
         CALLBACK(on_import_func, i, module_name, field_name,
                  ctx->num_func_imports, sig_index);
         ctx->num_func_imports++;
@@ -1770,6 +1770,7 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         Type elem_type;
         Limits elem_limits;
         read_table(ctx, &elem_type, &elem_limits);
+        CALLBACK(on_import, i, module_name, field_name);
         CALLBACK(on_import_table, i, module_name, field_name,
                  ctx->num_table_imports, elem_type, &elem_limits);
         ctx->num_table_imports++;
@@ -1779,6 +1780,7 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
       case ExternalKind::Memory: {
         Limits page_limits;
         read_memory(ctx, &page_limits);
+        CALLBACK(on_import, i, module_name, field_name);
         CALLBACK(on_import_memory, i, module_name, field_name,
                  ctx->num_memory_imports, &page_limits);
         ctx->num_memory_imports++;
@@ -1789,6 +1791,7 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         Type type;
         bool mutable_;
         read_global_header(ctx, &type, &mutable_);
+        CALLBACK(on_import, i, module_name, field_name);
         CALLBACK(on_import_global, i, module_name, field_name,
                  ctx->num_global_imports, type, mutable_);
         ctx->num_global_imports++;

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -351,7 +351,7 @@ static void write_commands(Context* ctx, Script* script) {
 
     switch (command->type) {
       case CommandType::Module: {
-        Module* module = &command->module;
+        Module* module = command->module;
         char* filename = get_module_filename(ctx);
         write_location(ctx, &module->loc);
         write_separator(ctx);

--- a/src/binding-hash.cc
+++ b/src/binding-hash.cc
@@ -16,164 +16,77 @@
 
 #include "binding-hash.h"
 
-#define INITIAL_HASH_CAPACITY 8
+#include <algorithm>
+#include <vector>
 
 namespace wabt {
 
-static size_t hash_name(const StringSlice* name) {
-  // FNV-1a hash
-  const uint32_t fnv_prime = 0x01000193;
-  const uint8_t* bp = reinterpret_cast<const uint8_t*>(name->start);
-  const uint8_t* be = bp + name->length;
-  uint32_t hval = 0x811c9dc5;
-  while (bp < be) {
-    hval ^= static_cast<uint32_t>(*bp++);
-    hval *= fnv_prime;
-  }
-  return hval;
-}
+namespace {
 
-static BindingHashEntry* hash_main_entry(const BindingHash* hash,
-                                         const StringSlice* name) {
-  return &hash->entries.data[hash_name(name) % hash->entries.capacity];
-}
+typedef std::vector<const BindingHash::value_type*> BindingHashValueTypeVector;
 
-bool hash_entry_is_free(const BindingHashEntry* entry) {
-  return !entry->binding.name.start;
-}
-
-static BindingHashEntry* hash_new_entry(BindingHash* hash,
-                                        const StringSlice* name) {
-  BindingHashEntry* entry = hash_main_entry(hash, name);
-  if (!hash_entry_is_free(entry)) {
-    assert(hash->free_head);
-    BindingHashEntry* free_entry = hash->free_head;
-    hash->free_head = free_entry->next;
-    if (free_entry->next)
-      free_entry->next->prev = nullptr;
-
-    /* our main position is already claimed. Check to see if the entry in that
-     * position is in its main position */
-    BindingHashEntry* other_entry = hash_main_entry(hash, &entry->binding.name);
-    if (other_entry == entry) {
-      /* yes, so add this new entry to the chain, even if it is already there */
-      /* add as the second entry in the chain */
-      free_entry->next = entry->next;
-      entry->next = free_entry;
-      entry = free_entry;
+BindingHashValueTypeVector create_binding_duplicates_vector(
+    const BindingHash& bindings) {
+  // This relies on the fact that in an unordered_multimap, all values with the
+  // same key are adjacent in iteration order.
+  std::vector<const BindingHash::value_type*> duplicates;
+  auto first = bindings.begin(), end = bindings.end();
+  bool is_first = true;
+  for (auto iter = std::next(first); iter != end; ++iter) {
+    if (first->first == iter->first) {
+      if (is_first)
+        duplicates.push_back(&*first);
+      duplicates.push_back(&*iter);
+      is_first = false;
     } else {
-      /* no, move the entry to the free entry */
-      assert(!hash_entry_is_free(other_entry));
-      while (other_entry->next != entry)
-        other_entry = other_entry->next;
-
-      other_entry->next = free_entry;
-      *free_entry = *entry;
-      entry->next = nullptr;
+      is_first = true;
+      first = iter;
     }
-  } else {
-    /* remove from the free list */
-    if (entry->next)
-      entry->next->prev = entry->prev;
-    if (entry->prev)
-      entry->prev->next = entry->next;
-    else
-      hash->free_head = entry->next;
-    entry->next = nullptr;
   }
-
-  WABT_ZERO_MEMORY(entry->binding);
-  entry->binding.name = *name;
-  entry->prev = nullptr;
-  /* entry->next is set above */
-  return entry;
+  return duplicates;
 }
 
-static void hash_resize(BindingHash* hash, size_t desired_capacity) {
-  BindingHash new_hash;
-  WABT_ZERO_MEMORY(new_hash);
-  /* TODO(binji): better plural */
-  reserve_binding_hash_entrys(&new_hash.entries, desired_capacity);
+void sort_duplicates_vector_by_location(
+    BindingHashValueTypeVector* duplicates) {
+  std::sort(
+      duplicates->begin(), duplicates->end(),
+      [](const BindingHash::value_type* lhs,
+         const BindingHash::value_type* rhs) -> bool {
+        return lhs->second.loc.line < rhs->second.loc.line ||
+               (lhs->second.loc.line == rhs->second.loc.line &&
+                lhs->second.loc.first_column < rhs->second.loc.first_column);
+      });
+}
 
-  /* update the free list */
-  for (size_t i = 0; i < new_hash.entries.capacity; ++i) {
-    BindingHashEntry* entry = &new_hash.entries.data[i];
-    if (new_hash.free_head)
-      new_hash.free_head->prev = entry;
-
-    WABT_ZERO_MEMORY(entry->binding.name);
-    entry->next = new_hash.free_head;
-    new_hash.free_head = entry;
-  }
-  new_hash.free_head->prev = nullptr;
-
-  /* copy from the old hash to the new hash */
-  for (size_t i = 0; i < hash->entries.capacity; ++i) {
-    BindingHashEntry* old_entry = &hash->entries.data[i];
-    if (hash_entry_is_free(old_entry))
+void call_callbacks(const BindingHashValueTypeVector& duplicates,
+                    DuplicateBindingCallback callback,
+                    void* user_data) {
+  // Loop through all duplicates in order, and call callback with first
+  // occurrence.
+  for (auto iter = duplicates.begin(), end = duplicates.end(); iter != end;
+       ++iter) {
+    auto first = std::find_if(duplicates.begin(), duplicates.end(),
+                              [iter](const BindingHash::value_type* x) -> bool {
+                                return x->first == (*iter)->first;
+                              });
+    if (first == iter)
       continue;
-
-    StringSlice* name = &old_entry->binding.name;
-    BindingHashEntry* new_entry = hash_new_entry(&new_hash, name);
-    new_entry->binding = old_entry->binding;
+    assert(first != duplicates.end());
+    callback(**first, **iter, user_data);
   }
-
-  /* we are sharing the StringSlices, so we only need to destroy the old
-   * binding vector */
-  destroy_binding_hash_entry_vector(&hash->entries);
-  *hash = new_hash;
 }
 
-Binding* insert_binding(BindingHash* hash, const StringSlice* name) {
-  if (hash->entries.size == 0)
-    hash_resize(hash, INITIAL_HASH_CAPACITY);
+} // namespace
 
-  if (!hash->free_head) {
-    /* no more free space, allocate more */
-    hash_resize(hash, hash->entries.capacity * 2);
+void find_duplicate_bindings(const BindingHash& bindings,
+                             DuplicateBindingCallback callback,
+                             void* user_data) {
+  if (bindings.size() > 0) {
+    BindingHashValueTypeVector duplicates =
+        create_binding_duplicates_vector(bindings);
+    sort_duplicates_vector_by_location(&duplicates);
+    call_callbacks(duplicates, callback, user_data);
   }
-
-  BindingHashEntry* entry = hash_new_entry(hash, name);
-  assert(entry);
-  hash->entries.size++;
-  return &entry->binding;
-}
-
-int find_binding_index_by_name(const BindingHash* hash,
-                               const StringSlice* name) {
-  if (hash->entries.capacity == 0)
-    return -1;
-
-  BindingHashEntry* entry = hash_main_entry(hash, name);
-  do {
-    if (string_slices_are_equal(&entry->binding.name, name))
-      return entry->binding.index;
-
-    entry = entry->next;
-  } while (entry && !hash_entry_is_free(entry));
-  return -1;
-}
-
-void remove_binding(BindingHash* hash, const StringSlice* name) {
-  int index = find_binding_index_by_name(hash, name);
-  if (index == -1)
-    return;
-
-  BindingHashEntry* entry = &hash->entries.data[index];
-  destroy_string_slice(&entry->binding.name);
-  WABT_ZERO_MEMORY(*entry);
-}
-
-static void destroy_binding_hash_entry(BindingHashEntry* entry) {
-  destroy_string_slice(&entry->binding.name);
-}
-
-void destroy_binding_hash(BindingHash* hash) {
-  /* Can't use WABT_DESTROY_VECTOR_AND_ELEMENTS, because it loops over size, not
-   * capacity. */
-  for (size_t i = 0; i < hash->entries.capacity; ++i)
-    destroy_binding_hash_entry(&hash->entries.data[i]);
-  destroy_binding_hash_entry_vector(&hash->entries);
 }
 
 }  // namespace wabt

--- a/src/binding-hash.cc
+++ b/src/binding-hash.cc
@@ -21,71 +21,61 @@
 
 namespace wabt {
 
-namespace {
+void BindingHash::find_duplicates(DuplicateCallback callback,
+                                  void* user_data) const {
+  if (size() > 0) {
+    ValueTypeVector duplicates;
+    create_duplicates_vector(&duplicates);
+    sort_duplicates_vector_by_location(&duplicates);
+    call_callbacks(duplicates, callback, user_data);
+  }
+}
 
-typedef std::vector<const BindingHash::value_type*> BindingHashValueTypeVector;
-
-BindingHashValueTypeVector create_binding_duplicates_vector(
-    const BindingHash& bindings) {
+void BindingHash::create_duplicates_vector(
+    ValueTypeVector* out_duplicates) const {
   // This relies on the fact that in an unordered_multimap, all values with the
   // same key are adjacent in iteration order.
-  std::vector<const BindingHash::value_type*> duplicates;
-  auto first = bindings.begin(), end = bindings.end();
+  auto first = begin();
   bool is_first = true;
-  for (auto iter = std::next(first); iter != end; ++iter) {
+  for (auto iter = std::next(first); iter != end(); ++iter) {
     if (first->first == iter->first) {
       if (is_first)
-        duplicates.push_back(&*first);
-      duplicates.push_back(&*iter);
+        out_duplicates->push_back(&*first);
+      out_duplicates->push_back(&*iter);
       is_first = false;
     } else {
       is_first = true;
       first = iter;
     }
   }
-  return duplicates;
 }
 
-void sort_duplicates_vector_by_location(
-    BindingHashValueTypeVector* duplicates) {
+void BindingHash::sort_duplicates_vector_by_location(
+    ValueTypeVector* duplicates) const {
   std::sort(
       duplicates->begin(), duplicates->end(),
-      [](const BindingHash::value_type* lhs,
-         const BindingHash::value_type* rhs) -> bool {
+      [](const value_type* lhs, const value_type* rhs) -> bool {
         return lhs->second.loc.line < rhs->second.loc.line ||
                (lhs->second.loc.line == rhs->second.loc.line &&
                 lhs->second.loc.first_column < rhs->second.loc.first_column);
       });
 }
 
-void call_callbacks(const BindingHashValueTypeVector& duplicates,
-                    DuplicateBindingCallback callback,
-                    void* user_data) {
+void BindingHash::call_callbacks(const ValueTypeVector& duplicates,
+                                 DuplicateCallback callback,
+                                 void* user_data) const {
   // Loop through all duplicates in order, and call callback with first
   // occurrence.
   for (auto iter = duplicates.begin(), end = duplicates.end(); iter != end;
        ++iter) {
     auto first = std::find_if(duplicates.begin(), duplicates.end(),
-                              [iter](const BindingHash::value_type* x) -> bool {
+                              [iter](const value_type* x) -> bool {
                                 return x->first == (*iter)->first;
                               });
     if (first == iter)
       continue;
     assert(first != duplicates.end());
     callback(**first, **iter, user_data);
-  }
-}
-
-} // namespace
-
-void find_duplicate_bindings(const BindingHash& bindings,
-                             DuplicateBindingCallback callback,
-                             void* user_data) {
-  if (bindings.size() > 0) {
-    BindingHashValueTypeVector duplicates =
-        create_binding_duplicates_vector(bindings);
-    sort_duplicates_vector_by_location(&duplicates);
-    call_callbacks(duplicates, callback, user_data);
   }
 }
 

--- a/src/binding-hash.h
+++ b/src/binding-hash.h
@@ -35,6 +35,9 @@ struct Binding {
   int index;
 };
 
+// This class derives from a C++ container, which is usually not advisable
+// because they don't have virtual destructors. So don't delete a BindingHash
+// object through a pointer to std::unordered_multimap.
 class BindingHash : public std::unordered_multimap<std::string, Binding> {
  public:
   typedef void (*DuplicateCallback)(const value_type& a,

--- a/src/common.h
+++ b/src/common.h
@@ -25,6 +25,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <string>
+
 #include "config.h"
 
 #define WABT_FATAL(...) fprintf(stderr, __VA_ARGS__), exit(1)
@@ -457,6 +459,17 @@ bool string_slice_is_empty(const StringSlice*);
 bool string_slices_are_equal(const StringSlice*, const StringSlice*);
 void destroy_string_slice(StringSlice*);
 Result read_file(const char* filename, char** out_data, size_t* out_size);
+
+inline std::string string_slice_to_string(const StringSlice& ss) {
+  return std::string(ss.start, ss.length);
+}
+
+inline StringSlice string_to_string_slice(const std::string& s) {
+  StringSlice ss;
+  ss.start = s.data();
+  ss.length = s.length();
+  return ss;
+}
 
 bool default_source_error_callback(const Location*,
                                    const char* error,

--- a/src/common.h
+++ b/src/common.h
@@ -26,12 +26,17 @@
 #include <string.h>
 
 #include <string>
+#include <type_traits>
 
 #include "config.h"
 
 #define WABT_FATAL(...) fprintf(stderr, __VA_ARGS__), exit(1)
 #define WABT_ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-#define WABT_ZERO_MEMORY(var) memset(static_cast<void*>(&(var)), 0, sizeof(var))
+#define WABT_ZERO_MEMORY(var)                                          \
+  WABT_STATIC_ASSERT(                                                  \
+      std::is_pod<std::remove_reference<decltype(var)>::type>::value); \
+  memset(static_cast<void*>(&(var)), 0, sizeof(var))
+
 #define WABT_USE(x) static_cast<void>(x)
 
 #define WABT_UNKNOWN_OFFSET (static_cast<uint32_t>(~0))
@@ -62,6 +67,10 @@
 
 #define WABT_ENUM_COUNT(name) \
   (static_cast<int>(name::Last) - static_cast<int>(name::First) + 1)
+
+#define WABT_DISALLOW_COPY_AND_ASSIGN(type) \
+  type(const type&) = delete;               \
+  type& operator=(const type&) = delete;
 
 namespace wabt {
 

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -32,9 +32,11 @@ namespace wabt {
 namespace {
 
 struct Context {
+  Context() : module(nullptr), label_count(0) { WABT_ZERO_MEMORY(visitor); }
+
   Module* module;
   ExprVisitor visitor;
-  StringSliceVector index_to_name;
+  std::vector<std::string> index_to_name;
   uint32_t label_count;
 };
 
@@ -70,9 +72,7 @@ static void generate_and_bind_name(BindingHash* bindings,
                                    uint32_t index,
                                    StringSlice* str) {
   generate_name(prefix, index, str);
-  Binding* binding;
-  binding = insert_binding(bindings, str);
-  binding->index = index;
+  bindings->emplace(string_slice_to_string(*str), Binding(index));
 }
 
 static void maybe_generate_and_bind_name(BindingHash* bindings,
@@ -83,17 +83,19 @@ static void maybe_generate_and_bind_name(BindingHash* bindings,
     generate_and_bind_name(bindings, prefix, index, str);
 }
 
-static void generate_and_bind_local_names(StringSliceVector* index_to_name,
-                                          BindingHash* bindings,
-                                          const char* prefix) {
-  for (size_t i = 0; i < index_to_name->size; ++i) {
-    StringSlice* old_name = &index_to_name->data[i];
-    if (has_name(old_name))
+static void generate_and_bind_local_names(
+    Context* ctx,
+    BindingHash* bindings,
+    const char* prefix) {
+  for (size_t i = 0; i < ctx->index_to_name.size(); ++i) {
+    const std::string& old_name = ctx->index_to_name[i];
+    if (!old_name.empty())
       continue;
 
     StringSlice new_name;
     generate_and_bind_name(bindings, prefix, i, &new_name);
-    index_to_name->data[i] = new_name;
+    ctx->index_to_name[i] = string_slice_to_string(new_name);
+    destroy_string_slice(&new_name);
   }
 }
 
@@ -119,15 +121,13 @@ static Result visit_func(Context* ctx, uint32_t func_index, Func* func) {
   maybe_generate_and_bind_name(&ctx->module->func_bindings, "$f", func_index,
                                &func->name);
 
-  make_type_binding_reverse_mapping(&func->decl.sig.param_types,
-                                    &func->param_bindings, &ctx->index_to_name);
-  generate_and_bind_local_names(&ctx->index_to_name, &func->param_bindings,
-                                "$p");
+  make_type_binding_reverse_mapping(func->decl.sig.param_types,
+                                    func->param_bindings, &ctx->index_to_name);
+  generate_and_bind_local_names(ctx, &func->param_bindings, "$p");
 
-  make_type_binding_reverse_mapping(&func->local_types, &func->local_bindings,
+  make_type_binding_reverse_mapping(func->local_types, func->local_bindings,
                                     &ctx->index_to_name);
-  generate_and_bind_local_names(&ctx->index_to_name, &func->local_bindings,
-                                "$l");
+  generate_and_bind_local_names(ctx, &func->local_bindings, "$l");
 
   ctx->label_count = 0;
   CHECK_RESULT(visit_func(func, &ctx->visitor));
@@ -180,14 +180,12 @@ static Result visit_module(Context* ctx, Module* module) {
 
 Result generate_names(Module* module) {
   Context ctx;
-  WABT_ZERO_MEMORY(ctx);
   ctx.visitor.user_data = &ctx;
   ctx.visitor.begin_block_expr = begin_block_expr;
   ctx.visitor.begin_loop_expr = begin_loop_expr;
   ctx.visitor.begin_if_expr = begin_if_expr;
   ctx.module = module;
   Result result = visit_module(&ctx, module);
-  destroy_string_slice_vector(&ctx.index_to_name);
   return result;
 }
 

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -54,14 +54,41 @@ static const char* get_interpreter_opcode_name(InterpreterOpcode opcode) {
   return s_interpreter_opcode_name[static_cast<int>(opcode)];
 }
 
-void init_interpreter_environment(InterpreterEnvironment* env) {
-  WABT_ZERO_MEMORY(*env);
-  init_output_buffer(&env->istream, INITIAL_ISTREAM_CAPACITY);
+InterpreterEnvironment::InterpreterEnvironment() {
+  WABT_ZERO_MEMORY(istream);
+  init_output_buffer(&istream, INITIAL_ISTREAM_CAPACITY);
 }
+
+InterpreterThread::InterpreterThread()
+    : env(nullptr),
+      value_stack_top(nullptr),
+      value_stack_end(nullptr),
+      call_stack_top(nullptr),
+      call_stack_end(nullptr),
+      pc(0) {}
 
 InterpreterImport::~InterpreterImport() {
   destroy_string_slice(&module_name);
   destroy_string_slice(&field_name);
+}
+
+InterpreterExport::InterpreterExport(InterpreterExport&& other)
+  : name(other.name),
+    kind(other.kind),
+    index(other.index) {
+  WABT_ZERO_MEMORY(other.name);
+}
+
+InterpreterExport& InterpreterExport::operator=(InterpreterExport&& other) {
+  name = other.name;
+  kind = other.kind;
+  index = other.index;
+  WABT_ZERO_MEMORY(other.name);
+  return *this;
+}
+
+InterpreterExport::~InterpreterExport() {
+  destroy_string_slice(&name);
 }
 
 InterpreterModule::InterpreterModule(bool is_host)
@@ -69,19 +96,15 @@ InterpreterModule::InterpreterModule(bool is_host)
       table_index(WABT_INVALID_INDEX),
       is_host(is_host) {
   WABT_ZERO_MEMORY(name);
-  WABT_ZERO_MEMORY(export_bindings);
 }
 
 InterpreterModule::InterpreterModule(const StringSlice& name, bool is_host)
     : name(name),
       memory_index(WABT_INVALID_INDEX),
       table_index(WABT_INVALID_INDEX),
-      is_host(is_host) {
-  WABT_ZERO_MEMORY(export_bindings);
-}
+      is_host(is_host) {}
 
 InterpreterModule::~InterpreterModule() {
-  destroy_binding_hash(&export_bindings);
   destroy_string_slice(&name);
 }
 
@@ -96,8 +119,6 @@ HostInterpreterModule::HostInterpreterModule(const StringSlice& name)
 
 void destroy_interpreter_environment(InterpreterEnvironment* env) {
   destroy_output_buffer(&env->istream);
-  destroy_binding_hash(&env->module_bindings);
-  destroy_binding_hash(&env->registered_module_bindings);
 }
 
 InterpreterEnvironmentMark mark_interpreter_environment(
@@ -120,19 +141,18 @@ void reset_interpreter_environment_to_mark(InterpreterEnvironment* env,
   for (size_t i = mark.modules_size; i < env->modules.size(); ++i) {
     const StringSlice* name = &env->modules[i]->name;
     if (!string_slice_is_empty(name))
-      remove_binding(&env->module_bindings, name);
+      env->module_bindings.erase(string_slice_to_string(*name));
   }
 
   /* registered_module_bindings maps from an arbitrary name to a module index,
    * so we have to iterate through the entire table to find entries to remove.
    */
-  for (size_t i = 0; i < env->registered_module_bindings.entries.capacity;
-       ++i) {
-    BindingHashEntry* entry = &env->registered_module_bindings.entries.data[i];
-    if (!hash_entry_is_free(entry) &&
-        entry->binding.index >= static_cast<int>(mark.modules_size)) {
-      remove_binding(&env->registered_module_bindings, &entry->binding.name);
-    }
+  auto iter = env->registered_module_bindings.begin();
+  while (iter != env->registered_module_bindings.end()) {
+    if (iter->second.index >= static_cast<int>(mark.modules_size))
+      iter = env->registered_module_bindings.erase(iter);
+    else
+      ++iter;
   }
 
   env->modules.erase(env->modules.begin() + mark.modules_size,
@@ -152,11 +172,8 @@ HostInterpreterModule* append_host_module(InterpreterEnvironment* env,
   HostInterpreterModule* module =
       new HostInterpreterModule(dup_string_slice(name));
   env->modules.emplace_back(module);
-
-  StringSlice dup_name = dup_string_slice(name);
-  Binding* binding =
-      insert_binding(&env->registered_module_bindings, &dup_name);
-  binding->index = env->modules.size() - 1;
+  env->registered_module_bindings.emplace(string_slice_to_string(name),
+                                          Binding(env->modules.size() - 1));
   return module;
 }
 
@@ -186,7 +203,7 @@ InterpreterResult push_thread_value(InterpreterThread* thread,
 
 InterpreterExport* get_interpreter_export_by_name(InterpreterModule* module,
                                                   const StringSlice* name) {
-  int field_index = find_binding_index_by_name(&module->export_bindings, name);
+  int field_index = find_binding_index_by_name(module->export_bindings, *name);
   if (field_index < 0)
     return nullptr;
   return &module->exports[field_index];

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -153,6 +153,9 @@ struct InterpreterGlobal {
 };
 
 struct InterpreterImport {
+  InterpreterImport();
+  InterpreterImport(InterpreterImport&&);
+  InterpreterImport& operator=(InterpreterImport&&);
   ~InterpreterImport();
 
   StringSlice module_name;
@@ -184,6 +187,7 @@ typedef Result (*InterpreterHostFuncCallback)(
     void* user_data);
 
 struct InterpreterFunc {
+  WABT_DISALLOW_COPY_AND_ASSIGN(InterpreterFunc);
   InterpreterFunc(uint32_t sig_index, bool is_host)
       : sig_index(sig_index), is_host(is_host) {}
   virtual ~InterpreterFunc() {}
@@ -235,8 +239,6 @@ HostInterpreterFunc* InterpreterFunc::as_host() {
 struct InterpreterExport {
   InterpreterExport(const StringSlice& name, ExternalKind kind, uint32_t index)
       : name(name), kind(kind), index(index) {}
-  InterpreterExport(const InterpreterExport&) = delete;
-  InterpreterExport& operator=(const InterpreterExport&) = delete;
   InterpreterExport(InterpreterExport&&);
   InterpreterExport& operator=(InterpreterExport&&);
   ~InterpreterExport();
@@ -273,6 +275,7 @@ struct InterpreterHostImportDelegate {
 };
 
 struct InterpreterModule {
+  WABT_DISALLOW_COPY_AND_ASSIGN(InterpreterModule);
   explicit InterpreterModule(bool is_host);
   InterpreterModule(const StringSlice& name, bool is_host);
   virtual ~InterpreterModule();

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -235,8 +235,13 @@ HostInterpreterFunc* InterpreterFunc::as_host() {
 struct InterpreterExport {
   InterpreterExport(const StringSlice& name, ExternalKind kind, uint32_t index)
       : name(name), kind(kind), index(index) {}
+  InterpreterExport(const InterpreterExport&) = delete;
+  InterpreterExport& operator=(const InterpreterExport&) = delete;
+  InterpreterExport(InterpreterExport&&);
+  InterpreterExport& operator=(InterpreterExport&&);
+  ~InterpreterExport();
 
-  StringSlice name; /* Owned by the export_bindings hash */
+  StringSlice name;
   ExternalKind kind;
   uint32_t index;
 };
@@ -320,6 +325,8 @@ struct InterpreterEnvironmentMark {
 };
 
 struct InterpreterEnvironment {
+  InterpreterEnvironment();
+
   std::vector<std::unique_ptr<InterpreterModule>> modules;
   std::vector<InterpreterFuncSignature> sigs;
   std::vector<std::unique_ptr<InterpreterFunc>> funcs;
@@ -332,6 +339,8 @@ struct InterpreterEnvironment {
 };
 
 struct InterpreterThread {
+  InterpreterThread();
+
   InterpreterEnvironment* env;
   std::vector<InterpreterValue> value_stack;
   std::vector<uint32_t> call_stack;
@@ -357,7 +366,6 @@ bool func_signatures_are_equal(InterpreterEnvironment* env,
                                uint32_t sig_index_0,
                                uint32_t sig_index_1);
 
-void init_interpreter_environment(InterpreterEnvironment* env);
 void destroy_interpreter_environment(InterpreterEnvironment* env);
 InterpreterEnvironmentMark mark_interpreter_environment(
     InterpreterEnvironment* env);

--- a/src/prebuilt/ast-parser-gen.cc
+++ b/src/prebuilt/ast-parser-gen.cc
@@ -209,7 +209,6 @@ ExprList join_exprs2(Location* loc,
                          Expr* expr2);
 
 FuncField* new_func_field(void) { return new FuncField(); }
-Func* new_func(void) { return new Func(); }
 Command* new_command(void) { return new Command(); }
 Module* new_module(void) { return new Module(); }
 Import* new_import(void) { return new Import(); }
@@ -241,7 +240,7 @@ static bool on_read_binary_error(uint32_t offset, const char* error,
 #define wabt_ast_parser_error ast_parser_error
 
 
-#line 245 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:339  */
+#line 244 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -388,7 +387,7 @@ int wabt_ast_parser_parse (::wabt::AstLexer* lexer, ::wabt::AstParser* parser);
 
 /* Copy the second part of user declarations.  */
 
-#line 392 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:358  */
+#line 391 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -694,24 +693,24 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   298,   298,   304,   314,   315,   319,   337,   338,   344,
-     347,   352,   359,   362,   363,   367,   372,   379,   382,   385,
-     390,   397,   403,   414,   418,   422,   429,   434,   441,   442,
-     448,   449,   452,   456,   457,   461,   462,   472,   473,   484,
-     485,   486,   489,   492,   495,   498,   501,   505,   509,   514,
-     517,   521,   525,   529,   533,   537,   541,   545,   551,   557,
-     569,   573,   577,   581,   585,   588,   593,   599,   605,   611,
-     621,   629,   633,   636,   642,   648,   657,   663,   668,   674,
-     679,   685,   693,   694,   702,   703,   711,   716,   717,   723,
-     729,   739,   745,   751,   761,   813,   822,   829,   836,   846,
-     849,   853,   859,   870,   876,   896,   903,   915,   922,   942,
-     964,   971,   984,   992,   999,  1005,  1011,  1019,  1024,  1032,
-    1039,  1045,  1051,  1060,  1068,  1073,  1078,  1083,  1090,  1097,
-    1101,  1104,  1115,  1119,  1126,  1130,  1133,  1141,  1149,  1166,
-    1182,  1191,  1198,  1205,  1211,  1247,  1257,  1278,  1288,  1314,
-    1319,  1327,  1335,  1345,  1351,  1357,  1363,  1369,  1375,  1380,
-    1386,  1395,  1400,  1401,  1406,  1415,  1416,  1424,  1436,  1437,
-    1444,  1504
+       0,   297,   297,   303,   313,   314,   318,   336,   337,   343,
+     346,   351,   358,   361,   362,   366,   371,   378,   381,   384,
+     389,   396,   402,   413,   417,   421,   428,   433,   440,   441,
+     447,   448,   451,   455,   456,   460,   461,   471,   472,   483,
+     484,   485,   488,   491,   494,   497,   500,   504,   508,   513,
+     516,   520,   524,   528,   532,   536,   540,   544,   550,   556,
+     568,   572,   576,   580,   584,   587,   592,   598,   604,   610,
+     620,   628,   632,   635,   641,   647,   656,   662,   667,   673,
+     678,   684,   692,   693,   701,   702,   710,   715,   716,   722,
+     728,   738,   744,   750,   760,   812,   821,   828,   835,   845,
+     848,   852,   858,   869,   875,   895,   902,   914,   921,   941,
+     963,   970,   983,   991,   998,  1004,  1010,  1018,  1023,  1031,
+    1038,  1044,  1050,  1059,  1067,  1072,  1077,  1082,  1089,  1096,
+    1100,  1103,  1114,  1118,  1125,  1129,  1132,  1140,  1148,  1165,
+    1181,  1190,  1197,  1204,  1210,  1246,  1256,  1277,  1287,  1313,
+    1318,  1326,  1334,  1344,  1350,  1356,  1362,  1368,  1374,  1379,
+    1385,  1394,  1399,  1400,  1405,  1414,  1415,  1423,  1435,  1436,
+    1443,  1503
 };
 #endif
 
@@ -1650,333 +1649,333 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 5: /* NAT  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1656 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1655 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 6: /* INT  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1662 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1661 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 7: /* FLOAT  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1668 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1667 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 8: /* TEXT  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1674 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1673 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 9: /* VAR  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1680 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1679 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 35: /* OFFSET_EQ_NAT  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1686 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1685 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 36: /* ALIGN_EQ_NAT  */
-#line 259 "src/ast-parser.y" /* yacc.c:1257  */
+#line 258 "src/ast-parser.y" /* yacc.c:1257  */
       {}
-#line 1692 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1691 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 75: /* non_empty_text_list  */
-#line 282 "src/ast-parser.y" /* yacc.c:1257  */
+#line 281 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1698 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1697 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 76: /* text_list  */
-#line 282 "src/ast-parser.y" /* yacc.c:1257  */
+#line 281 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1704 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1703 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 77: /* quoted_text  */
-#line 281 "src/ast-parser.y" /* yacc.c:1257  */
+#line 280 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1710 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1709 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 78: /* value_type_list  */
-#line 283 "src/ast-parser.y" /* yacc.c:1257  */
+#line 282 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_type_vector(&((*yyvaluep).types)); }
-#line 1716 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1715 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 81: /* func_type  */
-#line 273 "src/ast-parser.y" /* yacc.c:1257  */
+#line 272 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_func_signature(&((*yyvaluep).func_sig)); }
-#line 1722 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1721 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 82: /* func_sig  */
-#line 273 "src/ast-parser.y" /* yacc.c:1257  */
+#line 272 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_func_signature(&((*yyvaluep).func_sig)); }
-#line 1728 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1727 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 86: /* type_use  */
-#line 285 "src/ast-parser.y" /* yacc.c:1257  */
+#line 284 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1734 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1733 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 88: /* literal  */
-#line 279 "src/ast-parser.y" /* yacc.c:1257  */
+#line 278 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).literal).text); }
-#line 1740 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1739 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 89: /* var  */
-#line 285 "src/ast-parser.y" /* yacc.c:1257  */
+#line 284 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1746 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1745 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 90: /* var_list  */
-#line 284 "src/ast-parser.y" /* yacc.c:1257  */
+#line 283 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_var_vector_and_elements(&((*yyvaluep).vars)); }
-#line 1752 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1751 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 91: /* bind_var_opt  */
-#line 281 "src/ast-parser.y" /* yacc.c:1257  */
+#line 280 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1758 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1757 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 92: /* bind_var  */
-#line 281 "src/ast-parser.y" /* yacc.c:1257  */
+#line 280 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1764 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1763 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 93: /* labeling_opt  */
-#line 281 "src/ast-parser.y" /* yacc.c:1257  */
+#line 280 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1770 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1769 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 96: /* instr  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1776 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1775 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 97: /* plain_instr  */
-#line 269 "src/ast-parser.y" /* yacc.c:1257  */
+#line 268 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr(((*yyvaluep).expr)); }
-#line 1782 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1781 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 98: /* block_instr  */
-#line 269 "src/ast-parser.y" /* yacc.c:1257  */
+#line 268 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr(((*yyvaluep).expr)); }
-#line 1788 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1787 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 99: /* block  */
-#line 260 "src/ast-parser.y" /* yacc.c:1257  */
+#line 259 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_block(&((*yyvaluep).block)); }
-#line 1794 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1793 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 100: /* expr  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1800 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1799 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 101: /* expr1  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1806 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1805 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 102: /* if_  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1812 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1811 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 103: /* instr_list  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1818 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1817 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 104: /* expr_list  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1824 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1823 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 105: /* const_expr  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1830 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1829 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 106: /* func_fields  */
-#line 271 "src/ast-parser.y" /* yacc.c:1257  */
+#line 270 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_func_fields(((*yyvaluep).func_fields)); }
-#line 1836 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1835 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 107: /* func_body  */
-#line 271 "src/ast-parser.y" /* yacc.c:1257  */
+#line 270 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_func_fields(((*yyvaluep).func_fields)); }
-#line 1842 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1841 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 108: /* func_info  */
-#line 272 "src/ast-parser.y" /* yacc.c:1257  */
-      { destroy_func(((*yyvaluep).func)); delete ((*yyvaluep).func); }
-#line 1848 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 271 "src/ast-parser.y" /* yacc.c:1257  */
+      { delete ((*yyvaluep).func); }
+#line 1847 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 109: /* func  */
-#line 266 "src/ast-parser.y" /* yacc.c:1257  */
+#line 265 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_exported_func(&((*yyvaluep).exported_func)); }
-#line 1854 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1853 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 110: /* offset  */
-#line 270 "src/ast-parser.y" /* yacc.c:1257  */
+#line 269 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1860 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1859 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 111: /* elem  */
-#line 264 "src/ast-parser.y" /* yacc.c:1257  */
+#line 263 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_elem_segment(&((*yyvaluep).elem_segment)); }
-#line 1866 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1865 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 112: /* table  */
-#line 268 "src/ast-parser.y" /* yacc.c:1257  */
+#line 267 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_exported_table(&((*yyvaluep).exported_table)); }
-#line 1872 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1871 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 113: /* data  */
-#line 276 "src/ast-parser.y" /* yacc.c:1257  */
+#line 275 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_data_segment(&((*yyvaluep).data_segment)); }
-#line 1878 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1877 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 114: /* memory  */
-#line 267 "src/ast-parser.y" /* yacc.c:1257  */
+#line 266 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_exported_memory(&((*yyvaluep).exported_memory)); }
-#line 1884 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1883 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 116: /* import_kind  */
-#line 275 "src/ast-parser.y" /* yacc.c:1257  */
+#line 274 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_import(((*yyvaluep).import)); delete ((*yyvaluep).import); }
-#line 1890 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1889 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 117: /* import  */
-#line 275 "src/ast-parser.y" /* yacc.c:1257  */
+#line 274 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_import(((*yyvaluep).import)); delete ((*yyvaluep).import); }
-#line 1896 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1895 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 118: /* inline_import  */
-#line 275 "src/ast-parser.y" /* yacc.c:1257  */
+#line 274 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_import(((*yyvaluep).import)); delete ((*yyvaluep).import); }
-#line 1902 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1901 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 119: /* export_kind  */
-#line 265 "src/ast-parser.y" /* yacc.c:1257  */
+#line 264 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_export(&((*yyvaluep).export_)); }
-#line 1908 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1907 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 120: /* export  */
-#line 265 "src/ast-parser.y" /* yacc.c:1257  */
+#line 264 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_export(&((*yyvaluep).export_)); }
-#line 1914 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1913 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 123: /* type_def  */
-#line 274 "src/ast-parser.y" /* yacc.c:1257  */
+#line 273 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_func_type(&((*yyvaluep).func_type)); }
-#line 1920 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1919 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 124: /* start  */
-#line 285 "src/ast-parser.y" /* yacc.c:1257  */
+#line 284 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1926 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1925 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 125: /* module_fields  */
-#line 277 "src/ast-parser.y" /* yacc.c:1257  */
-      { destroy_module(((*yyvaluep).module)); delete ((*yyvaluep).module); }
-#line 1932 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 276 "src/ast-parser.y" /* yacc.c:1257  */
+      { delete ((*yyvaluep).module); }
+#line 1931 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 126: /* raw_module  */
-#line 278 "src/ast-parser.y" /* yacc.c:1257  */
+#line 277 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_raw_module(&((*yyvaluep).raw_module)); }
-#line 1938 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1937 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 127: /* module  */
-#line 277 "src/ast-parser.y" /* yacc.c:1257  */
-      { destroy_module(((*yyvaluep).module)); delete ((*yyvaluep).module); }
-#line 1944 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 276 "src/ast-parser.y" /* yacc.c:1257  */
+      { delete ((*yyvaluep).module); }
+#line 1943 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 128: /* script_var_opt  */
-#line 285 "src/ast-parser.y" /* yacc.c:1257  */
+#line 284 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1950 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1949 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 130: /* assertion  */
-#line 261 "src/ast-parser.y" /* yacc.c:1257  */
+#line 260 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_command(((*yyvaluep).command)); delete ((*yyvaluep).command); }
-#line 1956 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1955 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 131: /* cmd  */
-#line 261 "src/ast-parser.y" /* yacc.c:1257  */
+#line 260 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_command(((*yyvaluep).command)); delete ((*yyvaluep).command); }
-#line 1962 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1961 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 132: /* cmd_list  */
-#line 262 "src/ast-parser.y" /* yacc.c:1257  */
+#line 261 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_command_vector_and_elements(&((*yyvaluep).commands)); }
-#line 1968 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1967 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 134: /* const_list  */
-#line 263 "src/ast-parser.y" /* yacc.c:1257  */
+#line 262 "src/ast-parser.y" /* yacc.c:1257  */
       { destroy_const_vector(&((*yyvaluep).consts)); }
-#line 1974 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1973 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 135: /* script  */
-#line 280 "src/ast-parser.y" /* yacc.c:1257  */
+#line 279 "src/ast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script); }
-#line 1980 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
+#line 1979 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
 
@@ -2268,18 +2267,18 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 298 "src/ast-parser.y" /* yacc.c:1646  */
+#line 297 "src/ast-parser.y" /* yacc.c:1646  */
     {
       TextListNode* node = new_text_list_node();
       DUPTEXT(node->text, (yyvsp[0].text));
       node->next = nullptr;
       (yyval.text_list).first = (yyval.text_list).last = node;
     }
-#line 2279 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2278 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 304 "src/ast-parser.y" /* yacc.c:1646  */
+#line 303 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.text_list) = (yyvsp[-1].text_list);
       TextListNode* node = new_text_list_node();
@@ -2288,17 +2287,17 @@ yyreduce:
       (yyval.text_list).last->next = node;
       (yyval.text_list).last = node;
     }
-#line 2292 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2291 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 314 "src/ast-parser.y" /* yacc.c:1646  */
+#line 313 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.text_list).first = (yyval.text_list).last = nullptr; }
-#line 2298 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2297 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 319 "src/ast-parser.y" /* yacc.c:1646  */
+#line 318 "src/ast-parser.y" /* yacc.c:1646  */
     {
       TextListNode node;
       node.text = (yyvsp[0].text);
@@ -2312,130 +2311,130 @@ yyreduce:
       (yyval.text).start = data;
       (yyval.text).length = size;
     }
-#line 2316 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2315 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 337 "src/ast-parser.y" /* yacc.c:1646  */
+#line 336 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.types)); }
-#line 2322 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2321 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 338 "src/ast-parser.y" /* yacc.c:1646  */
+#line 337 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.types) = (yyvsp[-1].types);
       append_type_value(&(yyval.types), &(yyvsp[0].type));
     }
-#line 2331 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2330 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 344 "src/ast-parser.y" /* yacc.c:1646  */
+#line 343 "src/ast-parser.y" /* yacc.c:1646  */
     {}
-#line 2337 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2336 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 347 "src/ast-parser.y" /* yacc.c:1646  */
+#line 346 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.global));
       (yyval.global).type = (yyvsp[0].type);
       (yyval.global).mutable_ = false;
     }
-#line 2347 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2346 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 352 "src/ast-parser.y" /* yacc.c:1646  */
+#line 351 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.global));
       (yyval.global).type = (yyvsp[-1].type);
       (yyval.global).mutable_ = true;
     }
-#line 2357 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2356 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 359 "src/ast-parser.y" /* yacc.c:1646  */
+#line 358 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = (yyvsp[-1].func_sig); }
-#line 2363 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2362 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 362 "src/ast-parser.y" /* yacc.c:1646  */
+#line 361 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.func_sig)); }
-#line 2369 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2368 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 363 "src/ast-parser.y" /* yacc.c:1646  */
+#line 362 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.func_sig));
       (yyval.func_sig).param_types = (yyvsp[-1].types);
     }
-#line 2378 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2377 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 367 "src/ast-parser.y" /* yacc.c:1646  */
+#line 366 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.func_sig));
       (yyval.func_sig).param_types = (yyvsp[-5].types);
       (yyval.func_sig).result_types = (yyvsp[-1].types);
     }
-#line 2388 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2387 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 372 "src/ast-parser.y" /* yacc.c:1646  */
+#line 371 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.func_sig));
       (yyval.func_sig).result_types = (yyvsp[-1].types);
     }
-#line 2397 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2396 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 379 "src/ast-parser.y" /* yacc.c:1646  */
+#line 378 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.table).elem_limits = (yyvsp[-1].limits); }
-#line 2403 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2402 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 382 "src/ast-parser.y" /* yacc.c:1646  */
+#line 381 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.memory).page_limits = (yyvsp[0].limits); }
-#line 2409 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2408 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 385 "src/ast-parser.y" /* yacc.c:1646  */
+#line 384 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = false;
       (yyval.limits).initial = (yyvsp[0].u64);
       (yyval.limits).max = 0;
     }
-#line 2419 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2418 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 390 "src/ast-parser.y" /* yacc.c:1646  */
+#line 389 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = true;
       (yyval.limits).initial = (yyvsp[-1].u64);
       (yyval.limits).max = (yyvsp[0].u64);
     }
-#line 2429 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2428 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 397 "src/ast-parser.y" /* yacc.c:1646  */
+#line 396 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2435 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2434 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 403 "src/ast-parser.y" /* yacc.c:1646  */
+#line 402 "src/ast-parser.y" /* yacc.c:1646  */
     {
       if (WABT_FAILED(parse_uint64((yyvsp[0].literal).text.start,
                                         (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
@@ -2444,97 +2443,97 @@ yyreduce:
                               WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2448 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2447 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 414 "src/ast-parser.y" /* yacc.c:1646  */
+#line 413 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2457 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2456 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 418 "src/ast-parser.y" /* yacc.c:1646  */
+#line 417 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2466 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2465 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 422 "src/ast-parser.y" /* yacc.c:1646  */
+#line 421 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2475 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2474 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 429 "src/ast-parser.y" /* yacc.c:1646  */
+#line 428 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var).loc = (yylsp[0]);
       (yyval.var).type = VarType::Index;
       (yyval.var).index = (yyvsp[0].u64);
     }
-#line 2485 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2484 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 434 "src/ast-parser.y" /* yacc.c:1646  */
+#line 433 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var).loc = (yylsp[0]);
       (yyval.var).type = VarType::Name;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 2495 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2494 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 441 "src/ast-parser.y" /* yacc.c:1646  */
+#line 440 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.vars)); }
-#line 2501 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2500 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 442 "src/ast-parser.y" /* yacc.c:1646  */
+#line 441 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.vars) = (yyvsp[-1].vars);
       append_var_value(&(yyval.vars), &(yyvsp[0].var));
     }
-#line 2510 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2509 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 448 "src/ast-parser.y" /* yacc.c:1646  */
+#line 447 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.text)); }
-#line 2516 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2515 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 452 "src/ast-parser.y" /* yacc.c:1646  */
+#line 451 "src/ast-parser.y" /* yacc.c:1646  */
     { DUPTEXT((yyval.text), (yyvsp[0].text)); }
-#line 2522 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2521 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 456 "src/ast-parser.y" /* yacc.c:1646  */
+#line 455 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.text)); }
-#line 2528 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2527 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 461 "src/ast-parser.y" /* yacc.c:1646  */
+#line 460 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.u64) = 0; }
-#line 2534 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2533 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 462 "src/ast-parser.y" /* yacc.c:1646  */
+#line 461 "src/ast-parser.y" /* yacc.c:1646  */
     {
     if (WABT_FAILED(parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u64),
                                 ParseIntType::SignedAndUnsigned))) {
@@ -2543,17 +2542,17 @@ yyreduce:
                             WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
       }
     }
-#line 2547 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2546 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 472 "src/ast-parser.y" /* yacc.c:1646  */
+#line 471 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.u32) = USE_NATURAL_ALIGNMENT; }
-#line 2553 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2552 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 473 "src/ast-parser.y" /* yacc.c:1646  */
+#line 472 "src/ast-parser.y" /* yacc.c:1646  */
     {
     if (WABT_FAILED(parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
                                 ParseIntType::UnsignedOnly))) {
@@ -2562,182 +2561,182 @@ yyreduce:
                        WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
       }
     }
-#line 2566 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2565 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 484 "src/ast-parser.y" /* yacc.c:1646  */
+#line 483 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = join_exprs1(&(yylsp[0]), (yyvsp[0].expr)); }
-#line 2572 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2571 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 485 "src/ast-parser.y" /* yacc.c:1646  */
+#line 484 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = join_exprs1(&(yylsp[0]), (yyvsp[0].expr)); }
-#line 2578 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2577 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 486 "src/ast-parser.y" /* yacc.c:1646  */
+#line 485 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[0].expr_list); }
-#line 2584 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2583 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 489 "src/ast-parser.y" /* yacc.c:1646  */
+#line 488 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_unreachable_expr();
     }
-#line 2592 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2591 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 492 "src/ast-parser.y" /* yacc.c:1646  */
+#line 491 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_nop_expr();
     }
-#line 2600 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2599 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 495 "src/ast-parser.y" /* yacc.c:1646  */
+#line 494 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_drop_expr();
     }
-#line 2608 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2607 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 498 "src/ast-parser.y" /* yacc.c:1646  */
+#line 497 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_select_expr();
     }
-#line 2616 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2615 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 501 "src/ast-parser.y" /* yacc.c:1646  */
+#line 500 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_br_expr();
       (yyval.expr)->br.var = (yyvsp[0].var);
     }
-#line 2625 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2624 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 505 "src/ast-parser.y" /* yacc.c:1646  */
+#line 504 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_br_if_expr();
       (yyval.expr)->br_if.var = (yyvsp[0].var);
     }
-#line 2634 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2633 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 509 "src/ast-parser.y" /* yacc.c:1646  */
+#line 508 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_br_table_expr();
       (yyval.expr)->br_table.targets = (yyvsp[-1].vars);
       (yyval.expr)->br_table.default_target = (yyvsp[0].var);
     }
-#line 2644 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2643 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 514 "src/ast-parser.y" /* yacc.c:1646  */
+#line 513 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_return_expr();
     }
-#line 2652 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2651 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 517 "src/ast-parser.y" /* yacc.c:1646  */
+#line 516 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_call_expr();
       (yyval.expr)->call.var = (yyvsp[0].var);
     }
-#line 2661 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2660 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 521 "src/ast-parser.y" /* yacc.c:1646  */
+#line 520 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_call_indirect_expr();
       (yyval.expr)->call_indirect.var = (yyvsp[0].var);
     }
-#line 2670 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2669 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 525 "src/ast-parser.y" /* yacc.c:1646  */
+#line 524 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_get_local_expr();
       (yyval.expr)->get_local.var = (yyvsp[0].var);
     }
-#line 2679 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2678 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 529 "src/ast-parser.y" /* yacc.c:1646  */
+#line 528 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_set_local_expr();
       (yyval.expr)->set_local.var = (yyvsp[0].var);
     }
-#line 2688 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2687 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 533 "src/ast-parser.y" /* yacc.c:1646  */
+#line 532 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_tee_local_expr();
       (yyval.expr)->tee_local.var = (yyvsp[0].var);
     }
-#line 2697 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2696 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 537 "src/ast-parser.y" /* yacc.c:1646  */
+#line 536 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_get_global_expr();
       (yyval.expr)->get_global.var = (yyvsp[0].var);
     }
-#line 2706 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2705 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 541 "src/ast-parser.y" /* yacc.c:1646  */
+#line 540 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_set_global_expr();
       (yyval.expr)->set_global.var = (yyvsp[0].var);
     }
-#line 2715 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2714 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 545 "src/ast-parser.y" /* yacc.c:1646  */
+#line 544 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_load_expr();
       (yyval.expr)->load.opcode = (yyvsp[-2].opcode);
       (yyval.expr)->load.offset = (yyvsp[-1].u64);
       (yyval.expr)->load.align = (yyvsp[0].u32);
     }
-#line 2726 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2725 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 551 "src/ast-parser.y" /* yacc.c:1646  */
+#line 550 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_store_expr();
       (yyval.expr)->store.opcode = (yyvsp[-2].opcode);
       (yyval.expr)->store.offset = (yyvsp[-1].u64);
       (yyval.expr)->store.align = (yyvsp[0].u32);
     }
-#line 2737 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2736 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 557 "src/ast-parser.y" /* yacc.c:1646  */
+#line 556 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_const_expr();
       (yyval.expr)->const_.loc = (yylsp[-1]);
@@ -2750,96 +2749,96 @@ yyreduce:
       }
       delete [] (yyvsp[0].literal).text.start;
     }
-#line 2754 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2753 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 569 "src/ast-parser.y" /* yacc.c:1646  */
+#line 568 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_unary_expr();
       (yyval.expr)->unary.opcode = (yyvsp[0].opcode);
     }
-#line 2763 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2762 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 573 "src/ast-parser.y" /* yacc.c:1646  */
+#line 572 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_binary_expr();
       (yyval.expr)->binary.opcode = (yyvsp[0].opcode);
     }
-#line 2772 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2771 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 577 "src/ast-parser.y" /* yacc.c:1646  */
+#line 576 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_compare_expr();
       (yyval.expr)->compare.opcode = (yyvsp[0].opcode);
     }
-#line 2781 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2780 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 581 "src/ast-parser.y" /* yacc.c:1646  */
+#line 580 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_convert_expr();
       (yyval.expr)->convert.opcode = (yyvsp[0].opcode);
     }
-#line 2790 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2789 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 585 "src/ast-parser.y" /* yacc.c:1646  */
+#line 584 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_current_memory_expr();
     }
-#line 2798 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2797 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 588 "src/ast-parser.y" /* yacc.c:1646  */
+#line 587 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_grow_memory_expr();
     }
-#line 2806 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2805 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 593 "src/ast-parser.y" /* yacc.c:1646  */
+#line 592 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_block_expr();
       (yyval.expr)->block = (yyvsp[-2].block);
       (yyval.expr)->block.label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->block.label, (yyvsp[0].text));
     }
-#line 2817 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2816 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 599 "src/ast-parser.y" /* yacc.c:1646  */
+#line 598 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_loop_expr();
       (yyval.expr)->loop = (yyvsp[-2].block);
       (yyval.expr)->loop.label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->block.label, (yyvsp[0].text));
     }
-#line 2828 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2827 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 605 "src/ast-parser.y" /* yacc.c:1646  */
+#line 604 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_if_expr();
       (yyval.expr)->if_.true_ = (yyvsp[-2].block);
       (yyval.expr)->if_.true_.label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->block.label, (yyvsp[0].text));
     }
-#line 2839 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2838 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 611 "src/ast-parser.y" /* yacc.c:1646  */
+#line 610 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new_if_expr();
       (yyval.expr)->if_.true_ = (yyvsp[-5].block);
@@ -2848,57 +2847,57 @@ yyreduce:
       CHECK_END_LABEL((yylsp[-3]), (yyval.expr)->block.label, (yyvsp[-3].text));
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->block.label, (yyvsp[0].text));
     }
-#line 2852 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2851 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 621 "src/ast-parser.y" /* yacc.c:1646  */
+#line 620 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.block));
       (yyval.block).sig = (yyvsp[-1].types);
       (yyval.block).first = (yyvsp[0].expr_list).first;
     }
-#line 2862 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2861 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 629 "src/ast-parser.y" /* yacc.c:1646  */
+#line 628 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[-1].expr_list); }
-#line 2868 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2867 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 633 "src/ast-parser.y" /* yacc.c:1646  */
+#line 632 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = join_exprs2(&(yylsp[-1]), &(yyvsp[0].expr_list), (yyvsp[-1].expr));
     }
-#line 2876 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2875 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 636 "src/ast-parser.y" /* yacc.c:1646  */
+#line 635 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_block_expr();
       expr->block = (yyvsp[0].block);
       expr->block.label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), expr);
     }
-#line 2887 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2886 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 642 "src/ast-parser.y" /* yacc.c:1646  */
+#line 641 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_loop_expr();
       expr->loop = (yyvsp[0].block);
       expr->loop.label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), expr);
     }
-#line 2898 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2897 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 648 "src/ast-parser.y" /* yacc.c:1646  */
+#line 647 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       Expr* if_ = (yyvsp[0].expr_list).last;
@@ -2906,130 +2905,130 @@ yyreduce:
       if_->if_.true_.label = (yyvsp[-2].text);
       if_->if_.true_.sig = (yyvsp[-1].types);
     }
-#line 2910 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2909 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 657 "src/ast-parser.y" /* yacc.c:1646  */
+#line 656 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_if_expr();
       expr->if_.true_.first = (yyvsp[-5].expr_list).first;
       expr->if_.false_ = (yyvsp[-1].expr_list).first;
       (yyval.expr_list) = join_exprs1(&(yylsp[-7]), expr);
     }
-#line 2921 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2920 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 663 "src/ast-parser.y" /* yacc.c:1646  */
+#line 662 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_if_expr();
       expr->if_.true_.first = (yyvsp[-1].expr_list).first;
       (yyval.expr_list) = join_exprs1(&(yylsp[-3]), expr);
     }
-#line 2931 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2930 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 668 "src/ast-parser.y" /* yacc.c:1646  */
+#line 667 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_if_expr();
       expr->if_.true_.first = (yyvsp[-5].expr_list).first;
       expr->if_.false_ = (yyvsp[-1].expr_list).first;
       (yyval.expr_list) = join_exprs2(&(yylsp[-8]), &(yyvsp[-8].expr_list), expr);
     }
-#line 2942 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2941 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 674 "src/ast-parser.y" /* yacc.c:1646  */
+#line 673 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_if_expr();
       expr->if_.true_.first = (yyvsp[-1].expr_list).first;
       (yyval.expr_list) = join_exprs2(&(yylsp[-4]), &(yyvsp[-4].expr_list), expr);
     }
-#line 2952 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2951 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 679 "src/ast-parser.y" /* yacc.c:1646  */
+#line 678 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_if_expr();
       expr->if_.true_.first = (yyvsp[-1].expr_list).first;
       expr->if_.false_ = (yyvsp[0].expr_list).first;
       (yyval.expr_list) = join_exprs2(&(yylsp[-2]), &(yyvsp[-2].expr_list), expr);
     }
-#line 2963 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2962 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 685 "src/ast-parser.y" /* yacc.c:1646  */
+#line 684 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_if_expr();
       expr->if_.true_.first = (yyvsp[0].expr_list).first;
       (yyval.expr_list) = join_exprs2(&(yylsp[-1]), &(yyvsp[-1].expr_list), expr);
     }
-#line 2973 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2972 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 693 "src/ast-parser.y" /* yacc.c:1646  */
+#line 692 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.expr_list)); }
-#line 2979 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2978 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 694 "src/ast-parser.y" /* yacc.c:1646  */
+#line 693 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyvsp[-1].expr_list).first;
       (yyvsp[-1].expr_list).last->next = (yyvsp[0].expr_list).first;
       (yyval.expr_list).last = (yyvsp[0].expr_list).last ? (yyvsp[0].expr_list).last : (yyvsp[-1].expr_list).last;
       (yyval.expr_list).size = (yyvsp[-1].expr_list).size + (yyvsp[0].expr_list).size;
     }
-#line 2990 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2989 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 702 "src/ast-parser.y" /* yacc.c:1646  */
+#line 701 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.expr_list)); }
-#line 2996 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 2995 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 703 "src/ast-parser.y" /* yacc.c:1646  */
+#line 702 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyvsp[-1].expr_list).first;
       (yyvsp[-1].expr_list).last->next = (yyvsp[0].expr_list).first;
       (yyval.expr_list).last = (yyvsp[0].expr_list).last ? (yyvsp[0].expr_list).last : (yyvsp[-1].expr_list).last;
       (yyval.expr_list).size = (yyvsp[-1].expr_list).size + (yyvsp[0].expr_list).size;
     }
-#line 3007 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3006 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 717 "src/ast-parser.y" /* yacc.c:1646  */
+#line 716 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field();
       (yyval.func_fields)->type = FuncFieldType::ResultTypes;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3018 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3017 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 723 "src/ast-parser.y" /* yacc.c:1646  */
+#line 722 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field();
       (yyval.func_fields)->type = FuncFieldType::ParamTypes;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3029 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3028 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 729 "src/ast-parser.y" /* yacc.c:1646  */
+#line 728 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field();
       (yyval.func_fields)->type = FuncFieldType::BoundParam;
@@ -3038,33 +3037,33 @@ yyreduce:
       (yyval.func_fields)->bound_type.type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3042 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3041 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 739 "src/ast-parser.y" /* yacc.c:1646  */
+#line 738 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field();
       (yyval.func_fields)->type = FuncFieldType::Exprs;
       (yyval.func_fields)->first_expr = (yyvsp[0].expr_list).first;
       (yyval.func_fields)->next = nullptr;
     }
-#line 3053 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3052 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 745 "src/ast-parser.y" /* yacc.c:1646  */
+#line 744 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field();
       (yyval.func_fields)->type = FuncFieldType::LocalTypes;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3064 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3063 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 751 "src/ast-parser.y" /* yacc.c:1646  */
+#line 750 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new_func_field();
       (yyval.func_fields)->type = FuncFieldType::BoundLocal;
@@ -3073,13 +3072,13 @@ yyreduce:
       (yyval.func_fields)->bound_type.type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3077 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3076 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 761 "src/ast-parser.y" /* yacc.c:1646  */
+#line 760 "src/ast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.func) = new_func();
+      (yyval.func) = new Func();
       FuncField* field = (yyvsp[0].func_fields);
 
       while (field) {
@@ -3128,11 +3127,11 @@ yyreduce:
         field = next;
       }
     }
-#line 3132 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3131 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 813 "src/ast-parser.y" /* yacc.c:1646  */
+#line 812 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
@@ -3141,11 +3140,11 @@ yyreduce:
       (yyval.exported_func).func->name = (yyvsp[-4].text);
       (yyval.exported_func).export_ = (yyvsp[-3].optional_export);
     }
-#line 3145 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3144 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 822 "src/ast-parser.y" /* yacc.c:1646  */
+#line 821 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
@@ -3153,51 +3152,51 @@ yyreduce:
       (yyval.exported_func).func->decl.type_var = (yyvsp[-2].var);
       (yyval.exported_func).func->name = (yyvsp[-3].text);
     }
-#line 3157 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3156 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 829 "src/ast-parser.y" /* yacc.c:1646  */
+#line 828 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->name = (yyvsp[-3].text);
       (yyval.exported_func).export_ = (yyvsp[-2].optional_export);
     }
-#line 3168 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3167 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 836 "src/ast-parser.y" /* yacc.c:1646  */
+#line 835 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->name = (yyvsp[-2].text);
     }
-#line 3178 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3177 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 846 "src/ast-parser.y" /* yacc.c:1646  */
+#line 845 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[-1].expr_list);
     }
-#line 3186 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3185 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 853 "src/ast-parser.y" /* yacc.c:1646  */
+#line 852 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.elem_segment));
       (yyval.elem_segment).table_var = (yyvsp[-3].var);
       (yyval.elem_segment).offset = (yyvsp[-2].expr_list).first;
       (yyval.elem_segment).vars = (yyvsp[-1].vars);
     }
-#line 3197 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3196 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 859 "src/ast-parser.y" /* yacc.c:1646  */
+#line 858 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.elem_segment));
       (yyval.elem_segment).table_var.loc = (yylsp[-3]);
@@ -3206,22 +3205,22 @@ yyreduce:
       (yyval.elem_segment).offset = (yyvsp[-2].expr_list).first;
       (yyval.elem_segment).vars = (yyvsp[-1].vars);
     }
-#line 3210 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3209 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 870 "src/ast-parser.y" /* yacc.c:1646  */
+#line 869 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_table).table = (yyvsp[-1].table);
       (yyval.exported_table).table.name = (yyvsp[-3].text);
       (yyval.exported_table).has_elem_segment = false;
       (yyval.exported_table).export_ = (yyvsp[-2].optional_export);
     }
-#line 3221 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3220 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 877 "src/ast-parser.y" /* yacc.c:1646  */
+#line 876 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_const_expr();
       expr->loc = (yylsp[-8]);
@@ -3238,11 +3237,11 @@ yyreduce:
       (yyval.exported_table).elem_segment.vars = (yyvsp[-2].vars);
       (yyval.exported_table).export_ = (yyvsp[-6].optional_export);
     }
-#line 3242 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3241 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 896 "src/ast-parser.y" /* yacc.c:1646  */
+#line 895 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.data_segment));
       (yyval.data_segment).memory_var = (yyvsp[-3].var);
@@ -3250,11 +3249,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.data_segment).data, &(yyval.data_segment).size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3254 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3253 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 903 "src/ast-parser.y" /* yacc.c:1646  */
+#line 902 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.data_segment));
       (yyval.data_segment).memory_var.loc = (yylsp[-3]);
@@ -3264,11 +3263,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.data_segment).data, &(yyval.data_segment).size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3268 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3267 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 915 "src/ast-parser.y" /* yacc.c:1646  */
+#line 914 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_memory));
       (yyval.exported_memory).memory = (yyvsp[-1].memory);
@@ -3276,11 +3275,11 @@ yyreduce:
       (yyval.exported_memory).has_data_segment = false;
       (yyval.exported_memory).export_ = (yyvsp[-2].optional_export);
     }
-#line 3280 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3279 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 922 "src/ast-parser.y" /* yacc.c:1646  */
+#line 921 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_const_expr();
       expr->loc = (yylsp[-7]);
@@ -3300,11 +3299,11 @@ yyreduce:
       (yyval.exported_memory).memory.page_limits.has_max = true;
       (yyval.exported_memory).export_ = (yyvsp[-5].optional_export);
     }
-#line 3304 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3303 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 942 "src/ast-parser.y" /* yacc.c:1646  */
+#line 941 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_const_expr();
       expr->loc = (yylsp[-6]);
@@ -3324,11 +3323,11 @@ yyreduce:
       (yyval.exported_memory).memory.page_limits.has_max = true;
       (yyval.exported_memory).export_.has_export = false;
     }
-#line 3328 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3327 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 964 "src/ast-parser.y" /* yacc.c:1646  */
+#line 963 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_global));
       (yyval.exported_global).global = (yyvsp[-2].global);
@@ -3336,11 +3335,11 @@ yyreduce:
       (yyval.exported_global).global.init_expr = (yyvsp[-1].expr_list).first;
       (yyval.exported_global).export_ = (yyvsp[-3].optional_export);
     }
-#line 3340 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3339 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 971 "src/ast-parser.y" /* yacc.c:1646  */
+#line 970 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_global));
       (yyval.exported_global).global = (yyvsp[-2].global);
@@ -3348,11 +3347,11 @@ yyreduce:
       (yyval.exported_global).global.init_expr = (yyvsp[-1].expr_list).first;
       (yyval.exported_global).export_.has_export = false;
     }
-#line 3352 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3351 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 984 "src/ast-parser.y" /* yacc.c:1646  */
+#line 983 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Func;
@@ -3361,11 +3360,11 @@ yyreduce:
       (yyval.import)->func->decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
       (yyval.import)->func->decl.type_var = (yyvsp[-1].var);
     }
-#line 3365 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3364 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 992 "src/ast-parser.y" /* yacc.c:1646  */
+#line 991 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Func;
@@ -3373,54 +3372,54 @@ yyreduce:
       (yyval.import)->func->name = (yyvsp[-2].text);
       (yyval.import)->func->decl.sig = (yyvsp[-1].func_sig);
     }
-#line 3377 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3376 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 999 "src/ast-parser.y" /* yacc.c:1646  */
+#line 998 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table.name = (yyvsp[-2].text);
     }
-#line 3388 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3387 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 1005 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1004 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory.name = (yyvsp[-2].text);
     }
-#line 3399 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3398 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 1011 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1010 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global.name = (yyvsp[-2].text);
     }
-#line 3410 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3409 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 1019 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1018 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-1].import);
       (yyval.import)->module_name = (yyvsp[-3].text);
       (yyval.import)->field_name = (yyvsp[-2].text);
     }
-#line 3420 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3419 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 1024 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1023 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Func;
@@ -3429,11 +3428,11 @@ yyreduce:
       (yyval.import)->func->decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
       (yyval.import)->func->decl.type_var = (yyvsp[-1].var);
     }
-#line 3433 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3432 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 1032 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1031 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Func;
@@ -3441,154 +3440,154 @@ yyreduce:
       (yyval.import)->func->name = (yyvsp[-3].text);
       (yyval.import)->func->decl.sig = (yyvsp[-1].func_sig);
     }
-#line 3445 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3444 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 1039 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1038 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table.name = (yyvsp[-3].text);
     }
-#line 3456 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3455 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 1045 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1044 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory.name = (yyvsp[-3].text);
     }
-#line 3467 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3466 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 1051 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1050 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global.name = (yyvsp[-3].text);
     }
-#line 3478 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3477 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 1060 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1059 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->module_name = (yyvsp[-2].text);
       (yyval.import)->field_name = (yyvsp[-1].text);
     }
-#line 3488 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3487 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 1068 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1067 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Func;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3498 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3497 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 1073 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1072 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Table;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3508 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3507 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 126:
-#line 1078 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1077 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Memory;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3518 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3517 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 127:
-#line 1083 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1082 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Global;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3528 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3527 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 1090 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1089 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = (yyvsp[-1].export_);
       (yyval.export_).name = (yyvsp[-2].text);
     }
-#line 3537 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3536 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 129:
-#line 1097 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1096 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.optional_export));
       (yyval.optional_export).has_export = false;
     }
-#line 3546 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3545 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 1104 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1103 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.optional_export));
       (yyval.optional_export).has_export = true;
       (yyval.optional_export).export_.name = (yyvsp[-1].text);
     }
-#line 3556 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3555 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 1115 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1114 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.func_type));
       (yyval.func_type).sig = (yyvsp[-1].func_sig);
     }
-#line 3565 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3564 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 1119 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1118 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_type).name = (yyvsp[-2].text);
       (yyval.func_type).sig = (yyvsp[-1].func_sig);
     }
-#line 3574 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3573 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 1126 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1125 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 3580 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3579 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 1130 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1129 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new_module();
     }
-#line 3588 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3587 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 136:
-#line 1133 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1132 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3597,11 +3596,11 @@ yyreduce:
                             &field->func_type);
       INSERT_BINDING((yyval.module), func_type, func_types, (yylsp[0]), (yyvsp[0].func_type).name);
     }
-#line 3601 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3600 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 137:
-#line 1141 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1140 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3610,11 +3609,11 @@ yyreduce:
       INSERT_BINDING((yyval.module), global, globals, (yylsp[0]), (yyvsp[0].exported_global).global.name);
       APPEND_INLINE_EXPORT((yyval.module), Global, (yylsp[0]), (yyvsp[0].exported_global), (yyval.module)->globals.size - 1);
     }
-#line 3614 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3613 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 1149 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1148 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3632,11 +3631,11 @@ yyreduce:
       }
 
     }
-#line 3636 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3635 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 1166 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1165 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3653,11 +3652,11 @@ yyreduce:
                               &data_segment_field->data_segment);
       }
     }
-#line 3657 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3656 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 1182 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1181 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3667,11 +3666,11 @@ yyreduce:
       INSERT_BINDING((yyval.module), func, funcs, (yylsp[0]), (yyvsp[0].exported_func).func->name);
       APPEND_INLINE_EXPORT((yyval.module), Func, (yylsp[0]), (yyvsp[0].exported_func), (yyval.module)->funcs.size - 1);
     }
-#line 3671 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3670 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 1191 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1190 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3679,11 +3678,11 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), ElemSegment, elem_segment, elem_segments,
                             &field->elem_segment);
     }
-#line 3683 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3682 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 1198 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1197 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3691,22 +3690,22 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), DataSegment, data_segment, data_segments,
                             &field->data_segment);
     }
-#line 3695 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3694 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 1205 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1204 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
       APPEND_FIELD_TO_LIST((yyval.module), field, Start, start, (yylsp[0]), (yyvsp[0].var));
       (yyval.module)->start = &field->start;
     }
-#line 3706 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3705 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 1211 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1210 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3743,11 +3742,11 @@ yyreduce:
       }
       APPEND_ITEM_TO_VECTOR((yyval.module), Import, import, imports, field->import);
     }
-#line 3747 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3746 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 1247 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1246 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3755,11 +3754,11 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), Export, export, exports, &field->export_);
       INSERT_BINDING((yyval.module), export, exports, (yylsp[0]), (yyvsp[0].export_).name);
     }
-#line 3759 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3758 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 1257 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1256 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = RawModuleType::Text;
       (yyval.raw_module).text = (yyvsp[-1].module);
@@ -3781,11 +3780,11 @@ yyreduce:
         }
       }
     }
-#line 3785 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3784 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1278 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1277 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = RawModuleType::Binary;
       (yyval.raw_module).binary.name = (yyvsp[-2].text);
@@ -3793,11 +3792,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.raw_module).binary.data, &(yyval.raw_module).binary.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3797 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3796 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1288 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1287 "src/ast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].raw_module).type == RawModuleType::Text) {
         (yyval.module) = (yyvsp[0].raw_module).text;
@@ -3819,31 +3818,31 @@ yyreduce:
         (yyval.module)->loc = (yyvsp[0].raw_module).binary.loc;
       }
     }
-#line 3823 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3822 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1314 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1313 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Index;
       (yyval.var).index = INVALID_VAR_INDEX;
     }
-#line 3833 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3832 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1319 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1318 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Name;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 3843 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3842 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1327 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1326 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.action));
       (yyval.action).loc = (yylsp[-4]);
@@ -3852,11 +3851,11 @@ yyreduce:
       (yyval.action).invoke.name = (yyvsp[-2].text);
       (yyval.action).invoke.args = (yyvsp[-1].consts);
     }
-#line 3856 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3855 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1335 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1334 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.action));
       (yyval.action).loc = (yylsp[-3]);
@@ -3864,118 +3863,118 @@ yyreduce:
       (yyval.action).type = ActionType::Get;
       (yyval.action).invoke.name = (yyvsp[-1].text);
     }
-#line 3868 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3867 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1345 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1344 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertMalformed;
       (yyval.command)->assert_malformed.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_malformed.text = (yyvsp[-1].text);
     }
-#line 3879 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3878 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1351 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1350 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertInvalid;
       (yyval.command)->assert_invalid.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_invalid.text = (yyvsp[-1].text);
     }
-#line 3890 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3889 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1357 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1356 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertUnlinkable;
       (yyval.command)->assert_unlinkable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_unlinkable.text = (yyvsp[-1].text);
     }
-#line 3901 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3900 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1363 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1362 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertUninstantiable;
       (yyval.command)->assert_uninstantiable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_uninstantiable.text = (yyvsp[-1].text);
     }
-#line 3912 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3911 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1369 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1368 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertReturn;
       (yyval.command)->assert_return.action = (yyvsp[-2].action);
       (yyval.command)->assert_return.expected = (yyvsp[-1].consts);
     }
-#line 3923 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3922 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1375 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1374 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertReturnNan;
       (yyval.command)->assert_return_nan.action = (yyvsp[-1].action);
     }
-#line 3933 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3932 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1380 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1379 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertTrap;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3944 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3943 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1386 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1385 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertExhaustion;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3955 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3954 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1395 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1394 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Action;
       (yyval.command)->action = (yyvsp[0].action);
     }
-#line 3965 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3964 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 163:
-#line 1401 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1400 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Module;
       (yyval.command)->module = (yyvsp[0].module);
     }
-#line 3975 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3974 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1406 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1405 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Register;
@@ -3983,27 +3982,27 @@ yyreduce:
       (yyval.command)->register_.var = (yyvsp[-1].var);
       (yyval.command)->register_.var.loc = (yylsp[-1]);
     }
-#line 3987 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3986 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1414 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.commands)); }
-#line 3993 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3992 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1416 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       append_command_value(&(yyval.commands), (yyvsp[0].command));
       delete (yyvsp[0].command);
     }
-#line 4003 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4002 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1424 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1423 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WABT_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -4014,26 +4013,26 @@ yyreduce:
       }
       delete [] (yyvsp[-1].literal).text.start;
     }
-#line 4018 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4017 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1436 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1435 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.consts)); }
-#line 4024 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4023 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1437 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1436 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       append_const_value(&(yyval.consts), &(yyvsp[0].const_));
     }
-#line 4033 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4032 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1444 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1443 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       (yyval.script)->commands = (yyvsp[0].commands);
@@ -4089,11 +4088,11 @@ yyreduce:
       }
       parser->script = (yyval.script);
     }
-#line 4093 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4092 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4097 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4096 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4328,7 +4327,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1507 "src/ast-parser.y" /* yacc.c:1906  */
+#line 1506 "src/ast-parser.y" /* yacc.c:1906  */
 
 
 void append_expr_list(ExprList* expr_list, ExprList* expr) {

--- a/src/prebuilt/ast-parser-gen.cc
+++ b/src/prebuilt/ast-parser-gen.cc
@@ -144,13 +144,13 @@
     append_##kind##_ptr_value(&(module)->kinds, &dummy);           \
   } while (0)
 
-#define INSERT_BINDING(module, kind, kinds, loc_, name)                       \
-  do                                                                          \
-    if ((name).start) {                                                       \
-      Binding* binding = insert_binding(&(module)->kind##_bindings, &(name)); \
-      binding->loc = loc_;                                                    \
-      binding->index = (module)->kinds.size - 1;                              \
-    }                                                                         \
+#define INSERT_BINDING(module, kind, kinds, loc_, name) \
+  do                                                    \
+    if ((name).start) {                                 \
+      (module)->kind##_bindings.emplace(                \
+          string_slice_to_string(name),                 \
+          Binding(loc_, (module)->kinds.size - 1));     \
+    }                                                   \
   while (0)
 
 #define APPEND_INLINE_EXPORT(module, Kind, loc_, value, index_)         \
@@ -703,15 +703,15 @@ static const yytype_uint16 yyrline[] =
      569,   573,   577,   581,   585,   588,   593,   599,   605,   611,
      621,   629,   633,   636,   642,   648,   657,   663,   668,   674,
      679,   685,   693,   694,   702,   703,   711,   716,   717,   723,
-     729,   739,   745,   751,   761,   814,   823,   830,   837,   847,
-     850,   854,   860,   871,   877,   897,   904,   916,   923,   943,
-     965,   972,   985,   992,   998,  1004,  1010,  1018,  1023,  1030,
-    1036,  1042,  1048,  1057,  1065,  1070,  1075,  1080,  1087,  1094,
-    1098,  1101,  1112,  1116,  1123,  1127,  1130,  1138,  1146,  1163,
-    1179,  1189,  1196,  1203,  1209,  1245,  1255,  1276,  1286,  1312,
-    1317,  1325,  1333,  1343,  1349,  1355,  1361,  1367,  1373,  1378,
-    1384,  1393,  1398,  1399,  1405,  1414,  1415,  1423,  1435,  1436,
-    1443,  1506
+     729,   739,   745,   751,   761,   813,   822,   829,   836,   846,
+     849,   853,   859,   870,   876,   896,   903,   915,   922,   942,
+     964,   971,   984,   992,   999,  1005,  1011,  1019,  1024,  1032,
+    1039,  1045,  1051,  1060,  1068,  1073,  1078,  1083,  1090,  1097,
+    1101,  1104,  1115,  1119,  1126,  1130,  1133,  1141,  1149,  1166,
+    1182,  1191,  1198,  1205,  1211,  1247,  1257,  1278,  1288,  1314,
+    1319,  1327,  1335,  1345,  1351,  1357,  1363,  1369,  1375,  1380,
+    1386,  1395,  1400,  1401,  1406,  1415,  1416,  1424,  1436,  1437,
+    1444,  1504
 };
 #endif
 
@@ -1975,7 +1975,7 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
 
     case 135: /* script  */
 #line 280 "src/ast-parser.y" /* yacc.c:1257  */
-      { destroy_script(&((*yyvaluep).script)); }
+      { delete ((*yyvaluep).script); }
 #line 1980 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
@@ -3112,10 +3112,9 @@ yyreduce:
             }
 
             append_type_value(types, &field->bound_type.type);
-            Binding* binding =
-                insert_binding(bindings, &field->bound_type.name);
-            binding->loc = field->bound_type.loc;
-            binding->index = types->size - 1;
+            bindings->emplace(string_slice_to_string(field->bound_type.name),
+                              Binding(field->bound_type.loc, types->size - 1));
+            destroy_string_slice(&field->bound_type.name);
             break;
           }
 
@@ -3125,15 +3124,15 @@ yyreduce:
         }
 
         /* we steal memory from the func field, but not the linked list nodes */
-        delete (field);
+        delete field;
         field = next;
       }
     }
-#line 3133 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3132 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 814 "src/ast-parser.y" /* yacc.c:1646  */
+#line 813 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
@@ -3142,11 +3141,11 @@ yyreduce:
       (yyval.exported_func).func->name = (yyvsp[-4].text);
       (yyval.exported_func).export_ = (yyvsp[-3].optional_export);
     }
-#line 3146 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3145 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 823 "src/ast-parser.y" /* yacc.c:1646  */
+#line 822 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
@@ -3154,51 +3153,51 @@ yyreduce:
       (yyval.exported_func).func->decl.type_var = (yyvsp[-2].var);
       (yyval.exported_func).func->name = (yyvsp[-3].text);
     }
-#line 3158 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3157 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 830 "src/ast-parser.y" /* yacc.c:1646  */
+#line 829 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->name = (yyvsp[-3].text);
       (yyval.exported_func).export_ = (yyvsp[-2].optional_export);
     }
-#line 3169 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3168 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 837 "src/ast-parser.y" /* yacc.c:1646  */
+#line 836 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_func));
       (yyval.exported_func).func = (yyvsp[-1].func);
       (yyval.exported_func).func->name = (yyvsp[-2].text);
     }
-#line 3179 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3178 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 847 "src/ast-parser.y" /* yacc.c:1646  */
+#line 846 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[-1].expr_list);
     }
-#line 3187 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3186 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 854 "src/ast-parser.y" /* yacc.c:1646  */
+#line 853 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.elem_segment));
       (yyval.elem_segment).table_var = (yyvsp[-3].var);
       (yyval.elem_segment).offset = (yyvsp[-2].expr_list).first;
       (yyval.elem_segment).vars = (yyvsp[-1].vars);
     }
-#line 3198 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3197 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 860 "src/ast-parser.y" /* yacc.c:1646  */
+#line 859 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.elem_segment));
       (yyval.elem_segment).table_var.loc = (yylsp[-3]);
@@ -3207,22 +3206,22 @@ yyreduce:
       (yyval.elem_segment).offset = (yyvsp[-2].expr_list).first;
       (yyval.elem_segment).vars = (yyvsp[-1].vars);
     }
-#line 3211 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3210 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 871 "src/ast-parser.y" /* yacc.c:1646  */
+#line 870 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_table).table = (yyvsp[-1].table);
       (yyval.exported_table).table.name = (yyvsp[-3].text);
       (yyval.exported_table).has_elem_segment = false;
       (yyval.exported_table).export_ = (yyvsp[-2].optional_export);
     }
-#line 3222 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3221 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 878 "src/ast-parser.y" /* yacc.c:1646  */
+#line 877 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_const_expr();
       expr->loc = (yylsp[-8]);
@@ -3239,11 +3238,11 @@ yyreduce:
       (yyval.exported_table).elem_segment.vars = (yyvsp[-2].vars);
       (yyval.exported_table).export_ = (yyvsp[-6].optional_export);
     }
-#line 3243 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3242 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 897 "src/ast-parser.y" /* yacc.c:1646  */
+#line 896 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.data_segment));
       (yyval.data_segment).memory_var = (yyvsp[-3].var);
@@ -3251,11 +3250,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.data_segment).data, &(yyval.data_segment).size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3255 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3254 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 904 "src/ast-parser.y" /* yacc.c:1646  */
+#line 903 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.data_segment));
       (yyval.data_segment).memory_var.loc = (yylsp[-3]);
@@ -3265,11 +3264,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.data_segment).data, &(yyval.data_segment).size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3269 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3268 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 916 "src/ast-parser.y" /* yacc.c:1646  */
+#line 915 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_memory));
       (yyval.exported_memory).memory = (yyvsp[-1].memory);
@@ -3277,11 +3276,11 @@ yyreduce:
       (yyval.exported_memory).has_data_segment = false;
       (yyval.exported_memory).export_ = (yyvsp[-2].optional_export);
     }
-#line 3281 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3280 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 923 "src/ast-parser.y" /* yacc.c:1646  */
+#line 922 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_const_expr();
       expr->loc = (yylsp[-7]);
@@ -3301,11 +3300,11 @@ yyreduce:
       (yyval.exported_memory).memory.page_limits.has_max = true;
       (yyval.exported_memory).export_ = (yyvsp[-5].optional_export);
     }
-#line 3305 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3304 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 943 "src/ast-parser.y" /* yacc.c:1646  */
+#line 942 "src/ast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new_const_expr();
       expr->loc = (yylsp[-6]);
@@ -3325,11 +3324,11 @@ yyreduce:
       (yyval.exported_memory).memory.page_limits.has_max = true;
       (yyval.exported_memory).export_.has_export = false;
     }
-#line 3329 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3328 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 965 "src/ast-parser.y" /* yacc.c:1646  */
+#line 964 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_global));
       (yyval.exported_global).global = (yyvsp[-2].global);
@@ -3337,11 +3336,11 @@ yyreduce:
       (yyval.exported_global).global.init_expr = (yyvsp[-1].expr_list).first;
       (yyval.exported_global).export_ = (yyvsp[-3].optional_export);
     }
-#line 3341 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3340 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 972 "src/ast-parser.y" /* yacc.c:1646  */
+#line 971 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.exported_global));
       (yyval.exported_global).global = (yyvsp[-2].global);
@@ -3349,17 +3348,18 @@ yyreduce:
       (yyval.exported_global).global.init_expr = (yyvsp[-1].expr_list).first;
       (yyval.exported_global).export_.has_export = false;
     }
-#line 3353 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3352 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 985 "src/ast-parser.y" /* yacc.c:1646  */
+#line 984 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Func;
-      (yyval.import)->func.name = (yyvsp[-2].text);
-      (yyval.import)->func.decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
-      (yyval.import)->func.decl.type_var = (yyvsp[-1].var);
+      (yyval.import)->func = new Func();
+      (yyval.import)->func->name = (yyvsp[-2].text);
+      (yyval.import)->func->decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
+      (yyval.import)->func->decl.type_var = (yyvsp[-1].var);
     }
 #line 3365 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
@@ -3369,223 +3369,226 @@ yyreduce:
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Func;
-      (yyval.import)->func.name = (yyvsp[-2].text);
-      (yyval.import)->func.decl.sig = (yyvsp[-1].func_sig);
+      (yyval.import)->func = new Func();
+      (yyval.import)->func->name = (yyvsp[-2].text);
+      (yyval.import)->func->decl.sig = (yyvsp[-1].func_sig);
     }
-#line 3376 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3377 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 998 "src/ast-parser.y" /* yacc.c:1646  */
+#line 999 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table.name = (yyvsp[-2].text);
     }
-#line 3387 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3388 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 1004 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1005 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory.name = (yyvsp[-2].text);
     }
-#line 3398 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3399 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 1010 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1011 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global.name = (yyvsp[-2].text);
     }
-#line 3409 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3410 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 1018 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1019 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-1].import);
       (yyval.import)->module_name = (yyvsp[-3].text);
       (yyval.import)->field_name = (yyvsp[-2].text);
     }
-#line 3419 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3420 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 1023 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1024 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Func;
-      (yyval.import)->func.name = (yyvsp[-3].text);
-      (yyval.import)->func.decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
-      (yyval.import)->func.decl.type_var = (yyvsp[-1].var);
+      (yyval.import)->func = new Func();
+      (yyval.import)->func->name = (yyvsp[-3].text);
+      (yyval.import)->func->decl.flags = WABT_FUNC_DECLARATION_FLAG_HAS_FUNC_TYPE;
+      (yyval.import)->func->decl.type_var = (yyvsp[-1].var);
     }
-#line 3431 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3433 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 1030 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1032 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Func;
-      (yyval.import)->func.name = (yyvsp[-3].text);
-      (yyval.import)->func.decl.sig = (yyvsp[-1].func_sig);
+      (yyval.import)->func = new Func();
+      (yyval.import)->func->name = (yyvsp[-3].text);
+      (yyval.import)->func->decl.sig = (yyvsp[-1].func_sig);
     }
-#line 3442 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3445 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 1036 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1039 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table.name = (yyvsp[-3].text);
     }
-#line 3453 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3456 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 1042 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1045 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory.name = (yyvsp[-3].text);
     }
-#line 3464 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3467 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 1048 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1051 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global.name = (yyvsp[-3].text);
     }
-#line 3475 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3478 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 1057 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1060 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new_import();
       (yyval.import)->module_name = (yyvsp[-2].text);
       (yyval.import)->field_name = (yyvsp[-1].text);
     }
-#line 3485 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3488 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 1065 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1068 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Func;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3495 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3498 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 1070 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1073 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Table;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3505 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3508 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 126:
-#line 1075 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1078 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Memory;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3515 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3518 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 127:
-#line 1080 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1083 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.export_));
       (yyval.export_).kind = ExternalKind::Global;
       (yyval.export_).var = (yyvsp[-1].var);
     }
-#line 3525 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3528 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 1087 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1090 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = (yyvsp[-1].export_);
       (yyval.export_).name = (yyvsp[-2].text);
     }
-#line 3534 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3537 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 129:
-#line 1094 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1097 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.optional_export));
       (yyval.optional_export).has_export = false;
     }
-#line 3543 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3546 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 1101 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1104 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.optional_export));
       (yyval.optional_export).has_export = true;
       (yyval.optional_export).export_.name = (yyvsp[-1].text);
     }
-#line 3553 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3556 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 1112 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1115 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.func_type));
       (yyval.func_type).sig = (yyvsp[-1].func_sig);
     }
-#line 3562 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3565 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 1116 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1119 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_type).name = (yyvsp[-2].text);
       (yyval.func_type).sig = (yyvsp[-1].func_sig);
     }
-#line 3571 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3574 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 1123 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1126 "src/ast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 3577 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3580 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 1127 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1130 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new_module();
     }
-#line 3585 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3588 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 136:
-#line 1130 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1133 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3594,11 +3597,11 @@ yyreduce:
                             &field->func_type);
       INSERT_BINDING((yyval.module), func_type, func_types, (yylsp[0]), (yyvsp[0].func_type).name);
     }
-#line 3598 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3601 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 137:
-#line 1138 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1141 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3607,11 +3610,11 @@ yyreduce:
       INSERT_BINDING((yyval.module), global, globals, (yylsp[0]), (yyvsp[0].exported_global).global.name);
       APPEND_INLINE_EXPORT((yyval.module), Global, (yylsp[0]), (yyvsp[0].exported_global), (yyval.module)->globals.size - 1);
     }
-#line 3611 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3614 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 1146 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1149 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3629,11 +3632,11 @@ yyreduce:
       }
 
     }
-#line 3633 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3636 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 1163 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1166 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3650,26 +3653,25 @@ yyreduce:
                               &data_segment_field->data_segment);
       }
     }
-#line 3654 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3657 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 1179 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1182 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
-      APPEND_FIELD_TO_LIST((yyval.module), field, Func, func, (yylsp[0]), *(yyvsp[0].exported_func).func);
-      append_implicit_func_declaration(&(yylsp[0]), (yyval.module), &field->func.decl);
-      APPEND_ITEM_TO_VECTOR((yyval.module), Func, func, funcs, &field->func);
+      APPEND_FIELD_TO_LIST((yyval.module), field, Func, func, (yylsp[0]), (yyvsp[0].exported_func).func);
+      append_implicit_func_declaration(&(yylsp[0]), (yyval.module), &field->func->decl);
+      APPEND_ITEM_TO_VECTOR((yyval.module), Func, func, funcs, field->func);
       INSERT_BINDING((yyval.module), func, funcs, (yylsp[0]), (yyvsp[0].exported_func).func->name);
       APPEND_INLINE_EXPORT((yyval.module), Func, (yylsp[0]), (yyvsp[0].exported_func), (yyval.module)->funcs.size - 1);
-      delete (yyvsp[0].exported_func).func;
     }
-#line 3669 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3671 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 1189 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1191 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3677,11 +3679,11 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), ElemSegment, elem_segment, elem_segments,
                             &field->elem_segment);
     }
-#line 3681 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3683 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 1196 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1198 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3689,75 +3691,75 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), DataSegment, data_segment, data_segments,
                             &field->data_segment);
     }
-#line 3693 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3695 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 1203 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1205 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
       APPEND_FIELD_TO_LIST((yyval.module), field, Start, start, (yylsp[0]), (yyvsp[0].var));
       (yyval.module)->start = &field->start;
     }
-#line 3704 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3706 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 1209 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1211 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
-      APPEND_FIELD_TO_LIST((yyval.module), field, Import, import, (yylsp[0]), *(yyvsp[0].import));
+      APPEND_FIELD_TO_LIST((yyval.module), field, Import, import, (yylsp[0]), (yyvsp[0].import));
       CHECK_IMPORT_ORDERING((yyval.module), func, funcs, (yylsp[0]));
       CHECK_IMPORT_ORDERING((yyval.module), table, tables, (yylsp[0]));
       CHECK_IMPORT_ORDERING((yyval.module), memory, memories, (yylsp[0]));
       CHECK_IMPORT_ORDERING((yyval.module), global, globals, (yylsp[0]));
       switch ((yyvsp[0].import)->kind) {
         case ExternalKind::Func:
-          append_implicit_func_declaration(&(yylsp[0]), (yyval.module), &field->import.func.decl);
-          APPEND_ITEM_TO_VECTOR((yyval.module), Func, func, funcs, &field->import.func);
-          INSERT_BINDING((yyval.module), func, funcs, (yylsp[0]), field->import.func.name);
+          append_implicit_func_declaration(&(yylsp[0]), (yyval.module), &field->import->func->decl);
+          APPEND_ITEM_TO_VECTOR((yyval.module), Func, func, funcs, field->import->func);
+          INSERT_BINDING((yyval.module), func, funcs, (yylsp[0]), field->import->func->name);
           (yyval.module)->num_func_imports++;
           break;
         case ExternalKind::Table:
-          APPEND_ITEM_TO_VECTOR((yyval.module), Table, table, tables, &field->import.table);
-          INSERT_BINDING((yyval.module), table, tables, (yylsp[0]), field->import.table.name);
+          APPEND_ITEM_TO_VECTOR((yyval.module), Table, table, tables,
+                                &field->import->table);
+          INSERT_BINDING((yyval.module), table, tables, (yylsp[0]), field->import->table.name);
           (yyval.module)->num_table_imports++;
           break;
         case ExternalKind::Memory:
           APPEND_ITEM_TO_VECTOR((yyval.module), Memory, memory, memories,
-                                &field->import.memory);
-          INSERT_BINDING((yyval.module), memory, memories, (yylsp[0]), field->import.memory.name);
+                                &field->import->memory);
+          INSERT_BINDING((yyval.module), memory, memories, (yylsp[0]), field->import->memory.name);
           (yyval.module)->num_memory_imports++;
           break;
         case ExternalKind::Global:
           APPEND_ITEM_TO_VECTOR((yyval.module), Global, global, globals,
-                                &field->import.global);
-          INSERT_BINDING((yyval.module), global, globals, (yylsp[0]), field->import.global.name);
+                                &field->import->global);
+          INSERT_BINDING((yyval.module), global, globals, (yylsp[0]), field->import->global.name);
           (yyval.module)->num_global_imports++;
           break;
       }
-      delete (yyvsp[0].import);
-      APPEND_ITEM_TO_VECTOR((yyval.module), Import, import, imports, &field->import);
+      APPEND_ITEM_TO_VECTOR((yyval.module), Import, import, imports, field->import);
     }
-#line 3745 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3747 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 1245 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1247 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
-      ModuleField* field = append_module_field((yyval.module));
+      ModuleField* field;
       APPEND_FIELD_TO_LIST((yyval.module), field, Export, export_, (yylsp[0]), (yyvsp[0].export_));
       APPEND_ITEM_TO_VECTOR((yyval.module), Export, export, exports, &field->export_);
       INSERT_BINDING((yyval.module), export, exports, (yylsp[0]), (yyvsp[0].export_).name);
     }
-#line 3757 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3759 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 1255 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1257 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = RawModuleType::Text;
       (yyval.raw_module).text = (yyvsp[-1].module);
@@ -3779,11 +3781,11 @@ yyreduce:
         }
       }
     }
-#line 3783 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3785 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1276 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1278 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module).type = RawModuleType::Binary;
       (yyval.raw_module).binary.name = (yyvsp[-2].text);
@@ -3791,11 +3793,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.raw_module).binary.data, &(yyval.raw_module).binary.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3795 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3797 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1286 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1288 "src/ast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].raw_module).type == RawModuleType::Text) {
         (yyval.module) = (yyvsp[0].raw_module).text;
@@ -3817,31 +3819,31 @@ yyreduce:
         (yyval.module)->loc = (yyvsp[0].raw_module).binary.loc;
       }
     }
-#line 3821 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3823 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1312 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1314 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Index;
       (yyval.var).index = INVALID_VAR_INDEX;
     }
-#line 3831 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3833 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1317 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1319 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Name;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 3841 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3843 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1325 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1327 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.action));
       (yyval.action).loc = (yylsp[-4]);
@@ -3850,11 +3852,11 @@ yyreduce:
       (yyval.action).invoke.name = (yyvsp[-2].text);
       (yyval.action).invoke.args = (yyvsp[-1].consts);
     }
-#line 3854 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3856 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1333 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1335 "src/ast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.action));
       (yyval.action).loc = (yylsp[-3]);
@@ -3862,119 +3864,118 @@ yyreduce:
       (yyval.action).type = ActionType::Get;
       (yyval.action).invoke.name = (yyvsp[-1].text);
     }
-#line 3866 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3868 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1343 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1345 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertMalformed;
       (yyval.command)->assert_malformed.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_malformed.text = (yyvsp[-1].text);
     }
-#line 3877 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3879 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1349 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1351 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertInvalid;
       (yyval.command)->assert_invalid.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_invalid.text = (yyvsp[-1].text);
     }
-#line 3888 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3890 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1355 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1357 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertUnlinkable;
       (yyval.command)->assert_unlinkable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_unlinkable.text = (yyvsp[-1].text);
     }
-#line 3899 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3901 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1361 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1363 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertUninstantiable;
       (yyval.command)->assert_uninstantiable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_uninstantiable.text = (yyvsp[-1].text);
     }
-#line 3910 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3912 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1367 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1369 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertReturn;
       (yyval.command)->assert_return.action = (yyvsp[-2].action);
       (yyval.command)->assert_return.expected = (yyvsp[-1].consts);
     }
-#line 3921 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3923 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1373 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1375 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertReturnNan;
       (yyval.command)->assert_return_nan.action = (yyvsp[-1].action);
     }
-#line 3931 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3933 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1378 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1380 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertTrap;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3942 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3944 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1384 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1386 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::AssertExhaustion;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3953 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3955 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1393 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1395 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Action;
       (yyval.command)->action = (yyvsp[0].action);
     }
-#line 3963 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3965 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 163:
-#line 1399 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1401 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Module;
-      (yyval.command)->module = *(yyvsp[0].module);
-      delete (yyvsp[0].module);
+      (yyval.command)->module = (yyvsp[0].module);
     }
-#line 3974 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3975 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1405 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1406 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new_command();
       (yyval.command)->type = CommandType::Register;
@@ -3982,27 +3983,27 @@ yyreduce:
       (yyval.command)->register_.var = (yyvsp[-1].var);
       (yyval.command)->register_.var.loc = (yylsp[-1]);
     }
-#line 3986 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3987 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1414 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.commands)); }
-#line 3992 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 3993 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1415 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1416 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       append_command_value(&(yyval.commands), (yyvsp[0].command));
       delete (yyvsp[0].command);
     }
-#line 4002 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4003 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1423 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1424 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WABT_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -4013,48 +4014,45 @@ yyreduce:
       }
       delete [] (yyvsp[-1].literal).text.start;
     }
-#line 4017 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4018 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1435 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1436 "src/ast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.consts)); }
-#line 4023 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4024 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1436 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1437 "src/ast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       append_const_value(&(yyval.consts), &(yyvsp[0].const_));
     }
-#line 4032 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4033 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1443 "src/ast-parser.y" /* yacc.c:1646  */
+#line 1444 "src/ast-parser.y" /* yacc.c:1646  */
     {
-      WABT_ZERO_MEMORY((yyval.script));
-      (yyval.script).commands = (yyvsp[0].commands);
+      (yyval.script) = new Script();
+      (yyval.script)->commands = (yyvsp[0].commands);
 
       int last_module_index = -1;
-      for (size_t i = 0; i < (yyval.script).commands.size; ++i) {
-        Command* command = &(yyval.script).commands.data[i];
+      for (size_t i = 0; i < (yyval.script)->commands.size; ++i) {
+        Command* command = &(yyval.script)->commands.data[i];
         Var* module_var = nullptr;
         switch (command->type) {
           case CommandType::Module: {
             last_module_index = i;
 
             /* Wire up module name bindings. */
-            Module* module = &command->module;
+            Module* module = command->module;
             if (module->name.length == 0)
               continue;
 
-            StringSlice module_name = dup_string_slice(module->name);
-            Binding* binding =
-                insert_binding(&(yyval.script).module_bindings, &module_name);
-            binding->loc = module->loc;
-            binding->index = i;
+            (yyval.script)->module_bindings.emplace(string_slice_to_string(module->name),
+                                        Binding(module->loc, i));
             break;
           }
 
@@ -4091,11 +4089,11 @@ yyreduce:
       }
       parser->script = (yyval.script);
     }
-#line 4095 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4093 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4099 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
+#line 4097 "src/prebuilt/ast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4330,7 +4328,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1509 "src/ast-parser.y" /* yacc.c:1906  */
+#line 1507 "src/ast-parser.y" /* yacc.c:1906  */
 
 
 void append_expr_list(ExprList* expr_list, ExprList* expr) {
@@ -4486,8 +4484,8 @@ void append_implicit_func_declaration(Location* loc,
   decl->flags |= WABT_FUNC_DECLARATION_FLAG_SHARED_SIGNATURE;
 }
 
-Result parse_ast(AstLexer * lexer, struct Script * out_script,
-                 SourceErrorHandler * error_handler) {
+Result parse_ast(AstLexer* lexer, Script** out_script,
+                 SourceErrorHandler* error_handler) {
   AstParser parser;
   WABT_ZERO_MEMORY(parser);
   parser.error_handler = error_handler;

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -65,17 +65,17 @@ struct FindDuplicateBindingContext {
   const char* desc;
 };
 
-static void on_duplicate_binding(BindingHashEntry* a,
-                                 BindingHashEntry* b,
+static void on_duplicate_binding(const BindingHash::value_type& a,
+                                 const BindingHash::value_type& b,
                                  void* user_data) {
   FindDuplicateBindingContext* fdbc =
       static_cast<FindDuplicateBindingContext*>(user_data);
   /* choose the location that is later in the file */
-  Location* a_loc = &a->binding.loc;
-  Location* b_loc = &b->binding.loc;
-  Location* loc = a_loc->line > b_loc->line ? a_loc : b_loc;
-  print_error(fdbc->ctx, loc, "redefinition of %s \"" PRIstringslice "\"",
-              fdbc->desc, WABT_PRINTF_STRING_SLICE_ARG(a->binding.name));
+  const Location& a_loc = a.second.loc;
+  const Location& b_loc = b.second.loc;
+  const Location& loc = a_loc.line > b_loc.line ? a_loc : b_loc;
+  print_error(fdbc->ctx, &loc, "redefinition of %s \"%s\"", fdbc->desc,
+              a.first.c_str());
 }
 
 static void check_duplicate_bindings(Context* ctx,
@@ -84,7 +84,7 @@ static void check_duplicate_bindings(Context* ctx,
   FindDuplicateBindingContext fdbc;
   fdbc.ctx = ctx;
   fdbc.desc = desc;
-  find_duplicate_bindings(bindings, on_duplicate_binding, &fdbc);
+  find_duplicate_bindings(*bindings, on_duplicate_binding, &fdbc);
 }
 
 static void resolve_label_var(Context* ctx, Var* var) {
@@ -350,7 +350,7 @@ static bool dummy_source_error_callback(const Location* loc,
 static void visit_command(Context* ctx, Command* command) {
   switch (command->type) {
     case CommandType::Module:
-      visit_module(ctx, &command->module);
+      visit_module(ctx, command->module);
       break;
 
     case CommandType::Action:

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -84,7 +84,7 @@ static void check_duplicate_bindings(Context* ctx,
   FindDuplicateBindingContext fdbc;
   fdbc.ctx = ctx;
   fdbc.desc = desc;
-  find_duplicate_bindings(*bindings, on_duplicate_binding, &fdbc);
+  bindings->find_duplicates(on_duplicate_binding, &fdbc);
 }
 
 static void resolve_label_var(Context* ctx, Var* var) {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -640,7 +640,12 @@ enum class ActionType {
 };
 
 struct Action {
-  ActionType type;
+  Action() {
+    WABT_ZERO_MEMORY(module_name);
+    WABT_ZERO_MEMORY(field_name);
+  }
+
+  ActionType type = ActionType::Invoke;
   StringSlice module_name;
   StringSlice field_name;
   std::vector<InterpreterTypedValue> args;
@@ -956,7 +961,6 @@ static Result parse_const_vector(
 }
 
 static Result parse_action(Context* ctx, Action* out_action) {
-  WABT_ZERO_MEMORY(*out_action);
   EXPECT_KEY("action");
   EXPECT("{");
   EXPECT_KEY("type");
@@ -1042,8 +1046,7 @@ static Result run_action(Context* ctx,
 
   int module_index;
   if (!string_slice_is_empty(&action->module_name)) {
-    module_index = find_binding_index_by_name(ctx->env.module_bindings,
-                                              action->module_name);
+    module_index = ctx->env.module_bindings.find_index(action->module_name);
   } else {
     module_index = static_cast<int>(ctx->env.modules.size()) - 1;
   }
@@ -1445,7 +1448,6 @@ static Result parse_command(Context* ctx) {
     on_module_command(ctx, filename, name);
   } else if (match(ctx, "\"action\"")) {
     Action action;
-    WABT_ZERO_MEMORY(action);
 
     EXPECT(",");
     CHECK_RESULT(parse_line(ctx));
@@ -1516,7 +1518,6 @@ static Result parse_command(Context* ctx) {
   } else if (match(ctx, "\"assert_return\"")) {
     Action action;
     std::vector<InterpreterTypedValue> expected;
-    WABT_ZERO_MEMORY(action);
 
     EXPECT(",");
     CHECK_RESULT(parse_line(ctx));
@@ -1529,7 +1530,6 @@ static Result parse_command(Context* ctx) {
   } else if (match(ctx, "\"assert_return_nan\"")) {
     Action action;
     TypeVector expected;
-    WABT_ZERO_MEMORY(action);
 
     EXPECT(",");
     CHECK_RESULT(parse_line(ctx));
@@ -1544,7 +1544,6 @@ static Result parse_command(Context* ctx) {
   } else if (match(ctx, "\"assert_trap\"")) {
     Action action;
     StringSlice text;
-    WABT_ZERO_MEMORY(action);
     WABT_ZERO_MEMORY(text);
 
     EXPECT(",");
@@ -1557,7 +1556,6 @@ static Result parse_command(Context* ctx) {
   } else if (match(ctx, "\"assert_exhaustion\"")) {
     Action action;
     StringSlice text;
-    WABT_ZERO_MEMORY(action);
     WABT_ZERO_MEMORY(text);
 
     EXPECT(",");

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -612,7 +612,6 @@ WABT_DEFINE_VECTOR(export_info, ExportInfo);
 static void resolve_symbols(Context* ctx) {
   /* Create hashmap of all exported symbols from all inputs */
   BindingHash export_map;
-  WABT_ZERO_MEMORY(export_map);
   ExportInfoVector export_list;
   WABT_ZERO_MEMORY(export_list);
 
@@ -625,9 +624,8 @@ static void resolve_symbols(Context* ctx) {
       info->binary = binary;
 
       /* TODO(sbc): Handle duplicate names */
-      StringSlice name = dup_string_slice(export_->name);
-      Binding* binding = insert_binding(&export_map, &name);
-      binding->index = export_list.size - 1;
+      export_map.emplace(string_slice_to_string(export_->name),
+                         Binding(export_list.size - 1));
     }
   }
 
@@ -639,7 +637,7 @@ static void resolve_symbols(Context* ctx) {
     LinkerInputBinary* binary = &ctx->inputs.data[i];
     for (size_t j = 0; j < binary->function_imports.size; j++) {
       FunctionImport* import = &binary->function_imports.data[j];
-      int export_index = find_binding_index_by_name(&export_map, &import->name);
+      int export_index = find_binding_index_by_name(export_map, import->name);
       if (export_index == -1) {
         if (!s_relocatable)
           WABT_FATAL("undefined symbol: " PRIstringslice "\n",
@@ -659,7 +657,6 @@ static void resolve_symbols(Context* ctx) {
   }
 
   destroy_export_info_vector(&export_list);
-  destroy_binding_hash(&export_map);
 }
 
 static void calculate_reloc_offsets(Context* ctx) {

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -637,7 +637,7 @@ static void resolve_symbols(Context* ctx) {
     LinkerInputBinary* binary = &ctx->inputs.data[i];
     for (size_t j = 0; j < binary->function_imports.size; j++) {
       FunctionImport* import = &binary->function_imports.data[j];
-      int export_index = find_binding_index_by_name(export_map, import->name);
+      int export_index = export_map.find_index(import->name);
       if (export_index == -1) {
         if (!s_relocatable)
           WABT_FATAL("undefined symbol: " PRIstringslice "\n",

--- a/src/tools/wasm2wast.cc
+++ b/src/tools/wasm2wast.cc
@@ -146,7 +146,6 @@ int main(int argc, char** argv) {
   result = read_file(s_infile, &data, &size);
   if (WABT_SUCCEEDED(result)) {
     Module module;
-    WABT_ZERO_MEMORY(module);
     result = read_binary_ast(data, size, &s_read_binary_options,
                              &s_error_handler, &module);
     if (WABT_SUCCEEDED(result)) {

--- a/src/tools/wasm2wast.cc
+++ b/src/tools/wasm2wast.cc
@@ -172,7 +172,6 @@ int main(int argc, char** argv) {
           close_file_writer(&file_writer);
         }
       }
-      destroy_module(&module);
     }
     delete[] data;
   }

--- a/src/tools/wast-desugar.cc
+++ b/src/tools/wast-desugar.cc
@@ -134,11 +134,11 @@ int main(int argc, char** argv) {
   if (!lexer)
     WABT_FATAL("unable to read %s\n", s_infile);
 
-  Script script;
+  Script* script;
   Result result = parse_ast(lexer, &script, &s_error_handler);
 
   if (WABT_SUCCEEDED(result)) {
-    Module* module = get_first_module(&script);
+    Module* module = get_first_module(script);
     if (!module)
       WABT_FATAL("no module in file.\n");
 
@@ -164,6 +164,6 @@ int main(int argc, char** argv) {
   }
 
   destroy_ast_lexer(lexer);
-  destroy_script(&script);
+  delete script;
   return result != Result::Ok;
 }

--- a/src/tools/wast2wasm.cc
+++ b/src/tools/wast2wasm.cc
@@ -201,21 +201,21 @@ int main(int argc, char** argv) {
   if (!lexer)
     WABT_FATAL("unable to read file: %s\n", s_infile);
 
-  Script script;
+  Script* script;
   Result result = parse_ast(lexer, &script, &s_error_handler);
 
   if (WABT_SUCCEEDED(result)) {
-    result = resolve_names_script(lexer, &script, &s_error_handler);
+    result = resolve_names_script(lexer, script, &s_error_handler);
 
     if (WABT_SUCCEEDED(result) && s_validate)
-      result = validate_script(lexer, &script, &s_error_handler);
+      result = validate_script(lexer, script, &s_error_handler);
 
     if (WABT_SUCCEEDED(result)) {
       if (s_spec) {
         s_write_binary_spec_options.json_filename = s_outfile;
         s_write_binary_spec_options.write_binary_options =
             s_write_binary_options;
-        result = write_binary_spec_script(&script, s_infile,
+        result = write_binary_spec_script(script, s_infile,
                                           &s_write_binary_spec_options);
       } else {
         MemoryWriter writer;
@@ -223,7 +223,7 @@ int main(int argc, char** argv) {
         if (WABT_FAILED(init_mem_writer(&writer)))
           WABT_FATAL("unable to open memory writer for writing\n");
 
-        Module* module = get_first_module(&script);
+        Module* module = get_first_module(script);
         if (module) {
           result = write_binary_module(&writer.base, module,
                                        &s_write_binary_options);
@@ -239,6 +239,6 @@ int main(int argc, char** argv) {
   }
 
   destroy_ast_lexer(lexer);
-  destroy_script(&script);
+  delete script;
   return result != Result::Ok;
 }

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -746,7 +746,7 @@ static void on_duplicate_binding(const BindingHash::value_type& a,
 
 static void check_duplicate_export_bindings(Context* ctx,
                                             const Module* module) {
-  find_duplicate_bindings(module->export_bindings, on_duplicate_binding, ctx);
+  module->export_bindings.find_duplicates(on_duplicate_binding, ctx);
 }
 
 static void check_module(Context* ctx, const Module* module) {

--- a/test/regress/regress-2.txt
+++ b/test/regress/regress-2.txt
@@ -10,10 +10,10 @@
   (func $memory(param f32)(call 332 ))
   (func $memorGe ))
 (;; STDERR ;;;
-out/test/regress/regress-2.txt:10:3: redefinition of function "$memory"
-  (func $memory(param f32)(call 332 ))
-  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 out/test/regress/regress-2.txt:6:3: redefinition of function "$memor"
   (func $memor(call 2 ))
   ^^^^^^^^^^^^^^^^^^^^^^
+out/test/regress/regress-2.txt:10:3: redefinition of function "$memory"
+  (func $memory(param f32)(call 332 ))
+  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -6,10 +6,10 @@ out/third_party/testsuite/globals.wast:50: assert_invalid passed:
   error: @0x00000026: on_set_global_expr callback failed
 out/third_party/testsuite/globals.wast:55: assert_invalid passed:
   error: unknown import module "m"
-  error: @0x0000000f: on_import callback failed
+  error: @0x00000012: on_import callback failed
 out/third_party/testsuite/globals.wast:60: assert_invalid passed:
   error: unknown import module "m"
-  error: @0x0000000f: on_import callback failed
+  error: @0x00000012: on_import callback failed
 out/third_party/testsuite/globals.wast:65: assert_invalid passed:
   error: mutable globals cannot be exported
   error: @0x0000001a: on_export callback failed

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -13,7 +13,7 @@ called host spectest.print(f64:24) =>
 called host spectest.print(f64:24) =>
 out/third_party/testsuite/imports.wast:89: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x0000001e: on_import callback failed
+  error: @0x00000020: on_import callback failed
 out/third_party/testsuite/imports.wast:93: assert_unlinkable passed:
   error: unknown host function import "spectest.unknown"
   error: @0x00000024: on_import_func callback failed
@@ -85,7 +85,7 @@ out/third_party/testsuite/imports.wast:183: assert_unlinkable passed:
   error: @0x00000023: on_import_func callback failed
 out/third_party/testsuite/imports.wast:217: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x00000018: on_import callback failed
+  error: @0x0000001b: on_import callback failed
 out/third_party/testsuite/imports.wast:221: assert_unlinkable passed:
   error: unknown host global import "spectest.unknown"
   error: @0x0000001f: on_import_global callback failed
@@ -109,15 +109,15 @@ out/third_party/testsuite/imports.wast:246: assert_unlinkable passed:
   error: @0x0000001e: on_import_global callback failed
 out/third_party/testsuite/imports.wast:288: assert_invalid passed:
   error: unknown import module ""
-  error: @0x0000000d: on_import callback failed
+  error: @0x00000011: on_import callback failed
 out/third_party/testsuite/imports.wast:292: assert_invalid passed:
   error: unknown import module ""
-  error: @0x0000000d: on_import callback failed
+  error: @0x00000011: on_import callback failed
 out/third_party/testsuite/imports.wast:296: assert_invalid passed:
   error: @0x0000000b: table count (2) must be 0 or 1
 out/third_party/testsuite/imports.wast:313: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x00000018: on_import callback failed
+  error: @0x0000001c: on_import callback failed
 out/third_party/testsuite/imports.wast:317: assert_unlinkable passed:
   error: unknown host table import "spectest.unknown"
   error: @0x00000020: on_import_table callback failed
@@ -147,15 +147,15 @@ out/third_party/testsuite/imports.wast:351: assert_unlinkable passed:
   error: @0x0000001e: on_import_table callback failed
 out/third_party/testsuite/imports.wast:383: assert_invalid passed:
   error: unknown import module ""
-  error: @0x0000000d: on_import callback failed
+  error: @0x00000010: on_import callback failed
 out/third_party/testsuite/imports.wast:387: assert_invalid passed:
   error: unknown import module ""
-  error: @0x0000000d: on_import callback failed
+  error: @0x00000010: on_import callback failed
 out/third_party/testsuite/imports.wast:391: assert_invalid passed:
   error: @0x0000000b: memory count must be 0 or 1
 out/third_party/testsuite/imports.wast:406: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x00000018: on_import callback failed
+  error: @0x0000001b: on_import callback failed
 out/third_party/testsuite/imports.wast:410: assert_unlinkable passed:
   error: unknown host memory import "spectest.unknown"
   error: @0x0000001f: on_import_memory callback failed

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -12,7 +12,7 @@ out/third_party/testsuite/linking.wast:166: assert_unlinkable passed:
   error: @0x00000029: on_elem_segment_function_index callback failed
 out/third_party/testsuite/linking.wast:175: assert_unlinkable passed:
   error: unknown module field "mem"
-  error: @0x00000024: on_import callback failed
+  error: @0x00000027: on_import callback failed
 out/third_party/testsuite/linking.wast:187: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 12 >= max value 10
   error: @0x00000030: on_elem_segment_function_index callback failed
@@ -25,7 +25,7 @@ out/third_party/testsuite/linking.wast:258: assert_unlinkable passed:
 out/third_party/testsuite/linking.wast:283: assert_unlinkable passed:
   error: duplicate export "print"
   error: unknown module field "tab"
-  error: @0x00000033: on_import callback failed
+  error: @0x00000037: on_import callback failed
 out/third_party/testsuite/linking.wast:294: assert_unlinkable passed:
   error: data segment is out of bounds: [327680, 327681) >= max value 327680
   error: @0x00000028: on_data_segment_data callback failed


### PR DESCRIPTION
This change can't really be done in isolation, since once we add members
with constructors to a struct, it is no longer has a trivial
constructor. This propagates through all types that use it, etc.

There are a number of changes that are ugly, but hopefully reduced the
amount of code that needed to change. In particular, I changed some
union members to pointers so they would stay trivially constructable.

Another tricky change is the handling of duplicate bindings: previously
we just relied on the fact that our hash implementation would be
consistent. A nicer solution is to display the duplicated bindings in
source order. There's probably a nicer way to do this; bikeshedding
welcome. :-)