### PR TITLE
Fix function name indices for imported functions

### DIFF
--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -504,14 +504,22 @@ static void write_names_section(Context* ctx) {
   WRITE_UNKNOWN_SIZE(stream);
   write_u32_leb128(stream, total_count, "element count");
   for (const std::unique_ptr<LinkerInputBinary>& binary: ctx->inputs) {
+    size_t delta = 0;
+    uint32_t off;
     for (size_t i = 0; i < binary->debug_names.size(); i++) {
       if (binary->debug_names[i].empty())
         continue;
       if (i < binary->function_imports.size()) {
-        if (!binary->function_imports[i].active)
+        if (!binary->function_imports[i].active) {
+          delta++;
           continue;
+        }
+        off = binary->imported_function_index_offset - delta;
+      } else {
+        off = binary->function_index_offset;
       }
-      write_u32_leb128(stream, i + binary->function_index_offset, "function index");
+
+      write_u32_leb128(stream, i + off, "function index");
       write_string(stream, binary->debug_names[i], "function name");
     }
   }

--- a/test/link/names2.txt
+++ b/test/link/names2.txt
@@ -1,0 +1,77 @@
+;;; TOOL: run-wasm-link
+;;; FLAGS: --debug-names -r
+(module
+  (import "__extern" "missing" (func $import_func2))
+  (import "__extern" "baz" (func $import_func1))
+  (export "foo" (func $name1))
+  (func $name1 (param $param1 i32)
+     i32.const 1
+     call 0)
+  (func $name2 (param $param2 i64)
+     i64.const 1
+     call 1)
+  (func (param $param2 i64))
+)
+(module
+  (export "baz" (func 0))
+  (func $name3 (param $param3 i32)
+     i32.const 2
+     call 0)
+)
+(;; STDOUT ;;;
+linked.wasm:	file format wasm 0x000001
+Sections:
+     Type start=0x0000000a end=0x0000001a (size=0x00000010) count: 4
+   Import start=0x00000020 end=0x00000034 (size=0x00000014) count: 1
+ Function start=0x0000003a end=0x0000003f (size=0x00000005) count: 4
+   Export start=0x00000045 end=0x00000052 (size=0x0000000d) count: 2
+     Code start=0x00000054 end=0x00000079 (size=0x00000025) count: 4
+   Custom start=0x0000007f end=0x000000b2 (size=0x00000033) "name"
+   Custom start=0x000000b8 end=0x000000ce (size=0x00000016) "reloc.Code"
+Section Details:
+Type:
+ - [0] () -> nil
+ - [1] (i32) -> nil
+ - [2] (i64) -> nil
+ - [3] (i32) -> nil
+Import:
+ - func[0] sig=0 <- __extern.missing
+Function:
+ - func[1] sig=1
+ - func[2] sig=2
+ - func[3] sig=2
+ - func[4] sig=3
+Export:
+ - func[1] foo
+ - func[4] baz
+Custom:
+ - name: "name"
+ - func[0] $import_func2
+ - func[1] $name1
+ - func[2] $name2
+ - func[4] $name3
+Custom:
+ - name: "reloc.Code"
+  - section: Code
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x5a)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x11(file=0x65)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1f(file=0x73)
+Code Disassembly:
+000055 <$name1>:
+ 000057: 41 01                      | i32.const 0x1
+ 000059: 10 80 80 80 80 00          | call 0
+           00005a: R_FUNC_INDEX_LEB   0
+ 00005f: 0b                         | end
+000060 <$name2>:
+ 000062: 42 01                      | i64.const 1
+ 000064: 10 84 80 80 80 00          | call 0x4
+           000065: R_FUNC_INDEX_LEB   1
+ 00006a: 0b                         | end
+00006b func[3]:
+ 00006d: 0b                         | end
+00006e <$name3>:
+ 000070: 41 02                      | i32.const 0x2
+ 000072: 10 84 80 80 80 00          | call 0x4
+           000073: R_FUNC_INDEX_LEB   0
+ 000078: 0b                         | end
+;;; STDOUT ;;)


### PR DESCRIPTION
When linking, a source binary's imported function indices and its implemented function indices can be non-contiguous; the previous code didn't catch that.