### PR TITLE
Add debug names to wasm-link tests

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -757,7 +757,10 @@ Result BinaryReaderObjdump::OnExport(Index index,
 
 Result BinaryReaderObjdump::OnElemSegmentFunctionIndex(Index index,
                                                        Index func_index) {
-  PrintDetails("  - func[%" PRIindex "]\n", func_index);
+  PrintDetails("  - func[%" PRIindex "]", func_index);
+  if (const char* name = GetFunctionName(func_index))
+    PrintDetails(" <%s>", name);
+  PrintDetails("\n");
   return Result::Ok;
 }
 

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -29,7 +29,8 @@ Sections:
  Function start=0x00000047 end=0x0000004a (size=0x00000003) count: 2
    Export start=0x00000050 end=0x00000057 (size=0x00000007) count: 1
      Code start=0x00000059 end=0x0000008b (size=0x00000032) count: 2
-   Custom start=0x00000091 end=0x000000ad (size=0x0000001c) "reloc.Code"
+   Custom start=0x00000091 end=0x000000c7 (size=0x00000036) "name"
+   Custom start=0x000000cd end=0x000000e9 (size=0x0000001c) "reloc.Code"
 
 Section Details:
 
@@ -39,13 +40,19 @@ Type:
  - [2] (f64) -> nil
  - [3] (i64) -> nil
 Import:
- - func[0] sig=0 <- __extern.bar
- - func[1] sig=2 <- __extern.baz
+ - func[0] sig=0 <import1> <- __extern.bar
+ - func[1] sig=2 <import0> <- __extern.baz
 Function:
  - func[2] sig=1
- - func[3] sig=3
+ - func[3] sig=3 <local_func>
 Export:
- - func[3] -> "foo"
+ - func[3] <local_func> -> "foo"
+Custom:
+ - name: "name"
+ - func[0] import1
+ - func[2] local_func
+ - func[1] import0
+ - func[3] local_func
 Custom:
  - name: "reloc.Code"
   - section: Code
@@ -61,17 +68,17 @@ Code Disassembly:
  00005c: 20 00                      | get_local 0
  00005e: 10 82 80 80 80 00          | call 2
            00005f: R_FUNC_INDEX_LEB   2
- 000064: 10 83 80 80 80 00          | call 3
-           000065: R_FUNC_INDEX_LEB   3
- 00006a: 10 80 80 80 80 00          | call 0
-           00006b: R_FUNC_INDEX_LEB   0
+ 000064: 10 83 80 80 80 00          | call 3 <local_func>
+           000065: R_FUNC_INDEX_LEB   3 <local_func>
+ 00006a: 10 80 80 80 80 00          | call 0 <import1>
+           00006b: R_FUNC_INDEX_LEB   0 <import1>
  000070: 0b                         | end
-000071 func[3]:
+000071 <local_func>:
  000073: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
- 00007c: 10 81 80 80 80 00          | call 1
-           00007d: R_FUNC_INDEX_LEB   1
+ 00007c: 10 81 80 80 80 00          | call 1 <import0>
+           00007d: R_FUNC_INDEX_LEB   1 <import0>
  000082: 42 0a                      | i64.const 10
- 000084: 10 83 80 80 80 00          | call 3
-           000085: R_FUNC_INDEX_LEB   3
+ 000084: 10 83 80 80 80 00          | call 3 <local_func>
+           000085: R_FUNC_INDEX_LEB   3 <local_func>
  00008a: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -38,8 +38,9 @@ Sections:
     Table start=0x00000079 end=0x0000007e (size=0x00000005) count: 1
      Elem start=0x00000084 end=0x000000ad (size=0x00000029) count: 1
      Code start=0x000000af end=0x000000f1 (size=0x00000042) count: 3
-   Custom start=0x000000f7 end=0x00000119 (size=0x00000022) "reloc.Elem"
-   Custom start=0x0000011f end=0x0000013e (size=0x0000001f) "reloc.Code"
+   Custom start=0x000000f7 end=0x00000118 (size=0x00000021) "name"
+   Custom start=0x0000011e end=0x00000140 (size=0x00000022) "reloc.Elem"
+   Custom start=0x00000146 end=0x00000165 (size=0x0000001f) "reloc.Code"
 
 Section Details:
 
@@ -55,21 +56,26 @@ Import:
  - func[1] sig=2 <- __extern.does_nothing
  - func[2] sig=4 <- __extern.hello_world
 Function:
- - func[3] sig=1
- - func[4] sig=3
- - func[5] sig=5
+ - func[3] sig=1 <func1>
+ - func[4] sig=3 <func2>
+ - func[5] sig=5 <func3>
 Table:
  - table[0] type=anyfunc initial=7 max=7
 Elem:
  - segment[0] table=0
  - init i32=0
-  - func[3]
-  - func[3]
-  - func[3]
-  - func[4]
-  - func[4]
-  - func[5]
-  - func[5]
+  - func[3] <func1>
+  - func[3] <func1>
+  - func[3] <func1>
+  - func[4] <func2>
+  - func[4] <func2>
+  - func[5] <func3>
+  - func[5] <func3>
+Custom:
+ - name: "name"
+ - func[3] func1
+ - func[4] func2
+ - func[5] func3
 Custom:
  - name: "reloc.Elem"
   - section: Elem
@@ -92,27 +98,27 @@ Custom:
 
 Code Disassembly:
 
-0000b0 func[3]:
+0000b0 <func1>:
  0000b2: 20 00                      | get_local 0
  0000b4: 10 80 80 80 80 00          | call 0
            0000b5: R_FUNC_INDEX_LEB   0
- 0000ba: 10 83 80 80 80 00          | call 3
-           0000bb: R_FUNC_INDEX_LEB   3
+ 0000ba: 10 83 80 80 80 00          | call 3 <func1>
+           0000bb: R_FUNC_INDEX_LEB   3 <func1>
  0000c0: 0b                         | end
-0000c1 func[4]:
+0000c1 <func2>:
  0000c3: 44 00 00 00 00 00 00 f0 3f | f64.const 0x1p+0
  0000cc: 10 81 80 80 80 00          | call 1
            0000cd: R_FUNC_INDEX_LEB   1
  0000d2: 42 0a                      | i64.const 10
- 0000d4: 10 84 80 80 80 00          | call 4
-           0000d5: R_FUNC_INDEX_LEB   4
+ 0000d4: 10 84 80 80 80 00          | call 4 <func2>
+           0000d5: R_FUNC_INDEX_LEB   4 <func2>
  0000da: 0b                         | end
-0000db func[5]:
+0000db <func3>:
  0000dd: 43 00 00 80 3f             | f32.const 0x1p+0
  0000e2: 10 82 80 80 80 00          | call 2
            0000e3: R_FUNC_INDEX_LEB   2
  0000e8: 41 0a                      | i32.const 10
- 0000ea: 10 85 80 80 80 00          | call 5
-           0000eb: R_FUNC_INDEX_LEB   5
+ 0000ea: 10 85 80 80 80 00          | call 5 <func3>
+           0000eb: R_FUNC_INDEX_LEB   5 <func3>
  0000f0: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/link/interp.txt
+++ b/test/link/interp.txt
@@ -51,7 +51,8 @@ Sections:
  Function start=0x0000002c end=0x00000032 (size=0x00000006) count: 5
    Export start=0x00000038 end=0x00000075 (size=0x0000003d) count: 5
      Code start=0x00000077 end=0x000000a2 (size=0x0000002b) count: 5
-   Custom start=0x000000a8 end=0x000000bb (size=0x00000013) "reloc.Code"
+   Custom start=0x000000a8 end=0x000000eb (size=0x00000043) "name"
+   Custom start=0x000000f1 end=0x00000104 (size=0x00000013) "reloc.Code"
 
 Section Details:
 
@@ -63,17 +64,24 @@ Type:
  - [4] () -> i64
 Import:
 Function:
- - func[0] sig=2
- - func[1] sig=0
- - func[2] sig=1
- - func[3] sig=3
- - func[4] sig=4
+ - func[0] sig=2 <export1>
+ - func[1] sig=0 <call_import1>
+ - func[2] sig=1 <call_import2>
+ - func[3] sig=3 <export2>
+ - func[4] sig=4 <export3>
 Export:
- - func[0] -> "export1"
- - func[1] -> "call_import1"
- - func[2] -> "call_import2"
- - func[3] -> "export2"
- - func[4] -> "export3"
+ - func[0] <export1> -> "export1"
+ - func[1] <call_import1> -> "call_import1"
+ - func[2] <call_import2> -> "call_import2"
+ - func[3] <export2> -> "export2"
+ - func[4] <export3> -> "export3"
+Custom:
+ - name: "name"
+ - func[0] export1
+ - func[1] call_import1
+ - func[2] call_import2
+ - func[3] export2
+ - func[4] export3
 Custom:
  - name: "reloc.Code"
   - section: Code
@@ -82,25 +90,25 @@ Custom:
 
 Code Disassembly:
 
-000078 func[0]:
+000078 <export1>:
  00007a: 43 00 00 80 3f             | f32.const 0x1p+0
  00007f: 0f                         | return
  000080: 0b                         | end
-000081 func[1]:
- 000083: 10 83 80 80 80 00          | call 3
-           000084: R_FUNC_INDEX_LEB   3
+000081 <call_import1>:
+ 000083: 10 83 80 80 80 00          | call 3 <export2>
+           000084: R_FUNC_INDEX_LEB   3 <export2>
  000089: 0f                         | return
  00008a: 0b                         | end
-00008b func[2]:
- 00008d: 10 84 80 80 80 00          | call 4
-           00008e: R_FUNC_INDEX_LEB   4
+00008b <call_import2>:
+ 00008d: 10 84 80 80 80 00          | call 4 <export3>
+           00008e: R_FUNC_INDEX_LEB   4 <export3>
  000093: 0f                         | return
  000094: 0b                         | end
-000095 func[3]:
+000095 <export2>:
  000097: 41 2a                      | i32.const 42
  000099: 0f                         | return
  00009a: 0b                         | end
-00009b func[4]:
+00009b <export3>:
  00009d: 42 e3 00                   | i64.const 99
  0000a0: 0f                         | return
  0000a1: 0b                         | end

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -9,7 +9,7 @@
   (func $func3 (param f64))
   (type $t1 (func))
   (table anyfunc (elem $func3 $func2 $func2))
-  (func
+  (func $func4
     i64.const 7
     call_indirect $t1
   )
@@ -25,8 +25,9 @@ Sections:
     Table start=0x0000002b end=0x00000030 (size=0x00000005) count: 1
      Elem start=0x00000036 end=0x00000055 (size=0x0000001f) count: 1
      Code start=0x00000057 end=0x0000006d (size=0x00000016) count: 4
-   Custom start=0x00000073 end=0x0000008f (size=0x0000001c) "reloc.Elem"
-   Custom start=0x00000095 end=0x000000a5 (size=0x00000010) "reloc.Code"
+   Custom start=0x00000073 end=0x0000009b (size=0x00000028) "name"
+   Custom start=0x000000a1 end=0x000000bd (size=0x0000001c) "reloc.Elem"
+   Custom start=0x000000c3 end=0x000000d3 (size=0x00000010) "reloc.Code"
 
 Section Details:
 
@@ -36,20 +37,26 @@ Type:
  - [2] (f64) -> nil
  - [3] () -> nil
 Function:
- - func[0] sig=0
- - func[1] sig=1
- - func[2] sig=2
- - func[3] sig=3
+ - func[0] sig=0 <func1>
+ - func[1] sig=1 <func2>
+ - func[2] sig=2 <func3>
+ - func[3] sig=3 <func4>
 Table:
  - table[0] type=anyfunc initial=5 max=5
 Elem:
  - segment[0] table=0
  - init i32=0
-  - func[0]
-  - func[0]
-  - func[2]
-  - func[1]
-  - func[1]
+  - func[0] <func1>
+  - func[0] <func1>
+  - func[2] <func3>
+  - func[1] <func2>
+  - func[1] <func2>
+Custom:
+ - name: "name"
+ - func[0] func1
+ - func[1] func2
+ - func[2] func3
+ - func[3] func4
 Custom:
  - name: "reloc.Elem"
   - section: Elem
@@ -65,13 +72,13 @@ Custom:
 
 Code Disassembly:
 
-000058 func[0]:
+000058 <func1>:
  00005a: 0b                         | end
-00005b func[1]:
+00005b <func2>:
  00005d: 0b                         | end
-00005e func[2]:
+00005e <func3>:
  000060: 0b                         | end
-000061 func[3]:
+000061 <func4>:
  000063: 42 07                      | i64.const 7
  000065: 11 83 80 80 80 00 00       | call_indirect 3 0
            000066: R_TYPE_INDEX_LEB   3

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -87,8 +87,8 @@ def main(args):
     basename = os.path.basename(filename)
     basename_noext = os.path.splitext(basename)[0]
     out_file = os.path.join(out_dir, basename_noext + '.json')
-    wast2wasm.RunWithArgs('--spec', '--no-check', '-r', '-o', out_file,
-                          filename)
+    wast2wasm.RunWithArgs('--spec', '--debug-names', '--no-check', '-r', '-o',
+                          out_file, filename)
 
     wasm_files = utils.GetModuleFilenamesFromSpecJSON(out_file)
     wasm_files = [utils.ChangeDir(f, out_dir) for f in wasm_files]


### PR DESCRIPTION
Also, have wasmdump list debug names for function table
elements.

These changes make it easier to interpret the wasm-link
test outputs.