### PR TITLE
wasmdump: support multiple input files

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -85,8 +85,8 @@ Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
       printf("Code Disassembly:\n\n");
       break;
     case ObjdumpMode::Prepass: {
-      const char* last_slash = strrchr(options->infile, '/');
-      const char* last_backslash = strrchr(options->infile, '\\');
+      const char* last_slash = strrchr(options->filename, '/');
+      const char* last_backslash = strrchr(options->filename, '\\');
       const char* basename;
       if (last_slash && last_backslash) {
         basename = std::max(last_slash, last_backslash) + 1;
@@ -95,7 +95,7 @@ Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
       } else if (last_backslash) {
         basename = last_backslash + 1;
       } else {
-        basename = options->infile;
+        basename = options->filename;
       }
 
       printf("%s:\tfile format wasm %#x\n", basename, version);

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -45,7 +45,7 @@ struct ObjdumpOptions {
   bool debug;
   bool relocs;
   ObjdumpMode mode;
-  const char* infile;
+  const char* filename;
   const char* section_name;
   std::vector<std::string> function_names;
   std::vector<Reloc> code_relocations;

--- a/src/tools/wasmdump.cc
+++ b/src/tools/wasmdump.cc
@@ -209,7 +209,7 @@ int main(int argc, char** argv) {
   }
 
   for (const char* filename: s_infiles) {
-    if (dump_file(filename) != Result::Ok) {
+    if (WABT_FAILED(dump_file(filename))) {
       return 1;
     }
   }

--- a/src/tools/wasmdump.cc
+++ b/src/tools/wasmdump.cc
@@ -45,7 +45,7 @@ enum {
 };
 
 static const char s_description[] =
-    "  Print information about the contents of a wasm binary file.\n"
+    "  Print information about the contents of wasm binaries.\n"
     "\n"
     "examples:\n"
     "  $ wasmdump test.wasm\n";
@@ -68,10 +68,12 @@ WABT_STATIC_ASSERT(NUM_FLAGS == WABT_ARRAY_SIZE(s_options));
 
 static ObjdumpOptions s_objdump_options;
 
+static std::vector<const char*> s_infiles;
+
 static std::unique_ptr<FileStream> s_log_stream;
 
 static void on_argument(struct OptionParser* parser, const char* argument) {
-  s_objdump_options.infile = argument;
+  s_infiles.push_back(argument);
 }
 
 static void on_option(struct OptionParser* parser,
@@ -130,10 +132,66 @@ static void parse_options(int argc, char** argv) {
   parser.on_error = on_option_error;
   parse_options(&parser, argc, argv);
 
-  if (!s_objdump_options.infile) {
+  if (s_infiles.size() == 0) {
     print_help(&parser, PROGRAM_NAME);
     WABT_FATAL("No filename given.\n");
   }
+}
+
+Result dump_file(const char* filename) {
+  char* char_data;
+  size_t size;
+  Result result = read_file(filename, &char_data, &size);
+  if (WABT_FAILED(result))
+    return result;
+
+  uint8_t* data = reinterpret_cast<uint8_t*>(char_data);
+
+  // Perform serveral passed over the binary in order to print out different
+  // types of information.
+  s_objdump_options.filename = filename;
+  printf("\n");
+
+  // Pass 0: Prepass
+  s_objdump_options.mode = ObjdumpMode::Prepass;
+  result = read_binary_objdump(data, size, &s_objdump_options);
+  if (WABT_FAILED(result))
+    goto done;
+  s_objdump_options.log_stream = nullptr;
+
+  // Pass 1: Print the section headers
+  if (s_objdump_options.headers) {
+    s_objdump_options.mode = ObjdumpMode::Headers;
+    result = read_binary_objdump(data, size, &s_objdump_options);
+    if (WABT_FAILED(result))
+      goto done;
+  }
+
+  // Pass 2: Print extra information based on section type
+  if (s_objdump_options.details) {
+    s_objdump_options.mode = ObjdumpMode::Details;
+    result = read_binary_objdump(data, size, &s_objdump_options);
+    if (WABT_FAILED(result))
+      goto done;
+  }
+
+  // Pass 3: Disassemble code section
+  if (s_objdump_options.disassemble) {
+    s_objdump_options.mode = ObjdumpMode::Disassemble;
+    result = read_binary_objdump(data, size, &s_objdump_options);
+    if (WABT_FAILED(result))
+      goto done;
+  }
+
+  // Pass 4: Dump to raw contents of the sections
+  if (s_objdump_options.raw) {
+    s_objdump_options.mode = ObjdumpMode::RawData;
+    result = read_binary_objdump(data, size, &s_objdump_options);
+  }
+
+done:
+  delete[] data;
+  return result;
 }
 
 int main(int argc, char** argv) {
@@ -150,59 +208,11 @@ int main(int argc, char** argv) {
     return 1;
   }
 
-  char* char_data;
-  size_t size;
-  Result result = read_file(s_objdump_options.infile, &char_data, &size);
-  if (WABT_FAILED(result))
-    return result != Result::Ok;
-
-  uint8_t* data = reinterpret_cast<uint8_t*>(char_data);
-
-  // Perform serveral passed over the binary in order to print out different
-  // types of information.
-  if (!s_objdump_options.headers && !s_objdump_options.details &&
-      !s_objdump_options.disassemble && !s_objdump_options.raw) {
-    printf("At least one of the following switches must be given:\n");
-    printf(" -d/--disassemble\n");
-    printf(" -h/--headers\n");
-    printf(" -x/--details\n");
-    printf(" -s/--full-contents\n");
-    return 1;
+  for (const char* filename: s_infiles) {
+    if (dump_file(filename) != Result::Ok) {
+      return 1;
+    }
   }
 
-  s_objdump_options.mode = ObjdumpMode::Prepass;
-  result = read_binary_objdump(data, size, &s_objdump_options);
-  if (WABT_FAILED(result))
-    goto done;
-  s_objdump_options.log_stream = nullptr;
-
-  // Pass 1: Print the section headers
-  if (s_objdump_options.headers) {
-    s_objdump_options.mode = ObjdumpMode::Headers;
-    result = read_binary_objdump(data, size, &s_objdump_options);
-    if (WABT_FAILED(result))
-      goto done;
-  }
-  // Pass 2: Print extra information based on section type
-  if (s_objdump_options.details) {
-    s_objdump_options.mode = ObjdumpMode::Details;
-    result = read_binary_objdump(data, size, &s_objdump_options);
-    if (WABT_FAILED(result))
-      goto done;
-  }
-  if (s_objdump_options.disassemble) {
-    s_objdump_options.mode = ObjdumpMode::Disassemble;
-    result = read_binary_objdump(data, size, &s_objdump_options);
-    if (WABT_FAILED(result))
-      goto done;
-  }
-  // Pass 3: Dump to raw contents of the sections
-  if (s_objdump_options.raw) {
-    s_objdump_options.mode = ObjdumpMode::RawData;
-    result = read_binary_objdump(data, size, &s_objdump_options);
-  }
-
-done:
-  delete[] data;
-  return result != Result::Ok;
+  return 0;
 }

--- a/test/dump/multi_file.txt
+++ b/test/dump/multi_file.txt
@@ -1,0 +1,36 @@
+;;; TOOL: run-wasmdump
+;;; FLAGS: --headers --spec
+(module
+  (func (param $param2 i64))
+)
+(module
+  (func (param $param2 i64))
+)
+(;; STDOUT ;;;
+
+multi_file.0.wasm:	file format wasm 0x1
+
+Sections:
+
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+ Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
+     Code start=0x00000015 end=0x00000019 (size=0x00000004) count: 1
+
+Code Disassembly:
+
+000016 func[0]:
+ 000018: 0b                         | end
+
+multi_file.1.wasm:	file format wasm 0x1
+
+Sections:
+
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+ Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
+     Code start=0x00000015 end=0x00000019 (size=0x00000004) count: 1
+
+Code Disassembly:
+
+000016 func[0]:
+ 000018: 0b                         | end
+;;; STDOUT ;;)

--- a/test/run-wasmdump.py
+++ b/test/run-wasmdump.py
@@ -109,8 +109,7 @@ def main(args):
     else:
       wasm_files = [out_file]
 
-    for wasm_file in wasm_files:
-      wasmdump.RunWithArgs('-r', '-d', wasm_file)
+    wasmdump.RunWithArgs('-r', '-d', *wasm_files)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This mimics how objdump behaves. Also makes the code more
readable.

Looking into adding a test for this but looks tricky with the current framework.