### PR TITLE
Fix lexing from binary buffer

### DIFF
--- a/src/ast-lexer.cc
+++ b/src/ast-lexer.cc
@@ -149,7 +149,7 @@ static Result fill(Location* loc,
     size_t bytes_left = lexer->source.buffer.size - offset;
     if (read_size > bytes_left)
       read_size = bytes_left;
-    memcpy(lexer->buffer,
+    memcpy(lexer->limit,
            static_cast<const char*>(lexer->source.buffer.data) + offset,
            read_size);
     lexer->source.buffer.read_offset += read_size;

--- a/src/prebuilt/ast-lexer-gen.cc
+++ b/src/prebuilt/ast-lexer-gen.cc
@@ -151,7 +151,7 @@ static Result fill(Location* loc,
     size_t bytes_left = lexer->source.buffer.size - offset;
     if (read_size > bytes_left)
       read_size = bytes_left;
-    memcpy(lexer->buffer,
+    memcpy(lexer->limit,
            static_cast<const char*>(lexer->source.buffer.data) + offset,
            read_size);
     lexer->source.buffer.read_offset += read_size;


### PR DESCRIPTION
Fix bug when lexing from buffer where subsequent read from the buffer overwrites bytes still available.
Once the lexing reaches the end of the current read buffer, it currently copies the remaining bytes at the beginning of the read buffer instead of the end. This means it overwrites bytes that hasn't been read yet.

ie:
```cpp
// full wast  `(module (func $dummy))`
// initial buffer size = 12
// Before Fill()
lexer->buffer = "(module (fun";
lexer->token = "(fun";
// calling fill because there is not enough content left in the read buffer

// after fill now
lexer->token = lexer->buffer = " $dummy))";

// after fill with this fix
lexer->token = lexer->buffer = "(func $dummy))"
```
