### PR TITLE
wasmdump: Improve printing on relocation information

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -253,8 +253,18 @@ static void log_opcode(Context* ctx,
           ctx->section_starts[static_cast<size_t>(BinarySection::Code)];
       size_t abs_offset = code_start + reloc->offset;
       if (ctx->last_opcode_end > abs_offset) {
-        printf("           %06" PRIzx ": %s\t%d\n", abs_offset,
+        printf("           %06" PRIzx ": %s\t%d", abs_offset,
                get_reloc_type_name(reloc->type), reloc->index);
+        switch (reloc->type) {
+          case RelocType::MemoryAddressLEB:
+          case RelocType::MemoryAddressSLEB:
+          case RelocType::MemoryAddressI32:
+            printf(" + %d", reloc->addend);
+            break;
+          default:
+            break;
+        }
+        printf("\n");
         ctx->next_reloc++;
       }
     }
@@ -633,8 +643,8 @@ Result on_reloc(RelocType type,
   Context* ctx = static_cast<Context*>(user_data);
   uint32_t total_offset =
       ctx->section_starts[static_cast<size_t>(ctx->reloc_section)] + offset;
-  print_details(ctx, "   - %-18s offset=%#x (%#x)\n", get_reloc_type_name(type),
-                total_offset, offset);
+  print_details(ctx, "   - %s\tidx=%#x\toffset=%#x(file=%#x)\taddend=%#x\n",
+                get_reloc_type_name(type), index, offset, total_offset, addend);
   if (ctx->options->mode == ObjdumpMode::Prepass &&
       ctx->reloc_section == BinarySection::Code) {
     Reloc reloc;

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -253,7 +253,7 @@ static void log_opcode(Context* ctx,
           ctx->section_starts[static_cast<size_t>(BinarySection::Code)];
       size_t abs_offset = code_start + reloc->offset;
       if (ctx->last_opcode_end > abs_offset) {
-        printf("           %06" PRIzx ": %s\t%d", abs_offset,
+        printf("           %06" PRIzx ": %-18s %d", abs_offset,
                get_reloc_type_name(reloc->type), reloc->index);
         switch (reloc->type) {
           case RelocType::MemoryAddressLEB:
@@ -643,8 +643,8 @@ Result on_reloc(RelocType type,
   Context* ctx = static_cast<Context*>(user_data);
   uint32_t total_offset =
       ctx->section_starts[static_cast<size_t>(ctx->reloc_section)] + offset;
-  print_details(ctx, "   - %s\tidx=%#x\toffset=%#x(file=%#x)\taddend=%#x\n",
-                get_reloc_type_name(type), index, offset, total_offset, addend);
+  print_details(ctx, "   - %-18s idx=%#-4x addend=%#-4x offset=%#x(file=%#x)\n",
+                get_reloc_type_name(type), index, addend, offset, total_offset);
   if (ctx->options->mode == ObjdumpMode::Prepass &&
       ctx->reloc_section == BinarySection::Code) {
     Reloc reloc;

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -37,8 +37,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x37 (0x6)
-   - R_FUNC_INDEX_LEB   offset=0x42 (0x11)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x37)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x11(file=0x42)	addend=0
 
 Code Disassembly:
 

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -37,19 +37,19 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x37)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x11(file=0x42)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x37)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x11(file=0x42)
 
 Code Disassembly:
 
 000032 func[0]:
  000034: 41 01                      | i32.const 0x1
  000036: 10 80 80 80 80 00          | call 0
-           000037: R_FUNC_INDEX_LEB	0
+           000037: R_FUNC_INDEX_LEB   0
  00003c: 0b                         | end
 00003d func[1]:
  00003f: 41 02                      | i32.const 0x2
  000041: 10 81 80 80 80 00          | call 0x1
-           000042: R_FUNC_INDEX_LEB	0
+           000042: R_FUNC_INDEX_LEB   0
  000047: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -42,10 +42,10 @@ Function:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x52 (0x6)
-   - R_FUNC_INDEX_LEB   offset=0x58 (0xc)
-   - R_FUNC_INDEX_LEB   offset=0x6a (0x1e)
-   - R_FUNC_INDEX_LEB   offset=0x72 (0x26)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x52)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xc(file=0x58)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x1e(file=0x6a)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x26(file=0x72)	addend=0
 
 Code Disassembly:
 

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -42,26 +42,26 @@ Function:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x52)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xc(file=0x58)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x1e(file=0x6a)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x26(file=0x72)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x52)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xc(file=0x58)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1e(file=0x6a)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x26(file=0x72)
 
 Code Disassembly:
 
 00004d func[2]:
  00004f: 20 00                      | get_local 0
  000051: 10 80 80 80 80 00          | call 0
-           000052: R_FUNC_INDEX_LEB	0
+           000052: R_FUNC_INDEX_LEB   0
  000057: 10 82 80 80 80 00          | call 0x2
-           000058: R_FUNC_INDEX_LEB	1
+           000058: R_FUNC_INDEX_LEB   1
  00005d: 0b                         | end
 00005e func[3]:
  000060: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000069: 10 81 80 80 80 00          | call 0x1
-           00006a: R_FUNC_INDEX_LEB	0
+           00006a: R_FUNC_INDEX_LEB   0
  00006f: 42 0a                      | i64.const 10
  000071: 10 83 80 80 80 00          | call 0x3
-           000072: R_FUNC_INDEX_LEB	1
+           000072: R_FUNC_INDEX_LEB   1
  000077: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -54,36 +54,36 @@ Function:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x7b)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xc(file=0x81)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x1e(file=0x93)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x26(file=0x9b)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x34(file=0xa9)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x3c(file=0xb1)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x7b)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xc(file=0x81)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1e(file=0x93)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x26(file=0x9b)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x34(file=0xa9)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x3c(file=0xb1)
 
 Code Disassembly:
 
 000076 func[3]:
  000078: 20 00                      | get_local 0
  00007a: 10 80 80 80 80 00          | call 0
-           00007b: R_FUNC_INDEX_LEB	0
+           00007b: R_FUNC_INDEX_LEB   0
  000080: 10 83 80 80 80 00          | call 0x3
-           000081: R_FUNC_INDEX_LEB	1
+           000081: R_FUNC_INDEX_LEB   1
  000086: 0b                         | end
 000087 func[4]:
  000089: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000092: 10 81 80 80 80 00          | call 0x1
-           000093: R_FUNC_INDEX_LEB	0
+           000093: R_FUNC_INDEX_LEB   0
  000098: 42 0a                      | i64.const 10
  00009a: 10 84 80 80 80 00          | call 0x4
-           00009b: R_FUNC_INDEX_LEB	1
+           00009b: R_FUNC_INDEX_LEB   1
  0000a0: 0b                         | end
 0000a1 func[5]:
  0000a3: 43 00 00 80 3f             | f32.const 0x1p+0
  0000a8: 10 82 80 80 80 00          | call 0x2
-           0000a9: R_FUNC_INDEX_LEB	0
+           0000a9: R_FUNC_INDEX_LEB   0
  0000ae: 41 0a                      | i32.const 0xa
  0000b0: 10 85 80 80 80 00          | call 0x5
-           0000b1: R_FUNC_INDEX_LEB	1
+           0000b1: R_FUNC_INDEX_LEB   1
  0000b6: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -54,12 +54,12 @@ Function:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x7b (0x6)
-   - R_FUNC_INDEX_LEB   offset=0x81 (0xc)
-   - R_FUNC_INDEX_LEB   offset=0x93 (0x1e)
-   - R_FUNC_INDEX_LEB   offset=0x9b (0x26)
-   - R_FUNC_INDEX_LEB   offset=0xa9 (0x34)
-   - R_FUNC_INDEX_LEB   offset=0xb1 (0x3c)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x7b)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xc(file=0x81)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x1e(file=0x93)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x26(file=0x9b)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x34(file=0xa9)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x3c(file=0xb1)	addend=0
 
 Code Disassembly:
 

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -50,34 +50,34 @@ Global:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_GLOBAL_INDEX_LEB	idx=0x2	offset=0x4(file=0x5c)	addend=0
-   - R_GLOBAL_INDEX_LEB	idx=0x1	offset=0xa(file=0x62)	addend=0
-   - R_GLOBAL_INDEX_LEB	idx=0	offset=0x11(file=0x69)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x18(file=0x70)	addend=0
-   - R_GLOBAL_INDEX_LEB	idx=0	offset=0x21(file=0x79)	addend=0
-   - R_GLOBAL_INDEX_LEB	idx=0x1	offset=0x27(file=0x7f)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x2d(file=0x85)	addend=0
+   - R_GLOBAL_INDEX_LEB idx=0x2  addend=0    offset=0x4(file=0x5c)
+   - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0xa(file=0x62)
+   - R_GLOBAL_INDEX_LEB idx=0    addend=0    offset=0x11(file=0x69)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x18(file=0x70)
+   - R_GLOBAL_INDEX_LEB idx=0    addend=0    offset=0x21(file=0x79)
+   - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0x27(file=0x7f)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x2d(file=0x85)
 
 Code Disassembly:
 
 000059 func[0]:
  00005b: 23 83 80 80 80 00          | get_global 0x3
-           00005c: R_GLOBAL_INDEX_LEB	2
+           00005c: R_GLOBAL_INDEX_LEB 2
  000061: 23 82 80 80 80 00          | get_global 0x2
-           000062: R_GLOBAL_INDEX_LEB	1
+           000062: R_GLOBAL_INDEX_LEB 1
  000067: 6a                         | i32.add
  000068: 23 80 80 80 80 00          | get_global 0
-           000069: R_GLOBAL_INDEX_LEB	0
+           000069: R_GLOBAL_INDEX_LEB 0
  00006e: 6a                         | i32.add
  00006f: 10 80 80 80 80 00          | call 0
-           000070: R_FUNC_INDEX_LEB	0
+           000070: R_FUNC_INDEX_LEB   0
  000075: 0b                         | end
 000076 func[1]:
  000078: 23 81 80 80 80 00          | get_global 0x1
-           000079: R_GLOBAL_INDEX_LEB	0
+           000079: R_GLOBAL_INDEX_LEB 0
  00007e: 23 84 80 80 80 00          | get_global 0x4
-           00007f: R_GLOBAL_INDEX_LEB	1
+           00007f: R_GLOBAL_INDEX_LEB 1
  000084: 10 81 80 80 80 00          | call 0x1
-           000085: R_FUNC_INDEX_LEB	0
+           000085: R_FUNC_INDEX_LEB   0
  00008a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -50,13 +50,13 @@ Global:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_GLOBAL_INDEX_LEB offset=0x5c (0x4)
-   - R_GLOBAL_INDEX_LEB offset=0x62 (0xa)
-   - R_GLOBAL_INDEX_LEB offset=0x69 (0x11)
-   - R_FUNC_INDEX_LEB   offset=0x70 (0x18)
-   - R_GLOBAL_INDEX_LEB offset=0x79 (0x21)
-   - R_GLOBAL_INDEX_LEB offset=0x7f (0x27)
-   - R_FUNC_INDEX_LEB   offset=0x85 (0x2d)
+   - R_GLOBAL_INDEX_LEB	idx=0x2	offset=0x4(file=0x5c)	addend=0
+   - R_GLOBAL_INDEX_LEB	idx=0x1	offset=0xa(file=0x62)	addend=0
+   - R_GLOBAL_INDEX_LEB	idx=0	offset=0x11(file=0x69)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x18(file=0x70)	addend=0
+   - R_GLOBAL_INDEX_LEB	idx=0	offset=0x21(file=0x79)	addend=0
+   - R_GLOBAL_INDEX_LEB	idx=0x1	offset=0x27(file=0x7f)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x2d(file=0x85)	addend=0
 
 Code Disassembly:
 

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -72,22 +72,22 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   offset=0x8a (0x6)
-   - R_FUNC_INDEX_LEB   offset=0x8f (0xb)
-   - R_FUNC_INDEX_LEB   offset=0x94 (0x10)
-   - R_FUNC_INDEX_LEB   offset=0x99 (0x15)
-   - R_FUNC_INDEX_LEB   offset=0x9e (0x1a)
-   - R_FUNC_INDEX_LEB   offset=0xa3 (0x1f)
-   - R_FUNC_INDEX_LEB   offset=0xa8 (0x24)
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x6(file=0x8a)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xb(file=0x8f)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x10(file=0x94)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x15(file=0x99)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x1a(file=0x9e)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x1f(file=0xa3)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x24(file=0xa8)	addend=0
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0xb5 (0x6)
-   - R_FUNC_INDEX_LEB   offset=0xbb (0xc)
-   - R_FUNC_INDEX_LEB   offset=0xcd (0x1e)
-   - R_FUNC_INDEX_LEB   offset=0xd5 (0x26)
-   - R_FUNC_INDEX_LEB   offset=0xe3 (0x34)
-   - R_FUNC_INDEX_LEB   offset=0xeb (0x3c)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0xb5)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xc(file=0xbb)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x1e(file=0xcd)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x26(file=0xd5)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x34(file=0xe3)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x3c(file=0xeb)	addend=0
 
 Code Disassembly:
 

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -72,46 +72,46 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x6(file=0x8a)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xb(file=0x8f)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x10(file=0x94)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x15(file=0x99)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x1a(file=0x9e)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x1f(file=0xa3)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x24(file=0xa8)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x6(file=0x8a)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xb(file=0x8f)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x10(file=0x94)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x15(file=0x99)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1a(file=0x9e)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1f(file=0xa3)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x24(file=0xa8)
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0xb5)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0xc(file=0xbb)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x1e(file=0xcd)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x26(file=0xd5)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x34(file=0xe3)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x3c(file=0xeb)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0xb5)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xc(file=0xbb)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1e(file=0xcd)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x26(file=0xd5)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x34(file=0xe3)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x3c(file=0xeb)
 
 Code Disassembly:
 
 0000b0 func[3]:
  0000b2: 20 00                      | get_local 0
  0000b4: 10 80 80 80 80 00          | call 0
-           0000b5: R_FUNC_INDEX_LEB	0
+           0000b5: R_FUNC_INDEX_LEB   0
  0000ba: 10 83 80 80 80 00          | call 0x3
-           0000bb: R_FUNC_INDEX_LEB	1
+           0000bb: R_FUNC_INDEX_LEB   1
  0000c0: 0b                         | end
 0000c1 func[4]:
  0000c3: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  0000cc: 10 81 80 80 80 00          | call 0x1
-           0000cd: R_FUNC_INDEX_LEB	0
+           0000cd: R_FUNC_INDEX_LEB   0
  0000d2: 42 0a                      | i64.const 10
  0000d4: 10 84 80 80 80 00          | call 0x4
-           0000d5: R_FUNC_INDEX_LEB	1
+           0000d5: R_FUNC_INDEX_LEB   1
  0000da: 0b                         | end
 0000db func[5]:
  0000dd: 43 00 00 80 3f             | f32.const 0x1p+0
  0000e2: 10 82 80 80 80 00          | call 0x2
-           0000e3: R_FUNC_INDEX_LEB	0
+           0000e3: R_FUNC_INDEX_LEB   0
  0000e8: 41 0a                      | i32.const 0xa
  0000ea: 10 85 80 80 80 00          | call 0x5
-           0000eb: R_FUNC_INDEX_LEB	1
+           0000eb: R_FUNC_INDEX_LEB   1
  0000f0: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -76,8 +76,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x84 (0xd)
-   - R_FUNC_INDEX_LEB   offset=0x8e (0x17)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0xd(file=0x84)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x17(file=0x8e)	addend=0
 
 Code Disassembly:
 

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -76,8 +76,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB	idx=0	offset=0xd(file=0x84)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x17(file=0x8e)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0xd(file=0x84)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x17(file=0x8e)
 
 Code Disassembly:
 
@@ -87,12 +87,12 @@ Code Disassembly:
  000080: 0b                         | end
 000081 func[1]:
  000083: 10 83 80 80 80 00          | call 0x3
-           000084: R_FUNC_INDEX_LEB	0
+           000084: R_FUNC_INDEX_LEB   0
  000089: 0f                         | return
  00008a: 0b                         | end
 00008b func[2]:
  00008d: 10 84 80 80 80 00          | call 0x4
-           00008e: R_FUNC_INDEX_LEB	1
+           00008e: R_FUNC_INDEX_LEB   1
  000093: 0f                         | return
  000094: 0b                         | end
 000095 func[3]:

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -55,9 +55,9 @@ Custom:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x59 (0x6)
-   - R_FUNC_INDEX_LEB   offset=0x64 (0x11)
-   - R_FUNC_INDEX_LEB   offset=0x6f (0x1c)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x59)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x11(file=0x64)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x1c(file=0x6f)	addend=0
 
 Code Disassembly:
 

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -55,25 +55,25 @@ Custom:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x59)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x11(file=0x64)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x1c(file=0x6f)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x59)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x11(file=0x64)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1c(file=0x6f)
 
 Code Disassembly:
 
 000054 <$name1>:
  000056: 41 01                      | i32.const 0x1
  000058: 10 83 80 80 80 00          | call 0x3
-           000059: R_FUNC_INDEX_LEB	0
+           000059: R_FUNC_INDEX_LEB   0
  00005e: 0b                         | end
 00005f <$name2>:
  000061: 42 01                      | i64.const 1
  000063: 10 81 80 80 80 00          | call 0x1
-           000064: R_FUNC_INDEX_LEB	1
+           000064: R_FUNC_INDEX_LEB   1
  000069: 0b                         | end
 00006a <$name3>:
  00006c: 41 02                      | i32.const 0x2
  00006e: 10 83 80 80 80 00          | call 0x3
-           00006f: R_FUNC_INDEX_LEB	0
+           00006f: R_FUNC_INDEX_LEB   0
  000074: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -44,11 +44,11 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   offset=0x38 (0x6)
-   - R_FUNC_INDEX_LEB   offset=0x3d (0xb)
-   - R_FUNC_INDEX_LEB   offset=0x42 (0x10)
-   - R_FUNC_INDEX_LEB   offset=0x47 (0x15)
-   - R_FUNC_INDEX_LEB   offset=0x4c (0x1a)
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x38)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0xb(file=0x3d)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x10(file=0x42)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x15(file=0x47)	addend=0
+   - R_FUNC_INDEX_LEB	idx=0	offset=0x1a(file=0x4c)	addend=0
 
 Code Disassembly:
 

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -44,11 +44,11 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x6(file=0x38)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0xb(file=0x3d)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0x1	offset=0x10(file=0x42)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x15(file=0x47)	addend=0
-   - R_FUNC_INDEX_LEB	idx=0	offset=0x1a(file=0x4c)	addend=0
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x38)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0xb(file=0x3d)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x10(file=0x42)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x15(file=0x47)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1a(file=0x4c)
 
 Code Disassembly:
 


### PR DESCRIPTION
Print the addend and make it more clear what the
different offsets mean.