### PR TITLE
Fix type-checking bug w/ br_table and loop

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -324,8 +324,14 @@ Result typechecker_on_br_table_target(TypeChecker* tc, size_t depth) {
   Result result = Result::Ok;
   TypeCheckerLabel* label;
   CHECK_RESULT(typechecker_get_label(tc, depth, &label));
-  assert(label->sig.size() <= 1);
-  Type label_sig = label->sig.size() == 0 ? Type::Void : label->sig[0];
+  Type label_sig;
+  if (label->label_type == LabelType::Loop) {
+    label_sig = Type::Void;
+  } else {
+    assert(label->sig.size() <= 1);
+    label_sig = label->sig.size() == 0 ? Type::Void : label->sig[0];
+  }
+
   COMBINE_RESULT(result,
                  check_type(tc, tc->br_table_sig, label_sig, "br_table"));
   tc->br_table_sig = label_sig;

--- a/test/typecheck/br-table-loop.txt
+++ b/test/typecheck/br-table-loop.txt
@@ -1,0 +1,17 @@
+(module
+ (table 0 anyfunc)
+ (memory $0 17)
+ (func $foo (param $0 i32) (result i32)
+  (loop $label$1 i32
+   (block $label$2
+    (br_table $label$1 $label$2 $label$2
+     (get_local $0)
+    )
+    (return
+     (i32.const 0)
+    )
+   )
+   (i32.const 1)
+  )
+ )
+)


### PR DESCRIPTION
If a loop has a signature, it is the signature for fallthrough, not for
the branch target. So a br_table to the loop label should always be
void.

This fixes issue #389.