### PR TITLE
[wasmlink] Relocate indexes in the gererated reloc section

### DIFF
--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -38,7 +38,7 @@ Custom:
  - name: "reloc.Code"
   - section: Code
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x37)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x11(file=0x42)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x11(file=0x42)
 
 Code Disassembly:
 
@@ -50,6 +50,6 @@ Code Disassembly:
 00003d func[1]:
  00003f: 41 02                      | i32.const 0x2
  000041: 10 81 80 80 80 00          | call 0x1
-           000042: R_FUNC_INDEX_LEB   0
+           000042: R_FUNC_INDEX_LEB   1
  000047: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -1,19 +1,22 @@
 ;;; TOOL: run-wasm-link
 ;;; FLAGS: -r
 (module
-  (import "__extern" "bar" (func (param i32) (result i32)))
-  (func (param i32)
+  (import "__extern" "foo" (func $import0 (param i32) (result i32)))
+  (import "__extern" "bar" (func $import1 (param i32) (result i32)))
+  (func $local_func (param i32)
      get_local 0
-     call 0
-     call 1)
+     call $local_func
+     call $import0
+     call $import1)
 )
 (module
-  (import "__extern" "baz" (func (param f64)))
-  (func (param i64)
+  (import "__extern" "baz" (func $import0 (param f64)))
+  (export "foo" (func $local_func))
+  (func $local_func (param i64)
      f64.const 1
-     call 0
+     call $import0
      i64.const 10
-     call 1)
+     call $local_func)
 )
 (;; STDOUT ;;;
 linked.wasm:	file format wasm 0x000001
@@ -23,8 +26,9 @@ Sections:
      Type start=0x0000000a end=0x0000001c (size=0x00000012) count: 4
    Import start=0x00000022 end=0x00000041 (size=0x0000001f) count: 2
  Function start=0x00000047 end=0x0000004a (size=0x00000003) count: 2
-     Code start=0x0000004c end=0x00000078 (size=0x0000002c) count: 2
-   Custom start=0x0000007e end=0x00000097 (size=0x00000019) "reloc.Code"
+   Export start=0x00000050 end=0x00000057 (size=0x00000007) count: 1
+     Code start=0x00000059 end=0x0000008b (size=0x00000032) count: 2
+   Custom start=0x00000091 end=0x000000ad (size=0x0000001c) "reloc.Code"
 
 Section Details:
 
@@ -39,29 +43,34 @@ Import:
 Function:
  - func[2] sig=1
  - func[3] sig=3
+Export:
+ - func[3] foo
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x52)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xc(file=0x58)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1e(file=0x6a)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x26(file=0x72)
+   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x6(file=0x5f)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xc(file=0x65)
+   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x12(file=0x6b)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x24(file=0x7d)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x2c(file=0x85)
 
 Code Disassembly:
 
-00004d func[2]:
- 00004f: 20 00                      | get_local 0
- 000051: 10 80 80 80 80 00          | call 0
-           000052: R_FUNC_INDEX_LEB   0
- 000057: 10 82 80 80 80 00          | call 0x2
-           000058: R_FUNC_INDEX_LEB   1
- 00005d: 0b                         | end
-00005e func[3]:
- 000060: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
- 000069: 10 81 80 80 80 00          | call 0x1
-           00006a: R_FUNC_INDEX_LEB   0
- 00006f: 42 0a                      | i64.const 10
- 000071: 10 83 80 80 80 00          | call 0x3
-           000072: R_FUNC_INDEX_LEB   1
- 000077: 0b                         | end
+00005a func[2]:
+ 00005c: 20 00                      | get_local 0
+ 00005e: 10 82 80 80 80 00          | call 0x2
+           00005f: R_FUNC_INDEX_LEB   2
+ 000064: 10 83 80 80 80 00          | call 0x3
+           000065: R_FUNC_INDEX_LEB   3
+ 00006a: 10 80 80 80 80 00          | call 0
+           00006b: R_FUNC_INDEX_LEB   0
+ 000070: 0b                         | end
+000071 func[3]:
+ 000073: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
+ 00007c: 10 81 80 80 80 00          | call 0x1
+           00007d: R_FUNC_INDEX_LEB   1
+ 000082: 42 0a                      | i64.const 10
+ 000084: 10 83 80 80 80 00          | call 0x3
+           000085: R_FUNC_INDEX_LEB   3
+ 00008a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -55,11 +55,11 @@ Custom:
  - name: "reloc.Code"
   - section: Code
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x7b)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xc(file=0x81)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1e(file=0x93)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x26(file=0x9b)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x34(file=0xa9)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x3c(file=0xb1)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xc(file=0x81)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1e(file=0x93)
+   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x26(file=0x9b)
+   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x34(file=0xa9)
+   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x3c(file=0xb1)
 
 Code Disassembly:
 
@@ -68,22 +68,22 @@ Code Disassembly:
  00007a: 10 80 80 80 80 00          | call 0
            00007b: R_FUNC_INDEX_LEB   0
  000080: 10 83 80 80 80 00          | call 0x3
-           000081: R_FUNC_INDEX_LEB   1
+           000081: R_FUNC_INDEX_LEB   3
  000086: 0b                         | end
 000087 func[4]:
  000089: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  000092: 10 81 80 80 80 00          | call 0x1
-           000093: R_FUNC_INDEX_LEB   0
+           000093: R_FUNC_INDEX_LEB   1
  000098: 42 0a                      | i64.const 10
  00009a: 10 84 80 80 80 00          | call 0x4
-           00009b: R_FUNC_INDEX_LEB   1
+           00009b: R_FUNC_INDEX_LEB   4
  0000a0: 0b                         | end
 0000a1 func[5]:
  0000a3: 43 00 00 80 3f             | f32.const 0x1p+0
  0000a8: 10 82 80 80 80 00          | call 0x2
-           0000a9: R_FUNC_INDEX_LEB   0
+           0000a9: R_FUNC_INDEX_LEB   2
  0000ae: 41 0a                      | i32.const 0xa
  0000b0: 10 85 80 80 80 00          | call 0x5
-           0000b1: R_FUNC_INDEX_LEB   1
+           0000b1: R_FUNC_INDEX_LEB   5
  0000b6: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -56,7 +56,7 @@ Custom:
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x18(file=0x70)
    - R_GLOBAL_INDEX_LEB idx=0    addend=0    offset=0x21(file=0x79)
    - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0x27(file=0x7f)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x2d(file=0x85)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x2d(file=0x85)
 
 Code Disassembly:
 
@@ -78,6 +78,6 @@ Code Disassembly:
  00007e: 23 84 80 80 80 00          | get_global 0x4
            00007f: R_GLOBAL_INDEX_LEB 1
  000084: 10 81 80 80 80 00          | call 0x1
-           000085: R_FUNC_INDEX_LEB   0
+           000085: R_FUNC_INDEX_LEB   1
  00008a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -50,21 +50,21 @@ Global:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_GLOBAL_INDEX_LEB idx=0x2  addend=0    offset=0x4(file=0x5c)
-   - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0xa(file=0x62)
+   - R_GLOBAL_INDEX_LEB idx=0x3  addend=0    offset=0x4(file=0x5c)
+   - R_GLOBAL_INDEX_LEB idx=0x2  addend=0    offset=0xa(file=0x62)
    - R_GLOBAL_INDEX_LEB idx=0    addend=0    offset=0x11(file=0x69)
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x18(file=0x70)
-   - R_GLOBAL_INDEX_LEB idx=0    addend=0    offset=0x21(file=0x79)
-   - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0x27(file=0x7f)
+   - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0x21(file=0x79)
+   - R_GLOBAL_INDEX_LEB idx=0x4  addend=0    offset=0x27(file=0x7f)
    - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x2d(file=0x85)
 
 Code Disassembly:
 
 000059 func[0]:
  00005b: 23 83 80 80 80 00          | get_global 0x3
-           00005c: R_GLOBAL_INDEX_LEB 2
+           00005c: R_GLOBAL_INDEX_LEB 3
  000061: 23 82 80 80 80 00          | get_global 0x2
-           000062: R_GLOBAL_INDEX_LEB 1
+           000062: R_GLOBAL_INDEX_LEB 2
  000067: 6a                         | i32.add
  000068: 23 80 80 80 80 00          | get_global 0
            000069: R_GLOBAL_INDEX_LEB 0
@@ -74,9 +74,9 @@ Code Disassembly:
  000075: 0b                         | end
 000076 func[1]:
  000078: 23 81 80 80 80 00          | get_global 0x1
-           000079: R_GLOBAL_INDEX_LEB 0
+           000079: R_GLOBAL_INDEX_LEB 1
  00007e: 23 84 80 80 80 00          | get_global 0x4
-           00007f: R_GLOBAL_INDEX_LEB 1
+           00007f: R_GLOBAL_INDEX_LEB 4
  000084: 10 81 80 80 80 00          | call 0x1
            000085: R_FUNC_INDEX_LEB   1
  00008a: 0b                         | end

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -72,22 +72,22 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x6(file=0x8a)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xb(file=0x8f)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x10(file=0x94)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x15(file=0x99)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1a(file=0x9e)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1f(file=0xa3)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x24(file=0xa8)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x6(file=0x8a)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xb(file=0x8f)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x10(file=0x94)
+   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x15(file=0x99)
+   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x1a(file=0x9e)
+   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x1f(file=0xa3)
+   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x24(file=0xa8)
 Custom:
  - name: "reloc.Code"
   - section: Code
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0xb5)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0xc(file=0xbb)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1e(file=0xcd)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x26(file=0xd5)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x34(file=0xe3)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x3c(file=0xeb)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xc(file=0xbb)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1e(file=0xcd)
+   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x26(file=0xd5)
+   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x34(file=0xe3)
+   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x3c(file=0xeb)
 
 Code Disassembly:
 
@@ -96,22 +96,22 @@ Code Disassembly:
  0000b4: 10 80 80 80 80 00          | call 0
            0000b5: R_FUNC_INDEX_LEB   0
  0000ba: 10 83 80 80 80 00          | call 0x3
-           0000bb: R_FUNC_INDEX_LEB   1
+           0000bb: R_FUNC_INDEX_LEB   3
  0000c0: 0b                         | end
 0000c1 func[4]:
  0000c3: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  0000cc: 10 81 80 80 80 00          | call 0x1
-           0000cd: R_FUNC_INDEX_LEB   0
+           0000cd: R_FUNC_INDEX_LEB   1
  0000d2: 42 0a                      | i64.const 10
  0000d4: 10 84 80 80 80 00          | call 0x4
-           0000d5: R_FUNC_INDEX_LEB   1
+           0000d5: R_FUNC_INDEX_LEB   4
  0000da: 0b                         | end
 0000db func[5]:
  0000dd: 43 00 00 80 3f             | f32.const 0x1p+0
  0000e2: 10 82 80 80 80 00          | call 0x2
-           0000e3: R_FUNC_INDEX_LEB   0
+           0000e3: R_FUNC_INDEX_LEB   2
  0000e8: 41 0a                      | i32.const 0xa
  0000ea: 10 85 80 80 80 00          | call 0x5
-           0000eb: R_FUNC_INDEX_LEB   1
+           0000eb: R_FUNC_INDEX_LEB   5
  0000f0: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -76,8 +76,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0xd(file=0x84)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x17(file=0x8e)
+   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xd(file=0x84)
+   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x17(file=0x8e)
 
 Code Disassembly:
 
@@ -87,12 +87,12 @@ Code Disassembly:
  000080: 0b                         | end
 000081 func[1]:
  000083: 10 83 80 80 80 00          | call 0x3
-           000084: R_FUNC_INDEX_LEB   0
+           000084: R_FUNC_INDEX_LEB   3
  000089: 0f                         | return
  00008a: 0b                         | end
 00008b func[2]:
  00008d: 10 84 80 80 80 00          | call 0x4
-           00008e: R_FUNC_INDEX_LEB   1
+           00008e: R_FUNC_INDEX_LEB   4
  000093: 0f                         | return
  000094: 0b                         | end
 000095 func[3]:

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -62,27 +62,27 @@ Custom:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x6(file=0x83)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x11(file=0x8e)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1f(file=0x9c)
+   - R_FUNC_INDEX_LEB   idx=0x6  addend=0    offset=0x6(file=0x83)
+   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x11(file=0x8e)
+   - R_FUNC_INDEX_LEB   idx=0x6  addend=0    offset=0x1f(file=0x9c)
 
 Code Disassembly:
 
 00007e <$name1>:
  000080: 41 01                      | i32.const 0x1
  000082: 10 86 80 80 80 00          | call 0x6
-           000083: R_FUNC_INDEX_LEB   2
+           000083: R_FUNC_INDEX_LEB   6
  000088: 0b                         | end
 000089 <$name2>:
  00008b: 42 01                      | i64.const 1
  00008d: 10 82 80 80 80 00          | call 0x2
-           00008e: R_FUNC_INDEX_LEB   3
+           00008e: R_FUNC_INDEX_LEB   2
  000093: 0b                         | end
 000094 func[5]:
  000096: 0b                         | end
 000097 <$name3>:
  000099: 41 02                      | i32.const 0x2
  00009b: 10 86 80 80 80 00          | call 0x6
-           00009c: R_FUNC_INDEX_LEB   0
+           00009c: R_FUNC_INDEX_LEB   6
  0000a1: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -46,9 +46,9 @@ Custom:
   - section: Elem
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x38)
    - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0xb(file=0x3d)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x10(file=0x42)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x15(file=0x47)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x1a(file=0x4c)
+   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x10(file=0x42)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x15(file=0x47)
+   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1a(file=0x4c)
 
 Code Disassembly:
 


### PR DESCRIPTION
We recently switched to embedding the index of the relocation
within the relocation entry itself but overlooked the fact
that this needs to be updated when writing out the linked
reloc section.