### PR TITLE
Improve wasmdump output for relocations and data segments

### DIFF
--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -81,7 +81,7 @@ class BinaryReaderLinker : public BinaryReaderNop {
   virtual Result OnReloc(RelocType type,
                          uint32_t offset,
                          uint32_t index,
-                         int32_t addend);
+                         uint32_t addend);
 
   virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
 
@@ -117,7 +117,7 @@ Result BinaryReaderLinker::OnRelocCount(uint32_t count,
 Result BinaryReaderLinker::OnReloc(RelocType type,
                                    uint32_t offset,
                                    uint32_t index,
-                                   int32_t addend) {
+                                   uint32_t addend) {
   if (offset + RELOC_SIZE > reloc_section->size) {
     WABT_FATAL("invalid relocation offset: %#x\n", offset);
   }

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -407,7 +407,7 @@ Result BinaryReaderLogging::OnReloc(RelocType type,
   int32_t signed_addend = static_cast<int32_t>(addend);
   LOGF("OnReloc(type: %s, offset: %u, index: %u, addend: %d)\n",
        get_reloc_type_name(type), offset, index, signed_addend);
-  return reader->OnReloc(type, offset, index, static_cast<int32_t>(addend));
+  return reader->OnReloc(type, offset, index, addend);
 }
 
 #define DEFINE_BEGIN(name)                          \

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -403,10 +403,11 @@ Result BinaryReaderLogging::OnRelocCount(uint32_t count,
 Result BinaryReaderLogging::OnReloc(RelocType type,
                                     uint32_t offset,
                                     uint32_t index,
-                                    int32_t addend) {
+                                    uint32_t addend) {
+  int32_t signed_addend = static_cast<int32_t>(addend);
   LOGF("OnReloc(type: %s, offset: %u, index: %u, addend: %d)\n",
-       get_reloc_type_name(type), offset, index, addend);
-  return reader->OnReloc(type, offset, index, addend);
+       get_reloc_type_name(type), offset, index, signed_addend);
+  return reader->OnReloc(type, offset, index, static_cast<int32_t>(addend));
 }
 
 #define DEFINE_BEGIN(name)                          \

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -217,7 +217,7 @@ class BinaryReaderLogging : public BinaryReader {
   virtual Result OnReloc(RelocType type,
                          uint32_t offset,
                          uint32_t index,
-                         int32_t addend);
+                         uint32_t addend);
   virtual Result EndRelocSection();
 
   virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value);

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -299,7 +299,7 @@ class BinaryReaderNop : public BinaryReader {
   virtual Result OnReloc(RelocType type,
                          uint32_t offset,
                          uint32_t index,
-                         int32_t addend) {
+                         uint32_t addend) {
     return Result::Ok;
   }
   virtual Result EndRelocSection() { return Result::Ok; }

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1001,7 +1001,7 @@ static void read_reloc_section(Context* ctx, uint32_t section_size) {
       case RelocType::MemoryAddressLEB:
       case RelocType::MemoryAddressSLEB:
       case RelocType::MemoryAddressI32:
-        in_u32_leb128(ctx, &addend, "addend");
+        in_i32_leb128(ctx, &addend, "addend");
         break;
       default:
         break;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -255,7 +255,7 @@ class BinaryReader {
   virtual Result OnReloc(RelocType type,
                          uint32_t offset,
                          uint32_t index,
-                         int32_t addend) = 0;
+                         uint32_t addend) = 0;
   virtual Result EndRelocSection() = 0;
 
   /* InitExpr - used by elem, data and global sections; these functions are

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -46,11 +46,11 @@ Memory:
  - memory[0] pages: initial=1
 Data:
  - memory[0] - init i32=10
-  - 0000000: 6865 6c6c 6f                             hello
+  - 0000015: 6865 6c6c 6f                             hello
  - memory[0] - init i32=20
-  - 0000000: 676f 6f64 6279 652c 204c 6f72 656d 2069  goodbye, Lorem i
-  - 0000010: 7073 756d 2064 6f6c 6f72 2073 6974 2061  psum dolor sit a
-  - 0000020: 6d65 742c 2063 6f6e 7365 6374 6574 7572  met, consectetur
+  - 000001f: 676f 6f64 6279 652c 204c 6f72 656d 2069  goodbye, Lorem i
+  - 000002f: 7073 756d 2064 6f6c 6f72 2073 6974 2061  psum dolor sit a
+  - 000003f: 6d65 742c 2063 6f6e 7365 6374 6574 7572  met, consectetur
 
 Code Disassembly:
 

--- a/test/link/data.txt
+++ b/test/link/data.txt
@@ -24,13 +24,13 @@ Memory:
  - memory[0] pages: initial=2 max=2
 Data:
  - memory[0] - init i32=0
-  - 0000000: 666f 6f                                  foo
+  - 000001e: 666f 6f                                  foo
  - memory[0] - init i32=10
-  - 0000000: 6261 72                                  bar
+  - 0000026: 6261 72                                  bar
  - memory[0] - init i32=65536
-  - 0000000: 6865 6c6c 6f                             hello
+  - 0000030: 6865 6c6c 6f                             hello
  - memory[0] - init i32=65636
-  - 0000000: 776f 726c 64                             world
+  - 000003c: 776f 726c 64                             world
 
 Code Disassembly:
 

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -37,8 +37,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x37)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x11(file=0x42)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000037) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x000042) index=0x000001
 
 Code Disassembly:
 

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -48,11 +48,11 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x6(file=0x5f)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xc(file=0x65)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x12(file=0x6b)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x24(file=0x7d)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x2c(file=0x85)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00005f) index=0x000002
+   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x000065) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x000012(file=0x00006b) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x000024(file=0x00007d) index=0x000001
+   - R_FUNC_INDEX_LEB   offset=0x00002c(file=0x000085) index=0x000003
 
 Code Disassembly:
 

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -54,12 +54,12 @@ Function:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x7b)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xc(file=0x81)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1e(file=0x93)
-   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x26(file=0x9b)
-   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x34(file=0xa9)
-   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x3c(file=0xb1)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00007b) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x000081) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x00001e(file=0x000093) index=0x000001
+   - R_FUNC_INDEX_LEB   offset=0x000026(file=0x00009b) index=0x000004
+   - R_FUNC_INDEX_LEB   offset=0x000034(file=0x0000a9) index=0x000002
+   - R_FUNC_INDEX_LEB   offset=0x00003c(file=0x0000b1) index=0x000005
 
 Code Disassembly:
 

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -50,13 +50,13 @@ Global:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_GLOBAL_INDEX_LEB idx=0x3  addend=0    offset=0x4(file=0x5c)
-   - R_GLOBAL_INDEX_LEB idx=0x2  addend=0    offset=0xa(file=0x62)
-   - R_GLOBAL_INDEX_LEB idx=0    addend=0    offset=0x11(file=0x69)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x18(file=0x70)
-   - R_GLOBAL_INDEX_LEB idx=0x1  addend=0    offset=0x21(file=0x79)
-   - R_GLOBAL_INDEX_LEB idx=0x4  addend=0    offset=0x27(file=0x7f)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x2d(file=0x85)
+   - R_GLOBAL_INDEX_LEB offset=0x000004(file=0x00005c) index=0x000003
+   - R_GLOBAL_INDEX_LEB offset=0x00000a(file=0x000062) index=0x000002
+   - R_GLOBAL_INDEX_LEB offset=0x000011(file=0x000069) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x000018(file=0x000070) index=00000000
+   - R_GLOBAL_INDEX_LEB offset=0x000021(file=0x000079) index=0x000001
+   - R_GLOBAL_INDEX_LEB offset=0x000027(file=0x00007f) index=0x000004
+   - R_FUNC_INDEX_LEB   offset=0x00002d(file=0x000085) index=0x000001
 
 Code Disassembly:
 

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -72,22 +72,22 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x6(file=0x8a)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xb(file=0x8f)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0x10(file=0x94)
-   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x15(file=0x99)
-   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x1a(file=0x9e)
-   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x1f(file=0xa3)
-   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x24(file=0xa8)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00008a) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x00000b(file=0x00008f) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x000010(file=0x000094) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x000015(file=0x000099) index=0x000004
+   - R_FUNC_INDEX_LEB   offset=0x00001a(file=0x00009e) index=0x000004
+   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x0000a3) index=0x000005
+   - R_FUNC_INDEX_LEB   offset=0x000024(file=0x0000a8) index=0x000005
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0xb5)
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xc(file=0xbb)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1e(file=0xcd)
-   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x26(file=0xd5)
-   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x34(file=0xe3)
-   - R_FUNC_INDEX_LEB   idx=0x5  addend=0    offset=0x3c(file=0xeb)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x0000b5) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x0000bb) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x00001e(file=0x0000cd) index=0x000001
+   - R_FUNC_INDEX_LEB   offset=0x000026(file=0x0000d5) index=0x000004
+   - R_FUNC_INDEX_LEB   offset=0x000034(file=0x0000e3) index=0x000002
+   - R_FUNC_INDEX_LEB   offset=0x00003c(file=0x0000eb) index=0x000005
 
 Code Disassembly:
 

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -76,8 +76,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0x3  addend=0    offset=0xd(file=0x84)
-   - R_FUNC_INDEX_LEB   idx=0x4  addend=0    offset=0x17(file=0x8e)
+   - R_FUNC_INDEX_LEB   offset=0x00000d(file=0x000084) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x000017(file=0x00008e) index=0x000004
 
 Code Disassembly:
 

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -62,9 +62,9 @@ Custom:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   idx=0x6  addend=0    offset=0x6(file=0x83)
-   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x11(file=0x8e)
-   - R_FUNC_INDEX_LEB   idx=0x6  addend=0    offset=0x1f(file=0x9c)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000083) index=0x000006
+   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x00008e) index=0x000002
+   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x00009c) index=0x000006
 
 Code Disassembly:
 

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -44,11 +44,11 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0x6(file=0x38)
-   - R_FUNC_INDEX_LEB   idx=0    addend=0    offset=0xb(file=0x3d)
-   - R_FUNC_INDEX_LEB   idx=0x2  addend=0    offset=0x10(file=0x42)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x15(file=0x47)
-   - R_FUNC_INDEX_LEB   idx=0x1  addend=0    offset=0x1a(file=0x4c)
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000038) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x00000b(file=0x00003d) index=00000000
+   - R_FUNC_INDEX_LEB   offset=0x000010(file=0x000042) index=0x000002
+   - R_FUNC_INDEX_LEB   offset=0x000015(file=0x000047) index=0x000001
+   - R_FUNC_INDEX_LEB   offset=0x00001a(file=0x00004c) index=0x000001
 
 Code Disassembly:
 


### PR DESCRIPTION
For data segments, print the file offsets so they match
the file offsets shown when dumping relocations.

For relocations, only show the addend when one is present
and correctly display negative addends in the same way that
objdump does (e.g. symbol_foo-0x10 and symbol_foo+0x10)