### PR TITLE
Don't include leading $ in wasm binary name section

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -821,7 +821,8 @@ Result BinaryReaderIR::OnFunctionName(Index index, StringSlice name) {
 
   module->func_bindings.emplace(string_slice_to_string(name), Binding(index));
   Func* func = module->funcs[index];
-  func->name = dup_string_slice(name);
+  func->name = dup_string_slice(
+      string_to_string_slice(std::string("$") + string_slice_to_string(name)));
   return Result::Ok;
 }
 
@@ -883,7 +884,8 @@ Result BinaryReaderIR::OnLocalName(Index func_index,
     bindings = &func->local_bindings;
     index = local_index - num_params;
   }
-  bindings->emplace(string_slice_to_string(name), Binding(index));
+  bindings->emplace(std::string("$") + string_slice_to_string(name),
+                    Binding(index));
   return Result::Ok;
 }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -260,7 +260,7 @@ bool WatWriter::WriteStringSliceOpt(const StringSlice* str,
 
 void WatWriter::WriteName(const StringSlice* str, NextChar next_char) {
   // Debug names must begin with a $ for for wast file to be valid
-  assert(str->length == 0 || str->start[0] == '$');
+  assert(str->length > 0 && str->start[0] == '$');
   WriteStringSlice(str, next_char);
 }
 

--- a/test/binary/names.txt
+++ b/test/binary/names.txt
@@ -12,17 +12,17 @@ section(CODE) {
 }
 section("name") {
   subsection[1]
-  length[6]
+  length[5]
   func_count[1]
   index[0]
-  str("$F0")
+  str("F0")
   subsection[2]
-  length[8]
+  length[7]
   func_count[1]
   index[0]
   local_count[1]
   index[0]
-  str("$L0")
+  str("L0")
 }
 (;; STDOUT ;;;
 (module

--- a/test/binary/no-global-names.txt
+++ b/test/binary/no-global-names.txt
@@ -29,9 +29,9 @@ section("name") {
 (;; STDOUT ;;;
 (module
   (type (;0;) (func))
-  (func bar (type 0)
+  (func $bar (type 0)
     return)
   (global (;0;) i32 (i32.const 0))
-  (export "bar" (func bar))
+  (export "bar" (func $bar))
   (export "d_glob" (global 0)))
 ;;; STDOUT ;;)

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -35,16 +35,16 @@
 0000023: 00                                        ; subsection size (guess)
 0000024: 01                                        ; num functions
 0000025: 00                                        ; function index
-0000026: 04                                        ; string length
-0000027: 2466 6f6f                                $foo  ; func name 0
-0000023: 07                                        ; FIXUP subsection size
-000002b: 02                                        ; local name type
-000002c: 00                                        ; subsection size (guess)
-000002d: 01                                        ; num functions
-000002e: 00                                        ; function index
-000002f: 00                                        ; num locals
-000002c: 03                                        ; FIXUP subsection size
-000001c: 13                                        ; FIXUP section size
+0000026: 03                                        ; string length
+0000027: 666f 6f                                  foo  ; func name 0
+0000023: 06                                        ; FIXUP subsection size
+000002a: 02                                        ; local name type
+000002b: 00                                        ; subsection size (guess)
+000002c: 01                                        ; num functions
+000002d: 00                                        ; function index
+000002e: 00                                        ; num locals
+000002b: 03                                        ; FIXUP subsection size
+000001c: 12                                        ; FIXUP section size
 
 debug-import-names.wasm:	file format wasm 0x1
 
@@ -52,17 +52,17 @@ Sections:
 
      Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    Import start=0x00000010 end=0x0000001b (size=0x0000000b) count: 1
-   Custom start=0x0000001d end=0x00000030 (size=0x00000013) "name"
+   Custom start=0x0000001d end=0x0000002f (size=0x00000012) "name"
 
 Section Details:
 
 Type:
  - [0] () -> nil
 Import:
- - func[0] sig=0 <$foo> <- bar.foo
+ - func[0] sig=0 <foo> <- bar.foo
 Custom:
  - name: "name"
- - func[0] $foo
+ - func[0] foo
 
 Code Disassembly:
 

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -76,48 +76,48 @@
 0000035: 00                                        ; subsection size (guess)
 0000036: 02                                        ; num functions
 0000037: 00                                        ; function index
-0000038: 03                                        ; string length
-0000039: 2446 31                                  $F1  ; func name 0
-000003c: 02                                        ; function index
-000003d: 03                                        ; string length
-000003e: 2446 32                                  $F2  ; func name 2
-0000035: 0b                                        ; FIXUP subsection size
-0000041: 02                                        ; local name type
-0000042: 00                                        ; subsection size (guess)
-0000043: 03                                        ; num functions
-0000044: 00                                        ; function index
-0000045: 04                                        ; num locals
-0000046: 00                                        ; local index
-0000047: 05                                        ; string length
-0000048: 2446 3150 30                             $F1P0  ; local name 0
-000004d: 01                                        ; local index
-000004e: 05                                        ; string length
-000004f: 2446 314c 31                             $F1L1  ; local name 1
-0000054: 02                                        ; local index
-0000055: 05                                        ; string length
-0000056: 2446 314c 32                             $F1L2  ; local name 2
-000005b: 03                                        ; local index
-000005c: 00                                        ; string length
-000005d: 01                                        ; function index
-000005e: 01                                        ; num locals
-000005f: 00                                        ; local index
-0000060: 05                                        ; string length
-0000061: 2446 3250 30                             $F2P0  ; local name 0
-0000066: 02                                        ; function index
-0000067: 04                                        ; num locals
-0000068: 00                                        ; local index
-0000069: 05                                        ; string length
-000006a: 2446 3350 30                             $F3P0  ; local name 0
-000006f: 01                                        ; local index
-0000070: 05                                        ; string length
-0000071: 2446 334c 31                             $F3L1  ; local name 1
-0000076: 02                                        ; local index
-0000077: 00                                        ; string length
-0000078: 03                                        ; local index
-0000079: 05                                        ; string length
-000007a: 2446 334c 33                             $F3L3  ; local name 3
-0000042: 3c                                        ; FIXUP subsection size
-000002e: 50                                        ; FIXUP section size
+0000038: 02                                        ; string length
+0000039: 4631                                     F1  ; func name 0
+000003b: 02                                        ; function index
+000003c: 02                                        ; string length
+000003d: 4632                                     F2  ; func name 2
+0000035: 09                                        ; FIXUP subsection size
+000003f: 02                                        ; local name type
+0000040: 00                                        ; subsection size (guess)
+0000041: 03                                        ; num functions
+0000042: 00                                        ; function index
+0000043: 04                                        ; num locals
+0000044: 00                                        ; local index
+0000045: 04                                        ; string length
+0000046: 4631 5030                                F1P0  ; local name 0
+000004a: 01                                        ; local index
+000004b: 04                                        ; string length
+000004c: 4631 4c31                                F1L1  ; local name 1
+0000050: 02                                        ; local index
+0000051: 04                                        ; string length
+0000052: 4631 4c32                                F1L2  ; local name 2
+0000056: 03                                        ; local index
+0000057: 00                                        ; string length
+0000058: 01                                        ; function index
+0000059: 01                                        ; num locals
+000005a: 00                                        ; local index
+000005b: 04                                        ; string length
+000005c: 4632 5030                                F2P0  ; local name 0
+0000060: 02                                        ; function index
+0000061: 04                                        ; num locals
+0000062: 00                                        ; local index
+0000063: 04                                        ; string length
+0000064: 4633 5030                                F3P0  ; local name 0
+0000068: 01                                        ; local index
+0000069: 04                                        ; string length
+000006a: 4633 4c31                                F3L1  ; local name 1
+000006e: 02                                        ; local index
+000006f: 00                                        ; string length
+0000070: 03                                        ; local index
+0000071: 04                                        ; string length
+0000072: 4633 4c33                                F3L3  ; local name 3
+0000040: 35                                        ; FIXUP subsection size
+000002e: 47                                        ; FIXUP section size
 
 debug-names.wasm:	file format wasm 0x1
 
@@ -127,27 +127,27 @@ Type:
  - [0] (i32) -> nil
  - [1] (f32) -> nil
 Function:
- - func[0] sig=0 <$F1>
+ - func[0] sig=0 <F1>
  - func[1] sig=1
- - func[2] sig=1 <$F2>
+ - func[2] sig=1 <F2>
 Custom:
  - name: "name"
- - func[0] $F1
- - func[2] $F2
- - func[0] local[0] $F1P0
- - func[0] local[1] $F1L1
- - func[0] local[2] $F1L2
- - func[1] local[0] $F2P0
- - func[2] local[0] $F3P0
- - func[2] local[1] $F3L1
- - func[2] local[3] $F3L3
+ - func[0] F1
+ - func[2] F2
+ - func[0] local[0] F1P0
+ - func[0] local[1] F1L1
+ - func[0] local[2] F1L2
+ - func[1] local[0] F2P0
+ - func[2] local[0] F3P0
+ - func[2] local[1] F3L1
+ - func[2] local[3] F3L3
 
 Code Disassembly:
 
-00001c <$F1>:
+00001c <F1>:
  000022: 0b                         | end
 000023 func[1]:
  000025: 0b                         | end
-000026 <$F2>:
+000026 <F2>:
  00002c: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -31,8 +31,8 @@ Sections:
  Function start=0x00000062 end=0x00000067 (size=0x00000005) count: 4
    Export start=0x0000006d end=0x0000007a (size=0x0000000d) count: 2
      Code start=0x0000007c end=0x000000a1 (size=0x00000025) count: 4
-   Custom start=0x000000a7 end=0x000000e9 (size=0x00000042) "name"
-   Custom start=0x000000ef end=0x00000105 (size=0x00000016) "reloc.Code"
+   Custom start=0x000000a7 end=0x000000e4 (size=0x0000003d) "name"
+   Custom start=0x000000ea end=0x00000100 (size=0x00000016) "reloc.Code"
 
 Section Details:
 
@@ -42,24 +42,24 @@ Type:
  - [2] (i64) -> nil
  - [3] (i32) -> nil
 Import:
- - func[0] sig=0 <$import_func0> <- __extern.missing0
+ - func[0] sig=0 <import_func0> <- __extern.missing0
  - func[1] sig=0 <- _extern1.missing1
- - func[2] sig=0 <$import_func2> <- extern2.missing2
+ - func[2] sig=0 <import_func2> <- extern2.missing2
 Function:
- - func[3] sig=1 <$name1>
- - func[4] sig=2 <$name2>
+ - func[3] sig=1 <name1>
+ - func[4] sig=2 <name2>
  - func[5] sig=2
- - func[6] sig=3 <$name3>
+ - func[6] sig=3 <name3>
 Export:
- - func[3] <$name1> -> "foo"
- - func[6] <$name3> -> "baz"
+ - func[3] <name1> -> "foo"
+ - func[6] <name3> -> "baz"
 Custom:
  - name: "name"
- - func[0] $import_func0
- - func[2] $import_func2
- - func[3] $name1
- - func[4] $name2
- - func[6] $name3
+ - func[0] import_func0
+ - func[2] import_func2
+ - func[3] name1
+ - func[4] name2
+ - func[6] name3
 Custom:
  - name: "reloc.Code"
   - section: Code
@@ -69,21 +69,21 @@ Custom:
 
 Code Disassembly:
 
-00007d <$name1>:
+00007d <name1>:
  00007f: 41 01                      | i32.const 1
- 000081: 10 86 80 80 80 00          | call 6 <$name3>
-           000082: R_FUNC_INDEX_LEB   6 <$name3>
+ 000081: 10 86 80 80 80 00          | call 6 <name3>
+           000082: R_FUNC_INDEX_LEB   6 <name3>
  000087: 0b                         | end
-000088 <$name2>:
+000088 <name2>:
  00008a: 42 01                      | i64.const 1
- 00008c: 10 82 80 80 80 00          | call 2 <$import_func2>
-           00008d: R_FUNC_INDEX_LEB   2 <$import_func2>
+ 00008c: 10 82 80 80 80 00          | call 2 <import_func2>
+           00008d: R_FUNC_INDEX_LEB   2 <import_func2>
  000092: 0b                         | end
 000093 func[5]:
  000095: 0b                         | end
-000096 <$name3>:
+000096 <name3>:
  000098: 41 02                      | i32.const 2
- 00009a: 10 86 80 80 80 00          | call 6 <$name3>
-           00009b: R_FUNC_INDEX_LEB   6 <$name3>
+ 00009a: 10 86 80 80 80 00          | call 6 <name3>
+           00009b: R_FUNC_INDEX_LEB   6 <name3>
  0000a0: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/names_import_only.txt
+++ b/test/link/names_import_only.txt
@@ -11,17 +11,17 @@ Sections:
 
      Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    Import start=0x00000014 end=0x00000024 (size=0x00000010) count: 1
-   Custom start=0x0000002a end=0x00000045 (size=0x0000001b) "name"
+   Custom start=0x0000002a end=0x00000044 (size=0x0000001a) "name"
 
 Section Details:
 
 Type:
  - [0] () -> nil
 Import:
- - func[0] sig=0 <$import_func1> <- __extern.baz
+ - func[0] sig=0 <import_func1> <- __extern.baz
 Custom:
  - name: "name"
- - func[0] $import_func1
+ - func[0] import_func1
 
 Code Disassembly:
 

--- a/test/link/names_import_only_module_env.txt
+++ b/test/link/names_import_only_module_env.txt
@@ -11,17 +11,17 @@ Sections:
 
      Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    Import start=0x00000014 end=0x0000001f (size=0x0000000b) count: 1
-   Custom start=0x00000025 end=0x00000040 (size=0x0000001b) "name"
+   Custom start=0x00000025 end=0x0000003f (size=0x0000001a) "name"
 
 Section Details:
 
 Type:
  - [0] () -> nil
 Import:
- - func[0] sig=0 <$import_func1> <- env.baz
+ - func[0] sig=0 <import_func1> <- env.baz
 Custom:
  - name: "name"
- - func[0] $import_func1
+ - func[0] import_func1
 
 Code Disassembly:
 


### PR DESCRIPTION
Attempt at fixing #448 .. still need to figure out how to strip the $ on parse.