### PR TITLE
note CMake version dependency on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will fetch the testsuite and gtest repos, which are needed for some tests.
 You'll need [CMake](https://cmake.org). If you just run `make`, it will run
 CMake for you, and put the result in `out/clang/Debug/` by default:
 
-> Note: If you are on OSX, you will need to use CMake version 1.3.2 or higher
+> Note: If you are on OSX, you will need to use CMake version 3.2 or higher
 
 ```
 $ make

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ This will fetch the testsuite and gtest repos, which are needed for some tests.
 You'll need [CMake](https://cmake.org). If you just run `make`, it will run
 CMake for you, and put the result in `out/clang/Debug/` by default:
 
+> Note: If you are on OSX, you will need to use CMake version 1.3.2 or higher
+
 ```
 $ make
 ```


### PR DESCRIPTION
With CMake version <= 3.1 on OSX you will see errors like the following because of https://cmake.org/Bug/view.php?id=15355 

```
Make Error in CMakeLists.txt:
  Target "hexfloat_test" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wabt-unittests" requires the language dialect "CXX11" (with
  compiler extensions), but CMake does not know the compile flags to use to
  enable it.


CMake Error in CMakeLists.txt:
  Target "wasm-interp" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wasm-link" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wasm2wast" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wasmdump" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wasmopcodecnt" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wast-desugar" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.


CMake Error in CMakeLists.txt:
  Target "wast2wasm" requires the language dialect "CXX11" (with compiler
  extensions), but CMake does not know the compile flags to use to enable it.
```