### PR TITLE
Use + with $(MAKE) to use jobserver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ BUILD_CMD := ninja
 BUILD_FILE := build.ninja
 GENERATOR := Ninja
 else
-BUILD_CMD := $(MAKE) --no-print-directory
+BUILD_CMD := +$(MAKE) --no-print-directory
 BUILD_FILE := Makefile
 GENERATOR := "Unix Makefiles"
 endif


### PR DESCRIPTION
Without this, Make complains:

    make[1]: warning: jobserver unavailable: using -j1.  Add '+' to
    parent make rule.