### PR TITLE
Regenerate expected test output

### DIFF
--- a/test/dump/bad-version-logging.txt
+++ b/test/dump/bad-version-logging.txt
@@ -8,3 +8,6 @@ Error running "wasmdump":
 *ERROR*: @0x00000008: bad wasm file version: 0xe (expected 0x1)
 
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+
+;;; STDOUT ;;)

--- a/test/dump/bad-version.txt
+++ b/test/dump/bad-version.txt
@@ -8,3 +8,6 @@ Error running "wasmdump":
 *ERROR*: @0x00000008: bad wasm file version: 0xe (expected 0x1)
 
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+
+;;; STDOUT ;;)

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -79,6 +79,7 @@
 0000038: 0b                                        ; end
 0000024: 14                                        ; FIXUP func body size
 0000022: 16                                        ; FIXUP section size
+
 basic.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/dump/basic_dump_only.txt
+++ b/test/dump/basic_dump_only.txt
@@ -13,6 +13,7 @@
     i32.add)
   (export "f" (func $f)))
 (;; STDOUT ;;;
+
 basic_dump_only.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -275,6 +275,7 @@
 0000015: e201                                      ; FIXUP func body size
 ; move data: [14, f9) -> [15, fa)
 0000013: e501                                      ; FIXUP section size
+
 binary.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -340,6 +340,7 @@
 0000015: 8902                                      ; FIXUP func body size
 ; move data: [14, 120) -> [15, 121)
 0000013: 8c02                                      ; FIXUP section size
+
 block-257-exprs-br.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -336,6 +336,7 @@
 0000015: 8602                                      ; FIXUP func body size
 ; move data: [14, 11d) -> [15, 11e)
 0000013: 8902                                      ; FIXUP section size
+
 block-257-exprs.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -62,6 +62,7 @@
 000002a: 0b                                        ; end
 0000023: 07                                        ; FIXUP func body size
 0000018: 12                                        ; FIXUP section size
+
 block.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -61,6 +61,7 @@
 000002a: 0b                                        ; end
 0000015: 15                                        ; FIXUP func body size
 0000013: 17                                        ; FIXUP section size
+
 br-block-named.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -67,6 +67,7 @@
 000002e: 0b                                        ; end
 0000015: 19                                        ; FIXUP func body size
 0000013: 1b                                        ; FIXUP section size
+
 br-block.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -69,6 +69,7 @@
 0000030: 0b                                        ; end
 0000016: 1a                                        ; FIXUP func body size
 0000014: 1c                                        ; FIXUP section size
+
 br-loop-inner-expr.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -55,6 +55,7 @@
 000002b: 0b                                        ; end
 0000015: 16                                        ; FIXUP func body size
 0000013: 18                                        ; FIXUP section size
+
 br-loop-inner.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -46,6 +46,7 @@
 0000021: 0b                                        ; end
 0000015: 0c                                        ; FIXUP func body size
 0000013: 0e                                        ; FIXUP section size
+
 br-loop.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -41,6 +41,7 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+
 brif-loop.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -41,6 +41,7 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+
 brif.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -42,6 +42,7 @@
 000001f: 0b                                        ; end
 0000015: 0a                                        ; FIXUP func body size
 0000013: 0c                                        ; FIXUP section size
+
 brtable-empty.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -75,6 +75,7 @@
 0000032: 0b                                        ; end
 0000015: 1d                                        ; FIXUP func body size
 0000013: 1f                                        ; FIXUP section size
+
 brtable.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -37,6 +37,7 @@
 000001c: 0b                                        ; end
 0000016: 06                                        ; FIXUP func body size
 0000014: 08                                        ; FIXUP section size
+
 call.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -67,6 +67,7 @@
 0000037: 0b                                        ; end
 0000029: 0e                                        ; FIXUP func body size
 0000027: 10                                        ; FIXUP section size
+
 callimport.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -65,6 +65,7 @@
 000002f: 0b                                        ; end
 0000026: 09                                        ; FIXUP func body size
 0000024: 0b                                        ; FIXUP section size
+
 callindirect.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -58,6 +58,7 @@
 0000031: 0b                                        ; end
 0000015: 1c                                        ; FIXUP func body size
 0000013: 1e                                        ; FIXUP section size
+
 cast.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -310,6 +310,7 @@
 0000015: 9f02                                      ; FIXUP func body size
 ; move data: [14, 136) -> [15, 137)
 0000013: a202                                      ; FIXUP section size
+
 compare.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -222,6 +222,7 @@
 0000015: 9a02                                      ; FIXUP func body size
 ; move data: [14, 131) -> [15, 132)
 0000013: 9d02                                      ; FIXUP section size
+
 const.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -89,6 +89,7 @@
 0000038: 0b                                        ; end
 0000015: 23                                        ; FIXUP func body size
 0000013: 25                                        ; FIXUP section size
+
 convert.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -43,6 +43,7 @@
 000001f: 0b                                        ; end
 000001b: 04                                        ; FIXUP func body size
 0000019: 06                                        ; FIXUP section size
+
 current-memory.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -45,6 +45,7 @@
 000002f: 00                                        ; num locals
 000002c: 03                                        ; FIXUP subsection size
 000001c: 13                                        ; FIXUP section size
+
 debug-import-names.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -118,6 +118,7 @@
 000007a: 2446 334c 33                             $F3L3  ; local name 3
 0000042: 3c                                        ; FIXUP subsection size
 000002e: 50                                        ; FIXUP section size
+
 debug-names.wasm:	file format wasm 0x1
 
 Section Details:

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -49,6 +49,7 @@
 0000028: 0b                                        ; end
 0000024: 04                                        ; FIXUP func body size
 0000022: 06                                        ; FIXUP section size
+
 dedupe-sig.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/drop.txt
+++ b/test/dump/drop.txt
@@ -35,6 +35,7 @@
 000001a: 0b                                        ; end
 0000015: 05                                        ; FIXUP func body size
 0000013: 07                                        ; FIXUP section size
+
 drop.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -46,6 +46,7 @@
 0000023: 0b                                        ; end
 0000020: 03                                        ; FIXUP func body size
 000001e: 05                                        ; FIXUP section size
+
 export-multi.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -43,6 +43,7 @@
 000001f: 0b                                        ; end
 0000016: 09                                        ; FIXUP func body size
 0000014: 0b                                        ; FIXUP section size
+
 expr-br.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -50,6 +50,7 @@
 0000024: 0b                                        ; end
 0000016: 0e                                        ; FIXUP func body size
 0000014: 10                                        ; FIXUP section size
+
 expr-brif.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -40,6 +40,7 @@
 0000020: 0b                                        ; end
 000001e: 02                                        ; FIXUP func body size
 000001c: 04                                        ; FIXUP section size
+
 func-exported.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -44,6 +44,7 @@
 000001f: 0b                                        ; end
 000001d: 02                                        ; FIXUP func body size
 0000015: 0a                                        ; FIXUP section size
+
 func-multi.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -30,6 +30,7 @@
 0000017: 0b                                        ; end
 0000015: 02                                        ; FIXUP func body size
 0000013: 04                                        ; FIXUP section size
+
 func-named.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/getglobal.txt
+++ b/test/dump/getglobal.txt
@@ -45,6 +45,7 @@
 0000022: 0b                                        ; end
 000001e: 04                                        ; FIXUP func body size
 000001c: 06                                        ; FIXUP section size
+
 getglobal.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -71,6 +71,7 @@
 0000033: 0b                                        ; end
 0000017: 1c                                        ; FIXUP func body size
 0000015: 1e                                        ; FIXUP section size
+
 getlocal-param.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -85,6 +85,7 @@
 000003d: 0b                                        ; end
 0000015: 28                                        ; FIXUP func body size
 0000013: 2a                                        ; FIXUP section size
+
 getlocal.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/global.txt
+++ b/test/dump/global.txt
@@ -100,6 +100,7 @@
 0000086: 03                                        ; global index
 0000087: 0b                                        ; end
 0000054: 33                                        ; FIXUP section size
+
 global.wasm:	file format wasm 0x1
 
 Section Details:

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -49,6 +49,7 @@
 0000023: 0b                                        ; end
 000001c: 07                                        ; FIXUP func body size
 000001a: 09                                        ; FIXUP section size
+
 grow-memory.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/hexfloat_f32.txt
+++ b/test/dump/hexfloat_f32.txt
@@ -117,6 +117,7 @@
 000007d: 0b                                        ; end
 0000015: 68                                        ; FIXUP func body size
 0000013: 6a                                        ; FIXUP section size
+
 hexfloat_f32.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/hexfloat_f64.txt
+++ b/test/dump/hexfloat_f64.txt
@@ -119,6 +119,7 @@
 0000015: ac01                                      ; FIXUP func body size
 ; move data: [14, c3) -> [15, c4)
 0000013: af01                                      ; FIXUP section size
+
 hexfloat_f64.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -60,6 +60,7 @@
 0000029: 0b                                        ; end
 0000015: 14                                        ; FIXUP func body size
 0000013: 16                                        ; FIXUP section size
+
 if-then-else-list.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -42,6 +42,7 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+
 if-then-list.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -79,6 +79,7 @@
 000003a: 0b                                        ; end
 0000030: 0a                                        ; FIXUP func body size
 0000014: 26                                        ; FIXUP section size
+
 if.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -44,6 +44,7 @@
 0000037: 00                                        ; import kind
 0000038: 01                                        ; import signature index
 0000018: 20                                        ; FIXUP section size
+
 import.wasm:	file format wasm 0x1
 
 Section Details:

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -183,6 +183,7 @@
 000007c: 0b                                        ; end
 000001a: 62                                        ; FIXUP func body size
 0000018: 64                                        ; FIXUP section size
+
 load-aligned.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -165,6 +165,7 @@
 0000070: 0b                                        ; end
 000001a: 56                                        ; FIXUP func body size
 0000018: 58                                        ; FIXUP section size
+
 load.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -38,6 +38,7 @@
 000001f: 0b                                        ; end
 0000015: 0a                                        ; FIXUP func body size
 0000013: 0c                                        ; FIXUP section size
+
 locals.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -353,6 +353,7 @@
 0000015: 9002                                      ; FIXUP func body size
 ; move data: [14, 127) -> [15, 128)
 0000013: 9302                                      ; FIXUP section size
+
 loop-257-exprs-br.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -336,6 +336,7 @@
 0000015: 8602                                      ; FIXUP func body size
 ; move data: [14, 11d) -> [15, 11e)
 0000013: 8902                                      ; FIXUP section size
+
 loop-257-exprs.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -39,6 +39,7 @@
 000001c: 0b                                        ; end
 0000015: 07                                        ; FIXUP func body size
 0000013: 09                                        ; FIXUP section size
+
 loop.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/memory-1-byte.txt
+++ b/test/dump/memory-1-byte.txt
@@ -12,6 +12,7 @@
 000000b: 00                                        ; limits: flags
 000000c: 01                                        ; limits: initial
 0000009: 03                                        ; FIXUP section size
+
 memory-1-byte.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/memory-data-size.txt
+++ b/test/dump/memory-data-size.txt
@@ -45,17 +45,21 @@
 000000b: 00                                        ; limits: flags
 000000c: 05                                        ; limits: initial
 0000009: 03                                        ; FIXUP section size
+
 memory-data-size.0.wasm:	file format wasm 0x1
 
 Code Disassembly:
+
 
 memory-data-size.1.wasm:	file format wasm 0x1
 
 Code Disassembly:
 
+
 memory-data-size.2.wasm:	file format wasm 0x1
 
 Code Disassembly:
+
 
 memory-data-size.3.wasm:	file format wasm 0x1
 

--- a/test/dump/memory-hex.txt
+++ b/test/dump/memory-hex.txt
@@ -28,6 +28,7 @@
 ; data segment data 0
 0000016: 0001 0203 0405 0607 0809 0a               ; data segment data
 000000f: 11                                        ; FIXUP section size
+
 memory-hex.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -38,6 +38,7 @@
 000002f: 7073 756d 2064 6f6c 6f72 2073 6974 2061 
 000003f: 6d65 742c 2063 6f6e 7365 6374 6574 7572   ; data segment data
 000000e: 40                                        ; FIXUP section size
+
 memory.wasm:	file format wasm 0x1
 
 Section Details:

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -146,6 +146,7 @@
 0000099: 0b                                        ; end
 000008d: 8880 8080 00                              ; FIXUP func body size
 000006b: aa80 8080 00                              ; FIXUP section size
+
 no-canonicalize.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -49,6 +49,7 @@
 0000030: 0b                                        ; end
 000001f: 11                                        ; FIXUP func body size
 000001d: 13                                        ; FIXUP section size
+
 nocheck.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -32,6 +32,7 @@
 0000018: 0b                                        ; end
 0000015: 03                                        ; FIXUP func body size
 0000013: 05                                        ; FIXUP section size
+
 nop.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -34,6 +34,7 @@
 000001b: 0b                                        ; end
 0000019: 02                                        ; FIXUP func body size
 0000017: 04                                        ; FIXUP section size
+
 param-multi.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/relocations.txt
+++ b/test/dump/relocations.txt
@@ -11,6 +11,7 @@
   (export "f" (func $f))
   (table anyfunc (elem $f)))
 (;; STDOUT ;;;
+
 relocations.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -79,6 +79,7 @@
 0000042: 0b                                        ; end
 0000037: 0b                                        ; FIXUP func body size
 0000023: 1f                                        ; FIXUP section size
+
 result.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -49,6 +49,7 @@
 0000023: 0b                                        ; end
 0000020: 03                                        ; FIXUP func body size
 0000018: 0b                                        ; FIXUP section size
+
 return.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -82,6 +82,7 @@
 000004b: 0b                                        ; end
 0000015: 36                                        ; FIXUP func body size
 0000013: 38                                        ; FIXUP section size
+
 select.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -47,6 +47,7 @@
 0000029: 0b                                        ; end
 0000020: 09                                        ; FIXUP func body size
 000001e: 0b                                        ; FIXUP section size
+
 setglobal.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -81,6 +81,7 @@
 0000042: 0b                                        ; end
 0000017: 2b                                        ; FIXUP func body size
 0000015: 2d                                        ; FIXUP section size
+
 setlocal-param.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -97,6 +97,7 @@
 0000059: 0b                                        ; end
 0000015: 44                                        ; FIXUP func body size
 0000013: 46                                        ; FIXUP section size
+
 setlocal.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/signatures.txt
+++ b/test/dump/signatures.txt
@@ -66,6 +66,7 @@
 000002e: 01                                        ; num results
 000002f: 7c                                        ; f64
 0000009: 26                                        ; FIXUP section size
+
 signatures.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -199,6 +199,7 @@
 000008c: 0b                                        ; end
 000001a: 72                                        ; FIXUP func body size
 0000018: 74                                        ; FIXUP section size
+
 store-aligned.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -129,6 +129,7 @@
 0000065: 0b                                        ; end
 000001a: 4b                                        ; FIXUP func body size
 0000018: 4d                                        ; FIXUP section size
+
 store.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/string-escape.txt
+++ b/test/dump/string-escape.txt
@@ -40,6 +40,7 @@
 0000045: 0b                                        ; end
 0000043: 02                                        ; FIXUP func body size
 0000041: 04                                        ; FIXUP section size
+
 string-escape.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/string-hex.txt
+++ b/test/dump/string-hex.txt
@@ -38,6 +38,7 @@
 0000024: 0b                                        ; end
 0000022: 02                                        ; FIXUP func body size
 0000020: 04                                        ; FIXUP section size
+
 string-hex.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -86,6 +86,7 @@
 0000045: 0b                                        ; end
 000003a: 0b                                        ; FIXUP func body size
 0000032: 13                                        ; FIXUP section size
+
 table.wasm:	file format wasm 0x1
 
 Section Details:

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -41,6 +41,7 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+
 tee_local.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -95,6 +95,7 @@
 0000042: 0b                                        ; end
 0000015: 2d                                        ; FIXUP func body size
 0000013: 2f                                        ; FIXUP section size
+
 unary.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -32,6 +32,7 @@
 0000018: 0b                                        ; end
 0000015: 03                                        ; FIXUP func body size
 0000013: 05                                        ; FIXUP section size
+
 unreachable.wasm:	file format wasm 0x1
 
 Code Disassembly:

--- a/test/link/data.txt
+++ b/test/link/data.txt
@@ -11,6 +11,7 @@
   (data (i32.const 100) "world")
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -13,6 +13,7 @@
      call 0)
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -19,6 +19,7 @@
      call $local_func)
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -24,6 +24,7 @@
      call 1)
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -21,6 +21,7 @@
      call 0)
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -27,6 +27,7 @@
   (table anyfunc (elem $func3 $func3))
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -41,6 +41,7 @@
 (assert_return (invoke "call_import2") (i64.const 99))
 
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -21,6 +21,7 @@
      call 0)
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/names_import_only.txt
+++ b/test/link/names_import_only.txt
@@ -4,6 +4,7 @@
   (import "__extern" "baz" (func $import_func1))
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -10,6 +10,7 @@
   (table anyfunc (elem $func3 $func2 $func2))
 )
 (;; STDOUT ;;;
+
 linked.wasm:	file format wasm 0x1
 
 Sections:


### PR DESCRIPTION
The expected test output was out of sync because whitespace
at the start and end of stdout doesn't cause test failures
(because stdout/stderr are stripped before comparison).
