### PR TITLE
Supporting memory exports in wasm-link

### DIFF
--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -305,16 +305,19 @@ static void write_table_section(Context* ctx,
 }
 
 static void write_export_section(Context* ctx) {
-  bool seenMemory = false;
+  bool seenMemory = false, singleMemoryExport = false;
 
   Index total_exports = 0;
   for (const std::unique_ptr<LinkerInputBinary>& binary: ctx->inputs) {
     for (const Export& export_ : binary->exports) {
       if (export_.kind == ExternalKind::Memory) {
         if (string_slice_to_string(export_.name) != "memory") {
-          WABT_FATAL("Only a single memory export, \"memory\" is supported.");
+          singleMemoryExport = true;
         }
         if (seenMemory) {
+          if (singleMemoryExport) {
+            WABT_FATAL("Multiple memory exports only supported when named \"memory\".");
+          }
           continue;
         }
         seenMemory = true;

--- a/test/link/memory-export-single.txt
+++ b/test/link/memory-export-single.txt
@@ -1,0 +1,43 @@
+;;; TOOL: run-wasm-link
+;;; FLAGS:
+(module
+  (memory $0 1)
+  (export "customMemoryName" (memory $0))
+)
+(module
+  (memory $0 1)
+  (export "foo" (func $foo))
+  (func $foo (result i32)
+    (i32.const 41)
+  )
+)
+(;; STDOUT ;;;
+
+linked.wasm:	file format wasm 0x1
+
+Sections:
+
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+ Function start=0x00000015 end=0x00000017 (size=0x00000002) count: 1
+   Memory start=0x0000001d end=0x00000021 (size=0x00000004) count: 1
+   Export start=0x00000027 end=0x00000041 (size=0x0000001a) count: 2
+     Code start=0x00000043 end=0x00000049 (size=0x00000006) count: 1
+
+Section Details:
+
+Type:
+ - [0] () -> i32
+Function:
+ - func[0] sig=0
+Memory:
+ - memory[0] pages: initial=2 max=2
+Export:
+ - memory[0] -> "customMemoryName"
+ - func[0] -> "foo"
+
+Code Disassembly:
+
+000044 func[0]:
+ 000046: 41 29                      | i32.const 0x29
+ 000048: 0b                         | end
+;;; STDOUT ;;)

--- a/test/link/memory-export.txt
+++ b/test/link/memory-export.txt
@@ -1,0 +1,29 @@
+;;; TOOL: run-wasm-link
+;;; FLAGS:
+(module
+  (memory $0 1)
+  (export "memory" (memory $0))
+)
+(module
+  (memory $0 1)
+  (export "memory" (memory $0))
+)
+(;; STDOUT ;;;
+
+linked.wasm:	file format wasm 0x1
+
+Sections:
+
+   Memory start=0x0000000e end=0x00000012 (size=0x00000004) count: 1
+   Export start=0x00000018 end=0x00000022 (size=0x0000000a) count: 1
+
+Section Details:
+
+Memory:
+ - memory[0] pages: initial=2 max=2
+Export:
+ - memory[0] -> "memory"
+
+Code Disassembly:
+
+;;; STDOUT ;;)


### PR DESCRIPTION
PR for #439.

This only allows memories called "memory" to be coalesced as a single memory export. This seems the simplest way to support exported memory, although does further ingrain the "memory" name as a convention. Perhaps wasm-link could take advantage of multiple memories in future, which would avoid the need to have to do these memory merges, and linked modules could retain their original memories and memory names.