### PR TITLE
Don't force color diagnostics on Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,6 @@ else ()
     add_definitions(-Wno-clobbered)
   endif ()
 
-  if (COMPILER_IS_CLANG)
-    add_definitions(-fcolor-diagnostics)
-  endif ()
-
   if (NOT EMSCRIPTEN)
     # try to get the target architecture by compiling a dummy.c file and
     # checking the architecture using the file command.


### PR DESCRIPTION
It breaks my Vim workflow :) But seriously, we should just figure out a
nicer way to handle this with Ninja if that's what we want.