### PR TITLE
Use Index/Address/Offset instead of uint32_t

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -65,7 +65,7 @@ Label* find_label_by_var(Context* ctx, Var* var) {
     }
     return nullptr;
   } else {
-    if (var->index < 0 || static_cast<size_t>(var->index) >= ctx->labels.size())
+    if (var->index >= ctx->labels.size())
       return nullptr;
     return ctx->labels[ctx->labels.size() - 1 - var->index];
   }
@@ -123,21 +123,20 @@ Result use_name_for_memory_var(Module* module, Var* var) {
 }
 
 Result use_name_for_param_and_local_var(Context* ctx, Func* func, Var* var) {
-  int local_index = get_local_index_by_var(func, var);
-  if (local_index < 0 ||
-      static_cast<size_t>(local_index) >= get_num_params_and_locals(func))
+  Index local_index = get_local_index_by_var(func, var);
+  if (local_index >= get_num_params_and_locals(func))
     return Result::Error;
 
-  uint32_t num_params = get_num_params(func);
+  Index num_params = get_num_params(func);
   std::string* name;
-  if (static_cast<uint32_t>(local_index) < num_params) {
+  if (local_index < num_params) {
     /* param */
-    assert(static_cast<size_t>(local_index) < ctx->param_index_to_name.size());
+    assert(local_index < ctx->param_index_to_name.size());
     name = &ctx->param_index_to_name[local_index];
   } else {
     /* local */
     local_index -= num_params;
-    assert(static_cast<size_t>(local_index) < ctx->local_index_to_name.size());
+    assert(local_index < ctx->local_index_to_name.size());
     name = &ctx->local_index_to_name[local_index];
   }
 
@@ -263,7 +262,7 @@ Result on_tee_local_expr(Expr* expr, void* user_data) {
   return Result::Ok;
 }
 
-Result visit_func(Context* ctx, uint32_t func_index, Func* func) {
+Result visit_func(Context* ctx, Index func_index, Func* func) {
   ctx->current_func = func;
   if (decl_has_func_type(&func->decl)) {
     CHECK_RESULT(use_name_for_func_type_var(ctx->module, &func->decl.type_var));
@@ -281,7 +280,7 @@ Result visit_func(Context* ctx, uint32_t func_index, Func* func) {
   return Result::Ok;
 }
 
-Result visit_export(Context* ctx, uint32_t export_index, Export* export_) {
+Result visit_export(Context* ctx, Index export_index, Export* export_) {
   if (export_->kind == ExternalKind::Func) {
     use_name_for_func_var(ctx->module, &export_->var);
   }
@@ -289,7 +288,7 @@ Result visit_export(Context* ctx, uint32_t export_index, Export* export_) {
 }
 
 Result visit_elem_segment(Context* ctx,
-                          uint32_t elem_segment_index,
+                          Index elem_segment_index,
                           ElemSegment* segment) {
   CHECK_RESULT(use_name_for_table_var(ctx->module, &segment->table_var));
   for (Var& var : segment->vars) {
@@ -299,7 +298,7 @@ Result visit_elem_segment(Context* ctx,
 }
 
 Result visit_data_segment(Context* ctx,
-                          uint32_t data_segment_index,
+                          Index data_segment_index,
                           DataSegment* segment) {
   CHECK_RESULT(use_name_for_memory_var(ctx->module, &segment->memory_var));
   return Result::Ok;

--- a/src/binary-error-handler.cc
+++ b/src/binary-error-handler.cc
@@ -25,13 +25,12 @@ BinaryErrorHandlerFile::BinaryErrorHandlerFile(FILE* file,
                                                PrintHeader print_header)
     : file_(file), header_(header), print_header_(print_header) {}
 
-bool BinaryErrorHandlerFile::OnError(uint32_t offset,
-                                     const std::string& error) {
+bool BinaryErrorHandlerFile::OnError(Offset offset, const std::string& error) {
   PrintErrorHeader();
-  if (offset == WABT_UNKNOWN_OFFSET)
+  if (offset == kInvalidOffset)
     fprintf(file_, "error: %s\n", error.c_str());
   else
-    fprintf(file_, "error: @0x%08x: %s\n", offset, error.c_str());
+    fprintf(file_, "error: @0x%08" PRIzx ": %s\n", offset, error.c_str());
   fflush(file_);
   return true;
 }

--- a/src/binary-error-handler.h
+++ b/src/binary-error-handler.h
@@ -21,6 +21,8 @@
 #include <cstdio>
 #include <string>
 
+#include "common.h"
+
 namespace wabt {
 
 class BinaryErrorHandler {
@@ -28,7 +30,7 @@ class BinaryErrorHandler {
   virtual ~BinaryErrorHandler() {}
 
   // Returns true if the error was handled.
-  virtual bool OnError(uint32_t offset, const std::string& error) = 0;
+  virtual bool OnError(Offset offset, const std::string& error) = 0;
 };
 
 class BinaryErrorHandlerFile : public BinaryErrorHandler {
@@ -43,7 +45,7 @@ class BinaryErrorHandlerFile : public BinaryErrorHandler {
                          const std::string& header = std::string(),
                          PrintHeader print_header = PrintHeader::Never);
 
-  bool OnError(uint32_t offset, const std::string& error) override;
+  bool OnError(Offset offset, const std::string& error) override;
 
  private:
   void PrintErrorHeader();

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -53,148 +53,148 @@ class BinaryReaderIR : public BinaryReaderNop {
  public:
   BinaryReaderIR(Module* out_module, BinaryErrorHandler* error_handler);
 
-  virtual bool OnError(const char* message);
+  bool OnError(const char* message) override;
 
-  virtual Result OnTypeCount(uint32_t count);
-  virtual Result OnType(uint32_t index,
-                        uint32_t param_count,
-                        Type* param_types,
-                        uint32_t result_count,
-                        Type* result_types);
+  Result OnTypeCount(Index count) override;
+  Result OnType(Index index,
+                Index param_count,
+                Type* param_types,
+                Index result_count,
+                Type* result_types) override;
 
-  virtual Result OnImportCount(uint32_t count);
-  virtual Result OnImport(uint32_t index,
-                          StringSlice module_name,
-                          StringSlice field_name);
-  virtual Result OnImportFunc(uint32_t import_index,
-                              StringSlice module_name,
-                              StringSlice field_name,
-                              uint32_t func_index,
-                              uint32_t sig_index);
-  virtual Result OnImportTable(uint32_t import_index,
-                               StringSlice module_name,
-                               StringSlice field_name,
-                               uint32_t table_index,
-                               Type elem_type,
-                               const Limits* elem_limits);
-  virtual Result OnImportMemory(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t memory_index,
-                                const Limits* page_limits);
-  virtual Result OnImportGlobal(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t global_index,
-                                Type type,
-                                bool mutable_);
+  Result OnImportCount(Index count) override;
+  Result OnImport(Index index,
+                  StringSlice module_name,
+                  StringSlice field_name) override;
+  Result OnImportFunc(Index import_index,
+                      StringSlice module_name,
+                      StringSlice field_name,
+                      Index func_index,
+                      Index sig_index) override;
+  Result OnImportTable(Index import_index,
+                       StringSlice module_name,
+                       StringSlice field_name,
+                       Index table_index,
+                       Type elem_type,
+                       const Limits* elem_limits) override;
+  Result OnImportMemory(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index memory_index,
+                        const Limits* page_limits) override;
+  Result OnImportGlobal(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index global_index,
+                        Type type,
+                        bool mutable_) override;
 
-  virtual Result OnFunctionCount(uint32_t count);
-  virtual Result OnFunction(uint32_t index, uint32_t sig_index);
+  Result OnFunctionCount(Index count) override;
+  Result OnFunction(Index index, Index sig_index) override;
 
-  virtual Result OnTableCount(uint32_t count);
-  virtual Result OnTable(uint32_t index,
-                         Type elem_type,
-                         const Limits* elem_limits);
+  Result OnTableCount(Index count) override;
+  Result OnTable(Index index,
+                 Type elem_type,
+                 const Limits* elem_limits) override;
 
-  virtual Result OnMemoryCount(uint32_t count);
-  virtual Result OnMemory(uint32_t index, const Limits* limits);
+  Result OnMemoryCount(Index count) override;
+  Result OnMemory(Index index, const Limits* limits) override;
 
-  virtual Result OnGlobalCount(uint32_t count);
-  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_);
-  virtual Result BeginGlobalInitExpr(uint32_t index);
-  virtual Result EndGlobalInitExpr(uint32_t index);
+  Result OnGlobalCount(Index count) override;
+  Result BeginGlobal(Index index, Type type, bool mutable_) override;
+  Result BeginGlobalInitExpr(Index index) override;
+  Result EndGlobalInitExpr(Index index) override;
 
-  virtual Result OnExportCount(uint32_t count);
-  virtual Result OnExport(uint32_t index,
-                          ExternalKind kind,
-                          uint32_t item_index,
-                          StringSlice name);
+  Result OnExportCount(Index count) override;
+  Result OnExport(Index index,
+                  ExternalKind kind,
+                  Index item_index,
+                  StringSlice name) override;
 
-  virtual Result OnStartFunction(uint32_t func_index);
+  Result OnStartFunction(Index func_index) override;
 
-  virtual Result OnFunctionBodyCount(uint32_t count);
-  virtual Result BeginFunctionBody(uint32_t index);
-  virtual Result OnLocalDecl(uint32_t decl_index, uint32_t count, Type type);
+  Result OnFunctionBodyCount(Index count) override;
+  Result BeginFunctionBody(Index index) override;
+  Result OnLocalDecl(Index decl_index, Index count, Type type) override;
 
-  virtual Result OnBinaryExpr(Opcode opcode);
-  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types);
-  virtual Result OnBrExpr(uint32_t depth);
-  virtual Result OnBrIfExpr(uint32_t depth);
-  virtual Result OnBrTableExpr(uint32_t num_targets,
-                               uint32_t* target_depths,
-                               uint32_t default_target_depth);
-  virtual Result OnCallExpr(uint32_t func_index);
-  virtual Result OnCallIndirectExpr(uint32_t sig_index);
-  virtual Result OnCompareExpr(Opcode opcode);
-  virtual Result OnConvertExpr(Opcode opcode);
-  virtual Result OnDropExpr();
-  virtual Result OnElseExpr();
-  virtual Result OnEndExpr();
-  virtual Result OnF32ConstExpr(uint32_t value_bits);
-  virtual Result OnF64ConstExpr(uint64_t value_bits);
-  virtual Result OnGetGlobalExpr(uint32_t global_index);
-  virtual Result OnGetLocalExpr(uint32_t local_index);
-  virtual Result OnGrowMemoryExpr();
-  virtual Result OnI32ConstExpr(uint32_t value);
-  virtual Result OnI64ConstExpr(uint64_t value);
-  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types);
-  virtual Result OnLoadExpr(Opcode opcode,
-                            uint32_t alignment_log2,
-                            uint32_t offset);
-  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types);
-  virtual Result OnCurrentMemoryExpr();
-  virtual Result OnNopExpr();
-  virtual Result OnReturnExpr();
-  virtual Result OnSelectExpr();
-  virtual Result OnSetGlobalExpr(uint32_t global_index);
-  virtual Result OnSetLocalExpr(uint32_t local_index);
-  virtual Result OnStoreExpr(Opcode opcode,
-                             uint32_t alignment_log2,
-                             uint32_t offset);
-  virtual Result OnTeeLocalExpr(uint32_t local_index);
-  virtual Result OnUnaryExpr(Opcode opcode);
-  virtual Result OnUnreachableExpr();
-  virtual Result EndFunctionBody(uint32_t index);
+  Result OnBinaryExpr(Opcode opcode) override;
+  Result OnBlockExpr(Index num_types, Type* sig_types) override;
+  Result OnBrExpr(Index depth) override;
+  Result OnBrIfExpr(Index depth) override;
+  Result OnBrTableExpr(Index num_targets,
+                       Index* target_depths,
+                       Index default_target_depth) override;
+  Result OnCallExpr(Index func_index) override;
+  Result OnCallIndirectExpr(Index sig_index) override;
+  Result OnCompareExpr(Opcode opcode) override;
+  Result OnConvertExpr(Opcode opcode) override;
+  Result OnDropExpr() override;
+  Result OnElseExpr() override;
+  Result OnEndExpr() override;
+  Result OnF32ConstExpr(uint32_t value_bits) override;
+  Result OnF64ConstExpr(uint64_t value_bits) override;
+  Result OnGetGlobalExpr(Index global_index) override;
+  Result OnGetLocalExpr(Index local_index) override;
+  Result OnGrowMemoryExpr() override;
+  Result OnI32ConstExpr(uint32_t value) override;
+  Result OnI64ConstExpr(uint64_t value) override;
+  Result OnIfExpr(Index num_types, Type* sig_types) override;
+  Result OnLoadExpr(Opcode opcode,
+                    uint32_t alignment_log2,
+                    Address offset) override;
+  Result OnLoopExpr(Index num_types, Type* sig_types) override;
+  Result OnCurrentMemoryExpr() override;
+  Result OnNopExpr() override;
+  Result OnReturnExpr() override;
+  Result OnSelectExpr() override;
+  Result OnSetGlobalExpr(Index global_index) override;
+  Result OnSetLocalExpr(Index local_index) override;
+  Result OnStoreExpr(Opcode opcode,
+                     uint32_t alignment_log2,
+                     Address offset) override;
+  Result OnTeeLocalExpr(Index local_index) override;
+  Result OnUnaryExpr(Opcode opcode) override;
+  Result OnUnreachableExpr() override;
+  Result EndFunctionBody(Index index) override;
 
-  virtual Result OnElemSegmentCount(uint32_t count);
-  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index);
-  virtual Result BeginElemSegmentInitExpr(uint32_t index);
-  virtual Result EndElemSegmentInitExpr(uint32_t index);
-  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                 uint32_t count);
-  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
-                                            uint32_t func_index);
+  Result OnElemSegmentCount(Index count) override;
+  Result BeginElemSegment(Index index, Index table_index) override;
+  Result BeginElemSegmentInitExpr(Index index) override;
+  Result EndElemSegmentInitExpr(Index index) override;
+  Result OnElemSegmentFunctionIndexCount(Index index,
+                                         Index count) override;
+  Result OnElemSegmentFunctionIndex(Index index,
+                                    Index func_index) override;
 
-  virtual Result OnDataSegmentCount(uint32_t count);
-  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index);
-  virtual Result BeginDataSegmentInitExpr(uint32_t index);
-  virtual Result EndDataSegmentInitExpr(uint32_t index);
-  virtual Result OnDataSegmentData(uint32_t index,
-                                   const void* data,
-                                   uint32_t size);
+  Result OnDataSegmentCount(Index count) override;
+  Result BeginDataSegment(Index index, Index memory_index) override;
+  Result BeginDataSegmentInitExpr(Index index) override;
+  Result EndDataSegmentInitExpr(Index index) override;
+  Result OnDataSegmentData(Index index,
+                           const void* data,
+                           Address size) override;
 
-  virtual Result OnFunctionNamesCount(uint32_t num_functions);
-  virtual Result OnFunctionName(uint32_t function_index,
-                                StringSlice function_name);
-  virtual Result OnLocalNameLocalCount(uint32_t function_index,
-                                       uint32_t num_locals);
-  virtual Result OnLocalName(uint32_t function_index,
-                             uint32_t local_index,
-                             StringSlice local_name);
+  Result OnFunctionNamesCount(Index num_functions) override;
+  Result OnFunctionName(Index function_index,
+                        StringSlice function_name) override;
+  Result OnLocalNameLocalCount(Index function_index,
+                               Index num_locals) override;
+  Result OnLocalName(Index function_index,
+                     Index local_index,
+                     StringSlice local_name) override;
 
-  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value);
-  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value);
-  virtual Result OnInitExprGetGlobalExpr(uint32_t index, uint32_t global_index);
-  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
-  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value);
+  Result OnInitExprF32ConstExpr(Index index, uint32_t value) override;
+  Result OnInitExprF64ConstExpr(Index index, uint64_t value) override;
+  Result OnInitExprGetGlobalExpr(Index index, Index global_index) override;
+  Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
+  Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
 
  private:
-  bool HandleError(uint32_t offset, const char* message);
+  bool HandleError(Offset offset, const char* message);
   void PrintError(const char* format, ...);
   void PushLabel(LabelType label_type, Expr** first);
   Result PopLabel();
-  Result GetLabelAt(LabelNode** label, uint32_t depth);
+  Result GetLabelAt(LabelNode** label, Index depth);
   Result TopLabel(LabelNode** label);
   Result AppendExpr(Expr* expr);
 
@@ -203,7 +203,6 @@ class BinaryReaderIR : public BinaryReaderNop {
 
   Func* current_func = nullptr;
   std::vector<LabelNode> label_stack;
-  uint32_t max_depth = 0;
   Expr** current_init_expr = nullptr;
 };
 
@@ -214,11 +213,10 @@ BinaryReaderIR::BinaryReaderIR(Module* out_module,
 void WABT_PRINTF_FORMAT(2, 3) BinaryReaderIR::PrintError(const char* format,
                                                           ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  HandleError(WABT_UNKNOWN_OFFSET, buffer);
+  HandleError(kInvalidOffset, buffer);
 }
 
 void BinaryReaderIR::PushLabel(LabelType label_type, Expr** first) {
-  max_depth++;
   label_stack.emplace_back(label_type, first);
 }
 
@@ -228,14 +226,13 @@ Result BinaryReaderIR::PopLabel() {
     return Result::Error;
   }
 
-  max_depth--;
   label_stack.pop_back();
   return Result::Ok;
 }
 
-Result BinaryReaderIR::GetLabelAt(LabelNode** label, uint32_t depth) {
+Result BinaryReaderIR::GetLabelAt(LabelNode** label, Index depth) {
   if (depth >= label_stack.size()) {
-    PrintError("accessing stack depth: %u >= max: %" PRIzd, depth,
+    PrintError("accessing stack depth: %" PRIindex " >= max: %" PRIzd, depth,
                label_stack.size());
     return Result::Error;
   }
@@ -263,7 +260,7 @@ Result BinaryReaderIR::AppendExpr(Expr* expr) {
   return Result::Ok;
 }
 
-bool BinaryReaderIR::HandleError(uint32_t offset, const char* message) {
+bool BinaryReaderIR::HandleError(Offset offset, const char* message) {
   return error_handler->OnError(offset, message);
 }
 
@@ -271,15 +268,15 @@ bool BinaryReaderIR::OnError(const char* message) {
   return HandleError(state->offset, message);
 }
 
-Result BinaryReaderIR::OnTypeCount(uint32_t count) {
+Result BinaryReaderIR::OnTypeCount(Index count) {
   module->func_types.reserve(count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnType(uint32_t index,
-                               uint32_t param_count,
+Result BinaryReaderIR::OnType(Index index,
+                               Index param_count,
                                Type* param_types,
-                               uint32_t result_count,
+                               Index result_count,
                                Type* result_types) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::FuncType;
@@ -292,12 +289,12 @@ Result BinaryReaderIR::OnType(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnImportCount(uint32_t count) {
+Result BinaryReaderIR::OnImportCount(Index count) {
   module->imports.reserve(count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnImport(uint32_t index,
+Result BinaryReaderIR::OnImport(Index index,
                                  StringSlice module_name,
                                  StringSlice field_name) {
   ModuleField* field = append_module_field(module);
@@ -311,11 +308,11 @@ Result BinaryReaderIR::OnImport(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnImportFunc(uint32_t import_index,
-                                     StringSlice module_name,
-                                     StringSlice field_name,
-                                     uint32_t func_index,
-                                     uint32_t sig_index) {
+Result BinaryReaderIR::OnImportFunc(Index import_index,
+                                    StringSlice module_name,
+                                    StringSlice field_name,
+                                    Index func_index,
+                                    Index sig_index) {
   assert(import_index == module->imports.size() - 1);
   Import* import = module->imports[import_index];
 
@@ -331,12 +328,12 @@ Result BinaryReaderIR::OnImportFunc(uint32_t import_index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnImportTable(uint32_t import_index,
-                                      StringSlice module_name,
-                                      StringSlice field_name,
-                                      uint32_t table_index,
-                                      Type elem_type,
-                                      const Limits* elem_limits) {
+Result BinaryReaderIR::OnImportTable(Index import_index,
+                                     StringSlice module_name,
+                                     StringSlice field_name,
+                                     Index table_index,
+                                     Type elem_type,
+                                     const Limits* elem_limits) {
   assert(import_index == module->imports.size() - 1);
   Import* import = module->imports[import_index];
   import->kind = ExternalKind::Table;
@@ -347,11 +344,11 @@ Result BinaryReaderIR::OnImportTable(uint32_t import_index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnImportMemory(uint32_t import_index,
-                                       StringSlice module_name,
-                                       StringSlice field_name,
-                                       uint32_t memory_index,
-                                       const Limits* page_limits) {
+Result BinaryReaderIR::OnImportMemory(Index import_index,
+                                      StringSlice module_name,
+                                      StringSlice field_name,
+                                      Index memory_index,
+                                      const Limits* page_limits) {
   assert(import_index == module->imports.size() - 1);
   Import* import = module->imports[import_index];
   import->kind = ExternalKind::Memory;
@@ -362,12 +359,12 @@ Result BinaryReaderIR::OnImportMemory(uint32_t import_index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnImportGlobal(uint32_t import_index,
-                                       StringSlice module_name,
-                                       StringSlice field_name,
-                                       uint32_t global_index,
-                                       Type type,
-                                       bool mutable_) {
+Result BinaryReaderIR::OnImportGlobal(Index import_index,
+                                      StringSlice module_name,
+                                      StringSlice field_name,
+                                      Index global_index,
+                                      Type type,
+                                      bool mutable_) {
   assert(import_index == module->imports.size() - 1);
   Import* import = module->imports[import_index];
   import->kind = ExternalKind::Global;
@@ -379,12 +376,12 @@ Result BinaryReaderIR::OnImportGlobal(uint32_t import_index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnFunctionCount(uint32_t count) {
+Result BinaryReaderIR::OnFunctionCount(Index count) {
   module->funcs.reserve(module->num_func_imports + count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnFunction(uint32_t index, uint32_t sig_index) {
+Result BinaryReaderIR::OnFunction(Index index, Index sig_index) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::Func;
   field->func = new Func();
@@ -399,14 +396,14 @@ Result BinaryReaderIR::OnFunction(uint32_t index, uint32_t sig_index) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnTableCount(uint32_t count) {
+Result BinaryReaderIR::OnTableCount(Index count) {
   module->tables.reserve(module->num_table_imports + count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnTable(uint32_t index,
-                                Type elem_type,
-                                const Limits* elem_limits) {
+Result BinaryReaderIR::OnTable(Index index,
+                               Type elem_type,
+                               const Limits* elem_limits) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::Table;
   field->table = new Table();
@@ -415,12 +412,12 @@ Result BinaryReaderIR::OnTable(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnMemoryCount(uint32_t count) {
+Result BinaryReaderIR::OnMemoryCount(Index count) {
   module->memories.reserve(module->num_memory_imports + count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnMemory(uint32_t index, const Limits* page_limits) {
+Result BinaryReaderIR::OnMemory(Index index, const Limits* page_limits) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::Memory;
   field->memory = new Memory();
@@ -429,12 +426,12 @@ Result BinaryReaderIR::OnMemory(uint32_t index, const Limits* page_limits) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnGlobalCount(uint32_t count) {
+Result BinaryReaderIR::OnGlobalCount(Index count) {
   module->globals.reserve(module->num_global_imports + count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginGlobal(uint32_t index, Type type, bool mutable_) {
+Result BinaryReaderIR::BeginGlobal(Index index, Type type, bool mutable_) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::Global;
   field->global = new Global();
@@ -444,27 +441,27 @@ Result BinaryReaderIR::BeginGlobal(uint32_t index, Type type, bool mutable_) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginGlobalInitExpr(uint32_t index) {
+Result BinaryReaderIR::BeginGlobalInitExpr(Index index) {
   assert(index == module->globals.size() - 1);
   Global* global = module->globals[index];
   current_init_expr = &global->init_expr;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::EndGlobalInitExpr(uint32_t index) {
+Result BinaryReaderIR::EndGlobalInitExpr(Index index) {
   current_init_expr = nullptr;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnExportCount(uint32_t count) {
+Result BinaryReaderIR::OnExportCount(Index count) {
   module->exports.reserve(count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnExport(uint32_t index,
-                                 ExternalKind kind,
-                                 uint32_t item_index,
-                                 StringSlice name) {
+Result BinaryReaderIR::OnExport(Index index,
+                                ExternalKind kind,
+                                Index item_index,
+                                StringSlice name) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::Export;
   field->export_ = new Export();
@@ -492,7 +489,7 @@ Result BinaryReaderIR::OnExport(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnStartFunction(uint32_t func_index) {
+Result BinaryReaderIR::OnStartFunction(Index func_index) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::Start;
 
@@ -504,20 +501,18 @@ Result BinaryReaderIR::OnStartFunction(uint32_t func_index) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnFunctionBodyCount(uint32_t count) {
+Result BinaryReaderIR::OnFunctionBodyCount(Index count) {
   assert(module->num_func_imports + count == module->funcs.size());
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginFunctionBody(uint32_t index) {
+Result BinaryReaderIR::BeginFunctionBody(Index index) {
   current_func = module->funcs[index];
   PushLabel(LabelType::Func, &current_func->first_expr);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnLocalDecl(uint32_t decl_index,
-                                    uint32_t count,
-                                    Type type) {
+Result BinaryReaderIR::OnLocalDecl(Index decl_index, Index count, Type type) {
   TypeVector& types = current_func->local_types;
   types.reserve(types.size() + count);
   for (size_t i = 0; i < count; ++i)
@@ -530,7 +525,7 @@ Result BinaryReaderIR::OnBinaryExpr(Opcode opcode) {
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnBlockExpr(uint32_t num_types, Type* sig_types) {
+Result BinaryReaderIR::OnBlockExpr(Index num_types, Type* sig_types) {
   Expr* expr = Expr::CreateBlock(new Block());
   expr->block->sig.assign(sig_types, sig_types + num_types);
   AppendExpr(expr);
@@ -538,35 +533,35 @@ Result BinaryReaderIR::OnBlockExpr(uint32_t num_types, Type* sig_types) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnBrExpr(uint32_t depth) {
+Result BinaryReaderIR::OnBrExpr(Index depth) {
   Expr* expr = Expr::CreateBr(Var(depth));
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnBrIfExpr(uint32_t depth) {
+Result BinaryReaderIR::OnBrIfExpr(Index depth) {
   Expr* expr = Expr::CreateBrIf(Var(depth));
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnBrTableExpr(uint32_t num_targets,
-                                      uint32_t* target_depths,
-                                      uint32_t default_target_depth) {
+Result BinaryReaderIR::OnBrTableExpr(Index num_targets,
+                                     Index* target_depths,
+                                     Index default_target_depth) {
   VarVector* targets = new VarVector();
   targets->resize(num_targets);
-  for (uint32_t i = 0; i < num_targets; ++i) {
+  for (Index i = 0; i < num_targets; ++i) {
     (*targets)[i] = Var(target_depths[i]);
   }
   Expr* expr = Expr::CreateBrTable(targets, Var(default_target_depth));
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnCallExpr(uint32_t func_index) {
+Result BinaryReaderIR::OnCallExpr(Index func_index) {
   assert(func_index < module->funcs.size());
   Expr* expr = Expr::CreateCall(Var(func_index));
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnCallIndirectExpr(uint32_t sig_index) {
+Result BinaryReaderIR::OnCallIndirectExpr(Index sig_index) {
   assert(sig_index < module->func_types.size());
   Expr* expr = Expr::CreateCallIndirect(Var(sig_index));
   return AppendExpr(expr);
@@ -624,12 +619,12 @@ Result BinaryReaderIR::OnF64ConstExpr(uint64_t value_bits) {
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnGetGlobalExpr(uint32_t global_index) {
+Result BinaryReaderIR::OnGetGlobalExpr(Index global_index) {
   Expr* expr = Expr::CreateGetGlobal(Var(global_index));
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnGetLocalExpr(uint32_t local_index) {
+Result BinaryReaderIR::OnGetLocalExpr(Index local_index) {
   Expr* expr = Expr::CreateGetLocal(Var(local_index));
   return AppendExpr(expr);
 }
@@ -649,7 +644,7 @@ Result BinaryReaderIR::OnI64ConstExpr(uint64_t value) {
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnIfExpr(uint32_t num_types, Type* sig_types) {
+Result BinaryReaderIR::OnIfExpr(Index num_types, Type* sig_types) {
   Expr* expr = Expr::CreateIf(new Block());
   expr->if_.true_->sig.assign(sig_types, sig_types + num_types);
   expr->if_.false_ = nullptr;
@@ -659,13 +654,13 @@ Result BinaryReaderIR::OnIfExpr(uint32_t num_types, Type* sig_types) {
 }
 
 Result BinaryReaderIR::OnLoadExpr(Opcode opcode,
-                                   uint32_t alignment_log2,
-                                   uint32_t offset) {
+                                  uint32_t alignment_log2,
+                                  Address offset) {
   Expr* expr = Expr::CreateLoad(opcode, 1 << alignment_log2, offset);
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnLoopExpr(uint32_t num_types, Type* sig_types) {
+Result BinaryReaderIR::OnLoopExpr(Index num_types, Type* sig_types) {
   Expr* expr = Expr::CreateLoop(new Block());
   expr->loop->sig.assign(sig_types, sig_types + num_types);
   AppendExpr(expr);
@@ -688,24 +683,24 @@ Result BinaryReaderIR::OnSelectExpr() {
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnSetGlobalExpr(uint32_t global_index) {
+Result BinaryReaderIR::OnSetGlobalExpr(Index global_index) {
   Expr* expr = Expr::CreateSetGlobal(Var(global_index));
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnSetLocalExpr(uint32_t local_index) {
+Result BinaryReaderIR::OnSetLocalExpr(Index local_index) {
   Expr* expr = Expr::CreateSetLocal(Var(local_index));
   return AppendExpr(expr);
 }
 
 Result BinaryReaderIR::OnStoreExpr(Opcode opcode,
-                                    uint32_t alignment_log2,
-                                    uint32_t offset) {
+                                   uint32_t alignment_log2,
+                                   Address offset) {
   Expr* expr = Expr::CreateStore(opcode, 1 << alignment_log2, offset);
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::OnTeeLocalExpr(uint32_t local_index) {
+Result BinaryReaderIR::OnTeeLocalExpr(Index local_index) {
   Expr* expr = Expr::CreateTeeLocal(Var(local_index));
   return AppendExpr(expr);
 }
@@ -720,18 +715,18 @@ Result BinaryReaderIR::OnUnreachableExpr() {
   return AppendExpr(expr);
 }
 
-Result BinaryReaderIR::EndFunctionBody(uint32_t index) {
+Result BinaryReaderIR::EndFunctionBody(Index index) {
   CHECK_RESULT(PopLabel());
   current_func = nullptr;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnElemSegmentCount(uint32_t count) {
+Result BinaryReaderIR::OnElemSegmentCount(Index count) {
   module->elem_segments.reserve(count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginElemSegment(uint32_t index, uint32_t table_index) {
+Result BinaryReaderIR::BeginElemSegment(Index index, Index table_index) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::ElemSegment;
   field->elem_segment = new ElemSegment();
@@ -741,28 +736,28 @@ Result BinaryReaderIR::BeginElemSegment(uint32_t index, uint32_t table_index) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginElemSegmentInitExpr(uint32_t index) {
+Result BinaryReaderIR::BeginElemSegmentInitExpr(Index index) {
   assert(index == module->elem_segments.size() - 1);
   ElemSegment* segment = module->elem_segments[index];
   current_init_expr = &segment->offset;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::EndElemSegmentInitExpr(uint32_t index) {
+Result BinaryReaderIR::EndElemSegmentInitExpr(Index index) {
   current_init_expr = nullptr;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                        uint32_t count) {
+Result BinaryReaderIR::OnElemSegmentFunctionIndexCount(Index index,
+                                                       Index count) {
   assert(index == module->elem_segments.size() - 1);
   ElemSegment* segment = module->elem_segments[index];
   segment->vars.reserve(count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnElemSegmentFunctionIndex(uint32_t index,
-                                                   uint32_t func_index) {
+Result BinaryReaderIR::OnElemSegmentFunctionIndex(Index index,
+                                                  Index func_index) {
   assert(index == module->elem_segments.size() - 1);
   ElemSegment* segment = module->elem_segments[index];
   segment->vars.emplace_back();
@@ -772,13 +767,12 @@ Result BinaryReaderIR::OnElemSegmentFunctionIndex(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnDataSegmentCount(uint32_t count) {
+Result BinaryReaderIR::OnDataSegmentCount(Index count) {
   module->data_segments.reserve(count);
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginDataSegment(uint32_t index,
-                                         uint32_t memory_index) {
+Result BinaryReaderIR::BeginDataSegment(Index index, Index memory_index) {
   ModuleField* field = append_module_field(module);
   field->type = ModuleFieldType::DataSegment;
   field->data_segment = new DataSegment();
@@ -788,21 +782,21 @@ Result BinaryReaderIR::BeginDataSegment(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginDataSegmentInitExpr(uint32_t index) {
+Result BinaryReaderIR::BeginDataSegmentInitExpr(Index index) {
   assert(index == module->data_segments.size() - 1);
   DataSegment* segment = module->data_segments[index];
   current_init_expr = &segment->offset;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::EndDataSegmentInitExpr(uint32_t index) {
+Result BinaryReaderIR::EndDataSegmentInitExpr(Index index) {
   current_init_expr = nullptr;
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnDataSegmentData(uint32_t index,
-                                          const void* data,
-                                          uint32_t size) {
+Result BinaryReaderIR::OnDataSegmentData(Index index,
+                                         const void* data,
+                                         Address size) {
   assert(index == module->data_segments.size() - 1);
   DataSegment* segment = module->data_segments[index];
   segment->data = new char[size];
@@ -811,17 +805,17 @@ Result BinaryReaderIR::OnDataSegmentData(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnFunctionNamesCount(uint32_t count) {
+Result BinaryReaderIR::OnFunctionNamesCount(Index count) {
   if (count > module->funcs.size()) {
-    PrintError("expected function name count (%u) <= function count (%" PRIzd
-               ")",
+    PrintError("expected function name count (%" PRIindex
+               ") <= function count (%" PRIzd ")",
                count, module->funcs.size());
     return Result::Error;
   }
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnFunctionName(uint32_t index, StringSlice name) {
+Result BinaryReaderIR::OnFunctionName(Index index, StringSlice name) {
   if (string_slice_is_empty(&name))
     return Result::Ok;
 
@@ -831,54 +825,55 @@ Result BinaryReaderIR::OnFunctionName(uint32_t index, StringSlice name) {
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnLocalNameLocalCount(uint32_t index, uint32_t count) {
+Result BinaryReaderIR::OnLocalNameLocalCount(Index index, Index count) {
   assert(index < module->funcs.size());
   Func* func = module->funcs[index];
-  uint32_t num_params_and_locals = get_num_params_and_locals(func);
+  Index num_params_and_locals = get_num_params_and_locals(func);
   if (count > num_params_and_locals) {
-    PrintError("expected local name count (%d) <= local count (%d)", count,
-               num_params_and_locals);
+    PrintError("expected local name count (%" PRIindex
+               ") <= local count (%" PRIindex ")",
+               count, num_params_and_locals);
     return Result::Error;
   }
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnInitExprF32ConstExpr(uint32_t index, uint32_t value) {
+Result BinaryReaderIR::OnInitExprF32ConstExpr(Index index, uint32_t value) {
   *current_init_expr = Expr::CreateConst(Const(Const::F32(), value));
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnInitExprF64ConstExpr(uint32_t index, uint64_t value) {
+Result BinaryReaderIR::OnInitExprF64ConstExpr(Index index, uint64_t value) {
   *current_init_expr = Expr::CreateConst(Const(Const::F64(), value));
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnInitExprGetGlobalExpr(uint32_t index,
-                                                uint32_t global_index) {
+Result BinaryReaderIR::OnInitExprGetGlobalExpr(Index index,
+                                               Index global_index) {
   *current_init_expr = Expr::CreateGetGlobal(Var(global_index));
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnInitExprI32ConstExpr(uint32_t index, uint32_t value) {
+Result BinaryReaderIR::OnInitExprI32ConstExpr(Index index, uint32_t value) {
   *current_init_expr = Expr::CreateConst(Const(Const::I32(), value));
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnInitExprI64ConstExpr(uint32_t index, uint64_t value) {
+Result BinaryReaderIR::OnInitExprI64ConstExpr(Index index, uint64_t value) {
   *current_init_expr = Expr::CreateConst(Const(Const::I64(), value));
   return Result::Ok;
 }
 
-Result BinaryReaderIR::OnLocalName(uint32_t func_index,
-                                    uint32_t local_index,
-                                    StringSlice name) {
+Result BinaryReaderIR::OnLocalName(Index func_index,
+                                   Index local_index,
+                                   StringSlice name) {
   if (string_slice_is_empty(&name))
     return Result::Ok;
 
   Func* func = module->funcs[func_index];
-  uint32_t num_params = get_num_params(func);
+  Index num_params = get_num_params(func);
   BindingHash* bindings;
-  uint32_t index;
+  Index index;
   if (local_index < num_params) {
     /* param name */
     bindings = &func->param_bindings;

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -32,71 +32,71 @@ class BinaryReaderLinker : public BinaryReaderNop {
  public:
   explicit BinaryReaderLinker(LinkerInputBinary* binary);
 
-  virtual Result BeginSection(BinarySection section_type, uint32_t size);
+  Result BeginSection(BinarySection section_type, Offset size) override;
 
-  virtual Result OnImport(uint32_t index,
-                          StringSlice module_name,
-                          StringSlice field_name);
-  virtual Result OnImportFunc(uint32_t import_index,
-                              StringSlice module_name,
-                              StringSlice field_name,
-                              uint32_t func_index,
-                              uint32_t sig_index);
-  virtual Result OnImportGlobal(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t global_index,
-                                Type type,
-                                bool mutable_);
+  Result OnImport(Index index,
+                  StringSlice module_name,
+                  StringSlice field_name) override;
+  Result OnImportFunc(Index import_index,
+                      StringSlice module_name,
+                      StringSlice field_name,
+                      Index func_index,
+                      Index sig_index) override;
+  Result OnImportGlobal(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index global_index,
+                        Type type,
+                        bool mutable_) override;
 
-  virtual Result OnFunctionCount(uint32_t count);
+  Result OnFunctionCount(Index count) override;
 
-  virtual Result OnTable(uint32_t index,
-                         Type elem_type,
-                         const Limits* elem_limits);
+  Result OnTable(Index index,
+                 Type elem_type,
+                 const Limits* elem_limits) override;
 
-  virtual Result OnMemory(uint32_t index, const Limits* limits);
+  Result OnMemory(Index index, const Limits* limits) override;
 
-  virtual Result OnExport(uint32_t index,
-                          ExternalKind kind,
-                          uint32_t item_index,
-                          StringSlice name);
+  Result OnExport(Index index,
+                  ExternalKind kind,
+                  Index item_index,
+                  StringSlice name) override;
 
-  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                 uint32_t count);
+  Result OnElemSegmentFunctionIndexCount(Index index,
+                                         Index count) override;
 
-  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index);
-  virtual Result OnDataSegmentData(uint32_t index,
-                                   const void* data,
-                                   uint32_t size);
+  Result BeginDataSegment(Index index, Index memory_index) override;
+  Result OnDataSegmentData(Index index,
+                           const void* data,
+                           Address size) override;
 
-  virtual Result BeginNamesSection(uint32_t size);
+  Result BeginNamesSection(Offset size) override;
 
-  virtual Result OnFunctionName(uint32_t function_index,
-                                StringSlice function_name);
+  Result OnFunctionName(Index function_index,
+                        StringSlice function_name) override;
 
-  virtual Result OnRelocCount(uint32_t count,
-                              BinarySection section_code,
-                              StringSlice section_name);
-  virtual Result OnReloc(RelocType type,
-                         uint32_t offset,
-                         uint32_t index,
-                         uint32_t addend);
+  Result OnRelocCount(Index count,
+                      BinarySection section_code,
+                      StringSlice section_name) override;
+  Result OnReloc(RelocType type,
+                 Offset offset,
+                 Index index,
+                 uint32_t addend) override;
 
-  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
+  Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
 
  private:
   LinkerInputBinary* binary;
 
   Section* reloc_section = nullptr;
   Section* current_section = nullptr;
-  uint32_t function_count = 0;
+  Index function_count = 0;
 };
 
 BinaryReaderLinker::BinaryReaderLinker(LinkerInputBinary* binary)
     : binary(binary) {}
 
-Result BinaryReaderLinker::OnRelocCount(uint32_t count,
+Result BinaryReaderLinker::OnRelocCount(Index count,
                                         BinarySection section_code,
                                         StringSlice section_name) {
   if (section_code == BinarySection::Custom) {
@@ -115,11 +115,11 @@ Result BinaryReaderLinker::OnRelocCount(uint32_t count,
 }
 
 Result BinaryReaderLinker::OnReloc(RelocType type,
-                                   uint32_t offset,
-                                   uint32_t index,
+                                   Offset offset,
+                                   Index index,
                                    uint32_t addend) {
   if (offset + RELOC_SIZE > reloc_section->size) {
-    WABT_FATAL("invalid relocation offset: %#x\n", offset);
+    WABT_FATAL("invalid relocation offset: %#" PRIoffset "\n", offset);
   }
 
   reloc_section->relocations.emplace_back(type, offset, index, addend);
@@ -127,7 +127,7 @@ Result BinaryReaderLinker::OnReloc(RelocType type,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnImport(uint32_t index,
+Result BinaryReaderLinker::OnImport(Index index,
                                     StringSlice module_name,
                                     StringSlice field_name) {
   if (!string_slice_eq_cstr(&module_name, WABT_LINK_MODULE_NAME)) {
@@ -137,11 +137,11 @@ Result BinaryReaderLinker::OnImport(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnImportFunc(uint32_t import_index,
+Result BinaryReaderLinker::OnImportFunc(Index import_index,
                                         StringSlice module_name,
                                         StringSlice field_name,
-                                        uint32_t global_index,
-                                        uint32_t sig_index) {
+                                        Index global_index,
+                                        Index sig_index) {
   binary->function_imports.emplace_back();
   FunctionImport* import = &binary->function_imports.back();
   import->name = field_name;
@@ -151,10 +151,10 @@ Result BinaryReaderLinker::OnImportFunc(uint32_t import_index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnImportGlobal(uint32_t import_index,
+Result BinaryReaderLinker::OnImportGlobal(Index import_index,
                                           StringSlice module_name,
                                           StringSlice field_name,
-                                          uint32_t global_index,
+                                          Index global_index,
                                           Type type,
                                           bool mutable_) {
   binary->global_imports.emplace_back();
@@ -166,13 +166,13 @@ Result BinaryReaderLinker::OnImportGlobal(uint32_t import_index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnFunctionCount(uint32_t count) {
+Result BinaryReaderLinker::OnFunctionCount(Index count) {
   function_count = count;
   return Result::Ok;
 }
 
 Result BinaryReaderLinker::BeginSection(BinarySection section_code,
-                                        uint32_t size) {
+                                        Offset size) {
   Section* sec = new Section();
   binary->sections.emplace_back(sec);
   current_section = sec;
@@ -193,7 +193,7 @@ Result BinaryReaderLinker::BeginSection(BinarySection section_code,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnTable(uint32_t index,
+Result BinaryReaderLinker::OnTable(Index index,
                                    Type elem_type,
                                    const Limits* elem_limits) {
   if (elem_limits->has_max && (elem_limits->max != elem_limits->initial))
@@ -203,8 +203,8 @@ Result BinaryReaderLinker::OnTable(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                           uint32_t count) {
+Result BinaryReaderLinker::OnElemSegmentFunctionIndexCount(Index index,
+                                                           Index count) {
   Section* sec = current_section;
 
   /* Modify the payload to include only the actual function indexes */
@@ -214,15 +214,14 @@ Result BinaryReaderLinker::OnElemSegmentFunctionIndexCount(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnMemory(uint32_t index, const Limits* page_limits) {
+Result BinaryReaderLinker::OnMemory(Index index, const Limits* page_limits) {
   Section* sec = current_section;
   sec->data.memory_limits = *page_limits;
   binary->memory_page_count = page_limits->initial;
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::BeginDataSegment(uint32_t index,
-                                            uint32_t memory_index) {
+Result BinaryReaderLinker::BeginDataSegment(Index index, Index memory_index) {
   Section* sec = current_section;
   if (!sec->data.data_segments) {
     sec->data.data_segments = new std::vector<DataSegment>();
@@ -233,8 +232,7 @@ Result BinaryReaderLinker::BeginDataSegment(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnInitExprI32ConstExpr(uint32_t index,
-                                                  uint32_t value) {
+Result BinaryReaderLinker::OnInitExprI32ConstExpr(Index index, uint32_t value) {
   Section* sec = current_section;
   if (sec->section_code != BinarySection::Data)
     return Result::Ok;
@@ -243,9 +241,9 @@ Result BinaryReaderLinker::OnInitExprI32ConstExpr(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnDataSegmentData(uint32_t index,
+Result BinaryReaderLinker::OnDataSegmentData(Index index,
                                              const void* src_data,
-                                             uint32_t size) {
+                                             Address size) {
   Section* sec = current_section;
   DataSegment& segment = sec->data.data_segments->back();
   segment.data = static_cast<const uint8_t*>(src_data);
@@ -253,9 +251,9 @@ Result BinaryReaderLinker::OnDataSegmentData(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnExport(uint32_t index,
+Result BinaryReaderLinker::OnExport(Index index,
                                     ExternalKind kind,
-                                    uint32_t item_index,
+                                    Index item_index,
                                     StringSlice name) {
   binary->exports.emplace_back();
   Export* export_ = &binary->exports.back();
@@ -265,12 +263,12 @@ Result BinaryReaderLinker::OnExport(uint32_t index,
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::BeginNamesSection(uint32_t size) {
+Result BinaryReaderLinker::BeginNamesSection(Offset size) {
   binary->debug_names.resize(function_count + binary->function_imports.size());
   return Result::Ok;
 }
 
-Result BinaryReaderLinker::OnFunctionName(uint32_t index, StringSlice name) {
+Result BinaryReaderLinker::OnFunctionName(Index index, StringSlice name) {
   binary->debug_names[index] = string_slice_to_string(name);
   return Result::Ok;
 }

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -75,9 +75,9 @@ void BinaryReaderLogging::WriteIndent() {
   }
 }
 
-void BinaryReaderLogging::LogTypes(uint32_t type_count, Type* types) {
+void BinaryReaderLogging::LogTypes(Index type_count, Type* types) {
   LOGF_NOINDENT("[");
-  for (uint32_t i = 0; i < type_count; ++i) {
+  for (Index i = 0; i < type_count; ++i) {
     LOGF_NOINDENT("%s", get_type_name(types[i]));
     if (i != type_count - 1)
       LOGF_NOINDENT(", ");
@@ -101,24 +101,24 @@ Result BinaryReaderLogging::BeginModule(uint32_t version) {
 }
 
 Result BinaryReaderLogging::BeginSection(BinarySection section_type,
-                                         uint32_t size) {
+                                         Offset size) {
   return reader->BeginSection(section_type, size);
 }
 
-Result BinaryReaderLogging::BeginCustomSection(uint32_t size,
+Result BinaryReaderLogging::BeginCustomSection(Offset size,
                                                StringSlice section_name) {
-  LOGF("BeginCustomSection('" PRIstringslice "', size: %d)\n",
+  LOGF("BeginCustomSection('" PRIstringslice "', size: %" PRIzd ")\n",
        WABT_PRINTF_STRING_SLICE_ARG(section_name), size);
   Indent();
   return reader->BeginCustomSection(size, section_name);
 }
 
-Result BinaryReaderLogging::OnType(uint32_t index,
-                                   uint32_t param_count,
+Result BinaryReaderLogging::OnType(Index index,
+                                   Index param_count,
                                    Type* param_types,
-                                   uint32_t result_count,
+                                   Index result_count,
                                    Type* result_types) {
-  LOGF("OnType(index: %u, params: ", index);
+  LOGF("OnType(index: %" PRIindex ", params: ", index);
   LogTypes(param_count, param_types);
   LOGF_NOINDENT(", results: ");
   LogTypes(result_count, result_types);
@@ -127,141 +127,144 @@ Result BinaryReaderLogging::OnType(uint32_t index,
                         result_types);
 }
 
-Result BinaryReaderLogging::OnImport(uint32_t index,
+Result BinaryReaderLogging::OnImport(Index index,
                                      StringSlice module_name,
                                      StringSlice field_name) {
-  LOGF("OnImport(index: %u, module: \"" PRIstringslice
+  LOGF("OnImport(index: %" PRIindex ", module: \"" PRIstringslice
        "\", field: \"" PRIstringslice "\")\n",
        index, WABT_PRINTF_STRING_SLICE_ARG(module_name),
        WABT_PRINTF_STRING_SLICE_ARG(field_name));
   return reader->OnImport(index, module_name, field_name);
 }
 
-Result BinaryReaderLogging::OnImportFunc(uint32_t import_index,
+Result BinaryReaderLogging::OnImportFunc(Index import_index,
                                          StringSlice module_name,
                                          StringSlice field_name,
-                                         uint32_t func_index,
-                                         uint32_t sig_index) {
-  LOGF("OnImportFunc(import_index: %u, func_index: %u, sig_index: %u)\n",
+                                         Index func_index,
+                                         Index sig_index) {
+  LOGF("OnImportFunc(import_index: %" PRIindex ", func_index: %" PRIindex
+       ", sig_index: %" PRIindex ")\n",
        import_index, func_index, sig_index);
   return reader->OnImportFunc(import_index, module_name, field_name, func_index,
                               sig_index);
 }
 
-Result BinaryReaderLogging::OnImportTable(uint32_t import_index,
+Result BinaryReaderLogging::OnImportTable(Index import_index,
                                           StringSlice module_name,
                                           StringSlice field_name,
-                                          uint32_t table_index,
+                                          Index table_index,
                                           Type elem_type,
                                           const Limits* elem_limits) {
   char buf[100];
   sprint_limits(buf, sizeof(buf), elem_limits);
-  LOGF("OnImportTable(import_index: %u, table_index: %u, elem_type: %s, %s)\n",
+  LOGF("OnImportTable(import_index: %" PRIindex ", table_index: %" PRIindex
+       ", elem_type: %s, %s)\n",
        import_index, table_index, get_type_name(elem_type), buf);
   return reader->OnImportTable(import_index, module_name, field_name,
                                table_index, elem_type, elem_limits);
 }
 
-Result BinaryReaderLogging::OnImportMemory(uint32_t import_index,
+Result BinaryReaderLogging::OnImportMemory(Index import_index,
                                            StringSlice module_name,
                                            StringSlice field_name,
-                                           uint32_t memory_index,
+                                           Index memory_index,
                                            const Limits* page_limits) {
   char buf[100];
   sprint_limits(buf, sizeof(buf), page_limits);
-  LOGF("OnImportMemory(import_index: %u, memory_index: %u, %s)\n", import_index,
-       memory_index, buf);
+  LOGF("OnImportMemory(import_index: %" PRIindex ", memory_index: %" PRIindex
+       ", %s)\n",
+       import_index, memory_index, buf);
   return reader->OnImportMemory(import_index, module_name, field_name,
                                 memory_index, page_limits);
 }
 
-Result BinaryReaderLogging::OnImportGlobal(uint32_t import_index,
+Result BinaryReaderLogging::OnImportGlobal(Index import_index,
                                            StringSlice module_name,
                                            StringSlice field_name,
-                                           uint32_t global_index,
+                                           Index global_index,
                                            Type type,
                                            bool mutable_) {
-  LOGF(
-      "OnImportGlobal(import_index: %u, global_index: %u, type: %s, mutable: "
-      "%s)\n",
-      import_index, global_index, get_type_name(type),
-      mutable_ ? "true" : "false");
+  LOGF("OnImportGlobal(import_index: %" PRIindex ", global_index: %" PRIindex
+       ", type: %s, mutable: "
+       "%s)\n",
+       import_index, global_index, get_type_name(type),
+       mutable_ ? "true" : "false");
   return reader->OnImportGlobal(import_index, module_name, field_name,
                                 global_index, type, mutable_);
 }
 
-Result BinaryReaderLogging::OnTable(uint32_t index,
+Result BinaryReaderLogging::OnTable(Index index,
                                     Type elem_type,
                                     const Limits* elem_limits) {
   char buf[100];
   sprint_limits(buf, sizeof(buf), elem_limits);
-  LOGF("OnTable(index: %u, elem_type: %s, %s)\n", index,
+  LOGF("OnTable(index: %" PRIindex ", elem_type: %s, %s)\n", index,
        get_type_name(elem_type), buf);
   return reader->OnTable(index, elem_type, elem_limits);
 }
 
-Result BinaryReaderLogging::OnMemory(uint32_t index,
+Result BinaryReaderLogging::OnMemory(Index index,
                                      const Limits* page_limits) {
   char buf[100];
   sprint_limits(buf, sizeof(buf), page_limits);
-  LOGF("OnMemory(index: %u, %s)\n", index, buf);
+  LOGF("OnMemory(index: %" PRIindex ", %s)\n", index, buf);
   return reader->OnMemory(index, page_limits);
 }
 
-Result BinaryReaderLogging::BeginGlobal(uint32_t index,
+Result BinaryReaderLogging::BeginGlobal(Index index,
                                         Type type,
                                         bool mutable_) {
-  LOGF("BeginGlobal(index: %u, type: %s, mutable: %s)\n", index,
+  LOGF("BeginGlobal(index: %" PRIindex ", type: %s, mutable: %s)\n", index,
        get_type_name(type), mutable_ ? "true" : "false");
   return reader->BeginGlobal(index, type, mutable_);
 }
 
-Result BinaryReaderLogging::OnExport(uint32_t index,
+Result BinaryReaderLogging::OnExport(Index index,
                                      ExternalKind kind,
-                                     uint32_t item_index,
+                                     Index item_index,
                                      StringSlice name) {
-  LOGF("OnExport(index: %u, kind: %s, item_index: %u, name: \"" PRIstringslice
-       "\")\n",
+  LOGF("OnExport(index: %" PRIindex ", kind: %s, item_index: %" PRIindex
+       ", name: \"" PRIstringslice "\")\n",
        index, get_kind_name(kind), item_index,
        WABT_PRINTF_STRING_SLICE_ARG(name));
   return reader->OnExport(index, kind, item_index, name);
 }
 
-Result BinaryReaderLogging::OnLocalDecl(uint32_t decl_index,
-                                        uint32_t count,
+Result BinaryReaderLogging::OnLocalDecl(Index decl_index,
+                                        Index count,
                                         Type type) {
-  LOGF("OnLocalDecl(index: %u, count: %u, type: %s)\n", decl_index, count,
-       get_type_name(type));
+  LOGF("OnLocalDecl(index: %" PRIindex ", count: %" PRIindex ", type: %s)\n",
+       decl_index, count, get_type_name(type));
   return reader->OnLocalDecl(decl_index, count, type);
 }
 
-Result BinaryReaderLogging::OnBlockExpr(uint32_t num_types, Type* sig_types) {
+Result BinaryReaderLogging::OnBlockExpr(Index num_types, Type* sig_types) {
   LOGF("OnBlockExpr(sig: ");
   LogTypes(num_types, sig_types);
   LOGF_NOINDENT(")\n");
   return reader->OnBlockExpr(num_types, sig_types);
 }
 
-Result BinaryReaderLogging::OnBrExpr(uint32_t depth) {
-  LOGF("OnBrExpr(depth: %u)\n", depth);
+Result BinaryReaderLogging::OnBrExpr(Index depth) {
+  LOGF("OnBrExpr(depth: %" PRIindex ")\n", depth);
   return reader->OnBrExpr(depth);
 }
 
-Result BinaryReaderLogging::OnBrIfExpr(uint32_t depth) {
-  LOGF("OnBrIfExpr(depth: %u)\n", depth);
+Result BinaryReaderLogging::OnBrIfExpr(Index depth) {
+  LOGF("OnBrIfExpr(depth: %" PRIindex ")\n", depth);
   return reader->OnBrIfExpr(depth);
 }
 
-Result BinaryReaderLogging::OnBrTableExpr(uint32_t num_targets,
-                                          uint32_t* target_depths,
-                                          uint32_t default_target_depth) {
-  LOGF("OnBrTableExpr(num_targets: %u, depths: [", num_targets);
-  for (uint32_t i = 0; i < num_targets; ++i) {
-    LOGF_NOINDENT("%u", target_depths[i]);
+Result BinaryReaderLogging::OnBrTableExpr(Index num_targets,
+                                          Index* target_depths,
+                                          Index default_target_depth) {
+  LOGF("OnBrTableExpr(num_targets: %" PRIindex ", depths: [", num_targets);
+  for (Index i = 0; i < num_targets; ++i) {
+    LOGF_NOINDENT("%" PRIindex, target_depths[i]);
     if (i != num_targets - 1)
       LOGF_NOINDENT(", ");
   }
-  LOGF_NOINDENT("], default: %u)\n", default_target_depth);
+  LOGF_NOINDENT("], default: %" PRIindex ")\n", default_target_depth);
   return reader->OnBrTableExpr(num_targets, target_depths,
                                default_target_depth);
 }
@@ -290,7 +293,7 @@ Result BinaryReaderLogging::OnI64ConstExpr(uint64_t value) {
   return reader->OnI64ConstExpr(value);
 }
 
-Result BinaryReaderLogging::OnIfExpr(uint32_t num_types, Type* sig_types) {
+Result BinaryReaderLogging::OnIfExpr(Index num_types, Type* sig_types) {
   LOGF("OnIfExpr(sig: ");
   LogTypes(num_types, sig_types);
   LOGF_NOINDENT(")\n");
@@ -299,14 +302,15 @@ Result BinaryReaderLogging::OnIfExpr(uint32_t num_types, Type* sig_types) {
 
 Result BinaryReaderLogging::OnLoadExpr(Opcode opcode,
                                        uint32_t alignment_log2,
-                                       uint32_t offset) {
-  LOGF("OnLoadExpr(opcode: \"%s\" (%u), align log2: %u, offset: %u)\n",
+                                       Address offset) {
+  LOGF("OnLoadExpr(opcode: \"%s\" (%u), align log2: %u, offset: %" PRIaddress
+       ")\n",
        get_opcode_name(opcode), static_cast<unsigned>(opcode), alignment_log2,
        offset);
   return reader->OnLoadExpr(opcode, alignment_log2, offset);
 }
 
-Result BinaryReaderLogging::OnLoopExpr(uint32_t num_types, Type* sig_types) {
+Result BinaryReaderLogging::OnLoopExpr(Index num_types, Type* sig_types) {
   LOGF("OnLoopExpr(sig: ");
   LogTypes(num_types, sig_types);
   LOGF_NOINDENT(")\n");
@@ -315,106 +319,114 @@ Result BinaryReaderLogging::OnLoopExpr(uint32_t num_types, Type* sig_types) {
 
 Result BinaryReaderLogging::OnStoreExpr(Opcode opcode,
                                         uint32_t alignment_log2,
-                                        uint32_t offset) {
-  LOGF("OnStoreExpr(opcode: \"%s\" (%u), align log2: %u, offset: %u)\n",
+                                        Address offset) {
+  LOGF("OnStoreExpr(opcode: \"%s\" (%u), align log2: %u, offset: %" PRIaddress
+       ")\n",
        get_opcode_name(opcode), static_cast<unsigned>(opcode), alignment_log2,
        offset);
   return reader->OnStoreExpr(opcode, alignment_log2, offset);
 }
 
-Result BinaryReaderLogging::OnDataSegmentData(uint32_t index,
+Result BinaryReaderLogging::OnDataSegmentData(Index index,
                                               const void* data,
-                                              uint32_t size) {
-  LOGF("OnDataSegmentData(index:%u, size:%u)\n", index, size);
+                                              Address size) {
+  LOGF("OnDataSegmentData(index:%" PRIindex ", size:%" PRIaddress ")\n", index,
+       size);
   return reader->OnDataSegmentData(index, data, size);
 }
 
-Result BinaryReaderLogging::OnFunctionNameSubsection(uint32_t index,
+Result BinaryReaderLogging::OnFunctionNameSubsection(Index index,
                                                      uint32_t name_type,
-                                                     uint32_t subsection_size) {
-  LOGF("OnFunctionNameSubsection(index:%u, nametype:%u, size:%u)\n", index,
-       name_type, subsection_size);
+                                                     Offset subsection_size) {
+  LOGF("OnFunctionNameSubsection(index:%" PRIindex ", nametype:%u, size:%" PRIzd
+       ")\n",
+       index, name_type, subsection_size);
   return reader->OnFunctionNameSubsection(index, name_type, subsection_size);
 }
 
-Result BinaryReaderLogging::OnFunctionName(uint32_t index, StringSlice name) {
-  LOGF("OnFunctionName(index: %u, name: \"" PRIstringslice "\")\n", index,
-       WABT_PRINTF_STRING_SLICE_ARG(name));
+Result BinaryReaderLogging::OnFunctionName(Index index, StringSlice name) {
+  LOGF("OnFunctionName(index: %" PRIindex ", name: \"" PRIstringslice "\")\n",
+       index, WABT_PRINTF_STRING_SLICE_ARG(name));
   return reader->OnFunctionName(index, name);
 }
 
-Result BinaryReaderLogging::OnLocalNameSubsection(uint32_t index,
+Result BinaryReaderLogging::OnLocalNameSubsection(Index index,
                                                   uint32_t name_type,
-                                                  uint32_t subsection_size) {
-  LOGF("OnLocalNameSubsection(index:%u, nametype:%u, size:%u)\n", index,
-       name_type, subsection_size);
+                                                  Offset subsection_size) {
+  LOGF("OnLocalNameSubsection(index:%" PRIindex ", nametype:%u, size:%" PRIzd
+       ")\n",
+       index, name_type, subsection_size);
   return reader->OnLocalNameSubsection(index, name_type, subsection_size);
 }
 
-Result BinaryReaderLogging::OnLocalName(uint32_t func_index,
-                                        uint32_t local_index,
+Result BinaryReaderLogging::OnLocalName(Index func_index,
+                                        Index local_index,
                                         StringSlice name) {
-  LOGF("OnLocalName(func_index: %u, local_index: %u, name: \"" PRIstringslice
-       "\")\n",
+  LOGF("OnLocalName(func_index: %" PRIindex ", local_index: %" PRIindex
+       ", name: \"" PRIstringslice "\")\n",
        func_index, local_index, WABT_PRINTF_STRING_SLICE_ARG(name));
   return reader->OnLocalName(func_index, local_index, name);
 }
 
-Result BinaryReaderLogging::OnInitExprF32ConstExpr(uint32_t index,
+Result BinaryReaderLogging::OnInitExprF32ConstExpr(Index index,
                                                    uint32_t value_bits) {
   float value;
   memcpy(&value, &value_bits, sizeof(value));
-  LOGF("OnInitExprF32ConstExpr(index: %u, value: %g (0x04%x))\n", index, value,
-       value_bits);
+  LOGF("OnInitExprF32ConstExpr(index: %" PRIindex ", value: %g (0x04%x))\n",
+       index, value, value_bits);
   return reader->OnInitExprF32ConstExpr(index, value_bits);
 }
 
-Result BinaryReaderLogging::OnInitExprF64ConstExpr(uint32_t index,
+Result BinaryReaderLogging::OnInitExprF64ConstExpr(Index index,
                                                    uint64_t value_bits) {
   double value;
   memcpy(&value, &value_bits, sizeof(value));
-  LOGF("OnInitExprF64ConstExpr(index: %u value: %g (0x08%" PRIx64 "))\n", index,
-       value, value_bits);
+  LOGF("OnInitExprF64ConstExpr(index: %" PRIindex " value: %g (0x08%" PRIx64
+       "))\n",
+       index, value, value_bits);
   return reader->OnInitExprF64ConstExpr(index, value_bits);
 }
 
-Result BinaryReaderLogging::OnInitExprI32ConstExpr(uint32_t index,
+Result BinaryReaderLogging::OnInitExprI32ConstExpr(Index index,
                                                    uint32_t value) {
-  LOGF("OnInitExprI32ConstExpr(index: %u, value: %u)\n", index, value);
+  LOGF("OnInitExprI32ConstExpr(index: %" PRIindex ", value: %u)\n", index,
+       value);
   return reader->OnInitExprI32ConstExpr(index, value);
 }
 
-Result BinaryReaderLogging::OnInitExprI64ConstExpr(uint32_t index,
+Result BinaryReaderLogging::OnInitExprI64ConstExpr(Index index,
                                                    uint64_t value) {
-  LOGF("OnInitExprI64ConstExpr(index: %u, value: %" PRIu64 ")\n", index, value);
+  LOGF("OnInitExprI64ConstExpr(index: %" PRIindex ", value: %" PRIu64 ")\n",
+       index, value);
   return reader->OnInitExprI64ConstExpr(index, value);
 }
 
-Result BinaryReaderLogging::OnRelocCount(uint32_t count,
+Result BinaryReaderLogging::OnRelocCount(Index count,
                                          BinarySection section_code,
                                          StringSlice section_name) {
-  LOGF("OnRelocCount(count: %d, section: %s, section_name: " PRIstringslice
-       ")\n",
+  LOGF("OnRelocCount(count: %" PRIindex
+       ", section: %s, section_name: " PRIstringslice ")\n",
        count, get_section_name(section_code),
        WABT_PRINTF_STRING_SLICE_ARG(section_name));
   return reader->OnRelocCount(count, section_code, section_name);
 }
 
 Result BinaryReaderLogging::OnReloc(RelocType type,
-                                    uint32_t offset,
-                                    uint32_t index,
+                                    Offset offset,
+                                    Index index,
                                     uint32_t addend) {
   int32_t signed_addend = static_cast<int32_t>(addend);
-  LOGF("OnReloc(type: %s, offset: %u, index: %u, addend: %d)\n",
+  LOGF("OnReloc(type: %s, offset: %" PRIzd ", index: %" PRIindex
+       ", addend: %d)\n",
        get_reloc_type_name(type), offset, index, signed_addend);
   return reader->OnReloc(type, offset, index, addend);
 }
 
-#define DEFINE_BEGIN(name)                          \
-  Result BinaryReaderLogging::name(uint32_t size) { \
-    LOGF(#name "(%u)\n", size);                     \
-    Indent();                                       \
-    return reader->name(size);                      \
+#define DEFINE_BEGIN(name)                        \
+  Result BinaryReaderLogging::name(Offset size) { \
+    LOGF(#name "(%" PRIzd ")\n", size);           \
+    Indent();                                     \
+    return reader->name(size);                    \
   }
 
 #define DEFINE_END(name)               \
@@ -424,22 +436,23 @@ Result BinaryReaderLogging::OnReloc(RelocType type,
     return reader->name();             \
   }
 
-#define DEFINE_UINT32(name)                          \
-  Result BinaryReaderLogging::name(uint32_t value) { \
-    LOGF(#name "(%u)\n", value);                     \
-    return reader->name(value);                      \
+#define DEFINE_INDEX(name)                        \
+  Result BinaryReaderLogging::name(Index value) { \
+    LOGF(#name "(%" PRIindex ")\n", value);       \
+    return reader->name(value);                   \
   }
 
-#define DEFINE_UINT32_DESC(name, desc)               \
-  Result BinaryReaderLogging::name(uint32_t value) { \
-    LOGF(#name "(" desc ": %u)\n", value);           \
-    return reader->name(value);                      \
+#define DEFINE_INDEX_DESC(name, desc)                 \
+  Result BinaryReaderLogging::name(Index value) {     \
+    LOGF(#name "(" desc ": %" PRIindex ")\n", value); \
+    return reader->name(value);                       \
   }
 
-#define DEFINE_UINT32_UINT32(name, desc0, desc1)                       \
-  Result BinaryReaderLogging::name(uint32_t value0, uint32_t value1) { \
-    LOGF(#name "(" desc0 ": %u, " desc1 ": %u)\n", value0, value1);    \
-    return reader->name(value0, value1);                               \
+#define DEFINE_INDEX_INDEX(name, desc0, desc1)                           \
+  Result BinaryReaderLogging::name(Index value0, Index value1) {         \
+    LOGF(#name "(" desc0 ": %" PRIindex ", " desc1 ": %" PRIindex ")\n", \
+         value0, value1);                                                \
+    return reader->name(value0, value1);                                 \
   }
 
 #define DEFINE_OPCODE(name)                                \
@@ -460,95 +473,95 @@ DEFINE_END(EndModule)
 DEFINE_END(EndCustomSection)
 
 DEFINE_BEGIN(BeginTypeSection)
-DEFINE_UINT32(OnTypeCount)
+DEFINE_INDEX(OnTypeCount)
 DEFINE_END(EndTypeSection)
 
 DEFINE_BEGIN(BeginImportSection)
-DEFINE_UINT32(OnImportCount)
+DEFINE_INDEX(OnImportCount)
 DEFINE_END(EndImportSection)
 
 DEFINE_BEGIN(BeginFunctionSection)
-DEFINE_UINT32(OnFunctionCount)
-DEFINE_UINT32_UINT32(OnFunction, "index", "sig_index")
+DEFINE_INDEX(OnFunctionCount)
+DEFINE_INDEX_INDEX(OnFunction, "index", "sig_index")
 DEFINE_END(EndFunctionSection)
 
 DEFINE_BEGIN(BeginTableSection)
-DEFINE_UINT32(OnTableCount)
+DEFINE_INDEX(OnTableCount)
 DEFINE_END(EndTableSection)
 
 DEFINE_BEGIN(BeginMemorySection)
-DEFINE_UINT32(OnMemoryCount)
+DEFINE_INDEX(OnMemoryCount)
 DEFINE_END(EndMemorySection)
 
 DEFINE_BEGIN(BeginGlobalSection)
-DEFINE_UINT32(OnGlobalCount)
-DEFINE_UINT32(BeginGlobalInitExpr)
-DEFINE_UINT32(EndGlobalInitExpr)
-DEFINE_UINT32(EndGlobal)
+DEFINE_INDEX(OnGlobalCount)
+DEFINE_INDEX(BeginGlobalInitExpr)
+DEFINE_INDEX(EndGlobalInitExpr)
+DEFINE_INDEX(EndGlobal)
 DEFINE_END(EndGlobalSection)
 
 DEFINE_BEGIN(BeginExportSection)
-DEFINE_UINT32(OnExportCount)
+DEFINE_INDEX(OnExportCount)
 DEFINE_END(EndExportSection)
 
 DEFINE_BEGIN(BeginStartSection)
-DEFINE_UINT32(OnStartFunction)
+DEFINE_INDEX(OnStartFunction)
 DEFINE_END(EndStartSection)
 
 DEFINE_BEGIN(BeginCodeSection)
-DEFINE_UINT32(OnFunctionBodyCount)
-DEFINE_UINT32(BeginFunctionBody)
-DEFINE_UINT32(EndFunctionBody)
-DEFINE_UINT32(OnLocalDeclCount)
+DEFINE_INDEX(OnFunctionBodyCount)
+DEFINE_INDEX(BeginFunctionBody)
+DEFINE_INDEX(EndFunctionBody)
+DEFINE_INDEX(OnLocalDeclCount)
 DEFINE_OPCODE(OnBinaryExpr)
-DEFINE_UINT32_DESC(OnCallExpr, "func_index")
-DEFINE_UINT32_DESC(OnCallIndirectExpr, "sig_index")
+DEFINE_INDEX_DESC(OnCallExpr, "func_index")
+DEFINE_INDEX_DESC(OnCallIndirectExpr, "sig_index")
 DEFINE_OPCODE(OnCompareExpr)
 DEFINE_OPCODE(OnConvertExpr)
 DEFINE0(OnCurrentMemoryExpr)
 DEFINE0(OnDropExpr)
 DEFINE0(OnElseExpr)
 DEFINE0(OnEndExpr)
-DEFINE_UINT32_DESC(OnGetGlobalExpr, "index")
-DEFINE_UINT32_DESC(OnGetLocalExpr, "index")
+DEFINE_INDEX_DESC(OnGetGlobalExpr, "index")
+DEFINE_INDEX_DESC(OnGetLocalExpr, "index")
 DEFINE0(OnGrowMemoryExpr)
 DEFINE0(OnNopExpr)
 DEFINE0(OnReturnExpr)
 DEFINE0(OnSelectExpr)
-DEFINE_UINT32_DESC(OnSetGlobalExpr, "index")
-DEFINE_UINT32_DESC(OnSetLocalExpr, "index")
-DEFINE_UINT32_DESC(OnTeeLocalExpr, "index")
+DEFINE_INDEX_DESC(OnSetGlobalExpr, "index")
+DEFINE_INDEX_DESC(OnSetLocalExpr, "index")
+DEFINE_INDEX_DESC(OnTeeLocalExpr, "index")
 DEFINE0(OnUnreachableExpr)
 DEFINE_OPCODE(OnUnaryExpr)
 DEFINE_END(EndCodeSection)
 
 DEFINE_BEGIN(BeginElemSection)
-DEFINE_UINT32(OnElemSegmentCount)
-DEFINE_UINT32_UINT32(BeginElemSegment, "index", "table_index")
-DEFINE_UINT32(BeginElemSegmentInitExpr)
-DEFINE_UINT32(EndElemSegmentInitExpr)
-DEFINE_UINT32_UINT32(OnElemSegmentFunctionIndexCount, "index", "count")
-DEFINE_UINT32_UINT32(OnElemSegmentFunctionIndex, "index", "func_index")
-DEFINE_UINT32(EndElemSegment)
+DEFINE_INDEX(OnElemSegmentCount)
+DEFINE_INDEX_INDEX(BeginElemSegment, "index", "table_index")
+DEFINE_INDEX(BeginElemSegmentInitExpr)
+DEFINE_INDEX(EndElemSegmentInitExpr)
+DEFINE_INDEX_INDEX(OnElemSegmentFunctionIndexCount, "index", "count")
+DEFINE_INDEX_INDEX(OnElemSegmentFunctionIndex, "index", "func_index")
+DEFINE_INDEX(EndElemSegment)
 DEFINE_END(EndElemSection)
 
 DEFINE_BEGIN(BeginDataSection)
-DEFINE_UINT32(OnDataSegmentCount)
-DEFINE_UINT32_UINT32(BeginDataSegment, "index", "memory_index")
-DEFINE_UINT32(BeginDataSegmentInitExpr)
-DEFINE_UINT32(EndDataSegmentInitExpr)
-DEFINE_UINT32(EndDataSegment)
+DEFINE_INDEX(OnDataSegmentCount)
+DEFINE_INDEX_INDEX(BeginDataSegment, "index", "memory_index")
+DEFINE_INDEX(BeginDataSegmentInitExpr)
+DEFINE_INDEX(EndDataSegmentInitExpr)
+DEFINE_INDEX(EndDataSegment)
 DEFINE_END(EndDataSection)
 
 DEFINE_BEGIN(BeginNamesSection)
-DEFINE_UINT32(OnFunctionNamesCount)
-DEFINE_UINT32(OnLocalNameFunctionCount)
-DEFINE_UINT32_UINT32(OnLocalNameLocalCount, "index", "count")
+DEFINE_INDEX(OnFunctionNamesCount)
+DEFINE_INDEX(OnLocalNameFunctionCount)
+DEFINE_INDEX_INDEX(OnLocalNameLocalCount, "index", "count")
 DEFINE_END(EndNamesSection)
 
 DEFINE_BEGIN(BeginRelocSection)
 DEFINE_END(EndRelocSection)
-DEFINE_UINT32_UINT32(OnInitExprGetGlobalExpr, "index", "global_index")
+DEFINE_INDEX_INDEX(OnInitExprGetGlobalExpr, "index", "global_index")
 
 // We don't need to log these (the individual opcodes are logged instead), but
 // we still need to forward the calls.
@@ -581,8 +594,7 @@ Result BinaryReaderLogging::OnOpcodeF64(uint64_t value) {
   return reader->OnOpcodeF64(value);
 }
 
-Result BinaryReaderLogging::OnOpcodeBlockSig(uint32_t num_types,
-                                             Type* sig_types) {
+Result BinaryReaderLogging::OnOpcodeBlockSig(Index num_types, Type* sig_types) {
   return reader->OnOpcodeBlockSig(num_types, sig_types);
 }
 

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -27,210 +27,211 @@ class BinaryReaderLogging : public BinaryReader {
  public:
   BinaryReaderLogging(Stream*, BinaryReader* forward);
 
-  virtual bool OnError(const char* message);
-  virtual void OnSetState(const State* s);
+  bool OnError(const char* message) override;
+  void OnSetState(const State* s) override;
 
-  virtual Result BeginModule(uint32_t version);
-  virtual Result EndModule();
+  Result BeginModule(uint32_t version) override;
+  Result EndModule() override;
 
-  virtual Result BeginSection(BinarySection section_type, uint32_t size);
+  Result BeginSection(BinarySection section_type, Offset size) override;
 
-  virtual Result BeginCustomSection(uint32_t size, StringSlice section_name);
-  virtual Result EndCustomSection();
+  Result BeginCustomSection(Offset size, StringSlice section_name) override;
+  Result EndCustomSection() override;
 
-  virtual Result BeginTypeSection(uint32_t size);
-  virtual Result OnTypeCount(uint32_t count);
-  virtual Result OnType(uint32_t index,
-                        uint32_t param_count,
-                        Type* param_types,
-                        uint32_t result_count,
-                        Type* result_types);
-  virtual Result EndTypeSection();
+  Result BeginTypeSection(Offset size) override;
+  Result OnTypeCount(Index count) override;
+  Result OnType(Index index,
+                Index param_count,
+                Type* param_types,
+                Index result_count,
+                Type* result_types) override;
+  Result EndTypeSection() override;
 
-  virtual Result BeginImportSection(uint32_t size);
-  virtual Result OnImportCount(uint32_t count);
-  virtual Result OnImport(uint32_t index,
-                          StringSlice module_name,
-                          StringSlice field_name);
-  virtual Result OnImportFunc(uint32_t import_index,
-                              StringSlice module_name,
-                              StringSlice field_name,
-                              uint32_t func_index,
-                              uint32_t sig_index);
-  virtual Result OnImportTable(uint32_t import_index,
-                               StringSlice module_name,
-                               StringSlice field_name,
-                               uint32_t table_index,
-                               Type elem_type,
-                               const Limits* elem_limits);
-  virtual Result OnImportMemory(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t memory_index,
-                                const Limits* page_limits);
-  virtual Result OnImportGlobal(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t global_index,
-                                Type type,
-                                bool mutable_);
-  virtual Result EndImportSection();
+  Result BeginImportSection(Offset size) override;
+  Result OnImportCount(Index count) override;
+  Result OnImport(Index index,
+                  StringSlice module_name,
+                  StringSlice field_name) override;
+  Result OnImportFunc(Index import_index,
+                      StringSlice module_name,
+                      StringSlice field_name,
+                      Index func_index,
+                      Index sig_index) override;
+  Result OnImportTable(Index import_index,
+                       StringSlice module_name,
+                       StringSlice field_name,
+                       Index table_index,
+                       Type elem_type,
+                       const Limits* elem_limits) override;
+  Result OnImportMemory(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index memory_index,
+                        const Limits* page_limits) override;
+  Result OnImportGlobal(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index global_index,
+                        Type type,
+                        bool mutable_) override;
+  Result EndImportSection() override;
 
-  virtual Result BeginFunctionSection(uint32_t size);
-  virtual Result OnFunctionCount(uint32_t count);
-  virtual Result OnFunction(uint32_t index, uint32_t sig_index);
-  virtual Result EndFunctionSection();
+  Result BeginFunctionSection(Offset size) override;
+  Result OnFunctionCount(Index count) override;
+  Result OnFunction(Index index, Index sig_index) override;
+  Result EndFunctionSection() override;
 
-  virtual Result BeginTableSection(uint32_t size);
-  virtual Result OnTableCount(uint32_t count);
-  virtual Result OnTable(uint32_t index,
-                         Type elem_type,
-                         const Limits* elem_limits);
-  virtual Result EndTableSection();
+  Result BeginTableSection(Offset size) override;
+  Result OnTableCount(Index count) override;
+  Result OnTable(Index index,
+                 Type elem_type,
+                 const Limits* elem_limits) override;
+  Result EndTableSection() override;
 
-  virtual Result BeginMemorySection(uint32_t size);
-  virtual Result OnMemoryCount(uint32_t count);
-  virtual Result OnMemory(uint32_t index, const Limits* limits);
-  virtual Result EndMemorySection();
+  Result BeginMemorySection(Offset size) override;
+  Result OnMemoryCount(Index count) override;
+  Result OnMemory(Index index, const Limits* limits) override;
+  Result EndMemorySection() override;
 
-  virtual Result BeginGlobalSection(uint32_t size);
-  virtual Result OnGlobalCount(uint32_t count);
-  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_);
-  virtual Result BeginGlobalInitExpr(uint32_t index);
-  virtual Result EndGlobalInitExpr(uint32_t index);
-  virtual Result EndGlobal(uint32_t index);
-  virtual Result EndGlobalSection();
+  Result BeginGlobalSection(Offset size) override;
+  Result OnGlobalCount(Index count) override;
+  Result BeginGlobal(Index index, Type type, bool mutable_) override;
+  Result BeginGlobalInitExpr(Index index) override;
+  Result EndGlobalInitExpr(Index index) override;
+  Result EndGlobal(Index index) override;
+  Result EndGlobalSection() override;
 
-  virtual Result BeginExportSection(uint32_t size);
-  virtual Result OnExportCount(uint32_t count);
-  virtual Result OnExport(uint32_t index,
-                          ExternalKind kind,
-                          uint32_t item_index,
-                          StringSlice name);
-  virtual Result EndExportSection();
+  Result BeginExportSection(Offset size) override;
+  Result OnExportCount(Index count) override;
+  Result OnExport(Index index,
+                  ExternalKind kind,
+                  Index item_index,
+                  StringSlice name) override;
+  Result EndExportSection() override;
 
-  virtual Result BeginStartSection(uint32_t size);
-  virtual Result OnStartFunction(uint32_t func_index);
-  virtual Result EndStartSection();
+  Result BeginStartSection(Offset size) override;
+  Result OnStartFunction(Index func_index) override;
+  Result EndStartSection() override;
 
-  virtual Result BeginCodeSection(uint32_t size);
-  virtual Result OnFunctionBodyCount(uint32_t count);
-  virtual Result BeginFunctionBody(uint32_t index);
-  virtual Result OnLocalDeclCount(uint32_t count);
-  virtual Result OnLocalDecl(uint32_t decl_index, uint32_t count, Type type);
+  Result BeginCodeSection(Offset size) override;
+  Result OnFunctionBodyCount(Index count) override;
+  Result BeginFunctionBody(Index index) override;
+  Result OnLocalDeclCount(Index count) override;
+  Result OnLocalDecl(Index decl_index, Index count, Type type) override;
 
-  virtual Result OnOpcode(Opcode opcode);
-  virtual Result OnOpcodeBare();
-  virtual Result OnOpcodeUint32(uint32_t value);
-  virtual Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2);
-  virtual Result OnOpcodeUint64(uint64_t value);
-  virtual Result OnOpcodeF32(uint32_t value);
-  virtual Result OnOpcodeF64(uint64_t value);
-  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types);
-  virtual Result OnBinaryExpr(Opcode opcode);
-  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types);
-  virtual Result OnBrExpr(uint32_t depth);
-  virtual Result OnBrIfExpr(uint32_t depth);
-  virtual Result OnBrTableExpr(uint32_t num_targets,
-                               uint32_t* target_depths,
-                               uint32_t default_target_depth);
-  virtual Result OnCallExpr(uint32_t func_index);
-  virtual Result OnCallIndirectExpr(uint32_t sig_index);
-  virtual Result OnCompareExpr(Opcode opcode);
-  virtual Result OnConvertExpr(Opcode opcode);
-  virtual Result OnCurrentMemoryExpr();
-  virtual Result OnDropExpr();
-  virtual Result OnElseExpr();
-  virtual Result OnEndExpr();
-  virtual Result OnEndFunc();
-  virtual Result OnF32ConstExpr(uint32_t value_bits);
-  virtual Result OnF64ConstExpr(uint64_t value_bits);
-  virtual Result OnGetGlobalExpr(uint32_t global_index);
-  virtual Result OnGetLocalExpr(uint32_t local_index);
-  virtual Result OnGrowMemoryExpr();
-  virtual Result OnI32ConstExpr(uint32_t value);
-  virtual Result OnI64ConstExpr(uint64_t value);
-  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types);
-  virtual Result OnLoadExpr(Opcode opcode,
-                            uint32_t alignment_log2,
-                            uint32_t offset);
-  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types);
-  virtual Result OnNopExpr();
-  virtual Result OnReturnExpr();
-  virtual Result OnSelectExpr();
-  virtual Result OnSetGlobalExpr(uint32_t global_index);
-  virtual Result OnSetLocalExpr(uint32_t local_index);
-  virtual Result OnStoreExpr(Opcode opcode,
-                             uint32_t alignment_log2,
-                             uint32_t offset);
-  virtual Result OnTeeLocalExpr(uint32_t local_index);
-  virtual Result OnUnaryExpr(Opcode opcode);
-  virtual Result OnUnreachableExpr();
-  virtual Result EndFunctionBody(uint32_t index);
-  virtual Result EndCodeSection();
+  Result OnOpcode(Opcode opcode) override;
+  Result OnOpcodeBare() override;
+  Result OnOpcodeUint32(uint32_t value) override;
+  Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2) override;
+  Result OnOpcodeUint64(uint64_t value) override;
+  Result OnOpcodeF32(uint32_t value) override;
+  Result OnOpcodeF64(uint64_t value) override;
+  Result OnOpcodeBlockSig(Index num_types, Type* sig_types) override;
+  Result OnBinaryExpr(Opcode opcode) override;
+  Result OnBlockExpr(Index num_types, Type* sig_types) override;
+  Result OnBrExpr(Index depth) override;
+  Result OnBrIfExpr(Index depth) override;
+  Result OnBrTableExpr(Index num_targets,
+                       Index* target_depths,
+                       Index default_target_depth) override;
+  Result OnCallExpr(Index func_index) override;
+  Result OnCallIndirectExpr(Index sig_index) override;
+  Result OnCompareExpr(Opcode opcode) override;
+  Result OnConvertExpr(Opcode opcode) override;
+  Result OnCurrentMemoryExpr() override;
+  Result OnDropExpr() override;
+  Result OnElseExpr() override;
+  Result OnEndExpr() override;
+  Result OnEndFunc() override;
+  Result OnF32ConstExpr(uint32_t value_bits) override;
+  Result OnF64ConstExpr(uint64_t value_bits) override;
+  Result OnGetGlobalExpr(Index global_index) override;
+  Result OnGetLocalExpr(Index local_index) override;
+  Result OnGrowMemoryExpr() override;
+  Result OnI32ConstExpr(uint32_t value) override;
+  Result OnI64ConstExpr(uint64_t value) override;
+  Result OnIfExpr(Index num_types, Type* sig_types) override;
+  Result OnLoadExpr(Opcode opcode,
+                    uint32_t alignment_log2,
+                    Address offset) override;
+  Result OnLoopExpr(Index num_types, Type* sig_types) override;
+  Result OnNopExpr() override;
+  Result OnReturnExpr() override;
+  Result OnSelectExpr() override;
+  Result OnSetGlobalExpr(Index global_index) override;
+  Result OnSetLocalExpr(Index local_index) override;
+  Result OnStoreExpr(Opcode opcode,
+                     uint32_t alignment_log2,
+                     Address offset) override;
+  Result OnTeeLocalExpr(Index local_index) override;
+  Result OnUnaryExpr(Opcode opcode) override;
+  Result OnUnreachableExpr() override;
+  Result EndFunctionBody(Index index) override;
+  Result EndCodeSection() override;
 
-  virtual Result BeginElemSection(uint32_t size);
-  virtual Result OnElemSegmentCount(uint32_t count);
-  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index);
-  virtual Result BeginElemSegmentInitExpr(uint32_t index);
-  virtual Result EndElemSegmentInitExpr(uint32_t index);
-  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                 uint32_t count);
-  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
-                                            uint32_t func_index);
-  virtual Result EndElemSegment(uint32_t index);
-  virtual Result EndElemSection();
+  Result BeginElemSection(Offset size) override;
+  Result OnElemSegmentCount(Index count) override;
+  Result BeginElemSegment(Index index, Index table_index) override;
+  Result BeginElemSegmentInitExpr(Index index) override;
+  Result EndElemSegmentInitExpr(Index index) override;
+  Result OnElemSegmentFunctionIndexCount(Index index,
+                                         Index count) override;
+  Result OnElemSegmentFunctionIndex(Index index,
+                                    Index func_index) override;
+  Result EndElemSegment(Index index) override;
+  Result EndElemSection() override;
 
-  virtual Result BeginDataSection(uint32_t size);
-  virtual Result OnDataSegmentCount(uint32_t count);
-  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index);
-  virtual Result BeginDataSegmentInitExpr(uint32_t index);
-  virtual Result EndDataSegmentInitExpr(uint32_t index);
-  virtual Result OnDataSegmentData(uint32_t index,
-                                   const void* data,
-                                   uint32_t size);
-  virtual Result EndDataSegment(uint32_t index);
-  virtual Result EndDataSection();
+  Result BeginDataSection(Offset size) override;
+  Result OnDataSegmentCount(Index count) override;
+  Result BeginDataSegment(Index index, Index memory_index) override;
+  Result BeginDataSegmentInitExpr(Index index) override;
+  Result EndDataSegmentInitExpr(Index index) override;
+  Result OnDataSegmentData(Index index,
+                           const void* data,
+                           Address size) override;
+  Result EndDataSegment(Index index) override;
+  Result EndDataSection() override;
 
-  virtual Result BeginNamesSection(uint32_t size);
-  virtual Result OnFunctionNameSubsection(uint32_t index,
-                                          uint32_t name_type,
-                                          uint32_t subsection_size);
-  virtual Result OnFunctionNamesCount(uint32_t num_functions);
-  virtual Result OnFunctionName(uint32_t function_index,
-                                StringSlice function_name);
-  virtual Result OnLocalNameSubsection(uint32_t index,
-                                       uint32_t name_type,
-                                       uint32_t subsection_size);
-  virtual Result OnLocalNameFunctionCount(uint32_t num_functions);
-  virtual Result OnLocalNameLocalCount(uint32_t function_index,
-                                       uint32_t num_locals);
-  virtual Result OnLocalName(uint32_t function_index,
-                             uint32_t local_index,
-                             StringSlice local_name);
-  virtual Result EndNamesSection();
+  Result BeginNamesSection(Offset size) override;
+  Result OnFunctionNameSubsection(Index index,
+                                  uint32_t name_type,
+                                  Offset subsection_size) override;
+  Result OnFunctionNamesCount(Index num_functions) override;
+  Result OnFunctionName(Index function_index,
+                        StringSlice function_name) override;
+  Result OnLocalNameSubsection(Index index,
+                               uint32_t name_type,
+                               Offset subsection_size) override;
+  Result OnLocalNameFunctionCount(Index num_functions) override;
+  Result OnLocalNameLocalCount(Index function_index,
+                               Index num_locals) override;
+  Result OnLocalName(Index function_index,
+                     Index local_index,
+                     StringSlice local_name) override;
+  Result EndNamesSection() override;
 
-  virtual Result BeginRelocSection(uint32_t size);
-  virtual Result OnRelocCount(uint32_t count,
-                              BinarySection section_code,
-                              StringSlice section_name);
-  virtual Result OnReloc(RelocType type,
-                         uint32_t offset,
-                         uint32_t index,
-                         uint32_t addend);
-  virtual Result EndRelocSection();
+  Result BeginRelocSection(Offset size) override;
+  Result OnRelocCount(Index count,
+                      BinarySection section_code,
+                      StringSlice section_name) override;
+  Result OnReloc(RelocType type,
+                 Offset offset,
+                 Index index,
+                 uint32_t addend) override;
+  Result EndRelocSection() override;
 
-  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value);
-  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value);
-  virtual Result OnInitExprGetGlobalExpr(uint32_t index, uint32_t global_index);
-  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value);
-  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value);
+  Result OnInitExprF32ConstExpr(Index index, uint32_t value) override;
+  Result OnInitExprF64ConstExpr(Index index, uint64_t value) override;
+  Result OnInitExprGetGlobalExpr(Index index,
+                                 Index global_index) override;
+  Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
+  Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
 
  private:
   void Indent();
   void Dedent();
   void WriteIndent();
-  void LogTypes(uint32_t type_count, Type* types);
+  void LogTypes(Index type_count, Type* types);
 
   Stream* stream;
   BinaryReader* reader;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -23,303 +23,300 @@ namespace wabt {
 
 class BinaryReaderNop : public BinaryReader {
  public:
-  virtual bool OnError(const char* message) { return false; }
+  bool OnError(const char* message) override { return false; }
 
   /* Module */
-  virtual Result BeginModule(uint32_t version) { return Result::Ok; }
-  virtual Result EndModule() { return Result::Ok; }
+  Result BeginModule(uint32_t version) override { return Result::Ok; }
+  Result EndModule() override { return Result::Ok; }
 
-  virtual Result BeginSection(BinarySection section_type, uint32_t size) {
+  Result BeginSection(BinarySection section_type, Offset size) override {
     return Result::Ok;
   }
 
   /* Custom section */
-  virtual Result BeginCustomSection(uint32_t size, StringSlice section_name) {
+  Result BeginCustomSection(Offset size, StringSlice section_name) override {
     return Result::Ok;
   }
-  virtual Result EndCustomSection() { return Result::Ok; }
+  Result EndCustomSection() override { return Result::Ok; }
 
   /* Type section */
-  virtual Result BeginTypeSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnTypeCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnType(uint32_t index,
-                        uint32_t param_count,
-                        Type* param_types,
-                        uint32_t result_count,
-                        Type* result_types) {
+  Result BeginTypeSection(Offset size) override { return Result::Ok; }
+  Result OnTypeCount(Index count) override { return Result::Ok; }
+  Result OnType(Index index,
+                Index param_count,
+                Type* param_types,
+                Index result_count,
+                Type* result_types) override {
     return Result::Ok;
   }
-  virtual Result EndTypeSection() { return Result::Ok; }
+  Result EndTypeSection() override { return Result::Ok; }
 
   /* Import section */
-  virtual Result BeginImportSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnImportCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnImport(uint32_t index,
-                          StringSlice module_name,
-                          StringSlice field_name) {
+  Result BeginImportSection(Offset size) override { return Result::Ok; }
+  Result OnImportCount(Index count) override { return Result::Ok; }
+  Result OnImport(Index index,
+                  StringSlice module_name,
+                  StringSlice field_name) override {
     return Result::Ok;
   }
-  virtual Result OnImportFunc(uint32_t import_index,
-                              StringSlice module_name,
-                              StringSlice field_name,
-                              uint32_t func_index,
-                              uint32_t sig_index) {
+  Result OnImportFunc(Index import_index,
+                      StringSlice module_name,
+                      StringSlice field_name,
+                      Index func_index,
+                      Index sig_index) override {
     return Result::Ok;
   }
-  virtual Result OnImportTable(uint32_t import_index,
-                               StringSlice module_name,
-                               StringSlice field_name,
-                               uint32_t table_index,
-                               Type elem_type,
-                               const Limits* elem_limits) {
+  Result OnImportTable(Index import_index,
+                       StringSlice module_name,
+                       StringSlice field_name,
+                       Index table_index,
+                       Type elem_type,
+                       const Limits* elem_limits) override {
     return Result::Ok;
   }
-  virtual Result OnImportMemory(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t memory_index,
-                                const Limits* page_limits) {
+  Result OnImportMemory(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index memory_index,
+                        const Limits* page_limits) override {
     return Result::Ok;
   }
-  virtual Result OnImportGlobal(uint32_t import_index,
-                                StringSlice module_name,
-                                StringSlice field_name,
-                                uint32_t global_index,
-                                Type type,
-                                bool mutable_) {
+  Result OnImportGlobal(Index import_index,
+                        StringSlice module_name,
+                        StringSlice field_name,
+                        Index global_index,
+                        Type type,
+                        bool mutable_) override {
     return Result::Ok;
   }
-  virtual Result EndImportSection() { return Result::Ok; }
+  Result EndImportSection() override { return Result::Ok; }
 
   /* Function section */
-  virtual Result BeginFunctionSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnFunctionCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnFunction(uint32_t index, uint32_t sig_index) {
+  Result BeginFunctionSection(Offset size) override { return Result::Ok; }
+  Result OnFunctionCount(Index count) override { return Result::Ok; }
+  Result OnFunction(Index index, Index sig_index) override {
     return Result::Ok;
   }
-  virtual Result EndFunctionSection() { return Result::Ok; }
+  Result EndFunctionSection() override { return Result::Ok; }
 
   /* Table section */
-  virtual Result BeginTableSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnTableCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnTable(uint32_t index,
-                         Type elem_type,
-                         const Limits* elem_limits) {
+  Result BeginTableSection(Offset size) override { return Result::Ok; }
+  Result OnTableCount(Index count) override { return Result::Ok; }
+  Result OnTable(Index index,
+                 Type elem_type,
+                 const Limits* elem_limits) override {
     return Result::Ok;
   }
-  virtual Result EndTableSection() { return Result::Ok; }
+  Result EndTableSection() override { return Result::Ok; }
 
   /* Memory section */
-  virtual Result BeginMemorySection(uint32_t size) { return Result::Ok; }
-  virtual Result OnMemoryCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnMemory(uint32_t index, const Limits* limits) {
+  Result BeginMemorySection(Offset size) override { return Result::Ok; }
+  Result OnMemoryCount(Index count) override { return Result::Ok; }
+  Result OnMemory(Index index, const Limits* limits) override {
     return Result::Ok;
   }
-  virtual Result EndMemorySection() { return Result::Ok; }
+  Result EndMemorySection() override { return Result::Ok; }
 
   /* Global section */
-  virtual Result BeginGlobalSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnGlobalCount(uint32_t count) { return Result::Ok; }
-  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_) {
+  Result BeginGlobalSection(Offset size) override { return Result::Ok; }
+  Result OnGlobalCount(Index count) override { return Result::Ok; }
+  Result BeginGlobal(Index index, Type type, bool mutable_) override {
     return Result::Ok;
   }
-  virtual Result BeginGlobalInitExpr(uint32_t index) { return Result::Ok; }
-  virtual Result EndGlobalInitExpr(uint32_t index) { return Result::Ok; }
-  virtual Result EndGlobal(uint32_t index) { return Result::Ok; }
-  virtual Result EndGlobalSection() { return Result::Ok; }
+  Result BeginGlobalInitExpr(Index index) override { return Result::Ok; }
+  Result EndGlobalInitExpr(Index index) override { return Result::Ok; }
+  Result EndGlobal(Index index) override { return Result::Ok; }
+  Result EndGlobalSection() override { return Result::Ok; }
 
   /* Exports section */
-  virtual Result BeginExportSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnExportCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnExport(uint32_t index,
-                          ExternalKind kind,
-                          uint32_t item_index,
-                          StringSlice name) {
+  Result BeginExportSection(Offset size) override { return Result::Ok; }
+  Result OnExportCount(Index count) override { return Result::Ok; }
+  Result OnExport(Index index,
+                  ExternalKind kind,
+                  Index item_index,
+                  StringSlice name) override {
     return Result::Ok;
   }
-  virtual Result EndExportSection() { return Result::Ok; }
+  Result EndExportSection() override { return Result::Ok; }
 
   /* Start section */
-  virtual Result BeginStartSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnStartFunction(uint32_t func_index) { return Result::Ok; }
-  virtual Result EndStartSection() { return Result::Ok; }
+  Result BeginStartSection(Offset size) override { return Result::Ok; }
+  Result OnStartFunction(Index func_index) override { return Result::Ok; }
+  Result EndStartSection() override { return Result::Ok; }
 
   /* Code section */
-  virtual Result BeginCodeSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnFunctionBodyCount(uint32_t count) { return Result::Ok; }
-  virtual Result BeginFunctionBody(uint32_t index) { return Result::Ok; }
-  virtual Result OnLocalDeclCount(uint32_t count) { return Result::Ok; }
-  virtual Result OnLocalDecl(uint32_t decl_index, uint32_t count, Type type) {
+  Result BeginCodeSection(Offset size) override { return Result::Ok; }
+  Result OnFunctionBodyCount(Index count) override { return Result::Ok; }
+  Result BeginFunctionBody(Index index) override { return Result::Ok; }
+  Result OnLocalDeclCount(Index count) override { return Result::Ok; }
+  Result OnLocalDecl(Index decl_index, Index count, Type type) override {
     return Result::Ok;
   }
 
   /* Function expressions; called between BeginFunctionBody and
    EndFunctionBody */
-  virtual Result OnOpcode(Opcode Opcode) { return Result::Ok; }
-  virtual Result OnOpcodeBare() { return Result::Ok; }
-  virtual Result OnOpcodeUint32(uint32_t value) { return Result::Ok; }
-  virtual Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2) {
+  Result OnOpcode(Opcode Opcode) override { return Result::Ok; }
+  Result OnOpcodeBare() override { return Result::Ok; }
+  Result OnOpcodeUint32(uint32_t value) override { return Result::Ok; }
+  Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2) override {
     return Result::Ok;
   }
-  virtual Result OnOpcodeUint64(uint64_t value) { return Result::Ok; }
-  virtual Result OnOpcodeF32(uint32_t value) { return Result::Ok; }
-  virtual Result OnOpcodeF64(uint64_t value) { return Result::Ok; }
-  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types) {
+  Result OnOpcodeUint64(uint64_t value) override { return Result::Ok; }
+  Result OnOpcodeF32(uint32_t value) override { return Result::Ok; }
+  Result OnOpcodeF64(uint64_t value) override { return Result::Ok; }
+  Result OnOpcodeBlockSig(Index num_types, Type* sig_types) override {
     return Result::Ok;
   }
-  virtual Result OnBinaryExpr(Opcode opcode) { return Result::Ok; }
-  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types) {
+  Result OnBinaryExpr(Opcode opcode) override { return Result::Ok; }
+  Result OnBlockExpr(Index num_types, Type* sig_types) override {
     return Result::Ok;
   }
-  virtual Result OnBrExpr(uint32_t depth) { return Result::Ok; }
-  virtual Result OnBrIfExpr(uint32_t depth) { return Result::Ok; }
-  virtual Result OnBrTableExpr(uint32_t num_targets,
-                               uint32_t* target_depths,
-                               uint32_t default_target_depth) {
+  Result OnBrExpr(Index depth) override { return Result::Ok; }
+  Result OnBrIfExpr(Index depth) override { return Result::Ok; }
+  Result OnBrTableExpr(Index num_targets,
+                       Index* target_depths,
+                       Index default_target_depth) override {
     return Result::Ok;
   }
-  virtual Result OnCallExpr(uint32_t func_index) { return Result::Ok; }
-  virtual Result OnCallIndirectExpr(uint32_t sig_index) { return Result::Ok; }
-  virtual Result OnCompareExpr(Opcode opcode) { return Result::Ok; }
-  virtual Result OnConvertExpr(Opcode opcode) { return Result::Ok; }
-  virtual Result OnCurrentMemoryExpr() { return Result::Ok; }
-  virtual Result OnDropExpr() { return Result::Ok; }
-  virtual Result OnElseExpr() { return Result::Ok; }
-  virtual Result OnEndExpr() { return Result::Ok; }
-  virtual Result OnEndFunc() { return Result::Ok; }
-  virtual Result OnF32ConstExpr(uint32_t value_bits) { return Result::Ok; }
-  virtual Result OnF64ConstExpr(uint64_t value_bits) { return Result::Ok; }
-  virtual Result OnGetGlobalExpr(uint32_t global_index) { return Result::Ok; }
-  virtual Result OnGetLocalExpr(uint32_t local_index) { return Result::Ok; }
-  virtual Result OnGrowMemoryExpr() { return Result::Ok; }
-  virtual Result OnI32ConstExpr(uint32_t value) { return Result::Ok; }
-  virtual Result OnI64ConstExpr(uint64_t value) { return Result::Ok; }
-  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types) {
+  Result OnCallExpr(Index func_index) override { return Result::Ok; }
+  Result OnCallIndirectExpr(Index sig_index) override { return Result::Ok; }
+  Result OnCompareExpr(Opcode opcode) override { return Result::Ok; }
+  Result OnConvertExpr(Opcode opcode) override { return Result::Ok; }
+  Result OnCurrentMemoryExpr() override { return Result::Ok; }
+  Result OnDropExpr() override { return Result::Ok; }
+  Result OnElseExpr() override { return Result::Ok; }
+  Result OnEndExpr() override { return Result::Ok; }
+  Result OnEndFunc() override { return Result::Ok; }
+  Result OnF32ConstExpr(uint32_t value_bits) override { return Result::Ok; }
+  Result OnF64ConstExpr(uint64_t value_bits) override { return Result::Ok; }
+  Result OnGetGlobalExpr(Index global_index) override { return Result::Ok; }
+  Result OnGetLocalExpr(Index local_index) override { return Result::Ok; }
+  Result OnGrowMemoryExpr() override { return Result::Ok; }
+  Result OnI32ConstExpr(uint32_t value) override { return Result::Ok; }
+  Result OnI64ConstExpr(uint64_t value) override { return Result::Ok; }
+  Result OnIfExpr(Index num_types, Type* sig_types) override {
     return Result::Ok;
   }
-  virtual Result OnLoadExpr(Opcode opcode,
-                            uint32_t alignment_log2,
-                            uint32_t offset) {
+  Result OnLoadExpr(Opcode opcode,
+                    uint32_t alignment_log2,
+                    Address offset) override {
     return Result::Ok;
   }
-  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types) {
+  Result OnLoopExpr(Index num_types, Type* sig_types) override {
     return Result::Ok;
   }
-  virtual Result OnNopExpr() { return Result::Ok; }
-  virtual Result OnReturnExpr() { return Result::Ok; }
-  virtual Result OnSelectExpr() { return Result::Ok; }
-  virtual Result OnSetGlobalExpr(uint32_t global_index) { return Result::Ok; }
-  virtual Result OnSetLocalExpr(uint32_t local_index) { return Result::Ok; }
-  virtual Result OnStoreExpr(Opcode opcode,
-                             uint32_t alignment_log2,
-                             uint32_t offset) {
+  Result OnNopExpr() override { return Result::Ok; }
+  Result OnReturnExpr() override { return Result::Ok; }
+  Result OnSelectExpr() override { return Result::Ok; }
+  Result OnSetGlobalExpr(Index global_index) override { return Result::Ok; }
+  Result OnSetLocalExpr(Index local_index) override { return Result::Ok; }
+  Result OnStoreExpr(Opcode opcode,
+                     uint32_t alignment_log2,
+                     Address offset) override {
     return Result::Ok;
   }
-  virtual Result OnTeeLocalExpr(uint32_t local_index) { return Result::Ok; }
-  virtual Result OnUnaryExpr(Opcode opcode) { return Result::Ok; }
-  virtual Result OnUnreachableExpr() { return Result::Ok; }
-  virtual Result EndFunctionBody(uint32_t index) { return Result::Ok; }
-  virtual Result EndCodeSection() { return Result::Ok; }
+  Result OnTeeLocalExpr(Index local_index) override { return Result::Ok; }
+  Result OnUnaryExpr(Opcode opcode) override { return Result::Ok; }
+  Result OnUnreachableExpr() override { return Result::Ok; }
+  Result EndFunctionBody(Index index) override { return Result::Ok; }
+  Result EndCodeSection() override { return Result::Ok; }
 
   /* Elem section */
-  virtual Result BeginElemSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnElemSegmentCount(uint32_t count) { return Result::Ok; }
-  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index) {
+  Result BeginElemSection(Offset size) override { return Result::Ok; }
+  Result OnElemSegmentCount(Index count) override { return Result::Ok; }
+  Result BeginElemSegment(Index index, Index table_index) override {
     return Result::Ok;
   }
-  virtual Result BeginElemSegmentInitExpr(uint32_t index) { return Result::Ok; }
-  virtual Result EndElemSegmentInitExpr(uint32_t index) { return Result::Ok; }
-  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                 uint32_t count) {
+  Result BeginElemSegmentInitExpr(Index index) override { return Result::Ok; }
+  Result EndElemSegmentInitExpr(Index index) override { return Result::Ok; }
+  Result OnElemSegmentFunctionIndexCount(Index index, Index count) override {
     return Result::Ok;
   }
-  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
-                                            uint32_t func_index) {
+  Result OnElemSegmentFunctionIndex(Index index, Index func_index) override {
     return Result::Ok;
   }
-  virtual Result EndElemSegment(uint32_t index) { return Result::Ok; }
-  virtual Result EndElemSection() { return Result::Ok; }
+  Result EndElemSegment(Index index) override { return Result::Ok; }
+  Result EndElemSection() override { return Result::Ok; }
 
   /* Data section */
-  virtual Result BeginDataSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnDataSegmentCount(uint32_t count) { return Result::Ok; }
-  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index) {
+  Result BeginDataSection(Offset size) override { return Result::Ok; }
+  Result OnDataSegmentCount(Index count) override { return Result::Ok; }
+  Result BeginDataSegment(Index index, Index memory_index) override {
     return Result::Ok;
   }
-  virtual Result BeginDataSegmentInitExpr(uint32_t index) { return Result::Ok; }
-  virtual Result EndDataSegmentInitExpr(uint32_t index) { return Result::Ok; }
-  virtual Result OnDataSegmentData(uint32_t index,
-                                   const void* data,
-                                   uint32_t size) {
+  Result BeginDataSegmentInitExpr(Index index) override { return Result::Ok; }
+  Result EndDataSegmentInitExpr(Index index) override { return Result::Ok; }
+  Result OnDataSegmentData(Index index,
+                           const void* data,
+                           Address size) override {
     return Result::Ok;
   }
-  virtual Result EndDataSegment(uint32_t index) { return Result::Ok; }
-  virtual Result EndDataSection() { return Result::Ok; }
+  Result EndDataSegment(Index index) override { return Result::Ok; }
+  Result EndDataSection() override { return Result::Ok; }
 
   /* Names section */
-  virtual Result BeginNamesSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnFunctionNameSubsection(uint32_t index,
-                                          uint32_t name_type,
-                                          uint32_t subsection_size) {
+  Result BeginNamesSection(Offset size) override { return Result::Ok; }
+  Result OnFunctionNameSubsection(Index index,
+                                  uint32_t name_type,
+                                  Offset subsection_size) override {
     return Result::Ok;
   }
-  virtual Result OnFunctionNamesCount(uint32_t num_functions) {
+  Result OnFunctionNamesCount(Index num_functions) override {
     return Result::Ok;
   }
-  virtual Result OnFunctionName(uint32_t function_index,
-                                StringSlice function_name) {
+  Result OnFunctionName(Index function_index,
+                        StringSlice function_name) override {
     return Result::Ok;
   }
-  virtual Result OnLocalNameSubsection(uint32_t index,
-                                       uint32_t name_type,
-                                       uint32_t subsection_size) {
+  Result OnLocalNameSubsection(Index index,
+                               uint32_t name_type,
+                               Offset subsection_size) override {
     return Result::Ok;
   }
-  virtual Result OnLocalNameFunctionCount(uint32_t num_functions) {
+  Result OnLocalNameFunctionCount(Index num_functions) override {
     return Result::Ok;
   }
-  virtual Result OnLocalNameLocalCount(uint32_t function_index,
-                                       uint32_t num_locals) {
+  Result OnLocalNameLocalCount(Index function_index,
+                               Index num_locals) override {
     return Result::Ok;
   }
-  virtual Result OnLocalName(uint32_t function_index,
-                             uint32_t local_index,
-                             StringSlice local_name) {
+  Result OnLocalName(Index function_index,
+                     Index local_index,
+                     StringSlice local_name) override {
     return Result::Ok;
   }
-  virtual Result EndNamesSection() { return Result::Ok; }
+  Result EndNamesSection() override { return Result::Ok; }
 
   /* Reloc section */
-  virtual Result BeginRelocSection(uint32_t size) { return Result::Ok; }
-  virtual Result OnRelocCount(uint32_t count,
-                              BinarySection section_code,
-                              StringSlice section_name) {
+  Result BeginRelocSection(Offset size) override { return Result::Ok; }
+  Result OnRelocCount(Index count,
+                      BinarySection section_code,
+                      StringSlice section_name) override {
     return Result::Ok;
   }
-  virtual Result OnReloc(RelocType type,
-                         uint32_t offset,
-                         uint32_t index,
-                         uint32_t addend) {
+  Result OnReloc(RelocType type,
+                 Offset offset,
+                 Index index,
+                 uint32_t addend) override {
     return Result::Ok;
   }
-  virtual Result EndRelocSection() { return Result::Ok; }
+  Result EndRelocSection() override { return Result::Ok; }
 
   /* InitExpr - used by elem, data and global sections; these functions are
    * only called between calls to Begin*InitExpr and End*InitExpr */
-  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value) {
+  Result OnInitExprF32ConstExpr(Index index, uint32_t value) override {
     return Result::Ok;
   }
-  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value) {
+  Result OnInitExprF64ConstExpr(Index index, uint64_t value) override {
     return Result::Ok;
   }
-  virtual Result OnInitExprGetGlobalExpr(uint32_t index,
-                                         uint32_t global_index) {
+  Result OnInitExprGetGlobalExpr(Index index, Index global_index) override {
     return Result::Ok;
   }
-  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value) {
+  Result OnInitExprI32ConstExpr(Index index, uint32_t value) override {
     return Result::Ok;
   }
-  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value) {
+  Result OnInitExprI64ConstExpr(Index index, uint64_t value) override {
     return Result::Ok;
   }
 };

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -33,17 +33,17 @@ class BinaryReaderOpcnt : public BinaryReaderNop {
  public:
   explicit BinaryReaderOpcnt(OpcntData* data);
 
-  virtual Result OnOpcode(Opcode opcode);
-  virtual Result OnI32ConstExpr(uint32_t value);
-  virtual Result OnGetLocalExpr(uint32_t local_index);
-  virtual Result OnSetLocalExpr(uint32_t local_index);
-  virtual Result OnTeeLocalExpr(uint32_t local_index);
-  virtual Result OnLoadExpr(Opcode opcode,
-                            uint32_t alignment_log2,
-                            uint32_t offset);
-  virtual Result OnStoreExpr(Opcode opcode,
-                             uint32_t alignment_log2,
-                             uint32_t offset);
+  Result OnOpcode(Opcode opcode) override;
+  Result OnI32ConstExpr(uint32_t value) override;
+  Result OnGetLocalExpr(Index local_index) override;
+  Result OnSetLocalExpr(Index local_index) override;
+  Result OnTeeLocalExpr(Index local_index) override;
+  Result OnLoadExpr(Opcode opcode,
+                    uint32_t alignment_log2,
+                    Address offset) override;
+  Result OnStoreExpr(Opcode opcode,
+                     uint32_t alignment_log2,
+                     Address offset) override;
 
  private:
   OpcntData* opcnt_data;
@@ -89,21 +89,21 @@ Result BinaryReaderOpcnt::OnI32ConstExpr(uint32_t value) {
                             static_cast<int32_t>(value));
 }
 
-Result BinaryReaderOpcnt::OnGetLocalExpr(uint32_t local_index) {
+Result BinaryReaderOpcnt::OnGetLocalExpr(Index local_index) {
   return AddIntCounterValue(&opcnt_data->get_local_vec, local_index);
 }
 
-Result BinaryReaderOpcnt::OnSetLocalExpr(uint32_t local_index) {
+Result BinaryReaderOpcnt::OnSetLocalExpr(Index local_index) {
   return AddIntCounterValue(&opcnt_data->set_local_vec, local_index);
 }
 
-Result BinaryReaderOpcnt::OnTeeLocalExpr(uint32_t local_index) {
+Result BinaryReaderOpcnt::OnTeeLocalExpr(Index local_index) {
   return AddIntCounterValue(&opcnt_data->tee_local_vec, local_index);
 }
 
 Result BinaryReaderOpcnt::OnLoadExpr(Opcode opcode,
                                      uint32_t alignment_log2,
-                                     uint32_t offset) {
+                                     Address offset) {
   if (opcode == Opcode::I32Load) {
     return AddIntPairCounterValue(&opcnt_data->i32_load_vec, alignment_log2,
                                   offset);
@@ -113,7 +113,7 @@ Result BinaryReaderOpcnt::OnLoadExpr(Opcode opcode,
 
 Result BinaryReaderOpcnt::OnStoreExpr(Opcode opcode,
                                       uint32_t alignment_log2,
-                                      uint32_t offset) {
+                                      Address offset) {
   if (opcode == Opcode::I32Store) {
     return AddIntPairCounterValue(&opcnt_data->i32_store_vec, alignment_log2,
                                   offset);

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -40,8 +40,8 @@ class BinaryReader {
  public:
   struct State {
     const uint8_t* data;
-    size_t size;
-    size_t offset;
+    Offset size;
+    Offset offset;
   };
 
   virtual ~BinaryReader() {}
@@ -53,104 +53,101 @@ class BinaryReader {
   virtual Result BeginModule(uint32_t version) = 0;
   virtual Result EndModule() = 0;
 
-  virtual Result BeginSection(BinarySection section_type, uint32_t size) = 0;
+  virtual Result BeginSection(BinarySection section_type, Offset size) = 0;
 
   /* Custom section */
-  virtual Result BeginCustomSection(uint32_t size,
-                                    StringSlice section_name) = 0;
+  virtual Result BeginCustomSection(Offset size, StringSlice section_name) = 0;
   virtual Result EndCustomSection() = 0;
 
   /* Type section */
-  virtual Result BeginTypeSection(uint32_t size) = 0;
-  virtual Result OnTypeCount(uint32_t count) = 0;
-  virtual Result OnType(uint32_t index,
-                        uint32_t param_count,
+  virtual Result BeginTypeSection(Offset size) = 0;
+  virtual Result OnTypeCount(Index count) = 0;
+  virtual Result OnType(Index index,
+                        Index param_count,
                         Type* param_types,
-                        uint32_t result_count,
+                        Index result_count,
                         Type* result_types) = 0;
   virtual Result EndTypeSection() = 0;
 
   /* Import section */
-  virtual Result BeginImportSection(uint32_t size) = 0;
-  virtual Result OnImportCount(uint32_t count) = 0;
-  virtual Result OnImport(uint32_t index,
+  virtual Result BeginImportSection(Offset size) = 0;
+  virtual Result OnImportCount(Index count) = 0;
+  virtual Result OnImport(Index index,
                           StringSlice module_name,
                           StringSlice field_name) = 0;
-  virtual Result OnImportFunc(uint32_t import_index,
+  virtual Result OnImportFunc(Index import_index,
                               StringSlice module_name,
                               StringSlice field_name,
-                              uint32_t func_index,
-                              uint32_t sig_index) = 0;
-  virtual Result OnImportTable(uint32_t import_index,
+                              Index func_index,
+                              Index sig_index) = 0;
+  virtual Result OnImportTable(Index import_index,
                                StringSlice module_name,
                                StringSlice field_name,
-                               uint32_t table_index,
+                               Index table_index,
                                Type elem_type,
                                const Limits* elem_limits) = 0;
-  virtual Result OnImportMemory(uint32_t import_index,
+  virtual Result OnImportMemory(Index import_index,
                                 StringSlice module_name,
                                 StringSlice field_name,
-                                uint32_t memory_index,
+                                Index memory_index,
                                 const Limits* page_limits) = 0;
-  virtual Result OnImportGlobal(uint32_t import_index,
+  virtual Result OnImportGlobal(Index import_index,
                                 StringSlice module_name,
                                 StringSlice field_name,
-                                uint32_t global_index,
+                                Index global_index,
                                 Type type,
                                 bool mutable_) = 0;
   virtual Result EndImportSection() = 0;
 
   /* Function section */
-  virtual Result BeginFunctionSection(uint32_t size) = 0;
-  virtual Result OnFunctionCount(uint32_t count) = 0;
-  virtual Result OnFunction(uint32_t index, uint32_t sig_index) = 0;
+  virtual Result BeginFunctionSection(Offset size) = 0;
+  virtual Result OnFunctionCount(Index count) = 0;
+  virtual Result OnFunction(Index index, Index sig_index) = 0;
   virtual Result EndFunctionSection() = 0;
 
   /* Table section */
-  virtual Result BeginTableSection(uint32_t size) = 0;
-  virtual Result OnTableCount(uint32_t count) = 0;
-  virtual Result OnTable(uint32_t index,
+  virtual Result BeginTableSection(Offset size) = 0;
+  virtual Result OnTableCount(Index count) = 0;
+  virtual Result OnTable(Index index,
                          Type elem_type,
                          const Limits* elem_limits) = 0;
   virtual Result EndTableSection() = 0;
 
   /* Memory section */
-  virtual Result BeginMemorySection(uint32_t size) = 0;
-  virtual Result OnMemoryCount(uint32_t count) = 0;
-  virtual Result OnMemory(uint32_t index, const Limits* limits) = 0;
+  virtual Result BeginMemorySection(Offset size) = 0;
+  virtual Result OnMemoryCount(Index count) = 0;
+  virtual Result OnMemory(Index index, const Limits* limits) = 0;
   virtual Result EndMemorySection() = 0;
 
   /* Global section */
-  virtual Result BeginGlobalSection(uint32_t size) = 0;
-  virtual Result OnGlobalCount(uint32_t count) = 0;
-  virtual Result BeginGlobal(uint32_t index, Type type, bool mutable_) = 0;
-  virtual Result BeginGlobalInitExpr(uint32_t index) = 0;
-  virtual Result EndGlobalInitExpr(uint32_t index) = 0;
-  virtual Result EndGlobal(uint32_t index) = 0;
+  virtual Result BeginGlobalSection(Offset size) = 0;
+  virtual Result OnGlobalCount(Index count) = 0;
+  virtual Result BeginGlobal(Index index, Type type, bool mutable_) = 0;
+  virtual Result BeginGlobalInitExpr(Index index) = 0;
+  virtual Result EndGlobalInitExpr(Index index) = 0;
+  virtual Result EndGlobal(Index index) = 0;
   virtual Result EndGlobalSection() = 0;
 
   /* Exports section */
-  virtual Result BeginExportSection(uint32_t size) = 0;
-  virtual Result OnExportCount(uint32_t count) = 0;
-  virtual Result OnExport(uint32_t index,
+  virtual Result BeginExportSection(Offset size) = 0;
+  virtual Result OnExportCount(Index count) = 0;
+  virtual Result OnExport(Index index,
                           ExternalKind kind,
-                          uint32_t item_index,
+                          Index item_index,
                           StringSlice name) = 0;
   virtual Result EndExportSection() = 0;
 
   /* Start section */
-  virtual Result BeginStartSection(uint32_t size) = 0;
-  virtual Result OnStartFunction(uint32_t func_index) = 0;
+  virtual Result BeginStartSection(Offset size) = 0;
+  virtual Result OnStartFunction(Index func_index) = 0;
   virtual Result EndStartSection() = 0;
 
   /* Code section */
-  virtual Result BeginCodeSection(uint32_t size) = 0;
-  virtual Result OnFunctionBodyCount(uint32_t count) = 0;
-  virtual Result BeginFunctionBody(uint32_t index) = 0;
-  virtual Result OnLocalDeclCount(uint32_t count) = 0;
-  virtual Result OnLocalDecl(uint32_t decl_index,
-                             uint32_t count,
-                             Type type) = 0;
+  virtual Result BeginCodeSection(Offset size) = 0;
+  virtual Result OnFunctionBodyCount(Index count) = 0;
+  virtual Result BeginFunctionBody(Index index) = 0;
+  virtual Result OnLocalDeclCount(Index count) = 0;
+  virtual Result OnLocalDecl(Index decl_index, Index count, Type type) = 0;
 
   /* Function expressions; called between BeginFunctionBody and
    EndFunctionBody */
@@ -161,16 +158,16 @@ class BinaryReader {
   virtual Result OnOpcodeUint64(uint64_t value) = 0;
   virtual Result OnOpcodeF32(uint32_t value) = 0;
   virtual Result OnOpcodeF64(uint64_t value) = 0;
-  virtual Result OnOpcodeBlockSig(uint32_t num_types, Type* sig_types) = 0;
+  virtual Result OnOpcodeBlockSig(Index num_types, Type* sig_types) = 0;
   virtual Result OnBinaryExpr(Opcode opcode) = 0;
-  virtual Result OnBlockExpr(uint32_t num_types, Type* sig_types) = 0;
-  virtual Result OnBrExpr(uint32_t depth) = 0;
-  virtual Result OnBrIfExpr(uint32_t depth) = 0;
-  virtual Result OnBrTableExpr(uint32_t num_targets,
-                               uint32_t* target_depths,
-                               uint32_t default_target_depth) = 0;
-  virtual Result OnCallExpr(uint32_t func_index) = 0;
-  virtual Result OnCallIndirectExpr(uint32_t sig_index) = 0;
+  virtual Result OnBlockExpr(Index num_types, Type* sig_types) = 0;
+  virtual Result OnBrExpr(Index depth) = 0;
+  virtual Result OnBrIfExpr(Index depth) = 0;
+  virtual Result OnBrTableExpr(Index num_targets,
+                               Index* target_depths,
+                               Index default_target_depth) = 0;
+  virtual Result OnCallExpr(Index func_index) = 0;
+  virtual Result OnCallIndirectExpr(Index sig_index) = 0;
   virtual Result OnCompareExpr(Opcode opcode) = 0;
   virtual Result OnConvertExpr(Opcode opcode) = 0;
   virtual Result OnCurrentMemoryExpr() = 0;
@@ -180,93 +177,90 @@ class BinaryReader {
   virtual Result OnEndFunc() = 0;
   virtual Result OnF32ConstExpr(uint32_t value_bits) = 0;
   virtual Result OnF64ConstExpr(uint64_t value_bits) = 0;
-  virtual Result OnGetGlobalExpr(uint32_t global_index) = 0;
-  virtual Result OnGetLocalExpr(uint32_t local_index) = 0;
+  virtual Result OnGetGlobalExpr(Index global_index) = 0;
+  virtual Result OnGetLocalExpr(Index local_index) = 0;
   virtual Result OnGrowMemoryExpr() = 0;
   virtual Result OnI32ConstExpr(uint32_t value) = 0;
   virtual Result OnI64ConstExpr(uint64_t value) = 0;
-  virtual Result OnIfExpr(uint32_t num_types, Type* sig_types) = 0;
+  virtual Result OnIfExpr(Index num_types, Type* sig_types) = 0;
   virtual Result OnLoadExpr(Opcode opcode,
                             uint32_t alignment_log2,
-                            uint32_t offset) = 0;
-  virtual Result OnLoopExpr(uint32_t num_types, Type* sig_types) = 0;
+                            Address offset) = 0;
+  virtual Result OnLoopExpr(Index num_types, Type* sig_types) = 0;
   virtual Result OnNopExpr() = 0;
   virtual Result OnReturnExpr() = 0;
   virtual Result OnSelectExpr() = 0;
-  virtual Result OnSetGlobalExpr(uint32_t global_index) = 0;
-  virtual Result OnSetLocalExpr(uint32_t local_index) = 0;
+  virtual Result OnSetGlobalExpr(Index global_index) = 0;
+  virtual Result OnSetLocalExpr(Index local_index) = 0;
   virtual Result OnStoreExpr(Opcode opcode,
                              uint32_t alignment_log2,
-                             uint32_t offset) = 0;
-  virtual Result OnTeeLocalExpr(uint32_t local_index) = 0;
+                             Address offset) = 0;
+  virtual Result OnTeeLocalExpr(Index local_index) = 0;
   virtual Result OnUnaryExpr(Opcode opcode) = 0;
   virtual Result OnUnreachableExpr() = 0;
-  virtual Result EndFunctionBody(uint32_t index) = 0;
+  virtual Result EndFunctionBody(Index index) = 0;
   virtual Result EndCodeSection() = 0;
 
   /* Elem section */
-  virtual Result BeginElemSection(uint32_t size) = 0;
-  virtual Result OnElemSegmentCount(uint32_t count) = 0;
-  virtual Result BeginElemSegment(uint32_t index, uint32_t table_index) = 0;
-  virtual Result BeginElemSegmentInitExpr(uint32_t index) = 0;
-  virtual Result EndElemSegmentInitExpr(uint32_t index) = 0;
-  virtual Result OnElemSegmentFunctionIndexCount(uint32_t index,
-                                                 uint32_t count) = 0;
-  virtual Result OnElemSegmentFunctionIndex(uint32_t index,
-                                            uint32_t func_index) = 0;
-  virtual Result EndElemSegment(uint32_t index) = 0;
+  virtual Result BeginElemSection(Offset size) = 0;
+  virtual Result OnElemSegmentCount(Index count) = 0;
+  virtual Result BeginElemSegment(Index index, Index table_index) = 0;
+  virtual Result BeginElemSegmentInitExpr(Index index) = 0;
+  virtual Result EndElemSegmentInitExpr(Index index) = 0;
+  virtual Result OnElemSegmentFunctionIndexCount(Index index, Index count) = 0;
+  virtual Result OnElemSegmentFunctionIndex(Index index, Index func_index) = 0;
+  virtual Result EndElemSegment(Index index) = 0;
   virtual Result EndElemSection() = 0;
 
   /* Data section */
-  virtual Result BeginDataSection(uint32_t size) = 0;
-  virtual Result OnDataSegmentCount(uint32_t count) = 0;
-  virtual Result BeginDataSegment(uint32_t index, uint32_t memory_index) = 0;
-  virtual Result BeginDataSegmentInitExpr(uint32_t index) = 0;
-  virtual Result EndDataSegmentInitExpr(uint32_t index) = 0;
-  virtual Result OnDataSegmentData(uint32_t index,
+  virtual Result BeginDataSection(Offset size) = 0;
+  virtual Result OnDataSegmentCount(Index count) = 0;
+  virtual Result BeginDataSegment(Index index, Index memory_index) = 0;
+  virtual Result BeginDataSegmentInitExpr(Index index) = 0;
+  virtual Result EndDataSegmentInitExpr(Index index) = 0;
+  virtual Result OnDataSegmentData(Index index,
                                    const void* data,
-                                   uint32_t size) = 0;
-  virtual Result EndDataSegment(uint32_t index) = 0;
+                                   Address size) = 0;
+  virtual Result EndDataSegment(Index index) = 0;
   virtual Result EndDataSection() = 0;
 
   /* Names section */
-  virtual Result BeginNamesSection(uint32_t size) = 0;
-  virtual Result OnFunctionNameSubsection(uint32_t index,
+  virtual Result BeginNamesSection(Offset size) = 0;
+  virtual Result OnFunctionNameSubsection(Index index,
                                           uint32_t name_type,
-                                          uint32_t subsection_size) = 0;
-  virtual Result OnFunctionNamesCount(uint32_t num_functions) = 0;
-  virtual Result OnFunctionName(uint32_t function_index,
+                                          Offset subsection_size) = 0;
+  virtual Result OnFunctionNamesCount(Index num_functions) = 0;
+  virtual Result OnFunctionName(Index function_index,
                                 StringSlice function_name) = 0;
-  virtual Result OnLocalNameSubsection(uint32_t index,
+  virtual Result OnLocalNameSubsection(Index index,
                                        uint32_t name_type,
-                                       uint32_t subsection_size) = 0;
-  virtual Result OnLocalNameFunctionCount(uint32_t num_functions) = 0;
-  virtual Result OnLocalNameLocalCount(uint32_t function_index,
-                                       uint32_t num_locals) = 0;
-  virtual Result OnLocalName(uint32_t function_index,
-                             uint32_t local_index,
+                                       Offset subsection_size) = 0;
+  virtual Result OnLocalNameFunctionCount(Index num_functions) = 0;
+  virtual Result OnLocalNameLocalCount(Index function_index,
+                                       Index num_locals) = 0;
+  virtual Result OnLocalName(Index function_index,
+                             Index local_index,
                              StringSlice local_name) = 0;
   virtual Result EndNamesSection() = 0;
 
   /* Reloc section */
-  virtual Result BeginRelocSection(uint32_t size) = 0;
-  virtual Result OnRelocCount(uint32_t count,
+  virtual Result BeginRelocSection(Offset size) = 0;
+  virtual Result OnRelocCount(Index count,
                               BinarySection section_code,
                               StringSlice section_name) = 0;
   virtual Result OnReloc(RelocType type,
-                         uint32_t offset,
-                         uint32_t index,
+                         Offset offset,
+                         Index index,
                          uint32_t addend) = 0;
   virtual Result EndRelocSection() = 0;
 
   /* InitExpr - used by elem, data and global sections; these functions are
    * only called between calls to Begin*InitExpr and End*InitExpr */
-  virtual Result OnInitExprF32ConstExpr(uint32_t index, uint32_t value) = 0;
-  virtual Result OnInitExprF64ConstExpr(uint32_t index, uint64_t value) = 0;
-  virtual Result OnInitExprGetGlobalExpr(uint32_t index,
-                                         uint32_t global_index) = 0;
-  virtual Result OnInitExprI32ConstExpr(uint32_t index, uint32_t value) = 0;
-  virtual Result OnInitExprI64ConstExpr(uint32_t index, uint64_t value) = 0;
+  virtual Result OnInitExprF32ConstExpr(Index index, uint32_t value) = 0;
+  virtual Result OnInitExprF64ConstExpr(Index index, uint64_t value) = 0;
+  virtual Result OnInitExprGetGlobalExpr(Index index, Index global_index) = 0;
+  virtual Result OnInitExprI32ConstExpr(Index index, uint32_t value) = 0;
+  virtual Result OnInitExprI64ConstExpr(Index index, uint64_t value) = 0;
 
   const State* state = nullptr;
 };

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -198,7 +198,7 @@ void BinaryWriterSpec::WriteLocation(const Location* loc) {
 
 void BinaryWriterSpec::WriteVar(const Var* var) {
   if (var->type == VarType::Index)
-    json_stream_.Writef("\"%" PRIu64 "\"", var->index);
+    json_stream_.Writef("\"%" PRIindex "\"", var->index);
   else
     WriteEscapedStringSlice(var->name);
 }
@@ -365,7 +365,7 @@ void BinaryWriterSpec::WriteCommands(Script* script) {
   json_stream_.Writef("{\"source_filename\": ");
   WriteEscapedStringSlice(source_filename_);
   json_stream_.Writef(",\n \"commands\": [\n");
-  int last_module_index = -1;
+  Index last_module_index = kInvalidIndex;
   for (size_t i = 0; i < script->commands.size(); ++i) {
     const Command& command = *script->commands[i].get();
 
@@ -396,7 +396,7 @@ void BinaryWriterSpec::WriteCommands(Script* script) {
         WriteModule(filename, module);
         delete [] filename;
         num_modules_++;
-        last_module_index = static_cast<int>(i);
+        last_module_index = i;
         break;
       }
 

--- a/src/binary-writer.h
+++ b/src/binary-writer.h
@@ -40,7 +40,7 @@ struct WriteBinaryOptions {
 Result write_binary_module(Writer*, const Module*, const WriteBinaryOptions*);
 
 /* returns the length of the leb128 */
-uint32_t u32_leb128_length(uint32_t value);
+Offset u32_leb128_length(uint32_t value);
 
 void write_u32_leb128(Stream* stream, uint32_t value, const char* desc);
 
@@ -48,14 +48,12 @@ void write_i32_leb128(Stream* stream, int32_t value, const char* desc);
 
 void write_fixed_u32_leb128(Stream* stream, uint32_t value, const char* desc);
 
-uint32_t write_fixed_u32_leb128_at(Stream* stream,
-                                   uint32_t offset,
-                                   uint32_t value,
-                                   const char* desc);
+Offset write_fixed_u32_leb128_at(Stream* stream,
+                                 Offset offset,
+                                 uint32_t value,
+                                 const char* desc);
 
-uint32_t write_fixed_u32_leb128_raw(uint8_t* data,
-                                    uint8_t* end,
-                                    uint32_t value);
+Offset write_fixed_u32_leb128_raw(uint8_t* data, uint8_t* end, uint32_t value);
 
 void write_type(Stream* stream, Type type);
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -31,7 +31,7 @@
 
 namespace wabt {
 
-Reloc::Reloc(RelocType type, size_t offset, uint32_t index, int32_t addend)
+Reloc::Reloc(RelocType type, Offset offset, Index index, int32_t addend)
     : type(type), offset(offset), index(index), addend(addend) {}
 
 const char* g_kind_name[] = {"func", "table", "memory", "global"};

--- a/src/common.h
+++ b/src/common.h
@@ -40,7 +40,6 @@
 
 #define WABT_USE(x) static_cast<void>(x)
 
-#define WABT_UNKNOWN_OFFSET (static_cast<uint32_t>(~0))
 #define WABT_PAGE_SIZE 0x10000 /* 64k */
 #define WABT_MAX_PAGES 0x10000 /* # of pages that fit in 32-bit address space */
 #define WABT_BYTES_TO_PAGES(x) ((x) >> 16)
@@ -85,8 +84,19 @@
 #define WABT_CATCH_BAD_ALLOC_AND_EXIT
 #endif
 
+#define PRIindex "u"
+#define PRIaddress "u"
+#define PRIoffset PRIzx
 
 namespace wabt {
+
+typedef uint32_t Index;    // An index into one of the many index spaces.
+typedef uint32_t Address;  // An address or size in linear memory.
+typedef size_t Offset;     // An offset into a host's file or memory buffer.
+
+static const Address kInvalidAddress = ~0;
+static const Index kInvalidIndex = ~0;
+static const Offset kInvalidOffset = ~0;
 
 enum class Result {
   Ok,
@@ -164,11 +174,11 @@ enum class RelocType {
 static const int kRelocTypeCount = WABT_ENUM_COUNT(RelocType);
 
 struct Reloc {
-  Reloc(RelocType, size_t offset, uint32_t index, int32_t addend = 0);
+  Reloc(RelocType, size_t offset, Index index, int32_t addend = 0);
 
   RelocType type;
   size_t offset;
-  uint32_t index;
+  Index index;
   int32_t addend;
 };
 
@@ -250,17 +260,6 @@ inline StringSlice string_to_string_slice(const std::string& s) {
   ss.length = s.length();
   return ss;
 }
-
-bool default_source_error_callback(const Location*,
-                                   const char* error,
-                                   const char* source_line,
-                                   size_t source_line_length,
-                                   size_t source_line_column_offset,
-                                   void* user_data);
-
-bool default_binary_error_callback(uint32_t offset,
-                                   const char* error,
-                                   void* user_data);
 
 void init_stdio();
 

--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -27,12 +27,12 @@ OpcodeInfo g_opcode_info[kOpcodeCount] = {
 
 };
 
-bool is_naturally_aligned(Opcode opcode, uint32_t alignment) {
-  uint32_t opcode_align = get_opcode_memory_size(opcode);
+bool is_naturally_aligned(Opcode opcode, Address alignment) {
+  Address opcode_align = get_opcode_memory_size(opcode);
   return alignment == WABT_USE_NATURAL_ALIGNMENT || alignment == opcode_align;
 }
 
-uint32_t get_opcode_alignment(Opcode opcode, uint32_t alignment) {
+Address get_opcode_alignment(Opcode opcode, Address alignment) {
   if (alignment == WABT_USE_NATURAL_ALIGNMENT)
     return get_opcode_memory_size(opcode);
   return alignment;

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -38,16 +38,16 @@ struct OpcodeInfo {
   Type result_type;
   Type param1_type;
   Type param2_type;
-  int memory_size;
+  Address memory_size;
 };
 
 // Return 1 if |alignment| matches the alignment of |opcode|, or if |alignment|
 // is WABT_USE_NATURAL_ALIGNMENT.
-bool is_naturally_aligned(Opcode opcode, uint32_t alignment);
+bool is_naturally_aligned(Opcode opcode, Address alignment);
 
 // If |alignment| is WABT_USE_NATURAL_ALIGNMENT, return the alignment of
 // |opcode|, else return |alignment|.
-uint32_t get_opcode_alignment(Opcode opcode, uint32_t alignment);
+Address get_opcode_alignment(Opcode opcode, Address alignment);
 
 extern OpcodeInfo g_opcode_info[];
 

--- a/src/prebuilt/wast-parser-gen.cc
+++ b/src/prebuilt/wast-parser-gen.cc
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.0.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -85,8 +85,6 @@
 #include "literal.h"
 #include "wast-parser.h"
 #include "wast-parser-lexer-shared.h"
-
-#define INVALID_VAR_INDEX (-1)
 
 #define RELOCATE_STACK(type, array, stack_base, old_size, new_size)   \
   do {                                                                \
@@ -221,7 +219,7 @@ void append_implicit_func_declaration(Location*,
 class BinaryErrorHandlerModule : public BinaryErrorHandler {
  public:
   BinaryErrorHandlerModule(Location* loc, WastLexer* lexer, WastParser* parser);
-  bool OnError(uint32_t offset, const std::string& error) override;
+  bool OnError(Offset offset, const std::string& error) override;
 
  private:
   Location* loc_;
@@ -233,7 +231,7 @@ class BinaryErrorHandlerModule : public BinaryErrorHandler {
 #define wabt_wast_parser_error wast_parser_error
 
 
-#line 237 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
+#line 235 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -378,7 +376,7 @@ int wabt_wast_parser_parse (::wabt::WastLexer* lexer, ::wabt::WastParser* parser
 
 /* Copy the second part of user declarations.  */
 
-#line 382 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
+#line 380 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -684,24 +682,24 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   294,   294,   300,   310,   311,   315,   333,   334,   340,
-     343,   348,   355,   358,   359,   364,   371,   379,   385,   391,
-     396,   403,   409,   420,   424,   428,   435,   440,   447,   448,
-     454,   455,   458,   462,   463,   467,   468,   478,   479,   490,
-     491,   492,   495,   498,   501,   504,   507,   510,   513,   516,
-     519,   522,   525,   528,   531,   534,   537,   540,   543,   546,
-     559,   562,   565,   568,   571,   574,   579,   584,   589,   594,
-     602,   611,   615,   618,   623,   628,   638,   642,   646,   650,
-     654,   658,   665,   666,   674,   675,   683,   688,   689,   695,
-     701,   711,   717,   723,   733,   785,   795,   802,   810,   820,
-     823,   827,   834,   846,   854,   876,   883,   895,   903,   924,
-     946,   954,   967,   975,   983,   989,   995,  1003,  1008,  1016,
-    1024,  1030,  1036,  1045,  1053,  1058,  1063,  1068,  1075,  1082,
-    1086,  1089,  1101,  1106,  1115,  1119,  1122,  1129,  1138,  1155,
-    1172,  1184,  1190,  1196,  1202,  1235,  1245,  1265,  1276,  1298,
-    1303,  1311,  1321,  1331,  1337,  1343,  1349,  1355,  1361,  1366,
-    1371,  1377,  1386,  1391,  1392,  1397,  1406,  1407,  1414,  1426,
-    1427,  1434,  1500
+       0,   292,   292,   298,   308,   309,   313,   331,   332,   338,
+     341,   346,   353,   356,   357,   362,   369,   377,   383,   389,
+     394,   401,   407,   418,   422,   426,   433,   438,   445,   446,
+     452,   453,   456,   460,   461,   465,   466,   476,   477,   488,
+     489,   490,   493,   496,   499,   502,   505,   508,   511,   514,
+     517,   520,   523,   526,   529,   532,   535,   538,   541,   544,
+     557,   560,   563,   566,   569,   572,   577,   582,   587,   592,
+     600,   609,   613,   616,   621,   626,   636,   640,   644,   648,
+     652,   656,   663,   664,   672,   673,   681,   686,   687,   693,
+     699,   709,   715,   721,   731,   783,   793,   800,   808,   818,
+     821,   825,   832,   844,   852,   874,   881,   893,   901,   922,
+     944,   952,   965,   973,   981,   987,   993,  1001,  1006,  1014,
+    1022,  1028,  1034,  1043,  1051,  1056,  1061,  1066,  1073,  1080,
+    1084,  1087,  1099,  1104,  1113,  1117,  1120,  1127,  1136,  1153,
+    1170,  1182,  1188,  1194,  1200,  1233,  1243,  1263,  1274,  1296,
+    1301,  1309,  1319,  1329,  1335,  1341,  1347,  1353,  1359,  1364,
+    1369,  1375,  1384,  1389,  1390,  1395,  1404,  1405,  1412,  1424,
+    1425,  1432,  1498
 };
 #endif
 
@@ -1638,363 +1636,363 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 5: /* NAT  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1644 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1642 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 6: /* INT  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1650 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1648 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 7: /* FLOAT  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1656 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1654 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 8: /* TEXT  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1662 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1660 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 9: /* VAR  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1668 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1666 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 34: /* OFFSET_EQ_NAT  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1674 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1672 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 35: /* ALIGN_EQ_NAT  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1680 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1678 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 73: /* non_empty_text_list  */
-#line 278 "src/wast-parser.y" /* yacc.c:1257  */
+#line 276 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1686 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 74: /* text_list  */
-#line 278 "src/wast-parser.y" /* yacc.c:1257  */
+#line 276 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1692 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1690 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 75: /* quoted_text  */
-#line 252 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1698 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1696 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 76: /* value_type_list  */
-#line 279 "src/wast-parser.y" /* yacc.c:1257  */
+#line 277 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1704 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1702 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 78: /* global_type  */
-#line 271 "src/wast-parser.y" /* yacc.c:1257  */
+#line 269 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).global); }
-#line 1710 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1708 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 79: /* func_type  */
-#line 269 "src/wast-parser.y" /* yacc.c:1257  */
+#line 267 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1716 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1714 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 80: /* func_sig  */
-#line 269 "src/wast-parser.y" /* yacc.c:1257  */
+#line 267 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1722 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1720 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 82: /* memory_sig  */
-#line 274 "src/wast-parser.y" /* yacc.c:1257  */
+#line 272 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).memory); }
-#line 1728 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1726 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 84: /* type_use  */
-#line 280 "src/wast-parser.y" /* yacc.c:1257  */
+#line 278 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1734 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1732 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 86: /* literal  */
-#line 253 "src/wast-parser.y" /* yacc.c:1257  */
+#line 251 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).literal).text); }
-#line 1740 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1738 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 87: /* var  */
-#line 280 "src/wast-parser.y" /* yacc.c:1257  */
+#line 278 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1746 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1744 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 88: /* var_list  */
-#line 281 "src/wast-parser.y" /* yacc.c:1257  */
+#line 279 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).vars); }
-#line 1752 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1750 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 89: /* bind_var_opt  */
-#line 252 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1758 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1756 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 90: /* bind_var  */
-#line 252 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1764 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1762 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 91: /* labeling_opt  */
-#line 252 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1770 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1768 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 94: /* instr  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1776 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1774 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 95: /* plain_instr  */
-#line 265 "src/wast-parser.y" /* yacc.c:1257  */
+#line 263 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1782 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1780 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 96: /* block_instr  */
-#line 265 "src/wast-parser.y" /* yacc.c:1257  */
+#line 263 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1788 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1786 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 97: /* block  */
-#line 255 "src/wast-parser.y" /* yacc.c:1257  */
+#line 253 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).block); }
-#line 1794 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1792 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 98: /* expr  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1800 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1798 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 99: /* expr1  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1806 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1804 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 100: /* if_  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1812 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1810 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 101: /* instr_list  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1818 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1816 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 102: /* expr_list  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1822 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 103: /* const_expr  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1830 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1828 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 104: /* func_fields  */
-#line 267 "src/wast-parser.y" /* yacc.c:1257  */
+#line 265 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_func_fields(((*yyvaluep).func_fields)); }
-#line 1836 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1834 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 105: /* func_body  */
-#line 267 "src/wast-parser.y" /* yacc.c:1257  */
+#line 265 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_func_fields(((*yyvaluep).func_fields)); }
-#line 1842 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1840 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 106: /* func_info  */
-#line 268 "src/wast-parser.y" /* yacc.c:1257  */
+#line 266 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1848 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1846 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 107: /* func  */
-#line 262 "src/wast-parser.y" /* yacc.c:1257  */
+#line 260 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).exported_func); }
-#line 1854 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1852 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 108: /* offset  */
-#line 266 "src/wast-parser.y" /* yacc.c:1257  */
+#line 264 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_expr_list(((*yyvaluep).expr_list).first); }
-#line 1860 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1858 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 109: /* elem  */
-#line 260 "src/wast-parser.y" /* yacc.c:1257  */
+#line 258 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).elem_segment); }
-#line 1866 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 110: /* table  */
-#line 264 "src/wast-parser.y" /* yacc.c:1257  */
+#line 262 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).exported_table); }
-#line 1872 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1870 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 111: /* data  */
-#line 259 "src/wast-parser.y" /* yacc.c:1257  */
+#line 257 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).data_segment); }
-#line 1878 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1876 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 112: /* memory  */
-#line 263 "src/wast-parser.y" /* yacc.c:1257  */
+#line 261 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).exported_memory); }
-#line 1884 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1882 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 114: /* import_kind  */
-#line 272 "src/wast-parser.y" /* yacc.c:1257  */
+#line 270 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 1890 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1888 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 115: /* import  */
-#line 272 "src/wast-parser.y" /* yacc.c:1257  */
+#line 270 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 1896 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1894 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 116: /* inline_import  */
-#line 272 "src/wast-parser.y" /* yacc.c:1257  */
+#line 270 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 1902 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1900 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 117: /* export_kind  */
-#line 261 "src/wast-parser.y" /* yacc.c:1257  */
+#line 259 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 1908 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1906 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 118: /* export  */
-#line 261 "src/wast-parser.y" /* yacc.c:1257  */
+#line 259 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 1914 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1912 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 119: /* inline_export_opt  */
-#line 273 "src/wast-parser.y" /* yacc.c:1257  */
+#line 271 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).optional_export); }
-#line 1920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1918 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 120: /* inline_export  */
-#line 273 "src/wast-parser.y" /* yacc.c:1257  */
+#line 271 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).optional_export); }
-#line 1926 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1924 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 121: /* type_def  */
-#line 270 "src/wast-parser.y" /* yacc.c:1257  */
+#line 268 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_type); }
-#line 1932 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1930 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 122: /* start  */
-#line 280 "src/wast-parser.y" /* yacc.c:1257  */
+#line 278 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1938 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1936 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 123: /* module_fields  */
-#line 275 "src/wast-parser.y" /* yacc.c:1257  */
+#line 273 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 1944 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1942 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 124: /* raw_module  */
-#line 276 "src/wast-parser.y" /* yacc.c:1257  */
+#line 274 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).raw_module); }
-#line 1950 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1948 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 125: /* module  */
-#line 275 "src/wast-parser.y" /* yacc.c:1257  */
+#line 273 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 1956 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1954 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 126: /* script_var_opt  */
-#line 280 "src/wast-parser.y" /* yacc.c:1257  */
+#line 278 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_var(&((*yyvaluep).var)); }
-#line 1962 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1960 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 127: /* action  */
-#line 254 "src/wast-parser.y" /* yacc.c:1257  */
+#line 252 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).action); }
-#line 1968 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1966 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 128: /* assertion  */
-#line 256 "src/wast-parser.y" /* yacc.c:1257  */
+#line 254 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 1974 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1972 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 129: /* cmd  */
-#line 256 "src/wast-parser.y" /* yacc.c:1257  */
+#line 254 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 1980 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1978 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 130: /* cmd_list  */
-#line 257 "src/wast-parser.y" /* yacc.c:1257  */
+#line 255 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).commands); }
-#line 1986 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1984 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 132: /* const_list  */
-#line 258 "src/wast-parser.y" /* yacc.c:1257  */
+#line 256 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).consts); }
-#line 1992 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1990 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 133: /* script  */
-#line 277 "src/wast-parser.y" /* yacc.c:1257  */
+#line 275 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script); }
-#line 1998 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1996 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
 
@@ -2286,18 +2284,18 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 294 "src/wast-parser.y" /* yacc.c:1646  */
+#line 292 "src/wast-parser.y" /* yacc.c:1646  */
     {
       TextListNode* node = new TextListNode();
       DUPTEXT(node->text, (yyvsp[0].text));
       node->next = nullptr;
       (yyval.text_list).first = (yyval.text_list).last = node;
     }
-#line 2297 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2295 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 300 "src/wast-parser.y" /* yacc.c:1646  */
+#line 298 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.text_list) = (yyvsp[-1].text_list);
       TextListNode* node = new TextListNode();
@@ -2306,17 +2304,17 @@ yyreduce:
       (yyval.text_list).last->next = node;
       (yyval.text_list).last = node;
     }
-#line 2310 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2308 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 310 "src/wast-parser.y" /* yacc.c:1646  */
+#line 308 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.text_list).first = (yyval.text_list).last = nullptr; }
-#line 2316 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2314 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 315 "src/wast-parser.y" /* yacc.c:1646  */
+#line 313 "src/wast-parser.y" /* yacc.c:1646  */
     {
       TextListNode node;
       node.text = (yyvsp[0].text);
@@ -2330,74 +2328,74 @@ yyreduce:
       (yyval.text).start = data;
       (yyval.text).length = size;
     }
-#line 2334 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2332 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 333 "src/wast-parser.y" /* yacc.c:1646  */
+#line 331 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = new TypeVector(); }
-#line 2340 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2338 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 334 "src/wast-parser.y" /* yacc.c:1646  */
+#line 332 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.types) = (yyvsp[-1].types);
       (yyval.types)->push_back((yyvsp[0].type));
     }
-#line 2349 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2347 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 340 "src/wast-parser.y" /* yacc.c:1646  */
+#line 338 "src/wast-parser.y" /* yacc.c:1646  */
     {}
-#line 2355 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2353 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 343 "src/wast-parser.y" /* yacc.c:1646  */
+#line 341 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[0].type);
       (yyval.global)->mutable_ = false;
     }
-#line 2365 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2363 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 348 "src/wast-parser.y" /* yacc.c:1646  */
+#line 346 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[-1].type);
       (yyval.global)->mutable_ = true;
     }
-#line 2375 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2373 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 355 "src/wast-parser.y" /* yacc.c:1646  */
+#line 353 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = (yyvsp[-1].func_sig); }
-#line 2381 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2379 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 13:
-#line 358 "src/wast-parser.y" /* yacc.c:1646  */
+#line 356 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = new FuncSignature(); }
-#line 2387 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2385 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 359 "src/wast-parser.y" /* yacc.c:1646  */
+#line 357 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = new FuncSignature();
       (yyval.func_sig)->param_types = std::move(*(yyvsp[-1].types));
       delete (yyvsp[-1].types);
     }
-#line 2397 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2395 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 364 "src/wast-parser.y" /* yacc.c:1646  */
+#line 362 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = new FuncSignature();
       (yyval.func_sig)->param_types = std::move(*(yyvsp[-5].types));
@@ -2405,65 +2403,65 @@ yyreduce:
       (yyval.func_sig)->result_types = std::move(*(yyvsp[-1].types));
       delete (yyvsp[-1].types);
     }
-#line 2409 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2407 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 371 "src/wast-parser.y" /* yacc.c:1646  */
+#line 369 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = new FuncSignature();
       (yyval.func_sig)->result_types = std::move(*(yyvsp[-1].types));
       delete (yyvsp[-1].types);
     }
-#line 2419 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2417 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 379 "src/wast-parser.y" /* yacc.c:1646  */
+#line 377 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.table) = new Table();
       (yyval.table)->elem_limits = (yyvsp[-1].limits);
     }
-#line 2428 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2426 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 385 "src/wast-parser.y" /* yacc.c:1646  */
+#line 383 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.memory) = new Memory();
       (yyval.memory)->page_limits = (yyvsp[0].limits);
     }
-#line 2437 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2435 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 391 "src/wast-parser.y" /* yacc.c:1646  */
+#line 389 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = false;
       (yyval.limits).initial = (yyvsp[0].u64);
       (yyval.limits).max = 0;
     }
-#line 2447 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2445 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 396 "src/wast-parser.y" /* yacc.c:1646  */
+#line 394 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = true;
       (yyval.limits).initial = (yyvsp[-1].u64);
       (yyval.limits).max = (yyvsp[0].u64);
     }
-#line 2457 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2455 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 403 "src/wast-parser.y" /* yacc.c:1646  */
+#line 401 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2463 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2461 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 409 "src/wast-parser.y" /* yacc.c:1646  */
+#line 407 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if (WABT_FAILED(parse_uint64((yyvsp[0].literal).text.start,
                                         (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
@@ -2472,97 +2470,97 @@ yyreduce:
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2476 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2474 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 420 "src/wast-parser.y" /* yacc.c:1646  */
+#line 418 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2485 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2483 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 424 "src/wast-parser.y" /* yacc.c:1646  */
+#line 422 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2494 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2492 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 428 "src/wast-parser.y" /* yacc.c:1646  */
+#line 426 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2503 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2501 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 435 "src/wast-parser.y" /* yacc.c:1646  */
+#line 433 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var).loc = (yylsp[0]);
       (yyval.var).type = VarType::Index;
       (yyval.var).index = (yyvsp[0].u64);
     }
-#line 2513 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2511 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 440 "src/wast-parser.y" /* yacc.c:1646  */
+#line 438 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var).loc = (yylsp[0]);
       (yyval.var).type = VarType::Name;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 2523 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2521 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 447 "src/wast-parser.y" /* yacc.c:1646  */
+#line 445 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.vars) = new VarVector(); }
-#line 2529 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2527 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 448 "src/wast-parser.y" /* yacc.c:1646  */
+#line 446 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.vars) = (yyvsp[-1].vars);
       (yyval.vars)->push_back((yyvsp[0].var));
     }
-#line 2538 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2536 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 454 "src/wast-parser.y" /* yacc.c:1646  */
+#line 452 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.text)); }
-#line 2544 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2542 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 32:
-#line 458 "src/wast-parser.y" /* yacc.c:1646  */
+#line 456 "src/wast-parser.y" /* yacc.c:1646  */
     { DUPTEXT((yyval.text), (yyvsp[0].text)); }
-#line 2550 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2548 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 462 "src/wast-parser.y" /* yacc.c:1646  */
+#line 460 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.text)); }
-#line 2556 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2554 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 35:
-#line 467 "src/wast-parser.y" /* yacc.c:1646  */
+#line 465 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u64) = 0; }
-#line 2562 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2560 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 468 "src/wast-parser.y" /* yacc.c:1646  */
+#line 466 "src/wast-parser.y" /* yacc.c:1646  */
     {
     if (WABT_FAILED(parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u64),
                                 ParseIntType::SignedAndUnsigned))) {
@@ -2571,17 +2569,17 @@ yyreduce:
                         WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
       }
     }
-#line 2575 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2573 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 478 "src/wast-parser.y" /* yacc.c:1646  */
+#line 476 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u32) = USE_NATURAL_ALIGNMENT; }
-#line 2581 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2579 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 479 "src/wast-parser.y" /* yacc.c:1646  */
+#line 477 "src/wast-parser.y" /* yacc.c:1646  */
     {
     if (WABT_FAILED(parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
                                 ParseIntType::UnsignedOnly))) {
@@ -2590,165 +2588,165 @@ yyreduce:
                         WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
       }
     }
-#line 2594 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2592 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 490 "src/wast-parser.y" /* yacc.c:1646  */
+#line 488 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = join_exprs1(&(yylsp[0]), (yyvsp[0].expr)); }
-#line 2600 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2598 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 491 "src/wast-parser.y" /* yacc.c:1646  */
+#line 489 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = join_exprs1(&(yylsp[0]), (yyvsp[0].expr)); }
-#line 2606 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2604 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 492 "src/wast-parser.y" /* yacc.c:1646  */
+#line 490 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[0].expr_list); }
-#line 2612 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2610 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 42:
-#line 495 "src/wast-parser.y" /* yacc.c:1646  */
+#line 493 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateUnreachable();
     }
-#line 2620 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2618 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 498 "src/wast-parser.y" /* yacc.c:1646  */
+#line 496 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateNop();
     }
-#line 2628 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2626 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 501 "src/wast-parser.y" /* yacc.c:1646  */
+#line 499 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateDrop();
     }
-#line 2636 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2634 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 504 "src/wast-parser.y" /* yacc.c:1646  */
+#line 502 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateSelect();
     }
-#line 2644 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2642 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 507 "src/wast-parser.y" /* yacc.c:1646  */
+#line 505 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateBr((yyvsp[0].var));
     }
-#line 2652 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2650 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 510 "src/wast-parser.y" /* yacc.c:1646  */
+#line 508 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateBrIf((yyvsp[0].var));
     }
-#line 2660 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2658 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 513 "src/wast-parser.y" /* yacc.c:1646  */
+#line 511 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateBrTable((yyvsp[-1].vars), (yyvsp[0].var));
     }
-#line 2668 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2666 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 516 "src/wast-parser.y" /* yacc.c:1646  */
+#line 514 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateReturn();
     }
-#line 2676 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2674 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 519 "src/wast-parser.y" /* yacc.c:1646  */
+#line 517 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateCall((yyvsp[0].var));
     }
-#line 2684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2682 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 522 "src/wast-parser.y" /* yacc.c:1646  */
+#line 520 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateCallIndirect((yyvsp[0].var));
     }
-#line 2692 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2690 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 525 "src/wast-parser.y" /* yacc.c:1646  */
+#line 523 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateGetLocal((yyvsp[0].var));
     }
-#line 2700 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2698 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 528 "src/wast-parser.y" /* yacc.c:1646  */
+#line 526 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateSetLocal((yyvsp[0].var));
     }
-#line 2708 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2706 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 531 "src/wast-parser.y" /* yacc.c:1646  */
+#line 529 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateTeeLocal((yyvsp[0].var));
     }
-#line 2716 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2714 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 534 "src/wast-parser.y" /* yacc.c:1646  */
+#line 532 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateGetGlobal((yyvsp[0].var));
     }
-#line 2724 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2722 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 537 "src/wast-parser.y" /* yacc.c:1646  */
+#line 535 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateSetGlobal((yyvsp[0].var));
     }
-#line 2732 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2730 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 540 "src/wast-parser.y" /* yacc.c:1646  */
+#line 538 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateLoad((yyvsp[-2].opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2740 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2738 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 543 "src/wast-parser.y" /* yacc.c:1646  */
+#line 541 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateStore((yyvsp[-2].opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2748 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2746 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 546 "src/wast-parser.y" /* yacc.c:1646  */
+#line 544 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Const const_;
       WABT_ZERO_MEMORY(const_);
@@ -2762,145 +2760,145 @@ yyreduce:
       delete [] (yyvsp[0].literal).text.start;
       (yyval.expr) = Expr::CreateConst(const_);
     }
-#line 2766 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2764 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 559 "src/wast-parser.y" /* yacc.c:1646  */
+#line 557 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateUnary((yyvsp[0].opcode));
     }
-#line 2774 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2772 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 562 "src/wast-parser.y" /* yacc.c:1646  */
+#line 560 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateBinary((yyvsp[0].opcode));
     }
-#line 2782 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2780 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 565 "src/wast-parser.y" /* yacc.c:1646  */
+#line 563 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateCompare((yyvsp[0].opcode));
     }
-#line 2790 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2788 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 568 "src/wast-parser.y" /* yacc.c:1646  */
+#line 566 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateConvert((yyvsp[0].opcode));
     }
-#line 2798 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2796 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 571 "src/wast-parser.y" /* yacc.c:1646  */
+#line 569 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateCurrentMemory();
     }
-#line 2806 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2804 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 574 "src/wast-parser.y" /* yacc.c:1646  */
+#line 572 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateGrowMemory();
     }
-#line 2814 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2812 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 579 "src/wast-parser.y" /* yacc.c:1646  */
+#line 577 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateBlock((yyvsp[-2].block));
       (yyval.expr)->block->label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->block->label, (yyvsp[0].text));
     }
-#line 2824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2822 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 584 "src/wast-parser.y" /* yacc.c:1646  */
+#line 582 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateLoop((yyvsp[-2].block));
       (yyval.expr)->loop->label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->loop->label, (yyvsp[0].text));
     }
-#line 2834 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2832 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 589 "src/wast-parser.y" /* yacc.c:1646  */
+#line 587 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateIf((yyvsp[-2].block), nullptr);
       (yyval.expr)->if_.true_->label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->if_.true_->label, (yyvsp[0].text));
     }
-#line 2844 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2842 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 594 "src/wast-parser.y" /* yacc.c:1646  */
+#line 592 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = Expr::CreateIf((yyvsp[-5].block), (yyvsp[-2].expr_list).first);
       (yyval.expr)->if_.true_->label = (yyvsp[-6].text);
       CHECK_END_LABEL((yylsp[-3]), (yyval.expr)->if_.true_->label, (yyvsp[-3].text));
       CHECK_END_LABEL((yylsp[0]), (yyval.expr)->if_.true_->label, (yyvsp[0].text));
     }
-#line 2855 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2853 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 602 "src/wast-parser.y" /* yacc.c:1646  */
+#line 600 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.block) = new Block();
       (yyval.block)->sig = std::move(*(yyvsp[-1].types));
       delete (yyvsp[-1].types);
       (yyval.block)->first = (yyvsp[0].expr_list).first;
     }
-#line 2866 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 611 "src/wast-parser.y" /* yacc.c:1646  */
+#line 609 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[-1].expr_list); }
-#line 2872 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2870 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 615 "src/wast-parser.y" /* yacc.c:1646  */
+#line 613 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = join_exprs2(&(yylsp[-1]), &(yyvsp[0].expr_list), (yyvsp[-1].expr));
     }
-#line 2880 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2878 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 618 "src/wast-parser.y" /* yacc.c:1646  */
+#line 616 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateBlock((yyvsp[0].block));
       expr->block->label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), expr);
     }
-#line 2890 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2888 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 623 "src/wast-parser.y" /* yacc.c:1646  */
+#line 621 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateLoop((yyvsp[0].block));
       expr->loop->label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), expr);
     }
-#line 2900 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2898 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 628 "src/wast-parser.y" /* yacc.c:1646  */
+#line 626 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       Expr* if_ = (yyvsp[0].expr_list).last;
@@ -2909,121 +2907,121 @@ yyreduce:
       if_->if_.true_->sig = std::move(*(yyvsp[-1].types));
       delete (yyvsp[-1].types);
     }
-#line 2913 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2911 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 638 "src/wast-parser.y" /* yacc.c:1646  */
+#line 636 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateIf(new Block((yyvsp[-5].expr_list).first), (yyvsp[-1].expr_list).first);
       (yyval.expr_list) = join_exprs1(&(yylsp[-7]), expr);
     }
-#line 2922 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 642 "src/wast-parser.y" /* yacc.c:1646  */
+#line 640 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateIf(new Block((yyvsp[-1].expr_list).first), nullptr);
       (yyval.expr_list) = join_exprs1(&(yylsp[-3]), expr);
     }
-#line 2931 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2929 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 646 "src/wast-parser.y" /* yacc.c:1646  */
+#line 644 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateIf(new Block((yyvsp[-5].expr_list).first), (yyvsp[-1].expr_list).first);
       (yyval.expr_list) = join_exprs2(&(yylsp[-8]), &(yyvsp[-8].expr_list), expr);
     }
-#line 2940 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2938 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 79:
-#line 650 "src/wast-parser.y" /* yacc.c:1646  */
+#line 648 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateIf(new Block((yyvsp[-1].expr_list).first), nullptr);
       (yyval.expr_list) = join_exprs2(&(yylsp[-4]), &(yyvsp[-4].expr_list), expr);
     }
-#line 2949 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2947 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 80:
-#line 654 "src/wast-parser.y" /* yacc.c:1646  */
+#line 652 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateIf(new Block((yyvsp[-1].expr_list).first), (yyvsp[0].expr_list).first);
       (yyval.expr_list) = join_exprs2(&(yylsp[-2]), &(yyvsp[-2].expr_list), expr);
     }
-#line 2958 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2956 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 658 "src/wast-parser.y" /* yacc.c:1646  */
+#line 656 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateIf(new Block((yyvsp[0].expr_list).first), nullptr);
       (yyval.expr_list) = join_exprs2(&(yylsp[-1]), &(yyvsp[-1].expr_list), expr);
     }
-#line 2967 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2965 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 665 "src/wast-parser.y" /* yacc.c:1646  */
+#line 663 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.expr_list)); }
-#line 2973 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2971 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 666 "src/wast-parser.y" /* yacc.c:1646  */
+#line 664 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyvsp[-1].expr_list).first;
       (yyvsp[-1].expr_list).last->next = (yyvsp[0].expr_list).first;
       (yyval.expr_list).last = (yyvsp[0].expr_list).last ? (yyvsp[0].expr_list).last : (yyvsp[-1].expr_list).last;
       (yyval.expr_list).size = (yyvsp[-1].expr_list).size + (yyvsp[0].expr_list).size;
     }
-#line 2984 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2982 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 674 "src/wast-parser.y" /* yacc.c:1646  */
+#line 672 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.expr_list)); }
-#line 2990 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2988 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 675 "src/wast-parser.y" /* yacc.c:1646  */
+#line 673 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyvsp[-1].expr_list).first;
       (yyvsp[-1].expr_list).last->next = (yyvsp[0].expr_list).first;
       (yyval.expr_list).last = (yyvsp[0].expr_list).last ? (yyvsp[0].expr_list).last : (yyvsp[-1].expr_list).last;
       (yyval.expr_list).size = (yyvsp[-1].expr_list).size + (yyvsp[0].expr_list).size;
     }
-#line 3001 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2999 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 689 "src/wast-parser.y" /* yacc.c:1646  */
+#line 687 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new FuncField();
       (yyval.func_fields)->type = FuncFieldType::ResultTypes;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3012 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3010 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 695 "src/wast-parser.y" /* yacc.c:1646  */
+#line 693 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new FuncField();
       (yyval.func_fields)->type = FuncFieldType::ParamTypes;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3023 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3021 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 701 "src/wast-parser.y" /* yacc.c:1646  */
+#line 699 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new FuncField();
       (yyval.func_fields)->type = FuncFieldType::BoundParam;
@@ -3032,33 +3030,33 @@ yyreduce:
       (yyval.func_fields)->bound_type.type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3036 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3034 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 711 "src/wast-parser.y" /* yacc.c:1646  */
+#line 709 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new FuncField();
       (yyval.func_fields)->type = FuncFieldType::Exprs;
       (yyval.func_fields)->first_expr = (yyvsp[0].expr_list).first;
       (yyval.func_fields)->next = nullptr;
     }
-#line 3047 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3045 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 717 "src/wast-parser.y" /* yacc.c:1646  */
+#line 715 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new FuncField();
       (yyval.func_fields)->type = FuncFieldType::LocalTypes;
       (yyval.func_fields)->types = (yyvsp[-2].types);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3056 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 723 "src/wast-parser.y" /* yacc.c:1646  */
+#line 721 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_fields) = new FuncField();
       (yyval.func_fields)->type = FuncFieldType::BoundLocal;
@@ -3067,11 +3065,11 @@ yyreduce:
       (yyval.func_fields)->bound_type.type = (yyvsp[-2].type);
       (yyval.func_fields)->next = (yyvsp[0].func_fields);
     }
-#line 3071 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3069 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 733 "src/wast-parser.y" /* yacc.c:1646  */
+#line 731 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = new Func();
       FuncField* field = (yyvsp[0].func_fields);
@@ -3122,11 +3120,11 @@ yyreduce:
         field = next;
       }
     }
-#line 3126 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3124 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 785 "src/wast-parser.y" /* yacc.c:1646  */
+#line 783 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func) = new ExportedFunc();
       (yyval.exported_func)->func.reset((yyvsp[-1].func));
@@ -3136,11 +3134,11 @@ yyreduce:
       (yyval.exported_func)->export_ = std::move(*(yyvsp[-3].optional_export));
       delete (yyvsp[-3].optional_export);
     }
-#line 3140 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3138 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 96:
-#line 795 "src/wast-parser.y" /* yacc.c:1646  */
+#line 793 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func) = new ExportedFunc();
       (yyval.exported_func)->func.reset((yyvsp[-1].func));
@@ -3148,11 +3146,11 @@ yyreduce:
       (yyval.exported_func)->func->decl.type_var = (yyvsp[-2].var);
       (yyval.exported_func)->func->name = (yyvsp[-3].text);
     }
-#line 3152 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3150 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 802 "src/wast-parser.y" /* yacc.c:1646  */
+#line 800 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func) = new ExportedFunc();
       (yyval.exported_func)->func.reset((yyvsp[-1].func));
@@ -3160,29 +3158,29 @@ yyreduce:
       (yyval.exported_func)->export_ = std::move(*(yyvsp[-2].optional_export));
       delete (yyvsp[-2].optional_export);
     }
-#line 3164 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3162 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 810 "src/wast-parser.y" /* yacc.c:1646  */
+#line 808 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_func) = new ExportedFunc();
       (yyval.exported_func)->func.reset((yyvsp[-1].func));
       (yyval.exported_func)->func->name = (yyvsp[-2].text);
     }
-#line 3174 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3172 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 820 "src/wast-parser.y" /* yacc.c:1646  */
+#line 818 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[-1].expr_list);
     }
-#line 3182 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3180 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 827 "src/wast-parser.y" /* yacc.c:1646  */
+#line 825 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.elem_segment) = new ElemSegment();
       (yyval.elem_segment)->table_var = (yyvsp[-3].var);
@@ -3190,11 +3188,11 @@ yyreduce:
       (yyval.elem_segment)->vars = std::move(*(yyvsp[-1].vars));
       delete (yyvsp[-1].vars);
     }
-#line 3194 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3192 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 834 "src/wast-parser.y" /* yacc.c:1646  */
+#line 832 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.elem_segment) = new ElemSegment();
       (yyval.elem_segment)->table_var.loc = (yylsp[-3]);
@@ -3204,11 +3202,11 @@ yyreduce:
       (yyval.elem_segment)->vars = std::move(*(yyvsp[-1].vars));
       delete (yyvsp[-1].vars);
     }
-#line 3208 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3206 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 846 "src/wast-parser.y" /* yacc.c:1646  */
+#line 844 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_table) = new ExportedTable();
       (yyval.exported_table)->table.reset((yyvsp[-1].table));
@@ -3217,11 +3215,11 @@ yyreduce:
       (yyval.exported_table)->export_ = std::move(*(yyvsp[-2].optional_export));
       delete (yyvsp[-2].optional_export);
     }
-#line 3221 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3219 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 855 "src/wast-parser.y" /* yacc.c:1646  */
+#line 853 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateConst(Const(Const::I32(), 0));
       expr->loc = (yylsp[-8]);
@@ -3240,11 +3238,11 @@ yyreduce:
       (yyval.exported_table)->export_ = std::move(*(yyvsp[-6].optional_export));
       delete (yyvsp[-6].optional_export);
     }
-#line 3244 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3242 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 876 "src/wast-parser.y" /* yacc.c:1646  */
+#line 874 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.data_segment) = new DataSegment();
       (yyval.data_segment)->memory_var = (yyvsp[-3].var);
@@ -3252,11 +3250,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.data_segment)->data, &(yyval.data_segment)->size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3256 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3254 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 883 "src/wast-parser.y" /* yacc.c:1646  */
+#line 881 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.data_segment) = new DataSegment();
       (yyval.data_segment)->memory_var.loc = (yylsp[-3]);
@@ -3266,11 +3264,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.data_segment)->data, &(yyval.data_segment)->size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3270 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3268 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 895 "src/wast-parser.y" /* yacc.c:1646  */
+#line 893 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_memory) = new ExportedMemory();
       (yyval.exported_memory)->memory.reset((yyvsp[-1].memory));
@@ -3279,11 +3277,11 @@ yyreduce:
       (yyval.exported_memory)->export_ = std::move(*(yyvsp[-2].optional_export));
       delete (yyvsp[-2].optional_export);
     }
-#line 3283 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3281 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 903 "src/wast-parser.y" /* yacc.c:1646  */
+#line 901 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateConst(Const(Const::I32(), 0));
       expr->loc = (yylsp[-7]);
@@ -3304,11 +3302,11 @@ yyreduce:
       (yyval.exported_memory)->export_ = std::move(*(yyvsp[-5].optional_export));
       delete (yyvsp[-5].optional_export);
     }
-#line 3308 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3306 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 924 "src/wast-parser.y" /* yacc.c:1646  */
+#line 922 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = Expr::CreateConst(Const(Const::I32(), 0));
       expr->loc = (yylsp[-6]);
@@ -3328,11 +3326,11 @@ yyreduce:
       (yyval.exported_memory)->memory->page_limits.has_max = true;
       (yyval.exported_memory)->export_.has_export = false;
     }
-#line 3332 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3330 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 110:
-#line 946 "src/wast-parser.y" /* yacc.c:1646  */
+#line 944 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_global) = new ExportedGlobal();
       (yyval.exported_global)->global.reset((yyvsp[-2].global));
@@ -3341,11 +3339,11 @@ yyreduce:
       (yyval.exported_global)->export_ = std::move(*(yyvsp[-3].optional_export));
       delete (yyvsp[-3].optional_export);
     }
-#line 3345 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3343 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 954 "src/wast-parser.y" /* yacc.c:1646  */
+#line 952 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exported_global) = new ExportedGlobal();
       (yyval.exported_global)->global.reset((yyvsp[-2].global));
@@ -3353,11 +3351,11 @@ yyreduce:
       (yyval.exported_global)->global->init_expr = (yyvsp[-1].expr_list).first;
       (yyval.exported_global)->export_.has_export = false;
     }
-#line 3357 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3355 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 967 "src/wast-parser.y" /* yacc.c:1646  */
+#line 965 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
@@ -3366,11 +3364,11 @@ yyreduce:
       (yyval.import)->func->decl.has_func_type = true;
       (yyval.import)->func->decl.type_var = (yyvsp[-1].var);
     }
-#line 3370 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3368 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 975 "src/wast-parser.y" /* yacc.c:1646  */
+#line 973 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
@@ -3379,54 +3377,54 @@ yyreduce:
       (yyval.import)->func->decl.sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
     }
-#line 3383 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3381 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 983 "src/wast-parser.y" /* yacc.c:1646  */
+#line 981 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table->name = (yyvsp[-2].text);
     }
-#line 3394 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3392 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 989 "src/wast-parser.y" /* yacc.c:1646  */
+#line 987 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory->name = (yyvsp[-2].text);
     }
-#line 3405 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3403 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 995 "src/wast-parser.y" /* yacc.c:1646  */
+#line 993 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global->name = (yyvsp[-2].text);
     }
-#line 3416 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3414 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 1003 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1001 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-1].import);
       (yyval.import)->module_name = (yyvsp[-3].text);
       (yyval.import)->field_name = (yyvsp[-2].text);
     }
-#line 3426 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3424 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 1008 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1006 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Func;
@@ -3435,11 +3433,11 @@ yyreduce:
       (yyval.import)->func->decl.has_func_type = true;
       (yyval.import)->func->decl.type_var = (yyvsp[-1].var);
     }
-#line 3439 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3437 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 1016 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1014 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Func;
@@ -3448,158 +3446,158 @@ yyreduce:
       (yyval.import)->func->decl.sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
     }
-#line 3452 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3450 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 120:
-#line 1024 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1022 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table->name = (yyvsp[-3].text);
     }
-#line 3463 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3461 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 1030 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1028 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory->name = (yyvsp[-3].text);
     }
-#line 3474 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3472 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 1036 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1034 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = (yyvsp[-2].import);
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global->name = (yyvsp[-3].text);
     }
-#line 3485 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3483 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 1045 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1043 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->module_name = (yyvsp[-2].text);
       (yyval.import)->field_name = (yyvsp[-1].text);
     }
-#line 3495 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3493 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 1053 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1051 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Func;
       (yyval.export_)->var = (yyvsp[-1].var);
     }
-#line 3505 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3503 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 1058 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1056 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Table;
       (yyval.export_)->var = (yyvsp[-1].var);
     }
-#line 3515 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3513 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 126:
-#line 1063 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1061 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Memory;
       (yyval.export_)->var = (yyvsp[-1].var);
     }
-#line 3525 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3523 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 127:
-#line 1068 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1066 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Global;
       (yyval.export_)->var = (yyvsp[-1].var);
     }
-#line 3535 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3533 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 1075 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1073 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = (yyvsp[-1].export_);
       (yyval.export_)->name = (yyvsp[-2].text);
     }
-#line 3544 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3542 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 129:
-#line 1082 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1080 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.optional_export) = new OptionalExport();
       (yyval.optional_export)->has_export = false;
     }
-#line 3553 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3551 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 1089 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1087 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.optional_export) = new OptionalExport();
       (yyval.optional_export)->has_export = true;
       (yyval.optional_export)->export_.reset(new Export());
       (yyval.optional_export)->export_->name = (yyvsp[-1].text);
     }
-#line 3564 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3562 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 1101 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1099 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_type) = new FuncType();
       (yyval.func_type)->sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
     }
-#line 3574 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3572 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 1106 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1104 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_type) = new FuncType();
       (yyval.func_type)->name = (yyvsp[-2].text);
       (yyval.func_type)->sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
     }
-#line 3585 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3583 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 1115 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1113 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 3591 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3589 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 1119 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1117 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new Module();
     }
-#line 3599 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3597 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 136:
-#line 1122 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1120 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3607,11 +3605,11 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), func_types, field->func_type);
       INSERT_BINDING((yyval.module), func_type, func_types, (yylsp[0]), (yyvsp[0].func_type)->name);
     }
-#line 3611 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3609 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 137:
-#line 1129 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1127 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3621,11 +3619,11 @@ yyreduce:
       APPEND_INLINE_EXPORT((yyval.module), Global, (yylsp[0]), (yyvsp[0].exported_global), (yyval.module)->globals.size() - 1);
       delete (yyvsp[0].exported_global);
     }
-#line 3625 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3623 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 1138 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1136 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3643,11 +3641,11 @@ yyreduce:
       }
       delete (yyvsp[0].exported_table);
     }
-#line 3647 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3645 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 1155 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1153 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3665,11 +3663,11 @@ yyreduce:
       }
       delete (yyvsp[0].exported_memory);
     }
-#line 3669 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3667 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 1172 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1170 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3682,44 +3680,44 @@ yyreduce:
       APPEND_INLINE_EXPORT((yyval.module), Func, (yylsp[0]), (yyvsp[0].exported_func), (yyval.module)->funcs.size() - 1);
       delete (yyvsp[0].exported_func);
     }
-#line 3686 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 1184 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1182 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
       APPEND_FIELD_TO_LIST((yyval.module), field, ElemSegment, elem_segment, (yylsp[0]), (yyvsp[0].elem_segment));
       APPEND_ITEM_TO_VECTOR((yyval.module), elem_segments, field->elem_segment);
     }
-#line 3697 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3695 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 1190 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1188 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
       APPEND_FIELD_TO_LIST((yyval.module), field, DataSegment, data_segment, (yylsp[0]), (yyvsp[0].data_segment));
       APPEND_ITEM_TO_VECTOR((yyval.module), data_segments, field->data_segment);
     }
-#line 3708 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3706 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 1196 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1194 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
       APPEND_FIELD_TO_LIST((yyval.module), field, Start, start, (yylsp[0]), (yyvsp[0].var));
       (yyval.module)->start = &field->start;
     }
-#line 3719 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3717 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 1202 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1200 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3753,11 +3751,11 @@ yyreduce:
       }
       APPEND_ITEM_TO_VECTOR((yyval.module), imports, field->import);
     }
-#line 3757 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3755 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 1235 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1233 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       ModuleField* field;
@@ -3765,11 +3763,11 @@ yyreduce:
       APPEND_ITEM_TO_VECTOR((yyval.module), exports, field->export_);
       INSERT_BINDING((yyval.module), export, exports, (yylsp[0]), field->export_->name);
     }
-#line 3769 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3767 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 1245 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1243 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module) = new RawModule();
       (yyval.raw_module)->type = RawModuleType::Text;
@@ -3790,11 +3788,11 @@ yyreduce:
         }
       }
     }
-#line 3794 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3792 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1265 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1263 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.raw_module) = new RawModule();
       (yyval.raw_module)->type = RawModuleType::Binary;
@@ -3803,11 +3801,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.raw_module)->binary.data, &(yyval.raw_module)->binary.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 3807 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3805 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1276 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1274 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].raw_module)->type == RawModuleType::Text) {
         (yyval.module) = (yyvsp[0].raw_module)->text;
@@ -3825,31 +3823,31 @@ yyreduce:
       }
       delete (yyvsp[0].raw_module);
     }
-#line 3829 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3827 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1298 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1296 "src/wast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Index;
-      (yyval.var).index = INVALID_VAR_INDEX;
+      (yyval.var).index = kInvalidIndex;
     }
-#line 3839 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3837 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1303 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1301 "src/wast-parser.y" /* yacc.c:1646  */
     {
       WABT_ZERO_MEMORY((yyval.var));
       (yyval.var).type = VarType::Name;
       DUPTEXT((yyval.var).name, (yyvsp[0].text));
     }
-#line 3849 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3847 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1311 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1309 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-4]);
@@ -3860,11 +3858,11 @@ yyreduce:
       (yyval.action)->invoke->args = std::move(*(yyvsp[-1].consts));
       delete (yyvsp[-1].consts);
     }
-#line 3864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3862 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1321 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1319 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-3]);
@@ -3872,128 +3870,128 @@ yyreduce:
       (yyval.action)->type = ActionType::Get;
       (yyval.action)->name = (yyvsp[-1].text);
     }
-#line 3876 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3874 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1331 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1329 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertMalformed;
       (yyval.command)->assert_malformed.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_malformed.text = (yyvsp[-1].text);
     }
-#line 3887 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3885 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1337 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1335 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertInvalid;
       (yyval.command)->assert_invalid.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_invalid.text = (yyvsp[-1].text);
     }
-#line 3898 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3896 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1343 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1341 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertUnlinkable;
       (yyval.command)->assert_unlinkable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_unlinkable.text = (yyvsp[-1].text);
     }
-#line 3909 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3907 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1349 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1347 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertUninstantiable;
       (yyval.command)->assert_uninstantiable.module = (yyvsp[-2].raw_module);
       (yyval.command)->assert_uninstantiable.text = (yyvsp[-1].text);
     }
-#line 3920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3918 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1355 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1353 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertReturn;
       (yyval.command)->assert_return.action = (yyvsp[-2].action);
       (yyval.command)->assert_return.expected = (yyvsp[-1].consts);
     }
-#line 3931 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3929 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1361 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1359 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertReturnCanonicalNan;
       (yyval.command)->assert_return_canonical_nan.action = (yyvsp[-1].action);
     }
-#line 3941 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3939 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1366 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1364 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertReturnArithmeticNan;
       (yyval.command)->assert_return_arithmetic_nan.action = (yyvsp[-1].action);
     }
-#line 3951 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3949 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1371 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1369 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertTrap;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3962 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3960 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1377 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1375 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertExhaustion;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 3973 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3971 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 162:
-#line 1386 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1384 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::Action;
       (yyval.command)->action = (yyvsp[0].action);
     }
-#line 3983 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3981 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1392 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1390 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::Module;
       (yyval.command)->module = (yyvsp[0].module);
     }
-#line 3993 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3991 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1397 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1395 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::Register;
@@ -4001,26 +3999,26 @@ yyreduce:
       (yyval.command)->register_.var = (yyvsp[-1].var);
       (yyval.command)->register_.var.loc = (yylsp[-1]);
     }
-#line 4005 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4003 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1406 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1404 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.commands) = new CommandPtrVector(); }
-#line 4011 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4009 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1407 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1405 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4020 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4018 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1414 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1412 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WABT_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -4031,26 +4029,26 @@ yyreduce:
       }
       delete [] (yyvsp[-1].literal).text.start;
     }
-#line 4035 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4033 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1426 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1424 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.consts) = new ConstVector(); }
-#line 4041 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4039 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1427 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1425 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       (yyval.consts)->push_back((yyvsp[0].const_));
     }
-#line 4050 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4048 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 171:
-#line 1434 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1432 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       (yyval.script)->commands = std::move(*(yyvsp[0].commands));
@@ -4100,7 +4098,7 @@ yyreduce:
             /* Resolve actions with an invalid index to use the preceding
              * module. */
             if (module_var->type == VarType::Index &&
-                module_var->index == INVALID_VAR_INDEX) {
+                module_var->index == kInvalidIndex) {
               module_var->index = last_module_index;
             }
             break;
@@ -4112,11 +4110,11 @@ yyreduce:
       }
       parser->script = (yyval.script);
     }
-#line 4116 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4114 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4120 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4118 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4351,7 +4349,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1503 "src/wast-parser.y" /* yacc.c:1906  */
+#line 1501 "src/wast-parser.y" /* yacc.c:1906  */
 
 
 void append_expr_list(ExprList* expr_list, ExprList* expr) {
@@ -4519,14 +4517,14 @@ BinaryErrorHandlerModule::BinaryErrorHandlerModule(
     Location* loc, WastLexer* lexer, WastParser* parser)
   : loc_(loc), lexer_(lexer), parser_(parser) {}
 
-bool BinaryErrorHandlerModule::OnError(uint32_t offset,
+bool BinaryErrorHandlerModule::OnError(Offset offset,
                                        const std::string& error) {
-  if (offset == WABT_UNKNOWN_OFFSET) {
+  if (offset == kInvalidOffset) {
     wast_parser_error(loc_, lexer_, parser_, "error in binary module: %s",
                       error.c_str());
   } else {
     wast_parser_error(loc_, lexer_, parser_,
-                      "error in binary module: @0x%08x: %s", offset,
+                      "error in binary module: @0x%08" PRIzx ": %s", offset,
                       error.c_str());
   }
   return true;

--- a/src/prebuilt/wast-parser-gen.hh
+++ b/src/prebuilt/wast-parser-gen.hh
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -274,11 +274,11 @@ static void print_call(StringSlice module_name,
 }
 
 static InterpreterResult run_defined_function(InterpreterThread* thread,
-                                              uint32_t offset) {
+                                              IstreamOffset offset) {
   thread->pc = offset;
   InterpreterResult iresult = InterpreterResult::Ok;
-  uint32_t quantum = s_trace ? 1 : INSTRUCTION_QUANTUM;
-  uint32_t* call_stack_return_top = thread->call_stack_top;
+  int quantum = s_trace ? 1 : INSTRUCTION_QUANTUM;
+  IstreamOffset* call_stack_return_top = thread->call_stack_top;
   while (iresult == InterpreterResult::Ok) {
     if (s_trace)
       trace_pc(thread, s_stdout_stream.get());
@@ -326,12 +326,12 @@ static void copy_results(InterpreterThread* thread,
 
 static InterpreterResult run_function(
     InterpreterThread* thread,
-    uint32_t func_index,
+    Index func_index,
     const std::vector<InterpreterTypedValue>& args,
     std::vector<InterpreterTypedValue>* out_results) {
   assert(func_index < thread->env->funcs.size());
   InterpreterFunc* func = thread->env->funcs[func_index].get();
-  uint32_t sig_index = func->sig_index;
+  Index sig_index = func->sig_index;
   assert(sig_index < thread->env->sigs.size());
   InterpreterFuncSignature* sig = &thread->env->sigs[sig_index];
 
@@ -352,7 +352,7 @@ static InterpreterResult run_function(
 
 static InterpreterResult run_start_function(InterpreterThread* thread,
                                             DefinedInterpreterModule* module) {
-  if (module->start_func_index == WABT_INVALID_INDEX)
+  if (module->start_func_index == kInvalidIndex)
     return InterpreterResult::Ok;
 
   if (s_trace)
@@ -450,13 +450,13 @@ static Result read_module(const char* module_filename,
 
 static Result default_host_callback(const HostInterpreterFunc* func,
                                     const InterpreterFuncSignature* sig,
-                                    uint32_t num_args,
+                                    Index num_args,
                                     InterpreterTypedValue* args,
-                                    uint32_t num_results,
+                                    Index num_results,
                                     InterpreterTypedValue* out_results,
                                     void* user_data) {
   memset(out_results, 0, sizeof(InterpreterTypedValue) * num_results);
-  for (uint32_t i = 0; i < num_results; ++i)
+  for (Index i = 0; i < num_results; ++i)
     out_results[i].type = sig->result_types[i];
 
   std::vector<InterpreterTypedValue> vec_args(args, args + num_args);

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -47,7 +47,7 @@ static void WABT_PRINTF_FORMAT(2, 3)
 }
 
 Result typechecker_get_label(TypeChecker* tc,
-                             size_t depth,
+                             Index depth,
                              TypeCheckerLabel** out_label) {
   if (depth >= tc->label_stack.size()) {
     assert(tc->label_stack.size() > 0);
@@ -99,7 +99,7 @@ static Result check_label_type(TypeCheckerLabel* label, LabelType label_type) {
   return label->label_type == label_type ? Result::Ok : Result::Error;
 }
 
-static Result peek_type(TypeChecker* tc, uint32_t depth, Type* out_type) {
+static Result peek_type(TypeChecker* tc, Index depth, Type* out_type) {
   TypeCheckerLabel* label;
   CHECK_RESULT(top_label(tc, &label));
 
@@ -295,7 +295,7 @@ Result typechecker_on_block(TypeChecker* tc, const TypeVector* sig) {
   return Result::Ok;
 }
 
-Result typechecker_on_br(TypeChecker* tc, size_t depth) {
+Result typechecker_on_br(TypeChecker* tc, Index depth) {
   Result result = Result::Ok;
   TypeCheckerLabel* label;
   CHECK_RESULT(typechecker_get_label(tc, depth, &label));
@@ -305,7 +305,7 @@ Result typechecker_on_br(TypeChecker* tc, size_t depth) {
   return result;
 }
 
-Result typechecker_on_br_if(TypeChecker* tc, size_t depth) {
+Result typechecker_on_br_if(TypeChecker* tc, Index depth) {
   Result result = Result::Ok;
   COMBINE_RESULT(result, pop_and_check_1_type(tc, Type::I32, "br_if"));
   TypeCheckerLabel* label;
@@ -320,7 +320,7 @@ Result typechecker_begin_br_table(TypeChecker* tc) {
   return pop_and_check_1_type(tc, Type::I32, "br_table");
 }
 
-Result typechecker_on_br_table_target(TypeChecker* tc, size_t depth) {
+Result typechecker_on_br_table_target(TypeChecker* tc, Index depth) {
   Result result = Result::Ok;
   TypeCheckerLabel* label;
   CHECK_RESULT(typechecker_get_label(tc, depth, &label));

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -51,7 +51,7 @@ Result typechecker_get_label(TypeChecker* tc,
                              TypeCheckerLabel** out_label) {
   if (depth >= tc->label_stack.size()) {
     assert(tc->label_stack.size() > 0);
-    print_error(tc, "invalid depth: %" PRIzd " (max %" PRIzd ")", depth,
+    print_error(tc, "invalid depth: %" PRIindex " (max %" PRIzd ")", depth,
                 tc->label_stack.size() - 1);
     *out_label = nullptr;
     return Result::Error;

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -51,16 +51,16 @@ struct TypeChecker {
 
 bool typechecker_is_unreachable(TypeChecker* tc);
 Result typechecker_get_label(TypeChecker* tc,
-                             size_t depth,
+                             Index depth,
                              TypeCheckerLabel** out_label);
 
 Result typechecker_begin_function(TypeChecker*, const TypeVector* sig);
 Result typechecker_on_binary(TypeChecker*, Opcode);
 Result typechecker_on_block(TypeChecker*, const TypeVector* sig);
-Result typechecker_on_br(TypeChecker*, size_t depth);
-Result typechecker_on_br_if(TypeChecker*, size_t depth);
+Result typechecker_on_br(TypeChecker*, Index depth);
+Result typechecker_on_br_if(TypeChecker*, Index depth);
 Result typechecker_begin_br_table(TypeChecker*);
-Result typechecker_on_br_table_target(TypeChecker*, size_t depth);
+Result typechecker_on_br_table_target(TypeChecker*, Index depth);
 Result typechecker_end_br_table(TypeChecker*);
 Result typechecker_on_call(TypeChecker*,
                            const TypeVector* param_types,

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -32,11 +32,11 @@ struct LinkerInputBinary;
 
 struct FunctionImport {
   StringSlice name;
-  uint32_t sig_index;
+  Index sig_index;
   bool active; /* Is this import present in the linked binary */
-  uint32_t relocated_function_index;
+  Index relocated_function_index;
   struct LinkerInputBinary* foreign_binary;
-  uint32_t foreign_index;
+  Index foreign_index;
 };
 
 struct GlobalImport {
@@ -46,8 +46,8 @@ struct GlobalImport {
 };
 
 struct DataSegment {
-  uint32_t memory_index;
-  uint32_t offset;
+  Index memory_index;
+  Address offset;
   const uint8_t* data;
   size_t size;
 };
@@ -55,7 +55,7 @@ struct DataSegment {
 struct Export {
   ExternalKind kind;
   StringSlice name;
-  uint32_t index;
+  Index index;
 };
 
 struct SectionDataCustom {
@@ -80,7 +80,7 @@ struct Section {
   size_t payload_offset;
 
   /* For known sections, the count of the number of elements in the section */
-  uint32_t count;
+  Index count;
 
   union {
     /* CUSTOM section data */
@@ -110,20 +110,20 @@ struct LinkerInputBinary {
   std::vector<Export> exports;
 
   std::vector<FunctionImport> function_imports;
-  uint32_t active_function_imports;
+  Index active_function_imports;
   std::vector<GlobalImport> global_imports;
-  uint32_t active_global_imports;
+  Index active_global_imports;
 
-  uint32_t type_index_offset;
-  uint32_t function_index_offset;
-  uint32_t imported_function_index_offset;
-  uint32_t global_index_offset;
-  uint32_t imported_global_index_offset;
-  uint32_t table_index_offset;
-  uint32_t memory_page_count;
-  uint32_t memory_page_offset;
+  Index type_index_offset;
+  Index function_index_offset;
+  Index imported_function_index_offset;
+  Index global_index_offset;
+  Index imported_global_index_offset;
+  Index table_index_offset;
+  Index memory_page_count;
+  Index memory_page_offset;
 
-  uint32_t table_elem_count;
+  Index table_elem_count;
 
   std::vector<std::string> debug_names;
 };

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -85,7 +85,7 @@ class WatWriter {
   void WriteStringSlice(const StringSlice* str, NextChar next_char);
   bool WriteStringSliceOpt(const StringSlice* str, NextChar next_char);
   void WriteStringSliceOrIndex(const StringSlice* str,
-                               uint32_t index,
+                               Index index,
                                NextChar next_char);
   void WriteQuotedData(const void* data, size_t length);
   void WriteQuotedStringSlice(const StringSlice* str, NextChar next_char);
@@ -122,14 +122,14 @@ class WatWriter {
   Result result_ = Result::Ok;
   int indent_ = 0;
   NextChar next_char_ = NextChar::None;
-  int depth_ = 0;
+  Index depth_ = 0;
   std::vector<std::string> index_to_name_;
 
-  int func_index_ = 0;
-  int global_index_ = 0;
-  int table_index_ = 0;
-  int memory_index_ = 0;
-  int func_type_index_ = 0;
+  Index func_index_ = 0;
+  Index global_index_ = 0;
+  Index table_index_ = 0;
+  Index memory_index_ = 0;
+  Index func_type_index_ = 0;
 };
 
 }  // namespace
@@ -258,7 +258,7 @@ bool WatWriter::WriteStringSliceOpt(const StringSlice* str,
 }
 
 void WatWriter::WriteStringSliceOrIndex(const StringSlice* str,
-                                        uint32_t index,
+                                        Index index,
                                         NextChar next_char) {
   if (str->start)
     WriteStringSlice(str, next_char);
@@ -293,7 +293,7 @@ void WatWriter::WriteQuotedStringSlice(const StringSlice* str,
 
 void WatWriter::WriteVar(const Var* var, NextChar next_char) {
   if (var->type == VarType::Index) {
-    Writef("%" PRId64, var->index);
+    Writef("%" PRIindex, var->index);
     next_char_ = next_char;
   } else {
     WriteStringSlice(&var->name, next_char);
@@ -302,7 +302,8 @@ void WatWriter::WriteVar(const Var* var, NextChar next_char) {
 
 void WatWriter::WriteBrVar(const Var* var, NextChar next_char) {
   if (var->type == VarType::Index) {
-    Writef("%" PRId64 " (;@%" PRId64 ";)", var->index,
+    assert(var->index < depth_);
+    Writef("%" PRIindex " (;@%" PRIindex ";)", var->index,
            depth_ - var->index - 1);
     next_char_ = next_char;
   } else {
@@ -337,7 +338,7 @@ void WatWriter::WriteBeginBlock(const Block* block, const char* text) {
   bool has_label = WriteStringSliceOpt(&block->label, NextChar::Space);
   WriteTypes(block->sig, nullptr);
   if (!has_label)
-    Writef(" ;; label = @%d", depth_);
+    Writef(" ;; label = @%" PRIindex, depth_);
   WriteNewline(FORCE_NEWLINE);
   depth_++;
   Indent();

--- a/test/link/export.txt
+++ b/test/link/export.txt
@@ -38,8 +38,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000037) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x000042) index=0x000001
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000037) index=0
+   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x000042) index=1
 
 Code Disassembly:
 

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -49,11 +49,11 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00005f) index=0x000002
-   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x000065) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x000012(file=0x00006b) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x000024(file=0x00007d) index=0x000001
-   - R_FUNC_INDEX_LEB   offset=0x00002c(file=0x000085) index=0x000003
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00005f) index=2
+   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x000065) index=3
+   - R_FUNC_INDEX_LEB   offset=0x000012(file=0x00006b) index=0
+   - R_FUNC_INDEX_LEB   offset=0x000024(file=0x00007d) index=1
+   - R_FUNC_INDEX_LEB   offset=0x00002c(file=0x000085) index=3
 
 Code Disassembly:
 

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -55,12 +55,12 @@ Function:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00007b) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x000081) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x00001e(file=0x000093) index=0x000001
-   - R_FUNC_INDEX_LEB   offset=0x000026(file=0x00009b) index=0x000004
-   - R_FUNC_INDEX_LEB   offset=0x000034(file=0x0000a9) index=0x000002
-   - R_FUNC_INDEX_LEB   offset=0x00003c(file=0x0000b1) index=0x000005
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00007b) index=0
+   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x000081) index=3
+   - R_FUNC_INDEX_LEB   offset=0x00001e(file=0x000093) index=1
+   - R_FUNC_INDEX_LEB   offset=0x000026(file=0x00009b) index=4
+   - R_FUNC_INDEX_LEB   offset=0x000034(file=0x0000a9) index=2
+   - R_FUNC_INDEX_LEB   offset=0x00003c(file=0x0000b1) index=5
 
 Code Disassembly:
 

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -51,13 +51,13 @@ Global:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_GLOBAL_INDEX_LEB offset=0x000004(file=0x00005c) index=0x000003
-   - R_GLOBAL_INDEX_LEB offset=0x00000a(file=0x000062) index=0x000002
-   - R_GLOBAL_INDEX_LEB offset=0x000011(file=0x000069) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x000018(file=0x000070) index=00000000
-   - R_GLOBAL_INDEX_LEB offset=0x000021(file=0x000079) index=0x000001
-   - R_GLOBAL_INDEX_LEB offset=0x000027(file=0x00007f) index=0x000004
-   - R_FUNC_INDEX_LEB   offset=0x00002d(file=0x000085) index=0x000001
+   - R_GLOBAL_INDEX_LEB offset=0x000004(file=0x00005c) index=3
+   - R_GLOBAL_INDEX_LEB offset=0x00000a(file=0x000062) index=2
+   - R_GLOBAL_INDEX_LEB offset=0x000011(file=0x000069) index=0
+   - R_FUNC_INDEX_LEB   offset=0x000018(file=0x000070) index=0
+   - R_GLOBAL_INDEX_LEB offset=0x000021(file=0x000079) index=1
+   - R_GLOBAL_INDEX_LEB offset=0x000027(file=0x00007f) index=4
+   - R_FUNC_INDEX_LEB   offset=0x00002d(file=0x000085) index=1
 
 Code Disassembly:
 

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -73,22 +73,22 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00008a) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x00000b(file=0x00008f) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x000010(file=0x000094) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x000015(file=0x000099) index=0x000004
-   - R_FUNC_INDEX_LEB   offset=0x00001a(file=0x00009e) index=0x000004
-   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x0000a3) index=0x000005
-   - R_FUNC_INDEX_LEB   offset=0x000024(file=0x0000a8) index=0x000005
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x00008a) index=3
+   - R_FUNC_INDEX_LEB   offset=0x00000b(file=0x00008f) index=3
+   - R_FUNC_INDEX_LEB   offset=0x000010(file=0x000094) index=3
+   - R_FUNC_INDEX_LEB   offset=0x000015(file=0x000099) index=4
+   - R_FUNC_INDEX_LEB   offset=0x00001a(file=0x00009e) index=4
+   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x0000a3) index=5
+   - R_FUNC_INDEX_LEB   offset=0x000024(file=0x0000a8) index=5
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x0000b5) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x0000bb) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x00001e(file=0x0000cd) index=0x000001
-   - R_FUNC_INDEX_LEB   offset=0x000026(file=0x0000d5) index=0x000004
-   - R_FUNC_INDEX_LEB   offset=0x000034(file=0x0000e3) index=0x000002
-   - R_FUNC_INDEX_LEB   offset=0x00003c(file=0x0000eb) index=0x000005
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x0000b5) index=0
+   - R_FUNC_INDEX_LEB   offset=0x00000c(file=0x0000bb) index=3
+   - R_FUNC_INDEX_LEB   offset=0x00001e(file=0x0000cd) index=1
+   - R_FUNC_INDEX_LEB   offset=0x000026(file=0x0000d5) index=4
+   - R_FUNC_INDEX_LEB   offset=0x000034(file=0x0000e3) index=2
+   - R_FUNC_INDEX_LEB   offset=0x00003c(file=0x0000eb) index=5
 
 Code Disassembly:
 

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -77,8 +77,8 @@ Export:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x00000d(file=0x000084) index=0x000003
-   - R_FUNC_INDEX_LEB   offset=0x000017(file=0x00008e) index=0x000004
+   - R_FUNC_INDEX_LEB   offset=0x00000d(file=0x000084) index=3
+   - R_FUNC_INDEX_LEB   offset=0x000017(file=0x00008e) index=4
 
 Code Disassembly:
 

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -63,9 +63,9 @@ Custom:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000083) index=0x000006
-   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x00008e) index=0x000002
-   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x00009c) index=0x000006
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000083) index=6
+   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x00008e) index=2
+   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x00009c) index=6
 
 Code Disassembly:
 

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -45,11 +45,11 @@ Elem:
 Custom:
  - name: "reloc.Elem"
   - section: Elem
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000038) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x00000b(file=0x00003d) index=00000000
-   - R_FUNC_INDEX_LEB   offset=0x000010(file=0x000042) index=0x000002
-   - R_FUNC_INDEX_LEB   offset=0x000015(file=0x000047) index=0x000001
-   - R_FUNC_INDEX_LEB   offset=0x00001a(file=0x00004c) index=0x000001
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000038) index=0
+   - R_FUNC_INDEX_LEB   offset=0x00000b(file=0x00003d) index=0
+   - R_FUNC_INDEX_LEB   offset=0x000010(file=0x000042) index=2
+   - R_FUNC_INDEX_LEB   offset=0x000015(file=0x000047) index=1
+   - R_FUNC_INDEX_LEB   offset=0x00001a(file=0x00004c) index=1
 
 Code Disassembly:
 


### PR DESCRIPTION
An `Index` is an index into one of the WebAssembly index spaces. It also
is used for counts for these spaces, as well as parameter counts and
result counts.

An `Address` is an index into linear memory, or the size of a data
region in linear memory.

An `Offset` is an offset into the host's file or memory buffer.

This fixes issue #322.