### PR TITLE
Update the testsuite

### DIFF
--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -900,6 +900,7 @@ Result BinaryReaderInterpreter::BeginGlobal(uint32_t index,
   InterpreterGlobal* global = GetGlobalByModuleIndex(index);
   global->typed_value.type = type;
   global->mutable_ = mutable_;
+  init_expr_value.type = Type::Void;
   return Result::Ok;
 }
 

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -1,42 +1,33 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/br_table.wast:1386: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1405: assert_invalid passed:
   error: type stack at end of block is 1, expected 0
   error: @0x00000022: OnEndExpr callback failed
-out/third_party/testsuite/br_table.wast:1393: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1412: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
   error: @0x00000020: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1399: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1418: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got i64.
   error: @0x00000023: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1405: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1424: assert_invalid passed:
   error: type mismatch in br_table, expected void but got f32.
   error: @0x00000026: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1417: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1436: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
   error: @0x0000001f: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1423: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1442: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got i64.
   error: @0x0000001e: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1429: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1448: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
   error: @0x00000021: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1435: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1454: assert_invalid passed:
   error: type stack size too small at br_table. got 0, expected at least 1
   error: @0x00000023: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1441: assert_invalid passed:
+out/third_party/testsuite/br_table.wast:1460: assert_invalid passed:
   error: type mismatch in br_table, expected i32 but got i64.
   error: @0x00000022: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1448: assert_invalid passed:
-  error: invalid depth: 2 (max 1)
-  error: @0x0000001f: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1454: assert_invalid passed:
-  error: invalid depth: 5 (max 2)
-  error: @0x00000021: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1460: assert_invalid passed:
-  error: invalid depth: 268435457 (max 1)
-  error: @0x00000024: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1467: assert_invalid passed:
   error: invalid depth: 2 (max 1)
   error: @0x0000001f: OnBrTableExpr callback failed
@@ -46,5 +37,14 @@ out/third_party/testsuite/br_table.wast:1473: assert_invalid passed:
 out/third_party/testsuite/br_table.wast:1479: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
   error: @0x00000024: OnBrTableExpr callback failed
-158/158 tests passed.
+out/third_party/testsuite/br_table.wast:1486: assert_invalid passed:
+  error: invalid depth: 2 (max 1)
+  error: @0x0000001f: OnBrTableExpr callback failed
+out/third_party/testsuite/br_table.wast:1492: assert_invalid passed:
+  error: invalid depth: 5 (max 2)
+  error: @0x00000021: OnBrTableExpr callback failed
+out/third_party/testsuite/br_table.wast:1498: assert_invalid passed:
+  error: invalid depth: 268435457 (max 1)
+  error: @0x00000024: OnBrTableExpr callback failed
+159/159 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -21,21 +21,32 @@ out/third_party/testsuite/globals.wast:75: assert_invalid passed:
 out/third_party/testsuite/globals.wast:80: assert_invalid passed:
   error: @0x0000000e: unexpected opcode in initializer expression: 32 (0x20)
 out/third_party/testsuite/globals.wast:85: assert_invalid passed:
+  error: @0x00000013: expected END opcode after initializer expression
+out/third_party/testsuite/globals.wast:90: assert_invalid passed:
+  error: @0x00000010: expected END opcode after initializer expression
+out/third_party/testsuite/globals.wast:95: assert_invalid passed:
+  error: @0x0000000e: unexpected opcode in initializer expression: 1 (0x1)
+out/third_party/testsuite/globals.wast:100: assert_invalid passed:
   error: type mismatch in global, expected i32 but got f32.
   error: @0x00000013: EndGlobalInitExpr callback failed
-out/third_party/testsuite/globals.wast:90: assert_invalid passed:
+out/third_party/testsuite/globals.wast:105: assert_invalid passed:
+  error: @0x00000010: expected END opcode after initializer expression
+out/third_party/testsuite/globals.wast:110: assert_invalid passed:
+  error: type mismatch in global, expected i32 but got void.
+  error: @0x0000000e: EndGlobalInitExpr callback failed
+out/third_party/testsuite/globals.wast:115: assert_invalid passed:
   error: initializer expression can only reference an imported global
   error: @0x0000000f: OnInitExprGetGlobalExpr callback failed
-out/third_party/testsuite/globals.wast:95: assert_invalid passed:
+out/third_party/testsuite/globals.wast:120: assert_invalid passed:
   error: initializer expression can only reference an imported global
   error: @0x0000000f: OnInitExprGetGlobalExpr callback failed
-out/third_party/testsuite/globals.wast:103: assert_malformed passed:
+out/third_party/testsuite/globals.wast:128: assert_malformed passed:
   error: @0x00000022: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:116: assert_malformed passed:
+out/third_party/testsuite/globals.wast:141: assert_malformed passed:
   error: @0x00000022: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:133: assert_malformed passed:
+out/third_party/testsuite/globals.wast:158: assert_malformed passed:
   error: @0x00000011: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:145: assert_malformed passed:
+out/third_party/testsuite/globals.wast:170: assert_malformed passed:
   error: @0x00000011: global mutability must be 0 or 1
-30/30 tests passed.
+35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/import-after-global.fail.txt
+++ b/test/spec/import-after-global.fail.txt
@@ -3,8 +3,8 @@
 ;;; STDIN_FILE: third_party/testsuite/import-after-global.fail.wast
 (;; STDERR ;;;
 Error running "wast2wasm":
-out/third_party/testsuite/import-after-global.fail.wast:1:22: imports must occur before all non-import definitions
-(module (global i64) (import "" "" (table 0 anyfunc)))
-                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+out/third_party/testsuite/import-after-global.fail.wast:1:36: imports must occur before all non-import definitions
+(module (global i64 (i64.const 0)) (import "" "" (table 0 anyfunc)))
+                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 ;;; STDERR ;;)

--- a/test/spec/memory_trap.txt
+++ b/test/spec/memory_trap.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/memory_trap.wast
 (;; STDOUT ;;;
-41/41 tests passed.
+171/171 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
This exposed a small bug where an empty init expr would have type 0,
which would print as "(null)" since it didn't exist.