### PR TITLE
Return non-zero on travis if tests fail

### DIFF
--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -22,14 +22,18 @@ RTN=0
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd -P)"
 source "${SCRIPT_DIR}/travis-common.sh"
 
+cd ${ROOT_DIR}
+
 log_and_run() {
   echo $*
-  (exec $*) && true
-  [[ $? != 0 ]] && RTN=1
+  if ! $*; then
+    echo "travis-test.sh: sub-command failed: $*"
+    RTN=1;
+  fi
 }
 
 run_tests() {
-  (cd ${ROOT_DIR} && log_and_run test/run-tests.py -v --bindir ${BINDIR} $* --timeout=10)
+  log_and_run test/run-tests.py -v --bindir ${BINDIR} $* --timeout=10
   log_and_run ${BINDIR}/wabt-unittests
 }
 
@@ -55,8 +59,10 @@ for BUILD_TYPE in ${BUILD_TYPES_UPPER}; do
   else
     if set_run_test_args ${COMPILER} ${BUILD_TYPE}; then
       run_tests
+      break
     fi
   fi
 done
 
+echo "travis-test.sh done: $RTN"
 exit $RTN

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -59,7 +59,6 @@ for BUILD_TYPE in ${BUILD_TYPES_UPPER}; do
   else
     if set_run_test_args ${COMPILER} ${BUILD_TYPE}; then
       run_tests
-      break
     fi
   fi
 done

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -18,17 +18,19 @@
 set -o nounset
 set -o errexit
 
+RTN=0
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd -P)"
 source "${SCRIPT_DIR}/travis-common.sh"
 
 log_and_run() {
   echo $*
-  exec $*
+  (exec $*) && true
+  [[ $? != 0 ]] && RTN=1
 }
 
 run_tests() {
-  (cd ${ROOT_DIR} && log_and_run test/run-tests.py --bindir ${BINDIR} $* --timeout=10) && true
-  (log_and_run ${BINDIR}/wabt-unittests) && true
+  (cd ${ROOT_DIR} && log_and_run test/run-tests.py --bindir ${BINDIR} $* --timeout=10)
+  log_and_run ${BINDIR}/wabt-unittests
 }
 
 set_run_test_args() {
@@ -56,3 +58,5 @@ for BUILD_TYPE in ${BUILD_TYPES_UPPER}; do
     fi
   fi
 done
+
+exit $RTN

--- a/scripts/travis-test.sh
+++ b/scripts/travis-test.sh
@@ -29,7 +29,7 @@ log_and_run() {
 }
 
 run_tests() {
-  (cd ${ROOT_DIR} && log_and_run test/run-tests.py --bindir ${BINDIR} $* --timeout=10)
+  (cd ${ROOT_DIR} && log_and_run test/run-tests.py -v --bindir ${BINDIR} $* --timeout=10)
   log_and_run ${BINDIR}/wabt-unittests
 }
 

--- a/test/binary/relocs.txt
+++ b/test/binary/relocs.txt
@@ -17,4 +17,5 @@ section("reloc.name") {
 (;; STDOUT ;;;
 (module
   (type (;0;) (func (result i32))))
+XXXXX
 ;;; STDOUT ;;)

--- a/test/binary/relocs.txt
+++ b/test/binary/relocs.txt
@@ -17,5 +17,4 @@ section("reloc.name") {
 (;; STDOUT ;;;
 (module
   (type (;0;) (func (result i32))))
-XXXXX
 ;;; STDOUT ;;)


### PR DESCRIPTION
Oops, we were silently ignoring tests failures on travis.

Also turn on -v when running travis tests so it records the tests it runs