### PR TITLE
WIP: DO NOT COMMIT

### DIFF
--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -130,20 +130,48 @@ Result BinaryReaderLinker::OnReloc(RelocType type,
 Result BinaryReaderLinker::OnImport(Index index,
                                     StringSlice module_name,
                                     StringSlice field_name) {
-  if (!string_slice_eq_cstr(&module_name, WABT_LINK_MODULE_NAME)) {
+#if 0
+  if (!string_slice_eq_cstr(&module_name, "__extern")) {
     WABT_FATAL("unsupported import module: " PRIstringslice,
                WABT_PRINTF_STRING_SLICE_ARG(module_name));
   }
   return Result::Ok;
+#else
+  WABT_LOG("OnImport: module_name=\"" PRIstringslice "\""
+          " field_name=\"" PRIstringslice "\"\n",
+          WABT_PRINTF_STRING_SLICE_ARG(module_name),
+          WABT_PRINTF_STRING_SLICE_ARG(field_name));
+  std::vector<FunctionImport>& imports = binary->function_imports;
+  for (size_t j = 0; j < imports.size(); j++) {
+    FunctionImport* import = &imports[j];
+    if (string_slices_are_equal(&module_name, &import->module_name)) {
+      WABT_LOG("OnImport: module_name=\"" PRIstringslice "\""
+              " field_name=\"" PRIstringslice "\" FOUND\n",
+              WABT_PRINTF_STRING_SLICE_ARG(module_name),
+              WABT_PRINTF_STRING_SLICE_ARG(field_name));
+      return Result::Ok;
+    }
+  }
+  WABT_LOG("OnImport: module_name=\"" PRIstringslice "\""
+          " field_name=\"" PRIstringslice "\" NOT FOUND\n",
+          WABT_PRINTF_STRING_SLICE_ARG(module_name),
+          WABT_PRINTF_STRING_SLICE_ARG(field_name));
+  return Result::Ok;
+#endif
 }
 
 Result BinaryReaderLinker::OnImportFunc(Index import_index,
                                         StringSlice module_name,
                                         StringSlice field_name,
-                                        Index global_index,
-                                        Index sig_index) {
+                                        uint32_t global_index,
+                                        uint32_t sig_index) {
+  //WABT_LOG("OnImportFunction: module_name=\"" PRIstringslice "\""
+  //        " field_name=\"" PRIstringslice "\"\n",
+  //        WABT_PRINTF_STRING_SLICE_ARG(module_name),
+  //        WABT_PRINTF_STRING_SLICE_ARG(field_name));
   binary->function_imports.emplace_back();
   FunctionImport* import = &binary->function_imports.back();
+  import->module_name = module_name;
   import->name = field_name;
   import->sig_index = sig_index;
   import->active = true;
@@ -157,8 +185,13 @@ Result BinaryReaderLinker::OnImportGlobal(Index import_index,
                                           Index global_index,
                                           Type type,
                                           bool mutable_) {
+  //WABT_LOG("OnImportGlobal: module_name=\"" PRIstringslice "\""
+  //        " field_name=\"" PRIstringslice "\"\n",
+  //        WABT_PRINTF_STRING_SLICE_ARG(module_name),
+  //        WABT_PRINTF_STRING_SLICE_ARG(field_name));
   binary->global_imports.emplace_back();
   GlobalImport* import = &binary->global_imports.back();
+  import->module_name = module_name;
   import->name = field_name;
   import->type = type;
   import->mutable_ = mutable_;

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+//#define DLOG
+
 #include "binary-reader-linker.h"
 
 #include <vector>
@@ -137,7 +139,7 @@ Result BinaryReaderLinker::OnImport(Index index,
   }
   return Result::Ok;
 #else
-  WABT_LOG("OnImport: module_name=\"" PRIstringslice "\""
+  WABT_DLOG("OnImport: module_name=\"" PRIstringslice "\""
           " field_name=\"" PRIstringslice "\"\n",
           WABT_PRINTF_STRING_SLICE_ARG(module_name),
           WABT_PRINTF_STRING_SLICE_ARG(field_name));
@@ -145,14 +147,14 @@ Result BinaryReaderLinker::OnImport(Index index,
   for (size_t j = 0; j < imports.size(); j++) {
     FunctionImport* import = &imports[j];
     if (string_slices_are_equal(&module_name, &import->module_name)) {
-      WABT_LOG("OnImport: module_name=\"" PRIstringslice "\""
+      WABT_DLOG("OnImport: module_name=\"" PRIstringslice "\""
               " field_name=\"" PRIstringslice "\" FOUND\n",
               WABT_PRINTF_STRING_SLICE_ARG(module_name),
               WABT_PRINTF_STRING_SLICE_ARG(field_name));
       return Result::Ok;
     }
   }
-  WABT_LOG("OnImport: module_name=\"" PRIstringslice "\""
+  WABT_DLOG("OnImport: module_name=\"" PRIstringslice "\""
           " field_name=\"" PRIstringslice "\" NOT FOUND\n",
           WABT_PRINTF_STRING_SLICE_ARG(module_name),
           WABT_PRINTF_STRING_SLICE_ARG(field_name));
@@ -165,10 +167,10 @@ Result BinaryReaderLinker::OnImportFunc(Index import_index,
                                         StringSlice field_name,
                                         uint32_t global_index,
                                         uint32_t sig_index) {
-  //WABT_LOG("OnImportFunction: module_name=\"" PRIstringslice "\""
-  //        " field_name=\"" PRIstringslice "\"\n",
-  //        WABT_PRINTF_STRING_SLICE_ARG(module_name),
-  //        WABT_PRINTF_STRING_SLICE_ARG(field_name));
+  WABT_DLOG("OnImportFunction: module_name=\"" PRIstringslice "\""
+          " field_name=\"" PRIstringslice "\"\n",
+          WABT_PRINTF_STRING_SLICE_ARG(module_name),
+          WABT_PRINTF_STRING_SLICE_ARG(field_name));
   binary->function_imports.emplace_back();
   FunctionImport* import = &binary->function_imports.back();
   import->module_name = module_name;
@@ -185,10 +187,10 @@ Result BinaryReaderLinker::OnImportGlobal(Index import_index,
                                           Index global_index,
                                           Type type,
                                           bool mutable_) {
-  //WABT_LOG("OnImportGlobal: module_name=\"" PRIstringslice "\""
-  //        " field_name=\"" PRIstringslice "\"\n",
-  //        WABT_PRINTF_STRING_SLICE_ARG(module_name),
-  //        WABT_PRINTF_STRING_SLICE_ARG(field_name));
+  WABT_DLOG("OnImportGlobal: module_name=\"" PRIstringslice "\""
+          " field_name=\"" PRIstringslice "\"\n",
+          WABT_PRINTF_STRING_SLICE_ARG(module_name),
+          WABT_PRINTF_STRING_SLICE_ARG(field_name));
   binary->global_imports.emplace_back();
   GlobalImport* import = &binary->global_imports.back();
   import->module_name = module_name;

--- a/src/common.h
+++ b/src/common.h
@@ -31,6 +31,7 @@
 
 #include "config.h"
 
+#define WABT_LOG(...) do { fprintf(stdout, __VA_ARGS__); } while(0)
 #define WABT_FATAL(...) fprintf(stderr, __VA_ARGS__), exit(1)
 #define WABT_ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #define WABT_ZERO_MEMORY(var)                                          \

--- a/src/common.h
+++ b/src/common.h
@@ -31,7 +31,12 @@
 
 #include "config.h"
 
-#define WABT_LOG(...) do { fprintf(stdout, __VA_ARGS__); } while(0)
+#ifdef DLOG
+#define WABT_DLOG(...) do { fprintf(stdout, __VA_ARGS__); } while(0)
+#else
+#define WABT_DLOG(...)
+#endif
+
 #define WABT_FATAL(...) fprintf(stderr, __VA_ARGS__), exit(1)
 #define WABT_ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
 #define WABT_ZERO_MEMORY(var)                                          \

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -380,7 +380,7 @@ static void write_memory_section(Context* ctx,
 static void write_function_import(Context* ctx,
                                   FunctionImport* import,
                                   Index offset) {
-  write_c_str(&ctx->stream, WABT_LINK_MODULE_NAME, "import module name");
+  write_slice(&ctx->stream, import->module_name, "import module name");
   write_slice(&ctx->stream, import->name, "import field name");
   ctx->stream.WriteU8Enum(ExternalKind::Func, "import kind");
   write_u32_leb128(&ctx->stream, import->sig_index + offset,
@@ -388,7 +388,7 @@ static void write_function_import(Context* ctx,
 }
 
 static void write_global_import(Context* ctx, GlobalImport* import) {
-  write_c_str(&ctx->stream, WABT_LINK_MODULE_NAME, "import module name");
+  write_slice(&ctx->stream, import->module_name, "import module name");
   write_slice(&ctx->stream, import->name, "import field name");
   ctx->stream.WriteU8Enum(ExternalKind::Global, "import kind");
   write_type(&ctx->stream, import->type);

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -23,14 +23,13 @@
 #include "binary.h"
 #include "common.h"
 
-#define WABT_LINK_MODULE_NAME "__extern"
-
 namespace wabt {
 namespace link {
 
 struct LinkerInputBinary;
 
 struct FunctionImport {
+  StringSlice module_name;
   StringSlice name;
   Index sig_index;
   bool active; /* Is this import present in the linked binary */
@@ -40,6 +39,7 @@ struct FunctionImport {
 };
 
 struct GlobalImport {
+  StringSlice module_name;
   StringSlice name;
   Type type;
   bool mutable_;


### PR DESCRIPTION
Add module_name to FunctionImport and GlobalImport

Remove WABT_LINK_MODULE_NAME and thus it does not assuming it's always
__extern.

This is NOT passing tests and it just for review purposes.