### PR TITLE
MSVC++ 12.0 float hex string parse workaround

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -203,6 +203,14 @@ __inline unsigned __int64 __popcnt64(unsigned __int64 value) {
 #endif
 #define wabt_popcount_u64 __popcnt64
 
+#if _MSC_VER <= 1800
+// Reimplement buggy strtof and strtod
+namespace wabt {
+    float strtof(const char *nptr, char **endptr);
+    double strtod(const char *nptr, char **endptr);
+};
+#endif
+
 #else
 
 #error unknown compiler


### PR DESCRIPTION
Allow parse_double_hex and parse_float_hex to parse strings without a power.

In MSVC++ 12.0 (and previous versions ?) the float parsing doesn't support hex strings.
Not totally sure if it's a bug or just not supported, but this change is a workaround it for older MSVC compilers.

I tried to minimize changes to not affect modern compilers as `strtof` and `strtod` give the right result.
I used `parse_float_hex` and `parse_double_hex` to parse hex strings and fallback on normal implementation if not an hex string.