### PR TITLE
Refactor wasmdump so that the disassembly pass has its own reader class

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -60,8 +60,7 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
   bool print_details = false;
   BinarySection reloc_section = BinarySection::Invalid;
   uint32_t section_starts[kBinarySectionCount];
-  int section_found = false;
-  bool header_printed = false;
+  bool section_found = false;
   Stream* out_stream = nullptr;
 };
 
@@ -179,7 +178,6 @@ Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
       }
 
       printf("%s:\tfile format wasm %#08x\n", basename, version);
-      header_printed = true;
       break;
     }
     case ObjdumpMode::RawData:
@@ -589,11 +587,9 @@ Result BinaryReaderObjdump::OnCount(uint32_t count) {
 }
 
 Result BinaryReaderObjdump::EndModule() {
-  if (options->section_name) {
-    if (!section_found) {
-      printf("Section not found: %s\n", options->section_name);
-      return Result::Error;
-    }
+  if (options->section_name && !section_found) {
+    printf("Section not found: %s\n", options->section_name);
+    return Result::Error;
   }
 
   return Result::Ok;

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -46,7 +46,6 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
                               BinarySection section_code,
                               StringSlice section_name);
  protected:
-
   ObjdumpOptions* options = nullptr;
   const uint8_t* data = nullptr;
   size_t size = 0;
@@ -177,7 +176,6 @@ class BinaryReaderObjdumpDisassemble : public BinaryReaderObjdumpBase {
   virtual Result OnEndFunc();
 
  private:
-  Result OnCount(uint32_t count);
   void LogOpcode(const uint8_t* data, size_t data_size, const char* fmt, ...);
 
   Opcode current_opcode = Opcode::Unreachable;
@@ -483,17 +481,11 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
                          int32_t addend);
 
  private:
-
   bool ShouldPrintDetails();
   void PrintDetails(const char* fmt, ...);
   Result OnCount(uint32_t count);
-  void LogOpcode(const uint8_t* data, size_t data_size, const char* fmt, ...);
 
-  Opcode current_opcode = Opcode::Unreachable;
-  size_t current_opcode_offset = 0;
-  size_t last_opcode_end = 0;
-  int indent_level = 0;
-  Stream* out_stream = nullptr;
+  Stream* out_stream;
 };
 
 BinaryReaderObjdump::BinaryReaderObjdump(const uint8_t* data,

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -47,7 +47,6 @@ struct ObjdumpOptions {
   ObjdumpMode mode;
   const char* infile;
   const char* section_name;
-  bool print_header;
   std::vector<std::string> function_names;
   std::vector<Reloc> code_relocations;
 };

--- a/src/tools/wasmdump.cc
+++ b/src/tools/wasmdump.cc
@@ -161,7 +161,6 @@ int main(int argc, char** argv) {
 
   // Perform serveral passed over the binary in order to print out different
   // types of information.
-  s_objdump_options.print_header = true;
   if (!s_objdump_options.headers && !s_objdump_options.details &&
       !s_objdump_options.disassemble && !s_objdump_options.raw) {
     printf("At least one of the following switches must be given:\n");
@@ -184,7 +183,6 @@ int main(int argc, char** argv) {
     result = read_binary_objdump(data, size, &s_objdump_options);
     if (WABT_FAILED(result))
       goto done;
-    s_objdump_options.print_header = false;
   }
   // Pass 2: Print extra information based on section type
   if (s_objdump_options.details) {
@@ -192,14 +190,12 @@ int main(int argc, char** argv) {
     result = read_binary_objdump(data, size, &s_objdump_options);
     if (WABT_FAILED(result))
       goto done;
-    s_objdump_options.print_header = false;
   }
   if (s_objdump_options.disassemble) {
     s_objdump_options.mode = ObjdumpMode::Disassemble;
     result = read_binary_objdump(data, size, &s_objdump_options);
     if (WABT_FAILED(result))
       goto done;
-    s_objdump_options.print_header = false;
   }
   // Pass 3: Dump to raw contents of the sections
   if (s_objdump_options.raw) {


### PR DESCRIPTION
Its almost a pure refactor of the code in binary-reader-objdump.cc.  The one exception is the
change in the way the header printing is done.