### PR TITLE
Allow any module name

### DIFF
--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -130,18 +130,6 @@ Result BinaryReaderLinker::OnReloc(RelocType type,
 Result BinaryReaderLinker::OnImport(Index index,
                                     StringSlice module_name,
                                     StringSlice field_name) {
-#if 0
-  // Is this module been seen in the past
-  std::vector<FunctionImport>& imports = binary->function_imports;
-  for (size_t j = 0; j < imports.size(); j++) {
-    FunctionImport* import = &imports[j];
-    if (string_slices_are_equal(&module_name, &import->module_name)) {
-      // Found
-      return Result::Ok;
-    }
-  }
-  // A new module should anything be done?
-#endif
   return Result::Ok;
 }
 

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -34,9 +34,6 @@ class BinaryReaderLinker : public BinaryReaderNop {
 
   Result BeginSection(BinarySection section_type, Offset size) override;
 
-  Result OnImport(Index index,
-                  StringSlice module_name,
-                  StringSlice field_name) override;
   Result OnImportFunc(Index import_index,
                       StringSlice module_name,
                       StringSlice field_name,
@@ -124,12 +121,6 @@ Result BinaryReaderLinker::OnReloc(RelocType type,
 
   reloc_section->relocations.emplace_back(type, offset, index, addend);
 
-  return Result::Ok;
-}
-
-Result BinaryReaderLinker::OnImport(Index index,
-                                    StringSlice module_name,
-                                    StringSlice field_name) {
   return Result::Ok;
 }
 

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -130,10 +130,18 @@ Result BinaryReaderLinker::OnReloc(RelocType type,
 Result BinaryReaderLinker::OnImport(Index index,
                                     StringSlice module_name,
                                     StringSlice field_name) {
-  if (!string_slice_eq_cstr(&module_name, WABT_LINK_MODULE_NAME)) {
-    WABT_FATAL("unsupported import module: " PRIstringslice,
-               WABT_PRINTF_STRING_SLICE_ARG(module_name));
+#if 0
+  // Is this module been seen in the past
+  std::vector<FunctionImport>& imports = binary->function_imports;
+  for (size_t j = 0; j < imports.size(); j++) {
+    FunctionImport* import = &imports[j];
+    if (string_slices_are_equal(&module_name, &import->module_name)) {
+      // Found
+      return Result::Ok;
+    }
   }
+  // A new module should anything be done?
+#endif
   return Result::Ok;
 }
 
@@ -144,6 +152,7 @@ Result BinaryReaderLinker::OnImportFunc(Index import_index,
                                         Index sig_index) {
   binary->function_imports.emplace_back();
   FunctionImport* import = &binary->function_imports.back();
+  import->module_name = module_name;
   import->name = field_name;
   import->sig_index = sig_index;
   import->active = true;
@@ -159,6 +168,7 @@ Result BinaryReaderLinker::OnImportGlobal(Index import_index,
                                           bool mutable_) {
   binary->global_imports.emplace_back();
   GlobalImport* import = &binary->global_imports.back();
+  import->module_name = module_name;
   import->name = field_name;
   import->type = type;
   import->mutable_ = mutable_;

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -380,7 +380,7 @@ static void write_memory_section(Context* ctx,
 static void write_function_import(Context* ctx,
                                   FunctionImport* import,
                                   Index offset) {
-  write_c_str(&ctx->stream, WABT_LINK_MODULE_NAME, "import module name");
+  write_slice(&ctx->stream, import->module_name, "import module name");
   write_slice(&ctx->stream, import->name, "import field name");
   ctx->stream.WriteU8Enum(ExternalKind::Func, "import kind");
   write_u32_leb128(&ctx->stream, import->sig_index + offset,
@@ -388,7 +388,7 @@ static void write_function_import(Context* ctx,
 }
 
 static void write_global_import(Context* ctx, GlobalImport* import) {
-  write_c_str(&ctx->stream, WABT_LINK_MODULE_NAME, "import module name");
+  write_slice(&ctx->stream, import->module_name, "import module name");
   write_slice(&ctx->stream, import->name, "import field name");
   ctx->stream.WriteU8Enum(ExternalKind::Global, "import kind");
   write_type(&ctx->stream, import->type);

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -23,14 +23,13 @@
 #include "binary.h"
 #include "common.h"
 
-#define WABT_LINK_MODULE_NAME "__extern"
-
 namespace wabt {
 namespace link {
 
 struct LinkerInputBinary;
 
 struct FunctionImport {
+  StringSlice module_name;
   StringSlice name;
   Index sig_index;
   bool active; /* Is this import present in the linked binary */
@@ -40,6 +39,7 @@ struct FunctionImport {
 };
 
 struct GlobalImport {
+  StringSlice module_name;
   StringSlice name;
   Type type;
   bool mutable_;

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -2,9 +2,9 @@
 ;;; FLAGS: --debug-names -r
 (module
   (import "__extern" "missing0" (func $import_func0))
-  (import "__extern" "missing1" (func))
-  (import "__extern" "baz" (func $import_func1))
-  (import "__extern" "missing2" (func $import_func2))
+  (import "_extern1" "missing1" (func))
+  (import "anything" "baz" (func $import_func1))
+  (import "extern2" "missing2" (func $import_func2))
   (export "foo" (func $name1))
   (func $name1 (param $param1 i32)
      i32.const 1
@@ -27,12 +27,12 @@ linked.wasm:	file format wasm 0x1
 Sections:
 
      Type start=0x0000000a end=0x0000001a (size=0x00000010) count: 4
-   Import start=0x00000020 end=0x0000005d (size=0x0000003d) count: 3
- Function start=0x00000063 end=0x00000068 (size=0x00000005) count: 4
-   Export start=0x0000006e end=0x0000007b (size=0x0000000d) count: 2
-     Code start=0x0000007d end=0x000000a2 (size=0x00000025) count: 4
-   Custom start=0x000000a8 end=0x000000ea (size=0x00000042) "name"
-   Custom start=0x000000f0 end=0x00000106 (size=0x00000016) "reloc.Code"
+   Import start=0x00000020 end=0x0000005c (size=0x0000003c) count: 3
+ Function start=0x00000062 end=0x00000067 (size=0x00000005) count: 4
+   Export start=0x0000006d end=0x0000007a (size=0x0000000d) count: 2
+     Code start=0x0000007c end=0x000000a1 (size=0x00000025) count: 4
+   Custom start=0x000000a7 end=0x000000e9 (size=0x00000042) "name"
+   Custom start=0x000000ef end=0x00000105 (size=0x00000016) "reloc.Code"
 
 Section Details:
 
@@ -43,8 +43,8 @@ Type:
  - [3] (i32) -> nil
 Import:
  - func[0] sig=0 <- __extern.missing0
- - func[1] sig=0 <- __extern.missing1
- - func[2] sig=0 <- __extern.missing2
+ - func[1] sig=0 <- _extern1.missing1
+ - func[2] sig=0 <- extern2.missing2
 Function:
  - func[3] sig=1
  - func[4] sig=2
@@ -63,27 +63,27 @@ Custom:
 Custom:
  - name: "reloc.Code"
   - section: Code
-   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000083) index=6
-   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x00008e) index=2
-   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x00009c) index=6
+   - R_FUNC_INDEX_LEB   offset=0x000006(file=0x000082) index=6
+   - R_FUNC_INDEX_LEB   offset=0x000011(file=0x00008d) index=2
+   - R_FUNC_INDEX_LEB   offset=0x00001f(file=0x00009b) index=6
 
 Code Disassembly:
 
-00007e <$name1>:
- 000080: 41 01                      | i32.const 0x1
- 000082: 10 86 80 80 80 00          | call 0x6
-           000083: R_FUNC_INDEX_LEB   6 <$name3>
- 000088: 0b                         | end
-000089 <$name2>:
- 00008b: 42 01                      | i64.const 1
- 00008d: 10 82 80 80 80 00          | call 0x2
-           00008e: R_FUNC_INDEX_LEB   2 <$import_func2>
- 000093: 0b                         | end
-000094 func[5]:
- 000096: 0b                         | end
-000097 <$name3>:
- 000099: 41 02                      | i32.const 0x2
- 00009b: 10 86 80 80 80 00          | call 0x6
-           00009c: R_FUNC_INDEX_LEB   6 <$name3>
- 0000a1: 0b                         | end
+00007d <$name1>:
+ 00007f: 41 01                      | i32.const 0x1
+ 000081: 10 86 80 80 80 00          | call 0x6
+           000082: R_FUNC_INDEX_LEB   6 <$name3>
+ 000087: 0b                         | end
+000088 <$name2>:
+ 00008a: 42 01                      | i64.const 1
+ 00008c: 10 82 80 80 80 00          | call 0x2
+           00008d: R_FUNC_INDEX_LEB   2 <$import_func2>
+ 000092: 0b                         | end
+000093 func[5]:
+ 000095: 0b                         | end
+000096 <$name3>:
+ 000098: 41 02                      | i32.const 0x2
+ 00009a: 10 86 80 80 80 00          | call 0x6
+           00009b: R_FUNC_INDEX_LEB   6 <$name3>
+ 0000a0: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/names_import_only_module_env.txt
+++ b/test/link/names_import_only_module_env.txt
@@ -1,0 +1,28 @@
+;;; TOOL: run-wasm-link
+;;; FLAGS: --debug-names -r
+(module
+  (import "env" "baz" (func $import_func1))
+)
+(;; STDOUT ;;;
+
+linked.wasm:	file format wasm 0x1
+
+Sections:
+
+     Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
+   Import start=0x00000014 end=0x0000001f (size=0x0000000b) count: 1
+   Custom start=0x00000025 end=0x00000040 (size=0x0000001b) "name"
+
+Section Details:
+
+Type:
+ - [0] () -> nil
+Import:
+ - func[0] sig=0 <- env.baz
+Custom:
+ - name: "name"
+ - func[0] $import_func1
+
+Code Disassembly:
+
+;;; STDOUT ;;)


### PR DESCRIPTION
Currently a module name must be `__extern` with this change any module
name is allowed.