### PR TITLE
Update relocation names to match "spec"

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -267,9 +267,9 @@ void BinaryReaderObjdumpDisassemble::LogOpcode(const uint8_t* data,
       printf("           %06" PRIzx ": %-18s %d", abs_offset,
              get_reloc_type_name(reloc->type), reloc->index);
       switch (reloc->type) {
-        case RelocType::MemoryAddressLEB:
-        case RelocType::MemoryAddressSLEB:
-        case RelocType::MemoryAddressI32:
+        case RelocType::GlobalAddressLEB:
+        case RelocType::GlobalAddressSLEB:
+        case RelocType::GlobalAddressI32:
           printf(" + %d", reloc->addend);
           break;
         case RelocType::FuncIndexLEB:

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -998,9 +998,9 @@ static void read_reloc_section(Context* ctx, uint32_t section_size) {
     in_u32_leb128(ctx, &index, "index");
     RelocType type = static_cast<RelocType>(reloc_type);
     switch (type) {
-      case RelocType::MemoryAddressLEB:
-      case RelocType::MemoryAddressSLEB:
-      case RelocType::MemoryAddressI32:
+      case RelocType::GlobalAddressLEB:
+      case RelocType::GlobalAddressSLEB:
+      case RelocType::GlobalAddressI32:
         in_i32_leb128(ctx, &addend, "addend");
         break;
       default:

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -640,9 +640,9 @@ void BinaryWriter::WriteRelocSection(const RelocSection* reloc_section) {
     write_u32_leb128(&stream_, reloc.offset, "reloc offset");
     write_u32_leb128(&stream_, reloc.index, "reloc index");
     switch (reloc.type) {
-      case RelocType::MemoryAddressLEB:
-      case RelocType::MemoryAddressSLEB:
-      case RelocType::MemoryAddressI32:
+      case RelocType::GlobalAddressLEB:
+      case RelocType::GlobalAddressSLEB:
+      case RelocType::GlobalAddressI32:
         write_u32_leb128(&stream_, reloc.addend, "reloc addend");
         break;
       default:

--- a/src/common.cc
+++ b/src/common.cc
@@ -40,9 +40,9 @@ WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(g_kind_name) == kExternalKindCount);
 const char* g_reloc_type_name[] = {"R_FUNC_INDEX_LEB",
                                    "R_TABLE_INDEX_SLEB",
                                    "R_TABLE_INDEX_I32",
-                                   "R_MEMORY_ADDR_LEB",
-                                   "R_MEMORY_ADDR_SLEB",
-                                   "R_MEMORY_ADDR_I32",
+                                   "R_GLOBAL_ADDR_LEB",
+                                   "R_GLOBAL_ADDR_SLEB",
+                                   "R_GLOBAL_ADDR_I32",
                                    "R_TYPE_INDEX_LEB",
                                    "R_GLOBAL_INDEX_LEB",
                                    };

--- a/src/common.h
+++ b/src/common.h
@@ -139,9 +139,9 @@ enum class RelocType {
   FuncIndexLEB = 0,   /* e.g. immediate of call instruction */
   TableIndexSLEB = 1, /* e.g. loading address of function */
   TableIndexI32 = 2,  /* e.g. function address in DATA */
-  MemoryAddressLEB = 3,
-  MemoryAddressSLEB = 4,
-  MemoryAddressI32 = 5,
+  GlobalAddressLEB = 3,
+  GlobalAddressSLEB = 4,
+  GlobalAddressI32 = 5,
   TypeIndexLEB = 6, /* e.g immediate type in call_indirect */
   GlobalIndexLEB = 7, /* e.g immediate of get_global inst */
 


### PR DESCRIPTION
Sorry no tests for these names since they are not generated from .wast format yet.