### PR TITLE
wasmdump: Fix output of local names

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -598,15 +598,12 @@ static Result on_function_name(uint32_t index,
                                StringSlice name,
                                void* user_data) {
   Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - func[%d] " PRIstringslice "\n", index,
-                WABT_PRINTF_STRING_SLICE_ARG(name));
   if (ctx->options->mode == ObjdumpMode::Prepass) {
-    while (ctx->options->function_names.size() < index) {
-      ctx->options->function_names.emplace_back();
-    }
-    if (ctx->options->function_names.size() == index) {
-      ctx->options->function_names.push_back(string_slice_to_string(name));
-    }
+    ctx->options->function_names.resize(index+1);
+    ctx->options->function_names[index] = string_slice_to_string(name);
+  } else {
+    print_details(ctx, " - func[%d] " PRIstringslice "\n", index,
+                  WABT_PRINTF_STRING_SLICE_ARG(name));
   }
   return Result::Ok;
 }
@@ -617,8 +614,8 @@ static Result on_local_name(uint32_t func_index,
                             void* user_data) {
   Context* ctx = static_cast<Context*>(user_data);
   if (name.length) {
-    print_details(ctx, "  - local[%d] " PRIstringslice "\n", local_index,
-                  WABT_PRINTF_STRING_SLICE_ARG(name));
+    print_details(ctx, " - func[%d] local[%d] " PRIstringslice "\n", func_index,
+                  local_index, WABT_PRINTF_STRING_SLICE_ARG(name));
   }
   return Result::Ok;
 }

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -265,7 +265,7 @@ static void write_string(Stream* stream,
 
 #define FIXUP_SIZE(STREAM)                                                  \
   write_fixed_u32_leb128_at(STREAM, fixup_offset, (STREAM)->offset - start, \
-                            "fixup size");                              \
+                            "fixup size");                                  \
   }
 
 static void write_table_section(Context* ctx,

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -118,12 +118,12 @@ Custom:
  - name: "name"
  - func[0] $F1
  - func[1] $F2
-  - local[0] $F1P0
-  - local[1] $F1L1
-  - local[2] $F1L2
-  - local[0] $F2P0
-  - local[1] $F2L1
-  - local[3] $F2L3
+ - func[0] local[0] $F1P0
+ - func[0] local[1] $F1L1
+ - func[0] local[2] $F1L2
+ - func[1] local[0] $F2P0
+ - func[1] local[1] $F2L1
+ - func[1] local[3] $F2L3
 
 Code Disassembly:
 


### PR DESCRIPTION
Previously we could nest the local names inside the
function names, but in the new names sections the locals
all come later on.