### PR TITLE
Use classes + virtual functions for BinaryReader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ add_library(libwabt STATIC
   src/validator.cc
 
   src/binary-reader.cc
+  src/binary-reader-logging.cc
   src/binary-writer.cc
   src/binary-writer-spec.cc
   src/binary-reader-ast.cc

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-#include "binary-reader.h"
+#include "binary-reader-nop.h"
 #include "wasm-link.h"
 
 #define RELOC_SIZE 5
@@ -28,21 +28,74 @@ namespace link {
 
 namespace {
 
-struct Context {
+class BinaryReaderLinker : public BinaryReaderNop {
+ public:
+  explicit BinaryReaderLinker(LinkerInputBinary* binary);
+
+  virtual Result BeginSection(BinarySection section_type, uint32_t size);
+
+  virtual Result BeginCustomSection(uint32_t size, StringSlice section_name);
+
+  virtual Result OnImport(uint32_t index,
+                          StringSlice module_name,
+                          StringSlice field_name);
+  virtual Result OnImportFunc(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              uint32_t func_index,
+                              uint32_t sig_index);
+  virtual Result OnImportGlobal(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t global_index,
+                                Type type,
+                                bool mutable_);
+
+  virtual Result OnTable(uint32_t index,
+                         Type elem_type,
+                         const Limits* elem_limits);
+
+  virtual Result OnMemory(uint32_t index, const Limits* limits);
+
+  virtual Result OnExport(uint32_t index,
+                          ExternalKind kind,
+                          uint32_t item_index,
+                          StringSlice name);
+
+  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
+                                                 uint32_t count);
+
+  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index);
+  virtual Result OnDataSegmentData(uint32_t index,
+                                   const void* data,
+                                   uint32_t size);
+
+  virtual Result OnFunctionName(uint32_t function_index,
+                                StringSlice function_name);
+
+  virtual Result OnRelocCount(uint32_t count,
+                              BinarySection section_code,
+                              StringSlice section_name);
+  virtual Result OnReloc(RelocType type,
+                         uint32_t offset,
+                         uint32_t index,
+                         int32_t addend);
+
+  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
+
+ private:
   LinkerInputBinary* binary;
 
-  Section* reloc_section;
-  Section* current_section;
+  Section* reloc_section = nullptr;
+  Section* current_section = nullptr;
 };
 
-}  // namespace
+BinaryReaderLinker::BinaryReaderLinker(LinkerInputBinary* binary)
+    : binary(binary) {}
 
-static Result on_reloc_count(uint32_t count,
-                             BinarySection section_code,
-                             StringSlice section_name,
-                             void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  LinkerInputBinary* binary = ctx->binary;
+Result BinaryReaderLinker::OnRelocCount(uint32_t count,
+                                        BinarySection section_code,
+                                        StringSlice section_name) {
   if (section_code == BinarySection::Custom) {
     WABT_FATAL("relocation for custom sections not yet supported\n");
   }
@@ -50,7 +103,7 @@ static Result on_reloc_count(uint32_t count,
   for (const std::unique_ptr<Section>& section : binary->sections) {
     if (section->section_code != section_code)
       continue;
-    ctx->reloc_section = section.get();
+    reloc_section = section.get();
     return Result::Ok;
   }
 
@@ -58,26 +111,22 @@ static Result on_reloc_count(uint32_t count,
   return Result::Error;
 }
 
-static Result on_reloc(RelocType type,
-                       uint32_t offset,
-                       uint32_t index,
-                       int32_t addend,
-                       void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-
-  if (offset + RELOC_SIZE > ctx->reloc_section->size) {
+Result BinaryReaderLinker::OnReloc(RelocType type,
+                                   uint32_t offset,
+                                   uint32_t index,
+                                   int32_t addend) {
+  if (offset + RELOC_SIZE > reloc_section->size) {
     WABT_FATAL("invalid relocation offset: %#x\n", offset);
   }
 
-  ctx->reloc_section->relocations.emplace_back(type, offset, index, addend);
+  reloc_section->relocations.emplace_back(type, offset, index, addend);
 
   return Result::Ok;
 }
 
-static Result on_import(uint32_t index,
-                        StringSlice module_name,
-                        StringSlice field_name,
-                        void* user_data) {
+Result BinaryReaderLinker::OnImport(uint32_t index,
+                                    StringSlice module_name,
+                                    StringSlice field_name) {
   if (!string_slice_eq_cstr(&module_name, WABT_LINK_MODULE_NAME)) {
     WABT_FATAL("unsupported import module: " PRIstringslice,
                WABT_PRINTF_STRING_SLICE_ARG(module_name));
@@ -85,50 +134,43 @@ static Result on_import(uint32_t index,
   return Result::Ok;
 }
 
-static Result on_import_func(uint32_t import_index,
-                             StringSlice module_name,
-                             StringSlice field_name,
-                             uint32_t global_index,
-                             uint32_t sig_index,
-                             void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  ctx->binary->function_imports.emplace_back();
-  FunctionImport* import = &ctx->binary->function_imports.back();
+Result BinaryReaderLinker::OnImportFunc(uint32_t import_index,
+                                        StringSlice module_name,
+                                        StringSlice field_name,
+                                        uint32_t global_index,
+                                        uint32_t sig_index) {
+  binary->function_imports.emplace_back();
+  FunctionImport* import = &binary->function_imports.back();
   import->name = field_name;
   import->sig_index = sig_index;
   import->active = true;
-  ctx->binary->active_function_imports++;
+  binary->active_function_imports++;
   return Result::Ok;
 }
 
-static Result on_import_global(uint32_t import_index,
-                               StringSlice module_name,
-                               StringSlice field_name,
-                               uint32_t global_index,
-                               Type type,
-                               bool mutable_,
-                               void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  ctx->binary->global_imports.emplace_back();
-  GlobalImport* import = &ctx->binary->global_imports.back();
+Result BinaryReaderLinker::OnImportGlobal(uint32_t import_index,
+                                          StringSlice module_name,
+                                          StringSlice field_name,
+                                          uint32_t global_index,
+                                          Type type,
+                                          bool mutable_) {
+  binary->global_imports.emplace_back();
+  GlobalImport* import = &binary->global_imports.back();
   import->name = field_name;
   import->type = type;
   import->mutable_ = mutable_;
-  ctx->binary->active_global_imports++;
+  binary->active_global_imports++;
   return Result::Ok;
 }
 
-static Result begin_section(BinaryReaderContext* ctx,
-                            BinarySection section_code,
-                            uint32_t size) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  LinkerInputBinary* binary = context->binary;
+Result BinaryReaderLinker::BeginSection(BinarySection section_code,
+                                        uint32_t size) {
   Section* sec = new Section();
   binary->sections.emplace_back(sec);
-  context->current_section = sec;
+  current_section = sec;
   sec->section_code = section_code;
   sec->size = size;
-  sec->offset = ctx->offset;
+  sec->offset = state->offset;
   sec->binary = binary;
 
   if (sec->section_code != BinarySection::Custom &&
@@ -143,16 +185,13 @@ static Result begin_section(BinaryReaderContext* ctx,
   return Result::Ok;
 }
 
-static Result begin_custom_section(BinaryReaderContext* ctx,
-                                   uint32_t size,
-                                   StringSlice section_name) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  LinkerInputBinary* binary = context->binary;
-  Section* sec = context->current_section;
-  sec->data_custom.name = section_name;
+Result BinaryReaderLinker::BeginCustomSection(uint32_t size,
+                                              StringSlice section_name) {
+  Section* sec = current_section;
+  sec->data.custom.name = section_name;
 
   /* Modify section size and offset to not include the name itself. */
-  size_t delta = ctx->offset - sec->offset;
+  size_t delta = state->offset - sec->offset;
   sec->offset = sec->offset + delta;
   sec->size = sec->size - delta;
   sec->payload_offset = sec->offset;
@@ -164,7 +203,8 @@ static Result begin_custom_section(BinaryReaderContext* ctx,
     size_t bytes_read = read_u32_leb128(
         &binary->data[sec->offset], &binary->data[binary->size], &name_type);
 
-    if (static_cast<NameSectionSubsection>(name_type) != NameSectionSubsection::Function) {
+    if (static_cast<NameSectionSubsection>(name_type) !=
+        NameSectionSubsection::Function) {
       WABT_FATAL("no function name section");
     }
 
@@ -172,14 +212,14 @@ static Result begin_custom_section(BinaryReaderContext* ctx,
     sec->payload_size -= bytes_read;
 
     uint32_t subsection_size;
-    bytes_read = read_u32_leb128(
-        &binary->data[sec->offset], &binary->data[binary->size], &subsection_size);
+    bytes_read = read_u32_leb128(&binary->data[sec->offset],
+                                 &binary->data[binary->size], &subsection_size);
 
     sec->payload_offset += bytes_read;
     sec->payload_size -= bytes_read;
 
-    bytes_read = read_u32_leb128(
-        &binary->data[sec->payload_offset], &binary->data[binary->size], &sec->count);
+    bytes_read = read_u32_leb128(&binary->data[sec->payload_offset],
+                                 &binary->data[binary->size], &sec->count);
     sec->payload_offset += bytes_read;
     sec->payload_size -= bytes_read;
 
@@ -201,144 +241,97 @@ static Result begin_custom_section(BinaryReaderContext* ctx,
   return Result::Ok;
 }
 
-static Result on_table(uint32_t index,
-                       Type elem_type,
-                       const Limits* elem_limits,
-                       void* user_data) {
+Result BinaryReaderLinker::OnTable(uint32_t index,
+                                   Type elem_type,
+                                   const Limits* elem_limits) {
   if (elem_limits->has_max && (elem_limits->max != elem_limits->initial))
     WABT_FATAL("Tables with max != initial not supported by wabt-link\n");
 
-  Context* ctx = static_cast<Context*>(user_data);
-  ctx->binary->table_elem_count = elem_limits->initial;
+  binary->table_elem_count = elem_limits->initial;
   return Result::Ok;
 }
 
-static Result on_elem_segment_function_index_count(BinaryReaderContext* ctx,
-                                                   uint32_t index,
-                                                   uint32_t count) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  Section* sec = context->current_section;
+Result BinaryReaderLinker::OnElemSegmentFunctionIndexCount(uint32_t index,
+                                                           uint32_t count) {
+  Section* sec = current_section;
 
   /* Modify the payload to include only the actual function indexes */
-  size_t delta = ctx->offset - sec->payload_offset;
+  size_t delta = state->offset - sec->payload_offset;
   sec->payload_offset += delta;
   sec->payload_size -= delta;
   return Result::Ok;
 }
 
-static Result on_memory(uint32_t index,
-                        const Limits* page_limits,
-                        void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  Section* sec = ctx->current_section;
-  sec->memory_limits = *page_limits;
-  ctx->binary->memory_page_count = page_limits->initial;
+Result BinaryReaderLinker::OnMemory(uint32_t index, const Limits* page_limits) {
+  Section* sec = current_section;
+  sec->data.memory_limits = *page_limits;
+  binary->memory_page_count = page_limits->initial;
   return Result::Ok;
 }
 
-static Result begin_data_segment(uint32_t index,
-                                 uint32_t memory_index,
-                                 void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  Section* sec = ctx->current_section;
-  if (!sec->data_segments) {
-    sec->data_segments = new std::vector<DataSegment>();
+Result BinaryReaderLinker::BeginDataSegment(uint32_t index,
+                                            uint32_t memory_index) {
+  Section* sec = current_section;
+  if (!sec->data.data_segments) {
+    sec->data.data_segments = new std::vector<DataSegment>();
   }
-  sec->data_segments->emplace_back();
-  DataSegment& segment = sec->data_segments->back();
+  sec->data.data_segments->emplace_back();
+  DataSegment& segment = sec->data.data_segments->back();
   segment.memory_index = memory_index;
   return Result::Ok;
 }
 
-static Result on_init_expr_i32_const_expr(uint32_t index,
-                                          uint32_t value,
-                                          void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  Section* sec = ctx->current_section;
+Result BinaryReaderLinker::OnInitExprI32ConstExpr(uint32_t index,
+                                                  uint32_t value) {
+  Section* sec = current_section;
   if (sec->section_code != BinarySection::Data)
     return Result::Ok;
-  DataSegment& segment = sec->data_segments->back();
+  DataSegment& segment = sec->data.data_segments->back();
   segment.offset = value;
   return Result::Ok;
 }
 
-static Result on_data_segment_data(uint32_t index,
-                                   const void* src_data,
-                                   uint32_t size,
-                                   void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  Section* sec = ctx->current_section;
-  DataSegment& segment = sec->data_segments->back();
+Result BinaryReaderLinker::OnDataSegmentData(uint32_t index,
+                                             const void* src_data,
+                                             uint32_t size) {
+  Section* sec = current_section;
+  DataSegment& segment = sec->data.data_segments->back();
   segment.data = static_cast<const uint8_t*>(src_data);
   segment.size = size;
   return Result::Ok;
 }
 
-static Result on_export(uint32_t index,
-                        ExternalKind kind,
-                        uint32_t item_index,
-                        StringSlice name,
-                        void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  ctx->binary->exports.emplace_back();
-  Export* export_ = &ctx->binary->exports.back();
+Result BinaryReaderLinker::OnExport(uint32_t index,
+                                    ExternalKind kind,
+                                    uint32_t item_index,
+                                    StringSlice name) {
+  binary->exports.emplace_back();
+  Export* export_ = &binary->exports.back();
   export_->name = name;
   export_->kind = kind;
   export_->index = item_index;
   return Result::Ok;
 }
 
-static Result on_function_name(uint32_t index,
-                               StringSlice name,
-                               void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  while (ctx->binary->debug_names.size() < index) {
-    ctx->binary->debug_names.emplace_back();
+Result BinaryReaderLinker::OnFunctionName(uint32_t index, StringSlice name) {
+  while (binary->debug_names.size() < index) {
+    binary->debug_names.emplace_back();
   }
-  if (ctx->binary->debug_names.size() == index) {
-    ctx->binary->debug_names.push_back(string_slice_to_string(name));
+  if (binary->debug_names.size() == index) {
+    binary->debug_names.push_back(string_slice_to_string(name));
   }
   return Result::Ok;
 }
 
-Result read_binary_linker(LinkerInputBinary* input_info,
-                          LinkOptions* options) {
-  Context context;
-  WABT_ZERO_MEMORY(context);
-  context.binary = input_info;
+}  // namespace
 
-  BinaryReader reader;
-  WABT_ZERO_MEMORY(reader);
-  reader.user_data = &context;
-  reader.begin_section = begin_section;
-  reader.begin_custom_section = begin_custom_section;
-
-  reader.on_reloc_count = on_reloc_count;
-  reader.on_reloc = on_reloc;
-
-  reader.on_import = on_import;
-  reader.on_import_func = on_import_func;
-  reader.on_import_global = on_import_global;
-
-  reader.on_export = on_export;
-
-  reader.on_table = on_table;
-
-  reader.on_memory = on_memory;
-
-  reader.begin_data_segment = begin_data_segment;
-  reader.on_init_expr_i32_const_expr = on_init_expr_i32_const_expr;
-  reader.on_data_segment_data = on_data_segment_data;
-
-  reader.on_elem_segment_function_index_count =
-      on_elem_segment_function_index_count;
-
-  reader.on_function_name = on_function_name;
+Result read_binary_linker(LinkerInputBinary* input_info, LinkOptions* options) {
+  BinaryReaderLinker reader(input_info);
 
   ReadBinaryOptions read_options = WABT_READ_BINARY_OPTIONS_DEFAULT;
   read_options.read_debug_names = true;
   read_options.log_stream = options->log_stream;
-  return read_binary(input_info->data, input_info->size, &reader, 1,
+  return read_binary(input_info->data, input_info->size, &reader,
                      &read_options);
 }
 

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -1,0 +1,592 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "binary-reader-logging.h"
+
+#include <inttypes.h>
+
+#include "stream.h"
+
+namespace wabt {
+
+#define INDENT_SIZE 2
+
+#define LOGF_NOINDENT(...) writef(stream, __VA_ARGS__)
+
+#define LOGF(...)               \
+  do {                          \
+    WriteIndent();              \
+    LOGF_NOINDENT(__VA_ARGS__); \
+  } while (0)
+
+namespace {
+
+void sprint_limits(char* dst, size_t size, const Limits* limits) {
+  int result;
+  if (limits->has_max) {
+    result = wabt_snprintf(dst, size, "initial: %" PRIu64 ", max: %" PRIu64,
+                           limits->initial, limits->max);
+  } else {
+    result = wabt_snprintf(dst, size, "initial: %" PRIu64, limits->initial);
+  }
+  WABT_USE(result);
+  assert(static_cast<size_t>(result) < size);
+}
+
+}  // namespace
+
+BinaryReaderLogging::BinaryReaderLogging(Stream* stream, BinaryReader* forward)
+    : stream(stream), reader(forward), indent(0) {}
+
+void BinaryReaderLogging::Indent() {
+  indent += INDENT_SIZE;
+}
+
+void BinaryReaderLogging::Dedent() {
+  indent -= INDENT_SIZE;
+  assert(indent >= 0);
+}
+
+void BinaryReaderLogging::WriteIndent() {
+  static char s_indent[] =
+      "                                                                       "
+      "                                                                       ";
+  static size_t s_indent_len = sizeof(s_indent) - 1;
+  size_t i = indent;
+  while (i > s_indent_len) {
+    write_data(stream, s_indent, s_indent_len, nullptr);
+    i -= s_indent_len;
+  }
+  if (i > 0) {
+    write_data(stream, s_indent, indent, nullptr);
+  }
+}
+
+void BinaryReaderLogging::LogTypes(uint32_t type_count, Type* types) {
+  LOGF_NOINDENT("[");
+  for (uint32_t i = 0; i < type_count; ++i) {
+    LOGF_NOINDENT("%s", get_type_name(types[i]));
+    if (i != type_count - 1)
+      LOGF_NOINDENT(", ");
+  }
+  LOGF_NOINDENT("]");
+}
+
+bool BinaryReaderLogging::OnError(const char* message) {
+  return reader->OnError(message);
+}
+
+void BinaryReaderLogging::OnSetState(const State* s) {
+  BinaryReader::OnSetState(s);
+  reader->OnSetState(s);
+}
+
+Result BinaryReaderLogging::BeginModule(uint32_t version) {
+  LOGF("BeginModule(version: %u)\n", version);
+  Indent();
+  return reader->BeginModule(version);
+}
+
+Result BinaryReaderLogging::BeginSection(BinarySection section_type,
+                                         uint32_t size) {
+  return reader->BeginSection(section_type, size);
+}
+
+Result BinaryReaderLogging::BeginCustomSection(uint32_t size,
+                                               StringSlice section_name) {
+  LOGF("BeginCustomSection('" PRIstringslice "', size: %d)\n",
+       WABT_PRINTF_STRING_SLICE_ARG(section_name), size);
+  Indent();
+  return reader->BeginCustomSection(size, section_name);
+}
+
+Result BinaryReaderLogging::OnType(uint32_t index,
+                                   uint32_t param_count,
+                                   Type* param_types,
+                                   uint32_t result_count,
+                                   Type* result_types) {
+  LOGF("OnType(index: %u, params: ", index);
+  LogTypes(param_count, param_types);
+  LOGF_NOINDENT(", results: ");
+  LogTypes(result_count, result_types);
+  LOGF_NOINDENT(")\n");
+  return reader->OnType(index, param_count, param_types, result_count,
+                        result_types);
+}
+
+Result BinaryReaderLogging::OnImport(uint32_t index,
+                                     StringSlice module_name,
+                                     StringSlice field_name) {
+  LOGF("OnImport(index: %u, module: \"" PRIstringslice
+       "\", field: \"" PRIstringslice "\")\n",
+       index, WABT_PRINTF_STRING_SLICE_ARG(module_name),
+       WABT_PRINTF_STRING_SLICE_ARG(field_name));
+  return reader->OnImport(index, module_name, field_name);
+}
+
+Result BinaryReaderLogging::OnImportFunc(uint32_t import_index,
+                                         StringSlice module_name,
+                                         StringSlice field_name,
+                                         uint32_t func_index,
+                                         uint32_t sig_index) {
+  LOGF("OnImportFunc(import_index: %u, func_index: %u, sig_index: %u)\n",
+       import_index, func_index, sig_index);
+  return reader->OnImportFunc(import_index, module_name, field_name, func_index,
+                              sig_index);
+}
+
+Result BinaryReaderLogging::OnImportTable(uint32_t import_index,
+                                          StringSlice module_name,
+                                          StringSlice field_name,
+                                          uint32_t table_index,
+                                          Type elem_type,
+                                          const Limits* elem_limits) {
+  char buf[100];
+  sprint_limits(buf, sizeof(buf), elem_limits);
+  LOGF("OnImportTable(import_index: %u, table_index: %u, elem_type: %s, %s)\n",
+       import_index, table_index, get_type_name(elem_type), buf);
+  return reader->OnImportTable(import_index, module_name, field_name,
+                               table_index, elem_type, elem_limits);
+}
+
+Result BinaryReaderLogging::OnImportMemory(uint32_t import_index,
+                                           StringSlice module_name,
+                                           StringSlice field_name,
+                                           uint32_t memory_index,
+                                           const Limits* page_limits) {
+  char buf[100];
+  sprint_limits(buf, sizeof(buf), page_limits);
+  LOGF("OnImportMemory(import_index: %u, memory_index: %u, %s)\n", import_index,
+       memory_index, buf);
+  return reader->OnImportMemory(import_index, module_name, field_name,
+                                memory_index, page_limits);
+}
+
+Result BinaryReaderLogging::OnImportGlobal(uint32_t import_index,
+                                           StringSlice module_name,
+                                           StringSlice field_name,
+                                           uint32_t global_index,
+                                           Type type,
+                                           bool mutable_) {
+  LOGF(
+      "OnImportGlobal(import_index: %u, global_index: %u, type: %s, mutable: "
+      "%s)\n",
+      import_index, global_index, get_type_name(type),
+      mutable_ ? "true" : "false");
+  return reader->OnImportGlobal(import_index, module_name, field_name,
+                                global_index, type, mutable_);
+}
+
+Result BinaryReaderLogging::OnTable(uint32_t index,
+                                    Type elem_type,
+                                    const Limits* elem_limits) {
+  char buf[100];
+  sprint_limits(buf, sizeof(buf), elem_limits);
+  LOGF("OnTable(index: %u, elem_type: %s, %s)\n", index,
+       get_type_name(elem_type), buf);
+  return reader->OnTable(index, elem_type, elem_limits);
+}
+
+Result BinaryReaderLogging::OnMemory(uint32_t index,
+                                     const Limits* page_limits) {
+  char buf[100];
+  sprint_limits(buf, sizeof(buf), page_limits);
+  LOGF("OnMemory(index: %u, %s)\n", index, buf);
+  return reader->OnMemory(index, page_limits);
+}
+
+Result BinaryReaderLogging::BeginGlobal(uint32_t index,
+                                        Type type,
+                                        bool mutable_) {
+  LOGF("BeginGlobal(index: %u, type: %s, mutable: %s)\n", index,
+       get_type_name(type), mutable_ ? "true" : "false");
+  return reader->BeginGlobal(index, type, mutable_);
+}
+
+Result BinaryReaderLogging::OnExport(uint32_t index,
+                                     ExternalKind kind,
+                                     uint32_t item_index,
+                                     StringSlice name) {
+  LOGF("OnExport(index: %u, kind: %s, item_index: %u, name: \"" PRIstringslice
+       "\")\n",
+       index, get_kind_name(kind), item_index,
+       WABT_PRINTF_STRING_SLICE_ARG(name));
+  return reader->OnExport(index, kind, item_index, name);
+}
+
+Result BinaryReaderLogging::OnLocalDecl(uint32_t decl_index,
+                                        uint32_t count,
+                                        Type type) {
+  LOGF("OnLocalDecl(index: %u, count: %u, type: %s)\n", decl_index, count,
+       get_type_name(type));
+  return reader->OnLocalDecl(decl_index, count, type);
+}
+
+Result BinaryReaderLogging::OnBlockExpr(uint32_t num_types, Type* sig_types) {
+  LOGF("OnBlockExpr(sig: ");
+  LogTypes(num_types, sig_types);
+  LOGF_NOINDENT(")\n");
+  return reader->OnBlockExpr(num_types, sig_types);
+}
+
+Result BinaryReaderLogging::OnBrExpr(uint32_t depth) {
+  LOGF("OnBrExpr(depth: %u)\n", depth);
+  return reader->OnBrExpr(depth);
+}
+
+Result BinaryReaderLogging::OnBrIfExpr(uint32_t depth) {
+  LOGF("OnBrIfExpr(depth: %u)\n", depth);
+  return reader->OnBrIfExpr(depth);
+}
+
+Result BinaryReaderLogging::OnBrTableExpr(uint32_t num_targets,
+                                          uint32_t* target_depths,
+                                          uint32_t default_target_depth) {
+  LOGF("OnBrTableExpr(num_targets: %u, depths: [", num_targets);
+  for (uint32_t i = 0; i < num_targets; ++i) {
+    LOGF_NOINDENT("%u", target_depths[i]);
+    if (i != num_targets - 1)
+      LOGF_NOINDENT(", ");
+  }
+  LOGF_NOINDENT("], default: %u)\n", default_target_depth);
+  return reader->OnBrTableExpr(num_targets, target_depths,
+                               default_target_depth);
+}
+
+Result BinaryReaderLogging::OnF32ConstExpr(uint32_t value_bits) {
+  float value;
+  memcpy(&value, &value_bits, sizeof(value));
+  LOGF("OnF32ConstExpr(%g (0x04%x))\n", value, value_bits);
+  return reader->OnF32ConstExpr(value_bits);
+}
+
+Result BinaryReaderLogging::OnF64ConstExpr(uint64_t value_bits) {
+  double value;
+  memcpy(&value, &value_bits, sizeof(value));
+  LOGF("OnF64ConstExpr(%g (0x08%" PRIx64 "))\n", value, value_bits);
+  return reader->OnF64ConstExpr(value_bits);
+}
+
+Result BinaryReaderLogging::OnI32ConstExpr(uint32_t value) {
+  LOGF("OnI32ConstExpr(%u (0x%x))\n", value, value);
+  return reader->OnI32ConstExpr(value);
+}
+
+Result BinaryReaderLogging::OnI64ConstExpr(uint64_t value) {
+  LOGF("OnI64ConstExpr(%" PRIu64 " (0x%" PRIx64 "))\n", value, value);
+  return reader->OnI64ConstExpr(value);
+}
+
+Result BinaryReaderLogging::OnIfExpr(uint32_t num_types, Type* sig_types) {
+  LOGF("OnIfExpr(sig: ");
+  LogTypes(num_types, sig_types);
+  LOGF_NOINDENT(")\n");
+  return reader->OnIfExpr(num_types, sig_types);
+}
+
+Result BinaryReaderLogging::OnLoadExpr(Opcode opcode,
+                                       uint32_t alignment_log2,
+                                       uint32_t offset) {
+  LOGF("OnLoadExpr(opcode: \"%s\" (%u), align log2: %u, offset: %u)\n",
+       get_opcode_name(opcode), static_cast<unsigned>(opcode), alignment_log2,
+       offset);
+  return reader->OnLoadExpr(opcode, alignment_log2, offset);
+}
+
+Result BinaryReaderLogging::OnLoopExpr(uint32_t num_types, Type* sig_types) {
+  LOGF("OnLoopExpr(sig: ");
+  LogTypes(num_types, sig_types);
+  LOGF_NOINDENT(")\n");
+  return reader->OnLoopExpr(num_types, sig_types);
+}
+
+Result BinaryReaderLogging::OnStoreExpr(Opcode opcode,
+                                        uint32_t alignment_log2,
+                                        uint32_t offset) {
+  LOGF("OnStoreExpr(opcode: \"%s\" (%u), align log2: %u, offset: %u)\n",
+       get_opcode_name(opcode), static_cast<unsigned>(opcode), alignment_log2,
+       offset);
+  return reader->OnStoreExpr(opcode, alignment_log2, offset);
+}
+
+Result BinaryReaderLogging::OnDataSegmentData(uint32_t index,
+                                              const void* data,
+                                              uint32_t size) {
+  LOGF("OnDataSegmentData(index:%u, size:%u)\n", index, size);
+  return reader->OnDataSegmentData(index, data, size);
+}
+
+Result BinaryReaderLogging::OnFunctionNameSubsection(uint32_t index,
+                                                     uint32_t name_type,
+                                                     uint32_t subsection_size) {
+  LOGF("OnFunctionNameSubsection(index:%u, nametype:%u, size:%u)\n", index,
+       name_type, subsection_size);
+  return reader->OnFunctionNameSubsection(index, name_type, subsection_size);
+}
+
+Result BinaryReaderLogging::OnFunctionName(uint32_t index, StringSlice name) {
+  LOGF("OnFunctionName(index: %u, name: \"" PRIstringslice "\")\n", index,
+       WABT_PRINTF_STRING_SLICE_ARG(name));
+  return reader->OnFunctionName(index, name);
+}
+
+Result BinaryReaderLogging::OnLocalNameSubsection(uint32_t index,
+                                                  uint32_t name_type,
+                                                  uint32_t subsection_size) {
+  LOGF("OnLocalNameSubsection(index:%u, nametype:%u, size:%u)\n", index,
+       name_type, subsection_size);
+  return reader->OnLocalNameSubsection(index, name_type, subsection_size);
+}
+
+Result BinaryReaderLogging::OnLocalName(uint32_t func_index,
+                                        uint32_t local_index,
+                                        StringSlice name) {
+  LOGF("OnLocalName(func_index: %u, local_index: %u, name: \"" PRIstringslice
+       "\")\n",
+       func_index, local_index, WABT_PRINTF_STRING_SLICE_ARG(name));
+  return reader->OnLocalName(func_index, local_index, name);
+}
+
+Result BinaryReaderLogging::OnInitExprF32ConstExpr(uint32_t index,
+                                                   uint32_t value_bits) {
+  float value;
+  memcpy(&value, &value_bits, sizeof(value));
+  LOGF("OnInitExprF32ConstExpr(index: %u, value: %g (0x04%x))\n", index, value,
+       value_bits);
+  return reader->OnInitExprF32ConstExpr(index, value_bits);
+}
+
+Result BinaryReaderLogging::OnInitExprF64ConstExpr(uint32_t index,
+                                                   uint64_t value_bits) {
+  double value;
+  memcpy(&value, &value_bits, sizeof(value));
+  LOGF("OnInitExprF64ConstExpr(index: %u value: %g (0x08%" PRIx64 "))\n", index,
+       value, value_bits);
+  return reader->OnInitExprF64ConstExpr(index, value_bits);
+}
+
+Result BinaryReaderLogging::OnInitExprI32ConstExpr(uint32_t index,
+                                                   uint32_t value) {
+  LOGF("OnInitExprI32ConstExpr(index: %u, value: %u)\n", index, value);
+  return reader->OnInitExprI32ConstExpr(index, value);
+}
+
+Result BinaryReaderLogging::OnInitExprI64ConstExpr(uint32_t index,
+                                                   uint64_t value) {
+  LOGF("OnInitExprI64ConstExpr(index: %u, value: %" PRIu64 ")\n", index, value);
+  return reader->OnInitExprI64ConstExpr(index, value);
+}
+
+Result BinaryReaderLogging::OnRelocCount(uint32_t count,
+                                         BinarySection section_code,
+                                         StringSlice section_name) {
+  LOGF("OnRelocCount(count: %d, section: %s, section_name: " PRIstringslice
+       ")\n",
+       count, get_section_name(section_code),
+       WABT_PRINTF_STRING_SLICE_ARG(section_name));
+  return reader->OnRelocCount(count, section_code, section_name);
+}
+
+Result BinaryReaderLogging::OnReloc(RelocType type,
+                                    uint32_t offset,
+                                    uint32_t index,
+                                    int32_t addend) {
+  LOGF("OnReloc(type: %s, offset: %u, index: %u, addend: %d)\n",
+       get_reloc_type_name(type), offset, index, addend);
+  return reader->OnReloc(type, offset, index, addend);
+}
+
+#define DEFINE_BEGIN(name)                          \
+  Result BinaryReaderLogging::name(uint32_t size) { \
+    LOGF(#name "(%u)\n", size);                     \
+    Indent();                                       \
+    return reader->name(size);                      \
+  }
+
+#define DEFINE_END(name)               \
+  Result BinaryReaderLogging::name() { \
+    Dedent();                          \
+    LOGF(#name "\n");                  \
+    return reader->name();             \
+  }
+
+#define DEFINE_UINT32(name)                          \
+  Result BinaryReaderLogging::name(uint32_t value) { \
+    LOGF(#name "(%u)\n", value);                     \
+    return reader->name(value);                      \
+  }
+
+#define DEFINE_UINT32_DESC(name, desc)               \
+  Result BinaryReaderLogging::name(uint32_t value) { \
+    LOGF(#name "(" desc ": %u)\n", value);           \
+    return reader->name(value);                      \
+  }
+
+#define DEFINE_UINT32_UINT32(name, desc0, desc1)                       \
+  Result BinaryReaderLogging::name(uint32_t value0, uint32_t value1) { \
+    LOGF(#name "(" desc0 ": %u, " desc1 ": %u)\n", value0, value1);    \
+    return reader->name(value0, value1);                               \
+  }
+
+#define DEFINE_OPCODE(name)                                \
+  Result BinaryReaderLogging::name(Opcode opcode) {        \
+    LOGF(#name "(\"%s\" (%u))\n", get_opcode_name(opcode), \
+         static_cast<unsigned>(opcode));                   \
+    return reader->name(opcode);                           \
+  }
+
+#define DEFINE0(name)                  \
+  Result BinaryReaderLogging::name() { \
+    LOGF(#name "\n");                  \
+    return reader->name();             \
+  }
+
+DEFINE_END(EndModule)
+
+DEFINE_END(EndCustomSection)
+
+DEFINE_BEGIN(BeginTypeSection)
+DEFINE_UINT32(OnTypeCount)
+DEFINE_END(EndTypeSection)
+
+DEFINE_BEGIN(BeginImportSection)
+DEFINE_UINT32(OnImportCount)
+DEFINE_END(EndImportSection)
+
+DEFINE_BEGIN(BeginFunctionSection)
+DEFINE_UINT32(OnFunctionCount)
+DEFINE_UINT32_UINT32(OnFunction, "index", "sig_index")
+DEFINE_END(EndFunctionSection)
+
+DEFINE_BEGIN(BeginTableSection)
+DEFINE_UINT32(OnTableCount)
+DEFINE_END(EndTableSection)
+
+DEFINE_BEGIN(BeginMemorySection)
+DEFINE_UINT32(OnMemoryCount)
+DEFINE_END(EndMemorySection)
+
+DEFINE_BEGIN(BeginGlobalSection)
+DEFINE_UINT32(OnGlobalCount)
+DEFINE_UINT32(BeginGlobalInitExpr)
+DEFINE_UINT32(EndGlobalInitExpr)
+DEFINE_UINT32(EndGlobal)
+DEFINE_END(EndGlobalSection)
+
+DEFINE_BEGIN(BeginExportSection)
+DEFINE_UINT32(OnExportCount)
+DEFINE_END(EndExportSection)
+
+DEFINE_BEGIN(BeginStartSection)
+DEFINE_UINT32(OnStartFunction)
+DEFINE_END(EndStartSection)
+
+DEFINE_BEGIN(BeginCodeSection)
+DEFINE_UINT32(OnFunctionBodyCount)
+DEFINE_UINT32(BeginFunctionBody)
+DEFINE_UINT32(EndFunctionBody)
+DEFINE_UINT32(OnLocalDeclCount)
+DEFINE_OPCODE(OnBinaryExpr)
+DEFINE_UINT32_DESC(OnCallExpr, "func_index")
+DEFINE_UINT32_DESC(OnCallIndirectExpr, "sig_index")
+DEFINE_OPCODE(OnCompareExpr)
+DEFINE_OPCODE(OnConvertExpr)
+DEFINE0(OnCurrentMemoryExpr)
+DEFINE0(OnDropExpr)
+DEFINE0(OnElseExpr)
+DEFINE0(OnEndExpr)
+DEFINE_UINT32_DESC(OnGetGlobalExpr, "index")
+DEFINE_UINT32_DESC(OnGetLocalExpr, "index")
+DEFINE0(OnGrowMemoryExpr)
+DEFINE0(OnNopExpr)
+DEFINE0(OnReturnExpr)
+DEFINE0(OnSelectExpr)
+DEFINE_UINT32_DESC(OnSetGlobalExpr, "index")
+DEFINE_UINT32_DESC(OnSetLocalExpr, "index")
+DEFINE_UINT32_DESC(OnTeeLocalExpr, "index")
+DEFINE0(OnUnreachableExpr)
+DEFINE_OPCODE(OnUnaryExpr)
+DEFINE_END(EndCodeSection)
+
+DEFINE_BEGIN(BeginElemSection)
+DEFINE_UINT32(OnElemSegmentCount)
+DEFINE_UINT32_UINT32(BeginElemSegment, "index", "table_index")
+DEFINE_UINT32(BeginElemSegmentInitExpr)
+DEFINE_UINT32(EndElemSegmentInitExpr)
+DEFINE_UINT32_UINT32(OnElemSegmentFunctionIndexCount, "index", "count")
+DEFINE_UINT32_UINT32(OnElemSegmentFunctionIndex, "index", "func_index")
+DEFINE_UINT32(EndElemSegment)
+DEFINE_END(EndElemSection)
+
+DEFINE_BEGIN(BeginDataSection)
+DEFINE_UINT32(OnDataSegmentCount)
+DEFINE_UINT32_UINT32(BeginDataSegment, "index", "memory_index")
+DEFINE_UINT32(BeginDataSegmentInitExpr)
+DEFINE_UINT32(EndDataSegmentInitExpr)
+DEFINE_UINT32(EndDataSegment)
+DEFINE_END(EndDataSection)
+
+DEFINE_BEGIN(BeginNamesSection)
+DEFINE_UINT32(OnFunctionNamesCount)
+DEFINE_UINT32(OnLocalNameFunctionCount)
+DEFINE_UINT32_UINT32(OnLocalNameLocalCount, "index", "count")
+DEFINE_END(EndNamesSection)
+
+DEFINE_BEGIN(BeginRelocSection)
+DEFINE_END(EndRelocSection)
+DEFINE_UINT32_UINT32(OnInitExprGetGlobalExpr, "index", "global_index")
+
+// We don't need to log these (the individual opcodes are logged instead), but
+// we still need to forward the calls.
+Result BinaryReaderLogging::OnOpcode(Opcode opcode) {
+  return reader->OnOpcode(opcode);
+}
+
+Result BinaryReaderLogging::OnOpcodeBare() {
+  return reader->OnOpcodeBare();
+}
+
+Result BinaryReaderLogging::OnOpcodeUint32(uint32_t value) {
+  return reader->OnOpcodeUint32(value);
+}
+
+Result BinaryReaderLogging::OnOpcodeUint32Uint32(uint32_t value,
+                                                 uint32_t value2) {
+  return reader->OnOpcodeUint32Uint32(value, value2);
+}
+
+Result BinaryReaderLogging::OnOpcodeUint64(uint64_t value) {
+  return reader->OnOpcodeUint64(value);
+}
+
+Result BinaryReaderLogging::OnOpcodeF32(uint32_t value) {
+  return reader->OnOpcodeF32(value);
+}
+
+Result BinaryReaderLogging::OnOpcodeF64(uint64_t value) {
+  return reader->OnOpcodeF64(value);
+}
+
+Result BinaryReaderLogging::OnOpcodeBlockSig(uint32_t num_types,
+                                             Type* sig_types) {
+  return reader->OnOpcodeBlockSig(num_types, sig_types);
+}
+
+Result BinaryReaderLogging::OnEndFunc() {
+  return reader->OnEndFunc();
+}
+
+}  // namespace wabt

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -1,0 +1,242 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_BINARY_READER_LOGGING_H_
+#define WABT_BINARY_READER_LOGGING_H_
+
+#include "binary-reader.h"
+
+namespace wabt {
+
+struct Stream;
+
+class BinaryReaderLogging : public BinaryReader {
+ public:
+  BinaryReaderLogging(Stream*, BinaryReader* forward);
+
+  virtual bool OnError(const char* message);
+  virtual void OnSetState(const State* s);
+
+  virtual Result BeginModule(uint32_t version);
+  virtual Result EndModule();
+
+  virtual Result BeginSection(BinarySection section_type, uint32_t size);
+
+  virtual Result BeginCustomSection(uint32_t size, StringSlice section_name);
+  virtual Result EndCustomSection();
+
+  virtual Result BeginTypeSection(uint32_t size);
+  virtual Result OnTypeCount(uint32_t count);
+  virtual Result OnType(uint32_t index,
+                        uint32_t param_count,
+                        Type* param_types,
+                        uint32_t result_count,
+                        Type* result_types);
+  virtual Result EndTypeSection();
+
+  virtual Result BeginImportSection(uint32_t size);
+  virtual Result OnImportCount(uint32_t count);
+  virtual Result OnImport(uint32_t index,
+                          StringSlice module_name,
+                          StringSlice field_name);
+  virtual Result OnImportFunc(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              uint32_t func_index,
+                              uint32_t sig_index);
+  virtual Result OnImportTable(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
+                               uint32_t table_index,
+                               Type elem_type,
+                               const Limits* elem_limits);
+  virtual Result OnImportMemory(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t memory_index,
+                                const Limits* page_limits);
+  virtual Result OnImportGlobal(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t global_index,
+                                Type type,
+                                bool mutable_);
+  virtual Result EndImportSection();
+
+  virtual Result BeginFunctionSection(uint32_t size);
+  virtual Result OnFunctionCount(uint32_t count);
+  virtual Result OnFunction(uint32_t index, uint32_t sig_index);
+  virtual Result EndFunctionSection();
+
+  virtual Result BeginTableSection(uint32_t size);
+  virtual Result OnTableCount(uint32_t count);
+  virtual Result OnTable(uint32_t index,
+                         Type elem_type,
+                         const Limits* elem_limits);
+  virtual Result EndTableSection();
+
+  virtual Result BeginMemorySection(uint32_t size);
+  virtual Result OnMemoryCount(uint32_t count);
+  virtual Result OnMemory(uint32_t index, const Limits* limits);
+  virtual Result EndMemorySection();
+
+  virtual Result BeginGlobalSection(uint32_t size);
+  virtual Result OnGlobalCount(uint32_t count);
+  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_);
+  virtual Result BeginGlobalInitExpr(uint32_t index);
+  virtual Result EndGlobalInitExpr(uint32_t index);
+  virtual Result EndGlobal(uint32_t index);
+  virtual Result EndGlobalSection();
+
+  virtual Result BeginExportSection(uint32_t size);
+  virtual Result OnExportCount(uint32_t count);
+  virtual Result OnExport(uint32_t index,
+                          ExternalKind kind,
+                          uint32_t item_index,
+                          StringSlice name);
+  virtual Result EndExportSection();
+
+  virtual Result BeginStartSection(uint32_t size);
+  virtual Result OnStartFunction(uint32_t func_index);
+  virtual Result EndStartSection();
+
+  virtual Result BeginCodeSection(uint32_t size);
+  virtual Result OnFunctionBodyCount(uint32_t count);
+  virtual Result BeginFunctionBody(uint32_t index);
+  virtual Result OnLocalDeclCount(uint32_t count);
+  virtual Result OnLocalDecl(uint32_t decl_index, uint32_t count, Type type);
+
+  virtual Result OnOpcode(Opcode opcode);
+  virtual Result OnOpcodeBare();
+  virtual Result OnOpcodeUint32(uint32_t value);
+  virtual Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2);
+  virtual Result OnOpcodeUint64(uint64_t value);
+  virtual Result OnOpcodeF32(uint32_t value);
+  virtual Result OnOpcodeF64(uint64_t value);
+  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types);
+  virtual Result OnBinaryExpr(Opcode opcode);
+  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types);
+  virtual Result OnBrExpr(uint32_t depth);
+  virtual Result OnBrIfExpr(uint32_t depth);
+  virtual Result OnBrTableExpr(uint32_t num_targets,
+                               uint32_t* target_depths,
+                               uint32_t default_target_depth);
+  virtual Result OnCallExpr(uint32_t func_index);
+  virtual Result OnCallIndirectExpr(uint32_t sig_index);
+  virtual Result OnCompareExpr(Opcode opcode);
+  virtual Result OnConvertExpr(Opcode opcode);
+  virtual Result OnCurrentMemoryExpr();
+  virtual Result OnDropExpr();
+  virtual Result OnElseExpr();
+  virtual Result OnEndExpr();
+  virtual Result OnEndFunc();
+  virtual Result OnF32ConstExpr(uint32_t value_bits);
+  virtual Result OnF64ConstExpr(uint64_t value_bits);
+  virtual Result OnGetGlobalExpr(uint32_t global_index);
+  virtual Result OnGetLocalExpr(uint32_t local_index);
+  virtual Result OnGrowMemoryExpr();
+  virtual Result OnI32ConstExpr(uint32_t value);
+  virtual Result OnI64ConstExpr(uint64_t value);
+  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types);
+  virtual Result OnLoadExpr(Opcode opcode,
+                            uint32_t alignment_log2,
+                            uint32_t offset);
+  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types);
+  virtual Result OnNopExpr();
+  virtual Result OnReturnExpr();
+  virtual Result OnSelectExpr();
+  virtual Result OnSetGlobalExpr(uint32_t global_index);
+  virtual Result OnSetLocalExpr(uint32_t local_index);
+  virtual Result OnStoreExpr(Opcode opcode,
+                             uint32_t alignment_log2,
+                             uint32_t offset);
+  virtual Result OnTeeLocalExpr(uint32_t local_index);
+  virtual Result OnUnaryExpr(Opcode opcode);
+  virtual Result OnUnreachableExpr();
+  virtual Result EndFunctionBody(uint32_t index);
+  virtual Result EndCodeSection();
+
+  virtual Result BeginElemSection(uint32_t size);
+  virtual Result OnElemSegmentCount(uint32_t count);
+  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index);
+  virtual Result BeginElemSegmentInitExpr(uint32_t index);
+  virtual Result EndElemSegmentInitExpr(uint32_t index);
+  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
+                                                 uint32_t count);
+  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
+                                            uint32_t func_index);
+  virtual Result EndElemSegment(uint32_t index);
+  virtual Result EndElemSection();
+
+  virtual Result BeginDataSection(uint32_t size);
+  virtual Result OnDataSegmentCount(uint32_t count);
+  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index);
+  virtual Result BeginDataSegmentInitExpr(uint32_t index);
+  virtual Result EndDataSegmentInitExpr(uint32_t index);
+  virtual Result OnDataSegmentData(uint32_t index,
+                                   const void* data,
+                                   uint32_t size);
+  virtual Result EndDataSegment(uint32_t index);
+  virtual Result EndDataSection();
+
+  virtual Result BeginNamesSection(uint32_t size);
+  virtual Result OnFunctionNameSubsection(uint32_t index,
+                                          uint32_t name_type,
+                                          uint32_t subsection_size);
+  virtual Result OnFunctionNamesCount(uint32_t num_functions);
+  virtual Result OnFunctionName(uint32_t function_index,
+                                StringSlice function_name);
+  virtual Result OnLocalNameSubsection(uint32_t index,
+                                       uint32_t name_type,
+                                       uint32_t subsection_size);
+  virtual Result OnLocalNameFunctionCount(uint32_t num_functions);
+  virtual Result OnLocalNameLocalCount(uint32_t function_index,
+                                       uint32_t num_locals);
+  virtual Result OnLocalName(uint32_t function_index,
+                             uint32_t local_index,
+                             StringSlice local_name);
+  virtual Result EndNamesSection();
+
+  virtual Result BeginRelocSection(uint32_t size);
+  virtual Result OnRelocCount(uint32_t count,
+                              BinarySection section_code,
+                              StringSlice section_name);
+  virtual Result OnReloc(RelocType type,
+                         uint32_t offset,
+                         uint32_t index,
+                         int32_t addend);
+  virtual Result EndRelocSection();
+
+  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value);
+  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value);
+  virtual Result OnInitExprGetGlobalExpr(uint32_t index, uint32_t global_index);
+  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
+  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value);
+
+ private:
+  void Indent();
+  void Dedent();
+  void WriteIndent();
+  void LogTypes(uint32_t type_count, Type* types);
+
+  Stream* stream;
+  BinaryReader* reader;
+  int indent;
+};
+
+}  // namespace wabt
+
+#endif  // WABT_BINARY_READER_LOGGING_H_

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -1,0 +1,329 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_BINARY_READER_NOP_H_
+#define WABT_BINARY_READER_NOP_H_
+
+#include "binary-reader.h"
+
+namespace wabt {
+
+class BinaryReaderNop : public BinaryReader {
+ public:
+  virtual bool OnError(const char* message) { return false; }
+
+  /* Module */
+  virtual Result BeginModule(uint32_t version) { return Result::Ok; }
+  virtual Result EndModule() { return Result::Ok; }
+
+  virtual Result BeginSection(BinarySection section_type, uint32_t size) {
+    return Result::Ok;
+  }
+
+  /* Custom section */
+  virtual Result BeginCustomSection(uint32_t size, StringSlice section_name) {
+    return Result::Ok;
+  }
+  virtual Result EndCustomSection() { return Result::Ok; }
+
+  /* Type section */
+  virtual Result BeginTypeSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnTypeCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnType(uint32_t index,
+                        uint32_t param_count,
+                        Type* param_types,
+                        uint32_t result_count,
+                        Type* result_types) {
+    return Result::Ok;
+  }
+  virtual Result EndTypeSection() { return Result::Ok; }
+
+  /* Import section */
+  virtual Result BeginImportSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnImportCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnImport(uint32_t index,
+                          StringSlice module_name,
+                          StringSlice field_name) {
+    return Result::Ok;
+  }
+  virtual Result OnImportFunc(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              uint32_t func_index,
+                              uint32_t sig_index) {
+    return Result::Ok;
+  }
+  virtual Result OnImportTable(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
+                               uint32_t table_index,
+                               Type elem_type,
+                               const Limits* elem_limits) {
+    return Result::Ok;
+  }
+  virtual Result OnImportMemory(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t memory_index,
+                                const Limits* page_limits) {
+    return Result::Ok;
+  }
+  virtual Result OnImportGlobal(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t global_index,
+                                Type type,
+                                bool mutable_) {
+    return Result::Ok;
+  }
+  virtual Result EndImportSection() { return Result::Ok; }
+
+  /* Function section */
+  virtual Result BeginFunctionSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnFunctionCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnFunction(uint32_t index, uint32_t sig_index) {
+    return Result::Ok;
+  }
+  virtual Result EndFunctionSection() { return Result::Ok; }
+
+  /* Table section */
+  virtual Result BeginTableSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnTableCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnTable(uint32_t index,
+                         Type elem_type,
+                         const Limits* elem_limits) {
+    return Result::Ok;
+  }
+  virtual Result EndTableSection() { return Result::Ok; }
+
+  /* Memory section */
+  virtual Result BeginMemorySection(uint32_t size) { return Result::Ok; }
+  virtual Result OnMemoryCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnMemory(uint32_t index, const Limits* limits) {
+    return Result::Ok;
+  }
+  virtual Result EndMemorySection() { return Result::Ok; }
+
+  /* Global section */
+  virtual Result BeginGlobalSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnGlobalCount(uint32_t count) { return Result::Ok; }
+  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_) {
+    return Result::Ok;
+  }
+  virtual Result BeginGlobalInitExpr(uint32_t index) { return Result::Ok; }
+  virtual Result EndGlobalInitExpr(uint32_t index) { return Result::Ok; }
+  virtual Result EndGlobal(uint32_t index) { return Result::Ok; }
+  virtual Result EndGlobalSection() { return Result::Ok; }
+
+  /* Exports section */
+  virtual Result BeginExportSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnExportCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnExport(uint32_t index,
+                          ExternalKind kind,
+                          uint32_t item_index,
+                          StringSlice name) {
+    return Result::Ok;
+  }
+  virtual Result EndExportSection() { return Result::Ok; }
+
+  /* Start section */
+  virtual Result BeginStartSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnStartFunction(uint32_t func_index) { return Result::Ok; }
+  virtual Result EndStartSection() { return Result::Ok; }
+
+  /* Code section */
+  virtual Result BeginCodeSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnFunctionBodyCount(uint32_t count) { return Result::Ok; }
+  virtual Result BeginFunctionBody(uint32_t index) { return Result::Ok; }
+  virtual Result OnLocalDeclCount(uint32_t count) { return Result::Ok; }
+  virtual Result OnLocalDecl(uint32_t decl_index, uint32_t count, Type type) {
+    return Result::Ok;
+  }
+
+  /* Function expressions; called between BeginFunctionBody and
+   EndFunctionBody */
+  virtual Result OnOpcode(Opcode Opcode) { return Result::Ok; }
+  virtual Result OnOpcodeBare() { return Result::Ok; }
+  virtual Result OnOpcodeUint32(uint32_t value) { return Result::Ok; }
+  virtual Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2) {
+    return Result::Ok;
+  }
+  virtual Result OnOpcodeUint64(uint64_t value) { return Result::Ok; }
+  virtual Result OnOpcodeF32(uint32_t value) { return Result::Ok; }
+  virtual Result OnOpcodeF64(uint64_t value) { return Result::Ok; }
+  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types) {
+    return Result::Ok;
+  }
+  virtual Result OnBinaryExpr(Opcode opcode) { return Result::Ok; }
+  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types) {
+    return Result::Ok;
+  }
+  virtual Result OnBrExpr(uint32_t depth) { return Result::Ok; }
+  virtual Result OnBrIfExpr(uint32_t depth) { return Result::Ok; }
+  virtual Result OnBrTableExpr(uint32_t num_targets,
+                               uint32_t* target_depths,
+                               uint32_t default_target_depth) {
+    return Result::Ok;
+  }
+  virtual Result OnCallExpr(uint32_t func_index) { return Result::Ok; }
+  virtual Result OnCallIndirectExpr(uint32_t sig_index) { return Result::Ok; }
+  virtual Result OnCompareExpr(Opcode opcode) { return Result::Ok; }
+  virtual Result OnConvertExpr(Opcode opcode) { return Result::Ok; }
+  virtual Result OnCurrentMemoryExpr() { return Result::Ok; }
+  virtual Result OnDropExpr() { return Result::Ok; }
+  virtual Result OnElseExpr() { return Result::Ok; }
+  virtual Result OnEndExpr() { return Result::Ok; }
+  virtual Result OnEndFunc() { return Result::Ok; }
+  virtual Result OnF32ConstExpr(uint32_t value_bits) { return Result::Ok; }
+  virtual Result OnF64ConstExpr(uint64_t value_bits) { return Result::Ok; }
+  virtual Result OnGetGlobalExpr(uint32_t global_index) { return Result::Ok; }
+  virtual Result OnGetLocalExpr(uint32_t local_index) { return Result::Ok; }
+  virtual Result OnGrowMemoryExpr() { return Result::Ok; }
+  virtual Result OnI32ConstExpr(uint32_t value) { return Result::Ok; }
+  virtual Result OnI64ConstExpr(uint64_t value) { return Result::Ok; }
+  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types) {
+    return Result::Ok;
+  }
+  virtual Result OnLoadExpr(Opcode opcode,
+                            uint32_t alignment_log2,
+                            uint32_t offset) {
+    return Result::Ok;
+  }
+  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types) {
+    return Result::Ok;
+  }
+  virtual Result OnNopExpr() { return Result::Ok; }
+  virtual Result OnReturnExpr() { return Result::Ok; }
+  virtual Result OnSelectExpr() { return Result::Ok; }
+  virtual Result OnSetGlobalExpr(uint32_t global_index) { return Result::Ok; }
+  virtual Result OnSetLocalExpr(uint32_t local_index) { return Result::Ok; }
+  virtual Result OnStoreExpr(Opcode opcode,
+                             uint32_t alignment_log2,
+                             uint32_t offset) {
+    return Result::Ok;
+  }
+  virtual Result OnTeeLocalExpr(uint32_t local_index) { return Result::Ok; }
+  virtual Result OnUnaryExpr(Opcode opcode) { return Result::Ok; }
+  virtual Result OnUnreachableExpr() { return Result::Ok; }
+  virtual Result EndFunctionBody(uint32_t index) { return Result::Ok; }
+  virtual Result EndCodeSection() { return Result::Ok; }
+
+  /* Elem section */
+  virtual Result BeginElemSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnElemSegmentCount(uint32_t count) { return Result::Ok; }
+  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index) {
+    return Result::Ok;
+  }
+  virtual Result BeginElemSegmentInitExpr(uint32_t index) { return Result::Ok; }
+  virtual Result EndElemSegmentInitExpr(uint32_t index) { return Result::Ok; }
+  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
+                                                 uint32_t count) {
+    return Result::Ok;
+  }
+  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
+                                            uint32_t func_index) {
+    return Result::Ok;
+  }
+  virtual Result EndElemSegment(uint32_t index) { return Result::Ok; }
+  virtual Result EndElemSection() { return Result::Ok; }
+
+  /* Data section */
+  virtual Result BeginDataSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnDataSegmentCount(uint32_t count) { return Result::Ok; }
+  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index) {
+    return Result::Ok;
+  }
+  virtual Result BeginDataSegmentInitExpr(uint32_t index) { return Result::Ok; }
+  virtual Result EndDataSegmentInitExpr(uint32_t index) { return Result::Ok; }
+  virtual Result OnDataSegmentData(uint32_t index,
+                                   const void* data,
+                                   uint32_t size) {
+    return Result::Ok;
+  }
+  virtual Result EndDataSegment(uint32_t index) { return Result::Ok; }
+  virtual Result EndDataSection() { return Result::Ok; }
+
+  /* Names section */
+  virtual Result BeginNamesSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnFunctionNameSubsection(uint32_t index,
+                                          uint32_t name_type,
+                                          uint32_t subsection_size) {
+    return Result::Ok;
+  }
+  virtual Result OnFunctionNamesCount(uint32_t num_functions) {
+    return Result::Ok;
+  }
+  virtual Result OnFunctionName(uint32_t function_index,
+                                StringSlice function_name) {
+    return Result::Ok;
+  }
+  virtual Result OnLocalNameSubsection(uint32_t index,
+                                       uint32_t name_type,
+                                       uint32_t subsection_size) {
+    return Result::Ok;
+  }
+  virtual Result OnLocalNameFunctionCount(uint32_t num_functions) {
+    return Result::Ok;
+  }
+  virtual Result OnLocalNameLocalCount(uint32_t function_index,
+                                       uint32_t num_locals) {
+    return Result::Ok;
+  }
+  virtual Result OnLocalName(uint32_t function_index,
+                             uint32_t local_index,
+                             StringSlice local_name) {
+    return Result::Ok;
+  }
+  virtual Result EndNamesSection() { return Result::Ok; }
+
+  /* Reloc section */
+  virtual Result BeginRelocSection(uint32_t size) { return Result::Ok; }
+  virtual Result OnRelocCount(uint32_t count,
+                              BinarySection section_code,
+                              StringSlice section_name) {
+    return Result::Ok;
+  }
+  virtual Result OnReloc(RelocType type,
+                         uint32_t offset,
+                         uint32_t index,
+                         int32_t addend) {
+    return Result::Ok;
+  }
+  virtual Result EndRelocSection() { return Result::Ok; }
+
+  /* InitExpr - used by elem, data and global sections; these functions are
+   * only called between calls to Begin*InitExpr and End*InitExpr */
+  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value) {
+    return Result::Ok;
+  }
+  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value) {
+    return Result::Ok;
+  }
+  virtual Result OnInitExprGetGlobalExpr(uint32_t index,
+                                         uint32_t global_index) {
+    return Result::Ok;
+  }
+  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value) {
+    return Result::Ok;
+  }
+  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value) {
+    return Result::Ok;
+  }
+};
+
+}  // namespace wabt
+
+#endif /* WABT_BINARY_READER_H_ */

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -23,7 +23,7 @@
 
 #include <vector>
 
-#include "binary-reader.h"
+#include "binary-reader-nop.h"
 #include "literal.h"
 
 namespace wabt {
@@ -32,36 +32,48 @@ namespace {
 
 typedef std::vector<uint32_t> Uint32Vector;
 
-struct Context {
-  ObjdumpOptions* options;
-  Stream* out_stream;
-  const uint8_t* data;
-  size_t size;
-  Opcode current_opcode;
-  size_t current_opcode_offset;
-  size_t last_opcode_end;
-  int indent_level;
-  bool print_details;
-  bool header_printed;
-  int section_found;
+class BinaryReaderObjdumpBase : public BinaryReaderNop {
+ public:
+  BinaryReaderObjdumpBase(const uint8_t* data,
+                          size_t size,
+                          ObjdumpOptions* options);
 
+  virtual Result OnRelocCount(uint32_t count,
+                              BinarySection section_code,
+                              StringSlice section_name);
+  virtual Result OnReloc(RelocType type,
+                         uint32_t offset,
+                         uint32_t index,
+                         int32_t addend);
+
+ protected:
+  bool ShouldPrintDetails();
+  void PrintDetails(const char* fmt, ...);
+
+  ObjdumpOptions* options = nullptr;
+  const uint8_t* data = nullptr;
+  size_t size = 0;
+  bool print_details = false;
+  BinarySection reloc_section = BinarySection::Invalid;
   uint32_t section_starts[kBinarySectionCount];
-  BinarySection reloc_section;
-
-  uint32_t next_reloc;
 };
 
-}  // namespace
-
-static bool should_print_details(Context* ctx) {
-  if (ctx->options->mode != ObjdumpMode::Details)
-    return false;
-  return ctx->print_details;
+BinaryReaderObjdumpBase::BinaryReaderObjdumpBase(const uint8_t* data,
+                                                 size_t size,
+                                                 ObjdumpOptions* options)
+    : options(options), data(data), size(size) {
+  WABT_ZERO_MEMORY(section_starts);
 }
 
-static void WABT_PRINTF_FORMAT(2, 3)
-    print_details(Context* ctx, const char* fmt, ...) {
-  if (!should_print_details(ctx))
+bool BinaryReaderObjdumpBase::ShouldPrintDetails() {
+  if (options->mode != ObjdumpMode::Details)
+    return false;
+  return print_details;
+}
+
+void WABT_PRINTF_FORMAT(2, 3)
+    BinaryReaderObjdumpBase::PrintDetails(const char* fmt, ...) {
+  if (!ShouldPrintDetails())
     return;
   va_list args;
   va_start(args, fmt);
@@ -69,40 +81,224 @@ static void WABT_PRINTF_FORMAT(2, 3)
   va_end(args);
 }
 
-static Result begin_section(BinaryReaderContext* ctx,
-                            BinarySection section_code,
-                            uint32_t size) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  context->section_starts[static_cast<size_t>(section_code)] = ctx->offset;
+Result BinaryReaderObjdumpBase::OnRelocCount(uint32_t count,
+                                             BinarySection section_code,
+                                             StringSlice section_name) {
+  reloc_section = section_code;
+  PrintDetails("  - section: %s\n", get_section_name(section_code));
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdumpBase::OnReloc(RelocType type,
+                                        uint32_t offset,
+                                        uint32_t index,
+                                        int32_t addend) {
+  uint32_t total_offset =
+      section_starts[static_cast<size_t>(reloc_section)] + offset;
+  PrintDetails("   - %-18s idx=%#-4x addend=%#-4x offset=%#x(file=%#x)\n",
+               get_reloc_type_name(type), index, addend, offset, total_offset);
+  return Result::Ok;
+}
+
+class BinaryReaderObjdumpPrepass : public BinaryReaderObjdumpBase {
+ public:
+  BinaryReaderObjdumpPrepass(const uint8_t* data,
+                             size_t size,
+                             ObjdumpOptions* options);
+
+  virtual Result OnFunctionName(uint32_t function_index,
+                                StringSlice function_name);
+  virtual Result OnReloc(RelocType type,
+                         uint32_t offset,
+                         uint32_t index,
+                         int32_t addend);
+};
+
+BinaryReaderObjdumpPrepass::BinaryReaderObjdumpPrepass(const uint8_t* data,
+                                                       size_t size,
+                                                       ObjdumpOptions* options)
+    : BinaryReaderObjdumpBase(data, size, options) {}
+
+Result BinaryReaderObjdumpPrepass::OnFunctionName(uint32_t index,
+                                                  StringSlice name) {
+  if (options->mode == ObjdumpMode::Prepass) {
+    options->function_names.resize(index + 1);
+    options->function_names[index] = string_slice_to_string(name);
+  } else {
+    PrintDetails(" - func[%d] " PRIstringslice "\n", index,
+                 WABT_PRINTF_STRING_SLICE_ARG(name));
+  }
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdumpPrepass::OnReloc(RelocType type,
+                                           uint32_t offset,
+                                           uint32_t index,
+                                           int32_t addend) {
+  BinaryReaderObjdumpBase::OnReloc(type, offset, index, addend);
+  if (reloc_section == BinarySection::Code) {
+    options->code_relocations.emplace_back(type, offset, index, addend);
+  }
+  return Result::Ok;
+}
+
+class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
+ public:
+  BinaryReaderObjdump(const uint8_t* data,
+                      size_t size,
+                      ObjdumpOptions* options);
+
+  virtual Result BeginModule(uint32_t version);
+  virtual Result EndModule();
+
+  virtual Result BeginSection(BinarySection section_type, uint32_t size);
+
+  virtual Result BeginCustomSection(uint32_t size, StringSlice section_name);
+
+  virtual Result OnTypeCount(uint32_t count);
+  virtual Result OnType(uint32_t index,
+                        uint32_t param_count,
+                        Type* param_types,
+                        uint32_t result_count,
+                        Type* result_types);
+
+  virtual Result OnImportCount(uint32_t count);
+  virtual Result OnImportFunc(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              uint32_t func_index,
+                              uint32_t sig_index);
+  virtual Result OnImportTable(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
+                               uint32_t table_index,
+                               Type elem_type,
+                               const Limits* elem_limits);
+  virtual Result OnImportMemory(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t memory_index,
+                                const Limits* page_limits);
+  virtual Result OnImportGlobal(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t global_index,
+                                Type type,
+                                bool mutable_);
+
+  virtual Result OnFunctionCount(uint32_t count);
+  virtual Result OnFunction(uint32_t index, uint32_t sig_index);
+
+  virtual Result OnTableCount(uint32_t count);
+  virtual Result OnTable(uint32_t index,
+                         Type elem_type,
+                         const Limits* elem_limits);
+
+  virtual Result OnMemoryCount(uint32_t count);
+  virtual Result OnMemory(uint32_t index, const Limits* limits);
+
+  virtual Result OnGlobalCount(uint32_t count);
+  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_);
+
+  virtual Result OnExportCount(uint32_t count);
+  virtual Result OnExport(uint32_t index,
+                          ExternalKind kind,
+                          uint32_t item_index,
+                          StringSlice name);
+
+  virtual Result OnFunctionBodyCount(uint32_t count);
+  virtual Result BeginFunctionBody(uint32_t index);
+
+  virtual Result OnOpcode(Opcode Opcode);
+  virtual Result OnOpcodeBare();
+  virtual Result OnOpcodeUint32(uint32_t value);
+  virtual Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2);
+  virtual Result OnOpcodeUint64(uint64_t value);
+  virtual Result OnOpcodeF32(uint32_t value);
+  virtual Result OnOpcodeF64(uint64_t value);
+  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types);
+
+  virtual Result OnBrTableExpr(uint32_t num_targets,
+                               uint32_t* target_depths,
+                               uint32_t default_target_depth);
+  virtual Result OnEndExpr();
+  virtual Result OnEndFunc();
+
+  virtual Result OnElemSegmentCount(uint32_t count);
+  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index);
+  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
+                                            uint32_t func_index);
+
+  virtual Result OnDataSegmentCount(uint32_t count);
+  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index);
+  virtual Result OnDataSegmentData(uint32_t index,
+                                   const void* data,
+                                   uint32_t size);
+
+  virtual Result OnFunctionName(uint32_t function_index,
+                                StringSlice function_name);
+  virtual Result OnLocalName(uint32_t function_index,
+                             uint32_t local_index,
+                             StringSlice local_name);
+
+  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value);
+  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value);
+  virtual Result OnInitExprGetGlobalExpr(uint32_t index, uint32_t global_index);
+  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
+  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value);
+
+ private:
+  Result OnCount(uint32_t count);
+  void LogOpcode(const uint8_t* data, size_t data_size, const char* fmt, ...);
+
+  Stream* out_stream = nullptr;
+  Opcode current_opcode = Opcode::Unreachable;
+  size_t current_opcode_offset = 0;
+  size_t last_opcode_end = 0;
+  int indent_level = 0;
+  bool header_printed = false;
+  int section_found = false;
+  uint32_t next_reloc = 0;
+};
+
+BinaryReaderObjdump::BinaryReaderObjdump(const uint8_t* data,
+                                         size_t size,
+                                         ObjdumpOptions* options)
+    : BinaryReaderObjdumpBase(data, size, options),
+      out_stream(init_stdout_stream()) {}
+
+Result BinaryReaderObjdump::BeginSection(BinarySection section_code,
+                                         uint32_t size) {
+  section_starts[static_cast<size_t>(section_code)] = state->offset;
 
   const char* name = get_section_name(section_code);
 
-  bool section_match = !context->options->section_name ||
-                       !strcasecmp(context->options->section_name, name);
+  bool section_match =
+      !options->section_name || !strcasecmp(options->section_name, name);
   if (section_match)
-    context->section_found = true;
+    section_found = true;
 
-  switch (context->options->mode) {
+  switch (options->mode) {
     case ObjdumpMode::Prepass:
       break;
     case ObjdumpMode::Headers:
       printf("%9s start=%#010" PRIzx " end=%#010" PRIzx " (size=%#010x) ", name,
-             ctx->offset, ctx->offset + size, size);
+             state->offset, state->offset + size, size);
       break;
     case ObjdumpMode::Details:
       if (section_match) {
         if (section_code != BinarySection::Code)
           printf("%s:\n", name);
-        context->print_details = true;
+        print_details = true;
       } else {
-        context->print_details = false;
+        print_details = false;
       }
       break;
     case ObjdumpMode::RawData:
       if (section_match) {
         printf("\nContents of section %s:\n", name);
-        write_memory_dump(context->out_stream, context->data + ctx->offset,
-                          size, ctx->offset, PrintChars::Yes, nullptr, nullptr);
+        write_memory_dump(out_stream, data + state->offset, size, state->offset,
+                          PrintChars::Yes, nullptr, nullptr);
       }
       break;
     case ObjdumpMode::Disassemble:
@@ -111,40 +307,36 @@ static Result begin_section(BinaryReaderContext* ctx,
   return Result::Ok;
 }
 
-static Result begin_custom_section(BinaryReaderContext* ctx,
-                                   uint32_t size,
-                                   StringSlice section_name) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  print_details(context, " - name: \"" PRIstringslice "\"\n",
-                WABT_PRINTF_STRING_SLICE_ARG(section_name));
-  if (context->options->mode == ObjdumpMode::Headers) {
+Result BinaryReaderObjdump::BeginCustomSection(uint32_t size,
+                                               StringSlice section_name) {
+  PrintDetails(" - name: \"" PRIstringslice "\"\n",
+               WABT_PRINTF_STRING_SLICE_ARG(section_name));
+  if (options->mode == ObjdumpMode::Headers) {
     printf("\"" PRIstringslice "\"\n",
            WABT_PRINTF_STRING_SLICE_ARG(section_name));
   }
   return Result::Ok;
 }
 
-static Result on_count(uint32_t count, void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (ctx->options->mode == ObjdumpMode::Headers) {
+Result BinaryReaderObjdump::OnCount(uint32_t count) {
+  if (options->mode == ObjdumpMode::Headers) {
     printf("count: %d\n", count);
   }
   return Result::Ok;
 }
 
-static Result begin_module(uint32_t version, void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (ctx->options->print_header) {
-    const char* basename = strrchr(ctx->options->infile, '/');
+Result BinaryReaderObjdump::BeginModule(uint32_t version) {
+  if (options->print_header) {
+    const char* basename = strrchr(options->infile, '/');
     if (basename)
       basename++;
     else
-      basename = ctx->options->infile;
+      basename = options->infile;
     printf("%s:\tfile format wasm %#08x\n", basename, version);
-    ctx->header_printed = true;
+    header_printed = true;
   }
 
-  switch (ctx->options->mode) {
+  switch (options->mode) {
     case ObjdumpMode::Headers:
       printf("\n");
       printf("Sections:\n\n");
@@ -165,11 +357,10 @@ static Result begin_module(uint32_t version, void* user_data) {
   return Result::Ok;
 }
 
-static Result end_module(void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (ctx->options->section_name) {
-    if (!ctx->section_found) {
-      printf("Section not found: %s\n", ctx->options->section_name);
+Result BinaryReaderObjdump::EndModule() {
+  if (options->section_name) {
+    if (!section_found) {
+      printf("Section not found: %s\n", options->section_name);
       return Result::Error;
     }
   }
@@ -177,44 +368,44 @@ static Result end_module(void* user_data) {
   return Result::Ok;
 }
 
-static Result on_opcode(BinaryReaderContext* ctx, Opcode opcode) {
-  Context* context = static_cast<Context*>(ctx->user_data);
+Result BinaryReaderObjdump::OnOpcode(Opcode opcode) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
 
-  if (context->options->debug) {
+  if (options->debug) {
     const char* opcode_name = get_opcode_name(opcode);
-    printf("on_opcode: %#" PRIzx ": %s\n", ctx->offset, opcode_name);
+    printf("on_opcode: %#" PRIzx ": %s\n", state->offset, opcode_name);
   }
 
-  if (context->last_opcode_end) {
-    if (ctx->offset != context->last_opcode_end + 1) {
-      uint8_t missing_opcode = ctx->data[context->last_opcode_end];
+  if (last_opcode_end) {
+    if (state->offset != last_opcode_end + 1) {
+      uint8_t missing_opcode = data[last_opcode_end];
       const char* opcode_name =
           get_opcode_name(static_cast<Opcode>(missing_opcode));
       fprintf(stderr, "warning: %#" PRIzx " missing opcode callback at %#" PRIzx
                       " (%#02x=%s)\n",
-              ctx->offset, context->last_opcode_end + 1,
-              ctx->data[context->last_opcode_end], opcode_name);
+              state->offset, last_opcode_end + 1, data[last_opcode_end],
+              opcode_name);
       return Result::Error;
     }
   }
 
-  context->current_opcode_offset = ctx->offset;
-  context->current_opcode = opcode;
+  current_opcode_offset = state->offset;
+  current_opcode = opcode;
   return Result::Ok;
 }
 
 #define IMMEDIATE_OCTET_COUNT 9
 
-static void log_opcode(Context* ctx,
-                       const uint8_t* data,
-                       size_t data_size,
-                       const char* fmt,
-                       ...) {
-  size_t offset = ctx->current_opcode_offset;
+void BinaryReaderObjdump::LogOpcode(const uint8_t* data,
+                                    size_t data_size,
+                                    const char* fmt,
+                                    ...) {
+  size_t offset = current_opcode_offset;
 
   // Print binary data
   printf(" %06" PRIzx ": %02x", offset - 1,
-         static_cast<unsigned>(ctx->current_opcode));
+         static_cast<unsigned>(current_opcode));
   for (size_t i = 0; i < data_size && i < IMMEDIATE_OCTET_COUNT;
        i++, offset++) {
     printf(" %02x", data[offset]);
@@ -225,14 +416,14 @@ static void log_opcode(Context* ctx,
   printf(" | ");
 
   // Print disassemble
-  int indent_level = ctx->indent_level;
-  if (ctx->current_opcode == Opcode::Else)
+  int indent_level = this->indent_level;
+  if (current_opcode == Opcode::Else)
     indent_level--;
   for (int j = 0; j < indent_level; j++) {
     printf("  ");
   }
 
-  const char* opcode_name = get_opcode_name(ctx->current_opcode);
+  const char* opcode_name = get_opcode_name(current_opcode);
   printf("%s", opcode_name);
   if (fmt) {
     printf(" ");
@@ -244,15 +435,15 @@ static void log_opcode(Context* ctx,
 
   printf("\n");
 
-  ctx->last_opcode_end = ctx->current_opcode_offset + data_size;
+  last_opcode_end = current_opcode_offset + data_size;
 
-  if (ctx->options->relocs) {
-    if (ctx->next_reloc < ctx->options->code_relocations.size()) {
-      Reloc* reloc = &ctx->options->code_relocations[ctx->next_reloc];
+  if (options->relocs) {
+    if (next_reloc < options->code_relocations.size()) {
+      Reloc* reloc = &options->code_relocations[next_reloc];
       size_t code_start =
-          ctx->section_starts[static_cast<size_t>(BinarySection::Code)];
+          section_starts[static_cast<size_t>(BinarySection::Code)];
       size_t abs_offset = code_start + reloc->offset;
-      if (ctx->last_opcode_end > abs_offset) {
+      if (last_opcode_end > abs_offset) {
         printf("           %06" PRIzx ": %-18s %d", abs_offset,
                get_reloc_type_name(reloc->type), reloc->index);
         switch (reloc->type) {
@@ -265,85 +456,92 @@ static void log_opcode(Context* ctx,
             break;
         }
         printf("\n");
-        ctx->next_reloc++;
+        next_reloc++;
       }
     }
   }
 }
 
-static Result on_opcode_bare(BinaryReaderContext* ctx) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  log_opcode(context, ctx->data, 0, nullptr);
+Result BinaryReaderObjdump::OnOpcodeBare() {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  LogOpcode(data, 0, nullptr);
   return Result::Ok;
 }
 
-static Result on_opcode_uint32(BinaryReaderContext* ctx, uint32_t value) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  size_t immediate_len = ctx->offset - context->current_opcode_offset;
-  log_opcode(context, ctx->data, immediate_len, "%#x", value);
+Result BinaryReaderObjdump::OnOpcodeUint32(uint32_t value) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  size_t immediate_len = state->offset - current_opcode_offset;
+  LogOpcode(data, immediate_len, "%#x", value);
   return Result::Ok;
 }
 
-static Result on_opcode_uint32_uint32(BinaryReaderContext* ctx,
-                                      uint32_t value,
-                                      uint32_t value2) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  size_t immediate_len = ctx->offset - context->current_opcode_offset;
-  log_opcode(context, ctx->data, immediate_len, "%lu %lu", value, value2);
+Result BinaryReaderObjdump::OnOpcodeUint32Uint32(uint32_t value,
+                                                 uint32_t value2) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  size_t immediate_len = state->offset - current_opcode_offset;
+  LogOpcode(data, immediate_len, "%lu %lu", value, value2);
   return Result::Ok;
 }
 
-static Result on_opcode_uint64(BinaryReaderContext* ctx, uint64_t value) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  size_t immediate_len = ctx->offset - context->current_opcode_offset;
-  log_opcode(context, ctx->data, immediate_len, "%d", value);
+Result BinaryReaderObjdump::OnOpcodeUint64(uint64_t value) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  size_t immediate_len = state->offset - current_opcode_offset;
+  LogOpcode(data, immediate_len, "%d", value);
   return Result::Ok;
 }
 
-static Result on_opcode_f32(BinaryReaderContext* ctx, uint32_t value) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  size_t immediate_len = ctx->offset - context->current_opcode_offset;
+Result BinaryReaderObjdump::OnOpcodeF32(uint32_t value) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  size_t immediate_len = state->offset - current_opcode_offset;
   char buffer[WABT_MAX_FLOAT_HEX];
   write_float_hex(buffer, sizeof(buffer), value);
-  log_opcode(context, ctx->data, immediate_len, buffer);
+  LogOpcode(data, immediate_len, buffer);
   return Result::Ok;
 }
 
-static Result on_opcode_f64(BinaryReaderContext* ctx, uint64_t value) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  size_t immediate_len = ctx->offset - context->current_opcode_offset;
+Result BinaryReaderObjdump::OnOpcodeF64(uint64_t value) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  size_t immediate_len = state->offset - current_opcode_offset;
   char buffer[WABT_MAX_DOUBLE_HEX];
   write_double_hex(buffer, sizeof(buffer), value);
-  log_opcode(context, ctx->data, immediate_len, buffer);
+  LogOpcode(data, immediate_len, buffer);
   return Result::Ok;
 }
 
-Result on_br_table_expr(BinaryReaderContext* ctx,
-                        uint32_t num_targets,
-                        uint32_t* target_depths,
-                        uint32_t default_target_depth) {
-  Context* context = static_cast<Context*>(ctx->user_data);
-  size_t immediate_len = ctx->offset - context->current_opcode_offset;
+Result BinaryReaderObjdump::OnBrTableExpr(uint32_t num_targets,
+                                          uint32_t* target_depths,
+                                          uint32_t default_target_depth) {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  size_t immediate_len = state->offset - current_opcode_offset;
   /* TODO(sbc): Print targets */
-  log_opcode(context, ctx->data, immediate_len, nullptr);
+  LogOpcode(data, immediate_len, nullptr);
   return Result::Ok;
 }
 
-static Result on_end_func(void* user_data) {
-  Context* context = static_cast<Context*>(user_data);
-  log_opcode(context, nullptr, 0, nullptr);
+Result BinaryReaderObjdump::OnEndFunc() {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  LogOpcode(nullptr, 0, nullptr);
   return Result::Ok;
 }
 
-static Result on_end_expr(void* user_data) {
-  Context* context = static_cast<Context*>(user_data);
-  context->indent_level--;
-  assert(context->indent_level >= 0);
-  log_opcode(context, nullptr, 0, nullptr);
+Result BinaryReaderObjdump::OnEndExpr() {
+  if (options->mode != ObjdumpMode::Disassemble)
+    return Result::Ok;
+  indent_level--;
+  assert(indent_level >= 0);
+  LogOpcode(nullptr, 0, nullptr);
   return Result::Ok;
 }
 
-static const char* type_name(Type type) {
+const char* type_name(Type type) {
   switch (type) {
     case Type::I32:
       return "i32";
@@ -363,27 +561,26 @@ static const char* type_name(Type type) {
   }
 }
 
-static Result on_opcode_block_sig(BinaryReaderContext* ctx,
-                                  uint32_t num_types,
-                                  Type* sig_types) {
-  Context* context = static_cast<Context*>(ctx->user_data);
+Result BinaryReaderObjdump::OnOpcodeBlockSig(uint32_t num_types,
+                                             Type* sig_types) {
   if (num_types)
-    log_opcode(context, ctx->data, 1, "%s", type_name(*sig_types));
+    LogOpcode(data, 1, "%s", type_name(*sig_types));
   else
-    log_opcode(context, ctx->data, 1, nullptr);
-  context->indent_level++;
+    LogOpcode(data, 1, nullptr);
+  indent_level++;
   return Result::Ok;
 }
 
-static Result on_signature(uint32_t index,
-                           uint32_t param_count,
-                           Type* param_types,
-                           uint32_t result_count,
-                           Type* result_types,
-                           void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
+Result BinaryReaderObjdump::OnTypeCount(uint32_t count) {
+  return OnCount(count);
+}
 
-  if (!should_print_details(ctx))
+Result BinaryReaderObjdump::OnType(uint32_t index,
+                                   uint32_t param_count,
+                                   Type* param_types,
+                                   uint32_t result_count,
+                                   Type* result_types) {
+  if (!ShouldPrintDetails())
     return Result::Ok;
   printf(" - [%d] (", index);
   for (uint32_t i = 0; i < param_count; i++) {
@@ -401,380 +598,245 @@ static Result on_signature(uint32_t index,
   return Result::Ok;
 }
 
-static Result on_function_signature(uint32_t index,
-                                    uint32_t sig_index,
-                                    void* user_data) {
-  print_details(static_cast<Context*>(user_data), " - func[%d] sig=%d\n", index,
-                sig_index);
+Result BinaryReaderObjdump::OnFunctionCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::OnFunction(uint32_t index, uint32_t sig_index) {
+  PrintDetails(" - func[%d] sig=%d\n", index, sig_index);
   return Result::Ok;
 }
 
-static Result begin_function_body(BinaryReaderContext* context,
-                                  uint32_t index) {
-  Context* ctx = static_cast<Context*>(context->user_data);
+Result BinaryReaderObjdump::OnFunctionBodyCount(uint32_t count) {
+  return OnCount(count);
+}
 
-  if (ctx->options->mode == ObjdumpMode::Disassemble) {
-    if (index < ctx->options->function_names.size() &&
-        !ctx->options->function_names[index].empty())
-      printf("%06" PRIzx " <%s>:\n", context->offset,
-             ctx->options->function_names[index].c_str());
+Result BinaryReaderObjdump::BeginFunctionBody(uint32_t index) {
+  if (options->mode == ObjdumpMode::Disassemble) {
+    if (index < options->function_names.size() &&
+        !options->function_names[index].empty())
+      printf("%06" PRIzx " <%s>:\n", state->offset,
+             options->function_names[index].c_str());
     else
-      printf("%06" PRIzx " func[%d]:\n", context->offset, index);
+      printf("%06" PRIzx " func[%d]:\n", state->offset, index);
   }
 
-  ctx->last_opcode_end = 0;
+  last_opcode_end = 0;
   return Result::Ok;
 }
 
-static Result on_import_func(uint32_t import_index,
-                             StringSlice module_name,
-                             StringSlice field_name,
-                             uint32_t func_index,
-                             uint32_t sig_index,
-                             void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx,
-                " - func[%d] sig=%d <- " PRIstringslice "." PRIstringslice "\n",
-                func_index, sig_index,
-                WABT_PRINTF_STRING_SLICE_ARG(module_name),
-                WABT_PRINTF_STRING_SLICE_ARG(field_name));
+Result BinaryReaderObjdump::OnImportCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::OnImportFunc(uint32_t import_index,
+                                         StringSlice module_name,
+                                         StringSlice field_name,
+                                         uint32_t func_index,
+                                         uint32_t sig_index) {
+  PrintDetails(" - func[%d] sig=%d <- " PRIstringslice "." PRIstringslice "\n",
+               func_index, sig_index, WABT_PRINTF_STRING_SLICE_ARG(module_name),
+               WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return Result::Ok;
 }
 
-static Result on_import_table(uint32_t import_index,
-                              StringSlice module_name,
-                              StringSlice field_name,
-                              uint32_t table_index,
-                              Type elem_type,
-                              const Limits* elem_limits,
-                              void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(
-      ctx, " - " PRIstringslice "." PRIstringslice
-           " -> table elem_type=%s init=%" PRId64 " max=%" PRId64 "\n",
-      WABT_PRINTF_STRING_SLICE_ARG(module_name),
-      WABT_PRINTF_STRING_SLICE_ARG(field_name),
-      get_type_name(elem_type), elem_limits->initial, elem_limits->max);
+Result BinaryReaderObjdump::OnImportTable(uint32_t import_index,
+                                          StringSlice module_name,
+                                          StringSlice field_name,
+                                          uint32_t table_index,
+                                          Type elem_type,
+                                          const Limits* elem_limits) {
+  PrintDetails(" - " PRIstringslice "." PRIstringslice
+               " -> table elem_type=%s init=%" PRId64 " max=%" PRId64 "\n",
+               WABT_PRINTF_STRING_SLICE_ARG(module_name),
+               WABT_PRINTF_STRING_SLICE_ARG(field_name),
+               get_type_name(elem_type), elem_limits->initial,
+               elem_limits->max);
   return Result::Ok;
 }
 
-static Result on_import_memory(uint32_t import_index,
-                               StringSlice module_name,
-                               StringSlice field_name,
-                               uint32_t memory_index,
-                               const Limits* page_limits,
-                               void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - " PRIstringslice "." PRIstringslice " -> memory\n",
-                WABT_PRINTF_STRING_SLICE_ARG(module_name),
-                WABT_PRINTF_STRING_SLICE_ARG(field_name));
+Result BinaryReaderObjdump::OnImportMemory(uint32_t import_index,
+                                           StringSlice module_name,
+                                           StringSlice field_name,
+                                           uint32_t memory_index,
+                                           const Limits* page_limits) {
+  PrintDetails(" - " PRIstringslice "." PRIstringslice " -> memory\n",
+               WABT_PRINTF_STRING_SLICE_ARG(module_name),
+               WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return Result::Ok;
 }
 
-static Result on_import_global(uint32_t import_index,
-                               StringSlice module_name,
-                               StringSlice field_name,
-                               uint32_t global_index,
-                               Type type,
-                               bool mutable_,
-                               void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - global[%d] %s mutable=%d <- " PRIstringslice
-                     "." PRIstringslice "\n",
-                global_index, get_type_name(type), mutable_,
-                WABT_PRINTF_STRING_SLICE_ARG(module_name),
-                WABT_PRINTF_STRING_SLICE_ARG(field_name));
+Result BinaryReaderObjdump::OnImportGlobal(uint32_t import_index,
+                                           StringSlice module_name,
+                                           StringSlice field_name,
+                                           uint32_t global_index,
+                                           Type type,
+                                           bool mutable_) {
+  PrintDetails(" - global[%d] %s mutable=%d <- " PRIstringslice
+               "." PRIstringslice "\n",
+               global_index, get_type_name(type), mutable_,
+               WABT_PRINTF_STRING_SLICE_ARG(module_name),
+               WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return Result::Ok;
 }
 
-static Result on_memory(uint32_t index,
-                        const Limits* page_limits,
-                        void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - memory[%d] pages: initial=%" PRId64, index,
-                page_limits->initial);
+Result BinaryReaderObjdump::OnMemoryCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::OnMemory(uint32_t index,
+                                     const Limits* page_limits) {
+  PrintDetails(" - memory[%d] pages: initial=%" PRId64, index,
+               page_limits->initial);
   if (page_limits->has_max)
-    print_details(ctx, " max=%" PRId64, page_limits->max);
-  print_details(ctx, "\n");
+    PrintDetails(" max=%" PRId64, page_limits->max);
+  PrintDetails("\n");
   return Result::Ok;
 }
 
-static Result on_table(uint32_t index,
-                       Type elem_type,
-                       const Limits* elem_limits,
-                       void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - table[%d] type=%s initial=%" PRId64, index,
-                get_type_name(elem_type), elem_limits->initial);
+Result BinaryReaderObjdump::OnTableCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::OnTable(uint32_t index,
+                                    Type elem_type,
+                                    const Limits* elem_limits) {
+  PrintDetails(" - table[%d] type=%s initial=%" PRId64, index,
+               get_type_name(elem_type), elem_limits->initial);
   if (elem_limits->has_max)
-    print_details(ctx, " max=%" PRId64, elem_limits->max);
-  print_details(ctx, "\n");
+    PrintDetails(" max=%" PRId64, elem_limits->max);
+  PrintDetails("\n");
   return Result::Ok;
 }
 
-static Result on_export(uint32_t index,
-                        ExternalKind kind,
-                        uint32_t item_index,
-                        StringSlice name,
-                        void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - %s[%d] ", get_kind_name(kind), item_index);
-  print_details(ctx, PRIstringslice, WABT_PRINTF_STRING_SLICE_ARG(name));
-  print_details(ctx, "\n");
+Result BinaryReaderObjdump::OnExportCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::OnExport(uint32_t index,
+                                     ExternalKind kind,
+                                     uint32_t item_index,
+                                     StringSlice name) {
+  PrintDetails(" - %s[%d] ", get_kind_name(kind), item_index);
+  PrintDetails(PRIstringslice, WABT_PRINTF_STRING_SLICE_ARG(name));
+  PrintDetails("\n");
   return Result::Ok;
 }
 
-static Result on_elem_segment_function_index(uint32_t index,
-                                             uint32_t func_index,
-                                             void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, "  - func[%d]\n", func_index);
+Result BinaryReaderObjdump::OnElemSegmentFunctionIndex(uint32_t index,
+                                                       uint32_t func_index) {
+  PrintDetails("  - func[%d]\n", func_index);
   return Result::Ok;
 }
 
-static Result begin_elem_segment(uint32_t index,
-                                 uint32_t table_index,
-                                 void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - segment[%d] table=%d\n", index, table_index);
+Result BinaryReaderObjdump::OnElemSegmentCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::BeginElemSegment(uint32_t index,
+                                             uint32_t table_index) {
+  PrintDetails(" - segment[%d] table=%d\n", index, table_index);
   return Result::Ok;
 }
 
-static Result begin_global(uint32_t index,
-                           Type type,
-                           bool mutable_,
-                           void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - global[%d] %s mutable=%d", index, get_type_name(type),
-                mutable_);
+Result BinaryReaderObjdump::OnGlobalCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::BeginGlobal(uint32_t index,
+                                        Type type,
+                                        bool mutable_) {
+  PrintDetails(" - global[%d] %s mutable=%d", index, get_type_name(type),
+               mutable_);
   return Result::Ok;
 }
 
-static Result on_init_expr_f32_const_expr(uint32_t index,
-                                          uint32_t value,
-                                          void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
+Result BinaryReaderObjdump::OnInitExprF32ConstExpr(uint32_t index,
+                                                   uint32_t value) {
   char buffer[WABT_MAX_FLOAT_HEX];
   write_float_hex(buffer, sizeof(buffer), value);
-  print_details(ctx, " - init f32=%s\n", buffer);
+  PrintDetails(" - init f32=%s\n", buffer);
   return Result::Ok;
 }
 
-static Result on_init_expr_f64_const_expr(uint32_t index,
-                                          uint64_t value,
-                                          void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
+Result BinaryReaderObjdump::OnInitExprF64ConstExpr(uint32_t index,
+                                                   uint64_t value) {
   char buffer[WABT_MAX_DOUBLE_HEX];
   write_float_hex(buffer, sizeof(buffer), value);
-  print_details(ctx, " - init f64=%s\n", buffer);
+  PrintDetails(" - init f64=%s\n", buffer);
   return Result::Ok;
 }
 
-static Result on_init_expr_get_global_expr(uint32_t index,
-                                           uint32_t global_index,
-                                           void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - init global=%d\n", global_index);
+Result BinaryReaderObjdump::OnInitExprGetGlobalExpr(uint32_t index,
+                                                    uint32_t global_index) {
+  PrintDetails(" - init global=%d\n", global_index);
   return Result::Ok;
 }
 
-static Result on_init_expr_i32_const_expr(uint32_t index,
-                                          uint32_t value,
-                                          void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - init i32=%d\n", value);
+Result BinaryReaderObjdump::OnInitExprI32ConstExpr(uint32_t index,
+                                                   uint32_t value) {
+  PrintDetails(" - init i32=%d\n", value);
   return Result::Ok;
 }
 
-static Result on_init_expr_i64_const_expr(uint32_t index,
-                                          uint64_t value,
-                                          void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - init i64=%" PRId64 "\n", value);
+Result BinaryReaderObjdump::OnInitExprI64ConstExpr(uint32_t index,
+                                                   uint64_t value) {
+  PrintDetails(" - init i64=%" PRId64 "\n", value);
   return Result::Ok;
 }
 
-static Result on_function_name(uint32_t index,
-                               StringSlice name,
-                               void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (ctx->options->mode == ObjdumpMode::Prepass) {
-    ctx->options->function_names.resize(index+1);
-    ctx->options->function_names[index] = string_slice_to_string(name);
-  } else {
-    print_details(ctx, " - func[%d] " PRIstringslice "\n", index,
-                  WABT_PRINTF_STRING_SLICE_ARG(name));
-  }
+Result BinaryReaderObjdump::OnFunctionName(uint32_t index, StringSlice name) {
+  PrintDetails(" - func[%d] " PRIstringslice "\n", index,
+               WABT_PRINTF_STRING_SLICE_ARG(name));
   return Result::Ok;
 }
 
-static Result on_local_name(uint32_t func_index,
-                            uint32_t local_index,
-                            StringSlice name,
-                            void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
+Result BinaryReaderObjdump::OnLocalName(uint32_t func_index,
+                                        uint32_t local_index,
+                                        StringSlice name) {
   if (name.length) {
-    print_details(ctx, " - func[%d] local[%d] " PRIstringslice "\n", func_index,
-                  local_index, WABT_PRINTF_STRING_SLICE_ARG(name));
+    PrintDetails(" - func[%d] local[%d] " PRIstringslice "\n", func_index,
+                 local_index, WABT_PRINTF_STRING_SLICE_ARG(name));
   }
   return Result::Ok;
 }
 
-Result on_reloc_count(uint32_t count,
-                      BinarySection section_code,
-                      StringSlice section_name,
-                      void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  ctx->reloc_section = section_code;
-  print_details(ctx, "  - section: %s\n", get_section_name(section_code));
+Result BinaryReaderObjdump::OnDataSegmentCount(uint32_t count) {
+  return OnCount(count);
+}
+
+Result BinaryReaderObjdump::BeginDataSegment(uint32_t index,
+                                             uint32_t memory_index) {
+  PrintDetails(" - memory[%d]", memory_index);
   return Result::Ok;
 }
 
-Result on_reloc(RelocType type,
-                uint32_t offset,
-                uint32_t index,
-                int32_t addend,
-                void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  uint32_t total_offset =
-      ctx->section_starts[static_cast<size_t>(ctx->reloc_section)] + offset;
-  print_details(ctx, "   - %-18s idx=%#-4x addend=%#-4x offset=%#x(file=%#x)\n",
-                get_reloc_type_name(type), index, addend, offset, total_offset);
-  if (ctx->options->mode == ObjdumpMode::Prepass &&
-      ctx->reloc_section == BinarySection::Code) {
-    ctx->options->code_relocations.emplace_back(type, offset, index, addend);
+Result BinaryReaderObjdump::OnDataSegmentData(uint32_t index,
+                                              const void* src_data,
+                                              uint32_t size) {
+  if (ShouldPrintDetails()) {
+    write_memory_dump(out_stream, src_data, size, 0, PrintChars::Yes, "  - ",
+                      nullptr);
   }
   return Result::Ok;
 }
 
-static Result begin_data_segment(uint32_t index,
-                                 uint32_t memory_index,
-                                 void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  print_details(ctx, " - memory[%d]", memory_index);
-  return Result::Ok;
-}
-
-static Result on_data_segment_data(uint32_t index,
-                                   const void* src_data,
-                                   uint32_t size,
-                                   void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (should_print_details(ctx)) {
-    write_memory_dump(ctx->out_stream, src_data, size, 0, PrintChars::Yes,
-                      "  - ", nullptr);
-  }
-  return Result::Ok;
-}
+}  // namespace
 
 Result read_binary_objdump(const uint8_t* data,
                            size_t size,
                            ObjdumpOptions* options) {
-  Context context;
-  WABT_ZERO_MEMORY(context);
-  context.header_printed = false;
-  context.print_details = false;
-  context.section_found = false;
-  context.data = data;
-  context.size = size;
-  context.options = options;
-  context.out_stream = init_stdout_stream();
-
-  BinaryReader reader;
-  WABT_ZERO_MEMORY(reader);
-  if (options->mode == ObjdumpMode::Prepass) {
-    reader.on_function_name = on_function_name;
-    reader.on_reloc_count = on_reloc_count;
-    reader.on_reloc = on_reloc;
-  } else {
-    reader.begin_module = begin_module;
-    reader.end_module = end_module;
-
-    reader.begin_section = begin_section;
-
-    // User section
-    reader.begin_custom_section = begin_custom_section;
-
-    // Signature section
-    reader.on_signature_count = on_count;
-    reader.on_signature = on_signature;
-
-    // Import section
-    reader.on_import_count = on_count;
-    reader.on_import_func = on_import_func;
-    reader.on_import_table = on_import_table;
-    reader.on_import_memory = on_import_memory;
-    reader.on_import_global = on_import_global;
-
-    // Function sigs section
-    reader.on_function_signatures_count = on_count;
-    reader.on_function_signature = on_function_signature;
-
-    // Table section
-    reader.on_table_count = on_count;
-    reader.on_table = on_table;
-
-    // Memory section
-    reader.on_memory_count = on_count;
-    reader.on_memory = on_memory;
-
-    // Globl seciont
-    reader.begin_global = begin_global;
-    reader.on_global_count = on_count;
-
-    // Export section
-    reader.on_export_count = on_count;
-    reader.on_export = on_export;
-
-    // Body section
-    reader.on_function_bodies_count = on_count;
-    reader.begin_function_body = begin_function_body;
-
-    // Elems section
-    reader.begin_elem_segment = begin_elem_segment;
-    reader.on_elem_segment_count = on_count;
-    reader.on_elem_segment_function_index = on_elem_segment_function_index;
-
-    // Data section
-    reader.begin_data_segment = begin_data_segment;
-    reader.on_data_segment_data = on_data_segment_data;
-    reader.on_data_segment_count = on_count;
-
-    // Known "User" sections:
-    // - Names section
-    reader.on_function_name = on_function_name;
-    reader.on_local_name = on_local_name;
-
-    reader.on_reloc_count = on_reloc_count;
-    reader.on_reloc = on_reloc;
-
-    reader.on_init_expr_i32_const_expr = on_init_expr_i32_const_expr;
-    reader.on_init_expr_i64_const_expr = on_init_expr_i64_const_expr;
-    reader.on_init_expr_f32_const_expr = on_init_expr_f32_const_expr;
-    reader.on_init_expr_f64_const_expr = on_init_expr_f64_const_expr;
-    reader.on_init_expr_get_global_expr = on_init_expr_get_global_expr;
-  }
-
-  if (options->mode == ObjdumpMode::Disassemble) {
-    reader.on_opcode = on_opcode;
-    reader.on_opcode_bare = on_opcode_bare;
-    reader.on_opcode_uint32 = on_opcode_uint32;
-    reader.on_opcode_uint32_uint32 = on_opcode_uint32_uint32;
-    reader.on_opcode_uint64 = on_opcode_uint64;
-    reader.on_opcode_f32 = on_opcode_f32;
-    reader.on_opcode_f64 = on_opcode_f64;
-    reader.on_opcode_block_sig = on_opcode_block_sig;
-    reader.on_end_expr = on_end_expr;
-    reader.on_end_func = on_end_func;
-    reader.on_br_table_expr = on_br_table_expr;
-  }
-
-  reader.user_data = &context;
-
   ReadBinaryOptions read_options = WABT_READ_BINARY_OPTIONS_DEFAULT;
   read_options.read_debug_names = true;
   read_options.log_stream = options->log_stream;
-  return read_binary(data, size, &reader, 1, &read_options);
+
+  if (options->mode == ObjdumpMode::Prepass) {
+    BinaryReaderObjdumpPrepass reader(data, size, options);
+    return read_binary(data, size, &reader, &read_options);
+  } else {
+    BinaryReaderObjdump reader(data, size, options);
+    return read_binary(data, size, &reader, &read_options);
+  }
 }
 
 }  // namespace wabt

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -22,20 +22,34 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "binary-reader.h"
+#include "binary-reader-nop.h"
 #include "common.h"
 
 namespace wabt {
 
 namespace {
 
-struct Context {
+class BinaryReaderOpcnt : public BinaryReaderNop {
+ public:
+  explicit BinaryReaderOpcnt(OpcntData* data);
+
+  virtual Result OnOpcode(Opcode opcode);
+  virtual Result OnI32ConstExpr(uint32_t value);
+  virtual Result OnGetLocalExpr(uint32_t local_index);
+  virtual Result OnSetLocalExpr(uint32_t local_index);
+  virtual Result OnTeeLocalExpr(uint32_t local_index);
+  virtual Result OnLoadExpr(Opcode opcode,
+                            uint32_t alignment_log2,
+                            uint32_t offset);
+  virtual Result OnStoreExpr(Opcode opcode,
+                             uint32_t alignment_log2,
+                             uint32_t offset);
+
+ private:
   OpcntData* opcnt_data;
 };
 
-}  // namespace
-
-static Result add_int_counter_value(IntCounterVector* vec, intmax_t value) {
+static Result AddIntCounterValue(IntCounterVector* vec, intmax_t value) {
   for (IntCounter& counter : *vec) {
     if (counter.value == value) {
       ++counter.count;
@@ -46,9 +60,9 @@ static Result add_int_counter_value(IntCounterVector* vec, intmax_t value) {
   return Result::Ok;
 }
 
-static Result add_int_pair_counter_value(IntPairCounterVector* vec,
-                                         intmax_t first,
-                                         intmax_t second) {
+static Result AddIntPairCounterValue(IntPairCounterVector* vec,
+                                     intmax_t first,
+                                     intmax_t second) {
   for (IntPairCounter& pair : *vec) {
     if (pair.first == first && pair.second == second) {
       ++pair.count;
@@ -59,9 +73,10 @@ static Result add_int_pair_counter_value(IntPairCounterVector* vec,
   return Result::Ok;
 }
 
-static Result on_opcode(BinaryReaderContext* context, Opcode opcode) {
-  Context* ctx = static_cast<Context*>(context->user_data);
-  IntCounterVector& opcnt_vec = ctx->opcnt_data->opcode_vec;
+BinaryReaderOpcnt::BinaryReaderOpcnt(OpcntData* data) : opcnt_data(data) {}
+
+Result BinaryReaderOpcnt::OnOpcode(Opcode opcode) {
+  IntCounterVector& opcnt_vec = opcnt_data->opcode_vec;
   while (static_cast<size_t>(opcode) >= opcnt_vec.size()) {
     opcnt_vec.emplace_back(opcnt_vec.size(), 0);
   }
@@ -69,69 +84,51 @@ static Result on_opcode(BinaryReaderContext* context, Opcode opcode) {
   return Result::Ok;
 }
 
-static Result on_i32_const_expr(uint32_t value, void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  return add_int_counter_value(&ctx->opcnt_data->i32_const_vec,
-                               static_cast<int32_t>(value));
+Result BinaryReaderOpcnt::OnI32ConstExpr(uint32_t value) {
+  return AddIntCounterValue(&opcnt_data->i32_const_vec,
+                            static_cast<int32_t>(value));
 }
 
-static Result on_get_local_expr(uint32_t local_index, void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  return add_int_counter_value(&ctx->opcnt_data->get_local_vec, local_index);
+Result BinaryReaderOpcnt::OnGetLocalExpr(uint32_t local_index) {
+  return AddIntCounterValue(&opcnt_data->get_local_vec, local_index);
 }
 
-static Result on_set_local_expr(uint32_t local_index, void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  return add_int_counter_value(&ctx->opcnt_data->set_local_vec, local_index);
+Result BinaryReaderOpcnt::OnSetLocalExpr(uint32_t local_index) {
+  return AddIntCounterValue(&opcnt_data->set_local_vec, local_index);
 }
 
-static  Result on_tee_local_expr(uint32_t local_index, void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  return add_int_counter_value(&ctx->opcnt_data->tee_local_vec, local_index);
+Result BinaryReaderOpcnt::OnTeeLocalExpr(uint32_t local_index) {
+  return AddIntCounterValue(&opcnt_data->tee_local_vec, local_index);
 }
 
-static  Result on_load_expr(Opcode opcode,
-                                uint32_t alignment_log2,
-                                uint32_t offset,
-                                void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (opcode == Opcode::I32Load)
-    return add_int_pair_counter_value(&ctx->opcnt_data->i32_load_vec,
-                                      alignment_log2, offset);
+Result BinaryReaderOpcnt::OnLoadExpr(Opcode opcode,
+                                     uint32_t alignment_log2,
+                                     uint32_t offset) {
+  if (opcode == Opcode::I32Load) {
+    return AddIntPairCounterValue(&opcnt_data->i32_load_vec, alignment_log2,
+                                  offset);
+  }
   return Result::Ok;
 }
 
-static  Result on_store_expr(Opcode opcode,
-                                 uint32_t alignment_log2,
-                                 uint32_t offset,
-                                 void* user_data) {
-  Context* ctx = static_cast<Context*>(user_data);
-  if (opcode == Opcode::I32Store)
-    return add_int_pair_counter_value(&ctx->opcnt_data->i32_store_vec,
-                                      alignment_log2, offset);
+Result BinaryReaderOpcnt::OnStoreExpr(Opcode opcode,
+                                      uint32_t alignment_log2,
+                                      uint32_t offset) {
+  if (opcode == Opcode::I32Store) {
+    return AddIntPairCounterValue(&opcnt_data->i32_store_vec, alignment_log2,
+                                  offset);
+  }
   return Result::Ok;
 }
+
+}  // namespace
 
 Result read_binary_opcnt(const void* data,
-                                  size_t size,
-                                  const struct ReadBinaryOptions* options,
-                                  OpcntData* opcnt_data) {
-  Context ctx;
-  WABT_ZERO_MEMORY(ctx);
-  ctx.opcnt_data = opcnt_data;
-
-  BinaryReader reader;
-  WABT_ZERO_MEMORY(reader);
-  reader.user_data = &ctx;
-  reader.on_opcode = on_opcode;
-  reader.on_i32_const_expr = on_i32_const_expr;
-  reader.on_get_local_expr = on_get_local_expr;
-  reader.on_set_local_expr = on_set_local_expr;
-  reader.on_tee_local_expr = on_tee_local_expr;
-  reader.on_load_expr = on_load_expr;
-  reader.on_store_expr = on_store_expr;
-
-  return read_binary(data, size, &reader, 1, options);
+                         size_t size,
+                         const struct ReadBinaryOptions* options,
+                         OpcntData* opcnt_data) {
+  BinaryReaderOpcnt reader(opcnt_data);
+  return read_binary(data, size, &reader, options);
 }
 
 }  // namespace wabt

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "binary.h"
+#include "binary-reader-logging.h"
 #include "config.h"
 #include "stream.h"
 
@@ -34,70 +35,17 @@
 #include <alloca.h>
 #endif
 
-#define INDENT_SIZE 2
-
-#define INITIAL_PARAM_TYPES_CAPACITY 128
-#define INITIAL_BR_TABLE_TARGET_CAPACITY 1000
-
 namespace wabt {
 
 namespace {
 
-#define CALLBACK_CTX(member, ...)                                       \
-  RAISE_ERROR_UNLESS(                                                   \
-      WABT_SUCCEEDED(                                                   \
-          ctx->reader->member                                           \
-              ? ctx->reader->member(get_user_context(ctx), __VA_ARGS__) \
-              : Result::Ok),                                            \
-      #member " callback failed")
+#define CALLBACK0(member)                                   \
+  RAISE_ERROR_UNLESS(WABT_SUCCEEDED(ctx->reader->member()), \
+                     #member " callback failed")
 
-#define CALLBACK_CTX0(member)                                         \
-  RAISE_ERROR_UNLESS(                                                 \
-      WABT_SUCCEEDED(ctx->reader->member                              \
-                         ? ctx->reader->member(get_user_context(ctx)) \
-                         : Result::Ok),                               \
-      #member " callback failed")
-
-#define CALLBACK_SECTION(member, section_size) \
-  CALLBACK_CTX(member, section_size)
-
-#define CALLBACK0(member)                                              \
-  RAISE_ERROR_UNLESS(                                                  \
-      WABT_SUCCEEDED(ctx->reader->member                               \
-                         ? ctx->reader->member(ctx->reader->user_data) \
-                         : Result::Ok),                                \
-      #member " callback failed")
-
-#define CALLBACK(member, ...)                                            \
-  RAISE_ERROR_UNLESS(                                                    \
-      WABT_SUCCEEDED(                                                    \
-          ctx->reader->member                                            \
-              ? ctx->reader->member(__VA_ARGS__, ctx->reader->user_data) \
-              : Result::Ok),                                             \
-      #member " callback failed")
-
-#define FORWARD0(member)                                                   \
-  return ctx->reader->member ? ctx->reader->member(ctx->reader->user_data) \
-                             : Result::Ok
-
-#define FORWARD_CTX0(member)                  \
-  if (!ctx->reader->member)                   \
-    return Result::Ok;                        \
-  BinaryReaderContext new_ctx = *context;     \
-  new_ctx.user_data = ctx->reader->user_data; \
-  return ctx->reader->member(&new_ctx);
-
-#define FORWARD_CTX(member, ...)              \
-  if (!ctx->reader->member)                   \
-    return Result::Ok;                        \
-  BinaryReaderContext new_ctx = *context;     \
-  new_ctx.user_data = ctx->reader->user_data; \
-  return ctx->reader->member(&new_ctx, __VA_ARGS__);
-
-#define FORWARD(member, ...)                                            \
-  return ctx->reader->member                                            \
-             ? ctx->reader->member(__VA_ARGS__, ctx->reader->user_data) \
-             : Result::Ok
+#define CALLBACK(member, ...)                                          \
+  RAISE_ERROR_UNLESS(WABT_SUCCEEDED(ctx->reader->member(__VA_ARGS__)), \
+                     #member " callback failed")
 
 #define RAISE_ERROR(...) raise_error(ctx, __VA_ARGS__)
 
@@ -106,12 +54,9 @@ namespace {
     RAISE_ERROR(__VA_ARGS__);
 
 struct Context {
-  const uint8_t* data = nullptr;
-  size_t data_size = 0;
-  size_t offset = 0;
   size_t read_end = 0; /* Either the section end or data_size. */
-  BinaryReaderContext user_ctx;
   BinaryReader* reader = nullptr;
+  BinaryReader::State state;
   jmp_buf error_jmp_buf;
   TypeVector param_types;
   std::vector<uint32_t> target_depths;
@@ -131,43 +76,26 @@ struct Context {
   uint32_t num_function_bodies = 0;
 };
 
-struct LoggingContext {
-  Stream* stream;
-  BinaryReader* reader;
-  int indent;
-};
-
 }  // namespace
-
-static BinaryReaderContext* get_user_context(Context* ctx) {
-  ctx->user_ctx.user_data = ctx->reader->user_data;
-  ctx->user_ctx.data = ctx->data;
-  ctx->user_ctx.size = ctx->data_size;
-  ctx->user_ctx.offset = ctx->offset;
-  return &ctx->user_ctx;
-}
 
 static void WABT_PRINTF_FORMAT(2, 3)
     raise_error(Context* ctx, const char* format, ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  bool handled = false;
-  if (ctx->reader->on_error) {
-    handled = ctx->reader->on_error(get_user_context(ctx), buffer);
-  }
+  bool handled = ctx->reader->OnError(buffer);
 
   if (!handled) {
     /* Not great to just print, but we don't want to eat the error either. */
-    fprintf(stderr, "*ERROR*: @0x%08zx: %s\n", ctx->offset, buffer);
+    fprintf(stderr, "*ERROR*: @0x%08zx: %s\n", ctx->state.offset, buffer);
   }
   longjmp(ctx->error_jmp_buf, 1);
 }
 
-#define IN_SIZE(type)                                       \
-  if (ctx->offset + sizeof(type) > ctx->read_end) {         \
-    RAISE_ERROR("unable to read " #type ": %s", desc);      \
-  }                                                         \
-  memcpy(out_value, ctx->data + ctx->offset, sizeof(type)); \
-  ctx->offset += sizeof(type)
+#define IN_SIZE(type)                                                   \
+  if (ctx->state.offset + sizeof(type) > ctx->read_end) {               \
+    RAISE_ERROR("unable to read " #type ": %s", desc);                  \
+  }                                                                     \
+  memcpy(out_value, ctx->state.data + ctx->state.offset, sizeof(type)); \
+  ctx->state.offset += sizeof(type)
 
 static void in_u8(Context* ctx, uint8_t* out_value, const char* desc) {
   IN_SIZE(uint8_t);
@@ -234,12 +162,12 @@ size_t read_u32_leb128(const uint8_t* p,
 }
 
 static void in_u32_leb128(Context* ctx, uint32_t* out_value, const char* desc) {
-  const uint8_t* p = ctx->data + ctx->offset;
-  const uint8_t* end = ctx->data + ctx->read_end;
+  const uint8_t* p = ctx->state.data + ctx->state.offset;
+  const uint8_t* end = ctx->state.data + ctx->read_end;
   size_t bytes_read = read_u32_leb128(p, end, out_value);
   if (!bytes_read)
     RAISE_ERROR("unable to read u32 leb128: %s", desc);
-  ctx->offset += bytes_read;
+  ctx->state.offset += bytes_read;
 }
 
 size_t read_i32_leb128(const uint8_t* p,
@@ -279,54 +207,54 @@ size_t read_i32_leb128(const uint8_t* p,
 }
 
 static void in_i32_leb128(Context* ctx, uint32_t* out_value, const char* desc) {
-  const uint8_t* p = ctx->data + ctx->offset;
-  const uint8_t* end = ctx->data + ctx->read_end;
+  const uint8_t* p = ctx->state.data + ctx->state.offset;
+  const uint8_t* end = ctx->state.data + ctx->read_end;
   size_t bytes_read = read_i32_leb128(p, end, out_value);
   if (!bytes_read)
     RAISE_ERROR("unable to read i32 leb128: %s", desc);
-  ctx->offset += bytes_read;
+  ctx->state.offset += bytes_read;
 }
 
 static void in_i64_leb128(Context* ctx, uint64_t* out_value, const char* desc) {
-  const uint8_t* p = ctx->data + ctx->offset;
-  const uint8_t* end = ctx->data + ctx->read_end;
+  const uint8_t* p = ctx->state.data + ctx->state.offset;
+  const uint8_t* end = ctx->state.data + ctx->read_end;
 
   if (p < end && (p[0] & 0x80) == 0) {
     uint64_t result = LEB128_1(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 6);
-    ctx->offset += 1;
+    ctx->state.offset += 1;
   } else if (p + 1 < end && (p[1] & 0x80) == 0) {
     uint64_t result = LEB128_2(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 13);
-    ctx->offset += 2;
+    ctx->state.offset += 2;
   } else if (p + 2 < end && (p[2] & 0x80) == 0) {
     uint64_t result = LEB128_3(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 20);
-    ctx->offset += 3;
+    ctx->state.offset += 3;
   } else if (p + 3 < end && (p[3] & 0x80) == 0) {
     uint64_t result = LEB128_4(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 27);
-    ctx->offset += 4;
+    ctx->state.offset += 4;
   } else if (p + 4 < end && (p[4] & 0x80) == 0) {
     uint64_t result = LEB128_5(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 34);
-    ctx->offset += 5;
+    ctx->state.offset += 5;
   } else if (p + 5 < end && (p[5] & 0x80) == 0) {
     uint64_t result = LEB128_6(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 41);
-    ctx->offset += 6;
+    ctx->state.offset += 6;
   } else if (p + 6 < end && (p[6] & 0x80) == 0) {
     uint64_t result = LEB128_7(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 48);
-    ctx->offset += 7;
+    ctx->state.offset += 7;
   } else if (p + 7 < end && (p[7] & 0x80) == 0) {
     uint64_t result = LEB128_8(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 55);
-    ctx->offset += 8;
+    ctx->state.offset += 8;
   } else if (p + 8 < end && (p[8] & 0x80) == 0) {
     uint64_t result = LEB128_9(uint64_t);
     *out_value = SIGN_EXTEND(int64_t, result, 62);
-    ctx->offset += 9;
+    ctx->state.offset += 9;
   } else if (p + 9 < end && (p[9] & 0x80) == 0) {
     /* the top bits should be a sign-extension of the sign bit */
     bool sign_bit_set = (p[9] & 0x1);
@@ -337,7 +265,7 @@ static void in_i64_leb128(Context* ctx, uint64_t* out_value, const char* desc) {
     }
     uint64_t result = LEB128_10(uint64_t);
     *out_value = result;
-    ctx->offset += 10;
+    ctx->state.offset += 10;
   } else {
     /* past the end */
     RAISE_ERROR("unable to read i64 leb128: %s", desc);
@@ -371,12 +299,13 @@ static void in_str(Context* ctx, StringSlice* out_str, const char* desc) {
   uint32_t str_len = 0;
   in_u32_leb128(ctx, &str_len, "string length");
 
-  if (ctx->offset + str_len > ctx->read_end)
+  if (ctx->state.offset + str_len > ctx->read_end)
     RAISE_ERROR("unable to read string: %s", desc);
 
-  out_str->start = reinterpret_cast<const char*>(ctx->data) + ctx->offset;
+  out_str->start =
+      reinterpret_cast<const char*>(ctx->state.data) + ctx->state.offset;
   out_str->length = str_len;
-  ctx->offset += str_len;
+  ctx->state.offset += str_len;
 }
 
 static void in_bytes(Context* ctx,
@@ -386,12 +315,13 @@ static void in_bytes(Context* ctx,
   uint32_t data_size = 0;
   in_u32_leb128(ctx, &data_size, "data size");
 
-  if (ctx->offset + data_size > ctx->read_end)
+  if (ctx->state.offset + data_size > ctx->read_end)
     RAISE_ERROR("unable to read data: %s", desc);
 
-  *out_data = static_cast<const uint8_t*>(ctx->data) + ctx->offset;
+  *out_data =
+      static_cast<const uint8_t*>(ctx->state.data) + ctx->state.offset;
   *out_data_size = data_size;
-  ctx->offset += data_size;
+  ctx->state.offset += data_size;
 }
 
 static bool is_valid_external_kind(uint8_t kind) {
@@ -431,624 +361,6 @@ static uint32_t num_total_globals(Context* ctx) {
   return ctx->num_global_imports + ctx->num_globals;
 }
 
-/* Logging */
-
-static void indent(LoggingContext* ctx) {
-  ctx->indent += INDENT_SIZE;
-}
-
-static void dedent(LoggingContext* ctx) {
-  ctx->indent -= INDENT_SIZE;
-  assert(ctx->indent >= 0);
-}
-
-static void write_indent(LoggingContext* ctx) {
-  static char s_indent[] =
-      "                                                                       "
-      "                                                                       ";
-  static size_t s_indent_len = sizeof(s_indent) - 1;
-  size_t indent = ctx->indent;
-  while (indent > s_indent_len) {
-    write_data(ctx->stream, s_indent, s_indent_len, nullptr);
-    indent -= s_indent_len;
-  }
-  if (indent > 0) {
-    write_data(ctx->stream, s_indent, indent, nullptr);
-  }
-}
-
-#define LOGF_NOINDENT(...) writef(ctx->stream, __VA_ARGS__)
-
-#define LOGF(...)               \
-  do {                          \
-    write_indent(ctx);          \
-    LOGF_NOINDENT(__VA_ARGS__); \
-  } while (0)
-
-static bool logging_on_error(BinaryReaderContext* context,
-                             const char* message) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);
-  // Can't use FORWARD_CTX because it returns Result by default.
-  if (!ctx->reader->on_error)
-    return false;
-  BinaryReaderContext new_ctx = *context;
-  new_ctx.user_data = ctx->reader->user_data;
-  return ctx->reader->on_error(&new_ctx, message);
-}
-
-static Result logging_begin_section(BinaryReaderContext* context,
-                                    BinarySection section_type,
-                                    uint32_t size) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);
-  FORWARD_CTX(begin_section, section_type, size);
-}
-
-static Result logging_begin_custom_section(BinaryReaderContext* context,
-                                           uint32_t size,
-                                           StringSlice section_name) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);
-  LOGF("begin_custom_section: '" PRIstringslice "' size=%d\n",
-       WABT_PRINTF_STRING_SLICE_ARG(section_name), size);
-  indent(ctx);
-  FORWARD_CTX(begin_custom_section, size, section_name);
-}
-
-#define LOGGING_BEGIN(name)                                                 \
-  static Result logging_begin_##name(BinaryReaderContext* context,          \
-                                     uint32_t size) {                       \
-    LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data); \
-    LOGF("begin_" #name "(%u)\n", size);                                              \
-    indent(ctx);                                                            \
-    FORWARD_CTX(begin_##name, size);                                        \
-  }
-
-#define LOGGING_END(name)                                                   \
-  static Result logging_end_##name(BinaryReaderContext* context) {          \
-    LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data); \
-    dedent(ctx);                                                            \
-    LOGF("end_" #name "\n");                                                \
-    FORWARD_CTX0(end_##name);                                               \
-  }
-
-#define LOGGING_UINT32(name)                                       \
-  static Result logging_##name(uint32_t value, void* user_data) {  \
-    LoggingContext* ctx = static_cast<LoggingContext*>(user_data); \
-    LOGF(#name "(%u)\n", value);                                   \
-    FORWARD(name, value);                                          \
-  }
-
-#define LOGGING_UINT32_CTX(name)                                               \
-  static Result logging_##name(BinaryReaderContext* context, uint32_t value) { \
-    LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);    \
-    LOGF(#name "(%u)\n", value);                                               \
-    FORWARD_CTX(name, value);                                                  \
-  }
-
-#define LOGGING_UINT32_DESC(name, desc)                            \
-  static Result logging_##name(uint32_t value, void* user_data) {  \
-    LoggingContext* ctx = static_cast<LoggingContext*>(user_data); \
-    LOGF(#name "(" desc ": %u)\n", value);                         \
-    FORWARD(name, value);                                          \
-  }
-
-#define LOGGING_UINT32_UINT32(name, desc0, desc1)                   \
-  static Result logging_##name(uint32_t value0, uint32_t value1,    \
-                               void* user_data) {                   \
-    LoggingContext* ctx = static_cast<LoggingContext*>(user_data);  \
-    LOGF(#name "(" desc0 ": %u, " desc1 ": %u)\n", value0, value1); \
-    FORWARD(name, value0, value1);                                  \
-  }
-
-#define LOGGING_UINT32_UINT32_CTX(name, desc0, desc1)                         \
-  static Result logging_##name(BinaryReaderContext* context, uint32_t value0, \
-                               uint32_t value1) {                             \
-    LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);   \
-    LOGF(#name "(" desc0 ": %u, " desc1 ": %u)\n", value0, value1);           \
-    FORWARD_CTX(name, value0, value1);                                        \
-  }
-
-#define LOGGING_OPCODE(name)                                       \
-  static Result logging_##name(Opcode opcode, void* user_data) {   \
-    LoggingContext* ctx = static_cast<LoggingContext*>(user_data); \
-    LOGF(#name "(\"%s\" (%u))\n", get_opcode_name(opcode),         \
-         static_cast<unsigned>(opcode));                           \
-    FORWARD(name, opcode);                                         \
-  }
-
-#define LOGGING0(name)                                             \
-  static Result logging_##name(void* user_data) {                  \
-    LoggingContext* ctx = static_cast<LoggingContext*>(user_data); \
-    LOGF(#name "\n");                                              \
-    FORWARD0(name);                                                \
-  }
-
-LOGGING_UINT32(begin_module)
-LOGGING0(end_module)
-LOGGING_END(custom_section)
-LOGGING_BEGIN(signature_section)
-LOGGING_UINT32(on_signature_count)
-LOGGING_END(signature_section)
-LOGGING_BEGIN(import_section)
-LOGGING_UINT32(on_import_count)
-LOGGING_END(import_section)
-LOGGING_BEGIN(function_signatures_section)
-LOGGING_UINT32(on_function_signatures_count)
-LOGGING_UINT32_UINT32(on_function_signature, "index", "sig_index")
-LOGGING_END(function_signatures_section)
-LOGGING_BEGIN(table_section)
-LOGGING_UINT32(on_table_count)
-LOGGING_END(table_section)
-LOGGING_BEGIN(memory_section)
-LOGGING_UINT32(on_memory_count)
-LOGGING_END(memory_section)
-LOGGING_BEGIN(global_section)
-LOGGING_UINT32(on_global_count)
-LOGGING_UINT32(begin_global_init_expr)
-LOGGING_UINT32(end_global_init_expr)
-LOGGING_UINT32(end_global)
-LOGGING_END(global_section)
-LOGGING_BEGIN(export_section)
-LOGGING_UINT32(on_export_count)
-LOGGING_END(export_section)
-LOGGING_BEGIN(start_section)
-LOGGING_UINT32(on_start_function)
-LOGGING_END(start_section)
-LOGGING_BEGIN(function_bodies_section)
-LOGGING_UINT32(on_function_bodies_count)
-LOGGING_UINT32_CTX(begin_function_body)
-LOGGING_UINT32(end_function_body)
-LOGGING_UINT32(on_local_decl_count)
-LOGGING_OPCODE(on_binary_expr)
-LOGGING_UINT32_DESC(on_call_expr, "func_index")
-LOGGING_UINT32_DESC(on_call_import_expr, "import_index")
-LOGGING_UINT32_DESC(on_call_indirect_expr, "sig_index")
-LOGGING_OPCODE(on_compare_expr)
-LOGGING_OPCODE(on_convert_expr)
-LOGGING0(on_current_memory_expr)
-LOGGING0(on_drop_expr)
-LOGGING0(on_else_expr)
-LOGGING0(on_end_expr)
-LOGGING_UINT32_DESC(on_get_global_expr, "index")
-LOGGING_UINT32_DESC(on_get_local_expr, "index")
-LOGGING0(on_grow_memory_expr)
-LOGGING0(on_nop_expr)
-LOGGING0(on_return_expr)
-LOGGING0(on_select_expr)
-LOGGING_UINT32_DESC(on_set_global_expr, "index")
-LOGGING_UINT32_DESC(on_set_local_expr, "index")
-LOGGING_UINT32_DESC(on_tee_local_expr, "index")
-LOGGING0(on_unreachable_expr)
-LOGGING_OPCODE(on_unary_expr)
-LOGGING_END(function_bodies_section)
-LOGGING_BEGIN(elem_section)
-LOGGING_UINT32(on_elem_segment_count)
-LOGGING_UINT32_UINT32(begin_elem_segment, "index", "table_index")
-LOGGING_UINT32(begin_elem_segment_init_expr)
-LOGGING_UINT32(end_elem_segment_init_expr)
-LOGGING_UINT32_UINT32_CTX(on_elem_segment_function_index_count,
-                          "index",
-                          "count")
-LOGGING_UINT32_UINT32(on_elem_segment_function_index, "index", "func_index")
-LOGGING_UINT32(end_elem_segment)
-LOGGING_END(elem_section)
-LOGGING_BEGIN(data_section)
-LOGGING_UINT32(on_data_segment_count)
-LOGGING_UINT32_UINT32(begin_data_segment, "index", "memory_index")
-LOGGING_UINT32(begin_data_segment_init_expr)
-LOGGING_UINT32(end_data_segment_init_expr)
-LOGGING_UINT32(end_data_segment)
-LOGGING_END(data_section)
-LOGGING_BEGIN(names_section)
-LOGGING_UINT32(on_function_names_count)
-LOGGING_UINT32(on_local_name_function_count)
-LOGGING_UINT32_UINT32(on_local_name_local_count, "index", "count")
-LOGGING_END(names_section)
-LOGGING_BEGIN(reloc_section)
-LOGGING_END(reloc_section)
-LOGGING_UINT32_UINT32(on_init_expr_get_global_expr, "index", "global_index")
-
-static void sprint_limits(char* dst, size_t size, const Limits* limits) {
-  int result;
-  if (limits->has_max) {
-    result = wabt_snprintf(dst, size, "initial: %" PRIu64 ", max: %" PRIu64,
-                      limits->initial, limits->max);
-  } else {
-    result = wabt_snprintf(dst, size, "initial: %" PRIu64, limits->initial);
-  }
-  WABT_USE(result);
-  assert(static_cast<size_t>(result) < size);
-}
-
-static void log_types(LoggingContext* ctx, uint32_t type_count, Type* types) {
-  LOGF_NOINDENT("[");
-  for (uint32_t i = 0; i < type_count; ++i) {
-    LOGF_NOINDENT("%s", get_type_name(types[i]));
-    if (i != type_count - 1)
-      LOGF_NOINDENT(", ");
-  }
-  LOGF_NOINDENT("]");
-}
-
-static Result logging_on_signature(uint32_t index,
-                                   uint32_t param_count,
-                                   Type* param_types,
-                                   uint32_t result_count,
-                                   Type* result_types,
-                                   void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_signature(index: %u, params: ", index);
-  log_types(ctx, param_count, param_types);
-  LOGF_NOINDENT(", results: ");
-  log_types(ctx, result_count, result_types);
-  LOGF_NOINDENT(")\n");
-  FORWARD(on_signature, index, param_count, param_types, result_count,
-          result_types);
-}
-
-static Result logging_on_import(uint32_t index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_import(index: %u, module: \"" PRIstringslice
-       "\", field: \"" PRIstringslice "\")\n",
-       index, WABT_PRINTF_STRING_SLICE_ARG(module_name),
-       WABT_PRINTF_STRING_SLICE_ARG(field_name));
-  FORWARD(on_import, index, module_name, field_name);
-}
-
-static Result logging_on_import_func(uint32_t import_index,
-                                     StringSlice module_name,
-                                     StringSlice field_name,
-                                     uint32_t func_index,
-                                     uint32_t sig_index,
-                                     void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_import_func(import_index: %u, func_index: %u, sig_index: %u)\n",
-       import_index, func_index, sig_index);
-  FORWARD(on_import_func, import_index, module_name, field_name,
-          func_index, sig_index);
-}
-
-static Result logging_on_import_table(uint32_t import_index,
-                                      StringSlice module_name,
-                                      StringSlice field_name,
-                                      uint32_t table_index,
-                                      Type elem_type,
-                                      const Limits* elem_limits,
-                                      void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  char buf[100];
-  sprint_limits(buf, sizeof(buf), elem_limits);
-  LOGF(
-      "on_import_table(import_index: %u, table_index: %u, elem_type: %s, %s)\n",
-      import_index, table_index, get_type_name(elem_type), buf);
-  FORWARD(on_import_table, import_index, module_name, field_name,
-          table_index, elem_type, elem_limits);
-}
-
-static Result logging_on_import_memory(uint32_t import_index,
-                                       StringSlice module_name,
-                                       StringSlice field_name,
-                                       uint32_t memory_index,
-                                       const Limits* page_limits,
-                                       void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  char buf[100];
-  sprint_limits(buf, sizeof(buf), page_limits);
-  LOGF("on_import_memory(import_index: %u, memory_index: %u, %s)\n",
-       import_index, memory_index, buf);
-  FORWARD(on_import_memory, import_index, module_name, field_name,
-          memory_index, page_limits);
-}
-
-static Result logging_on_import_global(uint32_t import_index,
-                                       StringSlice module_name,
-                                       StringSlice field_name,
-                                       uint32_t global_index,
-                                       Type type,
-                                       bool mutable_,
-                                       void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF(
-      "on_import_global(import_index: %u, global_index: %u, type: %s, mutable: "
-      "%s)\n",
-      import_index, global_index, get_type_name(type),
-      mutable_ ? "true" : "false");
-  FORWARD(on_import_global, import_index, module_name, field_name,
-          global_index, type, mutable_);
-}
-
-static Result logging_on_table(uint32_t index,
-                               Type elem_type,
-                               const Limits* elem_limits,
-                               void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  char buf[100];
-  sprint_limits(buf, sizeof(buf), elem_limits);
-  LOGF("on_table(index: %u, elem_type: %s, %s)\n", index,
-       get_type_name(elem_type), buf);
-  FORWARD(on_table, index, elem_type, elem_limits);
-}
-
-static Result logging_on_memory(uint32_t index,
-                                const Limits* page_limits,
-                                void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  char buf[100];
-  sprint_limits(buf, sizeof(buf), page_limits);
-  LOGF("on_memory(index: %u, %s)\n", index, buf);
-  FORWARD(on_memory, index, page_limits);
-}
-
-static Result logging_begin_global(uint32_t index,
-                                   Type type,
-                                   bool mutable_,
-                                   void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("begin_global(index: %u, type: %s, mutable: %s)\n", index,
-       get_type_name(type), mutable_ ? "true" : "false");
-  FORWARD(begin_global, index, type, mutable_);
-}
-
-static Result logging_on_export(uint32_t index,
-                                ExternalKind kind,
-                                uint32_t item_index,
-                                StringSlice name,
-                                void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_export(index: %u, kind: %s, item_index: %u, name: \"" PRIstringslice
-       "\")\n",
-       index, get_kind_name(kind), item_index,
-       WABT_PRINTF_STRING_SLICE_ARG(name));
-  FORWARD(on_export, index, kind, item_index, name);
-}
-
-static Result logging_begin_function_body_pass(uint32_t index,
-                                               uint32_t pass,
-                                               void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("begin_function_body_pass(index: %u, pass: %u)\n", index, pass);
-  indent(ctx);
-  FORWARD(begin_function_body_pass, index, pass);
-}
-
-static Result logging_on_local_decl(uint32_t decl_index,
-                                    uint32_t count,
-                                    Type type,
-                                    void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_local_decl(index: %u, count: %u, type: %s)\n", decl_index, count,
-       get_type_name(type));
-  FORWARD(on_local_decl, decl_index, count, type);
-}
-
-static Result logging_on_block_expr(uint32_t num_types,
-                                    Type* sig_types,
-                                    void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_block_expr(sig: ");
-  log_types(ctx, num_types, sig_types);
-  LOGF_NOINDENT(")\n");
-  FORWARD(on_block_expr, num_types, sig_types);
-}
-
-static Result logging_on_br_expr(uint32_t depth, void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_br_expr(depth: %u)\n", depth);
-  FORWARD(on_br_expr, depth);
-}
-
-static Result logging_on_br_if_expr(uint32_t depth, void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_br_if_expr(depth: %u)\n", depth);
-  FORWARD(on_br_if_expr, depth);
-}
-
-static Result logging_on_br_table_expr(BinaryReaderContext* context,
-                                       uint32_t num_targets,
-                                       uint32_t* target_depths,
-                                       uint32_t default_target_depth) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(context->user_data);
-  LOGF("on_br_table_expr(num_targets: %u, depths: [", num_targets);
-  for (uint32_t i = 0; i < num_targets; ++i) {
-    LOGF_NOINDENT("%u", target_depths[i]);
-    if (i != num_targets - 1)
-      LOGF_NOINDENT(", ");
-  }
-  LOGF_NOINDENT("], default: %u)\n", default_target_depth);
-  FORWARD_CTX(on_br_table_expr, num_targets, target_depths,
-              default_target_depth);
-}
-
-static Result logging_on_f32_const_expr(uint32_t value_bits, void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  float value;
-  memcpy(&value, &value_bits, sizeof(value));
-  LOGF("on_f32_const_expr(%g (0x04%x))\n", value, value_bits);
-  FORWARD(on_f32_const_expr, value_bits);
-}
-
-static Result logging_on_f64_const_expr(uint64_t value_bits, void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  double value;
-  memcpy(&value, &value_bits, sizeof(value));
-  LOGF("on_f64_const_expr(%g (0x08%" PRIx64 "))\n", value, value_bits);
-  FORWARD(on_f64_const_expr, value_bits);
-}
-
-static Result logging_on_i32_const_expr(uint32_t value, void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_i32_const_expr(%u (0x%x))\n", value, value);
-  FORWARD(on_i32_const_expr, value);
-}
-
-static Result logging_on_i64_const_expr(uint64_t value, void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_i64_const_expr(%" PRIu64 " (0x%" PRIx64 "))\n", value, value);
-  FORWARD(on_i64_const_expr, value);
-}
-
-static Result logging_on_if_expr(uint32_t num_types,
-                                 Type* sig_types,
-                                 void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_if_expr(sig: ");
-  log_types(ctx, num_types, sig_types);
-  LOGF_NOINDENT(")\n");
-  FORWARD(on_if_expr, num_types, sig_types);
-}
-
-static Result logging_on_load_expr(Opcode opcode,
-                                   uint32_t alignment_log2,
-                                   uint32_t offset,
-                                   void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_load_expr(opcode: \"%s\" (%u), align log2: %u, offset: %u)\n",
-       get_opcode_name(opcode), static_cast<unsigned>(opcode), alignment_log2,
-       offset);
-  FORWARD(on_load_expr, opcode, alignment_log2, offset);
-}
-
-static Result logging_on_loop_expr(uint32_t num_types,
-                                   Type* sig_types,
-                                   void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_loop_expr(sig: ");
-  log_types(ctx, num_types, sig_types);
-  LOGF_NOINDENT(")\n");
-  FORWARD(on_loop_expr, num_types, sig_types);
-}
-
-static Result logging_on_store_expr(Opcode opcode,
-                                    uint32_t alignment_log2,
-                                    uint32_t offset,
-                                    void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_store_expr(opcode: \"%s\" (%u), align log2: %u, offset: %u)\n",
-       get_opcode_name(opcode), static_cast<unsigned>(opcode), alignment_log2,
-       offset);
-  FORWARD(on_store_expr, opcode, alignment_log2, offset);
-}
-
-static Result logging_end_function_body_pass(uint32_t index,
-                                             uint32_t pass,
-                                             void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  dedent(ctx);
-  LOGF("end_function_body_pass(index: %u, pass: %u)\n", index, pass);
-  FORWARD(end_function_body_pass, index, pass);
-}
-
-static Result logging_on_data_segment_data(uint32_t index,
-                                           const void* data,
-                                           uint32_t size,
-                                           void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_data_segment_data(index:%u, size:%u)\n", index, size);
-  FORWARD(on_data_segment_data, index, data, size);
-}
-
-static Result logging_on_function_name_subsection(uint32_t index,
-                                                  uint32_t name_type,
-                                                  uint32_t subsection_size,
-                                                  void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_function_name_subsection(index:%u, nametype:%u, size:%u)\n", index, name_type, subsection_size);
-  FORWARD(on_function_name_subsection, index, name_type, subsection_size);
-}
-
-static Result logging_on_function_name(uint32_t index,
-                                       StringSlice name,
-                                       void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_function_name(index: %u, name: \"" PRIstringslice "\")\n", index,
-       WABT_PRINTF_STRING_SLICE_ARG(name));
-  FORWARD(on_function_name, index, name);
-}
-
-static Result logging_on_local_name_subsection(uint32_t index,
-                                               uint32_t name_type,
-                                               uint32_t subsection_size,
-                                               void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_local_name_subsection(index:%u, nametype:%u, size:%u)\n", index, name_type, subsection_size);
-  FORWARD(on_local_name_subsection, index, name_type, subsection_size);
-}
-
-static Result logging_on_local_name(uint32_t func_index,
-                                    uint32_t local_index,
-                                    StringSlice name,
-                                    void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_local_name(func_index: %u, local_index: %u, name: \"" PRIstringslice
-       "\")\n",
-       func_index, local_index, WABT_PRINTF_STRING_SLICE_ARG(name));
-  FORWARD(on_local_name, func_index, local_index, name);
-}
-
-static Result logging_on_init_expr_f32_const_expr(uint32_t index,
-                                                  uint32_t value_bits,
-                                                  void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  float value;
-  memcpy(&value, &value_bits, sizeof(value));
-  LOGF("on_init_expr_f32_const_expr(index: %u, value: %g (0x04%x))\n", index,
-       value, value_bits);
-  FORWARD(on_init_expr_f32_const_expr, index, value_bits);
-}
-
-static Result logging_on_init_expr_f64_const_expr(uint32_t index,
-                                                  uint64_t value_bits,
-                                                  void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  double value;
-  memcpy(&value, &value_bits, sizeof(value));
-  LOGF("on_init_expr_f64_const_expr(index: %u value: %g (0x08%" PRIx64 "))\n",
-       index, value, value_bits);
-  FORWARD(on_init_expr_f64_const_expr, index, value_bits);
-}
-
-static Result logging_on_init_expr_i32_const_expr(uint32_t index,
-                                                  uint32_t value,
-                                                  void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_init_expr_i32_const_expr(index: %u, value: %u)\n", index, value);
-  FORWARD(on_init_expr_i32_const_expr, index, value);
-}
-
-static Result logging_on_init_expr_i64_const_expr(uint32_t index,
-                                                  uint64_t value,
-                                                  void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_init_expr_i64_const_expr(index: %u, value: %" PRIu64 ")\n", index,
-       value);
-  FORWARD(on_init_expr_i64_const_expr, index, value);
-}
-
-static Result logging_on_reloc_count(uint32_t count,
-                                     BinarySection section_code,
-                                     StringSlice section_name,
-                                     void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_reloc_count(count: %d, section: %s, section_name: " PRIstringslice
-       ")\n",
-       count, get_section_name(section_code),
-       WABT_PRINTF_STRING_SLICE_ARG(section_name));
-  FORWARD(on_reloc_count, count, section_code, section_name);
-}
-
-static Result logging_on_reloc(RelocType type,
-                               uint32_t offset,
-                               uint32_t index,
-                               int32_t addend,
-                               void* user_data) {
-  LoggingContext* ctx = static_cast<LoggingContext*>(user_data);
-  LOGF("on_reloc(type: %s, offset: %u, index: %u, addend: %d)\n",
-       get_reloc_type_name(type), offset, index, addend);
-  FORWARD(on_reloc, type, offset, index, addend);
-}
-
 static void read_init_expr(Context* ctx, uint32_t index) {
   uint8_t opcode;
   in_u8(ctx, &opcode, "opcode");
@@ -1056,35 +368,35 @@ static void read_init_expr(Context* ctx, uint32_t index) {
     case Opcode::I32Const: {
       uint32_t value = 0;
       in_i32_leb128(ctx, &value, "init_expr i32.const value");
-      CALLBACK(on_init_expr_i32_const_expr, index, value);
+      CALLBACK(OnInitExprI32ConstExpr, index, value);
       break;
     }
 
     case Opcode::I64Const: {
       uint64_t value = 0;
       in_i64_leb128(ctx, &value, "init_expr i64.const value");
-      CALLBACK(on_init_expr_i64_const_expr, index, value);
+      CALLBACK(OnInitExprI64ConstExpr, index, value);
       break;
     }
 
     case Opcode::F32Const: {
       uint32_t value_bits = 0;
       in_f32(ctx, &value_bits, "init_expr f32.const value");
-      CALLBACK(on_init_expr_f32_const_expr, index, value_bits);
+      CALLBACK(OnInitExprF32ConstExpr, index, value_bits);
       break;
     }
 
     case Opcode::F64Const: {
       uint64_t value_bits = 0;
       in_f64(ctx, &value_bits, "init_expr f64.const value");
-      CALLBACK(on_init_expr_f64_const_expr, index, value_bits);
+      CALLBACK(OnInitExprF64ConstExpr, index, value_bits);
       break;
     }
 
     case Opcode::GetGlobal: {
       uint32_t global_index;
       in_u32_leb128(ctx, &global_index, "init_expr get_global index");
-      CALLBACK(on_init_expr_get_global_expr, index, global_index);
+      CALLBACK(OnInitExprGetGlobalExpr, index, global_index);
       break;
     }
 
@@ -1164,15 +476,15 @@ static void read_global_header(Context* ctx,
 
 static void read_function_body(Context* ctx, uint32_t end_offset) {
   bool seen_end_opcode = false;
-  while (ctx->offset < end_offset) {
+  while (ctx->state.offset < end_offset) {
     uint8_t opcode_u8;
     in_u8(ctx, &opcode_u8, "opcode");
     Opcode opcode = static_cast<Opcode>(opcode_u8);
-    CALLBACK_CTX(on_opcode, opcode);
+    CALLBACK(OnOpcode, opcode);
     switch (opcode) {
       case Opcode::Unreachable:
-        CALLBACK0(on_unreachable_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK0(OnUnreachableExpr);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::Block: {
@@ -1181,8 +493,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         RAISE_ERROR_UNLESS(is_inline_sig_type(sig_type),
                            "expected valid block signature type");
         uint32_t num_types = sig_type == Type::Void ? 0 : 1;
-        CALLBACK(on_block_expr, num_types, &sig_type);
-        CALLBACK_CTX(on_opcode_block_sig, num_types, &sig_type);
+        CALLBACK(OnBlockExpr, num_types, &sig_type);
+        CALLBACK(OnOpcodeBlockSig, num_types, &sig_type);
         break;
       }
 
@@ -1192,8 +504,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         RAISE_ERROR_UNLESS(is_inline_sig_type(sig_type),
                            "expected valid block signature type");
         uint32_t num_types = sig_type == Type::Void ? 0 : 1;
-        CALLBACK(on_loop_expr, num_types, &sig_type);
-        CALLBACK_CTX(on_opcode_block_sig, num_types, &sig_type);
+        CALLBACK(OnLoopExpr, num_types, &sig_type);
+        CALLBACK(OnOpcodeBlockSig, num_types, &sig_type);
         break;
       }
 
@@ -1203,34 +515,34 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         RAISE_ERROR_UNLESS(is_inline_sig_type(sig_type),
                            "expected valid block signature type");
         uint32_t num_types = sig_type == Type::Void ? 0 : 1;
-        CALLBACK(on_if_expr, num_types, &sig_type);
-        CALLBACK_CTX(on_opcode_block_sig, num_types, &sig_type);
+        CALLBACK(OnIfExpr, num_types, &sig_type);
+        CALLBACK(OnOpcodeBlockSig, num_types, &sig_type);
         break;
       }
 
       case Opcode::Else:
-        CALLBACK0(on_else_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK0(OnElseExpr);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::Select:
-        CALLBACK0(on_select_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK0(OnSelectExpr);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::Br: {
         uint32_t depth;
         in_u32_leb128(ctx, &depth, "br depth");
-        CALLBACK(on_br_expr, depth);
-        CALLBACK_CTX(on_opcode_uint32, depth);
+        CALLBACK(OnBrExpr, depth);
+        CALLBACK(OnOpcodeUint32, depth);
         break;
       }
 
       case Opcode::BrIf: {
         uint32_t depth;
         in_u32_leb128(ctx, &depth, "br_if depth");
-        CALLBACK(on_br_if_expr, depth);
-        CALLBACK_CTX(on_opcode_uint32, depth);
+        CALLBACK(OnBrIfExpr, depth);
+        CALLBACK(OnOpcodeUint32, depth);
         break;
       }
 
@@ -1252,96 +564,96 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         uint32_t* target_depths =
             num_targets ? ctx->target_depths.data() : nullptr;
 
-        CALLBACK_CTX(on_br_table_expr, num_targets, target_depths,
-                     default_target_depth);
+        CALLBACK(OnBrTableExpr, num_targets, target_depths,
+                 default_target_depth);
         break;
       }
 
       case Opcode::Return:
-        CALLBACK0(on_return_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK0(OnReturnExpr);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::Nop:
-        CALLBACK0(on_nop_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK0(OnNopExpr);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::Drop:
-        CALLBACK0(on_drop_expr);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK0(OnDropExpr);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::End:
-        if (ctx->offset == end_offset) {
+        if (ctx->state.offset == end_offset) {
           seen_end_opcode = true;
-          CALLBACK0(on_end_func);
+          CALLBACK0(OnEndFunc);
         } else {
-          CALLBACK0(on_end_expr);
+          CALLBACK0(OnEndExpr);
         }
         break;
 
       case Opcode::I32Const: {
         uint32_t value = 0;
         in_i32_leb128(ctx, &value, "i32.const value");
-        CALLBACK(on_i32_const_expr, value);
-        CALLBACK_CTX(on_opcode_uint32, value);
+        CALLBACK(OnI32ConstExpr, value);
+        CALLBACK(OnOpcodeUint32, value);
         break;
       }
 
       case Opcode::I64Const: {
         uint64_t value = 0;
         in_i64_leb128(ctx, &value, "i64.const value");
-        CALLBACK(on_i64_const_expr, value);
-        CALLBACK_CTX(on_opcode_uint64, value);
+        CALLBACK(OnI64ConstExpr, value);
+        CALLBACK(OnOpcodeUint64, value);
         break;
       }
 
       case Opcode::F32Const: {
         uint32_t value_bits = 0;
         in_f32(ctx, &value_bits, "f32.const value");
-        CALLBACK(on_f32_const_expr, value_bits);
-        CALLBACK_CTX(on_opcode_f32, value_bits);
+        CALLBACK(OnF32ConstExpr, value_bits);
+        CALLBACK(OnOpcodeF32, value_bits);
         break;
       }
 
       case Opcode::F64Const: {
         uint64_t value_bits = 0;
         in_f64(ctx, &value_bits, "f64.const value");
-        CALLBACK(on_f64_const_expr, value_bits);
-        CALLBACK_CTX(on_opcode_f64, value_bits);
+        CALLBACK(OnF64ConstExpr, value_bits);
+        CALLBACK(OnOpcodeF64, value_bits);
         break;
       }
 
       case Opcode::GetGlobal: {
         uint32_t global_index;
         in_u32_leb128(ctx, &global_index, "get_global global index");
-        CALLBACK(on_get_global_expr, global_index);
-        CALLBACK_CTX(on_opcode_uint32, global_index);
+        CALLBACK(OnGetGlobalExpr, global_index);
+        CALLBACK(OnOpcodeUint32, global_index);
         break;
       }
 
       case Opcode::GetLocal: {
         uint32_t local_index;
         in_u32_leb128(ctx, &local_index, "get_local local index");
-        CALLBACK(on_get_local_expr, local_index);
-        CALLBACK_CTX(on_opcode_uint32, local_index);
+        CALLBACK(OnGetLocalExpr, local_index);
+        CALLBACK(OnOpcodeUint32, local_index);
         break;
       }
 
       case Opcode::SetGlobal: {
         uint32_t global_index;
         in_u32_leb128(ctx, &global_index, "set_global global index");
-        CALLBACK(on_set_global_expr, global_index);
-        CALLBACK_CTX(on_opcode_uint32, global_index);
+        CALLBACK(OnSetGlobalExpr, global_index);
+        CALLBACK(OnOpcodeUint32, global_index);
         break;
       }
 
       case Opcode::SetLocal: {
         uint32_t local_index;
         in_u32_leb128(ctx, &local_index, "set_local local index");
-        CALLBACK(on_set_local_expr, local_index);
-        CALLBACK_CTX(on_opcode_uint32, local_index);
+        CALLBACK(OnSetLocalExpr, local_index);
+        CALLBACK(OnOpcodeUint32, local_index);
         break;
       }
 
@@ -1350,8 +662,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         in_u32_leb128(ctx, &func_index, "call function index");
         RAISE_ERROR_UNLESS(func_index < num_total_funcs(ctx),
                            "invalid call function index");
-        CALLBACK(on_call_expr, func_index);
-        CALLBACK_CTX(on_opcode_uint32, func_index);
+        CALLBACK(OnCallExpr, func_index);
+        CALLBACK(OnOpcodeUint32, func_index);
         break;
       }
 
@@ -1364,16 +676,16 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         in_u32_leb128(ctx, &reserved, "call_indirect reserved");
         RAISE_ERROR_UNLESS(reserved == 0,
                            "call_indirect reserved value must be 0");
-        CALLBACK(on_call_indirect_expr, sig_index);
-        CALLBACK_CTX(on_opcode_uint32_uint32, sig_index, reserved);
+        CALLBACK(OnCallIndirectExpr, sig_index);
+        CALLBACK(OnOpcodeUint32Uint32, sig_index, reserved);
         break;
       }
 
       case Opcode::TeeLocal: {
         uint32_t local_index;
         in_u32_leb128(ctx, &local_index, "tee_local local index");
-        CALLBACK(on_tee_local_expr, local_index);
-        CALLBACK_CTX(on_opcode_uint32, local_index);
+        CALLBACK(OnTeeLocalExpr, local_index);
+        CALLBACK(OnOpcodeUint32, local_index);
         break;
       }
 
@@ -1396,8 +708,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         uint32_t offset;
         in_u32_leb128(ctx, &offset, "load offset");
 
-        CALLBACK(on_load_expr, opcode, alignment_log2, offset);
-        CALLBACK_CTX(on_opcode_uint32_uint32, alignment_log2, offset);
+        CALLBACK(OnLoadExpr, opcode, alignment_log2, offset);
+        CALLBACK(OnOpcodeUint32Uint32, alignment_log2, offset);
         break;
       }
 
@@ -1415,8 +727,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         uint32_t offset;
         in_u32_leb128(ctx, &offset, "store offset");
 
-        CALLBACK(on_store_expr, opcode, alignment_log2, offset);
-        CALLBACK_CTX(on_opcode_uint32_uint32, alignment_log2, offset);
+        CALLBACK(OnStoreExpr, opcode, alignment_log2, offset);
+        CALLBACK(OnOpcodeUint32Uint32, alignment_log2, offset);
         break;
       }
 
@@ -1425,8 +737,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         in_u32_leb128(ctx, &reserved, "current_memory reserved");
         RAISE_ERROR_UNLESS(reserved == 0,
                            "current_memory reserved value must be 0");
-        CALLBACK0(on_current_memory_expr);
-        CALLBACK_CTX(on_opcode_uint32, reserved);
+        CALLBACK0(OnCurrentMemoryExpr);
+        CALLBACK(OnOpcodeUint32, reserved);
         break;
       }
 
@@ -1435,8 +747,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
         in_u32_leb128(ctx, &reserved, "grow_memory reserved");
         RAISE_ERROR_UNLESS(reserved == 0,
                            "grow_memory reserved value must be 0");
-        CALLBACK0(on_grow_memory_expr);
-        CALLBACK_CTX(on_opcode_uint32, reserved);
+        CALLBACK0(OnGrowMemoryExpr);
+        CALLBACK(OnOpcodeUint32, reserved);
         break;
       }
 
@@ -1484,8 +796,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
       case Opcode::F64Min:
       case Opcode::F64Max:
       case Opcode::F64Copysign:
-        CALLBACK(on_binary_expr, opcode);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK(OnBinaryExpr, opcode);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::I32Eq:
@@ -1520,8 +832,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
       case Opcode::F64Le:
       case Opcode::F64Gt:
       case Opcode::F64Ge:
-        CALLBACK(on_compare_expr, opcode);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK(OnCompareExpr, opcode);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::I32Clz:
@@ -1544,8 +856,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
       case Opcode::F64Trunc:
       case Opcode::F64Nearest:
       case Opcode::F64Sqrt:
-        CALLBACK(on_unary_expr, opcode);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK(OnUnaryExpr, opcode);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::I32TruncSF32:
@@ -1575,8 +887,8 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
       case Opcode::I64ReinterpretF64:
       case Opcode::I32Eqz:
       case Opcode::I64Eqz:
-        CALLBACK(on_convert_expr, opcode);
-        CALLBACK_CTX0(on_opcode_bare);
+        CALLBACK(OnConvertExpr, opcode);
+        CALLBACK0(OnOpcodeBare);
         break;
 
       default:
@@ -1584,7 +896,7 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
                     static_cast<unsigned>(opcode));
     }
   }
-  RAISE_ERROR_UNLESS(ctx->offset == end_offset,
+  RAISE_ERROR_UNLESS(ctx->state.offset == end_offset,
                      "function body longer than given size");
   RAISE_ERROR_UNLESS(seen_end_opcode, "function body must end with END opcode");
 }
@@ -1592,17 +904,17 @@ static void read_function_body(Context* ctx, uint32_t end_offset) {
 static void read_custom_section(Context* ctx, uint32_t section_size) {
   StringSlice section_name;
   in_str(ctx, &section_name, "section name");
-  CALLBACK_CTX(begin_custom_section, section_size, section_name);
+  CALLBACK(BeginCustomSection, section_size, section_name);
 
   bool name_section_ok = ctx->last_known_section >= BinarySection::Import;
   if (ctx->options->read_debug_names && name_section_ok &&
       strncmp(section_name.start, WABT_BINARY_SECTION_NAME,
               section_name.length) == 0) {
-    CALLBACK_SECTION(begin_names_section, section_size);
+    CALLBACK(BeginNamesSection, section_size);
     uint32_t i = 0;
     size_t previous_read_end = ctx->read_end;
     uint32_t previous_subsection_type = 0;
-    while (ctx->offset < ctx->read_end) {
+    while (ctx->state.offset < ctx->read_end) {
       uint32_t name_type;
       uint32_t subsection_size;
       in_u32_leb128(ctx, &name_type, "name type");
@@ -1614,74 +926,74 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
       }
       previous_subsection_type = name_type;
       in_u32_leb128(ctx, &subsection_size, "subsection size");
-      size_t subsection_end = ctx->offset + subsection_size;
+      size_t subsection_end = ctx->state.offset + subsection_size;
       if (subsection_end > ctx->read_end)
         RAISE_ERROR("invalid sub-section size: extends past end");
       ctx->read_end = subsection_end;
 
       switch (static_cast<NameSectionSubsection>(name_type)) {
       case NameSectionSubsection::Function:
-        CALLBACK(on_function_name_subsection, i, name_type, subsection_size);
+        CALLBACK(OnFunctionNameSubsection, i, name_type, subsection_size);
         if (subsection_size) {
           uint32_t num_names;
           in_u32_leb128(ctx, &num_names, "name count");
-          CALLBACK(on_function_names_count, num_names);
+          CALLBACK(OnFunctionNamesCount, num_names);
           for (uint32_t j = 0; j < num_names; ++j) {
             uint32_t function_index;
             StringSlice function_name;
 
             in_u32_leb128(ctx, &function_index, "function index");
             in_str(ctx, &function_name, "function name");
-            CALLBACK(on_function_name, function_index, function_name);
+            CALLBACK(OnFunctionName, function_index, function_name);
           }
         }
         break;
       case NameSectionSubsection::Local:
-        CALLBACK(on_local_name_subsection, i, name_type, subsection_size);
+        CALLBACK(OnLocalNameSubsection, i, name_type, subsection_size);
         if (subsection_size) {
           uint32_t num_funcs;
           in_u32_leb128(ctx, &num_funcs, "function count");
-          CALLBACK(on_local_name_function_count, num_funcs);
+          CALLBACK(OnLocalNameFunctionCount, num_funcs);
           for (uint32_t j = 0; j < num_funcs; ++j) {
             uint32_t function_index;
             in_u32_leb128(ctx, &function_index, "function index");
             uint32_t num_locals;
             in_u32_leb128(ctx, &num_locals, "local count");
-            CALLBACK(on_local_name_local_count, function_index, num_locals);
+            CALLBACK(OnLocalNameLocalCount, function_index, num_locals);
             for (uint32_t k = 0; k < num_locals; ++k) {
               uint32_t local_index;
               StringSlice local_name;
 
               in_u32_leb128(ctx, &local_index, "named index");
               in_str(ctx, &local_name, "name");
-              CALLBACK(on_local_name, function_index, local_index, local_name);
+              CALLBACK(OnLocalName, function_index, local_index, local_name);
             }
           }
         }
         break;
       default:
         /* unknown subsection, skip it */
-        ctx->offset = subsection_end;
+        ctx->state.offset = subsection_end;
         break;
       }
       ++i;
-      if (ctx->offset != subsection_end) {
+      if (ctx->state.offset != subsection_end) {
         RAISE_ERROR("unfinished sub-section (expected end: 0x%" PRIzx ")",
                     subsection_end);
       }
       ctx->read_end = previous_read_end;
     }
-    CALLBACK_CTX0(end_names_section);
+    CALLBACK0(EndNamesSection);
   } else if (strncmp(section_name.start, WABT_BINARY_SECTION_RELOC,
                      strlen(WABT_BINARY_SECTION_RELOC)) == 0) {
-    CALLBACK_SECTION(begin_reloc_section, section_size);
+    CALLBACK(BeginRelocSection, section_size);
     uint32_t num_relocs, section;
     in_u32_leb128(ctx, &section, "section");
     WABT_ZERO_MEMORY(section_name);
     if (static_cast<BinarySection>(section) == BinarySection::Custom)
       in_str(ctx, &section_name, "section name");
     in_u32_leb128(ctx, &num_relocs, "relocation count");
-    CALLBACK(on_reloc_count, num_relocs, static_cast<BinarySection>(section),
+    CALLBACK(OnRelocCount, num_relocs, static_cast<BinarySection>(section),
              section_name);
     for (uint32_t i = 0; i < num_relocs; ++i) {
       uint32_t reloc_type, offset, index, addend = 0;
@@ -1698,20 +1010,20 @@ static void read_custom_section(Context* ctx, uint32_t section_size) {
         default:
           break;
       }
-      CALLBACK(on_reloc, type, offset, index, addend);
+      CALLBACK(OnReloc, type, offset, index, addend);
     }
-    CALLBACK_CTX0(end_reloc_section);
+    CALLBACK0(EndRelocSection);
   } else {
     /* This is an unknown custom section, skip it. */
-    ctx->offset = ctx->read_end;
+    ctx->state.offset = ctx->read_end;
   }
-  CALLBACK_CTX0(end_custom_section);
+  CALLBACK0(EndCustomSection);
 }
 
 static void read_type_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_signature_section, section_size);
+  CALLBACK(BeginTypeSection, section_size);
   in_u32_leb128(ctx, &ctx->num_signatures, "type count");
-  CALLBACK(on_signature_count, ctx->num_signatures);
+  CALLBACK(OnTypeCount, ctx->num_signatures);
 
   for (uint32_t i = 0; i < ctx->num_signatures; ++i) {
     Type form;
@@ -1747,16 +1059,15 @@ static void read_type_section(Context* ctx, uint32_t section_size) {
 
     Type* param_types = num_params ? ctx->param_types.data() : nullptr;
 
-    CALLBACK(on_signature, i, num_params, param_types, num_results,
-             &result_type);
+    CALLBACK(OnType, i, num_params, param_types, num_results, &result_type);
   }
-  CALLBACK_CTX0(end_signature_section);
+  CALLBACK0(EndTypeSection);
 }
 
 static void read_import_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_import_section, section_size);
+  CALLBACK(BeginImportSection, section_size);
   in_u32_leb128(ctx, &ctx->num_imports, "import count");
-  CALLBACK(on_import_count, ctx->num_imports);
+  CALLBACK(OnImportCount, ctx->num_imports);
   for (uint32_t i = 0; i < ctx->num_imports; ++i) {
     StringSlice module_name;
     in_str(ctx, &module_name, "import module name");
@@ -1771,8 +1082,8 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         in_u32_leb128(ctx, &sig_index, "import signature index");
         RAISE_ERROR_UNLESS(sig_index < ctx->num_signatures,
                            "invalid import signature index");
-        CALLBACK(on_import, i, module_name, field_name);
-        CALLBACK(on_import_func, i, module_name, field_name,
+        CALLBACK(OnImport, i, module_name, field_name);
+        CALLBACK(OnImportFunc, i, module_name, field_name,
                  ctx->num_func_imports, sig_index);
         ctx->num_func_imports++;
         break;
@@ -1782,8 +1093,8 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         Type elem_type;
         Limits elem_limits;
         read_table(ctx, &elem_type, &elem_limits);
-        CALLBACK(on_import, i, module_name, field_name);
-        CALLBACK(on_import_table, i, module_name, field_name,
+        CALLBACK(OnImport, i, module_name, field_name);
+        CALLBACK(OnImportTable, i, module_name, field_name,
                  ctx->num_table_imports, elem_type, &elem_limits);
         ctx->num_table_imports++;
         break;
@@ -1792,8 +1103,8 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
       case ExternalKind::Memory: {
         Limits page_limits;
         read_memory(ctx, &page_limits);
-        CALLBACK(on_import, i, module_name, field_name);
-        CALLBACK(on_import_memory, i, module_name, field_name,
+        CALLBACK(OnImport, i, module_name, field_name);
+        CALLBACK(OnImportMemory, i, module_name, field_name,
                  ctx->num_memory_imports, &page_limits);
         ctx->num_memory_imports++;
         break;
@@ -1803,8 +1114,8 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         Type type;
         bool mutable_;
         read_global_header(ctx, &type, &mutable_);
-        CALLBACK(on_import, i, module_name, field_name);
-        CALLBACK(on_import_global, i, module_name, field_name,
+        CALLBACK(OnImport, i, module_name, field_name);
+        CALLBACK(OnImportGlobal, i, module_name, field_name,
                  ctx->num_global_imports, type, mutable_);
         ctx->num_global_imports++;
         break;
@@ -1814,76 +1125,76 @@ static void read_import_section(Context* ctx, uint32_t section_size) {
         RAISE_ERROR("invalid import kind: %d", kind);
     }
   }
-  CALLBACK_CTX0(end_import_section);
+  CALLBACK0(EndImportSection);
 }
 
 static void read_function_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_function_signatures_section, section_size);
+  CALLBACK(BeginFunctionSection, section_size);
   in_u32_leb128(ctx, &ctx->num_function_signatures, "function signature count");
-  CALLBACK(on_function_signatures_count, ctx->num_function_signatures);
+  CALLBACK(OnFunctionCount, ctx->num_function_signatures);
   for (uint32_t i = 0; i < ctx->num_function_signatures; ++i) {
     uint32_t func_index = ctx->num_func_imports + i;
     uint32_t sig_index;
     in_u32_leb128(ctx, &sig_index, "function signature index");
     RAISE_ERROR_UNLESS(sig_index < ctx->num_signatures,
                        "invalid function signature index: %d", sig_index);
-    CALLBACK(on_function_signature, func_index, sig_index);
+    CALLBACK(OnFunction, func_index, sig_index);
   }
-  CALLBACK_CTX0(end_function_signatures_section);
+  CALLBACK0(EndFunctionSection);
 }
 
 static void read_table_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_table_section, section_size);
+  CALLBACK(BeginTableSection, section_size);
   in_u32_leb128(ctx, &ctx->num_tables, "table count");
   RAISE_ERROR_UNLESS(ctx->num_tables <= 1, "table count (%d) must be 0 or 1",
                      ctx->num_tables);
-  CALLBACK(on_table_count, ctx->num_tables);
+  CALLBACK(OnTableCount, ctx->num_tables);
   for (uint32_t i = 0; i < ctx->num_tables; ++i) {
     uint32_t table_index = ctx->num_table_imports + i;
     Type elem_type;
     Limits elem_limits;
     read_table(ctx, &elem_type, &elem_limits);
-    CALLBACK(on_table, table_index, elem_type, &elem_limits);
+    CALLBACK(OnTable, table_index, elem_type, &elem_limits);
   }
-  CALLBACK_CTX0(end_table_section);
+  CALLBACK0(EndTableSection);
 }
 
 static void read_memory_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_memory_section, section_size);
+  CALLBACK(BeginMemorySection, section_size);
   in_u32_leb128(ctx, &ctx->num_memories, "memory count");
   RAISE_ERROR_UNLESS(ctx->num_memories <= 1, "memory count must be 0 or 1");
-  CALLBACK(on_memory_count, ctx->num_memories);
+  CALLBACK(OnMemoryCount, ctx->num_memories);
   for (uint32_t i = 0; i < ctx->num_memories; ++i) {
     uint32_t memory_index = ctx->num_memory_imports + i;
     Limits page_limits;
     read_memory(ctx, &page_limits);
-    CALLBACK(on_memory, memory_index, &page_limits);
+    CALLBACK(OnMemory, memory_index, &page_limits);
   }
-  CALLBACK_CTX0(end_memory_section);
+  CALLBACK0(EndMemorySection);
 }
 
 static void read_global_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_global_section, section_size);
+  CALLBACK(BeginGlobalSection, section_size);
   in_u32_leb128(ctx, &ctx->num_globals, "global count");
-  CALLBACK(on_global_count, ctx->num_globals);
+  CALLBACK(OnGlobalCount, ctx->num_globals);
   for (uint32_t i = 0; i < ctx->num_globals; ++i) {
     uint32_t global_index = ctx->num_global_imports + i;
     Type global_type;
     bool mutable_;
     read_global_header(ctx, &global_type, &mutable_);
-    CALLBACK(begin_global, global_index, global_type, mutable_);
-    CALLBACK(begin_global_init_expr, global_index);
+    CALLBACK(BeginGlobal, global_index, global_type, mutable_);
+    CALLBACK(BeginGlobalInitExpr, global_index);
     read_init_expr(ctx, global_index);
-    CALLBACK(end_global_init_expr, global_index);
-    CALLBACK(end_global, global_index);
+    CALLBACK(EndGlobalInitExpr, global_index);
+    CALLBACK(EndGlobal, global_index);
   }
-  CALLBACK_CTX0(end_global_section);
+  CALLBACK0(EndGlobalSection);
 }
 
 static void read_export_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_export_section, section_size);
+  CALLBACK(BeginExportSection, section_size);
   in_u32_leb128(ctx, &ctx->num_exports, "export count");
-  CALLBACK(on_export_count, ctx->num_exports);
+  CALLBACK(OnExportCount, ctx->num_exports);
   for (uint32_t i = 0; i < ctx->num_exports; ++i) {
     StringSlice name;
     in_str(ctx, &name, "export item name");
@@ -1914,70 +1225,70 @@ static void read_export_section(Context* ctx, uint32_t section_size) {
         break;
     }
 
-    CALLBACK(on_export, i, static_cast<ExternalKind>(external_kind), item_index,
+    CALLBACK(OnExport, i, static_cast<ExternalKind>(external_kind), item_index,
              name);
   }
-  CALLBACK_CTX0(end_export_section);
+  CALLBACK0(EndExportSection);
 }
 
 static void read_start_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_start_section, section_size);
+  CALLBACK(BeginStartSection, section_size);
   uint32_t func_index;
   in_u32_leb128(ctx, &func_index, "start function index");
   RAISE_ERROR_UNLESS(func_index < num_total_funcs(ctx),
                      "invalid start function index");
-  CALLBACK(on_start_function, func_index);
-  CALLBACK_CTX0(end_start_section);
+  CALLBACK(OnStartFunction, func_index);
+  CALLBACK0(EndStartSection);
 }
 
 static void read_elem_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_elem_section, section_size);
+  CALLBACK(BeginElemSection, section_size);
   uint32_t num_elem_segments;
   in_u32_leb128(ctx, &num_elem_segments, "elem segment count");
-  CALLBACK(on_elem_segment_count, num_elem_segments);
+  CALLBACK(OnElemSegmentCount, num_elem_segments);
   RAISE_ERROR_UNLESS(num_elem_segments == 0 || num_total_tables(ctx) > 0,
                      "elem section without table section");
   for (uint32_t i = 0; i < num_elem_segments; ++i) {
     uint32_t table_index;
     in_u32_leb128(ctx, &table_index, "elem segment table index");
-    CALLBACK(begin_elem_segment, i, table_index);
-    CALLBACK(begin_elem_segment_init_expr, i);
+    CALLBACK(BeginElemSegment, i, table_index);
+    CALLBACK(BeginElemSegmentInitExpr, i);
     read_init_expr(ctx, i);
-    CALLBACK(end_elem_segment_init_expr, i);
+    CALLBACK(EndElemSegmentInitExpr, i);
 
     uint32_t num_function_indexes;
     in_u32_leb128(ctx, &num_function_indexes,
                   "elem segment function index count");
-    CALLBACK_CTX(on_elem_segment_function_index_count, i, num_function_indexes);
+    CALLBACK(OnElemSegmentFunctionIndexCount, i, num_function_indexes);
     for (uint32_t j = 0; j < num_function_indexes; ++j) {
       uint32_t func_index;
       in_u32_leb128(ctx, &func_index, "elem segment function index");
-      CALLBACK(on_elem_segment_function_index, i, func_index);
+      CALLBACK(OnElemSegmentFunctionIndex, i, func_index);
     }
-    CALLBACK(end_elem_segment, i);
+    CALLBACK(EndElemSegment, i);
   }
-  CALLBACK_CTX0(end_elem_section);
+  CALLBACK0(EndElemSection);
 }
 
 static void read_code_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_function_bodies_section, section_size);
+  CALLBACK(BeginCodeSection, section_size);
   in_u32_leb128(ctx, &ctx->num_function_bodies, "function body count");
   RAISE_ERROR_UNLESS(ctx->num_function_signatures == ctx->num_function_bodies,
                      "function signature count != function body count");
-  CALLBACK(on_function_bodies_count, ctx->num_function_bodies);
+  CALLBACK(OnFunctionBodyCount, ctx->num_function_bodies);
   for (uint32_t i = 0; i < ctx->num_function_bodies; ++i) {
     uint32_t func_index = ctx->num_func_imports + i;
-    uint32_t func_offset = ctx->offset;
-    ctx->offset = func_offset;
-    CALLBACK_CTX(begin_function_body, func_index);
+    uint32_t func_offset = ctx->state.offset;
+    ctx->state.offset = func_offset;
+    CALLBACK(BeginFunctionBody, func_index);
     uint32_t body_size;
     in_u32_leb128(ctx, &body_size, "function body size");
-    uint32_t body_start_offset = ctx->offset;
+    uint32_t body_start_offset = ctx->state.offset;
     uint32_t end_offset = body_start_offset + body_size;
 
     uint32_t num_local_decls;
     in_u32_leb128(ctx, &num_local_decls, "local declaration count");
-    CALLBACK(on_local_decl_count, num_local_decls);
+    CALLBACK(OnLocalDeclCount, num_local_decls);
     for (uint32_t k = 0; k < num_local_decls; ++k) {
       uint32_t num_local_types;
       in_u32_leb128(ctx, &num_local_types, "local type count");
@@ -1985,50 +1296,50 @@ static void read_code_section(Context* ctx, uint32_t section_size) {
       in_type(ctx, &local_type, "local type");
       RAISE_ERROR_UNLESS(is_concrete_type(local_type),
                          "expected valid local type");
-      CALLBACK(on_local_decl, k, num_local_types, local_type);
+      CALLBACK(OnLocalDecl, k, num_local_types, local_type);
     }
 
     read_function_body(ctx, end_offset);
 
-    CALLBACK(end_function_body, func_index);
+    CALLBACK(EndFunctionBody, func_index);
   }
-  CALLBACK_CTX0(end_function_bodies_section);
+  CALLBACK0(EndCodeSection);
 }
 
 static void read_data_section(Context* ctx, uint32_t section_size) {
-  CALLBACK_SECTION(begin_data_section, section_size);
+  CALLBACK(BeginDataSection, section_size);
   uint32_t num_data_segments;
   in_u32_leb128(ctx, &num_data_segments, "data segment count");
-  CALLBACK(on_data_segment_count, num_data_segments);
+  CALLBACK(OnDataSegmentCount, num_data_segments);
   RAISE_ERROR_UNLESS(num_data_segments == 0 || num_total_memories(ctx) > 0,
                      "data section without memory section");
   for (uint32_t i = 0; i < num_data_segments; ++i) {
     uint32_t memory_index;
     in_u32_leb128(ctx, &memory_index, "data segment memory index");
-    CALLBACK(begin_data_segment, i, memory_index);
-    CALLBACK(begin_data_segment_init_expr, i);
+    CALLBACK(BeginDataSegment, i, memory_index);
+    CALLBACK(BeginDataSegmentInitExpr, i);
     read_init_expr(ctx, i);
-    CALLBACK(end_data_segment_init_expr, i);
+    CALLBACK(EndDataSegmentInitExpr, i);
 
     uint32_t data_size;
     const void* data;
     in_bytes(ctx, &data, &data_size, "data segment data");
-    CALLBACK(on_data_segment_data, i, data, data_size);
-    CALLBACK(end_data_segment, i);
+    CALLBACK(OnDataSegmentData, i, data, data_size);
+    CALLBACK(EndDataSegment, i);
   }
-  CALLBACK_CTX0(end_data_section);
+  CALLBACK0(EndDataSection);
 }
 
 static void read_sections(Context* ctx) {
-  while (ctx->offset < ctx->data_size) {
+  while (ctx->state.offset < ctx->state.size) {
     uint32_t section_code;
     uint32_t section_size;
     /* Temporarily reset read_end to the full data size so the next section
      * can be read. */
-    ctx->read_end = ctx->data_size;
+    ctx->read_end = ctx->state.size;
     in_u32_leb128(ctx, &section_code, "section code");
     in_u32_leb128(ctx, &section_size, "section size");
-    ctx->read_end = ctx->offset + section_size;
+    ctx->read_end = ctx->state.offset + section_size;
     if (section_code >= kBinarySectionCount) {
       RAISE_ERROR("invalid section code: %u; max is %u", section_code,
                   kBinarySectionCount - 1);
@@ -2036,7 +1347,7 @@ static void read_sections(Context* ctx) {
 
     BinarySection section = static_cast<BinarySection>(section_code);
 
-    if (ctx->read_end > ctx->data_size)
+    if (ctx->read_end > ctx->state.size)
       RAISE_ERROR("invalid section size: extends past end");
 
     if (ctx->last_known_section != BinarySection::Invalid &&
@@ -2045,7 +1356,7 @@ static void read_sections(Context* ctx) {
       RAISE_ERROR("section %s out of order", get_section_name(section));
     }
 
-    CALLBACK_CTX(begin_section, section, section_size);
+    CALLBACK(BeginSection, section, section_size);
 
 #define V(Name, name, code)                   \
   case BinarySection::Name:                   \
@@ -2062,7 +1373,7 @@ static void read_sections(Context* ctx) {
 
 #undef V
 
-    if (ctx->offset != ctx->read_end) {
+    if (ctx->state.offset != ctx->read_end) {
       RAISE_ERROR("unfinished section (expected end: 0x%" PRIzx ")",
                   ctx->read_end);
     }
@@ -2075,175 +1386,14 @@ static void read_sections(Context* ctx) {
 Result read_binary(const void* data,
                    size_t size,
                    BinaryReader* reader,
-                   uint32_t num_function_passes,
                    const ReadBinaryOptions* options) {
-  LoggingContext logging_context;
-  WABT_ZERO_MEMORY(logging_context);
-  logging_context.reader = reader;
-  logging_context.stream = options->log_stream;
-
-  BinaryReader logging_reader;
-  WABT_ZERO_MEMORY(logging_reader);
-  logging_reader.user_data = &logging_context;
-
-  logging_reader.on_error = logging_on_error;
-  logging_reader.begin_section = logging_begin_section;
-  logging_reader.begin_module = logging_begin_module;
-  logging_reader.end_module = logging_end_module;
-
-  logging_reader.begin_custom_section = logging_begin_custom_section;
-  logging_reader.end_custom_section = logging_end_custom_section;
-
-  logging_reader.begin_signature_section = logging_begin_signature_section;
-  logging_reader.on_signature_count = logging_on_signature_count;
-  logging_reader.on_signature = logging_on_signature;
-  logging_reader.end_signature_section = logging_end_signature_section;
-
-  logging_reader.begin_import_section = logging_begin_import_section;
-  logging_reader.on_import_count = logging_on_import_count;
-  logging_reader.on_import = logging_on_import;
-  logging_reader.on_import_func = logging_on_import_func;
-  logging_reader.on_import_table = logging_on_import_table;
-  logging_reader.on_import_memory = logging_on_import_memory;
-  logging_reader.on_import_global = logging_on_import_global;
-  logging_reader.end_import_section = logging_end_import_section;
-
-  logging_reader.begin_function_signatures_section =
-      logging_begin_function_signatures_section;
-  logging_reader.on_function_signatures_count =
-      logging_on_function_signatures_count;
-  logging_reader.on_function_signature = logging_on_function_signature;
-  logging_reader.end_function_signatures_section =
-      logging_end_function_signatures_section;
-
-  logging_reader.begin_table_section = logging_begin_table_section;
-  logging_reader.on_table_count = logging_on_table_count;
-  logging_reader.on_table = logging_on_table;
-  logging_reader.end_table_section = logging_end_table_section;
-
-  logging_reader.begin_memory_section = logging_begin_memory_section;
-  logging_reader.on_memory_count = logging_on_memory_count;
-  logging_reader.on_memory = logging_on_memory;
-  logging_reader.end_memory_section = logging_end_memory_section;
-
-  logging_reader.begin_global_section = logging_begin_global_section;
-  logging_reader.on_global_count = logging_on_global_count;
-  logging_reader.begin_global = logging_begin_global;
-  logging_reader.begin_global_init_expr = logging_begin_global_init_expr;
-  logging_reader.end_global_init_expr = logging_end_global_init_expr;
-  logging_reader.end_global = logging_end_global;
-  logging_reader.end_global_section = logging_end_global_section;
-
-  logging_reader.begin_export_section = logging_begin_export_section;
-  logging_reader.on_export_count = logging_on_export_count;
-  logging_reader.on_export = logging_on_export;
-  logging_reader.end_export_section = logging_end_export_section;
-
-  logging_reader.begin_start_section = logging_begin_start_section;
-  logging_reader.on_start_function = logging_on_start_function;
-  logging_reader.end_start_section = logging_end_start_section;
-
-  logging_reader.begin_function_bodies_section =
-      logging_begin_function_bodies_section;
-  logging_reader.on_function_bodies_count = logging_on_function_bodies_count;
-  logging_reader.begin_function_body_pass = logging_begin_function_body_pass;
-  logging_reader.begin_function_body = logging_begin_function_body;
-  logging_reader.on_local_decl_count = logging_on_local_decl_count;
-  logging_reader.on_local_decl = logging_on_local_decl;
-  logging_reader.on_binary_expr = logging_on_binary_expr;
-  logging_reader.on_block_expr = logging_on_block_expr;
-  logging_reader.on_br_expr = logging_on_br_expr;
-  logging_reader.on_br_if_expr = logging_on_br_if_expr;
-  logging_reader.on_br_table_expr = logging_on_br_table_expr;
-  logging_reader.on_call_expr = logging_on_call_expr;
-  logging_reader.on_call_import_expr = logging_on_call_import_expr;
-  logging_reader.on_call_indirect_expr = logging_on_call_indirect_expr;
-  logging_reader.on_compare_expr = logging_on_compare_expr;
-  logging_reader.on_convert_expr = logging_on_convert_expr;
-  logging_reader.on_drop_expr = logging_on_drop_expr;
-  logging_reader.on_else_expr = logging_on_else_expr;
-  logging_reader.on_end_expr = logging_on_end_expr;
-  logging_reader.on_f32_const_expr = logging_on_f32_const_expr;
-  logging_reader.on_f64_const_expr = logging_on_f64_const_expr;
-  logging_reader.on_get_global_expr = logging_on_get_global_expr;
-  logging_reader.on_get_local_expr = logging_on_get_local_expr;
-  logging_reader.on_grow_memory_expr = logging_on_grow_memory_expr;
-  logging_reader.on_i32_const_expr = logging_on_i32_const_expr;
-  logging_reader.on_i64_const_expr = logging_on_i64_const_expr;
-  logging_reader.on_if_expr = logging_on_if_expr;
-  logging_reader.on_load_expr = logging_on_load_expr;
-  logging_reader.on_loop_expr = logging_on_loop_expr;
-  logging_reader.on_current_memory_expr = logging_on_current_memory_expr;
-  logging_reader.on_nop_expr = logging_on_nop_expr;
-  logging_reader.on_return_expr = logging_on_return_expr;
-  logging_reader.on_select_expr = logging_on_select_expr;
-  logging_reader.on_set_global_expr = logging_on_set_global_expr;
-  logging_reader.on_set_local_expr = logging_on_set_local_expr;
-  logging_reader.on_store_expr = logging_on_store_expr;
-  logging_reader.on_tee_local_expr = logging_on_tee_local_expr;
-  logging_reader.on_unary_expr = logging_on_unary_expr;
-  logging_reader.on_unreachable_expr = logging_on_unreachable_expr;
-  logging_reader.end_function_body = logging_end_function_body;
-  logging_reader.end_function_body_pass = logging_end_function_body_pass;
-  logging_reader.end_function_bodies_section =
-      logging_end_function_bodies_section;
-
-  logging_reader.begin_elem_section = logging_begin_elem_section;
-  logging_reader.on_elem_segment_count = logging_on_elem_segment_count;
-  logging_reader.begin_elem_segment = logging_begin_elem_segment;
-  logging_reader.begin_elem_segment_init_expr =
-      logging_begin_elem_segment_init_expr;
-  logging_reader.end_elem_segment_init_expr =
-      logging_end_elem_segment_init_expr;
-  logging_reader.on_elem_segment_function_index_count =
-      logging_on_elem_segment_function_index_count;
-  logging_reader.on_elem_segment_function_index =
-      logging_on_elem_segment_function_index;
-  logging_reader.end_elem_segment = logging_end_elem_segment;
-  logging_reader.end_elem_section = logging_end_elem_section;
-
-  logging_reader.begin_data_section = logging_begin_data_section;
-  logging_reader.on_data_segment_count = logging_on_data_segment_count;
-  logging_reader.begin_data_segment = logging_begin_data_segment;
-  logging_reader.begin_data_segment_init_expr =
-      logging_begin_data_segment_init_expr;
-  logging_reader.end_data_segment_init_expr =
-      logging_end_data_segment_init_expr;
-  logging_reader.on_data_segment_data = logging_on_data_segment_data;
-  logging_reader.end_data_segment = logging_end_data_segment;
-  logging_reader.end_data_section = logging_end_data_section;
-
-  logging_reader.begin_names_section = logging_begin_names_section;
-  logging_reader.on_function_name_subsection = logging_on_function_name_subsection;
-  logging_reader.on_function_names_count = logging_on_function_names_count;
-  logging_reader.on_function_name = logging_on_function_name;
-  logging_reader.on_local_name_subsection = logging_on_local_name_subsection;
-  logging_reader.on_local_name_function_count = logging_on_local_name_function_count;
-  logging_reader.on_local_name_local_count = logging_on_local_name_local_count;
-  logging_reader.on_local_name = logging_on_local_name;
-  logging_reader.end_names_section = logging_end_names_section;
-
-  logging_reader.begin_reloc_section = logging_begin_reloc_section;
-  logging_reader.on_reloc_count = logging_on_reloc_count;
-  logging_reader.on_reloc = logging_on_reloc;
-  logging_reader.end_reloc_section = logging_end_reloc_section;
-
-  logging_reader.on_init_expr_f32_const_expr =
-      logging_on_init_expr_f32_const_expr;
-  logging_reader.on_init_expr_f64_const_expr =
-      logging_on_init_expr_f64_const_expr;
-  logging_reader.on_init_expr_get_global_expr =
-      logging_on_init_expr_get_global_expr;
-  logging_reader.on_init_expr_i32_const_expr =
-      logging_on_init_expr_i32_const_expr;
-  logging_reader.on_init_expr_i64_const_expr =
-      logging_on_init_expr_i64_const_expr;
-
+  BinaryReaderLogging logging_reader(options->log_stream, reader);
   Context context;
   /* all the macros assume a Context* named ctx */
   Context* ctx = &context;
-  ctx->data = static_cast<const uint8_t*>(data);
-  ctx->data_size = ctx->read_end = size;
+  ctx->state.data = static_cast<const uint8_t*>(data);
+  ctx->state.size = ctx->read_end = size;
+  ctx->state.offset = 0;
   ctx->reader = options->log_stream ? &logging_reader : reader;
   ctx->options = options;
   ctx->last_known_section = BinarySection::Invalid;
@@ -2251,6 +1401,8 @@ Result read_binary(const void* data,
   if (setjmp(ctx->error_jmp_buf) == 1) {
     return Result::Error;
   }
+
+  ctx->reader->OnSetState(&ctx->state);
 
   uint32_t magic;
   in_u32(ctx, &magic, "magic");
@@ -2261,9 +1413,9 @@ Result read_binary(const void* data,
                      "bad wasm file version: %#x (expected %#x)", version,
                      WABT_BINARY_VERSION);
 
-  CALLBACK(begin_module, version);
+  CALLBACK(BeginModule, version);
   read_sections(ctx);
-  CALLBACK0(end_module);
+  CALLBACK0(EndModule);
   return Result::Ok;
 }
 

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -33,303 +33,244 @@ struct ReadBinaryOptions {
   bool read_debug_names;
 };
 
-struct BinaryReaderContext {
-  const uint8_t* data;
-  size_t size;
-  size_t offset;
-  void* user_data;
-};
+class BinaryReader {
+ public:
+  struct State {
+    const uint8_t* data;
+    size_t size;
+    size_t offset;
+  };
 
-struct BinaryReader {
-  void* user_data;
+  virtual ~BinaryReader() {}
 
-  bool (*on_error)(BinaryReaderContext* ctx, const char* message);
+  virtual bool OnError(const char* message) = 0;
+  virtual void OnSetState(const State* s) { state = s; }
 
-  /* module */
-  Result (*begin_module)(uint32_t version, void* user_data);
-  Result (*end_module)(void* user_data);
+  /* Module */
+  virtual Result BeginModule(uint32_t version) = 0;
+  virtual Result EndModule() = 0;
 
-  Result (*begin_section)(BinaryReaderContext* ctx,
-                          BinarySection section_type,
-                          uint32_t size);
+  virtual Result BeginSection(BinarySection section_type, uint32_t size) = 0;
 
-  /* custom section */
-  Result (*begin_custom_section)(BinaryReaderContext* ctx,
-                                 uint32_t size,
-                                 StringSlice section_name);
-  Result (*end_custom_section)(BinaryReaderContext* ctx);
+  /* Custom section */
+  virtual Result BeginCustomSection(uint32_t size,
+                                    StringSlice section_name) = 0;
+  virtual Result EndCustomSection() = 0;
 
-  /* signatures section */
-  /* TODO(binji): rename to "type" section */
-  Result (*begin_signature_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_signature_count)(uint32_t count, void* user_data);
-  Result (*on_signature)(uint32_t index,
-                         uint32_t param_count,
-                         Type* param_types,
-                         uint32_t result_count,
-                         Type* result_types,
-                         void* user_data);
-  Result (*end_signature_section)(BinaryReaderContext* ctx);
+  /* Type section */
+  virtual Result BeginTypeSection(uint32_t size) = 0;
+  virtual Result OnTypeCount(uint32_t count) = 0;
+  virtual Result OnType(uint32_t index,
+                        uint32_t param_count,
+                        Type* param_types,
+                        uint32_t result_count,
+                        Type* result_types) = 0;
+  virtual Result EndTypeSection() = 0;
 
-  /* import section */
-  Result (*begin_import_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_import_count)(uint32_t count, void* user_data);
-  Result (*on_import)(uint32_t index,
-                      StringSlice module_name,
-                      StringSlice field_name,
-                      void* user_data);
-  Result (*on_import_func)(uint32_t import_index,
-                           StringSlice module_name,
-                           StringSlice field_name,
-                           uint32_t func_index,
-                           uint32_t sig_index,
-                           void* user_data);
-  Result (*on_import_table)(uint32_t import_index,
-                            StringSlice module_name,
-                            StringSlice field_name,
-                            uint32_t table_index,
-                            Type elem_type,
-                            const Limits* elem_limits,
-                            void* user_data);
-  Result (*on_import_memory)(uint32_t import_index,
-                             StringSlice module_name,
-                             StringSlice field_name,
-                             uint32_t memory_index,
-                             const Limits* page_limits,
-                             void* user_data);
-  Result (*on_import_global)(uint32_t import_index,
-                             StringSlice module_name,
-                             StringSlice field_name,
-                             uint32_t global_index,
-                             Type type,
-                             bool mutable_,
-                             void* user_data);
-  Result (*end_import_section)(BinaryReaderContext* ctx);
-
-  /* function signatures section */
-  /* TODO(binji): rename to "function" section */
-  Result (*begin_function_signatures_section)(BinaryReaderContext* ctx,
-                                              uint32_t size);
-  Result (*on_function_signatures_count)(uint32_t count, void* user_data);
-  Result (*on_function_signature)(uint32_t index,
-                                  uint32_t sig_index,
-                                  void* user_data);
-  Result (*end_function_signatures_section)(BinaryReaderContext* ctx);
-
-  /* table section */
-  Result (*begin_table_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_table_count)(uint32_t count, void* user_data);
-  Result (*on_table)(uint32_t index,
-                     Type elem_type,
-                     const Limits* elem_limits,
-                     void* user_data);
-  Result (*end_table_section)(BinaryReaderContext* ctx);
-
-  /* memory section */
-  Result (*begin_memory_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_memory_count)(uint32_t count, void* user_data);
-  Result (*on_memory)(uint32_t index, const Limits* limits, void* user_data);
-  Result (*end_memory_section)(BinaryReaderContext* ctx);
-
-  /* global section */
-  Result (*begin_global_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_global_count)(uint32_t count, void* user_data);
-  Result (*begin_global)(uint32_t index,
-                         Type type,
-                         bool mutable_,
-                         void* user_data);
-  Result (*begin_global_init_expr)(uint32_t index, void* user_data);
-  Result (*end_global_init_expr)(uint32_t index, void* user_data);
-  Result (*end_global)(uint32_t index, void* user_data);
-  Result (*end_global_section)(BinaryReaderContext* ctx);
-
-  /* exports section */
-  Result (*begin_export_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_export_count)(uint32_t count, void* user_data);
-  Result (*on_export)(uint32_t index,
-                      ExternalKind kind,
-                      uint32_t item_index,
-                      StringSlice name,
-                      void* user_data);
-  Result (*end_export_section)(BinaryReaderContext* ctx);
-
-  /* start section */
-  Result (*begin_start_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_start_function)(uint32_t func_index, void* user_data);
-  Result (*end_start_section)(BinaryReaderContext* ctx);
-
-  /* function bodies section */
-  /* TODO(binji): rename to code section */
-  Result (*begin_function_bodies_section)(BinaryReaderContext* ctx,
-                                          uint32_t size);
-  Result (*on_function_bodies_count)(uint32_t count, void* user_data);
-  Result (*begin_function_body_pass)(uint32_t index,
-                                     uint32_t pass,
-                                     void* user_data);
-  Result (*begin_function_body)(BinaryReaderContext* ctx, uint32_t index);
-  Result (*on_local_decl_count)(uint32_t count, void* user_data);
-  Result (*on_local_decl)(uint32_t decl_index,
-                          uint32_t count,
-                          Type type,
-                          void* user_data);
-
-  /* function expressions; called between begin_function_body and
-   end_function_body */
-  Result (*on_opcode)(BinaryReaderContext* ctx, Opcode Opcode);
-  Result (*on_opcode_bare)(BinaryReaderContext* ctx);
-  Result (*on_opcode_uint32)(BinaryReaderContext* ctx, uint32_t value);
-  Result (*on_opcode_uint32_uint32)(BinaryReaderContext* ctx,
-                                    uint32_t value,
-                                    uint32_t value2);
-  Result (*on_opcode_uint64)(BinaryReaderContext* ctx, uint64_t value);
-  Result (*on_opcode_f32)(BinaryReaderContext* ctx, uint32_t value);
-  Result (*on_opcode_f64)(BinaryReaderContext* ctx, uint64_t value);
-  Result (*on_opcode_block_sig)(BinaryReaderContext* ctx,
-                                uint32_t num_types,
-                                Type* sig_types);
-  Result (*on_binary_expr)(Opcode opcode, void* user_data);
-  Result (*on_block_expr)(uint32_t num_types, Type* sig_types, void* user_data);
-  Result (*on_br_expr)(uint32_t depth, void* user_data);
-  Result (*on_br_if_expr)(uint32_t depth, void* user_data);
-  Result (*on_br_table_expr)(BinaryReaderContext* ctx,
-                             uint32_t num_targets,
-                             uint32_t* target_depths,
-                             uint32_t default_target_depth);
-  Result (*on_call_expr)(uint32_t func_index, void* user_data);
-  Result (*on_call_import_expr)(uint32_t import_index, void* user_data);
-  Result (*on_call_indirect_expr)(uint32_t sig_index, void* user_data);
-  Result (*on_compare_expr)(Opcode opcode, void* user_data);
-  Result (*on_convert_expr)(Opcode opcode, void* user_data);
-  Result (*on_drop_expr)(void* user_data);
-  Result (*on_else_expr)(void* user_data);
-  Result (*on_end_expr)(void* user_data);
-  Result (*on_end_func)(void* user_data);
-  Result (*on_f32_const_expr)(uint32_t value_bits, void* user_data);
-  Result (*on_f64_const_expr)(uint64_t value_bits, void* user_data);
-  Result (*on_get_global_expr)(uint32_t global_index, void* user_data);
-  Result (*on_get_local_expr)(uint32_t local_index, void* user_data);
-  Result (*on_grow_memory_expr)(void* user_data);
-  Result (*on_i32_const_expr)(uint32_t value, void* user_data);
-  Result (*on_i64_const_expr)(uint64_t value, void* user_data);
-  Result (*on_if_expr)(uint32_t num_types, Type* sig_types, void* user_data);
-  Result (*on_load_expr)(Opcode opcode,
-                         uint32_t alignment_log2,
-                         uint32_t offset,
-                         void* user_data);
-  Result (*on_loop_expr)(uint32_t num_types, Type* sig_types, void* user_data);
-  Result (*on_current_memory_expr)(void* user_data);
-  Result (*on_nop_expr)(void* user_data);
-  Result (*on_return_expr)(void* user_data);
-  Result (*on_select_expr)(void* user_data);
-  Result (*on_set_global_expr)(uint32_t global_index, void* user_data);
-  Result (*on_set_local_expr)(uint32_t local_index, void* user_data);
-  Result (*on_store_expr)(Opcode opcode,
-                          uint32_t alignment_log2,
-                          uint32_t offset,
-                          void* user_data);
-  Result (*on_tee_local_expr)(uint32_t local_index, void* user_data);
-  Result (*on_unary_expr)(Opcode opcode, void* user_data);
-  Result (*on_unreachable_expr)(void* user_data);
-  Result (*end_function_body)(uint32_t index, void* user_data);
-  Result (*end_function_body_pass)(uint32_t index,
-                                   uint32_t pass,
-                                   void* user_data);
-  Result (*end_function_bodies_section)(BinaryReaderContext* ctx);
-
-  /* elem section */
-  Result (*begin_elem_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_elem_segment_count)(uint32_t count, void* user_data);
-  Result (*begin_elem_segment)(uint32_t index,
+  /* Import section */
+  virtual Result BeginImportSection(uint32_t size) = 0;
+  virtual Result OnImportCount(uint32_t count) = 0;
+  virtual Result OnImport(uint32_t index,
+                          StringSlice module_name,
+                          StringSlice field_name) = 0;
+  virtual Result OnImportFunc(uint32_t import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              uint32_t func_index,
+                              uint32_t sig_index) = 0;
+  virtual Result OnImportTable(uint32_t import_index,
+                               StringSlice module_name,
+                               StringSlice field_name,
                                uint32_t table_index,
-                               void* user_data);
-  Result (*begin_elem_segment_init_expr)(uint32_t index, void* user_data);
-  Result (*end_elem_segment_init_expr)(uint32_t index, void* user_data);
-  Result (*on_elem_segment_function_index_count)(BinaryReaderContext* ctx,
-                                                 uint32_t index,
-                                                 uint32_t count);
-  Result (*on_elem_segment_function_index)(uint32_t index,
-                                           uint32_t func_index,
-                                           void* user_data);
-  Result (*end_elem_segment)(uint32_t index, void* user_data);
-  Result (*end_elem_section)(BinaryReaderContext* ctx);
+                               Type elem_type,
+                               const Limits* elem_limits) = 0;
+  virtual Result OnImportMemory(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t memory_index,
+                                const Limits* page_limits) = 0;
+  virtual Result OnImportGlobal(uint32_t import_index,
+                                StringSlice module_name,
+                                StringSlice field_name,
+                                uint32_t global_index,
+                                Type type,
+                                bool mutable_) = 0;
+  virtual Result EndImportSection() = 0;
 
-  /* data section */
-  Result (*begin_data_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_data_segment_count)(uint32_t count, void* user_data);
-  Result (*begin_data_segment)(uint32_t index,
-                               uint32_t memory_index,
-                               void* user_data);
-  Result (*begin_data_segment_init_expr)(uint32_t index, void* user_data);
-  Result (*end_data_segment_init_expr)(uint32_t index, void* user_data);
-  Result (*on_data_segment_data)(uint32_t index,
-                                 const void* data,
-                                 uint32_t size,
-                                 void* user_data);
-  Result (*end_data_segment)(uint32_t index, void* user_data);
-  Result (*end_data_section)(BinaryReaderContext* ctx);
+  /* Function section */
+  virtual Result BeginFunctionSection(uint32_t size) = 0;
+  virtual Result OnFunctionCount(uint32_t count) = 0;
+  virtual Result OnFunction(uint32_t index, uint32_t sig_index) = 0;
+  virtual Result EndFunctionSection() = 0;
 
-  /* names section */
-  Result (*begin_names_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_function_name_subsection)(uint32_t index,
-                                        uint32_t name_type,
-                                        uint32_t subsection_size,
-                                        void* user_data);
-  Result (*on_function_names_count)(uint32_t num_functions,
-                                    void* user_data);
-  Result (*on_function_name)(uint32_t function_index,
-                             StringSlice function_name,
-                             void* user_data);
-  Result (*on_local_name_subsection)(uint32_t index,
-                                     uint32_t name_type,
-                                     uint32_t subsection_size,
-                                     void* user_data);
-  Result (*on_local_name_function_count)(uint32_t num_functions,
-                                         void* user_data);
-  Result (*on_local_name_local_count)(uint32_t function_index,
-                                      uint32_t num_locals,
-                                      void* user_data);
-  Result (*on_local_name)(uint32_t function_index,
-                          uint32_t local_index,
-                          StringSlice local_name,
-                          void* user_data);
-  Result (*end_names_section)(BinaryReaderContext* ctx);
+  /* Table section */
+  virtual Result BeginTableSection(uint32_t size) = 0;
+  virtual Result OnTableCount(uint32_t count) = 0;
+  virtual Result OnTable(uint32_t index,
+                         Type elem_type,
+                         const Limits* elem_limits) = 0;
+  virtual Result EndTableSection() = 0;
 
-  /* names section */
-  Result (*begin_reloc_section)(BinaryReaderContext* ctx, uint32_t size);
-  Result (*on_reloc_count)(uint32_t count,
-                           BinarySection section_code,
-                           StringSlice section_name,
-                           void* user_data);
-  Result (*on_reloc)(RelocType type,
-                     uint32_t offset,
-                     uint32_t index,
-                     int32_t addend,
-                     void* user_data);
-  Result (*end_reloc_section)(BinaryReaderContext* ctx);
+  /* Memory section */
+  virtual Result BeginMemorySection(uint32_t size) = 0;
+  virtual Result OnMemoryCount(uint32_t count) = 0;
+  virtual Result OnMemory(uint32_t index, const Limits* limits) = 0;
+  virtual Result EndMemorySection() = 0;
 
-  /* init_expr - used by elem, data and global sections; these functions are
-   * only called between calls to begin_*_init_expr and end_*_init_expr */
-  Result (*on_init_expr_f32_const_expr)(uint32_t index,
-                                        uint32_t value,
-                                        void* user_data);
-  Result (*on_init_expr_f64_const_expr)(uint32_t index,
-                                        uint64_t value,
-                                        void* user_data);
-  Result (*on_init_expr_get_global_expr)(uint32_t index,
-                                         uint32_t global_index,
-                                         void* user_data);
-  Result (*on_init_expr_i32_const_expr)(uint32_t index,
-                                        uint32_t value,
-                                        void* user_data);
-  Result (*on_init_expr_i64_const_expr)(uint32_t index,
-                                        uint64_t value,
-                                        void* user_data);
+  /* Global section */
+  virtual Result BeginGlobalSection(uint32_t size) = 0;
+  virtual Result OnGlobalCount(uint32_t count) = 0;
+  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_) = 0;
+  virtual Result BeginGlobalInitExpr(uint32_t index) = 0;
+  virtual Result EndGlobalInitExpr(uint32_t index) = 0;
+  virtual Result EndGlobal(uint32_t index) = 0;
+  virtual Result EndGlobalSection() = 0;
+
+  /* Exports section */
+  virtual Result BeginExportSection(uint32_t size) = 0;
+  virtual Result OnExportCount(uint32_t count) = 0;
+  virtual Result OnExport(uint32_t index,
+                          ExternalKind kind,
+                          uint32_t item_index,
+                          StringSlice name) = 0;
+  virtual Result EndExportSection() = 0;
+
+  /* Start section */
+  virtual Result BeginStartSection(uint32_t size) = 0;
+  virtual Result OnStartFunction(uint32_t func_index) = 0;
+  virtual Result EndStartSection() = 0;
+
+  /* Code section */
+  virtual Result BeginCodeSection(uint32_t size) = 0;
+  virtual Result OnFunctionBodyCount(uint32_t count) = 0;
+  virtual Result BeginFunctionBody(uint32_t index) = 0;
+  virtual Result OnLocalDeclCount(uint32_t count) = 0;
+  virtual Result OnLocalDecl(uint32_t decl_index,
+                             uint32_t count,
+                             Type type) = 0;
+
+  /* Function expressions; called between BeginFunctionBody and
+   EndFunctionBody */
+  virtual Result OnOpcode(Opcode Opcode) = 0;
+  virtual Result OnOpcodeBare() = 0;
+  virtual Result OnOpcodeUint32(uint32_t value) = 0;
+  virtual Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2) = 0;
+  virtual Result OnOpcodeUint64(uint64_t value) = 0;
+  virtual Result OnOpcodeF32(uint32_t value) = 0;
+  virtual Result OnOpcodeF64(uint64_t value) = 0;
+  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types) = 0;
+  virtual Result OnBinaryExpr(Opcode opcode) = 0;
+  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types) = 0;
+  virtual Result OnBrExpr(uint32_t depth) = 0;
+  virtual Result OnBrIfExpr(uint32_t depth) = 0;
+  virtual Result OnBrTableExpr(uint32_t num_targets,
+                               uint32_t* target_depths,
+                               uint32_t default_target_depth) = 0;
+  virtual Result OnCallExpr(uint32_t func_index) = 0;
+  virtual Result OnCallIndirectExpr(uint32_t sig_index) = 0;
+  virtual Result OnCompareExpr(Opcode opcode) = 0;
+  virtual Result OnConvertExpr(Opcode opcode) = 0;
+  virtual Result OnCurrentMemoryExpr() = 0;
+  virtual Result OnDropExpr() = 0;
+  virtual Result OnElseExpr() = 0;
+  virtual Result OnEndExpr() = 0;
+  virtual Result OnEndFunc() = 0;
+  virtual Result OnF32ConstExpr(uint32_t value_bits) = 0;
+  virtual Result OnF64ConstExpr(uint64_t value_bits) = 0;
+  virtual Result OnGetGlobalExpr(uint32_t global_index) = 0;
+  virtual Result OnGetLocalExpr(uint32_t local_index) = 0;
+  virtual Result OnGrowMemoryExpr() = 0;
+  virtual Result OnI32ConstExpr(uint32_t value) = 0;
+  virtual Result OnI64ConstExpr(uint64_t value) = 0;
+  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types) = 0;
+  virtual Result OnLoadExpr(Opcode opcode,
+                            uint32_t alignment_log2,
+                            uint32_t offset) = 0;
+  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types) = 0;
+  virtual Result OnNopExpr() = 0;
+  virtual Result OnReturnExpr() = 0;
+  virtual Result OnSelectExpr() = 0;
+  virtual Result OnSetGlobalExpr(uint32_t global_index) = 0;
+  virtual Result OnSetLocalExpr(uint32_t local_index) = 0;
+  virtual Result OnStoreExpr(Opcode opcode,
+                             uint32_t alignment_log2,
+                             uint32_t offset) = 0;
+  virtual Result OnTeeLocalExpr(uint32_t local_index) = 0;
+  virtual Result OnUnaryExpr(Opcode opcode) = 0;
+  virtual Result OnUnreachableExpr() = 0;
+  virtual Result EndFunctionBody(uint32_t index) = 0;
+  virtual Result EndCodeSection() = 0;
+
+  /* Elem section */
+  virtual Result BeginElemSection(uint32_t size) = 0;
+  virtual Result OnElemSegmentCount(uint32_t count) = 0;
+  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index) = 0;
+  virtual Result BeginElemSegmentInitExpr(uint32_t index) = 0;
+  virtual Result EndElemSegmentInitExpr(uint32_t index) = 0;
+  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
+                                                 uint32_t count) = 0;
+  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
+                                            uint32_t func_index) = 0;
+  virtual Result EndElemSegment(uint32_t index) = 0;
+  virtual Result EndElemSection() = 0;
+
+  /* Data section */
+  virtual Result BeginDataSection(uint32_t size) = 0;
+  virtual Result OnDataSegmentCount(uint32_t count) = 0;
+  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index) = 0;
+  virtual Result BeginDataSegmentInitExpr(uint32_t index) = 0;
+  virtual Result EndDataSegmentInitExpr(uint32_t index) = 0;
+  virtual Result OnDataSegmentData(uint32_t index,
+                                   const void* data,
+                                   uint32_t size) = 0;
+  virtual Result EndDataSegment(uint32_t index) = 0;
+  virtual Result EndDataSection() = 0;
+
+  /* Names section */
+  virtual Result BeginNamesSection(uint32_t size) = 0;
+  virtual Result OnFunctionNameSubsection(uint32_t index,
+                                          uint32_t name_type,
+                                          uint32_t subsection_size) = 0;
+  virtual Result OnFunctionNamesCount(uint32_t num_functions) = 0;
+  virtual Result OnFunctionName(uint32_t function_index,
+                                StringSlice function_name) = 0;
+  virtual Result OnLocalNameSubsection(uint32_t index,
+                                       uint32_t name_type,
+                                       uint32_t subsection_size) = 0;
+  virtual Result OnLocalNameFunctionCount(uint32_t num_functions) = 0;
+  virtual Result OnLocalNameLocalCount(uint32_t function_index,
+                                       uint32_t num_locals) = 0;
+  virtual Result OnLocalName(uint32_t function_index,
+                             uint32_t local_index,
+                             StringSlice local_name) = 0;
+  virtual Result EndNamesSection() = 0;
+
+  /* Reloc section */
+  virtual Result BeginRelocSection(uint32_t size) = 0;
+  virtual Result OnRelocCount(uint32_t count,
+                              BinarySection section_code,
+                              StringSlice section_name) = 0;
+  virtual Result OnReloc(RelocType type,
+                         uint32_t offset,
+                         uint32_t index,
+                         int32_t addend) = 0;
+  virtual Result EndRelocSection() = 0;
+
+  /* InitExpr - used by elem, data and global sections; these functions are
+   * only called between calls to Begin*InitExpr and End*InitExpr */
+  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value) = 0;
+  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value) = 0;
+  virtual Result OnInitExprGetGlobalExpr(uint32_t index,
+                                         uint32_t global_index) = 0;
+  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value) = 0;
+  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value) = 0;
+
+  const State* state = nullptr;
 };
 
 Result read_binary(const void* data,
                    size_t size,
                    BinaryReader* reader,
-                   uint32_t num_function_passes,
                    const ReadBinaryOptions* options);
 
 size_t read_u32_leb128(const uint8_t* ptr,

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -128,11 +128,13 @@ Section::Section()
       payload_size(0),
       payload_offset(0),
       count(0),
-      output_payload_offset(0) {}
+      output_payload_offset(0) {
+  WABT_ZERO_MEMORY(data);
+}
 
 Section::~Section() {
   if (section_code == BinarySection::Data) {
-    delete data_segments;
+    delete data.data_segments;
   }
 }
 
@@ -359,7 +361,7 @@ static void write_memory_section(Context* ctx,
   limits.has_max = true;
   for (size_t i = 0; i < sections.size(); i++) {
     Section* sec = sections[i];
-    limits.initial += sec->memory_limits.initial;
+    limits.initial += sec->data.memory_limits.initial;
   }
   limits.max = limits.initial;
   write_limits(stream, &limits);
@@ -466,8 +468,8 @@ static void write_data_section(Context* ctx,
   write_u32_leb128(stream, total_count, "data segment count");
   for (size_t i = 0; i < sections.size(); i++) {
     Section* sec = sections[i];
-    for (size_t j = 0; j < sec->data_segments->size(); j++) {
-      const DataSegment& segment = (*sec->data_segments)[j];
+    for (size_t j = 0; j < sec->data.data_segments->size(); j++) {
+      const DataSegment& segment = (*sec->data.data_segments)[j];
       write_data_segment(stream, segment,
                          sec->binary->memory_page_offset * WABT_PAGE_SIZE);
     }

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -83,12 +83,12 @@ struct Section {
 
   union {
     /* CUSTOM section data */
-    SectionDataCustom data_custom;
+    SectionDataCustom custom;
     /* DATA section data */
     std::vector<DataSegment>* data_segments;
     /* MEMORY section data */
     Limits memory_limits;
-  };
+  } data;
 
   /* The offset at which this section appears within the combined output
    * section. */

--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -16,6 +16,6 @@ section(DATA) {
 (;; STDERR ;;;
 Error running "wasm-interp":
 error: data segment is out of bounds: [0, 8) >= max value 0
-error: @0x0000001d: on_data_segment_data callback failed
+error: @0x0000001d: OnDataSegmentData callback failed
 
 ;;; STDERR ;;)

--- a/test/binary/bad-extra-end.txt
+++ b/test/binary/bad-extra-end.txt
@@ -15,6 +15,6 @@ section(CODE) {
 (;; STDERR ;;;
 Error running "wasm2wast":
 error: popping empty label stack
-error: @0x0000001a: on_end_expr callback failed
+error: @0x0000001a: OnEndExpr callback failed
 
 ;;; STDERR ;;)

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -17,6 +17,6 @@ section("name") {
 (;; STDERR ;;;
 Error running "wasm2wast":
 error: expected function name count (2) <= function count (1)
-error: @0x00000023: on_function_names_count callback failed
+error: @0x00000023: OnFunctionNamesCount callback failed
 
 ;;; STDERR ;;)

--- a/test/binary/bad-logging-basic.txt
+++ b/test/binary/bad-logging-basic.txt
@@ -17,14 +17,14 @@ error: @0x00000015: function signature count != function body count
 
 ;;; STDERR ;;)
 (;; STDOUT ;;;
-begin_module(1)
-begin_signature_section(4)
-  on_signature_count(1)
-  on_signature(index: 0, params: [], results: [])
-end_signature_section
-begin_function_signatures_section(2)
-  on_function_signatures_count(1)
-  on_function_signature(index: 0, sig_index: 0)
-end_function_signatures_section
-begin_function_bodies_section(4)
+BeginModule(version: 1)
+  BeginTypeSection(4)
+    OnTypeCount(1)
+    OnType(index: 0, params: [], results: [])
+  EndTypeSection
+  BeginFunctionSection(2)
+    OnFunctionCount(1)
+    OnFunction(index: 0, sig_index: 0)
+  EndFunctionSection
+  BeginCodeSection(4)
 ;;; STDOUT ;;)

--- a/test/binary/bad-op-after-end.txt
+++ b/test/binary/bad-op-after-end.txt
@@ -15,6 +15,6 @@ section(CODE) {
 (;; STDERR ;;;
 Error running "wasm2wast":
 error: accessing stack depth: 0 >= max: 0
-error: @0x0000001a: on_nop_expr callback failed
+error: @0x0000001a: OnNopExpr callback failed
 
 ;;; STDERR ;;)

--- a/test/binary/user-section.txt
+++ b/test/binary/user-section.txt
@@ -7,18 +7,18 @@ section(TYPE) { count[1] function params[0] results[1] i32 }
 section("bar") { count[5] }
 section("foo") { count[6] }
 (;; STDOUT ;;;
-begin_module(1)
-begin_custom_section: 'foo' size=5
-end_custom_section
-begin_signature_section(5)
-  on_signature_count(1)
-  on_signature(index: 0, params: [], results: [i32])
-end_signature_section
-begin_custom_section: 'bar' size=5
-end_custom_section
-begin_custom_section: 'foo' size=5
-end_custom_section
-end_module
+BeginModule(version: 1)
+  BeginCustomSection('foo', size: 5)
+  EndCustomSection
+  BeginTypeSection(5)
+    OnTypeCount(1)
+    OnType(index: 0, params: [], results: [i32])
+  EndTypeSection
+  BeginCustomSection('bar', size: 5)
+  EndCustomSection
+  BeginCustomSection('foo', size: 5)
+  EndCustomSection
+EndModule
 (module
   (type (;0;) (func (result i32))))
 ;;; STDOUT ;;)

--- a/test/interp/basic-logging.txt
+++ b/test/interp/basic-logging.txt
@@ -45,50 +45,28 @@
 0000025: 0b                                        ; end
 0000020: 05                                        ; FIXUP func body size
 000001e: 07                                        ; FIXUP section size
-begin_module(1)
-begin_signature_section(5)
-  on_signature_count(1)
-  on_signature(index: 0, params: [], results: [i32])
-end_signature_section
-begin_function_signatures_section(2)
-  on_function_signatures_count(1)
-  on_function_signature(index: 0, sig_index: 0)
-end_function_signatures_section
-begin_export_section(8)
-  on_export_count(1)
-  on_export(index: 0, kind: func, item_index: 0, name: "main")
-end_export_section
-begin_function_bodies_section(7)
-  on_function_bodies_count(1)
-  begin_function_body(0)
-  on_local_decl_count(0)
-  on_i32_const_expr(42 (0x2a))
-  on_return_expr
-  end_function_body(0)
-end_function_bodies_section
-end_module
-begin_module(1)
-begin_signature_section(5)
-  on_signature_count(1)
-  on_signature(index: 0, params: [], results: [i32])
-end_signature_section
-begin_function_signatures_section(2)
-  on_function_signatures_count(1)
-  on_function_signature(index: 0, sig_index: 0)
-end_function_signatures_section
-begin_export_section(8)
-  on_export_count(1)
-  on_export(index: 0, kind: func, item_index: 0, name: "main")
-end_export_section
-begin_function_bodies_section(7)
-  on_function_bodies_count(1)
-  begin_function_body(0)
-  on_local_decl_count(0)
-  on_i32_const_expr(42 (0x2a))
-  on_return_expr
-  end_function_body(0)
-end_function_bodies_section
-end_module
+BeginModule(version: 1)
+  BeginTypeSection(5)
+    OnTypeCount(1)
+    OnType(index: 0, params: [], results: [i32])
+  EndTypeSection
+  BeginFunctionSection(2)
+    OnFunctionCount(1)
+    OnFunction(index: 0, sig_index: 0)
+  EndFunctionSection
+  BeginExportSection(8)
+    OnExportCount(1)
+    OnExport(index: 0, kind: func, item_index: 0, name: "main")
+  EndExportSection
+  BeginCodeSection(7)
+    OnFunctionBodyCount(1)
+    BeginFunctionBody(0)
+    OnLocalDeclCount(0)
+    OnI32ConstExpr(42 (0x2a))
+    OnReturnExpr
+    EndFunctionBody(0)
+  EndCodeSection
+EndModule
    0| i32.const $42
    5| return
    6| return

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -3,69 +3,69 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/block.wast:133: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:137: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:141: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:145: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:150: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x0000001c: on_end_expr callback failed
+  error: @0x0000001c: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:156: assert_invalid passed:
   error: type stack size too small at block. got 0, expected at least 1
-  error: @0x0000001b: on_end_expr callback failed
+  error: @0x0000001b: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:162: assert_invalid passed:
   error: type stack size too small at block. got 0, expected at least 1
-  error: @0x0000001c: on_end_expr callback failed
+  error: @0x0000001c: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:168: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:174: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000020: end_function_body callback failed
+  error: @0x00000020: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:181: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001c: on_br_expr callback failed
+  error: @0x0000001c: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:187: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001c: on_br_expr callback failed
+  error: @0x0000001c: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:194: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:200: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:206: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:212: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:219: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x00000024: end_function_body callback failed
+  error: @0x00000024: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:225: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:232: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001f: on_br_expr callback failed
+  error: @0x0000001f: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:238: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x00000020: on_br_expr callback failed
+  error: @0x00000020: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:245: assert_invalid passed:
   error: type stack size too small at i32.ctz. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/block.wast:251: assert_invalid passed:
   error: type stack size too small at i64.ctz. got 0, expected at least 1
-  error: @0x0000001f: on_unary_expr callback failed
+  error: @0x0000001f: OnUnaryExpr callback failed
 out/third_party/testsuite/block.wast:257: assert_invalid passed:
   error: type stack size too small at i64.ctz. got 0, expected at least 1
-  error: @0x00000020: on_unary_expr callback failed
+  error: @0x00000020: OnUnaryExpr callback failed
 36/36 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -3,24 +3,24 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/br.wast:372: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001c: on_br_expr callback failed
+  error: @0x0000001c: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:379: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:385: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x00000020: on_br_expr callback failed
+  error: @0x00000020: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:391: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:398: assert_invalid passed:
   error: invalid depth: 1 (max 0)
-  error: @0x00000019: on_br_expr callback failed
+  error: @0x00000019: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:402: assert_invalid passed:
   error: invalid depth: 5 (max 2)
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:406: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 68/68 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_if.txt
+++ b/test/spec/br_if.txt
@@ -3,75 +3,75 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/br_if.wast:171: assert_invalid passed:
   error: type stack size too small at i32.ctz. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:175: assert_invalid passed:
   error: type stack size too small at i64.ctz. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:179: assert_invalid passed:
   error: type stack size too small at f32.neg. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:183: assert_invalid passed:
   error: type stack size too small at f64.neg. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:188: assert_invalid passed:
   error: type stack size too small at i32.ctz. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:192: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got i64.
-  error: @0x0000001d: on_br_if_expr callback failed
+  error: @0x0000001d: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:196: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got f32.
-  error: @0x00000020: on_br_if_expr callback failed
+  error: @0x00000020: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:200: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got i64.
-  error: @0x0000001d: on_br_if_expr callback failed
+  error: @0x0000001d: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:205: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x0000001e: on_br_if_expr callback failed
+  error: @0x0000001e: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:211: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x0000001e: on_br_if_expr callback failed
+  error: @0x0000001e: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:217: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/br_if.wast:223: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/br_if.wast:230: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x0000001f: on_br_if_expr callback failed
+  error: @0x0000001f: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:236: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x0000001f: on_br_if_expr callback failed
+  error: @0x0000001f: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:242: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got i64.
-  error: @0x00000020: on_br_if_expr callback failed
+  error: @0x00000020: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:248: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got i64.
-  error: @0x00000020: on_br_if_expr callback failed
+  error: @0x00000020: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:255: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x0000001c: on_br_if_expr callback failed
+  error: @0x0000001c: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:261: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got i64.
-  error: @0x0000001d: on_br_if_expr callback failed
+  error: @0x0000001d: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:267: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x0000001f: on_br_if_expr callback failed
+  error: @0x0000001f: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:273: assert_invalid passed:
   error: type stack size too small at br_if. got 0, expected at least 1
-  error: @0x00000022: on_br_if_expr callback failed
+  error: @0x00000022: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:279: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got i64.
-  error: @0x00000020: on_br_if_expr callback failed
+  error: @0x00000020: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:286: assert_invalid passed:
   error: invalid depth: 1 (max 0)
-  error: @0x0000001b: on_br_if_expr callback failed
+  error: @0x0000001b: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:290: assert_invalid passed:
   error: invalid depth: 5 (max 2)
-  error: @0x0000001f: on_br_if_expr callback failed
+  error: @0x0000001f: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:294: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
-  error: @0x0000001f: on_br_if_expr callback failed
+  error: @0x0000001f: OnBrIfExpr callback failed
 58/58 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -3,48 +3,48 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/br_table.wast:1386: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000022: on_end_expr callback failed
+  error: @0x00000022: OnEndExpr callback failed
 out/third_party/testsuite/br_table.wast:1393: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
-  error: @0x00000020: on_br_table_expr callback failed
+  error: @0x00000020: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1399: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got i64.
-  error: @0x00000023: on_br_table_expr callback failed
+  error: @0x00000023: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1405: assert_invalid passed:
   error: type mismatch in br_table, expected void but got f32.
-  error: @0x00000026: on_br_table_expr callback failed
+  error: @0x00000026: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1417: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
-  error: @0x0000001f: on_br_table_expr callback failed
+  error: @0x0000001f: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1423: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got i64.
-  error: @0x0000001e: on_br_table_expr callback failed
+  error: @0x0000001e: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1429: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
-  error: @0x00000021: on_br_table_expr callback failed
+  error: @0x00000021: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1435: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
-  error: @0x00000023: on_br_table_expr callback failed
+  error: @0x00000023: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1441: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got i64.
-  error: @0x00000022: on_br_table_expr callback failed
+  error: @0x00000022: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1448: assert_invalid passed:
   error: invalid depth: 2 (max 1)
-  error: @0x0000001f: on_br_table_expr callback failed
+  error: @0x0000001f: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1454: assert_invalid passed:
   error: invalid depth: 5 (max 2)
-  error: @0x00000021: on_br_table_expr callback failed
+  error: @0x00000021: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1460: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
-  error: @0x00000024: on_br_table_expr callback failed
+  error: @0x00000024: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1467: assert_invalid passed:
   error: invalid depth: 2 (max 1)
-  error: @0x0000001f: on_br_table_expr callback failed
+  error: @0x0000001f: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1473: assert_invalid passed:
   error: invalid depth: 5 (max 2)
-  error: @0x00000021: on_br_table_expr callback failed
+  error: @0x00000021: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1479: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
-  error: @0x00000024: on_br_table_expr callback failed
+  error: @0x00000024: OnBrTableExpr callback failed
 158/158 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -3,36 +3,36 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/call.wast:151: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001b: on_convert_expr callback failed
+  error: @0x0000001b: OnConvertExpr callback failed
 out/third_party/testsuite/call.wast:158: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got i64.
-  error: @0x0000001f: on_convert_expr callback failed
+  error: @0x0000001f: OnConvertExpr callback failed
 out/third_party/testsuite/call.wast:166: assert_invalid passed:
   error: type stack size too small at call. got 0, expected at least 1
-  error: @0x0000001e: on_call_expr callback failed
+  error: @0x0000001e: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:173: assert_invalid passed:
   error: type stack size too small at call. got 0, expected at least 2
-  error: @0x0000001f: on_call_expr callback failed
+  error: @0x0000001f: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:180: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001d: end_function_body callback failed
+  error: @0x0000001d: EndFunctionBody callback failed
 out/third_party/testsuite/call.wast:187: assert_invalid passed:
   error: type stack at end of function is 2, expected 0
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/call.wast:195: assert_invalid passed:
   error: type stack size too small at call. got 1, expected at least 2
-  error: @0x00000022: on_call_expr callback failed
+  error: @0x00000022: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:202: assert_invalid passed:
   error: type stack size too small at call. got 1, expected at least 2
-  error: @0x00000022: on_call_expr callback failed
+  error: @0x00000022: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:209: assert_invalid passed:
   error: type mismatch in call, expected i32 but got f64.
   error: type mismatch in call, expected f64 but got i32.
-  error: @0x0000002a: on_call_expr callback failed
+  error: @0x0000002a: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:216: assert_invalid passed:
   error: type mismatch in call, expected f64 but got i32.
   error: type mismatch in call, expected i32 but got f64.
-  error: @0x0000002a: on_call_expr callback failed
+  error: @0x0000002a: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:227: assert_invalid passed:
   error: @0x00000019: invalid call function index
 out/third_party/testsuite/call.wast:231: assert_invalid passed:

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -3,60 +3,60 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/call_indirect.wast:229: assert_invalid passed:
   error: found call_indirect operator, but no table
-  error: @0x0000001c: on_call_indirect_expr callback failed
+  error: @0x0000001c: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:237: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x00000023: on_convert_expr callback failed
+  error: @0x00000023: OnConvertExpr callback failed
 out/third_party/testsuite/call_indirect.wast:245: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got i64.
-  error: @0x00000027: on_convert_expr callback failed
+  error: @0x00000027: OnConvertExpr callback failed
 out/third_party/testsuite/call_indirect.wast:254: assert_invalid passed:
   error: type stack size too small at call_indirect. got 0, expected at least 1
-  error: @0x00000026: on_call_indirect_expr callback failed
+  error: @0x00000026: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:262: assert_invalid passed:
   error: type stack size too small at call_indirect. got 0, expected at least 2
-  error: @0x00000027: on_call_indirect_expr callback failed
+  error: @0x00000027: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:270: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x00000025: end_function_body callback failed
+  error: @0x00000025: EndFunctionBody callback failed
 out/third_party/testsuite/call_indirect.wast:278: assert_invalid passed:
   error: type stack at end of function is 2, expected 0
-  error: @0x0000002e: end_function_body callback failed
+  error: @0x0000002e: EndFunctionBody callback failed
 out/third_party/testsuite/call_indirect.wast:289: assert_invalid passed:
   error: type stack size too small at call_indirect. got 0, expected at least 1
-  error: @0x00000027: on_call_indirect_expr callback failed
+  error: @0x00000027: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:297: assert_invalid passed:
   error: type mismatch in call_indirect, expected i32 but got i64.
-  error: @0x00000028: on_call_indirect_expr callback failed
+  error: @0x00000028: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:306: assert_invalid passed:
   error: type stack size too small at call_indirect. got 1, expected at least 2
-  error: @0x0000002a: on_call_indirect_expr callback failed
+  error: @0x0000002a: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:316: assert_invalid passed:
   error: type stack size too small at call_indirect. got 1, expected at least 2
-  error: @0x0000002a: on_call_indirect_expr callback failed
+  error: @0x0000002a: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:326: assert_invalid passed:
   error: type mismatch in call_indirect, expected i32 but got f64.
   error: type mismatch in call_indirect, expected f64 but got i32.
-  error: @0x00000032: on_call_indirect_expr callback failed
+  error: @0x00000032: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:336: assert_invalid passed:
   error: type mismatch in call_indirect, expected f64 but got i32.
   error: type mismatch in call_indirect, expected i32 but got f64.
-  error: @0x00000032: on_call_indirect_expr callback failed
+  error: @0x00000032: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:350: assert_invalid passed:
   error: @0x00000021: invalid call_indirect signature index
 out/third_party/testsuite/call_indirect.wast:357: assert_invalid passed:
   error: @0x00000025: invalid call_indirect signature index
 out/third_party/testsuite/call_indirect.wast:368: assert_invalid passed:
   error: invalid func_index: 0 (max 0)
-  error: @0x00000018: on_elem_segment_function_index callback failed
+  error: @0x00000018: OnElemSegmentFunctionIndex callback failed
 out/third_party/testsuite/call_indirect.wast:376: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 10 >= max value 10
-  error: @0x00000021: on_elem_segment_function_index callback failed
+  error: @0x00000021: OnElemSegmentFunctionIndex callback failed
 out/third_party/testsuite/call_indirect.wast:385: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 4294967295 >= max value 10
-  error: @0x00000021: on_elem_segment_function_index callback failed
+  error: @0x00000021: OnElemSegmentFunctionIndex callback failed
 out/third_party/testsuite/call_indirect.wast:394: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 4294967286 >= max value 10
-  error: @0x00000021: on_elem_segment_function_index callback failed
+  error: @0x00000021: OnElemSegmentFunctionIndex callback failed
 67/67 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exports.txt
+++ b/test/spec/exports.txt
@@ -5,63 +5,63 @@ out/third_party/testsuite/exports.wast:27: assert_invalid passed:
   error: @0x00000019: invalid export func index: 1
 out/third_party/testsuite/exports.wast:31: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x0000001d: on_export callback failed
+  error: @0x0000001d: OnExport callback failed
 out/third_party/testsuite/exports.wast:35: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x0000001e: on_export callback failed
+  error: @0x0000001e: OnExport callback failed
 out/third_party/testsuite/exports.wast:39: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000025: on_export callback failed
+  error: @0x00000025: OnExport callback failed
 out/third_party/testsuite/exports.wast:43: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000023: on_export callback failed
+  error: @0x00000023: OnExport callback failed
 out/third_party/testsuite/exports.wast:47: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000022: on_export callback failed
+  error: @0x00000022: OnExport callback failed
 out/third_party/testsuite/exports.wast:76: assert_invalid passed:
   error: @0x00000017: invalid export global index
 out/third_party/testsuite/exports.wast:80: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x0000001b: on_export callback failed
+  error: @0x0000001b: OnExport callback failed
 out/third_party/testsuite/exports.wast:84: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000020: on_export callback failed
+  error: @0x00000020: OnExport callback failed
 out/third_party/testsuite/exports.wast:88: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000025: on_export callback failed
+  error: @0x00000025: OnExport callback failed
 out/third_party/testsuite/exports.wast:92: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000021: on_export callback failed
+  error: @0x00000021: OnExport callback failed
 out/third_party/testsuite/exports.wast:96: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000020: on_export callback failed
+  error: @0x00000020: OnExport callback failed
 out/third_party/testsuite/exports.wast:124: assert_invalid passed:
   error: @0x00000015: invalid export table index
 out/third_party/testsuite/exports.wast:128: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000019: on_export callback failed
+  error: @0x00000019: OnExport callback failed
 out/third_party/testsuite/exports.wast:137: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000023: on_export callback failed
+  error: @0x00000023: OnExport callback failed
 out/third_party/testsuite/exports.wast:141: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000021: on_export callback failed
+  error: @0x00000021: OnExport callback failed
 out/third_party/testsuite/exports.wast:145: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x0000001e: on_export callback failed
+  error: @0x0000001e: OnExport callback failed
 out/third_party/testsuite/exports.wast:173: assert_invalid passed:
   error: @0x00000014: invalid export memory index
 out/third_party/testsuite/exports.wast:177: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000018: on_export callback failed
+  error: @0x00000018: OnExport callback failed
 out/third_party/testsuite/exports.wast:186: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000022: on_export callback failed
+  error: @0x00000022: OnExport callback failed
 out/third_party/testsuite/exports.wast:190: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x00000020: on_export callback failed
+  error: @0x00000020: OnExport callback failed
 out/third_party/testsuite/exports.wast:194: assert_invalid passed:
   error: duplicate export "a"
-  error: @0x0000001e: on_export callback failed
+  error: @0x0000001e: OnExport callback failed
 28/28 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -3,91 +3,91 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/func.wast:315: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001d: end_function_body callback failed
+  error: @0x0000001d: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:319: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001c: on_convert_expr callback failed
+  error: @0x0000001c: OnConvertExpr callback failed
 out/third_party/testsuite/func.wast:323: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/func.wast:331: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:335: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001b: on_convert_expr callback failed
+  error: @0x0000001b: OnConvertExpr callback failed
 out/third_party/testsuite/func.wast:339: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001c: on_unary_expr callback failed
+  error: @0x0000001c: OnUnaryExpr callback failed
 out/third_party/testsuite/func.wast:347: assert_invalid passed:
   error: @0x0000000e: result count must be 0 or 1
 out/third_party/testsuite/func.wast:351: assert_invalid passed:
   error: @0x0000000e: result count must be 0 or 1
 out/third_party/testsuite/func.wast:360: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000019: end_function_body callback failed
+  error: @0x00000019: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:364: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000019: end_function_body callback failed
+  error: @0x00000019: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:368: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000019: end_function_body callback failed
+  error: @0x00000019: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:372: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000019: end_function_body callback failed
+  error: @0x00000019: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:377: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:383: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:389: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got f32.
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:396: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x00000019: on_return_expr callback failed
+  error: @0x00000019: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:402: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x0000001a: on_return_expr callback failed
+  error: @0x0000001a: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:408: assert_invalid passed:
   error: type mismatch in return, expected i32 but got i64.
-  error: @0x0000001b: on_return_expr callback failed
+  error: @0x0000001b: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:415: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x00000019: on_return_expr callback failed
+  error: @0x00000019: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:421: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x0000001a: on_return_expr callback failed
+  error: @0x0000001a: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:427: assert_invalid passed:
   error: type mismatch in return, expected i32 but got i64.
-  error: @0x0000001b: on_return_expr callback failed
+  error: @0x0000001b: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:433: assert_invalid passed:
   error: type mismatch in return, expected i32 but got i64.
-  error: @0x0000001b: on_return_expr callback failed
+  error: @0x0000001b: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:440: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001a: on_br_expr callback failed
+  error: @0x0000001a: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:446: assert_invalid passed:
   error: type mismatch in br, expected i32 but got f32.
-  error: @0x0000001f: on_br_expr callback failed
+  error: @0x0000001f: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:452: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001a: on_br_expr callback failed
+  error: @0x0000001a: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:458: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x0000001c: on_br_expr callback failed
+  error: @0x0000001c: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:464: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x0000001c: on_br_expr callback failed
+  error: @0x0000001c: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:471: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001c: on_br_expr callback failed
+  error: @0x0000001c: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:477: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:483: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -9,7 +9,7 @@ out/third_party/testsuite/func_ptrs.wast:32: assert_invalid passed:
   error: @0x00000015: elem section without table section
 out/third_party/testsuite/func_ptrs.wast:35: assert_invalid passed:
   error: type mismatch in elem segment, expected i32 but got i64
-  error: @0x00000015: end_elem_segment_init_expr callback failed
+  error: @0x00000015: EndElemSegmentInitExpr callback failed
 out/third_party/testsuite/func_ptrs.wast:39: assert_invalid passed:
   error: @0x00000015: expected END opcode after initializer expression
 out/third_party/testsuite/func_ptrs.wast:43: assert_invalid passed:

--- a/test/spec/get_local.txt
+++ b/test/spec/get_local.txt
@@ -3,39 +3,39 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/get_local.wast:91: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001d: end_function_body callback failed
+  error: @0x0000001d: EndFunctionBody callback failed
 out/third_party/testsuite/get_local.wast:95: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001c: on_convert_expr callback failed
+  error: @0x0000001c: OnConvertExpr callback failed
 out/third_party/testsuite/get_local.wast:99: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/get_local.wast:107: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/get_local.wast:111: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001b: on_convert_expr callback failed
+  error: @0x0000001b: OnConvertExpr callback failed
 out/third_party/testsuite/get_local.wast:115: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001c: on_unary_expr callback failed
+  error: @0x0000001c: OnUnaryExpr callback failed
 out/third_party/testsuite/get_local.wast:123: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
-  error: @0x0000001d: on_get_local_expr callback failed
+  error: @0x0000001d: OnGetLocalExpr callback failed
 out/third_party/testsuite/get_local.wast:127: assert_invalid passed:
   error: invalid local_index: 14324343 (max 2)
-  error: @0x00000020: on_get_local_expr callback failed
+  error: @0x00000020: OnGetLocalExpr callback failed
 out/third_party/testsuite/get_local.wast:132: assert_invalid passed:
   error: invalid local_index: 2 (max 2)
-  error: @0x0000001b: on_get_local_expr callback failed
+  error: @0x0000001b: OnGetLocalExpr callback failed
 out/third_party/testsuite/get_local.wast:136: assert_invalid passed:
   error: invalid local_index: 714324343 (max 2)
-  error: @0x00000021: on_get_local_expr callback failed
+  error: @0x00000021: OnGetLocalExpr callback failed
 out/third_party/testsuite/get_local.wast:141: assert_invalid passed:
   error: invalid local_index: 3 (max 3)
-  error: @0x0000001e: on_get_local_expr callback failed
+  error: @0x0000001e: OnGetLocalExpr callback failed
 out/third_party/testsuite/get_local.wast:145: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
-  error: @0x00000021: on_get_local_expr callback failed
+  error: @0x00000021: OnGetLocalExpr callback failed
 22/22 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -3,32 +3,32 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/globals.wast:50: assert_invalid passed:
   error: can't set_global on immutable global at index 0.
-  error: @0x00000026: on_set_global_expr callback failed
+  error: @0x00000026: OnSetGlobalExpr callback failed
 out/third_party/testsuite/globals.wast:55: assert_invalid passed:
   error: unknown import module "m"
-  error: @0x00000012: on_import callback failed
+  error: @0x00000012: OnImport callback failed
 out/third_party/testsuite/globals.wast:60: assert_invalid passed:
   error: unknown import module "m"
-  error: @0x00000012: on_import callback failed
+  error: @0x00000012: OnImport callback failed
 out/third_party/testsuite/globals.wast:65: assert_invalid passed:
   error: mutable globals cannot be exported
-  error: @0x0000001a: on_export callback failed
+  error: @0x0000001a: OnExport callback failed
 out/third_party/testsuite/globals.wast:70: assert_invalid passed:
   error: mutable globals cannot be exported
-  error: @0x0000001a: on_export callback failed
+  error: @0x0000001a: OnExport callback failed
 out/third_party/testsuite/globals.wast:75: assert_invalid passed:
   error: @0x00000013: expected END opcode after initializer expression
 out/third_party/testsuite/globals.wast:80: assert_invalid passed:
   error: @0x0000000e: unexpected opcode in initializer expression: 32 (0x20)
 out/third_party/testsuite/globals.wast:85: assert_invalid passed:
   error: type mismatch in global, expected i32 but got f32.
-  error: @0x00000013: end_global_init_expr callback failed
+  error: @0x00000013: EndGlobalInitExpr callback failed
 out/third_party/testsuite/globals.wast:90: assert_invalid passed:
   error: initializer expression can only reference an imported global
-  error: @0x0000000f: on_init_expr_get_global_expr callback failed
+  error: @0x0000000f: OnInitExprGetGlobalExpr callback failed
 out/third_party/testsuite/globals.wast:95: assert_invalid passed:
   error: initializer expression can only reference an imported global
-  error: @0x0000000f: on_init_expr_get_global_expr callback failed
+  error: @0x0000000f: OnInitExprGetGlobalExpr callback failed
 out/third_party/testsuite/globals.wast:103: assert_malformed passed:
   error: @0x00000022: global mutability must be 0 or 1
 out/third_party/testsuite/globals.wast:116: assert_malformed passed:

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -3,106 +3,106 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/if.wast:183: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:187: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:191: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:195: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:200: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:204: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:208: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:212: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:217: assert_invalid passed:
   error: type stack at end of if is 1, expected 0
-  error: @0x0000001e: on_end_expr callback failed
+  error: @0x0000001e: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:223: assert_invalid passed:
   error: type stack at end of if is 1, expected 0
-  error: @0x0000001e: on_end_expr callback failed
+  error: @0x0000001e: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:229: assert_invalid passed:
   error: type stack at end of if false branch is 1, expected 0
-  error: @0x0000001f: on_end_expr callback failed
+  error: @0x0000001f: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:235: assert_invalid passed:
   error: type stack at end of if true branch is 1, expected 0
-  error: @0x0000001e: on_else_expr callback failed
+  error: @0x0000001e: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:242: assert_invalid passed:
   error: type stack size too small at if true branch. got 0, expected at least 1
-  error: @0x0000001d: on_else_expr callback failed
+  error: @0x0000001d: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:248: assert_invalid passed:
   error: if without else cannot have type signature.
-  error: @0x0000001f: on_end_expr callback failed
+  error: @0x0000001f: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:254: assert_invalid passed:
   error: if without else cannot have type signature.
   error: type stack size too small at if. got 0, expected at least 1
-  error: @0x0000001d: on_end_expr callback failed
+  error: @0x0000001d: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:260: assert_invalid passed:
   error: if without else cannot have type signature.
-  error: @0x0000001f: on_end_expr callback failed
+  error: @0x0000001f: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:267: assert_invalid passed:
   error: type stack size too small at if true branch. got 0, expected at least 1
-  error: @0x0000001e: on_else_expr callback failed
+  error: @0x0000001e: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:273: assert_invalid passed:
   error: type stack size too small at if false branch. got 0, expected at least 1
-  error: @0x00000021: on_end_expr callback failed
+  error: @0x00000021: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:279: assert_invalid passed:
   error: type stack size too small at if true branch. got 0, expected at least 1
-  error: @0x0000001e: on_else_expr callback failed
+  error: @0x0000001e: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:286: assert_invalid passed:
   error: type mismatch in if true branch, expected i32 but got i64.
-  error: @0x0000001f: on_else_expr callback failed
+  error: @0x0000001f: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:292: assert_invalid passed:
   error: type mismatch in if false branch, expected i32 but got i64.
-  error: @0x00000022: on_end_expr callback failed
+  error: @0x00000022: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:298: assert_invalid passed:
   error: type mismatch in if true branch, expected i32 but got i64.
-  error: @0x0000001f: on_else_expr callback failed
+  error: @0x0000001f: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:304: assert_invalid passed:
   error: type mismatch in if true branch, expected i32 but got i64.
-  error: @0x0000001f: on_else_expr callback failed
+  error: @0x0000001f: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:311: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000025: end_function_body callback failed
+  error: @0x00000025: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:321: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000025: end_function_body callback failed
+  error: @0x00000025: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:331: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000027: end_function_body callback failed
+  error: @0x00000027: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:342: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:348: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x00000021: on_br_expr callback failed
+  error: @0x00000021: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:354: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001e: on_br_expr callback failed
+  error: @0x0000001e: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:360: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x00000021: on_br_expr callback failed
+  error: @0x00000021: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:366: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001f: on_br_expr callback failed
+  error: @0x0000001f: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:372: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x00000022: on_br_expr callback failed
+  error: @0x00000022: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:379: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x00000020: on_br_expr callback failed
+  error: @0x00000020: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:385: assert_invalid passed:
   error: type mismatch in br, expected i32 but got i64.
-  error: @0x00000023: on_br_expr callback failed
+  error: @0x00000023: OnBrExpr callback failed
 72/72 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -13,187 +13,187 @@ called host spectest.print(f64:24) =>
 called host spectest.print(f64:24) =>
 out/third_party/testsuite/imports.wast:89: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x00000020: on_import callback failed
+  error: @0x00000020: OnImport callback failed
 out/third_party/testsuite/imports.wast:93: assert_unlinkable passed:
   error: unknown host function import "spectest.unknown"
-  error: @0x00000024: on_import_func callback failed
+  error: @0x00000024: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:98: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x0000001e: on_import_func callback failed
+  error: @0x0000001e: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:102: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x0000001e: on_import_func callback failed
+  error: @0x0000001e: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:106: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x0000001f: on_import_func callback failed
+  error: @0x0000001f: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:110: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000021: on_import_func callback failed
+  error: @0x00000021: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:114: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000022: on_import_func callback failed
+  error: @0x00000022: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:118: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000022: on_import_func callback failed
+  error: @0x00000022: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:122: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000022: on_import_func callback failed
+  error: @0x00000022: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:126: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000023: on_import_func callback failed
+  error: @0x00000023: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:130: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000022: on_import_func callback failed
+  error: @0x00000022: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:134: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000023: on_import_func callback failed
+  error: @0x00000023: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:138: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000023: on_import_func callback failed
+  error: @0x00000023: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:142: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000023: on_import_func callback failed
+  error: @0x00000023: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:146: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000024: on_import_func callback failed
+  error: @0x00000024: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:150: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000026: on_import_func callback failed
+  error: @0x00000026: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:154: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000027: on_import_func callback failed
+  error: @0x00000027: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:158: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000027: on_import_func callback failed
+  error: @0x00000027: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:163: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind func, not global
-  error: @0x00000024: on_import_func callback failed
+  error: @0x00000024: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:167: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind func, not table
-  error: @0x00000025: on_import_func callback failed
+  error: @0x00000025: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:171: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind func, not memory
-  error: @0x00000025: on_import_func callback failed
+  error: @0x00000025: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:175: assert_unlinkable passed:
   error: unknown host function import "spectest.global"
-  error: @0x00000023: on_import_func callback failed
+  error: @0x00000023: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:179: assert_unlinkable passed:
   error: unknown host function import "spectest.table"
-  error: @0x00000022: on_import_func callback failed
+  error: @0x00000022: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:183: assert_unlinkable passed:
   error: unknown host function import "spectest.memory"
-  error: @0x00000023: on_import_func callback failed
+  error: @0x00000023: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:217: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x0000001b: on_import callback failed
+  error: @0x0000001b: OnImport callback failed
 out/third_party/testsuite/imports.wast:221: assert_unlinkable passed:
   error: unknown host global import "spectest.unknown"
-  error: @0x0000001f: on_import_global callback failed
+  error: @0x0000001f: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:226: assert_unlinkable passed:
   error: expected import "test.func" to have kind global, not func
-  error: @0x00000018: on_import_global callback failed
+  error: @0x00000018: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:230: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind global, not table
-  error: @0x00000020: on_import_global callback failed
+  error: @0x00000020: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:234: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind global, not memory
-  error: @0x00000020: on_import_global callback failed
+  error: @0x00000020: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:238: assert_unlinkable passed:
   error: unknown host global import "spectest.print"
-  error: @0x0000001d: on_import_global callback failed
+  error: @0x0000001d: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:242: assert_unlinkable passed:
   error: unknown host global import "spectest.table"
-  error: @0x0000001d: on_import_global callback failed
+  error: @0x0000001d: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:246: assert_unlinkable passed:
   error: unknown host global import "spectest.memory"
-  error: @0x0000001e: on_import_global callback failed
+  error: @0x0000001e: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:288: assert_invalid passed:
   error: unknown import module ""
-  error: @0x00000011: on_import callback failed
+  error: @0x00000011: OnImport callback failed
 out/third_party/testsuite/imports.wast:292: assert_invalid passed:
   error: unknown import module ""
-  error: @0x00000011: on_import callback failed
+  error: @0x00000011: OnImport callback failed
 out/third_party/testsuite/imports.wast:296: assert_invalid passed:
   error: @0x0000000b: table count (2) must be 0 or 1
 out/third_party/testsuite/imports.wast:313: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x0000001c: on_import callback failed
+  error: @0x0000001c: OnImport callback failed
 out/third_party/testsuite/imports.wast:317: assert_unlinkable passed:
   error: unknown host table import "spectest.unknown"
-  error: @0x00000020: on_import_table callback failed
+  error: @0x00000020: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:322: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
-  error: @0x00000021: on_import_table callback failed
+  error: @0x00000021: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:326: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (20)
-  error: @0x00000022: on_import_table callback failed
+  error: @0x00000022: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:330: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
-  error: @0x0000001e: on_import_table callback failed
+  error: @0x0000001e: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:334: assert_unlinkable passed:
   error: max size (20) larger than declared (15)
-  error: @0x0000001f: on_import_table callback failed
+  error: @0x0000001f: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:339: assert_unlinkable passed:
   error: expected import "test.func" to have kind table, not func
-  error: @0x00000019: on_import_table callback failed
+  error: @0x00000019: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:343: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind table, not global
-  error: @0x0000001f: on_import_table callback failed
+  error: @0x0000001f: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:347: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind table, not memory
-  error: @0x00000021: on_import_table callback failed
+  error: @0x00000021: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:351: assert_unlinkable passed:
   error: unknown host table import "spectest.print"
-  error: @0x0000001e: on_import_table callback failed
+  error: @0x0000001e: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:383: assert_invalid passed:
   error: unknown import module ""
-  error: @0x00000010: on_import callback failed
+  error: @0x00000010: OnImport callback failed
 out/third_party/testsuite/imports.wast:387: assert_invalid passed:
   error: unknown import module ""
-  error: @0x00000010: on_import callback failed
+  error: @0x00000010: OnImport callback failed
 out/third_party/testsuite/imports.wast:391: assert_invalid passed:
   error: @0x0000000b: memory count must be 0 or 1
 out/third_party/testsuite/imports.wast:406: assert_unlinkable passed:
   error: unknown module field "unknown"
-  error: @0x0000001b: on_import callback failed
+  error: @0x0000001b: OnImport callback failed
 out/third_party/testsuite/imports.wast:410: assert_unlinkable passed:
   error: unknown host memory import "spectest.unknown"
-  error: @0x0000001f: on_import_memory callback failed
+  error: @0x0000001f: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:415: assert_unlinkable passed:
   error: actual size (2) smaller than declared (3)
-  error: @0x00000020: on_import_memory callback failed
+  error: @0x00000020: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:419: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (3)
-  error: @0x00000021: on_import_memory callback failed
+  error: @0x00000021: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:423: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
-  error: @0x0000001e: on_import_memory callback failed
+  error: @0x0000001e: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:427: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
-  error: @0x0000001f: on_import_memory callback failed
+  error: @0x0000001f: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:432: assert_unlinkable passed:
   error: expected import "test.func-i32" to have kind memory, not func
-  error: @0x0000001c: on_import_memory callback failed
+  error: @0x0000001c: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:436: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind memory, not global
-  error: @0x0000001e: on_import_memory callback failed
+  error: @0x0000001e: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:440: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind memory, not table
-  error: @0x00000020: on_import_memory callback failed
+  error: @0x00000020: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:444: assert_unlinkable passed:
   error: unknown host memory import "spectest.print"
-  error: @0x0000001d: on_import_memory callback failed
+  error: @0x0000001d: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:448: assert_unlinkable passed:
   error: unknown host memory import "spectest.global"
-  error: @0x0000001e: on_import_memory callback failed
+  error: @0x0000001e: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:452: assert_unlinkable passed:
   error: unknown host memory import "spectest.table"
-  error: @0x0000001d: on_import_memory callback failed
+  error: @0x0000001d: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:457: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
-  error: @0x0000001e: on_import_memory callback failed
+  error: @0x0000001e: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:461: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
-  error: @0x0000001f: on_import_memory callback failed
+  error: @0x0000001f: OnImportMemory callback failed
 91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/labels.txt
+++ b/test/spec/labels.txt
@@ -3,12 +3,12 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/labels.wast:298: assert_invalid passed:
   error: type stack size too small at f32.neg. got 0, expected at least 1
-  error: @0x0000001e: on_unary_expr callback failed
+  error: @0x0000001e: OnUnaryExpr callback failed
 out/third_party/testsuite/labels.wast:302: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 out/third_party/testsuite/labels.wast:306: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 27/27 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -3,34 +3,34 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/linking.wast:28: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000025: on_import_func callback failed
+  error: @0x00000025: OnImportFunc callback failed
 out/third_party/testsuite/linking.wast:32: assert_unlinkable passed:
   error: import signature mismatch
-  error: @0x00000026: on_import_func callback failed
+  error: @0x00000026: OnImportFunc callback failed
 out/third_party/testsuite/linking.wast:166: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 10 >= max value 10
-  error: @0x00000029: on_elem_segment_function_index callback failed
+  error: @0x00000029: OnElemSegmentFunctionIndex callback failed
 out/third_party/testsuite/linking.wast:175: assert_unlinkable passed:
   error: unknown module field "mem"
-  error: @0x00000027: on_import callback failed
+  error: @0x00000027: OnImport callback failed
 out/third_party/testsuite/linking.wast:187: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 12 >= max value 10
-  error: @0x00000030: on_elem_segment_function_index callback failed
+  error: @0x00000030: OnElemSegmentFunctionIndex callback failed
 out/third_party/testsuite/linking.wast:198: assert_unlinkable passed:
   error: data segment is out of bounds: [65536, 65537) >= max value 65536
-  error: @0x00000042: on_data_segment_data callback failed
+  error: @0x00000042: OnDataSegmentData callback failed
 out/third_party/testsuite/linking.wast:258: assert_unlinkable passed:
   error: data segment is out of bounds: [65536, 65537) >= max value 65536
-  error: @0x00000020: on_data_segment_data callback failed
+  error: @0x00000020: OnDataSegmentData callback failed
 out/third_party/testsuite/linking.wast:283: assert_unlinkable passed:
   error: duplicate export "print"
   error: unknown module field "tab"
-  error: @0x00000037: on_import callback failed
+  error: @0x00000037: OnImport callback failed
 out/third_party/testsuite/linking.wast:294: assert_unlinkable passed:
   error: data segment is out of bounds: [327680, 327681) >= max value 327680
-  error: @0x00000028: on_data_segment_data callback failed
+  error: @0x00000028: OnDataSegmentData callback failed
 out/third_party/testsuite/linking.wast:304: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 0 >= max value 0
-  error: @0x0000002e: on_elem_segment_function_index callback failed
+  error: @0x0000002e: OnElemSegmentFunctionIndex callback failed
 79/79 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -3,30 +3,30 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/loop.wast:226: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:230: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:234: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:238: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:243: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x0000001c: on_end_expr callback failed
+  error: @0x0000001c: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:249: assert_invalid passed:
   error: type stack size too small at loop. got 0, expected at least 1
-  error: @0x0000001b: on_end_expr callback failed
+  error: @0x0000001b: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:255: assert_invalid passed:
   error: type stack size too small at loop. got 0, expected at least 1
-  error: @0x0000001c: on_end_expr callback failed
+  error: @0x0000001c: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:261: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:267: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000020: end_function_body callback failed
+  error: @0x00000020: EndFunctionBody callback failed
 51/51 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -5,7 +5,7 @@ out/third_party/testsuite/memory.wast:19: assert_invalid passed:
   error: @0x0000000b: memory count must be 0 or 1
 out/third_party/testsuite/memory.wast:20: assert_invalid passed:
   error: only one memory allowed
-  error: @0x00000023: on_memory callback failed
+  error: @0x00000023: OnMemory callback failed
 out/third_party/testsuite/memory.wast:29: assert_invalid passed:
   error: @0x0000000b: data section without memory section
 out/third_party/testsuite/memory.wast:30: assert_invalid passed:
@@ -14,57 +14,57 @@ out/third_party/testsuite/memory.wast:31: assert_invalid passed:
   error: @0x0000000b: data section without memory section
 out/third_party/testsuite/memory.wast:34: assert_invalid passed:
   error: f32.load requires an imported or defined memory.
-  error: @0x0000001c: on_load_expr callback failed
+  error: @0x0000001c: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:38: assert_invalid passed:
   error: f32.store requires an imported or defined memory.
-  error: @0x00000021: on_store_expr callback failed
+  error: @0x00000021: OnStoreExpr callback failed
 out/third_party/testsuite/memory.wast:42: assert_invalid passed:
   error: i32.load8_s requires an imported or defined memory.
-  error: @0x0000001c: on_load_expr callback failed
+  error: @0x0000001c: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:46: assert_invalid passed:
   error: i32.store8 requires an imported or defined memory.
-  error: @0x0000001e: on_store_expr callback failed
+  error: @0x0000001e: OnStoreExpr callback failed
 out/third_party/testsuite/memory.wast:50: assert_invalid passed:
   error: current_memory requires an imported or defined memory.
-  error: @0x00000019: on_current_memory_expr callback failed
+  error: @0x00000019: OnCurrentMemoryExpr callback failed
 out/third_party/testsuite/memory.wast:54: assert_invalid passed:
   error: grow_memory requires an imported or defined memory.
-  error: @0x0000001b: on_grow_memory_expr callback failed
+  error: @0x0000001b: OnGrowMemoryExpr callback failed
 out/third_party/testsuite/memory.wast:59: assert_invalid passed:
   error: type mismatch in data segment, expected i32 but got i64
-  error: @0x00000015: on_data_segment_data callback failed
+  error: @0x00000015: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:63: assert_invalid passed:
   error: @0x00000014: expected END opcode after initializer expression
 out/third_party/testsuite/memory.wast:67: assert_invalid passed:
   error: @0x00000012: unexpected opcode in initializer expression: 1 (0x1)
 out/third_party/testsuite/memory.wast:77: assert_unlinkable passed:
   error: data segment is out of bounds: [0, 1) >= max value 0
-  error: @0x00000017: on_data_segment_data callback failed
+  error: @0x00000017: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:81: assert_unlinkable passed:
   error: data segment is out of bounds: [0, 1) >= max value 0
-  error: @0x00000017: on_data_segment_data callback failed
+  error: @0x00000017: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:85: assert_unlinkable passed:
   error: data segment is out of bounds: [4294967295, 4294967296) >= max value 65536
-  error: @0x00000017: on_data_segment_data callback failed
+  error: @0x00000017: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:89: assert_unlinkable passed:
   error: data segment is out of bounds: [4294966296, 4294966297) >= max value 65536
-  error: @0x00000018: on_data_segment_data callback failed
+  error: @0x00000018: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:93: assert_unlinkable passed:
   error: data segment is out of bounds: [98304, 98305) >= max value 65536
-  error: @0x0000001f: on_data_segment_data callback failed
+  error: @0x0000001f: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:97: assert_unlinkable passed:
   error: data segment is out of bounds: [1, 1) >= max value 0
-  error: @0x00000016: on_data_segment_data callback failed
+  error: @0x00000016: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:101: assert_unlinkable passed:
   error: data segment is out of bounds: [73728, 73728) >= max value 65536
-  error: @0x00000017: on_data_segment_data callback failed
+  error: @0x00000017: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:105: assert_unlinkable passed:
   error: data segment is out of bounds: [4294967295, 4294967295) >= max value 65536
-  error: @0x00000016: on_data_segment_data callback failed
+  error: @0x00000016: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:114: assert_unlinkable passed:
   error: duplicate export "global"
   error: data segment is out of bounds: [666, 667) >= max value 0
-  error: @0x0000002c: on_data_segment_data callback failed
+  error: @0x0000002c: OnDataSegmentData callback failed
 out/third_party/testsuite/memory.wast:131: assert_invalid passed:
   error: @0x0000000e: memory initial size must be <= max size
 out/third_party/testsuite/memory.wast:135: assert_invalid passed:
@@ -81,30 +81,30 @@ out/third_party/testsuite/memory.wast:155: assert_invalid passed:
   error: @0x00000012: invalid memory max size
 out/third_party/testsuite/memory.wast:166: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:170: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:174: assert_invalid passed:
   error: alignment must not be larger than natural alignment (4)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:178: assert_invalid passed:
   error: alignment must not be larger than natural alignment (2)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:182: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:186: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
-  error: @0x00000023: on_store_expr callback failed
+  error: @0x00000023: OnStoreExpr callback failed
 out/third_party/testsuite/memory.wast:190: assert_invalid passed:
   error: alignment must not be larger than natural alignment (2)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:194: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
-  error: @0x00000021: on_load_expr callback failed
+  error: @0x00000021: OnLoadExpr callback failed
 out/third_party/testsuite/memory.wast:198: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
-  error: @0x00000023: on_store_expr callback failed
+  error: @0x00000023: OnStoreExpr callback failed
 66/66 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/nop.txt
+++ b/test/spec/nop.txt
@@ -3,15 +3,15 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/nop.wast:246: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/nop.wast:250: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/nop.wast:254: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/nop.wast:258: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 54/54 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/return.txt
+++ b/test/spec/return.txt
@@ -3,12 +3,12 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/return.wast:270: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x00000019: on_return_expr callback failed
+  error: @0x00000019: OnReturnExpr callback failed
 out/third_party/testsuite/return.wast:274: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x0000001a: on_return_expr callback failed
+  error: @0x0000001a: OnReturnExpr callback failed
 out/third_party/testsuite/return.wast:278: assert_invalid passed:
   error: type mismatch in return, expected f64 but got i64.
-  error: @0x0000001b: on_return_expr callback failed
+  error: @0x0000001b: OnReturnExpr callback failed
 60/60 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -3,6 +3,6 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/select.wast:65: assert_invalid passed:
   error: type stack size too small at select. got 0, expected at least 2
-  error: @0x0000001c: on_select_expr callback failed
+  error: @0x0000001c: OnSelectExpr callback failed
 29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/set_local.txt
+++ b/test/spec/set_local.txt
@@ -3,72 +3,72 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/set_local.wast:95: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001f: end_function_body callback failed
+  error: @0x0000001f: EndFunctionBody callback failed
 out/third_party/testsuite/set_local.wast:101: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x00000021: on_convert_expr callback failed
+  error: @0x00000021: OnConvertExpr callback failed
 out/third_party/testsuite/set_local.wast:107: assert_invalid passed:
   error: type stack size too small at f64.neg. got 0, expected at least 1
-  error: @0x00000020: on_unary_expr callback failed
+  error: @0x00000020: OnUnaryExpr callback failed
 out/third_party/testsuite/set_local.wast:114: assert_invalid passed:
   error: type stack size too small at set_local. got 0, expected at least 1
-  error: @0x0000001c: on_set_local_expr callback failed
+  error: @0x0000001c: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:118: assert_invalid passed:
   error: type mismatch in set_local, expected i32 but got f32.
-  error: @0x00000020: on_set_local_expr callback failed
+  error: @0x00000020: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:122: assert_invalid passed:
   error: type mismatch in set_local, expected f32 but got f64.
-  error: @0x00000024: on_set_local_expr callback failed
+  error: @0x00000024: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:126: assert_invalid passed:
   error: type mismatch in set_local, expected i64 but got f64.
-  error: @0x00000026: on_set_local_expr callback failed
+  error: @0x00000026: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:134: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/set_local.wast:138: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001b: on_convert_expr callback failed
+  error: @0x0000001b: OnConvertExpr callback failed
 out/third_party/testsuite/set_local.wast:142: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001c: on_unary_expr callback failed
+  error: @0x0000001c: OnUnaryExpr callback failed
 out/third_party/testsuite/set_local.wast:147: assert_invalid passed:
   error: type stack size too small at set_local. got 0, expected at least 1
-  error: @0x0000001b: on_set_local_expr callback failed
+  error: @0x0000001b: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:151: assert_invalid passed:
   error: type mismatch in set_local, expected i32 but got f32.
-  error: @0x0000001f: on_set_local_expr callback failed
+  error: @0x0000001f: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:155: assert_invalid passed:
   error: type mismatch in set_local, expected f32 but got f64.
-  error: @0x00000023: on_set_local_expr callback failed
+  error: @0x00000023: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:159: assert_invalid passed:
   error: type mismatch in set_local, expected i64 but got f64.
-  error: @0x00000024: on_set_local_expr callback failed
+  error: @0x00000024: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:167: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
-  error: @0x0000001d: on_get_local_expr callback failed
+  error: @0x0000001d: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:171: assert_invalid passed:
   error: invalid local_index: 14324343 (max 2)
-  error: @0x00000020: on_get_local_expr callback failed
+  error: @0x00000020: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:176: assert_invalid passed:
   error: invalid local_index: 2 (max 2)
-  error: @0x0000001b: on_get_local_expr callback failed
+  error: @0x0000001b: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:180: assert_invalid passed:
   error: invalid local_index: 714324343 (max 2)
-  error: @0x00000021: on_get_local_expr callback failed
+  error: @0x00000021: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:185: assert_invalid passed:
   error: invalid local_index: 3 (max 3)
-  error: @0x0000001e: on_get_local_expr callback failed
+  error: @0x0000001e: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:189: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
-  error: @0x00000021: on_get_local_expr callback failed
+  error: @0x00000021: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:194: assert_invalid passed:
   error: type mismatch in set_local, expected i32 but got f32.
-  error: @0x00000021: on_set_local_expr callback failed
+  error: @0x00000021: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:198: assert_invalid passed:
   error: type mismatch in set_local, expected i32 but got f32.
-  error: @0x00000022: on_set_local_expr callback failed
+  error: @0x00000022: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:202: assert_invalid passed:
   error: type mismatch in set_local, expected f64 but got i64.
-  error: @0x00000020: on_set_local_expr callback failed
+  error: @0x00000020: OnSetLocalExpr callback failed
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -5,10 +5,10 @@ out/third_party/testsuite/start.wast:2: assert_invalid passed:
   error: @0x00000015: invalid start function index
 out/third_party/testsuite/start.wast:7: assert_invalid passed:
   error: start function must not return anything
-  error: @0x00000016: on_start_function callback failed
+  error: @0x00000016: OnStartFunction callback failed
 out/third_party/testsuite/start.wast:14: assert_invalid passed:
   error: start function must be nullary
-  error: @0x00000016: on_start_function callback failed
+  error: @0x00000016: OnStartFunction callback failed
 inc() =>
 inc() =>
 inc() =>

--- a/test/spec/store_retval.txt
+++ b/test/spec/store_retval.txt
@@ -3,42 +3,42 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/store_retval.wast:2: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:6: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:10: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000021: end_function_body callback failed
+  error: @0x00000021: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:14: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000025: end_function_body callback failed
+  error: @0x00000025: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:19: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:23: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:27: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000029: end_function_body callback failed
+  error: @0x00000029: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:31: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000002d: end_function_body callback failed
+  error: @0x0000002d: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:36: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:40: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:44: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:48: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:52: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000026: end_function_body callback failed
+  error: @0x00000026: EndFunctionBody callback failed
 13/13 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/switch.txt
+++ b/test/spec/switch.txt
@@ -3,6 +3,6 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/switch.wast:150: assert_invalid passed:
   error: invalid depth: 3 (max 0)
-  error: @0x0000001c: on_br_table_expr callback failed
+  error: @0x0000001c: OnBrTableExpr callback failed
 27/27 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/tee_local.txt
+++ b/test/spec/tee_local.txt
@@ -3,72 +3,72 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/tee_local.wast:132: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001f: end_function_body callback failed
+  error: @0x0000001f: EndFunctionBody callback failed
 out/third_party/testsuite/tee_local.wast:136: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x00000021: on_convert_expr callback failed
+  error: @0x00000021: OnConvertExpr callback failed
 out/third_party/testsuite/tee_local.wast:140: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x00000020: on_unary_expr callback failed
+  error: @0x00000020: OnUnaryExpr callback failed
 out/third_party/testsuite/tee_local.wast:145: assert_invalid passed:
   error: type stack size too small at tee_local. got 0, expected at least 1
-  error: @0x0000001c: on_tee_local_expr callback failed
+  error: @0x0000001c: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:149: assert_invalid passed:
   error: type mismatch in tee_local, expected i32 but got f32.
-  error: @0x00000020: on_tee_local_expr callback failed
+  error: @0x00000020: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:153: assert_invalid passed:
   error: type mismatch in tee_local, expected f32 but got f64.
-  error: @0x00000024: on_tee_local_expr callback failed
+  error: @0x00000024: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:157: assert_invalid passed:
   error: type mismatch in tee_local, expected i64 but got f64.
-  error: @0x00000026: on_tee_local_expr callback failed
+  error: @0x00000026: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:165: assert_invalid passed:
   error: type mismatch in implicit return, expected i64 but got i32.
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/tee_local.wast:169: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001b: on_convert_expr callback failed
+  error: @0x0000001b: OnConvertExpr callback failed
 out/third_party/testsuite/tee_local.wast:173: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001c: on_unary_expr callback failed
+  error: @0x0000001c: OnUnaryExpr callback failed
 out/third_party/testsuite/tee_local.wast:178: assert_invalid passed:
   error: type stack size too small at tee_local. got 0, expected at least 1
-  error: @0x0000001b: on_tee_local_expr callback failed
+  error: @0x0000001b: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:182: assert_invalid passed:
   error: type mismatch in tee_local, expected i32 but got f32.
-  error: @0x0000001f: on_tee_local_expr callback failed
+  error: @0x0000001f: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:186: assert_invalid passed:
   error: type mismatch in tee_local, expected f32 but got f64.
-  error: @0x00000023: on_tee_local_expr callback failed
+  error: @0x00000023: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:190: assert_invalid passed:
   error: type mismatch in tee_local, expected i64 but got f64.
-  error: @0x00000024: on_tee_local_expr callback failed
+  error: @0x00000024: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:198: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
-  error: @0x0000001d: on_get_local_expr callback failed
+  error: @0x0000001d: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:202: assert_invalid passed:
   error: invalid local_index: 14324343 (max 2)
-  error: @0x00000020: on_get_local_expr callback failed
+  error: @0x00000020: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:207: assert_invalid passed:
   error: invalid local_index: 2 (max 2)
-  error: @0x0000001b: on_get_local_expr callback failed
+  error: @0x0000001b: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:211: assert_invalid passed:
   error: invalid local_index: 714324343 (max 2)
-  error: @0x00000021: on_get_local_expr callback failed
+  error: @0x00000021: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:216: assert_invalid passed:
   error: invalid local_index: 3 (max 3)
-  error: @0x0000001e: on_get_local_expr callback failed
+  error: @0x0000001e: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:220: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
-  error: @0x00000021: on_get_local_expr callback failed
+  error: @0x00000021: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:225: assert_invalid passed:
   error: type mismatch in tee_local, expected i32 but got f32.
-  error: @0x00000021: on_tee_local_expr callback failed
+  error: @0x00000021: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:229: assert_invalid passed:
   error: type mismatch in tee_local, expected i32 but got f32.
-  error: @0x00000022: on_tee_local_expr callback failed
+  error: @0x00000022: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:233: assert_invalid passed:
   error: type mismatch in tee_local, expected f64 but got i64.
-  error: @0x00000020: on_tee_local_expr callback failed
+  error: @0x00000020: OnTeeLocalExpr callback failed
 34/34 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/typecheck.txt
+++ b/test/spec/typecheck.txt
@@ -3,659 +3,659 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/typecheck.wast:4: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x00000018: on_convert_expr callback failed
+  error: @0x00000018: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:10: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001c: on_convert_expr callback failed
+  error: @0x0000001c: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:17: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001c: on_convert_expr callback failed
+  error: @0x0000001c: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:24: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001e: on_convert_expr callback failed
+  error: @0x0000001e: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:31: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x00000021: on_convert_expr callback failed
+  error: @0x00000021: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:39: assert_invalid passed:
   error: type stack size too small at i32.add. got 0, expected at least 2
-  error: @0x00000018: on_binary_expr callback failed
+  error: @0x00000018: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:45: assert_invalid passed:
   error: type stack size too small at i32.add. got 1, expected at least 2
-  error: @0x0000001a: on_binary_expr callback failed
+  error: @0x0000001a: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:51: assert_invalid passed:
   error: type stack size too small at i32.add. got 0, expected at least 2
-  error: @0x0000001e: on_binary_expr callback failed
+  error: @0x0000001e: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:58: assert_invalid passed:
   error: type stack size too small at i32.add. got 1, expected at least 2
-  error: @0x0000001e: on_binary_expr callback failed
+  error: @0x0000001e: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:65: assert_invalid passed:
   error: type stack size too small at i32.add. got 0, expected at least 2
-  error: @0x0000001e: on_binary_expr callback failed
+  error: @0x0000001e: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:72: assert_invalid passed:
   error: type stack size too small at i32.add. got 1, expected at least 2
-  error: @0x0000001e: on_binary_expr callback failed
+  error: @0x0000001e: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:79: assert_invalid passed:
   error: type stack size too small at drop. got 0, expected at least 1
-  error: @0x00000021: on_drop_expr callback failed
+  error: @0x00000021: OnDropExpr callback failed
 out/third_party/testsuite/typecheck.wast:86: assert_invalid passed:
   error: type stack size too small at i32.add. got 0, expected at least 2
-  error: @0x00000020: on_binary_expr callback failed
+  error: @0x00000020: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:93: assert_invalid passed:
   error: type stack size too small at i32.add. got 0, expected at least 2
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:101: assert_invalid passed:
   error: type stack size too small at i32.add. got 0, expected at least 2
-  error: @0x00000021: on_binary_expr callback failed
+  error: @0x00000021: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:110: assert_invalid passed:
   error: type stack size too small at if. got 0, expected at least 1
-  error: @0x00000019: on_if_expr callback failed
+  error: @0x00000019: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:116: assert_invalid passed:
   error: type stack size too small at if. got 0, expected at least 1
-  error: @0x0000001d: on_if_expr callback failed
+  error: @0x0000001d: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:123: assert_invalid passed:
   error: type stack size too small at if. got 0, expected at least 1
-  error: @0x0000001d: on_if_expr callback failed
+  error: @0x0000001d: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:130: assert_invalid passed:
   error: type stack size too small at if. got 0, expected at least 1
-  error: @0x0000001f: on_if_expr callback failed
+  error: @0x0000001f: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:137: assert_invalid passed:
   error: type stack size too small at if. got 0, expected at least 1
-  error: @0x00000022: on_if_expr callback failed
+  error: @0x00000022: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:146: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001b: on_br_expr callback failed
+  error: @0x0000001b: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:153: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x0000001d: on_br_expr callback failed
+  error: @0x0000001d: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:161: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x00000021: on_br_expr callback failed
+  error: @0x00000021: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:171: assert_invalid passed:
   error: type stack size too small at br. got 0, expected at least 1
-  error: @0x00000024: on_br_expr callback failed
+  error: @0x00000024: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:182: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x00000019: on_return_expr callback failed
+  error: @0x00000019: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:188: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x0000001d: on_return_expr callback failed
+  error: @0x0000001d: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:195: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x0000001d: on_return_expr callback failed
+  error: @0x0000001d: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:202: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x0000001f: on_return_expr callback failed
+  error: @0x0000001f: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:209: assert_invalid passed:
   error: type stack size too small at return. got 0, expected at least 1
-  error: @0x00000022: on_return_expr callback failed
+  error: @0x00000022: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:219: assert_invalid passed:
   error: type mismatch in if, expected i32 but got f32.
-  error: @0x0000001e: on_if_expr callback failed
+  error: @0x0000001e: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:222: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got f32.
-  error: @0x00000020: on_br_if_expr callback failed
+  error: @0x00000020: OnBrIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:226: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got f32.
-  error: @0x00000021: on_br_table_expr callback failed
+  error: @0x00000021: OnBrTableExpr callback failed
 out/third_party/testsuite/typecheck.wast:230: assert_invalid passed:
   error: type mismatch in call, expected i32 but got f32.
-  error: @0x00000026: on_call_expr callback failed
+  error: @0x00000026: OnCallExpr callback failed
 out/third_party/testsuite/typecheck.wast:232: assert_invalid passed:
   error: type mismatch in call_indirect, expected i32 but got f32.
-  error: @0x0000002f: on_call_indirect_expr callback failed
+  error: @0x0000002f: OnCallIndirectExpr callback failed
 out/third_party/testsuite/typecheck.wast:242: assert_invalid passed:
   error: type mismatch in call_indirect, expected i32 but got f32.
-  error: @0x00000029: on_call_indirect_expr callback failed
+  error: @0x00000029: OnCallIndirectExpr callback failed
 out/third_party/testsuite/typecheck.wast:250: assert_invalid passed:
   error: type mismatch in return, expected i32 but got f32.
-  error: @0x0000001e: on_return_expr callback failed
+  error: @0x0000001e: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:253: assert_invalid passed:
   error: type mismatch in set_local, expected i32 but got f32.
-  error: @0x00000020: on_set_local_expr callback failed
+  error: @0x00000020: OnSetLocalExpr callback failed
 out/third_party/testsuite/typecheck.wast:256: assert_invalid passed:
   error: type mismatch in i32.load, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:257: assert_invalid passed:
   error: type mismatch in i32.load8_s, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:258: assert_invalid passed:
   error: type mismatch in i32.load8_u, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:259: assert_invalid passed:
   error: type mismatch in i32.load16_s, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:260: assert_invalid passed:
   error: type mismatch in i32.load16_u, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:261: assert_invalid passed:
   error: type mismatch in i64.load, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:262: assert_invalid passed:
   error: type mismatch in i64.load8_s, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:263: assert_invalid passed:
   error: type mismatch in i64.load8_u, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:264: assert_invalid passed:
   error: type mismatch in i64.load16_s, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:265: assert_invalid passed:
   error: type mismatch in i64.load16_u, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:266: assert_invalid passed:
   error: type mismatch in i64.load32_s, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:267: assert_invalid passed:
   error: type mismatch in i64.load32_u, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:268: assert_invalid passed:
   error: type mismatch in f32.load, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:269: assert_invalid passed:
   error: type mismatch in f64.load, expected i32 but got f32.
-  error: @0x00000024: on_load_expr callback failed
+  error: @0x00000024: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:272: assert_invalid passed:
   error: type mismatch in i32.store, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:273: assert_invalid passed:
   error: type mismatch in i32.store8, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:274: assert_invalid passed:
   error: type mismatch in i32.store16, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:275: assert_invalid passed:
   error: type mismatch in i64.store, expected i32 but got f32.
   error: type mismatch in i64.store, expected i64 but got i32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:276: assert_invalid passed:
   error: type mismatch in i64.store8, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:277: assert_invalid passed:
   error: type mismatch in i64.store16, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:278: assert_invalid passed:
   error: type mismatch in i64.store32, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:279: assert_invalid passed:
   error: type mismatch in f32.store, expected i32 but got f32.
-  error: @0x00000029: on_store_expr callback failed
+  error: @0x00000029: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:280: assert_invalid passed:
   error: type mismatch in f64.store, expected i32 but got f32.
-  error: @0x0000002d: on_store_expr callback failed
+  error: @0x0000002d: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:283: assert_invalid passed:
   error: type mismatch in i32.store, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:284: assert_invalid passed:
   error: type mismatch in i32.store8, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:285: assert_invalid passed:
   error: type mismatch in i32.store16, expected i32 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:286: assert_invalid passed:
   error: type mismatch in i64.store, expected i64 but got f32.
-  error: @0x00000026: on_store_expr callback failed
+  error: @0x00000026: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:287: assert_invalid passed:
   error: type mismatch in i64.store8, expected i64 but got f64.
-  error: @0x0000002a: on_store_expr callback failed
+  error: @0x0000002a: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:288: assert_invalid passed:
   error: type mismatch in i64.store16, expected i64 but got f64.
-  error: @0x0000002a: on_store_expr callback failed
+  error: @0x0000002a: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:289: assert_invalid passed:
   error: type mismatch in i64.store32, expected i64 but got f64.
-  error: @0x0000002a: on_store_expr callback failed
+  error: @0x0000002a: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:290: assert_invalid passed:
   error: type mismatch in f32.store, expected f32 but got i32.
-  error: @0x00000023: on_store_expr callback failed
+  error: @0x00000023: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:291: assert_invalid passed:
   error: type mismatch in f64.store, expected f64 but got i64.
-  error: @0x00000023: on_store_expr callback failed
+  error: @0x00000023: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:294: assert_invalid passed:
   error: type mismatch in i32.add, expected i32 but got i64.
   error: type mismatch in i32.add, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:295: assert_invalid passed:
   error: type mismatch in i32.and, expected i32 but got i64.
   error: type mismatch in i32.and, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:296: assert_invalid passed:
   error: type mismatch in i32.div_s, expected i32 but got i64.
   error: type mismatch in i32.div_s, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:297: assert_invalid passed:
   error: type mismatch in i32.div_u, expected i32 but got i64.
   error: type mismatch in i32.div_u, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:298: assert_invalid passed:
   error: type mismatch in i32.mul, expected i32 but got i64.
   error: type mismatch in i32.mul, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:299: assert_invalid passed:
   error: type mismatch in i32.or, expected i32 but got i64.
   error: type mismatch in i32.or, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:300: assert_invalid passed:
   error: type mismatch in i32.rem_s, expected i32 but got i64.
   error: type mismatch in i32.rem_s, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:301: assert_invalid passed:
   error: type mismatch in i32.rem_u, expected i32 but got i64.
   error: type mismatch in i32.rem_u, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:302: assert_invalid passed:
   error: type mismatch in i32.rotl, expected i32 but got i64.
   error: type mismatch in i32.rotl, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:303: assert_invalid passed:
   error: type mismatch in i32.rotr, expected i32 but got i64.
   error: type mismatch in i32.rotr, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:304: assert_invalid passed:
   error: type mismatch in i32.shl, expected i32 but got i64.
   error: type mismatch in i32.shl, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:305: assert_invalid passed:
   error: type mismatch in i32.shr_s, expected i32 but got i64.
   error: type mismatch in i32.shr_s, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:306: assert_invalid passed:
   error: type mismatch in i32.shr_u, expected i32 but got i64.
   error: type mismatch in i32.shr_u, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:307: assert_invalid passed:
   error: type mismatch in i32.sub, expected i32 but got i64.
   error: type mismatch in i32.sub, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:308: assert_invalid passed:
   error: type mismatch in i32.xor, expected i32 but got i64.
   error: type mismatch in i32.xor, expected i32 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:309: assert_invalid passed:
   error: type mismatch in i64.add, expected i64 but got i32.
   error: type mismatch in i64.add, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:310: assert_invalid passed:
   error: type mismatch in i64.and, expected i64 but got i32.
   error: type mismatch in i64.and, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:311: assert_invalid passed:
   error: type mismatch in i64.div_s, expected i64 but got i32.
   error: type mismatch in i64.div_s, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:312: assert_invalid passed:
   error: type mismatch in i64.div_u, expected i64 but got i32.
   error: type mismatch in i64.div_u, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:313: assert_invalid passed:
   error: type mismatch in i64.mul, expected i64 but got i32.
   error: type mismatch in i64.mul, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:314: assert_invalid passed:
   error: type mismatch in i64.or, expected i64 but got i32.
   error: type mismatch in i64.or, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:315: assert_invalid passed:
   error: type mismatch in i64.rem_s, expected i64 but got i32.
   error: type mismatch in i64.rem_s, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:316: assert_invalid passed:
   error: type mismatch in i64.rem_u, expected i64 but got i32.
   error: type mismatch in i64.rem_u, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:317: assert_invalid passed:
   error: type mismatch in i64.rotl, expected i64 but got i32.
   error: type mismatch in i64.rotl, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:318: assert_invalid passed:
   error: type mismatch in i64.rotr, expected i64 but got i32.
   error: type mismatch in i64.rotr, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:319: assert_invalid passed:
   error: type mismatch in i64.shl, expected i64 but got i32.
   error: type mismatch in i64.shl, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:320: assert_invalid passed:
   error: type mismatch in i64.shr_s, expected i64 but got i32.
   error: type mismatch in i64.shr_s, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:321: assert_invalid passed:
   error: type mismatch in i64.shr_u, expected i64 but got i32.
   error: type mismatch in i64.shr_u, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:322: assert_invalid passed:
   error: type mismatch in i64.sub, expected i64 but got i32.
   error: type mismatch in i64.sub, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:323: assert_invalid passed:
   error: type mismatch in i64.xor, expected i64 but got i32.
   error: type mismatch in i64.xor, expected i64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:324: assert_invalid passed:
   error: type mismatch in f32.add, expected f32 but got i64.
   error: type mismatch in f32.add, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:325: assert_invalid passed:
   error: type mismatch in f32.copysign, expected f32 but got i64.
   error: type mismatch in f32.copysign, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:326: assert_invalid passed:
   error: type mismatch in f32.div, expected f32 but got i64.
   error: type mismatch in f32.div, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:327: assert_invalid passed:
   error: type mismatch in f32.max, expected f32 but got i64.
   error: type mismatch in f32.max, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:328: assert_invalid passed:
   error: type mismatch in f32.min, expected f32 but got i64.
   error: type mismatch in f32.min, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:329: assert_invalid passed:
   error: type mismatch in f32.mul, expected f32 but got i64.
   error: type mismatch in f32.mul, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:330: assert_invalid passed:
   error: type mismatch in f32.sub, expected f32 but got i64.
   error: type mismatch in f32.sub, expected f32 but got f64.
-  error: @0x00000023: on_binary_expr callback failed
+  error: @0x00000023: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:331: assert_invalid passed:
   error: type mismatch in f64.add, expected f64 but got i64.
   error: type mismatch in f64.add, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:332: assert_invalid passed:
   error: type mismatch in f64.copysign, expected f64 but got i64.
   error: type mismatch in f64.copysign, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:333: assert_invalid passed:
   error: type mismatch in f64.div, expected f64 but got i64.
   error: type mismatch in f64.div, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:334: assert_invalid passed:
   error: type mismatch in f64.max, expected f64 but got i64.
   error: type mismatch in f64.max, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:335: assert_invalid passed:
   error: type mismatch in f64.min, expected f64 but got i64.
   error: type mismatch in f64.min, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:336: assert_invalid passed:
   error: type mismatch in f64.mul, expected f64 but got i64.
   error: type mismatch in f64.mul, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:337: assert_invalid passed:
   error: type mismatch in f64.sub, expected f64 but got i64.
   error: type mismatch in f64.sub, expected f64 but got f32.
-  error: @0x0000001f: on_binary_expr callback failed
+  error: @0x0000001f: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:340: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:341: assert_invalid passed:
   error: type mismatch in i32.clz, expected i32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:342: assert_invalid passed:
   error: type mismatch in i32.ctz, expected i32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:343: assert_invalid passed:
   error: type mismatch in i32.popcnt, expected i32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:344: assert_invalid passed:
   error: type mismatch in i64.eqz, expected i64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:345: assert_invalid passed:
   error: type mismatch in i64.clz, expected i64 but got i32.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:346: assert_invalid passed:
   error: type mismatch in i64.ctz, expected i64 but got i32.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:347: assert_invalid passed:
   error: type mismatch in i64.popcnt, expected i64 but got i32.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:348: assert_invalid passed:
   error: type mismatch in f32.abs, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:349: assert_invalid passed:
   error: type mismatch in f32.ceil, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:350: assert_invalid passed:
   error: type mismatch in f32.floor, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:351: assert_invalid passed:
   error: type mismatch in f32.nearest, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:352: assert_invalid passed:
   error: type mismatch in f32.neg, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:353: assert_invalid passed:
   error: type mismatch in f32.sqrt, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:354: assert_invalid passed:
   error: type mismatch in f32.trunc, expected f32 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:355: assert_invalid passed:
   error: type mismatch in f64.abs, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:356: assert_invalid passed:
   error: type mismatch in f64.ceil, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:357: assert_invalid passed:
   error: type mismatch in f64.floor, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:358: assert_invalid passed:
   error: type mismatch in f64.nearest, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:359: assert_invalid passed:
   error: type mismatch in f64.neg, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:360: assert_invalid passed:
   error: type mismatch in f64.sqrt, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:361: assert_invalid passed:
   error: type mismatch in f64.trunc, expected f64 but got i64.
-  error: @0x0000001a: on_unary_expr callback failed
+  error: @0x0000001a: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:364: assert_invalid passed:
   error: type mismatch in i32.eq, expected i32 but got i64.
   error: type mismatch in i32.eq, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:365: assert_invalid passed:
   error: type mismatch in i32.ge_s, expected i32 but got i64.
   error: type mismatch in i32.ge_s, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:366: assert_invalid passed:
   error: type mismatch in i32.ge_u, expected i32 but got i64.
   error: type mismatch in i32.ge_u, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:367: assert_invalid passed:
   error: type mismatch in i32.gt_s, expected i32 but got i64.
   error: type mismatch in i32.gt_s, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:368: assert_invalid passed:
   error: type mismatch in i32.gt_u, expected i32 but got i64.
   error: type mismatch in i32.gt_u, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:369: assert_invalid passed:
   error: type mismatch in i32.le_s, expected i32 but got i64.
   error: type mismatch in i32.le_s, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:370: assert_invalid passed:
   error: type mismatch in i32.le_u, expected i32 but got i64.
   error: type mismatch in i32.le_u, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:371: assert_invalid passed:
   error: type mismatch in i32.lt_s, expected i32 but got i64.
   error: type mismatch in i32.lt_s, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:372: assert_invalid passed:
   error: type mismatch in i32.lt_u, expected i32 but got i64.
   error: type mismatch in i32.lt_u, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:373: assert_invalid passed:
   error: type mismatch in i32.ne, expected i32 but got i64.
   error: type mismatch in i32.ne, expected i32 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:374: assert_invalid passed:
   error: type mismatch in i64.eq, expected i64 but got i32.
   error: type mismatch in i64.eq, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:375: assert_invalid passed:
   error: type mismatch in i64.ge_s, expected i64 but got i32.
   error: type mismatch in i64.ge_s, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:376: assert_invalid passed:
   error: type mismatch in i64.ge_u, expected i64 but got i32.
   error: type mismatch in i64.ge_u, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:377: assert_invalid passed:
   error: type mismatch in i64.gt_s, expected i64 but got i32.
   error: type mismatch in i64.gt_s, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:378: assert_invalid passed:
   error: type mismatch in i64.gt_u, expected i64 but got i32.
   error: type mismatch in i64.gt_u, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:379: assert_invalid passed:
   error: type mismatch in i64.le_s, expected i64 but got i32.
   error: type mismatch in i64.le_s, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:380: assert_invalid passed:
   error: type mismatch in i64.le_u, expected i64 but got i32.
   error: type mismatch in i64.le_u, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:381: assert_invalid passed:
   error: type mismatch in i64.lt_s, expected i64 but got i32.
   error: type mismatch in i64.lt_s, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:382: assert_invalid passed:
   error: type mismatch in i64.lt_u, expected i64 but got i32.
   error: type mismatch in i64.lt_u, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:383: assert_invalid passed:
   error: type mismatch in i64.ne, expected i64 but got i32.
   error: type mismatch in i64.ne, expected i64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:384: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i64.
   error: type mismatch in f32.eq, expected f32 but got f64.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:385: assert_invalid passed:
   error: type mismatch in f32.ge, expected f32 but got i64.
   error: type mismatch in f32.ge, expected f32 but got f64.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:386: assert_invalid passed:
   error: type mismatch in f32.gt, expected f32 but got i64.
   error: type mismatch in f32.gt, expected f32 but got f64.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:387: assert_invalid passed:
   error: type mismatch in f32.le, expected f32 but got i64.
   error: type mismatch in f32.le, expected f32 but got f64.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:388: assert_invalid passed:
   error: type mismatch in f32.lt, expected f32 but got i64.
   error: type mismatch in f32.lt, expected f32 but got f64.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:389: assert_invalid passed:
   error: type mismatch in f32.ne, expected f32 but got i64.
   error: type mismatch in f32.ne, expected f32 but got f64.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:390: assert_invalid passed:
   error: type mismatch in f64.eq, expected f64 but got i64.
   error: type mismatch in f64.eq, expected f64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:391: assert_invalid passed:
   error: type mismatch in f64.ge, expected f64 but got i64.
   error: type mismatch in f64.ge, expected f64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:392: assert_invalid passed:
   error: type mismatch in f64.gt, expected f64 but got i64.
   error: type mismatch in f64.gt, expected f64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:393: assert_invalid passed:
   error: type mismatch in f64.le, expected f64 but got i64.
   error: type mismatch in f64.le, expected f64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:394: assert_invalid passed:
   error: type mismatch in f64.lt, expected f64 but got i64.
   error: type mismatch in f64.lt, expected f64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:395: assert_invalid passed:
   error: type mismatch in f64.ne, expected f64 but got i64.
   error: type mismatch in f64.ne, expected f64 but got f32.
-  error: @0x0000001f: on_compare_expr callback failed
+  error: @0x0000001f: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:398: assert_invalid passed:
   error: type mismatch in i32.wrap/i64, expected i64 but got f32.
-  error: @0x0000001d: on_convert_expr callback failed
+  error: @0x0000001d: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:399: assert_invalid passed:
   error: type mismatch in i32.trunc_s/f32, expected f32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:400: assert_invalid passed:
   error: type mismatch in i32.trunc_u/f32, expected f32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:401: assert_invalid passed:
   error: type mismatch in i32.trunc_s/f64, expected f64 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:402: assert_invalid passed:
   error: type mismatch in i32.trunc_u/f64, expected f64 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:403: assert_invalid passed:
   error: type mismatch in i32.reinterpret/f32, expected f32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:404: assert_invalid passed:
   error: type mismatch in i64.extend_s/i32, expected i32 but got f32.
-  error: @0x0000001d: on_convert_expr callback failed
+  error: @0x0000001d: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:405: assert_invalid passed:
   error: type mismatch in i64.extend_u/i32, expected i32 but got f32.
-  error: @0x0000001d: on_convert_expr callback failed
+  error: @0x0000001d: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:406: assert_invalid passed:
   error: type mismatch in i64.trunc_s/f32, expected f32 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:407: assert_invalid passed:
   error: type mismatch in i64.trunc_u/f32, expected f32 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:408: assert_invalid passed:
   error: type mismatch in i64.trunc_s/f64, expected f64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:409: assert_invalid passed:
   error: type mismatch in i64.trunc_u/f64, expected f64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:410: assert_invalid passed:
   error: type mismatch in i64.reinterpret/f64, expected f64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:411: assert_invalid passed:
   error: type mismatch in f32.convert_s/i32, expected i32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:412: assert_invalid passed:
   error: type mismatch in f32.convert_u/i32, expected i32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:413: assert_invalid passed:
   error: type mismatch in f32.convert_s/i64, expected i64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:414: assert_invalid passed:
   error: type mismatch in f32.convert_u/i64, expected i64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:415: assert_invalid passed:
   error: type mismatch in f32.demote/f64, expected f64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:416: assert_invalid passed:
   error: type mismatch in f32.reinterpret/i32, expected i32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:417: assert_invalid passed:
   error: type mismatch in f64.convert_s/i32, expected i32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:418: assert_invalid passed:
   error: type mismatch in f64.convert_u/i32, expected i32 but got i64.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:419: assert_invalid passed:
   error: type mismatch in f64.convert_s/i64, expected i64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:420: assert_invalid passed:
   error: type mismatch in f64.convert_u/i64, expected i64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:421: assert_invalid passed:
   error: type mismatch in f64.promote/f32, expected f32 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:422: assert_invalid passed:
   error: type mismatch in f64.reinterpret/i64, expected i64 but got i32.
-  error: @0x0000001a: on_convert_expr callback failed
+  error: @0x0000001a: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:425: assert_invalid passed:
   error: type mismatch in grow_memory, expected i32 but got f32.
-  error: @0x00000023: on_grow_memory_expr callback failed
+  error: @0x00000023: OnGrowMemoryExpr callback failed
 193/193 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -3,311 +3,311 @@
 (;; STDOUT ;;;
 out/third_party/testsuite/unreached-invalid.wast:4: assert_invalid passed:
   error: invalid local_index: 0 (max 0)
-  error: @0x0000001a: on_get_local_expr callback failed
+  error: @0x0000001a: OnGetLocalExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:8: assert_invalid passed:
   error: invalid global_index: 0 (max 0)
-  error: @0x0000001a: on_get_global_expr callback failed
+  error: @0x0000001a: OnGetGlobalExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:12: assert_invalid passed:
   error: @0x0000001a: invalid call function index
 out/third_party/testsuite/unreached-invalid.wast:16: assert_invalid passed:
   error: invalid depth: 1 (max 0)
-  error: @0x0000001a: on_br_expr callback failed
+  error: @0x0000001a: OnBrExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:21: assert_invalid passed:
   error: type mismatch in i64.eqz, expected i64 but got i32.
-  error: @0x0000001b: on_convert_expr callback failed
+  error: @0x0000001b: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:27: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x0000001f: end_function_body callback failed
+  error: @0x0000001f: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:33: assert_invalid passed:
   error: type mismatch in select, expected i32 but got i64.
-  error: @0x00000023: on_select_expr callback failed
+  error: @0x00000023: OnSelectExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:42: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001b: end_function_body callback failed
+  error: @0x0000001b: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:46: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:50: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:56: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001a: end_function_body callback failed
+  error: @0x0000001a: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:60: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:64: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:71: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001f: on_convert_expr callback failed
+  error: @0x0000001f: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:77: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x00000021: on_convert_expr callback failed
+  error: @0x00000021: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:83: assert_invalid passed:
   error: type stack size too small at f32.eq. got 1, expected at least 2
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000020: on_compare_expr callback failed
+  error: @0x00000020: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:89: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:95: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x0000001e: on_end_expr callback failed
+  error: @0x0000001e: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:101: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:107: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:113: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:119: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001c: end_function_body callback failed
+  error: @0x0000001c: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:125: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got f32.
-  error: @0x00000022: end_function_body callback failed
+  error: @0x00000022: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:132: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001c: on_convert_expr callback failed
+  error: @0x0000001c: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:138: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001e: on_convert_expr callback failed
+  error: @0x0000001e: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:144: assert_invalid passed:
   error: type stack size too small at f32.eq. got 1, expected at least 2
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x0000001d: on_compare_expr callback failed
+  error: @0x0000001d: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:150: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000020: on_compare_expr callback failed
+  error: @0x00000020: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:156: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x0000001d: on_end_expr callback failed
+  error: @0x0000001d: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:162: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
-  error: @0x00000025: on_end_expr callback failed
+  error: @0x00000025: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:168: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x0000001f: on_end_expr callback failed
+  error: @0x0000001f: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:174: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:180: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001b: end_function_body callback failed
+  error: @0x0000001b: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:186: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got f32.
-  error: @0x00000021: end_function_body callback failed
+  error: @0x00000021: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:193: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001c: on_convert_expr callback failed
+  error: @0x0000001c: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:199: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x0000001e: on_convert_expr callback failed
+  error: @0x0000001e: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:205: assert_invalid passed:
   error: type stack size too small at f32.eq. got 1, expected at least 2
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x0000001d: on_compare_expr callback failed
+  error: @0x0000001d: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:211: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000020: on_compare_expr callback failed
+  error: @0x00000020: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:217: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x0000001d: on_end_expr callback failed
+  error: @0x0000001d: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:223: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:229: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x0000001f: on_end_expr callback failed
+  error: @0x0000001f: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:235: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000021: on_end_expr callback failed
+  error: @0x00000021: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:241: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001b: end_function_body callback failed
+  error: @0x0000001b: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:247: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got f32.
-  error: @0x0000001f: end_function_body callback failed
+  error: @0x0000001f: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:254: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001f: on_convert_expr callback failed
+  error: @0x0000001f: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:260: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x00000021: on_convert_expr callback failed
+  error: @0x00000021: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:266: assert_invalid passed:
   error: type stack size too small at f32.eq. got 1, expected at least 2
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000020: on_compare_expr callback failed
+  error: @0x00000020: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:272: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:278: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:284: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
   error: type stack at end of block is 1, expected 0
-  error: @0x00000026: on_end_expr callback failed
+  error: @0x00000026: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:291: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x00000022: on_end_expr callback failed
+  error: @0x00000022: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:297: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:304: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001e: end_function_body callback failed
+  error: @0x0000001e: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:310: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got f32.
-  error: @0x00000022: end_function_body callback failed
+  error: @0x00000022: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:318: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x00000020: on_convert_expr callback failed
+  error: @0x00000020: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:324: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x00000022: on_convert_expr callback failed
+  error: @0x00000022: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:330: assert_invalid passed:
   error: type stack size too small at f32.eq. got 1, expected at least 2
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000021: on_compare_expr callback failed
+  error: @0x00000021: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:336: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000024: on_compare_expr callback failed
+  error: @0x00000024: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:342: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000021: on_end_expr callback failed
+  error: @0x00000021: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:348: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
   error: type stack at end of block is 1, expected 0
-  error: @0x00000027: on_end_expr callback failed
+  error: @0x00000027: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:354: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:360: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000025: on_end_expr callback failed
+  error: @0x00000025: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:366: assert_invalid passed:
   error: type stack at end of function is 1, expected 0
-  error: @0x0000001f: end_function_body callback failed
+  error: @0x0000001f: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:372: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got f32.
-  error: @0x00000023: end_function_body callback failed
+  error: @0x00000023: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:379: assert_invalid passed:
   error: type stack size too small at i32.eqz. got 0, expected at least 1
-  error: @0x0000001d: on_convert_expr callback failed
+  error: @0x0000001d: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:385: assert_invalid passed:
   error: type mismatch in i32.eqz, expected i32 but got f32.
-  error: @0x00000021: on_convert_expr callback failed
+  error: @0x00000021: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:391: assert_invalid passed:
   error: type stack size too small at f32.eq. got 1, expected at least 2
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x0000001e: on_compare_expr callback failed
+  error: @0x0000001e: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:397: assert_invalid passed:
   error: type mismatch in f32.eq, expected f32 but got i32.
-  error: @0x00000023: on_compare_expr callback failed
+  error: @0x00000023: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:403: assert_invalid passed:
   error: type stack at end of if is 1, expected 0
-  error: @0x0000001e: on_end_expr callback failed
+  error: @0x0000001e: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:409: assert_invalid passed:
   error: if without else cannot have type signature.
   error: type mismatch in if, expected i32 but got f32.
-  error: @0x00000022: on_end_expr callback failed
+  error: @0x00000022: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:415: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:421: assert_invalid passed:
   error: type mismatch in block, expected i32 but got f32.
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:427: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:433: assert_invalid passed:
   error: type mismatch in loop, expected i32 but got f32.
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:440: assert_invalid passed:
   error: type mismatch in return, expected i32 but got f64.
-  error: @0x00000025: on_return_expr callback failed
+  error: @0x00000025: OnReturnExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:447: assert_invalid passed:
   error: type mismatch in br, expected i32 but got f64.
-  error: @0x00000029: on_br_expr callback failed
+  error: @0x00000029: OnBrExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:454: assert_invalid passed:
   error: type mismatch in br_if, expected i32 but got f32.
-  error: @0x00000021: on_br_if_expr callback failed
+  error: @0x00000021: OnBrIfExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:460: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got f32.
-  error: @0x00000022: on_br_table_expr callback failed
+  error: @0x00000022: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:466: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got f32.
-  error: @0x00000025: on_br_table_expr callback failed
+  error: @0x00000025: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:472: assert_invalid passed:
   error: type mismatch in br_table, expected void but got f32.
-  error: @0x00000023: on_br_table_expr callback failed
+  error: @0x00000023: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:484: assert_invalid passed:
   error: type mismatch in br_table, expected f64 but got f32.
-  error: @0x00000023: on_br_table_expr callback failed
+  error: @0x00000023: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:499: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:505: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000020: end_function_body callback failed
+  error: @0x00000020: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:511: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000022: end_function_body callback failed
+  error: @0x00000022: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:517: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:524: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000021: on_end_expr callback failed
+  error: @0x00000021: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:530: assert_invalid passed:
   error: type stack size too small at block. got 0, expected at least 1
-  error: @0x00000022: on_end_expr callback failed
+  error: @0x00000022: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:536: assert_invalid passed:
   error: type mismatch in block, expected i32 but got i64.
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:543: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000023: on_end_expr callback failed
+  error: @0x00000023: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:549: assert_invalid passed:
   error: type stack size too small at block. got 0, expected at least 1
-  error: @0x00000025: on_end_expr callback failed
+  error: @0x00000025: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:555: assert_invalid passed:
   error: type mismatch in block, expected i32 but got i64.
-  error: @0x00000027: on_end_expr callback failed
+  error: @0x00000027: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:561: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000024: on_end_expr callback failed
+  error: @0x00000024: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:568: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:574: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000022: end_function_body callback failed
+  error: @0x00000022: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:580: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000024: end_function_body callback failed
+  error: @0x00000024: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:586: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
-  error: @0x00000025: on_end_expr callback failed
+  error: @0x00000025: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:594: assert_invalid passed:
   error: type stack at end of loop is 1, expected 0
-  error: @0x00000020: on_end_expr callback failed
+  error: @0x00000020: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:600: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000020: end_function_body callback failed
+  error: @0x00000020: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:606: assert_invalid passed:
   error: type mismatch in implicit return, expected i32 but got i64.
-  error: @0x00000022: end_function_body callback failed
+  error: @0x00000022: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:613: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x0000001f: end_function_body callback failed
+  error: @0x0000001f: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:619: assert_invalid passed:
   error: type stack size too small at implicit return. got 0, expected at least 1
-  error: @0x00000020: end_function_body callback failed
+  error: @0x00000020: EndFunctionBody callback failed
 100/100 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
This adds a few new classes:

* BinaryReader: the abstract base class
* BinaryReaderNop: implements all of BinaryReader, but does nothing
* LoggingBinaryReader: logs calls through BinaryReader, and forwards to
  another BinaryReader

Typically this means we can remove the Context structs from these
implementations, since that data can just move into the BinaryReader
subclasses.

I also took the opportunity to rename the new member functions to
MixedCase instead of snake_case, since that's more common in C++.