### PR TITLE
Add callback for end opcode and end of function

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -315,6 +315,12 @@ Result on_br_table_expr(BinaryReaderContext* ctx,
   return Result::Ok;
 }
 
+static Result on_end_func(void* user_data) {
+  Context* context = static_cast<Context*>(user_data);
+  log_opcode(context, nullptr, 0, nullptr);
+  return Result::Ok;
+}
+
 static Result on_end_expr(void* user_data) {
   Context* context = static_cast<Context*>(user_data);
   context->indent_level--;
@@ -755,6 +761,7 @@ Result read_binary_objdump(const uint8_t* data,
     reader.on_opcode_f64 = on_opcode_f64;
     reader.on_opcode_block_sig = on_opcode_block_sig;
     reader.on_end_expr = on_end_expr;
+    reader.on_end_func = on_end_func;
     reader.on_br_table_expr = on_br_table_expr;
   }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1157,7 +1157,7 @@ static void read_global_header(Context* ctx,
   uint8_t mutable_;
   in_type(ctx, &global_type, "global type");
   RAISE_ERROR_UNLESS(is_concrete_type(global_type),
-                     "expected valid global type");
+                     "invalid global type: %#x", global_type);
 
   in_u8(ctx, &mutable_, "global mutability");
   RAISE_ERROR_UNLESS(mutable_ <= 1, "global mutability must be 0 or 1");
@@ -1277,10 +1277,12 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         break;
 
       case Opcode::End:
-        if (ctx->offset == end_offset)
+        if (ctx->offset == end_offset) {
           seen_end_opcode = true;
-        else
+          CALLBACK0(on_end_func);
+        } else {
           CALLBACK0(on_end_expr);
+        }
         break;
 
       case Opcode::I32Const: {

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1157,7 +1157,7 @@ static void read_global_header(Context* ctx,
   uint8_t mutable_;
   in_type(ctx, &global_type, "global type");
   RAISE_ERROR_UNLESS(is_concrete_type(global_type),
-                     "invalid global type: %#x", global_type);
+                     "invalid global type: %#x", static_cast<int>(global_type));
 
   in_u8(ctx, &mutable_, "global mutability");
   RAISE_ERROR_UNLESS(mutable_ <= 1, "global mutability must be 0 or 1");

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -203,6 +203,7 @@ struct BinaryReader {
   Result (*on_drop_expr)(void* user_data);
   Result (*on_else_expr)(void* user_data);
   Result (*on_end_expr)(void* user_data);
+  Result (*on_end_func)(void* user_data);
   Result (*on_f32_const_expr)(uint32_t value_bits, void* user_data);
   Result (*on_f64_const_expr)(uint64_t value_bits, void* user_data);
   Result (*on_get_global_expr)(uint32_t global_index, void* user_data);

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -101,4 +101,5 @@ Code Disassembly:
  000033: 20 00                      | get_local 0
  000035: 20 01                      | get_local 0x1
  000037: 6a                         | i32.add
+ 000038: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/basic_dump_only.txt
+++ b/test/dump/basic_dump_only.txt
@@ -27,4 +27,5 @@ Code Disassembly:
  000033: 20 00                      | get_local 0
  000035: 20 01                      | get_local 0x1
  000037: 6a                         | i32.add
+ 000038: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -376,4 +376,5 @@ Code Disassembly:
  0000ee: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
  0000f7: a0                         | f64.add
  0000f8: 1a                         | drop
+ 0000f9: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -605,4 +605,5 @@ Code Disassembly:
  00011b: 0c 00                      |   br 0
  00011d: 0c 00                      |   br 0
  00011f: 0b                         | end
+ 000120: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -600,4 +600,5 @@ Code Disassembly:
  00011a: 01                         |   nop
  00011b: 01                         |   nop
  00011c: 0b                         | end
+ 00011d: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -72,8 +72,10 @@ Code Disassembly:
  00001f: 01                         |   nop
  000020: 01                         |   nop
  000021: 0b                         | end
+ 000022: 0b                         | end
 000023 func[1]:
  000025: 02 7f                      | block i32
  000027: 41 01                      |   i32.const 0x1
  000029: 0b                         | end
+ 00002a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -78,4 +78,5 @@ Code Disassembly:
  000027: 0b                         |     end
  000028: 0b                         |   end
  000029: 0b                         | end
+ 00002a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -86,4 +86,5 @@ Code Disassembly:
  00002b: 0b                         |     end
  00002c: 0b                         |   end
  00002d: 0b                         | end
+ 00002e: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -88,4 +88,5 @@ Code Disassembly:
  00002c: 41 05                      |     i32.const 0x5
  00002e: 0b                         |   end
  00002f: 0b                         | end
+ 000030: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -72,4 +72,5 @@ Code Disassembly:
  000028: 0b                         |     end
  000029: 0b                         |   end
  00002a: 0b                         | end
+ 00002b: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -57,4 +57,5 @@ Code Disassembly:
  00001d: 0c 01                      |     br 0x1
  00001f: 0b                         |   end
  000020: 0b                         | end
+ 000021: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -50,4 +50,5 @@ Code Disassembly:
  000019: 41 00                      |   i32.const 0
  00001b: 0d 00                      |   br_if 0
  00001d: 0b                         | end
+ 00001e: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -50,4 +50,5 @@ Code Disassembly:
  000019: 41 01                      |   i32.const 0x1
  00001b: 0d 00                      |   br_if 0
  00001d: 0b                         | end
+ 00001e: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -51,4 +51,5 @@ Code Disassembly:
  000019: 41 00                      |   i32.const 0
  00001b: 0e 00 00                   |   br_table
  00001e: 0b                         | end
+ 00001f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -95,4 +95,5 @@ Code Disassembly:
  00002e: 0b                         | end
  00002f: 41 03                      | i32.const 0x3
  000031: 1a                         | drop
+ 000032: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -44,4 +44,5 @@ Code Disassembly:
 000016 func[0]:
  000018: 41 01                      | i32.const 0x1
  00001a: 10 00                      | call 0
+ 00001c: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -77,4 +77,5 @@ Code Disassembly:
  000032: 10 00                      | call 0
  000034: 1a                         | drop
  000035: 10 01                      | call 0x1
+ 000037: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -73,4 +73,5 @@ Code Disassembly:
  000028: 41 00                      | i32.const 0
  00002a: 41 00                      | i32.const 0
  00002c: 11 00 00                   | call_indirect 0 0
+ 00002f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -75,4 +75,5 @@ Code Disassembly:
  000026: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
  00002f: bd                         | i64.reinterpret/f64
  000030: 1a                         | drop
+ 000031: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -425,4 +425,5 @@ Code Disassembly:
  00012b: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
  000134: 66                         | f64.ge
  000135: 1a                         | drop
+ 000136: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -303,4 +303,5 @@ Code Disassembly:
  000126: 1a                         | drop
  000127: 44 18 2d 44 54 fb 21 19 40 | f64.const 0x1.921fb54442d18p+2
  000130: 1a                         | drop
+ 000131: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -121,4 +121,5 @@ Code Disassembly:
  000035: bb                         | f64.promote/f32
  000036: b6                         | f32.demote/f64
  000037: 1a                         | drop
+ 000038: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -49,4 +49,5 @@ Code Disassembly:
 
 00001b func[0]:
  00001d: 3f 00                      | current_memory 0
+ 00001f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -128,5 +128,7 @@ Custom:
 Code Disassembly:
 
 00001b <$F1>:
+ 000021: 0b                         | end
 000022 <$F2>:
+ 000028: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -55,4 +55,5 @@ Code Disassembly:
 
 000024 func[1]:
  000026: 42 00                      | i64.const 0
+ 000028: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/drop.txt
+++ b/test/dump/drop.txt
@@ -42,4 +42,5 @@ Code Disassembly:
 000015 func[0]:
  000017: 41 00                      | i32.const 0
  000019: 1a                         | drop
+ 00001a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -52,4 +52,5 @@ Code Disassembly:
 
 000020 func[0]:
  000022: 01                         | nop
+ 000023: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -52,4 +52,5 @@ Code Disassembly:
  00001a: 41 01                      |   i32.const 0x1
  00001c: 0c 00                      |   br 0
  00001e: 0b                         | end
+ 00001f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -62,4 +62,5 @@ Code Disassembly:
  000020: 1a                         |   drop
  000021: 41 1d                      |   i32.const 0x1d
  000023: 0b                         | end
+ 000024: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -45,4 +45,5 @@ func-exported.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 00001e func[0]:
+ 000020: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -49,6 +49,9 @@ func-multi.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 000017 func[0]:
+ 000019: 0b                         | end
 00001a func[1]:
+ 00001c: 0b                         | end
 00001d func[2]:
+ 00001f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -35,4 +35,5 @@ func-named.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 000015 func[0]:
+ 000017: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/getglobal.txt
+++ b/test/dump/getglobal.txt
@@ -51,4 +51,5 @@ Code Disassembly:
 
 00001e func[0]:
  000020: 23 00                      | get_global 0
+ 000022: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -88,4 +88,5 @@ Code Disassembly:
  00002f: 1a                         | drop
  000030: 20 05                      | get_local 0x5
  000032: 1a                         | drop
+ 000033: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -106,4 +106,5 @@ Code Disassembly:
  000039: 1a                         | drop
  00003a: 20 07                      | get_local 0x7
  00003c: 1a                         | drop
+ 00003d: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -57,4 +57,5 @@ Code Disassembly:
  00001e: 20 00                      | get_local 0
  000020: 40 00                      | grow_memory 0
  000022: 1a                         | drop
+ 000023: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/hexfloat_f32.txt
+++ b/test/dump/hexfloat_f32.txt
@@ -156,4 +156,5 @@ Code Disassembly:
  000076: 1a                         | drop
  000077: 43 80 80 7f c0             | f32.const -0x1.ff01p+1
  00007c: 1a                         | drop
+ 00007d: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/hexfloat_f64.txt
+++ b/test/dump/hexfloat_f64.txt
@@ -158,4 +158,5 @@ Code Disassembly:
  0000b8: 1a                         | drop
  0000b9: 44 00 00 00 00 10 f0 0f c0 | f64.const -0x1.ff01p+1
  0000c2: 1a                         | drop
+ 0000c3: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -77,4 +77,5 @@ Code Disassembly:
  000025: 41 05                      |   i32.const 0x5
  000027: 1a                         |   drop
  000028: 0b                         | end
+ 000029: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -52,4 +52,5 @@ Code Disassembly:
  00001b: 01                         |   nop
  00001c: 01                         |   nop
  00001d: 0b                         | end
+ 00001e: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -95,6 +95,7 @@ Code Disassembly:
  000028: 43 00 00 00 40             |   f32.const 0x1p+1
  00002d: 0b                         | end
  00002e: 1a                         | drop
+ 00002f: 0b                         | end
 000030 func[1]:
  000032: 41 01                      | i32.const 0x1
  000034: 04 40                      | if
@@ -102,4 +103,5 @@ Code Disassembly:
  000037: 05                         | else
  000038: 0f                         |   return
  000039: 0b                         | end
+ 00003a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -236,4 +236,5 @@ Code Disassembly:
  000076: 41 00                      | i32.const 0
  000078: 29 03 00                   | i64.load 3 0
  00007b: 1a                         | drop
+ 00007c: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -212,4 +212,5 @@ Code Disassembly:
  00006a: 41 00                      | i32.const 0
  00006c: 2b 03 00                   | f64.load 3 0
  00006f: 1a                         | drop
+ 000070: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -43,4 +43,5 @@ locals.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 000015 func[0]:
+ 00001f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -622,4 +622,5 @@ Code Disassembly:
  000123: 0c 00                      |     br 0
  000125: 0b                         |   end
  000126: 0b                         | end
+ 000127: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -600,4 +600,5 @@ Code Disassembly:
  00011a: 01                         |   nop
  00011b: 01                         |   nop
  00011c: 0b                         | end
+ 00011d: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -48,4 +48,5 @@ Code Disassembly:
  000019: 01                         |   nop
  00001a: 01                         |   nop
  00001b: 0b                         | end
+ 00001c: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -155,14 +155,17 @@ Code Disassembly:
  000079: 20 01                      | get_local 0x1
  00007b: 11 01 00                   | call_indirect 1 0
  00007e: 1a                         | drop
+ 00007f: 0b                         | end
 000080 func[2]:
  000086: 20 00                      | get_local 0
  000088: 41 01                      | i32.const 0x1
  00008a: 6a                         | i32.add
  00008b: 1a                         | drop
+ 00008c: 0b                         | end
 00008d func[3]:
  000093: 20 00                      | get_local 0
  000095: 41 02                      | i32.const 0x2
  000097: 6c                         | i32.mul
  000098: 1a                         | drop
+ 000099: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -57,4 +57,5 @@ Code Disassembly:
  000021: 43 00 00 80 3f             | f32.const 0x1p+0
  000026: 44 00 00 00 00 00 00 00 40 | f64.const 0x1p+1
  00002f: 6a                         | i32.add
+ 000030: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -38,4 +38,5 @@ Code Disassembly:
 
 000015 func[0]:
  000017: 01                         | nop
+ 000018: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -39,4 +39,5 @@ param-multi.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 000019 func[0]:
+ 00001b: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -85,10 +85,14 @@ Code Disassembly:
 
 000025 func[0]:
  000027: 41 00                      | i32.const 0
+ 000029: 0b                         | end
 00002a func[1]:
  00002c: 42 00                      | i64.const 0
+ 00002e: 0b                         | end
 00002f func[2]:
  000031: 43 00 00 00 00             | f32.const 0x0p+0
+ 000036: 0b                         | end
 000037 func[3]:
  000039: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
+ 000042: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -56,6 +56,8 @@ Code Disassembly:
 00001a func[0]:
  00001c: 41 2a                      | i32.const 0x2a
  00001e: 0f                         | return
+ 00001f: 0b                         | end
 000020 func[1]:
  000022: 0f                         | return
+ 000023: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -107,4 +107,5 @@ Code Disassembly:
  000047: 41 01                      | i32.const 0x1
  000049: 1b                         | select
  00004a: 1a                         | drop
+ 00004b: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -54,4 +54,5 @@ Code Disassembly:
 000020 func[0]:
  000022: 43 00 00 00 40             | f32.const 0x1p+1
  000027: 24 00                      | set_global 0
+ 000029: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -98,4 +98,5 @@ Code Disassembly:
  000039: 21 04                      | set_local 0x4
  00003b: 43 00 00 00 00             | f32.const 0x0p+0
  000040: 21 05                      | set_local 0x5
+ 000042: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -118,4 +118,5 @@ Code Disassembly:
  000053: 21 06                      | set_local 0x6
  000055: 42 00                      | i64.const 0
  000057: 21 07                      | set_local 0x7
+ 000059: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -252,4 +252,5 @@ Code Disassembly:
  000085: 41 00                      | i32.const 0
  000087: 42 00                      | i64.const 0
  000089: 37 03 00                   | i64.store 3 0
+ 00008c: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -161,4 +161,5 @@ Code Disassembly:
  000057: 41 00                      | i32.const 0
  000059: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
  000062: 39 03 00                   | f64.store 3 0
+ 000065: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/string-escape.txt
+++ b/test/dump/string-escape.txt
@@ -45,4 +45,5 @@ string-escape.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 000043 func[0]:
+ 000045: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/string-hex.txt
+++ b/test/dump/string-hex.txt
@@ -43,4 +43,5 @@ string-hex.wasm:	file format wasm 0x000001
 Code Disassembly:
 
 000022 func[0]:
+ 000024: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -111,7 +111,10 @@ Elem:
 Code Disassembly:
 
 000034 func[0]:
+ 000036: 0b                         | end
 000037 func[1]:
+ 000039: 0b                         | end
 00003a func[2]:
  00003c: 44 00 00 00 00 00 00 00 00 | f64.const 0x0p+0
+ 000045: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -49,4 +49,5 @@ Code Disassembly:
  000019: 41 00                      | i32.const 0
  00001b: 22 00                      | tee_local 0
  00001d: 1a                         | drop
+ 00001e: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -129,4 +129,5 @@ Code Disassembly:
  00003f: 99                         | f64.abs
  000040: 9a                         | f64.neg
  000041: 1a                         | drop
+ 000042: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -38,4 +38,5 @@ Code Disassembly:
 
 000015 func[0]:
  000017: 00                         | unreachable
+ 000018: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -46,8 +46,10 @@ Code Disassembly:
  000034: 41 01                      | i32.const 0x1
  000036: 10 80 80 80 80 00          | call 0
            000037: R_FUNC_INDEX_LEB	0
+ 00003c: 0b                         | end
 00003d func[1]:
  00003f: 41 02                      | i32.const 0x2
  000041: 10 81 80 80 80 00          | call 0x1
            000042: R_FUNC_INDEX_LEB	0
+ 000047: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -55,6 +55,7 @@ Code Disassembly:
            000052: R_FUNC_INDEX_LEB	0
  000057: 10 82 80 80 80 00          | call 0x2
            000058: R_FUNC_INDEX_LEB	1
+ 00005d: 0b                         | end
 00005e func[3]:
  000060: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000069: 10 81 80 80 80 00          | call 0x1
@@ -62,4 +63,5 @@ Code Disassembly:
  00006f: 42 0a                      | i64.const 10
  000071: 10 83 80 80 80 00          | call 0x3
            000072: R_FUNC_INDEX_LEB	1
+ 000077: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -69,6 +69,7 @@ Code Disassembly:
            00007b: R_FUNC_INDEX_LEB	0
  000080: 10 83 80 80 80 00          | call 0x3
            000081: R_FUNC_INDEX_LEB	1
+ 000086: 0b                         | end
 000087 func[4]:
  000089: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000092: 10 81 80 80 80 00          | call 0x1
@@ -76,6 +77,7 @@ Code Disassembly:
  000098: 42 0a                      | i64.const 10
  00009a: 10 84 80 80 80 00          | call 0x4
            00009b: R_FUNC_INDEX_LEB	1
+ 0000a0: 0b                         | end
 0000a1 func[5]:
  0000a3: 43 00 00 80 3f             | f32.const 0x1p+0
  0000a8: 10 82 80 80 80 00          | call 0x2
@@ -83,4 +85,5 @@ Code Disassembly:
  0000ae: 41 0a                      | i32.const 0xa
  0000b0: 10 85 80 80 80 00          | call 0x5
            0000b1: R_FUNC_INDEX_LEB	1
+ 0000b6: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -71,6 +71,7 @@ Code Disassembly:
  00006e: 6a                         | i32.add
  00006f: 10 80 80 80 80 00          | call 0
            000070: R_FUNC_INDEX_LEB	0
+ 000075: 0b                         | end
 000076 func[1]:
  000078: 23 81 80 80 80 00          | get_global 0x1
            000079: R_GLOBAL_INDEX_LEB	0
@@ -78,4 +79,5 @@ Code Disassembly:
            00007f: R_GLOBAL_INDEX_LEB	1
  000084: 10 81 80 80 80 00          | call 0x1
            000085: R_FUNC_INDEX_LEB	0
+ 00008a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -97,6 +97,7 @@ Code Disassembly:
            0000b5: R_FUNC_INDEX_LEB	0
  0000ba: 10 83 80 80 80 00          | call 0x3
            0000bb: R_FUNC_INDEX_LEB	1
+ 0000c0: 0b                         | end
 0000c1 func[4]:
  0000c3: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  0000cc: 10 81 80 80 80 00          | call 0x1
@@ -104,6 +105,7 @@ Code Disassembly:
  0000d2: 42 0a                      | i64.const 10
  0000d4: 10 84 80 80 80 00          | call 0x4
            0000d5: R_FUNC_INDEX_LEB	1
+ 0000da: 0b                         | end
 0000db func[5]:
  0000dd: 43 00 00 80 3f             | f32.const 0x1p+0
  0000e2: 10 82 80 80 80 00          | call 0x2
@@ -111,4 +113,5 @@ Code Disassembly:
  0000e8: 41 0a                      | i32.const 0xa
  0000ea: 10 85 80 80 80 00          | call 0x5
            0000eb: R_FUNC_INDEX_LEB	1
+ 0000f0: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -84,19 +84,24 @@ Code Disassembly:
 000078 func[0]:
  00007a: 43 00 00 80 3f             | f32.const 0x1p+0
  00007f: 0f                         | return
+ 000080: 0b                         | end
 000081 func[1]:
  000083: 10 83 80 80 80 00          | call 0x3
            000084: R_FUNC_INDEX_LEB	0
  000089: 0f                         | return
+ 00008a: 0b                         | end
 00008b func[2]:
  00008d: 10 84 80 80 80 00          | call 0x4
            00008e: R_FUNC_INDEX_LEB	1
  000093: 0f                         | return
+ 000094: 0b                         | end
 000095 func[3]:
  000097: 41 2a                      | i32.const 0x2a
  000099: 0f                         | return
+ 00009a: 0b                         | end
 00009b func[4]:
  00009d: 42 e3 00                   | i64.const 99
  0000a0: 0f                         | return
+ 0000a1: 0b                         | end
 5/5 tests passed.
 ;;; STDOUT ;;)

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -65,12 +65,15 @@ Code Disassembly:
  000056: 41 01                      | i32.const 0x1
  000058: 10 83 80 80 80 00          | call 0x3
            000059: R_FUNC_INDEX_LEB	0
+ 00005e: 0b                         | end
 00005f <$name2>:
  000061: 42 01                      | i64.const 1
  000063: 10 81 80 80 80 00          | call 0x1
            000064: R_FUNC_INDEX_LEB	1
+ 000069: 0b                         | end
 00006a <$name3>:
  00006c: 41 02                      | i32.const 0x2
  00006e: 10 83 80 80 80 00          | call 0x3
            00006f: R_FUNC_INDEX_LEB	0
+ 000074: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -53,6 +53,9 @@ Custom:
 Code Disassembly:
 
 000054 func[0]:
+ 000056: 0b                         | end
 000057 func[1]:
+ 000059: 0b                         | end
 00005a func[2]:
+ 00005c: 0b                         | end
 ;;; STDOUT ;;)


### PR DESCRIPTION
Without this objdump doesn't show the final byte/opcode
of each function.