### PR TITLE
wasmlink: Fix function indexes in name section

### DIFF
--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -10,6 +10,7 @@
   (func $name2 (param $param2 i64)
      i64.const 1
      call 1)
+  (func (param $param2 i64))
 )
 (module
   (export "baz" (func 0))
@@ -24,11 +25,11 @@ Sections:
 
      Type start=0x0000000a end=0x0000001a (size=0x00000010) count: 4
    Import start=0x00000020 end=0x00000034 (size=0x00000014) count: 1
- Function start=0x0000003a end=0x0000003e (size=0x00000004) count: 3
-   Export start=0x00000044 end=0x00000051 (size=0x0000000d) count: 2
-     Code start=0x00000053 end=0x00000075 (size=0x00000022) count: 3
-   Custom start=0x0000007b end=0x000000ae (size=0x00000033) "name"
-   Custom start=0x000000b4 end=0x000000ca (size=0x00000016) "reloc.Code"
+ Function start=0x0000003a end=0x0000003f (size=0x00000005) count: 4
+   Export start=0x00000045 end=0x00000052 (size=0x0000000d) count: 2
+     Code start=0x00000054 end=0x00000079 (size=0x00000025) count: 4
+   Custom start=0x0000007f end=0x000000b2 (size=0x00000033) "name"
+   Custom start=0x000000b8 end=0x000000ce (size=0x00000016) "reloc.Code"
 
 Section Details:
 
@@ -42,38 +43,41 @@ Import:
 Function:
  - func[1] sig=1
  - func[2] sig=2
- - func[3] sig=3
+ - func[3] sig=2
+ - func[4] sig=3
 Export:
  - func[1] foo
- - func[3] baz
+ - func[4] baz
 Custom:
  - name: "name"
  - func[0] $import_func2
  - func[1] $name1
  - func[2] $name2
- - func[3] $name3
+ - func[4] $name3
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x59)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x11(file=0x64)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1c(file=0x6f)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x5a)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x11(file=0x65)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1f(file=0x73)
 
 Code Disassembly:
 
-000054 <$name1>:
- 000056: 41 01                      | i32.const 0x1
- 000058: 10 83 80 80 80 00          | call 0x3
-           000059: R_FUNC_INDEX_LEB   0
- 00005e: 0b                         | end
-00005f <$name2>:
- 000061: 42 01                      | i64.const 1
- 000063: 10 81 80 80 80 00          | call 0x1
-           000064: R_FUNC_INDEX_LEB   1
- 000069: 0b                         | end
-00006a <$name3>:
- 00006c: 41 02                      | i32.const 0x2
- 00006e: 10 83 80 80 80 00          | call 0x3
-           00006f: R_FUNC_INDEX_LEB   0
- 000074: 0b                         | end
+000055 <$name1>:
+ 000057: 41 01                      | i32.const 0x1
+ 000059: 10 84 80 80 80 00          | call 0x4
+           00005a: R_FUNC_INDEX_LEB   0
+ 00005f: 0b                         | end
+000060 <$name2>:
+ 000062: 42 01                      | i64.const 1
+ 000064: 10 81 80 80 80 00          | call 0x1
+           000065: R_FUNC_INDEX_LEB   1
+ 00006a: 0b                         | end
+00006b func[3]:
+ 00006d: 0b                         | end
+00006e <$name3>:
+ 000070: 41 02                      | i32.const 0x2
+ 000072: 10 84 80 80 80 00          | call 0x4
+           000073: R_FUNC_INDEX_LEB   0
+ 000078: 0b                         | end
 ;;; STDOUT ;;)


### PR DESCRIPTION
The code was assuming that all functions were named
and using a simple increment rather than calculating
the actual function index in the new binary.