### PR TITLE
Move interpreter stuff into its own namespace

### DIFF
--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -28,13 +28,15 @@
 #include "type-checker.h"
 #include "writer.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (WABT_FAILED(expr))  \
-      return Result::Error; \
+#define CHECK_RESULT(expr)        \
+  do {                            \
+    if (WABT_FAILED(expr))        \
+      return wabt::Result::Error; \
   } while (0)
 
 namespace wabt {
+
+using namespace interpreter;
 
 namespace {
 
@@ -71,8 +73,8 @@ struct DataSegmentInfo {
 
 class BinaryReaderInterpreter : public BinaryReaderNop {
  public:
-  BinaryReaderInterpreter(InterpreterEnvironment* env,
-                          DefinedInterpreterModule* module,
+  BinaryReaderInterpreter(Environment* env,
+                          DefinedModule* module,
                           IstreamOffset istream_offset,
                           BinaryErrorHandler* error_handler);
 
@@ -82,120 +84,120 @@ class BinaryReaderInterpreter : public BinaryReaderNop {
   // Implement BinaryReader.
   bool OnError(const char* message) override;
 
-  Result EndModule() override;
+  wabt::Result EndModule() override;
 
-  Result OnTypeCount(Index count) override;
-  Result OnType(Index index,
-                Index param_count,
-                Type* param_types,
-                Index result_count,
-                Type* result_types) override;
+  wabt::Result OnTypeCount(Index count) override;
+  wabt::Result OnType(Index index,
+                      Index param_count,
+                      Type* param_types,
+                      Index result_count,
+                      Type* result_types) override;
 
-  Result OnImportCount(Index count) override;
-  Result OnImport(Index index,
-                  StringSlice module_name,
-                  StringSlice field_name) override;
-  Result OnImportFunc(Index import_index,
-                      StringSlice module_name,
-                      StringSlice field_name,
-                      Index func_index,
-                      Index sig_index) override;
-  Result OnImportTable(Index import_index,
-                       StringSlice module_name,
-                       StringSlice field_name,
-                       Index table_index,
+  wabt::Result OnImportCount(Index count) override;
+  wabt::Result OnImport(Index index,
+                        StringSlice module_name,
+                        StringSlice field_name) override;
+  wabt::Result OnImportFunc(Index import_index,
+                            StringSlice module_name,
+                            StringSlice field_name,
+                            Index func_index,
+                            Index sig_index) override;
+  wabt::Result OnImportTable(Index import_index,
+                             StringSlice module_name,
+                             StringSlice field_name,
+                             Index table_index,
+                             Type elem_type,
+                             const Limits* elem_limits) override;
+  wabt::Result OnImportMemory(Index import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              Index memory_index,
+                              const Limits* page_limits) override;
+  wabt::Result OnImportGlobal(Index import_index,
+                              StringSlice module_name,
+                              StringSlice field_name,
+                              Index global_index,
+                              Type type,
+                              bool mutable_) override;
+
+  wabt::Result OnFunctionCount(Index count) override;
+  wabt::Result OnFunction(Index index, Index sig_index) override;
+
+  wabt::Result OnTable(Index index,
                        Type elem_type,
                        const Limits* elem_limits) override;
-  Result OnImportMemory(Index import_index,
-                        StringSlice module_name,
-                        StringSlice field_name,
-                        Index memory_index,
-                        const Limits* page_limits) override;
-  Result OnImportGlobal(Index import_index,
-                        StringSlice module_name,
-                        StringSlice field_name,
-                        Index global_index,
-                        Type type,
-                        bool mutable_) override;
 
-  Result OnFunctionCount(Index count) override;
-  Result OnFunction(Index index, Index sig_index) override;
+  wabt::Result OnMemory(Index index, const Limits* limits) override;
 
-  Result OnTable(Index index,
-                 Type elem_type,
-                 const Limits* elem_limits) override;
+  wabt::Result OnGlobalCount(Index count) override;
+  wabt::Result BeginGlobal(Index index, Type type, bool mutable_) override;
+  wabt::Result EndGlobalInitExpr(Index index) override;
 
-  Result OnMemory(Index index, const Limits* limits) override;
+  wabt::Result OnExport(Index index,
+                        ExternalKind kind,
+                        Index item_index,
+                        StringSlice name) override;
 
-  Result OnGlobalCount(Index count) override;
-  Result BeginGlobal(Index index, Type type, bool mutable_) override;
-  Result EndGlobalInitExpr(Index index) override;
+  wabt::Result OnStartFunction(Index func_index) override;
 
-  Result OnExport(Index index,
-                  ExternalKind kind,
-                  Index item_index,
-                  StringSlice name) override;
+  wabt::Result BeginFunctionBody(Index index) override;
+  wabt::Result OnLocalDeclCount(Index count) override;
+  wabt::Result OnLocalDecl(Index decl_index, Index count, Type type) override;
 
-  Result OnStartFunction(Index func_index) override;
+  wabt::Result OnBinaryExpr(wabt::Opcode opcode) override;
+  wabt::Result OnBlockExpr(Index num_types, Type* sig_types) override;
+  wabt::Result OnBrExpr(Index depth) override;
+  wabt::Result OnBrIfExpr(Index depth) override;
+  wabt::Result OnBrTableExpr(Index num_targets,
+                             Index* target_depths,
+                             Index default_target_depth) override;
+  wabt::Result OnCallExpr(Index func_index) override;
+  wabt::Result OnCallIndirectExpr(Index sig_index) override;
+  wabt::Result OnCompareExpr(wabt::Opcode opcode) override;
+  wabt::Result OnConvertExpr(wabt::Opcode opcode) override;
+  wabt::Result OnCurrentMemoryExpr() override;
+  wabt::Result OnDropExpr() override;
+  wabt::Result OnElseExpr() override;
+  wabt::Result OnEndExpr() override;
+  wabt::Result OnF32ConstExpr(uint32_t value_bits) override;
+  wabt::Result OnF64ConstExpr(uint64_t value_bits) override;
+  wabt::Result OnGetGlobalExpr(Index global_index) override;
+  wabt::Result OnGetLocalExpr(Index local_index) override;
+  wabt::Result OnGrowMemoryExpr() override;
+  wabt::Result OnI32ConstExpr(uint32_t value) override;
+  wabt::Result OnI64ConstExpr(uint64_t value) override;
+  wabt::Result OnIfExpr(Index num_types, Type* sig_types) override;
+  wabt::Result OnLoadExpr(wabt::Opcode opcode,
+                          uint32_t alignment_log2,
+                          Address offset) override;
+  wabt::Result OnLoopExpr(Index num_types, Type* sig_types) override;
+  wabt::Result OnNopExpr() override;
+  wabt::Result OnReturnExpr() override;
+  wabt::Result OnSelectExpr() override;
+  wabt::Result OnSetGlobalExpr(Index global_index) override;
+  wabt::Result OnSetLocalExpr(Index local_index) override;
+  wabt::Result OnStoreExpr(wabt::Opcode opcode,
+                           uint32_t alignment_log2,
+                           Address offset) override;
+  wabt::Result OnTeeLocalExpr(Index local_index) override;
+  wabt::Result OnUnaryExpr(wabt::Opcode opcode) override;
+  wabt::Result OnUnreachableExpr() override;
+  wabt::Result EndFunctionBody(Index index) override;
 
-  Result BeginFunctionBody(Index index) override;
-  Result OnLocalDeclCount(Index count) override;
-  Result OnLocalDecl(Index decl_index, Index count, Type type) override;
+  wabt::Result EndElemSegmentInitExpr(Index index) override;
+  wabt::Result OnElemSegmentFunctionIndex(Index index,
+                                          Index func_index) override;
 
-  Result OnBinaryExpr(Opcode opcode) override;
-  Result OnBlockExpr(Index num_types, Type* sig_types) override;
-  Result OnBrExpr(Index depth) override;
-  Result OnBrIfExpr(Index depth) override;
-  Result OnBrTableExpr(Index num_targets,
-                       Index* target_depths,
-                       Index default_target_depth) override;
-  Result OnCallExpr(Index func_index) override;
-  Result OnCallIndirectExpr(Index sig_index) override;
-  Result OnCompareExpr(Opcode opcode) override;
-  Result OnConvertExpr(Opcode opcode) override;
-  Result OnCurrentMemoryExpr() override;
-  Result OnDropExpr() override;
-  Result OnElseExpr() override;
-  Result OnEndExpr() override;
-  Result OnF32ConstExpr(uint32_t value_bits) override;
-  Result OnF64ConstExpr(uint64_t value_bits) override;
-  Result OnGetGlobalExpr(Index global_index) override;
-  Result OnGetLocalExpr(Index local_index) override;
-  Result OnGrowMemoryExpr() override;
-  Result OnI32ConstExpr(uint32_t value) override;
-  Result OnI64ConstExpr(uint64_t value) override;
-  Result OnIfExpr(Index num_types, Type* sig_types) override;
-  Result OnLoadExpr(Opcode opcode,
-                    uint32_t alignment_log2,
-                    Address offset) override;
-  Result OnLoopExpr(Index num_types, Type* sig_types) override;
-  Result OnNopExpr() override;
-  Result OnReturnExpr() override;
-  Result OnSelectExpr() override;
-  Result OnSetGlobalExpr(Index global_index) override;
-  Result OnSetLocalExpr(Index local_index) override;
-  Result OnStoreExpr(Opcode opcode,
-                     uint32_t alignment_log2,
-                     Address offset) override;
-  Result OnTeeLocalExpr(Index local_index) override;
-  Result OnUnaryExpr(Opcode opcode) override;
-  Result OnUnreachableExpr() override;
-  Result EndFunctionBody(Index index) override;
+  wabt::Result OnDataSegmentData(Index index,
+                                 const void* data,
+                                 Address size) override;
 
-  Result EndElemSegmentInitExpr(Index index) override;
-  Result OnElemSegmentFunctionIndex(Index index,
-                                    Index func_index) override;
-
-  Result OnDataSegmentData(Index index,
-                           const void* data,
-                           Address size) override;
-
-  Result OnInitExprF32ConstExpr(Index index, uint32_t value) override;
-  Result OnInitExprF64ConstExpr(Index index, uint64_t value) override;
-  Result OnInitExprGetGlobalExpr(Index index,
-                                 Index global_index) override;
-  Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
-  Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
+  wabt::Result OnInitExprF32ConstExpr(Index index, uint32_t value) override;
+  wabt::Result OnInitExprF64ConstExpr(Index index, uint64_t value) override;
+  wabt::Result OnInitExprGetGlobalExpr(Index index,
+                                       Index global_index) override;
+  wabt::Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
+  wabt::Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
 
  private:
   Label* GetLabel(Index depth);
@@ -208,64 +210,65 @@ class BinaryReaderInterpreter : public BinaryReaderNop {
   static void OnTypecheckerError(const char* msg, void* user_data);
 
   Index TranslateSigIndexToEnv(Index sig_index);
-  InterpreterFuncSignature* GetSignatureByEnvIndex(Index sig_index);
-  InterpreterFuncSignature* GetSignatureByModuleIndex(Index sig_index);
+  FuncSignature* GetSignatureByEnvIndex(Index sig_index);
+  FuncSignature* GetSignatureByModuleIndex(Index sig_index);
   Index TranslateFuncIndexToEnv(Index func_index);
   Index TranslateModuleFuncIndexToDefined(Index func_index);
-  InterpreterFunc* GetFuncByEnvIndex(Index func_index);
-  InterpreterFunc* GetFuncByModuleIndex(Index func_index);
+  Func* GetFuncByEnvIndex(Index func_index);
+  Func* GetFuncByModuleIndex(Index func_index);
   Index TranslateGlobalIndexToEnv(Index global_index);
-  InterpreterGlobal* GetGlobalByEnvIndex(Index global_index);
-  InterpreterGlobal* GetGlobalByModuleIndex(Index global_index);
+  Global* GetGlobalByEnvIndex(Index global_index);
+  Global* GetGlobalByModuleIndex(Index global_index);
   Type GetGlobalTypeByModuleIndex(Index global_index);
   Index TranslateLocalIndex(Index local_index);
-  Type GetLocalTypeByIndex(InterpreterFunc* func, Index local_index);
+  Type GetLocalTypeByIndex(Func* func, Index local_index);
 
   IstreamOffset GetIstreamOffset();
 
-  Result EmitDataAt(IstreamOffset offset,
-                    const void* data,
-                    IstreamOffset size);
-  Result EmitData(const void* data, IstreamOffset size);
-  Result EmitOpcode(Opcode opcode);
-  Result EmitOpcode(InterpreterOpcode opcode);
-  Result EmitI8(uint8_t value);
-  Result EmitI32(uint32_t value);
-  Result EmitI64(uint64_t value);
-  Result EmitI32At(IstreamOffset offset, uint32_t value);
-  Result EmitDropKeep(uint32_t drop, uint8_t keep);
-  Result AppendFixup(IstreamOffsetVectorVector* fixups_vector, Index index);
-  Result EmitBrOffset(Index depth, IstreamOffset offset);
-  Result GetBrDropKeepCount(Index depth,
-                            Index* out_drop_count,
-                            Index* out_keep_count);
-  Result GetReturnDropKeepCount(Index* out_drop_count,
-                                Index* out_keep_count);
-  Result EmitBr(Index depth, Index drop_count, Index keep_count);
-  Result EmitBrTableOffset(Index depth);
-  Result FixupTopLabel();
-  Result EmitFuncOffset(DefinedInterpreterFunc* func, Index func_index);
+  wabt::Result EmitDataAt(IstreamOffset offset,
+                          const void* data,
+                          IstreamOffset size);
+  wabt::Result EmitData(const void* data, IstreamOffset size);
+  wabt::Result EmitOpcode(wabt::Opcode opcode);
+  wabt::Result EmitOpcode(interpreter::Opcode opcode);
+  wabt::Result EmitI8(uint8_t value);
+  wabt::Result EmitI32(uint32_t value);
+  wabt::Result EmitI64(uint64_t value);
+  wabt::Result EmitI32At(IstreamOffset offset, uint32_t value);
+  wabt::Result EmitDropKeep(uint32_t drop, uint8_t keep);
+  wabt::Result AppendFixup(IstreamOffsetVectorVector* fixups_vector,
+                           Index index);
+  wabt::Result EmitBrOffset(Index depth, IstreamOffset offset);
+  wabt::Result GetBrDropKeepCount(Index depth,
+                                  Index* out_drop_count,
+                                  Index* out_keep_count);
+  wabt::Result GetReturnDropKeepCount(Index* out_drop_count,
+                                      Index* out_keep_count);
+  wabt::Result EmitBr(Index depth, Index drop_count, Index keep_count);
+  wabt::Result EmitBrTableOffset(Index depth);
+  wabt::Result FixupTopLabel();
+  wabt::Result EmitFuncOffset(DefinedFunc* func, Index func_index);
 
-  Result CheckLocal(Index local_index);
-  Result CheckGlobal(Index global_index);
-  Result CheckImportKind(InterpreterImport* import, ExternalKind expected_kind);
-  Result CheckImportLimits(const Limits* declared_limits,
-                           const Limits* actual_limits);
-  Result CheckHasMemory(Opcode opcode);
-  Result CheckAlign(uint32_t alignment_log2, Address natural_alignment);
+  wabt::Result CheckLocal(Index local_index);
+  wabt::Result CheckGlobal(Index global_index);
+  wabt::Result CheckImportKind(Import* import, ExternalKind expected_kind);
+  wabt::Result CheckImportLimits(const Limits* declared_limits,
+                                 const Limits* actual_limits);
+  wabt::Result CheckHasMemory(wabt::Opcode opcode);
+  wabt::Result CheckAlign(uint32_t alignment_log2, Address natural_alignment);
 
-  Result AppendExport(InterpreterModule* module,
-                      ExternalKind kind,
-                      Index item_index,
-                      StringSlice name);
+  wabt::Result AppendExport(Module* module,
+                            ExternalKind kind,
+                            Index item_index,
+                            StringSlice name);
 
   PrintErrorCallback MakePrintErrorCallback();
   static void OnHostImportPrintError(const char* msg, void* user_data);
 
   BinaryErrorHandler* error_handler = nullptr;
-  InterpreterEnvironment* env = nullptr;
-  DefinedInterpreterModule* module = nullptr;
-  DefinedInterpreterFunc* current_func = nullptr;
+  Environment* env = nullptr;
+  DefinedModule* module = nullptr;
+  DefinedFunc* current_func = nullptr;
   TypeCheckerErrorHandler tc_error_handler;
   TypeChecker typechecker;
   std::vector<Label> label_stack;
@@ -289,16 +292,16 @@ class BinaryReaderInterpreter : public BinaryReaderNop {
   std::vector<DataSegmentInfo> data_segment_infos;
 
   /* values cached so they can be shared between callbacks */
-  InterpreterTypedValue init_expr_value;
+  TypedValue init_expr_value;
   IstreamOffset table_offset = 0;
   bool is_host_import = false;
-  HostInterpreterModule* host_import_module = nullptr;
+  HostModule* host_import_module = nullptr;
   Index import_env_index = 0;
 };
 
 BinaryReaderInterpreter::BinaryReaderInterpreter(
-    InterpreterEnvironment* env,
-    DefinedInterpreterModule* module,
+    Environment* env,
+    DefinedModule* module,
     IstreamOffset istream_offset,
     BinaryErrorHandler* error_handler)
     : error_handler(error_handler),
@@ -345,12 +348,12 @@ Index BinaryReaderInterpreter::TranslateSigIndexToEnv(Index sig_index) {
   return sig_index_mapping[sig_index];
 }
 
-InterpreterFuncSignature* BinaryReaderInterpreter::GetSignatureByEnvIndex(
+FuncSignature* BinaryReaderInterpreter::GetSignatureByEnvIndex(
     Index sig_index) {
   return &env->sigs[sig_index];
 }
 
-InterpreterFuncSignature* BinaryReaderInterpreter::GetSignatureByModuleIndex(
+FuncSignature* BinaryReaderInterpreter::GetSignatureByModuleIndex(
     Index sig_index) {
   return GetSignatureByEnvIndex(TranslateSigIndexToEnv(sig_index));
 }
@@ -366,13 +369,11 @@ Index BinaryReaderInterpreter::TranslateModuleFuncIndexToDefined(
   return func_index - num_func_imports;
 }
 
-InterpreterFunc* BinaryReaderInterpreter::GetFuncByEnvIndex(
-    Index func_index) {
+Func* BinaryReaderInterpreter::GetFuncByEnvIndex(Index func_index) {
   return env->funcs[func_index].get();
 }
 
-InterpreterFunc* BinaryReaderInterpreter::GetFuncByModuleIndex(
-    Index func_index) {
+Func* BinaryReaderInterpreter::GetFuncByModuleIndex(Index func_index) {
   return GetFuncByEnvIndex(TranslateFuncIndexToEnv(func_index));
 }
 
@@ -380,13 +381,11 @@ Index BinaryReaderInterpreter::TranslateGlobalIndexToEnv(Index global_index) {
   return global_index_mapping[global_index];
 }
 
-InterpreterGlobal* BinaryReaderInterpreter::GetGlobalByEnvIndex(
-    Index global_index) {
+Global* BinaryReaderInterpreter::GetGlobalByEnvIndex(Index global_index) {
   return &env->globals[global_index];
 }
 
-InterpreterGlobal* BinaryReaderInterpreter::GetGlobalByModuleIndex(
-    Index global_index) {
+Global* BinaryReaderInterpreter::GetGlobalByModuleIndex(Index global_index) {
   return GetGlobalByEnvIndex(TranslateGlobalIndexToEnv(global_index));
 }
 
@@ -394,7 +393,7 @@ Type BinaryReaderInterpreter::GetGlobalTypeByModuleIndex(Index global_index) {
   return GetGlobalByModuleIndex(global_index)->typed_value.type;
 }
 
-Type BinaryReaderInterpreter::GetLocalTypeByIndex(InterpreterFunc* func,
+Type BinaryReaderInterpreter::GetLocalTypeByIndex(Func* func,
                                                   Index local_index) {
   assert(!func->is_host);
   return func->as_defined()->param_and_local_types[local_index];
@@ -404,69 +403,71 @@ IstreamOffset BinaryReaderInterpreter::GetIstreamOffset() {
   return istream_offset;
 }
 
-Result BinaryReaderInterpreter::EmitDataAt(IstreamOffset offset,
-                                           const void* data,
-                                           IstreamOffset size) {
+wabt::Result BinaryReaderInterpreter::EmitDataAt(IstreamOffset offset,
+                                                 const void* data,
+                                                 IstreamOffset size) {
   return istream_writer.WriteData(offset, data, size);
 }
 
-Result BinaryReaderInterpreter::EmitData(const void* data, IstreamOffset size) {
+wabt::Result BinaryReaderInterpreter::EmitData(const void* data,
+                                               IstreamOffset size) {
   CHECK_RESULT(EmitDataAt(istream_offset, data, size));
   istream_offset += size;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EmitOpcode(Opcode opcode) {
+wabt::Result BinaryReaderInterpreter::EmitOpcode(wabt::Opcode opcode) {
   return EmitData(&opcode, sizeof(uint8_t));
 }
 
-Result BinaryReaderInterpreter::EmitOpcode(InterpreterOpcode opcode) {
+wabt::Result BinaryReaderInterpreter::EmitOpcode(interpreter::Opcode opcode) {
   return EmitData(&opcode, sizeof(uint8_t));
 }
 
-Result BinaryReaderInterpreter::EmitI8(uint8_t value) {
+wabt::Result BinaryReaderInterpreter::EmitI8(uint8_t value) {
   return EmitData(&value, sizeof(value));
 }
 
-Result BinaryReaderInterpreter::EmitI32(uint32_t value) {
+wabt::Result BinaryReaderInterpreter::EmitI32(uint32_t value) {
   return EmitData(&value, sizeof(value));
 }
 
-Result BinaryReaderInterpreter::EmitI64(uint64_t value) {
+wabt::Result BinaryReaderInterpreter::EmitI64(uint64_t value) {
   return EmitData(&value, sizeof(value));
 }
 
-Result BinaryReaderInterpreter::EmitI32At(IstreamOffset offset,
-                                          uint32_t value) {
+wabt::Result BinaryReaderInterpreter::EmitI32At(IstreamOffset offset,
+                                                uint32_t value) {
   return EmitDataAt(offset, &value, sizeof(value));
 }
 
-Result BinaryReaderInterpreter::EmitDropKeep(uint32_t drop, uint8_t keep) {
+wabt::Result BinaryReaderInterpreter::EmitDropKeep(uint32_t drop,
+                                                   uint8_t keep) {
   assert(drop != UINT32_MAX);
   assert(keep <= 1);
   if (drop > 0) {
     if (drop == 1 && keep == 0) {
-      CHECK_RESULT(EmitOpcode(InterpreterOpcode::Drop));
+      CHECK_RESULT(EmitOpcode(interpreter::Opcode::Drop));
     } else {
-      CHECK_RESULT(EmitOpcode(InterpreterOpcode::DropKeep));
+      CHECK_RESULT(EmitOpcode(interpreter::Opcode::DropKeep));
       CHECK_RESULT(EmitI32(drop));
       CHECK_RESULT(EmitI8(keep));
     }
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::AppendFixup(
+wabt::Result BinaryReaderInterpreter::AppendFixup(
     IstreamOffsetVectorVector* fixups_vector,
     Index index) {
   if (index >= fixups_vector->size())
     fixups_vector->resize(index + 1);
   (*fixups_vector)[index].push_back(GetIstreamOffset());
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EmitBrOffset(Index depth,
-                                             IstreamOffset offset) {
+wabt::Result BinaryReaderInterpreter::EmitBrOffset(Index depth,
+                                                   IstreamOffset offset) {
   if (offset == kInvalidIstreamOffset) {
     /* depth_fixups stores the depth counting up from zero, where zero is the
      * top-level function scope. */
@@ -474,12 +475,13 @@ Result BinaryReaderInterpreter::EmitBrOffset(Index depth,
     CHECK_RESULT(AppendFixup(&depth_fixups, depth));
   }
   CHECK_RESULT(EmitI32(offset));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::GetBrDropKeepCount(Index depth,
-                                                   Index* out_drop_count,
-                                                   Index* out_keep_count) {
+wabt::Result BinaryReaderInterpreter::GetBrDropKeepCount(
+    Index depth,
+    Index* out_drop_count,
+    Index* out_keep_count) {
   TypeCheckerLabel* label;
   CHECK_RESULT(typechecker_get_label(&typechecker, depth, &label));
   *out_keep_count =
@@ -491,97 +493,98 @@ Result BinaryReaderInterpreter::GetBrDropKeepCount(Index depth,
         (typechecker.type_stack.size() - label->type_stack_limit) -
         *out_keep_count;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::GetReturnDropKeepCount(Index* out_drop_count,
-                                                       Index* out_keep_count) {
+wabt::Result BinaryReaderInterpreter::GetReturnDropKeepCount(
+    Index* out_drop_count,
+    Index* out_keep_count) {
   if (WABT_FAILED(GetBrDropKeepCount(label_stack.size() - 1, out_drop_count,
                                      out_keep_count))) {
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   *out_drop_count += current_func->param_and_local_types.size();
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EmitBr(Index depth,
-                                       Index drop_count,
-                                       Index keep_count) {
+wabt::Result BinaryReaderInterpreter::EmitBr(Index depth,
+                                             Index drop_count,
+                                             Index keep_count) {
   CHECK_RESULT(EmitDropKeep(drop_count, keep_count));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Br));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Br));
   CHECK_RESULT(EmitBrOffset(depth, GetLabel(depth)->offset));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EmitBrTableOffset(Index depth) {
+wabt::Result BinaryReaderInterpreter::EmitBrTableOffset(Index depth) {
   Index drop_count, keep_count;
   CHECK_RESULT(GetBrDropKeepCount(depth, &drop_count, &keep_count));
   CHECK_RESULT(EmitBrOffset(depth, GetLabel(depth)->offset));
   CHECK_RESULT(EmitI32(drop_count));
   CHECK_RESULT(EmitI8(keep_count));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::FixupTopLabel() {
+wabt::Result BinaryReaderInterpreter::FixupTopLabel() {
   IstreamOffset offset = GetIstreamOffset();
   Index top = label_stack.size() - 1;
   if (top >= depth_fixups.size()) {
     /* nothing to fixup */
-    return Result::Ok;
+    return wabt::Result::Ok;
   }
 
   IstreamOffsetVector& fixups = depth_fixups[top];
   for (IstreamOffset fixup : fixups)
     CHECK_RESULT(EmitI32At(fixup, offset));
   fixups.clear();
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EmitFuncOffset(DefinedInterpreterFunc* func,
-                                               Index func_index) {
+wabt::Result BinaryReaderInterpreter::EmitFuncOffset(DefinedFunc* func,
+                                                     Index func_index) {
   if (func->offset == kInvalidIstreamOffset) {
     Index defined_index = TranslateModuleFuncIndexToDefined(func_index);
     CHECK_RESULT(AppendFixup(&func_fixups, defined_index));
   }
   CHECK_RESULT(EmitI32(func->offset));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 bool BinaryReaderInterpreter::OnError(const char* message) {
   return HandleError(state->offset, message);
 }
 
-Result BinaryReaderInterpreter::OnTypeCount(Index count) {
+wabt::Result BinaryReaderInterpreter::OnTypeCount(Index count) {
   sig_index_mapping.resize(count);
   for (Index i = 0; i < count; ++i)
     sig_index_mapping[i] = env->sigs.size() + i;
   env->sigs.resize(env->sigs.size() + count);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnType(Index index,
-                                       Index param_count,
-                                       Type* param_types,
-                                       Index result_count,
-                                       Type* result_types) {
-  InterpreterFuncSignature* sig = GetSignatureByModuleIndex(index);
+wabt::Result BinaryReaderInterpreter::OnType(Index index,
+                                             Index param_count,
+                                             Type* param_types,
+                                             Index result_count,
+                                             Type* result_types) {
+  FuncSignature* sig = GetSignatureByModuleIndex(index);
   sig->param_types.insert(sig->param_types.end(), param_types,
                           param_types + param_count);
   sig->result_types.insert(sig->result_types.end(), result_types,
                            result_types + result_count);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnImportCount(Index count) {
+wabt::Result BinaryReaderInterpreter::OnImportCount(Index count) {
   module->imports.resize(count);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnImport(Index index,
-                                         StringSlice module_name,
-                                         StringSlice field_name) {
-  InterpreterImport* import = &module->imports[index];
+wabt::Result BinaryReaderInterpreter::OnImport(Index index,
+                                               StringSlice module_name,
+                                               StringSlice field_name) {
+  Import* import = &module->imports[index];
   import->module_name = dup_string_slice(module_name);
   import->field_name = dup_string_slice(field_name);
   int module_index =
@@ -589,10 +592,10 @@ Result BinaryReaderInterpreter::OnImport(Index index,
   if (module_index < 0) {
     PrintError("unknown import module \"" PRIstringslice "\"",
                WABT_PRINTF_STRING_SLICE_ARG(import->module_name));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
-  InterpreterModule* module = env->modules[module_index].get();
+  Module* module = env->modules[module_index].get();
   if (module->is_host) {
     /* We don't yet know the kind of a host import module, so just assume it
      * exists for now. We'll fail later (in on_import_* below) if it doesn't
@@ -600,93 +603,94 @@ Result BinaryReaderInterpreter::OnImport(Index index,
     is_host_import = true;
     host_import_module = module->as_host();
   } else {
-    InterpreterExport* export_ =
-        get_interpreter_export_by_name(module, &import->field_name);
+    Export* export_ = get_export_by_name(module, &import->field_name);
     if (!export_) {
       PrintError("unknown module field \"" PRIstringslice "\"",
                  WABT_PRINTF_STRING_SLICE_ARG(import->field_name));
-      return Result::Error;
+      return wabt::Result::Error;
     }
 
     import->kind = export_->kind;
     is_host_import = false;
     import_env_index = export_->index;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::CheckLocal(Index local_index) {
+wabt::Result BinaryReaderInterpreter::CheckLocal(Index local_index) {
   Index max_local_index = current_func->param_and_local_types.size();
   if (local_index >= max_local_index) {
     PrintError("invalid local_index: %" PRIindex " (max %" PRIindex ")",
                local_index, max_local_index);
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::CheckGlobal(Index global_index) {
+wabt::Result BinaryReaderInterpreter::CheckGlobal(Index global_index) {
   Index max_global_index = global_index_mapping.size();
   if (global_index >= max_global_index) {
     PrintError("invalid global_index: %" PRIindex " (max %" PRIindex ")",
                global_index, max_global_index);
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::CheckImportKind(InterpreterImport* import,
-                                                ExternalKind expected_kind) {
+wabt::Result BinaryReaderInterpreter::CheckImportKind(
+    Import* import,
+    ExternalKind expected_kind) {
   if (import->kind != expected_kind) {
     PrintError("expected import \"" PRIstringslice "." PRIstringslice
                "\" to have kind %s, not %s",
                WABT_PRINTF_STRING_SLICE_ARG(import->module_name),
                WABT_PRINTF_STRING_SLICE_ARG(import->field_name),
                get_kind_name(expected_kind), get_kind_name(import->kind));
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::CheckImportLimits(const Limits* declared_limits,
-                                                  const Limits* actual_limits) {
+wabt::Result BinaryReaderInterpreter::CheckImportLimits(
+    const Limits* declared_limits,
+    const Limits* actual_limits) {
   if (actual_limits->initial < declared_limits->initial) {
     PrintError("actual size (%" PRIu64 ") smaller than declared (%" PRIu64 ")",
                actual_limits->initial, declared_limits->initial);
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   if (declared_limits->has_max) {
     if (!actual_limits->has_max) {
       PrintError("max size (unspecified) larger than declared (%" PRIu64 ")",
                  declared_limits->max);
-      return Result::Error;
+      return wabt::Result::Error;
     } else if (actual_limits->max > declared_limits->max) {
       PrintError("max size (%" PRIu64 ") larger than declared (%" PRIu64 ")",
                  actual_limits->max, declared_limits->max);
-      return Result::Error;
+      return wabt::Result::Error;
     }
   }
 
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::AppendExport(InterpreterModule* module,
-                                             ExternalKind kind,
-                                             Index item_index,
-                                             StringSlice name) {
+wabt::Result BinaryReaderInterpreter::AppendExport(Module* module,
+                                                   ExternalKind kind,
+                                                   Index item_index,
+                                                   StringSlice name) {
   if (module->export_bindings.find_index(name) != -1) {
     PrintError("duplicate export \"" PRIstringslice "\"",
                WABT_PRINTF_STRING_SLICE_ARG(name));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   module->exports.emplace_back(dup_string_slice(name), kind, item_index);
-  InterpreterExport* export_ = &module->exports.back();
+  Export* export_ = &module->exports.back();
 
   module->export_bindings.emplace(string_slice_to_string(export_->name),
                                   Binding(module->exports.size() - 1));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 // static
@@ -702,24 +706,23 @@ PrintErrorCallback BinaryReaderInterpreter::MakePrintErrorCallback() {
   return result;
 }
 
-Result BinaryReaderInterpreter::OnImportFunc(Index import_index,
-                                             StringSlice module_name,
-                                             StringSlice field_name,
-                                             Index func_index,
-                                             Index sig_index) {
-  InterpreterImport* import = &module->imports[import_index];
+wabt::Result BinaryReaderInterpreter::OnImportFunc(Index import_index,
+                                                   StringSlice module_name,
+                                                   StringSlice field_name,
+                                                   Index func_index,
+                                                   Index sig_index) {
+  Import* import = &module->imports[import_index];
   import->func.sig_index = TranslateSigIndexToEnv(sig_index);
 
   Index func_env_index;
   if (is_host_import) {
-    HostInterpreterFunc* func = new HostInterpreterFunc(
-        import->module_name, import->field_name, import->func.sig_index);
+    HostFunc* func = new HostFunc(import->module_name, import->field_name,
+                                  import->func.sig_index);
 
     env->funcs.emplace_back(func);
 
-    InterpreterHostImportDelegate* host_delegate =
-        &host_import_module->import_delegate;
-    InterpreterFuncSignature* sig = &env->sigs[func->sig_index];
+    HostImportDelegate* host_delegate = &host_import_module->import_delegate;
+    FuncSignature* sig = &env->sigs[func->sig_index];
     CHECK_RESULT(host_delegate->import_func(
         import, func, sig, MakePrintErrorCallback(), host_delegate->user_data));
     assert(func->callback);
@@ -729,39 +732,38 @@ Result BinaryReaderInterpreter::OnImportFunc(Index import_index,
                  import->field_name);
   } else {
     CHECK_RESULT(CheckImportKind(import, ExternalKind::Func));
-    InterpreterFunc* func = env->funcs[import_env_index].get();
+    Func* func = env->funcs[import_env_index].get();
     if (!func_signatures_are_equal(env, import->func.sig_index,
                                    func->sig_index)) {
       PrintError("import signature mismatch");
-      return Result::Error;
+      return wabt::Result::Error;
     }
 
     func_env_index = import_env_index;
   }
   func_index_mapping.push_back(func_env_index);
   num_func_imports++;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnImportTable(Index import_index,
-                                              StringSlice module_name,
-                                              StringSlice field_name,
-                                              Index table_index,
-                                              Type elem_type,
-                                              const Limits* elem_limits) {
+wabt::Result BinaryReaderInterpreter::OnImportTable(Index import_index,
+                                                    StringSlice module_name,
+                                                    StringSlice field_name,
+                                                    Index table_index,
+                                                    Type elem_type,
+                                                    const Limits* elem_limits) {
   if (module->table_index != kInvalidIndex) {
     PrintError("only one table allowed");
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
-  InterpreterImport* import = &module->imports[import_index];
+  Import* import = &module->imports[import_index];
 
   if (is_host_import) {
     env->tables.emplace_back(*elem_limits);
-    InterpreterTable* table = &env->tables.back();
+    Table* table = &env->tables.back();
 
-    InterpreterHostImportDelegate* host_delegate =
-        &host_import_module->import_delegate;
+    HostImportDelegate* host_delegate = &host_import_module->import_delegate;
     CHECK_RESULT(host_delegate->import_table(
         import, table, MakePrintErrorCallback(), host_delegate->user_data));
 
@@ -772,33 +774,33 @@ Result BinaryReaderInterpreter::OnImportTable(Index import_index,
                  import->field_name);
   } else {
     CHECK_RESULT(CheckImportKind(import, ExternalKind::Table));
-    InterpreterTable* table = &env->tables[import_env_index];
+    Table* table = &env->tables[import_env_index];
     CHECK_RESULT(CheckImportLimits(elem_limits, &table->limits));
 
     import->table.limits = *elem_limits;
     module->table_index = import_env_index;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnImportMemory(Index import_index,
-                                               StringSlice module_name,
-                                               StringSlice field_name,
-                                               Index memory_index,
-                                               const Limits* page_limits) {
+wabt::Result BinaryReaderInterpreter::OnImportMemory(
+    Index import_index,
+    StringSlice module_name,
+    StringSlice field_name,
+    Index memory_index,
+    const Limits* page_limits) {
   if (module->memory_index != kInvalidIndex) {
     PrintError("only one memory allowed");
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
-  InterpreterImport* import = &module->imports[import_index];
+  Import* import = &module->imports[import_index];
 
   if (is_host_import) {
     env->memories.emplace_back();
-    InterpreterMemory* memory = &env->memories.back();
+    Memory* memory = &env->memories.back();
 
-    InterpreterHostImportDelegate* host_delegate =
-        &host_import_module->import_delegate;
+    HostImportDelegate* host_delegate = &host_import_module->import_delegate;
     CHECK_RESULT(host_delegate->import_memory(
         import, memory, MakePrintErrorCallback(), host_delegate->user_data));
 
@@ -809,30 +811,29 @@ Result BinaryReaderInterpreter::OnImportMemory(Index import_index,
                  import->field_name);
   } else {
     CHECK_RESULT(CheckImportKind(import, ExternalKind::Memory));
-    InterpreterMemory* memory = &env->memories[import_env_index];
+    Memory* memory = &env->memories[import_env_index];
     CHECK_RESULT(CheckImportLimits(page_limits, &memory->page_limits));
 
     import->memory.limits = *page_limits;
     module->memory_index = import_env_index;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnImportGlobal(Index import_index,
-                                               StringSlice module_name,
-                                               StringSlice field_name,
-                                               Index global_index,
-                                               Type type,
-                                               bool mutable_) {
-  InterpreterImport* import = &module->imports[import_index];
+wabt::Result BinaryReaderInterpreter::OnImportGlobal(Index import_index,
+                                                     StringSlice module_name,
+                                                     StringSlice field_name,
+                                                     Index global_index,
+                                                     Type type,
+                                                     bool mutable_) {
+  Import* import = &module->imports[import_index];
 
   Index global_env_index = env->globals.size() - 1;
   if (is_host_import) {
-    env->globals.emplace_back(InterpreterTypedValue(type), mutable_);
-    InterpreterGlobal* global = &env->globals.back();
+    env->globals.emplace_back(TypedValue(type), mutable_);
+    Global* global = &env->globals.back();
 
-    InterpreterHostImportDelegate* host_delegate =
-        &host_import_module->import_delegate;
+    HostImportDelegate* host_delegate = &host_import_module->import_delegate;
     CHECK_RESULT(host_delegate->import_global(
         import, global, MakePrintErrorCallback(), host_delegate->user_data));
 
@@ -848,123 +849,125 @@ Result BinaryReaderInterpreter::OnImportGlobal(Index import_index,
   }
   global_index_mapping.push_back(global_env_index);
   num_global_imports++;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnFunctionCount(Index count) {
+wabt::Result BinaryReaderInterpreter::OnFunctionCount(Index count) {
   for (Index i = 0; i < count; ++i)
     func_index_mapping.push_back(env->funcs.size() + i);
   env->funcs.reserve(env->funcs.size() + count);
   func_fixups.resize(count);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnFunction(Index index, Index sig_index) {
-  DefinedInterpreterFunc* func =
-      new DefinedInterpreterFunc(TranslateSigIndexToEnv(sig_index));
+wabt::Result BinaryReaderInterpreter::OnFunction(Index index, Index sig_index) {
+  DefinedFunc* func = new DefinedFunc(TranslateSigIndexToEnv(sig_index));
   env->funcs.emplace_back(func);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnTable(Index index,
-                                        Type elem_type,
-                                        const Limits* elem_limits) {
+wabt::Result BinaryReaderInterpreter::OnTable(Index index,
+                                              Type elem_type,
+                                              const Limits* elem_limits) {
   if (module->table_index != kInvalidIndex) {
     PrintError("only one table allowed");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   env->tables.emplace_back(*elem_limits);
   module->table_index = env->tables.size() - 1;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnMemory(Index index,
-                                         const Limits* page_limits) {
+wabt::Result BinaryReaderInterpreter::OnMemory(Index index,
+                                               const Limits* page_limits) {
   if (module->memory_index != kInvalidIndex) {
     PrintError("only one memory allowed");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   env->memories.emplace_back(*page_limits);
   module->memory_index = env->memories.size() - 1;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnGlobalCount(Index count) {
+wabt::Result BinaryReaderInterpreter::OnGlobalCount(Index count) {
   for (Index i = 0; i < count; ++i)
     global_index_mapping.push_back(env->globals.size() + i);
   env->globals.resize(env->globals.size() + count);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::BeginGlobal(Index index,
-                                            Type type,
-                                            bool mutable_) {
-  InterpreterGlobal* global = GetGlobalByModuleIndex(index);
+wabt::Result BinaryReaderInterpreter::BeginGlobal(Index index,
+                                                  Type type,
+                                                  bool mutable_) {
+  Global* global = GetGlobalByModuleIndex(index);
   global->typed_value.type = type;
   global->mutable_ = mutable_;
   init_expr_value.type = Type::Void;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EndGlobalInitExpr(Index index) {
-  InterpreterGlobal* global = GetGlobalByModuleIndex(index);
+wabt::Result BinaryReaderInterpreter::EndGlobalInitExpr(Index index) {
+  Global* global = GetGlobalByModuleIndex(index);
   if (init_expr_value.type != global->typed_value.type) {
     PrintError("type mismatch in global, expected %s but got %s.",
                get_type_name(global->typed_value.type),
                get_type_name(init_expr_value.type));
-    return Result::Error;
+    return wabt::Result::Error;
   }
   global->typed_value = init_expr_value;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnInitExprF32ConstExpr(Index index,
-                                                       uint32_t value_bits) {
+wabt::Result BinaryReaderInterpreter::OnInitExprF32ConstExpr(
+    Index index,
+    uint32_t value_bits) {
   init_expr_value.type = Type::F32;
   init_expr_value.value.f32_bits = value_bits;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnInitExprF64ConstExpr(Index index,
-                                                       uint64_t value_bits) {
+wabt::Result BinaryReaderInterpreter::OnInitExprF64ConstExpr(
+    Index index,
+    uint64_t value_bits) {
   init_expr_value.type = Type::F64;
   init_expr_value.value.f64_bits = value_bits;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnInitExprGetGlobalExpr(Index index,
-                                                        Index global_index) {
+wabt::Result BinaryReaderInterpreter::OnInitExprGetGlobalExpr(
+    Index index,
+    Index global_index) {
   if (global_index >= num_global_imports) {
     PrintError("initializer expression can only reference an imported global");
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  InterpreterGlobal* ref_global = GetGlobalByModuleIndex(global_index);
+  Global* ref_global = GetGlobalByModuleIndex(global_index);
   if (ref_global->mutable_) {
     PrintError("initializer expression cannot reference a mutable global");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   init_expr_value = ref_global->typed_value;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnInitExprI32ConstExpr(Index index,
-                                                       uint32_t value) {
+wabt::Result BinaryReaderInterpreter::OnInitExprI32ConstExpr(Index index,
+                                                             uint32_t value) {
   init_expr_value.type = Type::I32;
   init_expr_value.value.i32 = value;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnInitExprI64ConstExpr(Index index,
-                                                       uint64_t value) {
+wabt::Result BinaryReaderInterpreter::OnInitExprI64ConstExpr(Index index,
+                                                             uint64_t value) {
   init_expr_value.type = Type::I64;
   init_expr_value.value.i64 = value;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnExport(Index index,
-                                         ExternalKind kind,
-                                         Index item_index,
-                                         StringSlice name) {
+wabt::Result BinaryReaderInterpreter::OnExport(Index index,
+                                               ExternalKind kind,
+                                               Index item_index,
+                                               StringSlice name) {
   switch (kind) {
     case ExternalKind::Func:
       item_index = TranslateFuncIndexToEnv(item_index);
@@ -980,10 +983,10 @@ Result BinaryReaderInterpreter::OnExport(Index index,
 
     case ExternalKind::Global: {
       item_index = TranslateGlobalIndexToEnv(item_index);
-      InterpreterGlobal* global = &env->globals[item_index];
+      Global* global = &env->globals[item_index];
       if (global->mutable_) {
         PrintError("mutable globals cannot be exported");
-        return Result::Error;
+        return wabt::Result::Error;
       }
       break;
     }
@@ -991,63 +994,64 @@ Result BinaryReaderInterpreter::OnExport(Index index,
   return AppendExport(module, kind, item_index, name);
 }
 
-Result BinaryReaderInterpreter::OnStartFunction(Index func_index) {
+wabt::Result BinaryReaderInterpreter::OnStartFunction(Index func_index) {
   Index start_func_index = TranslateFuncIndexToEnv(func_index);
-  InterpreterFunc* start_func = GetFuncByEnvIndex(start_func_index);
-  InterpreterFuncSignature* sig = GetSignatureByEnvIndex(start_func->sig_index);
+  Func* start_func = GetFuncByEnvIndex(start_func_index);
+  FuncSignature* sig = GetSignatureByEnvIndex(start_func->sig_index);
   if (sig->param_types.size() != 0) {
     PrintError("start function must be nullary");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   if (sig->result_types.size() != 0) {
     PrintError("start function must not return anything");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   module->start_func_index = start_func_index;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EndElemSegmentInitExpr(Index index) {
+wabt::Result BinaryReaderInterpreter::EndElemSegmentInitExpr(Index index) {
   if (init_expr_value.type != Type::I32) {
     PrintError("type mismatch in elem segment, expected i32 but got %s",
                get_type_name(init_expr_value.type));
-    return Result::Error;
+    return wabt::Result::Error;
   }
   table_offset = init_expr_value.value.i32;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnElemSegmentFunctionIndex(Index index,
-                                                           Index func_index) {
+wabt::Result BinaryReaderInterpreter::OnElemSegmentFunctionIndex(
+    Index index,
+    Index func_index) {
   assert(module->table_index != kInvalidIndex);
-  InterpreterTable* table = &env->tables[module->table_index];
+  Table* table = &env->tables[module->table_index];
   if (table_offset >= table->func_indexes.size()) {
     PrintError("elem segment offset is out of bounds: %u >= max value %" PRIzd,
                table_offset, table->func_indexes.size());
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   Index max_func_index = func_index_mapping.size();
   if (func_index >= max_func_index) {
     PrintError("invalid func_index: %" PRIindex " (max %" PRIindex ")",
                func_index, max_func_index);
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   elem_segment_infos.emplace_back(&table->func_indexes[table_offset++],
                                   TranslateFuncIndexToEnv(func_index));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnDataSegmentData(Index index,
-                                                  const void* src_data,
-                                                  Address size) {
+wabt::Result BinaryReaderInterpreter::OnDataSegmentData(Index index,
+                                                        const void* src_data,
+                                                        Address size) {
   assert(module->memory_index != kInvalidIndex);
-  InterpreterMemory* memory = &env->memories[module->memory_index];
+  Memory* memory = &env->memories[module->memory_index];
   if (init_expr_value.type != Type::I32) {
     PrintError("type mismatch in data segment, expected i32 but got %s",
                get_type_name(init_expr_value.type));
-    return Result::Error;
+    return wabt::Result::Error;
   }
   Address address = init_expr_value.value.i32;
   uint64_t end_address =
@@ -1056,13 +1060,13 @@ Result BinaryReaderInterpreter::OnDataSegmentData(Index index,
     PrintError("data segment is out of bounds: [%" PRIaddress ", %" PRIu64
                ") >= max value %" PRIzd,
                address, end_address, memory->data.size());
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   if (size > 0)
     data_segment_infos.emplace_back(&memory->data[address], src_data, size);
 
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 void BinaryReaderInterpreter::PushLabel(IstreamOffset offset,
@@ -1080,9 +1084,9 @@ void BinaryReaderInterpreter::PopLabel() {
   }
 }
 
-Result BinaryReaderInterpreter::BeginFunctionBody(Index index) {
-  DefinedInterpreterFunc* func = GetFuncByModuleIndex(index)->as_defined();
-  InterpreterFuncSignature* sig = GetSignatureByEnvIndex(func->sig_index);
+wabt::Result BinaryReaderInterpreter::BeginFunctionBody(Index index) {
+  DefinedFunc* func = GetFuncByModuleIndex(index)->as_defined();
+  FuncSignature* sig = GetSignatureByEnvIndex(func->sig_index);
 
   func->offset = GetIstreamOffset();
   func->local_decl_count = 0;
@@ -1106,29 +1110,29 @@ Result BinaryReaderInterpreter::BeginFunctionBody(Index index) {
 
   /* push implicit func label (equivalent to return) */
   PushLabel(kInvalidIstreamOffset, kInvalidIstreamOffset);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EndFunctionBody(Index index) {
+wabt::Result BinaryReaderInterpreter::EndFunctionBody(Index index) {
   FixupTopLabel();
   Index drop_count, keep_count;
   CHECK_RESULT(GetReturnDropKeepCount(&drop_count, &keep_count));
   CHECK_RESULT(typechecker_end_function(&typechecker));
   CHECK_RESULT(EmitDropKeep(drop_count, keep_count));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Return));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Return));
   PopLabel();
   current_func = nullptr;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnLocalDeclCount(Index count) {
+wabt::Result BinaryReaderInterpreter::OnLocalDeclCount(Index count) {
   current_func->local_decl_count = count;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnLocalDecl(Index decl_index,
-                                            Index count,
-                                            Type type) {
+wabt::Result BinaryReaderInterpreter::OnLocalDecl(Index decl_index,
+                                                  Index count,
+                                                  Type type) {
   current_func->local_count += count;
 
   for (Index i = 0; i < count; ++i)
@@ -1136,79 +1140,82 @@ Result BinaryReaderInterpreter::OnLocalDecl(Index decl_index,
 
   if (decl_index == current_func->local_decl_count - 1) {
     /* last local declaration, allocate space for all locals. */
-    CHECK_RESULT(EmitOpcode(InterpreterOpcode::Alloca));
+    CHECK_RESULT(EmitOpcode(interpreter::Opcode::Alloca));
     CHECK_RESULT(EmitI32(current_func->local_count));
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::CheckHasMemory(Opcode opcode) {
+wabt::Result BinaryReaderInterpreter::CheckHasMemory(wabt::Opcode opcode) {
   if (module->memory_index == kInvalidIndex) {
     PrintError("%s requires an imported or defined memory.",
                get_opcode_name(opcode));
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::CheckAlign(uint32_t alignment_log2,
-                                           Address natural_alignment) {
+wabt::Result BinaryReaderInterpreter::CheckAlign(uint32_t alignment_log2,
+                                                 Address natural_alignment) {
   if (alignment_log2 >= 32 || (1U << alignment_log2) > natural_alignment) {
     PrintError("alignment must not be larger than natural alignment (%u)",
                natural_alignment);
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnUnaryExpr(Opcode opcode) {
+wabt::Result BinaryReaderInterpreter::OnUnaryExpr(wabt::Opcode opcode) {
   CHECK_RESULT(typechecker_on_unary(&typechecker, opcode));
   CHECK_RESULT(EmitOpcode(opcode));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnBinaryExpr(Opcode opcode) {
+wabt::Result BinaryReaderInterpreter::OnBinaryExpr(wabt::Opcode opcode) {
   CHECK_RESULT(typechecker_on_binary(&typechecker, opcode));
   CHECK_RESULT(EmitOpcode(opcode));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnBlockExpr(Index num_types, Type* sig_types) {
+wabt::Result BinaryReaderInterpreter::OnBlockExpr(Index num_types,
+                                                  Type* sig_types) {
   TypeVector sig(sig_types, sig_types + num_types);
   CHECK_RESULT(typechecker_on_block(&typechecker, &sig));
   PushLabel(kInvalidIstreamOffset, kInvalidIstreamOffset);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnLoopExpr(Index num_types, Type* sig_types) {
+wabt::Result BinaryReaderInterpreter::OnLoopExpr(Index num_types,
+                                                 Type* sig_types) {
   TypeVector sig(sig_types, sig_types + num_types);
   CHECK_RESULT(typechecker_on_loop(&typechecker, &sig));
   PushLabel(GetIstreamOffset(), kInvalidIstreamOffset);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnIfExpr(Index num_types, Type* sig_types) {
+wabt::Result BinaryReaderInterpreter::OnIfExpr(Index num_types,
+                                               Type* sig_types) {
   TypeVector sig(sig_types, sig_types + num_types);
   CHECK_RESULT(typechecker_on_if(&typechecker, &sig));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::BrUnless));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::BrUnless));
   IstreamOffset fixup_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
   PushLabel(kInvalidIstreamOffset, fixup_offset);
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnElseExpr() {
+wabt::Result BinaryReaderInterpreter::OnElseExpr() {
   CHECK_RESULT(typechecker_on_else(&typechecker));
   Label* label = TopLabel();
   IstreamOffset fixup_cond_offset = label->fixup_offset;
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Br));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Br));
   label->fixup_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
   CHECK_RESULT(EmitI32At(fixup_cond_offset, GetIstreamOffset()));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnEndExpr() {
+wabt::Result BinaryReaderInterpreter::OnEndExpr() {
   TypeCheckerLabel* label;
   CHECK_RESULT(typechecker_get_label(&typechecker, 0, &label));
   LabelType label_type = label->label_type;
@@ -1218,41 +1225,42 @@ Result BinaryReaderInterpreter::OnEndExpr() {
   }
   FixupTopLabel();
   PopLabel();
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnBrExpr(Index depth) {
+wabt::Result BinaryReaderInterpreter::OnBrExpr(Index depth) {
   Index drop_count, keep_count;
   CHECK_RESULT(GetBrDropKeepCount(depth, &drop_count, &keep_count));
   CHECK_RESULT(typechecker_on_br(&typechecker, depth));
   CHECK_RESULT(EmitBr(depth, drop_count, keep_count));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnBrIfExpr(Index depth) {
+wabt::Result BinaryReaderInterpreter::OnBrIfExpr(Index depth) {
   Index drop_count, keep_count;
   CHECK_RESULT(typechecker_on_br_if(&typechecker, depth));
   CHECK_RESULT(GetBrDropKeepCount(depth, &drop_count, &keep_count));
   /* flip the br_if so if <cond> is true it can drop values from the stack */
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::BrUnless));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::BrUnless));
   IstreamOffset fixup_br_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
   CHECK_RESULT(EmitBr(depth, drop_count, keep_count));
   CHECK_RESULT(EmitI32At(fixup_br_offset, GetIstreamOffset()));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnBrTableExpr(Index num_targets,
-                                              Index* target_depths,
-                                              Index default_target_depth) {
+wabt::Result BinaryReaderInterpreter::OnBrTableExpr(
+    Index num_targets,
+    Index* target_depths,
+    Index default_target_depth) {
   CHECK_RESULT(typechecker_begin_br_table(&typechecker));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::BrTable));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::BrTable));
   CHECK_RESULT(EmitI32(num_targets));
   IstreamOffset fixup_table_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
   /* not necessary for the interpreter, but it makes it easier to disassemble.
    * This opcode specifies how many bytes of data follow. */
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Data));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Data));
   CHECK_RESULT(EmitI32((num_targets + 1) * WABT_TABLE_ENTRY_SIZE));
   CHECK_RESULT(EmitI32At(fixup_table_offset, GetIstreamOffset()));
 
@@ -1263,105 +1271,105 @@ Result BinaryReaderInterpreter::OnBrTableExpr(Index num_targets,
   }
 
   CHECK_RESULT(typechecker_end_br_table(&typechecker));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnCallExpr(Index func_index) {
-  InterpreterFunc* func = GetFuncByModuleIndex(func_index);
-  InterpreterFuncSignature* sig = GetSignatureByEnvIndex(func->sig_index);
+wabt::Result BinaryReaderInterpreter::OnCallExpr(Index func_index) {
+  Func* func = GetFuncByModuleIndex(func_index);
+  FuncSignature* sig = GetSignatureByEnvIndex(func->sig_index);
   CHECK_RESULT(
       typechecker_on_call(&typechecker, &sig->param_types, &sig->result_types));
 
   if (func->is_host) {
-    CHECK_RESULT(EmitOpcode(InterpreterOpcode::CallHost));
+    CHECK_RESULT(EmitOpcode(interpreter::Opcode::CallHost));
     CHECK_RESULT(EmitI32(TranslateFuncIndexToEnv(func_index)));
   } else {
-    CHECK_RESULT(EmitOpcode(InterpreterOpcode::Call));
+    CHECK_RESULT(EmitOpcode(interpreter::Opcode::Call));
     CHECK_RESULT(EmitFuncOffset(func->as_defined(), func_index));
   }
 
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnCallIndirectExpr(Index sig_index) {
+wabt::Result BinaryReaderInterpreter::OnCallIndirectExpr(Index sig_index) {
   if (module->table_index == kInvalidIndex) {
     PrintError("found call_indirect operator, but no table");
-    return Result::Error;
+    return wabt::Result::Error;
   }
-  InterpreterFuncSignature* sig = GetSignatureByModuleIndex(sig_index);
+  FuncSignature* sig = GetSignatureByModuleIndex(sig_index);
   CHECK_RESULT(typechecker_on_call_indirect(&typechecker, &sig->param_types,
                                             &sig->result_types));
 
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::CallIndirect));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::CallIndirect));
   CHECK_RESULT(EmitI32(module->table_index));
   CHECK_RESULT(EmitI32(TranslateSigIndexToEnv(sig_index)));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnCompareExpr(Opcode opcode) {
+wabt::Result BinaryReaderInterpreter::OnCompareExpr(wabt::Opcode opcode) {
   return OnBinaryExpr(opcode);
 }
 
-Result BinaryReaderInterpreter::OnConvertExpr(Opcode opcode) {
+wabt::Result BinaryReaderInterpreter::OnConvertExpr(wabt::Opcode opcode) {
   return OnUnaryExpr(opcode);
 }
 
-Result BinaryReaderInterpreter::OnDropExpr() {
+wabt::Result BinaryReaderInterpreter::OnDropExpr() {
   CHECK_RESULT(typechecker_on_drop(&typechecker));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Drop));
-  return Result::Ok;
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Drop));
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnI32ConstExpr(uint32_t value) {
+wabt::Result BinaryReaderInterpreter::OnI32ConstExpr(uint32_t value) {
   CHECK_RESULT(typechecker_on_const(&typechecker, Type::I32));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::I32Const));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::I32Const));
   CHECK_RESULT(EmitI32(value));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnI64ConstExpr(uint64_t value) {
+wabt::Result BinaryReaderInterpreter::OnI64ConstExpr(uint64_t value) {
   CHECK_RESULT(typechecker_on_const(&typechecker, Type::I64));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::I64Const));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::I64Const));
   CHECK_RESULT(EmitI64(value));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnF32ConstExpr(uint32_t value_bits) {
+wabt::Result BinaryReaderInterpreter::OnF32ConstExpr(uint32_t value_bits) {
   CHECK_RESULT(typechecker_on_const(&typechecker, Type::F32));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::F32Const));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::F32Const));
   CHECK_RESULT(EmitI32(value_bits));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnF64ConstExpr(uint64_t value_bits) {
+wabt::Result BinaryReaderInterpreter::OnF64ConstExpr(uint64_t value_bits) {
   CHECK_RESULT(typechecker_on_const(&typechecker, Type::F64));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::F64Const));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::F64Const));
   CHECK_RESULT(EmitI64(value_bits));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnGetGlobalExpr(Index global_index) {
+wabt::Result BinaryReaderInterpreter::OnGetGlobalExpr(Index global_index) {
   CHECK_RESULT(CheckGlobal(global_index));
   Type type = GetGlobalTypeByModuleIndex(global_index);
   CHECK_RESULT(typechecker_on_get_global(&typechecker, type));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::GetGlobal));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::GetGlobal));
   CHECK_RESULT(EmitI32(TranslateGlobalIndexToEnv(global_index)));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnSetGlobalExpr(Index global_index) {
+wabt::Result BinaryReaderInterpreter::OnSetGlobalExpr(Index global_index) {
   CHECK_RESULT(CheckGlobal(global_index));
-  InterpreterGlobal* global = GetGlobalByModuleIndex(global_index);
+  Global* global = GetGlobalByModuleIndex(global_index);
   if (!global->mutable_) {
     PrintError("can't set_global on immutable global at index %" PRIindex ".",
                global_index);
-    return Result::Error;
+    return wabt::Result::Error;
   }
   CHECK_RESULT(
       typechecker_on_set_global(&typechecker, global->typed_value.type));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::SetGlobal));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::SetGlobal));
   CHECK_RESULT(EmitI32(TranslateGlobalIndexToEnv(global_index)));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 Index BinaryReaderInterpreter::TranslateLocalIndex(Index local_index) {
@@ -1369,7 +1377,7 @@ Index BinaryReaderInterpreter::TranslateLocalIndex(Index local_index) {
          current_func->param_and_local_types.size() - local_index;
 }
 
-Result BinaryReaderInterpreter::OnGetLocalExpr(Index local_index) {
+wabt::Result BinaryReaderInterpreter::OnGetLocalExpr(Index local_index) {
   CHECK_RESULT(CheckLocal(local_index));
   Type type = GetLocalTypeByIndex(current_func, local_index);
   /* Get the translated index before calling typechecker_on_get_local
@@ -1377,130 +1385,129 @@ Result BinaryReaderInterpreter::OnGetLocalExpr(Index local_index) {
    * relative to the old stack size. */
   Index translated_local_index = TranslateLocalIndex(local_index);
   CHECK_RESULT(typechecker_on_get_local(&typechecker, type));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::GetLocal));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::GetLocal));
   CHECK_RESULT(EmitI32(translated_local_index));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnSetLocalExpr(Index local_index) {
+wabt::Result BinaryReaderInterpreter::OnSetLocalExpr(Index local_index) {
   CHECK_RESULT(CheckLocal(local_index));
   Type type = GetLocalTypeByIndex(current_func, local_index);
   CHECK_RESULT(typechecker_on_set_local(&typechecker, type));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::SetLocal));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::SetLocal));
   CHECK_RESULT(EmitI32(TranslateLocalIndex(local_index)));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnTeeLocalExpr(Index local_index) {
+wabt::Result BinaryReaderInterpreter::OnTeeLocalExpr(Index local_index) {
   CHECK_RESULT(CheckLocal(local_index));
   Type type = GetLocalTypeByIndex(current_func, local_index);
   CHECK_RESULT(typechecker_on_tee_local(&typechecker, type));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::TeeLocal));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::TeeLocal));
   CHECK_RESULT(EmitI32(TranslateLocalIndex(local_index)));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnGrowMemoryExpr() {
-  CHECK_RESULT(CheckHasMemory(Opcode::GrowMemory));
+wabt::Result BinaryReaderInterpreter::OnGrowMemoryExpr() {
+  CHECK_RESULT(CheckHasMemory(wabt::Opcode::GrowMemory));
   CHECK_RESULT(typechecker_on_grow_memory(&typechecker));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::GrowMemory));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::GrowMemory));
   CHECK_RESULT(EmitI32(module->memory_index));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnLoadExpr(Opcode opcode,
-                                           uint32_t alignment_log2,
-                                           Address offset) {
+wabt::Result BinaryReaderInterpreter::OnLoadExpr(wabt::Opcode opcode,
+                                                 uint32_t alignment_log2,
+                                                 Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAlign(alignment_log2, get_opcode_memory_size(opcode)));
   CHECK_RESULT(typechecker_on_load(&typechecker, opcode));
   CHECK_RESULT(EmitOpcode(opcode));
   CHECK_RESULT(EmitI32(module->memory_index));
   CHECK_RESULT(EmitI32(offset));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnStoreExpr(Opcode opcode,
-                                            uint32_t alignment_log2,
-                                            Address offset) {
+wabt::Result BinaryReaderInterpreter::OnStoreExpr(wabt::Opcode opcode,
+                                                  uint32_t alignment_log2,
+                                                  Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAlign(alignment_log2, get_opcode_memory_size(opcode)));
   CHECK_RESULT(typechecker_on_store(&typechecker, opcode));
   CHECK_RESULT(EmitOpcode(opcode));
   CHECK_RESULT(EmitI32(module->memory_index));
   CHECK_RESULT(EmitI32(offset));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnCurrentMemoryExpr() {
-  CHECK_RESULT(CheckHasMemory(Opcode::CurrentMemory));
+wabt::Result BinaryReaderInterpreter::OnCurrentMemoryExpr() {
+  CHECK_RESULT(CheckHasMemory(wabt::Opcode::CurrentMemory));
   CHECK_RESULT(typechecker_on_current_memory(&typechecker));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::CurrentMemory));
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::CurrentMemory));
   CHECK_RESULT(EmitI32(module->memory_index));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnNopExpr() {
-  return Result::Ok;
+wabt::Result BinaryReaderInterpreter::OnNopExpr() {
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnReturnExpr() {
+wabt::Result BinaryReaderInterpreter::OnReturnExpr() {
   Index drop_count, keep_count;
   CHECK_RESULT(GetReturnDropKeepCount(&drop_count, &keep_count));
   CHECK_RESULT(typechecker_on_return(&typechecker));
   CHECK_RESULT(EmitDropKeep(drop_count, keep_count));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Return));
-  return Result::Ok;
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Return));
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnSelectExpr() {
+wabt::Result BinaryReaderInterpreter::OnSelectExpr() {
   CHECK_RESULT(typechecker_on_select(&typechecker));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Select));
-  return Result::Ok;
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Select));
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::OnUnreachableExpr() {
+wabt::Result BinaryReaderInterpreter::OnUnreachableExpr() {
   CHECK_RESULT(typechecker_on_unreachable(&typechecker));
-  CHECK_RESULT(EmitOpcode(InterpreterOpcode::Unreachable));
-  return Result::Ok;
+  CHECK_RESULT(EmitOpcode(interpreter::Opcode::Unreachable));
+  return wabt::Result::Ok;
 }
 
-Result BinaryReaderInterpreter::EndModule() {
+wabt::Result BinaryReaderInterpreter::EndModule() {
   for (ElemSegmentInfo& info : elem_segment_infos) {
     *info.dst = info.func_index;
   }
   for (DataSegmentInfo& info : data_segment_infos) {
     memcpy(info.dst_data, info.src_data, info.size);
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 }  // namespace
 
-Result read_binary_interpreter(InterpreterEnvironment* env,
-                               const void* data,
-                               size_t size,
-                               const ReadBinaryOptions* options,
-                               BinaryErrorHandler* error_handler,
-                               DefinedInterpreterModule** out_module) {
+wabt::Result read_binary_interpreter(Environment* env,
+                                     const void* data,
+                                     size_t size,
+                                     const ReadBinaryOptions* options,
+                                     BinaryErrorHandler* error_handler,
+                                     DefinedModule** out_module) {
   IstreamOffset istream_offset = env->istream->data.size();
-  DefinedInterpreterModule* module =
-      new DefinedInterpreterModule(istream_offset);
+  DefinedModule* module = new DefinedModule(istream_offset);
 
   // Need to mark before constructing the reader since it takes ownership of
   // env->istream, which makes env->istream == nullptr.
-  InterpreterEnvironmentMark mark = mark_interpreter_environment(env);
+  EnvironmentMark mark = mark_environment(env);
   BinaryReaderInterpreter reader(env, module, istream_offset, error_handler);
   env->modules.emplace_back(module);
 
-  Result result = read_binary(data, size, &reader, options);
+  wabt::Result result = read_binary(data, size, &reader, options);
   env->istream = reader.ReleaseOutputBuffer();
   if (WABT_SUCCEEDED(result)) {
     env->istream->data.resize(reader.get_istream_offset());
     module->istream_end = env->istream->data.size();
     *out_module = module;
   } else {
-    reset_interpreter_environment_to_mark(env, mark);
+    reset_environment_to_mark(env, mark);
     *out_module = nullptr;
   }
   return result;

--- a/src/binary-reader-interpreter.h
+++ b/src/binary-reader-interpreter.h
@@ -21,17 +21,22 @@
 
 namespace wabt {
 
+namespace interpreter {
+
+struct DefinedModule;
+struct Environment;
+
+} // namespace interpreter
+
 class BinaryErrorHandler;
-struct DefinedInterpreterModule;
-struct InterpreterEnvironment;
 struct ReadBinaryOptions;
 
-Result read_binary_interpreter(InterpreterEnvironment* env,
+Result read_binary_interpreter(interpreter::Environment* env,
                                const void* data,
                                size_t size,
                                const ReadBinaryOptions* options,
                                BinaryErrorHandler*,
-                               DefinedInterpreterModule** out_module);
+                               interpreter::DefinedModule** out_module);
 
 }  // namespace wabt
 

--- a/src/common.h
+++ b/src/common.h
@@ -102,8 +102,8 @@ enum class Result {
   Error,
 };
 
-#define WABT_SUCCEEDED(x) ((x) == Result::Ok)
-#define WABT_FAILED(x) ((x) == Result::Error)
+#define WABT_SUCCEEDED(x) ((x) == ::wabt::Result::Ok)
+#define WABT_FAILED(x) ((x) == ::wabt::Result::Error)
 
 inline std::string WABT_PRINTF_FORMAT(1, 2)
     string_printf(const char* format, ...) {

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -25,8 +25,9 @@
 #include "stream.h"
 
 namespace wabt {
+namespace interpreter {
 
-static const char* s_interpreter_opcode_name[256] = {
+static const char* s_opcode_name[256] = {
 
 #define WABT_OPCODE(rtype, type1, type2, mem_size, code, NAME, text) text,
 #include "interpreter-opcode.def"
@@ -40,14 +41,13 @@ static const char* s_interpreter_opcode_name[256] = {
       return Result::Error; \
   } while (0)
 
-static const char* get_interpreter_opcode_name(InterpreterOpcode opcode) {
-  return s_interpreter_opcode_name[static_cast<int>(opcode)];
+static const char* get_opcode_name(Opcode opcode) {
+  return s_opcode_name[static_cast<int>(opcode)];
 }
 
-InterpreterEnvironment::InterpreterEnvironment()
-    : istream(new OutputBuffer()) {}
+Environment::Environment() : istream(new OutputBuffer()) {}
 
-InterpreterThread::InterpreterThread()
+Thread::Thread()
     : env(nullptr),
       value_stack_top(nullptr),
       value_stack_end(nullptr),
@@ -55,18 +55,17 @@ InterpreterThread::InterpreterThread()
       call_stack_end(nullptr),
       pc(0) {}
 
-InterpreterImport::InterpreterImport() 
-  : kind(ExternalKind::Func) {
+Import::Import() : kind(ExternalKind::Func) {
   WABT_ZERO_MEMORY(module_name);
   WABT_ZERO_MEMORY(field_name);
   WABT_ZERO_MEMORY(func.sig_index);
 }
 
-InterpreterImport::InterpreterImport(InterpreterImport&& other) {
+Import::Import(Import&& other) {
   *this = std::move(other);
 }
 
-InterpreterImport& InterpreterImport::operator=(InterpreterImport&& other) {
+Import& Import::operator=(Import&& other) {
   kind = other.kind;
   module_name = other.module_name;
   WABT_ZERO_MEMORY(other.module_name);
@@ -90,20 +89,17 @@ InterpreterImport& InterpreterImport::operator=(InterpreterImport&& other) {
   return *this;
 }
 
-
-InterpreterImport::~InterpreterImport() {
+Import::~Import() {
   destroy_string_slice(&module_name);
   destroy_string_slice(&field_name);
 }
 
-InterpreterExport::InterpreterExport(InterpreterExport&& other)
-  : name(other.name),
-    kind(other.kind),
-    index(other.index) {
+Export::Export(Export&& other)
+    : name(other.name), kind(other.kind), index(other.index) {
   WABT_ZERO_MEMORY(other.name);
 }
 
-InterpreterExport& InterpreterExport::operator=(InterpreterExport&& other) {
+Export& Export::operator=(Export&& other) {
   name = other.name;
   kind = other.kind;
   index = other.index;
@@ -111,39 +107,37 @@ InterpreterExport& InterpreterExport::operator=(InterpreterExport&& other) {
   return *this;
 }
 
-InterpreterExport::~InterpreterExport() {
+Export::~Export() {
   destroy_string_slice(&name);
 }
 
-InterpreterModule::InterpreterModule(bool is_host)
+Module::Module(bool is_host)
     : memory_index(kInvalidIndex),
       table_index(kInvalidIndex),
       is_host(is_host) {
   WABT_ZERO_MEMORY(name);
 }
 
-InterpreterModule::InterpreterModule(const StringSlice& name, bool is_host)
+Module::Module(const StringSlice& name, bool is_host)
     : name(name),
       memory_index(kInvalidIndex),
       table_index(kInvalidIndex),
       is_host(is_host) {}
 
-InterpreterModule::~InterpreterModule() {
+Module::~Module() {
   destroy_string_slice(&name);
 }
 
-DefinedInterpreterModule::DefinedInterpreterModule(size_t istream_start)
-    : InterpreterModule(false),
+DefinedModule::DefinedModule(size_t istream_start)
+    : Module(false),
       start_func_index(kInvalidIndex),
       istream_start(istream_start),
       istream_end(istream_start) {}
 
-HostInterpreterModule::HostInterpreterModule(const StringSlice& name)
-    : InterpreterModule(name, true) {}
+HostModule::HostModule(const StringSlice& name) : Module(name, true) {}
 
-InterpreterEnvironmentMark mark_interpreter_environment(
-    InterpreterEnvironment* env) {
-  InterpreterEnvironmentMark mark;
+EnvironmentMark mark_environment(Environment* env) {
+  EnvironmentMark mark;
   WABT_ZERO_MEMORY(mark);
   mark.modules_size = env->modules.size();
   mark.sigs_size = env->sigs.size();
@@ -155,8 +149,7 @@ InterpreterEnvironmentMark mark_interpreter_environment(
   return mark;
 }
 
-void reset_interpreter_environment_to_mark(InterpreterEnvironment* env,
-                                           InterpreterEnvironmentMark mark) {
+void reset_environment_to_mark(Environment* env, EnvironmentMark mark) {
   /* Destroy entries in the binding hash. */
   for (size_t i = mark.modules_size; i < env->modules.size(); ++i) {
     const StringSlice* name = &env->modules[i]->name;
@@ -187,19 +180,15 @@ void reset_interpreter_environment_to_mark(InterpreterEnvironment* env,
   env->istream->data.resize(mark.istream_size);
 }
 
-HostInterpreterModule* append_host_module(InterpreterEnvironment* env,
-                                          StringSlice name) {
-  HostInterpreterModule* module =
-      new HostInterpreterModule(dup_string_slice(name));
+HostModule* append_host_module(Environment* env, StringSlice name) {
+  HostModule* module = new HostModule(dup_string_slice(name));
   env->modules.emplace_back(module);
   env->registered_module_bindings.emplace(string_slice_to_string(name),
                                           Binding(env->modules.size() - 1));
   return module;
 }
 
-void init_interpreter_thread(InterpreterEnvironment* env,
-                             InterpreterThread* thread,
-                             InterpreterThreadOptions* options) {
+void init_thread(Environment* env, Thread* thread, ThreadOptions* options) {
   thread->value_stack.resize(options->value_stack_size);
   thread->call_stack.resize(options->call_stack_size);
   thread->env = env;
@@ -212,16 +201,14 @@ void init_interpreter_thread(InterpreterEnvironment* env,
   thread->pc = options->pc;
 }
 
-InterpreterResult push_thread_value(InterpreterThread* thread,
-                                    InterpreterValue value) {
+Result push_thread_value(Thread* thread, Value value) {
   if (thread->value_stack_top >= thread->value_stack_end)
-    return InterpreterResult::TrapValueStackExhausted;
+    return Result::TrapValueStackExhausted;
   *thread->value_stack_top++ = value;
-  return InterpreterResult::Ok;
+  return Result::Ok;
 }
 
-InterpreterExport* get_interpreter_export_by_name(InterpreterModule* module,
-                                                  const StringSlice* name) {
+Export* get_export_by_name(Module* module, const StringSlice* name) {
   int field_index = module->export_bindings.find_index(*name);
   if (field_index < 0)
     return nullptr;
@@ -475,7 +462,7 @@ DEFINE_BITCAST(bitcast_u64_to_f64, uint64_t, double)
 #define TYPE_FIELD_NAME_F32 f32_bits
 #define TYPE_FIELD_NAME_F64 f64_bits
 
-#define TRAP(type) return InterpreterResult::Trap##type
+#define TRAP(type) return Result::Trap##type
 #define TRAP_UNLESS(cond, type) TRAP_IF(!(cond), type)
 #define TRAP_IF(cond, type)  \
   do {                       \
@@ -539,7 +526,7 @@ DEFINE_BITCAST(bitcast_u64_to_f64, uint64_t, double)
 
 #define GET_MEMORY(var)               \
   Index memory_index = read_u32(&pc); \
-  InterpreterMemory* var = &env->memories[memory_index]
+  Memory* var = &env->memories[memory_index]
 
 #define LOAD(type, mem_type)                                              \
   do {                                                                    \
@@ -751,27 +738,26 @@ static WABT_INLINE void read_table_entry_at(const uint8_t* pc,
   *out_keep = *(pc + WABT_TABLE_ENTRY_KEEP_OFFSET);
 }
 
-bool func_signatures_are_equal(InterpreterEnvironment* env,
+bool func_signatures_are_equal(Environment* env,
                                Index sig_index_0,
                                Index sig_index_1) {
   if (sig_index_0 == sig_index_1)
     return true;
-  InterpreterFuncSignature* sig_0 = &env->sigs[sig_index_0];
-  InterpreterFuncSignature* sig_1 = &env->sigs[sig_index_1];
+  FuncSignature* sig_0 = &env->sigs[sig_index_0];
+  FuncSignature* sig_1 = &env->sigs[sig_index_1];
   return sig_0->param_types == sig_1->param_types &&
          sig_0->result_types == sig_1->result_types;
 }
 
-InterpreterResult call_host(InterpreterThread* thread,
-                            HostInterpreterFunc* func) {
-  InterpreterFuncSignature* sig = &thread->env->sigs[func->sig_index];
+Result call_host(Thread* thread, HostFunc* func) {
+  FuncSignature* sig = &thread->env->sigs[func->sig_index];
 
   size_t num_params = sig->param_types.size();
   size_t num_results = sig->result_types.size();
   // + 1 is a workaround for using data() below; UBSAN doesn't like calling
   // data() with an empty vector.
-  std::vector<InterpreterTypedValue> params(num_params + 1);
-  std::vector<InterpreterTypedValue> results(num_results + 1);
+  std::vector<TypedValue> params(num_params + 1);
+  std::vector<TypedValue> results(num_results + 1);
 
   for (size_t i = num_params; i > 0; --i) {
     params[i - 1].value = POP();
@@ -788,42 +774,42 @@ InterpreterResult call_host(InterpreterThread* thread,
     PUSH(results[i].value);
   }
 
-  return InterpreterResult::Ok;
+  return Result::Ok;
 }
 
-InterpreterResult run_interpreter(InterpreterThread* thread,
-                                  int num_instructions,
-                                  IstreamOffset* call_stack_return_top) {
-  InterpreterResult result = InterpreterResult::Ok;
+Result run_interpreter(Thread* thread,
+                       int num_instructions,
+                       IstreamOffset* call_stack_return_top) {
+  Result result = Result::Ok;
   assert(call_stack_return_top < thread->call_stack_end);
 
-  InterpreterEnvironment* env = thread->env;
+  Environment* env = thread->env;
 
   const uint8_t* istream = env->istream->data.data();
   const uint8_t* pc = &istream[thread->pc];
   for (int i = 0; i < num_instructions; ++i) {
-    InterpreterOpcode opcode = static_cast<InterpreterOpcode>(*pc++);
+    Opcode opcode = static_cast<Opcode>(*pc++);
     switch (opcode) {
-      case InterpreterOpcode::Select: {
+      case Opcode::Select: {
         VALUE_TYPE_I32 cond = POP_I32();
-        InterpreterValue false_ = POP();
-        InterpreterValue true_ = POP();
+        Value false_ = POP();
+        Value true_ = POP();
         PUSH(cond ? true_ : false_);
         break;
       }
 
-      case InterpreterOpcode::Br:
+      case Opcode::Br:
         GOTO(read_u32(&pc));
         break;
 
-      case InterpreterOpcode::BrIf: {
+      case Opcode::BrIf: {
         IstreamOffset new_pc = read_u32(&pc);
         if (POP_I32())
           GOTO(new_pc);
         break;
       }
 
-      case InterpreterOpcode::BrTable: {
+      case Opcode::BrTable: {
         Index num_targets = read_u32(&pc);
         IstreamOffset table_offset = read_u32(&pc);
         VALUE_TYPE_I32 key = POP_I32();
@@ -839,80 +825,80 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::Return:
+      case Opcode::Return:
         if (thread->call_stack_top == call_stack_return_top) {
-          result = InterpreterResult::Returned;
+          result = Result::Returned;
           goto exit_loop;
         }
         GOTO(POP_CALL());
         break;
 
-      case InterpreterOpcode::Unreachable:
+      case Opcode::Unreachable:
         TRAP(Unreachable);
         break;
 
-      case InterpreterOpcode::I32Const:
+      case Opcode::I32Const:
         PUSH_I32(read_u32(&pc));
         break;
 
-      case InterpreterOpcode::I64Const:
+      case Opcode::I64Const:
         PUSH_I64(read_u64(&pc));
         break;
 
-      case InterpreterOpcode::F32Const:
+      case Opcode::F32Const:
         PUSH_F32(read_u32(&pc));
         break;
 
-      case InterpreterOpcode::F64Const:
+      case Opcode::F64Const:
         PUSH_F64(read_u64(&pc));
         break;
 
-      case InterpreterOpcode::GetGlobal: {
+      case Opcode::GetGlobal: {
         Index index = read_u32(&pc);
         assert(index < env->globals.size());
         PUSH(env->globals[index].typed_value.value);
         break;
       }
 
-      case InterpreterOpcode::SetGlobal: {
+      case Opcode::SetGlobal: {
         Index index = read_u32(&pc);
         assert(index < env->globals.size());
         env->globals[index].typed_value.value = POP();
         break;
       }
 
-      case InterpreterOpcode::GetLocal: {
-        InterpreterValue value = PICK(read_u32(&pc));
+      case Opcode::GetLocal: {
+        Value value = PICK(read_u32(&pc));
         PUSH(value);
         break;
       }
 
-      case InterpreterOpcode::SetLocal: {
-        InterpreterValue value = POP();
+      case Opcode::SetLocal: {
+        Value value = POP();
         PICK(read_u32(&pc)) = value;
         break;
       }
 
-      case InterpreterOpcode::TeeLocal:
+      case Opcode::TeeLocal:
         PICK(read_u32(&pc)) = TOP();
         break;
 
-      case InterpreterOpcode::Call: {
+      case Opcode::Call: {
         IstreamOffset offset = read_u32(&pc);
         PUSH_CALL();
         GOTO(offset);
         break;
       }
 
-      case InterpreterOpcode::CallIndirect: {
+      case Opcode::CallIndirect: {
         Index table_index = read_u32(&pc);
-        InterpreterTable* table = &env->tables[table_index];
+        Table* table = &env->tables[table_index];
         Index sig_index = read_u32(&pc);
         VALUE_TYPE_I32 entry_index = POP_I32();
         TRAP_IF(entry_index >= table->func_indexes.size(), UndefinedTableIndex);
         Index func_index = table->func_indexes[entry_index];
         TRAP_IF(func_index == kInvalidIndex, UninitializedTableElement);
-        InterpreterFunc* func = env->funcs[func_index].get();
+        Func* func = env->funcs[func_index].get();
         TRAP_UNLESS(func_signatures_are_equal(env, func->sig_index, sig_index),
                     IndirectCallSignatureMismatch);
         if (func->is_host) {
@@ -924,111 +910,111 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::CallHost: {
+      case Opcode::CallHost: {
         Index func_index = read_u32(&pc);
         call_host(thread, env->funcs[func_index]->as_host());
         break;
       }
 
-      case InterpreterOpcode::I32Load8S:
+      case Opcode::I32Load8S:
         LOAD(I32, I8);
         break;
 
-      case InterpreterOpcode::I32Load8U:
+      case Opcode::I32Load8U:
         LOAD(I32, U8);
         break;
 
-      case InterpreterOpcode::I32Load16S:
+      case Opcode::I32Load16S:
         LOAD(I32, I16);
         break;
 
-      case InterpreterOpcode::I32Load16U:
+      case Opcode::I32Load16U:
         LOAD(I32, U16);
         break;
 
-      case InterpreterOpcode::I64Load8S:
+      case Opcode::I64Load8S:
         LOAD(I64, I8);
         break;
 
-      case InterpreterOpcode::I64Load8U:
+      case Opcode::I64Load8U:
         LOAD(I64, U8);
         break;
 
-      case InterpreterOpcode::I64Load16S:
+      case Opcode::I64Load16S:
         LOAD(I64, I16);
         break;
 
-      case InterpreterOpcode::I64Load16U:
+      case Opcode::I64Load16U:
         LOAD(I64, U16);
         break;
 
-      case InterpreterOpcode::I64Load32S:
+      case Opcode::I64Load32S:
         LOAD(I64, I32);
         break;
 
-      case InterpreterOpcode::I64Load32U:
+      case Opcode::I64Load32U:
         LOAD(I64, U32);
         break;
 
-      case InterpreterOpcode::I32Load:
+      case Opcode::I32Load:
         LOAD(I32, U32);
         break;
 
-      case InterpreterOpcode::I64Load:
+      case Opcode::I64Load:
         LOAD(I64, U64);
         break;
 
-      case InterpreterOpcode::F32Load:
+      case Opcode::F32Load:
         LOAD(F32, F32);
         break;
 
-      case InterpreterOpcode::F64Load:
+      case Opcode::F64Load:
         LOAD(F64, F64);
         break;
 
-      case InterpreterOpcode::I32Store8:
+      case Opcode::I32Store8:
         STORE(I32, U8);
         break;
 
-      case InterpreterOpcode::I32Store16:
+      case Opcode::I32Store16:
         STORE(I32, U16);
         break;
 
-      case InterpreterOpcode::I64Store8:
+      case Opcode::I64Store8:
         STORE(I64, U8);
         break;
 
-      case InterpreterOpcode::I64Store16:
+      case Opcode::I64Store16:
         STORE(I64, U16);
         break;
 
-      case InterpreterOpcode::I64Store32:
+      case Opcode::I64Store32:
         STORE(I64, U32);
         break;
 
-      case InterpreterOpcode::I32Store:
+      case Opcode::I32Store:
         STORE(I32, U32);
         break;
 
-      case InterpreterOpcode::I64Store:
+      case Opcode::I64Store:
         STORE(I64, U64);
         break;
 
-      case InterpreterOpcode::F32Store:
+      case Opcode::F32Store:
         STORE(F32, F32);
         break;
 
-      case InterpreterOpcode::F64Store:
+      case Opcode::F64Store:
         STORE(F64, F64);
         break;
 
-      case InterpreterOpcode::CurrentMemory: {
+      case Opcode::CurrentMemory: {
         GET_MEMORY(memory);
         PUSH_I32(memory->page_limits.initial);
         break;
       }
 
-      case InterpreterOpcode::GrowMemory: {
+      case Opcode::GrowMemory: {
         GET_MEMORY(memory);
         uint32_t old_page_size = memory->page_limits.initial;
         VALUE_TYPE_I32 grow_pages = POP_I32();
@@ -1045,399 +1031,399 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I32Add:
+      case Opcode::I32Add:
         BINOP(I32, I32, +);
         break;
 
-      case InterpreterOpcode::I32Sub:
+      case Opcode::I32Sub:
         BINOP(I32, I32, -);
         break;
 
-      case InterpreterOpcode::I32Mul:
+      case Opcode::I32Mul:
         BINOP(I32, I32, *);
         break;
 
-      case InterpreterOpcode::I32DivS:
+      case Opcode::I32DivS:
         BINOP_DIV_S(I32);
         break;
 
-      case InterpreterOpcode::I32DivU:
+      case Opcode::I32DivU:
         BINOP_DIV_REM_U(I32, /);
         break;
 
-      case InterpreterOpcode::I32RemS:
+      case Opcode::I32RemS:
         BINOP_REM_S(I32);
         break;
 
-      case InterpreterOpcode::I32RemU:
+      case Opcode::I32RemU:
         BINOP_DIV_REM_U(I32, %);
         break;
 
-      case InterpreterOpcode::I32And:
+      case Opcode::I32And:
         BINOP(I32, I32, &);
         break;
 
-      case InterpreterOpcode::I32Or:
+      case Opcode::I32Or:
         BINOP(I32, I32, |);
         break;
 
-      case InterpreterOpcode::I32Xor:
+      case Opcode::I32Xor:
         BINOP(I32, I32, ^);
         break;
 
-      case InterpreterOpcode::I32Shl:
+      case Opcode::I32Shl:
         BINOP_SHIFT(I32, <<, UNSIGNED);
         break;
 
-      case InterpreterOpcode::I32ShrU:
+      case Opcode::I32ShrU:
         BINOP_SHIFT(I32, >>, UNSIGNED);
         break;
 
-      case InterpreterOpcode::I32ShrS:
+      case Opcode::I32ShrS:
         BINOP_SHIFT(I32, >>, SIGNED);
         break;
 
-      case InterpreterOpcode::I32Eq:
+      case Opcode::I32Eq:
         BINOP(I32, I32, ==);
         break;
 
-      case InterpreterOpcode::I32Ne:
+      case Opcode::I32Ne:
         BINOP(I32, I32, !=);
         break;
 
-      case InterpreterOpcode::I32LtS:
+      case Opcode::I32LtS:
         BINOP_SIGNED(I32, I32, <);
         break;
 
-      case InterpreterOpcode::I32LeS:
+      case Opcode::I32LeS:
         BINOP_SIGNED(I32, I32, <=);
         break;
 
-      case InterpreterOpcode::I32LtU:
+      case Opcode::I32LtU:
         BINOP(I32, I32, <);
         break;
 
-      case InterpreterOpcode::I32LeU:
+      case Opcode::I32LeU:
         BINOP(I32, I32, <=);
         break;
 
-      case InterpreterOpcode::I32GtS:
+      case Opcode::I32GtS:
         BINOP_SIGNED(I32, I32, >);
         break;
 
-      case InterpreterOpcode::I32GeS:
+      case Opcode::I32GeS:
         BINOP_SIGNED(I32, I32, >=);
         break;
 
-      case InterpreterOpcode::I32GtU:
+      case Opcode::I32GtU:
         BINOP(I32, I32, >);
         break;
 
-      case InterpreterOpcode::I32GeU:
+      case Opcode::I32GeU:
         BINOP(I32, I32, >=);
         break;
 
-      case InterpreterOpcode::I32Clz: {
+      case Opcode::I32Clz: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_I32(value != 0 ? wabt_clz_u32(value) : 32);
         break;
       }
 
-      case InterpreterOpcode::I32Ctz: {
+      case Opcode::I32Ctz: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_I32(value != 0 ? wabt_ctz_u32(value) : 32);
         break;
       }
 
-      case InterpreterOpcode::I32Popcnt: {
+      case Opcode::I32Popcnt: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_I32(wabt_popcount_u32(value));
         break;
       }
 
-      case InterpreterOpcode::I32Eqz: {
+      case Opcode::I32Eqz: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_I32(value == 0);
         break;
       }
 
-      case InterpreterOpcode::I64Add:
+      case Opcode::I64Add:
         BINOP(I64, I64, +);
         break;
 
-      case InterpreterOpcode::I64Sub:
+      case Opcode::I64Sub:
         BINOP(I64, I64, -);
         break;
 
-      case InterpreterOpcode::I64Mul:
+      case Opcode::I64Mul:
         BINOP(I64, I64, *);
         break;
 
-      case InterpreterOpcode::I64DivS:
+      case Opcode::I64DivS:
         BINOP_DIV_S(I64);
         break;
 
-      case InterpreterOpcode::I64DivU:
+      case Opcode::I64DivU:
         BINOP_DIV_REM_U(I64, /);
         break;
 
-      case InterpreterOpcode::I64RemS:
+      case Opcode::I64RemS:
         BINOP_REM_S(I64);
         break;
 
-      case InterpreterOpcode::I64RemU:
+      case Opcode::I64RemU:
         BINOP_DIV_REM_U(I64, %);
         break;
 
-      case InterpreterOpcode::I64And:
+      case Opcode::I64And:
         BINOP(I64, I64, &);
         break;
 
-      case InterpreterOpcode::I64Or:
+      case Opcode::I64Or:
         BINOP(I64, I64, |);
         break;
 
-      case InterpreterOpcode::I64Xor:
+      case Opcode::I64Xor:
         BINOP(I64, I64, ^);
         break;
 
-      case InterpreterOpcode::I64Shl:
+      case Opcode::I64Shl:
         BINOP_SHIFT(I64, <<, UNSIGNED);
         break;
 
-      case InterpreterOpcode::I64ShrU:
+      case Opcode::I64ShrU:
         BINOP_SHIFT(I64, >>, UNSIGNED);
         break;
 
-      case InterpreterOpcode::I64ShrS:
+      case Opcode::I64ShrS:
         BINOP_SHIFT(I64, >>, SIGNED);
         break;
 
-      case InterpreterOpcode::I64Eq:
+      case Opcode::I64Eq:
         BINOP(I32, I64, ==);
         break;
 
-      case InterpreterOpcode::I64Ne:
+      case Opcode::I64Ne:
         BINOP(I32, I64, !=);
         break;
 
-      case InterpreterOpcode::I64LtS:
+      case Opcode::I64LtS:
         BINOP_SIGNED(I32, I64, <);
         break;
 
-      case InterpreterOpcode::I64LeS:
+      case Opcode::I64LeS:
         BINOP_SIGNED(I32, I64, <=);
         break;
 
-      case InterpreterOpcode::I64LtU:
+      case Opcode::I64LtU:
         BINOP(I32, I64, <);
         break;
 
-      case InterpreterOpcode::I64LeU:
+      case Opcode::I64LeU:
         BINOP(I32, I64, <=);
         break;
 
-      case InterpreterOpcode::I64GtS:
+      case Opcode::I64GtS:
         BINOP_SIGNED(I32, I64, >);
         break;
 
-      case InterpreterOpcode::I64GeS:
+      case Opcode::I64GeS:
         BINOP_SIGNED(I32, I64, >=);
         break;
 
-      case InterpreterOpcode::I64GtU:
+      case Opcode::I64GtU:
         BINOP(I32, I64, >);
         break;
 
-      case InterpreterOpcode::I64GeU:
+      case Opcode::I64GeU:
         BINOP(I32, I64, >=);
         break;
 
-      case InterpreterOpcode::I64Clz: {
+      case Opcode::I64Clz: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_I64(value != 0 ? wabt_clz_u64(value) : 64);
         break;
       }
 
-      case InterpreterOpcode::I64Ctz: {
+      case Opcode::I64Ctz: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_I64(value != 0 ? wabt_ctz_u64(value) : 64);
         break;
       }
 
-      case InterpreterOpcode::I64Popcnt: {
+      case Opcode::I64Popcnt: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_I64(wabt_popcount_u64(value));
         break;
       }
 
-      case InterpreterOpcode::F32Add:
+      case Opcode::F32Add:
         BINOP_FLOAT(F32, +);
         break;
 
-      case InterpreterOpcode::F32Sub:
+      case Opcode::F32Sub:
         BINOP_FLOAT(F32, -);
         break;
 
-      case InterpreterOpcode::F32Mul:
+      case Opcode::F32Mul:
         BINOP_FLOAT(F32, *);
         break;
 
-      case InterpreterOpcode::F32Div:
+      case Opcode::F32Div:
         BINOP_FLOAT_DIV(F32);
         break;
 
-      case InterpreterOpcode::F32Min:
+      case Opcode::F32Min:
         MINMAX_FLOAT(F32, MIN);
         break;
 
-      case InterpreterOpcode::F32Max:
+      case Opcode::F32Max:
         MINMAX_FLOAT(F32, MAX);
         break;
 
-      case InterpreterOpcode::F32Abs:
+      case Opcode::F32Abs:
         TOP().f32_bits &= ~F32_SIGN_MASK;
         break;
 
-      case InterpreterOpcode::F32Neg:
+      case Opcode::F32Neg:
         TOP().f32_bits ^= F32_SIGN_MASK;
         break;
 
-      case InterpreterOpcode::F32Copysign: {
+      case Opcode::F32Copysign: {
         VALUE_TYPE_F32 rhs = POP_F32();
         VALUE_TYPE_F32 lhs = POP_F32();
         PUSH_F32((lhs & ~F32_SIGN_MASK) | (rhs & F32_SIGN_MASK));
         break;
       }
 
-      case InterpreterOpcode::F32Ceil:
+      case Opcode::F32Ceil:
         UNOP_FLOAT(F32, ceilf);
         break;
 
-      case InterpreterOpcode::F32Floor:
+      case Opcode::F32Floor:
         UNOP_FLOAT(F32, floorf);
         break;
 
-      case InterpreterOpcode::F32Trunc:
+      case Opcode::F32Trunc:
         UNOP_FLOAT(F32, truncf);
         break;
 
-      case InterpreterOpcode::F32Nearest:
+      case Opcode::F32Nearest:
         UNOP_FLOAT(F32, nearbyintf);
         break;
 
-      case InterpreterOpcode::F32Sqrt:
+      case Opcode::F32Sqrt:
         UNOP_FLOAT(F32, sqrtf);
         break;
 
-      case InterpreterOpcode::F32Eq:
+      case Opcode::F32Eq:
         BINOP_FLOAT_COMPARE(F32, ==);
         break;
 
-      case InterpreterOpcode::F32Ne:
+      case Opcode::F32Ne:
         BINOP_FLOAT_COMPARE(F32, !=);
         break;
 
-      case InterpreterOpcode::F32Lt:
+      case Opcode::F32Lt:
         BINOP_FLOAT_COMPARE(F32, <);
         break;
 
-      case InterpreterOpcode::F32Le:
+      case Opcode::F32Le:
         BINOP_FLOAT_COMPARE(F32, <=);
         break;
 
-      case InterpreterOpcode::F32Gt:
+      case Opcode::F32Gt:
         BINOP_FLOAT_COMPARE(F32, >);
         break;
 
-      case InterpreterOpcode::F32Ge:
+      case Opcode::F32Ge:
         BINOP_FLOAT_COMPARE(F32, >=);
         break;
 
-      case InterpreterOpcode::F64Add:
+      case Opcode::F64Add:
         BINOP_FLOAT(F64, +);
         break;
 
-      case InterpreterOpcode::F64Sub:
+      case Opcode::F64Sub:
         BINOP_FLOAT(F64, -);
         break;
 
-      case InterpreterOpcode::F64Mul:
+      case Opcode::F64Mul:
         BINOP_FLOAT(F64, *);
         break;
 
-      case InterpreterOpcode::F64Div:
+      case Opcode::F64Div:
         BINOP_FLOAT_DIV(F64);
         break;
 
-      case InterpreterOpcode::F64Min:
+      case Opcode::F64Min:
         MINMAX_FLOAT(F64, MIN);
         break;
 
-      case InterpreterOpcode::F64Max:
+      case Opcode::F64Max:
         MINMAX_FLOAT(F64, MAX);
         break;
 
-      case InterpreterOpcode::F64Abs:
+      case Opcode::F64Abs:
         TOP().f64_bits &= ~F64_SIGN_MASK;
         break;
 
-      case InterpreterOpcode::F64Neg:
+      case Opcode::F64Neg:
         TOP().f64_bits ^= F64_SIGN_MASK;
         break;
 
-      case InterpreterOpcode::F64Copysign: {
+      case Opcode::F64Copysign: {
         VALUE_TYPE_F64 rhs = POP_F64();
         VALUE_TYPE_F64 lhs = POP_F64();
         PUSH_F64((lhs & ~F64_SIGN_MASK) | (rhs & F64_SIGN_MASK));
         break;
       }
 
-      case InterpreterOpcode::F64Ceil:
+      case Opcode::F64Ceil:
         UNOP_FLOAT(F64, ceil);
         break;
 
-      case InterpreterOpcode::F64Floor:
+      case Opcode::F64Floor:
         UNOP_FLOAT(F64, floor);
         break;
 
-      case InterpreterOpcode::F64Trunc:
+      case Opcode::F64Trunc:
         UNOP_FLOAT(F64, trunc);
         break;
 
-      case InterpreterOpcode::F64Nearest:
+      case Opcode::F64Nearest:
         UNOP_FLOAT(F64, nearbyint);
         break;
 
-      case InterpreterOpcode::F64Sqrt:
+      case Opcode::F64Sqrt:
         UNOP_FLOAT(F64, sqrt);
         break;
 
-      case InterpreterOpcode::F64Eq:
+      case Opcode::F64Eq:
         BINOP_FLOAT_COMPARE(F64, ==);
         break;
 
-      case InterpreterOpcode::F64Ne:
+      case Opcode::F64Ne:
         BINOP_FLOAT_COMPARE(F64, !=);
         break;
 
-      case InterpreterOpcode::F64Lt:
+      case Opcode::F64Lt:
         BINOP_FLOAT_COMPARE(F64, <);
         break;
 
-      case InterpreterOpcode::F64Le:
+      case Opcode::F64Le:
         BINOP_FLOAT_COMPARE(F64, <=);
         break;
 
-      case InterpreterOpcode::F64Gt:
+      case Opcode::F64Gt:
         BINOP_FLOAT_COMPARE(F64, >);
         break;
 
-      case InterpreterOpcode::F64Ge:
+      case Opcode::F64Ge:
         BINOP_FLOAT_COMPARE(F64, >=);
         break;
 
-      case InterpreterOpcode::I32TruncSF32: {
+      case Opcode::I32TruncSF32: {
         VALUE_TYPE_F32 value = POP_F32();
         TRAP_IF(is_nan_f32(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i32_trunc_s_f32(value), IntegerOverflow);
@@ -1445,7 +1431,7 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I32TruncSF64: {
+      case Opcode::I32TruncSF64: {
         VALUE_TYPE_F64 value = POP_F64();
         TRAP_IF(is_nan_f64(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i32_trunc_s_f64(value), IntegerOverflow);
@@ -1453,7 +1439,7 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I32TruncUF32: {
+      case Opcode::I32TruncUF32: {
         VALUE_TYPE_F32 value = POP_F32();
         TRAP_IF(is_nan_f32(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i32_trunc_u_f32(value), IntegerOverflow);
@@ -1461,7 +1447,7 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I32TruncUF64: {
+      case Opcode::I32TruncUF64: {
         VALUE_TYPE_F64 value = POP_F64();
         TRAP_IF(is_nan_f64(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i32_trunc_u_f64(value), IntegerOverflow);
@@ -1469,13 +1455,13 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I32WrapI64: {
+      case Opcode::I32WrapI64: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_I32(static_cast<uint32_t>(value));
         break;
       }
 
-      case InterpreterOpcode::I64TruncSF32: {
+      case Opcode::I64TruncSF32: {
         VALUE_TYPE_F32 value = POP_F32();
         TRAP_IF(is_nan_f32(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i64_trunc_s_f32(value), IntegerOverflow);
@@ -1483,7 +1469,7 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I64TruncSF64: {
+      case Opcode::I64TruncSF64: {
         VALUE_TYPE_F64 value = POP_F64();
         TRAP_IF(is_nan_f64(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i64_trunc_s_f64(value), IntegerOverflow);
@@ -1491,7 +1477,7 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I64TruncUF32: {
+      case Opcode::I64TruncUF32: {
         VALUE_TYPE_F32 value = POP_F32();
         TRAP_IF(is_nan_f32(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i64_trunc_u_f32(value), IntegerOverflow);
@@ -1499,7 +1485,7 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I64TruncUF64: {
+      case Opcode::I64TruncUF64: {
         VALUE_TYPE_F64 value = POP_F64();
         TRAP_IF(is_nan_f64(value), InvalidConversionToInteger);
         TRAP_UNLESS(is_in_range_i64_trunc_u_f64(value), IntegerOverflow);
@@ -1507,45 +1493,45 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::I64ExtendSI32: {
+      case Opcode::I64ExtendSI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_I64(static_cast<int64_t>(BITCAST_I32_TO_SIGNED(value)));
         break;
       }
 
-      case InterpreterOpcode::I64ExtendUI32: {
+      case Opcode::I64ExtendUI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_I64(static_cast<uint64_t>(value));
         break;
       }
 
-      case InterpreterOpcode::F32ConvertSI32: {
+      case Opcode::F32ConvertSI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_F32(
             BITCAST_FROM_F32(static_cast<float>(BITCAST_I32_TO_SIGNED(value))));
         break;
       }
 
-      case InterpreterOpcode::F32ConvertUI32: {
+      case Opcode::F32ConvertUI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_F32(BITCAST_FROM_F32(static_cast<float>(value)));
         break;
       }
 
-      case InterpreterOpcode::F32ConvertSI64: {
+      case Opcode::F32ConvertSI64: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_F32(
             BITCAST_FROM_F32(static_cast<float>(BITCAST_I64_TO_SIGNED(value))));
         break;
       }
 
-      case InterpreterOpcode::F32ConvertUI64: {
+      case Opcode::F32ConvertUI64: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_F32(BITCAST_FROM_F32(wabt_convert_uint64_to_float(value)));
         break;
       }
 
-      case InterpreterOpcode::F32DemoteF64: {
+      case Opcode::F32DemoteF64: {
         VALUE_TYPE_F64 value = POP_F64();
         if (WABT_LIKELY(is_in_range_f64_demote_f32(value))) {
           PUSH_F32(BITCAST_FROM_F32(static_cast<float>(BITCAST_TO_F64(value))));
@@ -1565,118 +1551,117 @@ InterpreterResult run_interpreter(InterpreterThread* thread,
         break;
       }
 
-      case InterpreterOpcode::F32ReinterpretI32: {
+      case Opcode::F32ReinterpretI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_F32(value);
         break;
       }
 
-      case InterpreterOpcode::F64ConvertSI32: {
+      case Opcode::F64ConvertSI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_F64(BITCAST_FROM_F64(
             static_cast<double>(BITCAST_I32_TO_SIGNED(value))));
         break;
       }
 
-      case InterpreterOpcode::F64ConvertUI32: {
+      case Opcode::F64ConvertUI32: {
         VALUE_TYPE_I32 value = POP_I32();
         PUSH_F64(BITCAST_FROM_F64(static_cast<double>(value)));
         break;
       }
 
-      case InterpreterOpcode::F64ConvertSI64: {
+      case Opcode::F64ConvertSI64: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_F64(BITCAST_FROM_F64(
             static_cast<double>(BITCAST_I64_TO_SIGNED(value))));
         break;
       }
 
-      case InterpreterOpcode::F64ConvertUI64: {
+      case Opcode::F64ConvertUI64: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_F64(BITCAST_FROM_F64(wabt_convert_uint64_to_double(value)));
         break;
       }
 
-      case InterpreterOpcode::F64PromoteF32: {
+      case Opcode::F64PromoteF32: {
         VALUE_TYPE_F32 value = POP_F32();
         PUSH_F64(BITCAST_FROM_F64(static_cast<double>(BITCAST_TO_F32(value))));
         break;
       }
 
-      case InterpreterOpcode::F64ReinterpretI64: {
+      case Opcode::F64ReinterpretI64: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_F64(value);
         break;
       }
 
-      case InterpreterOpcode::I32ReinterpretF32: {
+      case Opcode::I32ReinterpretF32: {
         VALUE_TYPE_F32 value = POP_F32();
         PUSH_I32(value);
         break;
       }
 
-      case InterpreterOpcode::I64ReinterpretF64: {
+      case Opcode::I64ReinterpretF64: {
         VALUE_TYPE_F64 value = POP_F64();
         PUSH_I64(value);
         break;
       }
 
-      case InterpreterOpcode::I32Rotr:
+      case Opcode::I32Rotr:
         BINOP_ROT(I32, RIGHT);
         break;
 
-      case InterpreterOpcode::I32Rotl:
+      case Opcode::I32Rotl:
         BINOP_ROT(I32, LEFT);
         break;
 
-      case InterpreterOpcode::I64Rotr:
+      case Opcode::I64Rotr:
         BINOP_ROT(I64, RIGHT);
         break;
 
-      case InterpreterOpcode::I64Rotl:
+      case Opcode::I64Rotl:
         BINOP_ROT(I64, LEFT);
         break;
 
-      case InterpreterOpcode::I64Eqz: {
+      case Opcode::I64Eqz: {
         VALUE_TYPE_I64 value = POP_I64();
         PUSH_I64(value == 0);
         break;
       }
 
-      case InterpreterOpcode::Alloca: {
-        InterpreterValue* old_value_stack_top = thread->value_stack_top;
+      case Opcode::Alloca: {
+        Value* old_value_stack_top = thread->value_stack_top;
         thread->value_stack_top += read_u32(&pc);
         CHECK_STACK();
         memset(old_value_stack_top, 0,
-               (thread->value_stack_top - old_value_stack_top) *
-                   sizeof(InterpreterValue));
+               (thread->value_stack_top - old_value_stack_top) * sizeof(Value));
         break;
       }
 
-      case InterpreterOpcode::BrUnless: {
+      case Opcode::BrUnless: {
         IstreamOffset new_pc = read_u32(&pc);
         if (!POP_I32())
           GOTO(new_pc);
         break;
       }
 
-      case InterpreterOpcode::Drop:
+      case Opcode::Drop:
         (void)POP();
         break;
 
-      case InterpreterOpcode::DropKeep: {
+      case Opcode::DropKeep: {
         uint32_t drop_count = read_u32(&pc);
         uint8_t keep_count = *pc++;
         DROP_KEEP(drop_count, keep_count);
         break;
       }
 
-      case InterpreterOpcode::Data:
+      case Opcode::Data:
         /* shouldn't ever execute this */
         assert(0);
         break;
 
-      case InterpreterOpcode::Nop:
+      case Opcode::Nop:
         break;
 
       default:
@@ -1690,7 +1675,7 @@ exit_loop:
   return result;
 }
 
-void trace_pc(InterpreterThread* thread, Stream* stream) {
+void trace_pc(Thread* thread, Stream* stream) {
   const uint8_t* istream = thread->env->istream->data.data();
   const uint8_t* pc = &istream[thread->pc];
   size_t value_stack_depth =
@@ -1700,352 +1685,337 @@ void trace_pc(InterpreterThread* thread, Stream* stream) {
   stream->Writef("#%" PRIzd ". %4" PRIzd ": V:%-3" PRIzd "| ", call_stack_depth,
                  pc - thread->env->istream->data.data(), value_stack_depth);
 
-  InterpreterOpcode opcode = static_cast<InterpreterOpcode>(*pc++);
+  Opcode opcode = static_cast<Opcode>(*pc++);
   switch (opcode) {
-    case InterpreterOpcode::Select:
+    case Opcode::Select:
       stream->Writef("%s %u, %" PRIu64 ", %" PRIu64 "\n",
-                     get_interpreter_opcode_name(opcode), PICK(3).i32,
-                     PICK(2).i64, PICK(1).i64);
+                     get_opcode_name(opcode), PICK(3).i32, PICK(2).i64,
+                     PICK(1).i64);
       break;
 
-    case InterpreterOpcode::Br:
-      stream->Writef("%s @%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc));
+    case Opcode::Br:
+      stream->Writef("%s @%u\n", get_opcode_name(opcode), read_u32_at(pc));
       break;
 
-    case InterpreterOpcode::BrIf:
-      stream->Writef("%s @%u, %u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc), TOP().i32);
+    case Opcode::BrIf:
+      stream->Writef("%s @%u, %u\n", get_opcode_name(opcode), read_u32_at(pc),
+                     TOP().i32);
       break;
 
-    case InterpreterOpcode::BrTable: {
+    case Opcode::BrTable: {
       Index num_targets = read_u32_at(pc);
       IstreamOffset table_offset = read_u32_at(pc + 4);
       VALUE_TYPE_I32 key = TOP().i32;
       stream->Writef("%s %u, $#%" PRIindex ", table:$%u\n",
-                     get_interpreter_opcode_name(opcode), key, num_targets,
-                     table_offset);
+                     get_opcode_name(opcode), key, num_targets, table_offset);
       break;
     }
 
-    case InterpreterOpcode::Nop:
-    case InterpreterOpcode::Return:
-    case InterpreterOpcode::Unreachable:
-    case InterpreterOpcode::Drop:
-      stream->Writef("%s\n", get_interpreter_opcode_name(opcode));
+    case Opcode::Nop:
+    case Opcode::Return:
+    case Opcode::Unreachable:
+    case Opcode::Drop:
+      stream->Writef("%s\n", get_opcode_name(opcode));
       break;
 
-    case InterpreterOpcode::CurrentMemory: {
+    case Opcode::CurrentMemory: {
       Index memory_index = read_u32(&pc);
-      stream->Writef("%s $%" PRIindex "\n", get_interpreter_opcode_name(opcode),
+      stream->Writef("%s $%" PRIindex "\n", get_opcode_name(opcode),
                      memory_index);
       break;
     }
 
-    case InterpreterOpcode::I32Const:
-      stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc));
+    case Opcode::I32Const:
+      stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32_at(pc));
       break;
 
-    case InterpreterOpcode::I64Const:
-      stream->Writef("%s $%" PRIu64 "\n", get_interpreter_opcode_name(opcode),
+    case Opcode::I64Const:
+      stream->Writef("%s $%" PRIu64 "\n", get_opcode_name(opcode),
                      read_u64_at(pc));
       break;
 
-    case InterpreterOpcode::F32Const:
-      stream->Writef("%s $%g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::F32Const:
+      stream->Writef("%s $%g\n", get_opcode_name(opcode),
                      bitcast_u32_to_f32(read_u32_at(pc)));
       break;
 
-    case InterpreterOpcode::F64Const:
-      stream->Writef("%s $%g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::F64Const:
+      stream->Writef("%s $%g\n", get_opcode_name(opcode),
                      bitcast_u64_to_f64(read_u64_at(pc)));
       break;
 
-    case InterpreterOpcode::GetLocal:
-    case InterpreterOpcode::GetGlobal:
-      stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc));
+    case Opcode::GetLocal:
+    case Opcode::GetGlobal:
+      stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32_at(pc));
       break;
 
-    case InterpreterOpcode::SetLocal:
-    case InterpreterOpcode::SetGlobal:
-    case InterpreterOpcode::TeeLocal:
-      stream->Writef("%s $%u, %u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc), TOP().i32);
+    case Opcode::SetLocal:
+    case Opcode::SetGlobal:
+    case Opcode::TeeLocal:
+      stream->Writef("%s $%u, %u\n", get_opcode_name(opcode), read_u32_at(pc),
+                     TOP().i32);
       break;
 
-    case InterpreterOpcode::Call:
-      stream->Writef("%s @%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc));
+    case Opcode::Call:
+      stream->Writef("%s @%u\n", get_opcode_name(opcode), read_u32_at(pc));
       break;
 
-    case InterpreterOpcode::CallIndirect:
-      stream->Writef("%s $%u, %u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc), TOP().i32);
+    case Opcode::CallIndirect:
+      stream->Writef("%s $%u, %u\n", get_opcode_name(opcode), read_u32_at(pc),
+                     TOP().i32);
       break;
 
-    case InterpreterOpcode::CallHost:
-      stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc));
+    case Opcode::CallHost:
+      stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32_at(pc));
       break;
 
-    case InterpreterOpcode::I32Load8S:
-    case InterpreterOpcode::I32Load8U:
-    case InterpreterOpcode::I32Load16S:
-    case InterpreterOpcode::I32Load16U:
-    case InterpreterOpcode::I64Load8S:
-    case InterpreterOpcode::I64Load8U:
-    case InterpreterOpcode::I64Load16S:
-    case InterpreterOpcode::I64Load16U:
-    case InterpreterOpcode::I64Load32S:
-    case InterpreterOpcode::I64Load32U:
-    case InterpreterOpcode::I32Load:
-    case InterpreterOpcode::I64Load:
-    case InterpreterOpcode::F32Load:
-    case InterpreterOpcode::F64Load: {
+    case Opcode::I32Load8S:
+    case Opcode::I32Load8U:
+    case Opcode::I32Load16S:
+    case Opcode::I32Load16U:
+    case Opcode::I64Load8S:
+    case Opcode::I64Load8U:
+    case Opcode::I64Load16S:
+    case Opcode::I64Load16U:
+    case Opcode::I64Load32S:
+    case Opcode::I64Load32U:
+    case Opcode::I32Load:
+    case Opcode::I64Load:
+    case Opcode::F32Load:
+    case Opcode::F64Load: {
       Index memory_index = read_u32(&pc);
-      stream->Writef("%s $%" PRIindex ":%u+$%u\n",
-                     get_interpreter_opcode_name(opcode), memory_index,
-                     TOP().i32, read_u32_at(pc));
+      stream->Writef("%s $%" PRIindex ":%u+$%u\n", get_opcode_name(opcode),
+                     memory_index, TOP().i32, read_u32_at(pc));
       break;
     }
 
-    case InterpreterOpcode::I32Store8:
-    case InterpreterOpcode::I32Store16:
-    case InterpreterOpcode::I32Store: {
+    case Opcode::I32Store8:
+    case Opcode::I32Store16:
+    case Opcode::I32Store: {
       Index memory_index = read_u32(&pc);
-      stream->Writef("%s $%" PRIindex ":%u+$%u, %u\n",
-                     get_interpreter_opcode_name(opcode), memory_index,
-                     PICK(2).i32, read_u32_at(pc), PICK(1).i32);
+      stream->Writef("%s $%" PRIindex ":%u+$%u, %u\n", get_opcode_name(opcode),
+                     memory_index, PICK(2).i32, read_u32_at(pc), PICK(1).i32);
       break;
     }
 
-    case InterpreterOpcode::I64Store8:
-    case InterpreterOpcode::I64Store16:
-    case InterpreterOpcode::I64Store32:
-    case InterpreterOpcode::I64Store: {
+    case Opcode::I64Store8:
+    case Opcode::I64Store16:
+    case Opcode::I64Store32:
+    case Opcode::I64Store: {
       Index memory_index = read_u32(&pc);
       stream->Writef("%s $%" PRIindex ":%u+$%u, %" PRIu64 "\n",
-                     get_interpreter_opcode_name(opcode), memory_index,
-                     PICK(2).i32, read_u32_at(pc), PICK(1).i64);
+                     get_opcode_name(opcode), memory_index, PICK(2).i32,
+                     read_u32_at(pc), PICK(1).i64);
       break;
     }
 
-    case InterpreterOpcode::F32Store: {
+    case Opcode::F32Store: {
       Index memory_index = read_u32(&pc);
-      stream->Writef("%s $%" PRIindex ":%u+$%u, %g\n",
-                     get_interpreter_opcode_name(opcode), memory_index,
-                     PICK(2).i32, read_u32_at(pc),
+      stream->Writef("%s $%" PRIindex ":%u+$%u, %g\n", get_opcode_name(opcode),
+                     memory_index, PICK(2).i32, read_u32_at(pc),
                      bitcast_u32_to_f32(PICK(1).f32_bits));
       break;
     }
 
-    case InterpreterOpcode::F64Store: {
+    case Opcode::F64Store: {
       Index memory_index = read_u32(&pc);
-      stream->Writef("%s $%" PRIindex ":%u+$%u, %g\n",
-                     get_interpreter_opcode_name(opcode), memory_index,
-                     PICK(2).i32, read_u32_at(pc),
+      stream->Writef("%s $%" PRIindex ":%u+$%u, %g\n", get_opcode_name(opcode),
+                     memory_index, PICK(2).i32, read_u32_at(pc),
                      bitcast_u64_to_f64(PICK(1).f64_bits));
       break;
     }
 
-    case InterpreterOpcode::GrowMemory: {
+    case Opcode::GrowMemory: {
       Index memory_index = read_u32(&pc);
-      stream->Writef("%s $%" PRIindex ":%u\n",
-                     get_interpreter_opcode_name(opcode), memory_index,
-                     TOP().i32);
+      stream->Writef("%s $%" PRIindex ":%u\n", get_opcode_name(opcode),
+                     memory_index, TOP().i32);
       break;
     }
 
-    case InterpreterOpcode::I32Add:
-    case InterpreterOpcode::I32Sub:
-    case InterpreterOpcode::I32Mul:
-    case InterpreterOpcode::I32DivS:
-    case InterpreterOpcode::I32DivU:
-    case InterpreterOpcode::I32RemS:
-    case InterpreterOpcode::I32RemU:
-    case InterpreterOpcode::I32And:
-    case InterpreterOpcode::I32Or:
-    case InterpreterOpcode::I32Xor:
-    case InterpreterOpcode::I32Shl:
-    case InterpreterOpcode::I32ShrU:
-    case InterpreterOpcode::I32ShrS:
-    case InterpreterOpcode::I32Eq:
-    case InterpreterOpcode::I32Ne:
-    case InterpreterOpcode::I32LtS:
-    case InterpreterOpcode::I32LeS:
-    case InterpreterOpcode::I32LtU:
-    case InterpreterOpcode::I32LeU:
-    case InterpreterOpcode::I32GtS:
-    case InterpreterOpcode::I32GeS:
-    case InterpreterOpcode::I32GtU:
-    case InterpreterOpcode::I32GeU:
-    case InterpreterOpcode::I32Rotr:
-    case InterpreterOpcode::I32Rotl:
-      stream->Writef("%s %u, %u\n", get_interpreter_opcode_name(opcode),
-                     PICK(2).i32, PICK(1).i32);
+    case Opcode::I32Add:
+    case Opcode::I32Sub:
+    case Opcode::I32Mul:
+    case Opcode::I32DivS:
+    case Opcode::I32DivU:
+    case Opcode::I32RemS:
+    case Opcode::I32RemU:
+    case Opcode::I32And:
+    case Opcode::I32Or:
+    case Opcode::I32Xor:
+    case Opcode::I32Shl:
+    case Opcode::I32ShrU:
+    case Opcode::I32ShrS:
+    case Opcode::I32Eq:
+    case Opcode::I32Ne:
+    case Opcode::I32LtS:
+    case Opcode::I32LeS:
+    case Opcode::I32LtU:
+    case Opcode::I32LeU:
+    case Opcode::I32GtS:
+    case Opcode::I32GeS:
+    case Opcode::I32GtU:
+    case Opcode::I32GeU:
+    case Opcode::I32Rotr:
+    case Opcode::I32Rotl:
+      stream->Writef("%s %u, %u\n", get_opcode_name(opcode), PICK(2).i32,
+                     PICK(1).i32);
       break;
 
-    case InterpreterOpcode::I32Clz:
-    case InterpreterOpcode::I32Ctz:
-    case InterpreterOpcode::I32Popcnt:
-    case InterpreterOpcode::I32Eqz:
-      stream->Writef("%s %u\n", get_interpreter_opcode_name(opcode), TOP().i32);
+    case Opcode::I32Clz:
+    case Opcode::I32Ctz:
+    case Opcode::I32Popcnt:
+    case Opcode::I32Eqz:
+      stream->Writef("%s %u\n", get_opcode_name(opcode), TOP().i32);
       break;
 
-    case InterpreterOpcode::I64Add:
-    case InterpreterOpcode::I64Sub:
-    case InterpreterOpcode::I64Mul:
-    case InterpreterOpcode::I64DivS:
-    case InterpreterOpcode::I64DivU:
-    case InterpreterOpcode::I64RemS:
-    case InterpreterOpcode::I64RemU:
-    case InterpreterOpcode::I64And:
-    case InterpreterOpcode::I64Or:
-    case InterpreterOpcode::I64Xor:
-    case InterpreterOpcode::I64Shl:
-    case InterpreterOpcode::I64ShrU:
-    case InterpreterOpcode::I64ShrS:
-    case InterpreterOpcode::I64Eq:
-    case InterpreterOpcode::I64Ne:
-    case InterpreterOpcode::I64LtS:
-    case InterpreterOpcode::I64LeS:
-    case InterpreterOpcode::I64LtU:
-    case InterpreterOpcode::I64LeU:
-    case InterpreterOpcode::I64GtS:
-    case InterpreterOpcode::I64GeS:
-    case InterpreterOpcode::I64GtU:
-    case InterpreterOpcode::I64GeU:
-    case InterpreterOpcode::I64Rotr:
-    case InterpreterOpcode::I64Rotl:
-      stream->Writef("%s %" PRIu64 ", %" PRIu64 "\n",
-                     get_interpreter_opcode_name(opcode), PICK(2).i64,
-                     PICK(1).i64);
+    case Opcode::I64Add:
+    case Opcode::I64Sub:
+    case Opcode::I64Mul:
+    case Opcode::I64DivS:
+    case Opcode::I64DivU:
+    case Opcode::I64RemS:
+    case Opcode::I64RemU:
+    case Opcode::I64And:
+    case Opcode::I64Or:
+    case Opcode::I64Xor:
+    case Opcode::I64Shl:
+    case Opcode::I64ShrU:
+    case Opcode::I64ShrS:
+    case Opcode::I64Eq:
+    case Opcode::I64Ne:
+    case Opcode::I64LtS:
+    case Opcode::I64LeS:
+    case Opcode::I64LtU:
+    case Opcode::I64LeU:
+    case Opcode::I64GtS:
+    case Opcode::I64GeS:
+    case Opcode::I64GtU:
+    case Opcode::I64GeU:
+    case Opcode::I64Rotr:
+    case Opcode::I64Rotl:
+      stream->Writef("%s %" PRIu64 ", %" PRIu64 "\n", get_opcode_name(opcode),
+                     PICK(2).i64, PICK(1).i64);
       break;
 
-    case InterpreterOpcode::I64Clz:
-    case InterpreterOpcode::I64Ctz:
-    case InterpreterOpcode::I64Popcnt:
-    case InterpreterOpcode::I64Eqz:
-      stream->Writef("%s %" PRIu64 "\n", get_interpreter_opcode_name(opcode),
-                     TOP().i64);
+    case Opcode::I64Clz:
+    case Opcode::I64Ctz:
+    case Opcode::I64Popcnt:
+    case Opcode::I64Eqz:
+      stream->Writef("%s %" PRIu64 "\n", get_opcode_name(opcode), TOP().i64);
       break;
 
-    case InterpreterOpcode::F32Add:
-    case InterpreterOpcode::F32Sub:
-    case InterpreterOpcode::F32Mul:
-    case InterpreterOpcode::F32Div:
-    case InterpreterOpcode::F32Min:
-    case InterpreterOpcode::F32Max:
-    case InterpreterOpcode::F32Copysign:
-    case InterpreterOpcode::F32Eq:
-    case InterpreterOpcode::F32Ne:
-    case InterpreterOpcode::F32Lt:
-    case InterpreterOpcode::F32Le:
-    case InterpreterOpcode::F32Gt:
-    case InterpreterOpcode::F32Ge:
-      stream->Writef("%s %g, %g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::F32Add:
+    case Opcode::F32Sub:
+    case Opcode::F32Mul:
+    case Opcode::F32Div:
+    case Opcode::F32Min:
+    case Opcode::F32Max:
+    case Opcode::F32Copysign:
+    case Opcode::F32Eq:
+    case Opcode::F32Ne:
+    case Opcode::F32Lt:
+    case Opcode::F32Le:
+    case Opcode::F32Gt:
+    case Opcode::F32Ge:
+      stream->Writef("%s %g, %g\n", get_opcode_name(opcode),
                      bitcast_u32_to_f32(PICK(2).i32),
                      bitcast_u32_to_f32(PICK(1).i32));
       break;
 
-    case InterpreterOpcode::F32Abs:
-    case InterpreterOpcode::F32Neg:
-    case InterpreterOpcode::F32Ceil:
-    case InterpreterOpcode::F32Floor:
-    case InterpreterOpcode::F32Trunc:
-    case InterpreterOpcode::F32Nearest:
-    case InterpreterOpcode::F32Sqrt:
-      stream->Writef("%s %g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::F32Abs:
+    case Opcode::F32Neg:
+    case Opcode::F32Ceil:
+    case Opcode::F32Floor:
+    case Opcode::F32Trunc:
+    case Opcode::F32Nearest:
+    case Opcode::F32Sqrt:
+      stream->Writef("%s %g\n", get_opcode_name(opcode),
                      bitcast_u32_to_f32(TOP().i32));
       break;
 
-    case InterpreterOpcode::F64Add:
-    case InterpreterOpcode::F64Sub:
-    case InterpreterOpcode::F64Mul:
-    case InterpreterOpcode::F64Div:
-    case InterpreterOpcode::F64Min:
-    case InterpreterOpcode::F64Max:
-    case InterpreterOpcode::F64Copysign:
-    case InterpreterOpcode::F64Eq:
-    case InterpreterOpcode::F64Ne:
-    case InterpreterOpcode::F64Lt:
-    case InterpreterOpcode::F64Le:
-    case InterpreterOpcode::F64Gt:
-    case InterpreterOpcode::F64Ge:
-      stream->Writef("%s %g, %g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::F64Add:
+    case Opcode::F64Sub:
+    case Opcode::F64Mul:
+    case Opcode::F64Div:
+    case Opcode::F64Min:
+    case Opcode::F64Max:
+    case Opcode::F64Copysign:
+    case Opcode::F64Eq:
+    case Opcode::F64Ne:
+    case Opcode::F64Lt:
+    case Opcode::F64Le:
+    case Opcode::F64Gt:
+    case Opcode::F64Ge:
+      stream->Writef("%s %g, %g\n", get_opcode_name(opcode),
                      bitcast_u64_to_f64(PICK(2).i64),
                      bitcast_u64_to_f64(PICK(1).i64));
       break;
 
-    case InterpreterOpcode::F64Abs:
-    case InterpreterOpcode::F64Neg:
-    case InterpreterOpcode::F64Ceil:
-    case InterpreterOpcode::F64Floor:
-    case InterpreterOpcode::F64Trunc:
-    case InterpreterOpcode::F64Nearest:
-    case InterpreterOpcode::F64Sqrt:
-      stream->Writef("%s %g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::F64Abs:
+    case Opcode::F64Neg:
+    case Opcode::F64Ceil:
+    case Opcode::F64Floor:
+    case Opcode::F64Trunc:
+    case Opcode::F64Nearest:
+    case Opcode::F64Sqrt:
+      stream->Writef("%s %g\n", get_opcode_name(opcode),
                      bitcast_u64_to_f64(TOP().i64));
       break;
 
-    case InterpreterOpcode::I32TruncSF32:
-    case InterpreterOpcode::I32TruncUF32:
-    case InterpreterOpcode::I64TruncSF32:
-    case InterpreterOpcode::I64TruncUF32:
-    case InterpreterOpcode::F64PromoteF32:
-    case InterpreterOpcode::I32ReinterpretF32:
-      stream->Writef("%s %g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::I32TruncSF32:
+    case Opcode::I32TruncUF32:
+    case Opcode::I64TruncSF32:
+    case Opcode::I64TruncUF32:
+    case Opcode::F64PromoteF32:
+    case Opcode::I32ReinterpretF32:
+      stream->Writef("%s %g\n", get_opcode_name(opcode),
                      bitcast_u32_to_f32(TOP().i32));
       break;
 
-    case InterpreterOpcode::I32TruncSF64:
-    case InterpreterOpcode::I32TruncUF64:
-    case InterpreterOpcode::I64TruncSF64:
-    case InterpreterOpcode::I64TruncUF64:
-    case InterpreterOpcode::F32DemoteF64:
-    case InterpreterOpcode::I64ReinterpretF64:
-      stream->Writef("%s %g\n", get_interpreter_opcode_name(opcode),
+    case Opcode::I32TruncSF64:
+    case Opcode::I32TruncUF64:
+    case Opcode::I64TruncSF64:
+    case Opcode::I64TruncUF64:
+    case Opcode::F32DemoteF64:
+    case Opcode::I64ReinterpretF64:
+      stream->Writef("%s %g\n", get_opcode_name(opcode),
                      bitcast_u64_to_f64(TOP().i64));
       break;
 
-    case InterpreterOpcode::I32WrapI64:
-    case InterpreterOpcode::F32ConvertSI64:
-    case InterpreterOpcode::F32ConvertUI64:
-    case InterpreterOpcode::F64ConvertSI64:
-    case InterpreterOpcode::F64ConvertUI64:
-    case InterpreterOpcode::F64ReinterpretI64:
-      stream->Writef("%s %" PRIu64 "\n", get_interpreter_opcode_name(opcode),
-                     TOP().i64);
+    case Opcode::I32WrapI64:
+    case Opcode::F32ConvertSI64:
+    case Opcode::F32ConvertUI64:
+    case Opcode::F64ConvertSI64:
+    case Opcode::F64ConvertUI64:
+    case Opcode::F64ReinterpretI64:
+      stream->Writef("%s %" PRIu64 "\n", get_opcode_name(opcode), TOP().i64);
       break;
 
-    case InterpreterOpcode::I64ExtendSI32:
-    case InterpreterOpcode::I64ExtendUI32:
-    case InterpreterOpcode::F32ConvertSI32:
-    case InterpreterOpcode::F32ConvertUI32:
-    case InterpreterOpcode::F32ReinterpretI32:
-    case InterpreterOpcode::F64ConvertSI32:
-    case InterpreterOpcode::F64ConvertUI32:
-      stream->Writef("%s %u\n", get_interpreter_opcode_name(opcode), TOP().i32);
+    case Opcode::I64ExtendSI32:
+    case Opcode::I64ExtendUI32:
+    case Opcode::F32ConvertSI32:
+    case Opcode::F32ConvertUI32:
+    case Opcode::F32ReinterpretI32:
+    case Opcode::F64ConvertSI32:
+    case Opcode::F64ConvertUI32:
+      stream->Writef("%s %u\n", get_opcode_name(opcode), TOP().i32);
       break;
 
-    case InterpreterOpcode::Alloca:
-      stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc));
+    case Opcode::Alloca:
+      stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32_at(pc));
       break;
 
-    case InterpreterOpcode::BrUnless:
-      stream->Writef("%s @%u, %u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc), TOP().i32);
+    case Opcode::BrUnless:
+      stream->Writef("%s @%u, %u\n", get_opcode_name(opcode), read_u32_at(pc),
+                     TOP().i32);
       break;
 
-    case InterpreterOpcode::DropKeep:
-      stream->Writef("%s $%u $%u\n", get_interpreter_opcode_name(opcode),
-                     read_u32_at(pc), *(pc + 4));
+    case Opcode::DropKeep:
+      stream->Writef("%s $%u $%u\n", get_opcode_name(opcode), read_u32_at(pc),
+                     *(pc + 4));
       break;
 
-    case InterpreterOpcode::Data:
+    case Opcode::Data:
       /* shouldn't ever execute this */
       assert(0);
       break;
@@ -2056,7 +2026,7 @@ void trace_pc(InterpreterThread* thread, Stream* stream) {
   }
 }
 
-void disassemble(InterpreterEnvironment* env,
+void disassemble(Environment* env,
                  Stream* stream,
                  IstreamOffset from,
                  IstreamOffset to) {
@@ -2071,293 +2041,279 @@ void disassemble(InterpreterEnvironment* env,
   while (static_cast<IstreamOffset>(pc - istream) < to) {
     stream->Writef("%4" PRIzd "| ", pc - istream);
 
-    InterpreterOpcode opcode = static_cast<InterpreterOpcode>(*pc++);
+    Opcode opcode = static_cast<Opcode>(*pc++);
     switch (opcode) {
-      case InterpreterOpcode::Select:
-        stream->Writef("%s %%[-3], %%[-2], %%[-1]\n",
-                       get_interpreter_opcode_name(opcode));
+      case Opcode::Select:
+        stream->Writef("%s %%[-3], %%[-2], %%[-1]\n", get_opcode_name(opcode));
         break;
 
-      case InterpreterOpcode::Br:
-        stream->Writef("%s @%u\n", get_interpreter_opcode_name(opcode),
+      case Opcode::Br:
+        stream->Writef("%s @%u\n", get_opcode_name(opcode), read_u32(&pc));
+        break;
+
+      case Opcode::BrIf:
+        stream->Writef("%s @%u, %%[-1]\n", get_opcode_name(opcode),
                        read_u32(&pc));
         break;
 
-      case InterpreterOpcode::BrIf:
-        stream->Writef("%s @%u, %%[-1]\n", get_interpreter_opcode_name(opcode),
-                       read_u32(&pc));
-        break;
-
-      case InterpreterOpcode::BrTable: {
+      case Opcode::BrTable: {
         Index num_targets = read_u32(&pc);
         IstreamOffset table_offset = read_u32(&pc);
         stream->Writef("%s %%[-1], $#%" PRIindex ", table:$%u\n",
-                       get_interpreter_opcode_name(opcode), num_targets,
-                       table_offset);
+                       get_opcode_name(opcode), num_targets, table_offset);
         break;
       }
 
-      case InterpreterOpcode::Nop:
-      case InterpreterOpcode::Return:
-      case InterpreterOpcode::Unreachable:
-      case InterpreterOpcode::Drop:
-        stream->Writef("%s\n", get_interpreter_opcode_name(opcode));
+      case Opcode::Nop:
+      case Opcode::Return:
+      case Opcode::Unreachable:
+      case Opcode::Drop:
+        stream->Writef("%s\n", get_opcode_name(opcode));
         break;
 
-      case InterpreterOpcode::CurrentMemory: {
+      case Opcode::CurrentMemory: {
         Index memory_index = read_u32(&pc);
-        stream->Writef("%s $%" PRIindex "\n",
-                       get_interpreter_opcode_name(opcode), memory_index);
+        stream->Writef("%s $%" PRIindex "\n", get_opcode_name(opcode),
+                       memory_index);
         break;
       }
 
-      case InterpreterOpcode::I32Const:
-        stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                       read_u32(&pc));
+      case Opcode::I32Const:
+        stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32(&pc));
         break;
 
-      case InterpreterOpcode::I64Const:
-        stream->Writef("%s $%" PRIu64 "\n", get_interpreter_opcode_name(opcode),
+      case Opcode::I64Const:
+        stream->Writef("%s $%" PRIu64 "\n", get_opcode_name(opcode),
                        read_u64(&pc));
         break;
 
-      case InterpreterOpcode::F32Const:
-        stream->Writef("%s $%g\n", get_interpreter_opcode_name(opcode),
+      case Opcode::F32Const:
+        stream->Writef("%s $%g\n", get_opcode_name(opcode),
                        bitcast_u32_to_f32(read_u32(&pc)));
         break;
 
-      case InterpreterOpcode::F64Const:
-        stream->Writef("%s $%g\n", get_interpreter_opcode_name(opcode),
+      case Opcode::F64Const:
+        stream->Writef("%s $%g\n", get_opcode_name(opcode),
                        bitcast_u64_to_f64(read_u64(&pc)));
         break;
 
-      case InterpreterOpcode::GetLocal:
-      case InterpreterOpcode::GetGlobal:
-        stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
+      case Opcode::GetLocal:
+      case Opcode::GetGlobal:
+        stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32(&pc));
+        break;
+
+      case Opcode::SetLocal:
+      case Opcode::SetGlobal:
+      case Opcode::TeeLocal:
+        stream->Writef("%s $%u, %%[-1]\n", get_opcode_name(opcode),
                        read_u32(&pc));
         break;
 
-      case InterpreterOpcode::SetLocal:
-      case InterpreterOpcode::SetGlobal:
-      case InterpreterOpcode::TeeLocal:
-        stream->Writef("%s $%u, %%[-1]\n", get_interpreter_opcode_name(opcode),
-                       read_u32(&pc));
+      case Opcode::Call:
+        stream->Writef("%s @%u\n", get_opcode_name(opcode), read_u32(&pc));
         break;
 
-      case InterpreterOpcode::Call:
-        stream->Writef("%s @%u\n", get_interpreter_opcode_name(opcode),
-                       read_u32(&pc));
-        break;
-
-      case InterpreterOpcode::CallIndirect: {
+      case Opcode::CallIndirect: {
         Index table_index = read_u32(&pc);
         stream->Writef("%s $%" PRIindex ":%u, %%[-1]\n",
-                       get_interpreter_opcode_name(opcode), table_index,
-                       read_u32(&pc));
+                       get_opcode_name(opcode), table_index, read_u32(&pc));
         break;
       }
 
-      case InterpreterOpcode::CallHost:
-        stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                       read_u32(&pc));
+      case Opcode::CallHost:
+        stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32(&pc));
         break;
 
-      case InterpreterOpcode::I32Load8S:
-      case InterpreterOpcode::I32Load8U:
-      case InterpreterOpcode::I32Load16S:
-      case InterpreterOpcode::I32Load16U:
-      case InterpreterOpcode::I64Load8S:
-      case InterpreterOpcode::I64Load8U:
-      case InterpreterOpcode::I64Load16S:
-      case InterpreterOpcode::I64Load16U:
-      case InterpreterOpcode::I64Load32S:
-      case InterpreterOpcode::I64Load32U:
-      case InterpreterOpcode::I32Load:
-      case InterpreterOpcode::I64Load:
-      case InterpreterOpcode::F32Load:
-      case InterpreterOpcode::F64Load: {
+      case Opcode::I32Load8S:
+      case Opcode::I32Load8U:
+      case Opcode::I32Load16S:
+      case Opcode::I32Load16U:
+      case Opcode::I64Load8S:
+      case Opcode::I64Load8U:
+      case Opcode::I64Load16S:
+      case Opcode::I64Load16U:
+      case Opcode::I64Load32S:
+      case Opcode::I64Load32U:
+      case Opcode::I32Load:
+      case Opcode::I64Load:
+      case Opcode::F32Load:
+      case Opcode::F64Load: {
         Index memory_index = read_u32(&pc);
         stream->Writef("%s $%" PRIindex ":%%[-1]+$%u\n",
-                       get_interpreter_opcode_name(opcode), memory_index,
-                       read_u32(&pc));
+                       get_opcode_name(opcode), memory_index, read_u32(&pc));
         break;
       }
 
-      case InterpreterOpcode::I32Store8:
-      case InterpreterOpcode::I32Store16:
-      case InterpreterOpcode::I32Store:
-      case InterpreterOpcode::I64Store8:
-      case InterpreterOpcode::I64Store16:
-      case InterpreterOpcode::I64Store32:
-      case InterpreterOpcode::I64Store:
-      case InterpreterOpcode::F32Store:
-      case InterpreterOpcode::F64Store: {
+      case Opcode::I32Store8:
+      case Opcode::I32Store16:
+      case Opcode::I32Store:
+      case Opcode::I64Store8:
+      case Opcode::I64Store16:
+      case Opcode::I64Store32:
+      case Opcode::I64Store:
+      case Opcode::F32Store:
+      case Opcode::F64Store: {
         Index memory_index = read_u32(&pc);
         stream->Writef("%s %%[-2]+$%" PRIindex ", $%u:%%[-1]\n",
-                       get_interpreter_opcode_name(opcode), memory_index,
-                       read_u32(&pc));
+                       get_opcode_name(opcode), memory_index, read_u32(&pc));
         break;
       }
 
-      case InterpreterOpcode::I32Add:
-      case InterpreterOpcode::I32Sub:
-      case InterpreterOpcode::I32Mul:
-      case InterpreterOpcode::I32DivS:
-      case InterpreterOpcode::I32DivU:
-      case InterpreterOpcode::I32RemS:
-      case InterpreterOpcode::I32RemU:
-      case InterpreterOpcode::I32And:
-      case InterpreterOpcode::I32Or:
-      case InterpreterOpcode::I32Xor:
-      case InterpreterOpcode::I32Shl:
-      case InterpreterOpcode::I32ShrU:
-      case InterpreterOpcode::I32ShrS:
-      case InterpreterOpcode::I32Eq:
-      case InterpreterOpcode::I32Ne:
-      case InterpreterOpcode::I32LtS:
-      case InterpreterOpcode::I32LeS:
-      case InterpreterOpcode::I32LtU:
-      case InterpreterOpcode::I32LeU:
-      case InterpreterOpcode::I32GtS:
-      case InterpreterOpcode::I32GeS:
-      case InterpreterOpcode::I32GtU:
-      case InterpreterOpcode::I32GeU:
-      case InterpreterOpcode::I32Rotr:
-      case InterpreterOpcode::I32Rotl:
-      case InterpreterOpcode::F32Add:
-      case InterpreterOpcode::F32Sub:
-      case InterpreterOpcode::F32Mul:
-      case InterpreterOpcode::F32Div:
-      case InterpreterOpcode::F32Min:
-      case InterpreterOpcode::F32Max:
-      case InterpreterOpcode::F32Copysign:
-      case InterpreterOpcode::F32Eq:
-      case InterpreterOpcode::F32Ne:
-      case InterpreterOpcode::F32Lt:
-      case InterpreterOpcode::F32Le:
-      case InterpreterOpcode::F32Gt:
-      case InterpreterOpcode::F32Ge:
-      case InterpreterOpcode::I64Add:
-      case InterpreterOpcode::I64Sub:
-      case InterpreterOpcode::I64Mul:
-      case InterpreterOpcode::I64DivS:
-      case InterpreterOpcode::I64DivU:
-      case InterpreterOpcode::I64RemS:
-      case InterpreterOpcode::I64RemU:
-      case InterpreterOpcode::I64And:
-      case InterpreterOpcode::I64Or:
-      case InterpreterOpcode::I64Xor:
-      case InterpreterOpcode::I64Shl:
-      case InterpreterOpcode::I64ShrU:
-      case InterpreterOpcode::I64ShrS:
-      case InterpreterOpcode::I64Eq:
-      case InterpreterOpcode::I64Ne:
-      case InterpreterOpcode::I64LtS:
-      case InterpreterOpcode::I64LeS:
-      case InterpreterOpcode::I64LtU:
-      case InterpreterOpcode::I64LeU:
-      case InterpreterOpcode::I64GtS:
-      case InterpreterOpcode::I64GeS:
-      case InterpreterOpcode::I64GtU:
-      case InterpreterOpcode::I64GeU:
-      case InterpreterOpcode::I64Rotr:
-      case InterpreterOpcode::I64Rotl:
-      case InterpreterOpcode::F64Add:
-      case InterpreterOpcode::F64Sub:
-      case InterpreterOpcode::F64Mul:
-      case InterpreterOpcode::F64Div:
-      case InterpreterOpcode::F64Min:
-      case InterpreterOpcode::F64Max:
-      case InterpreterOpcode::F64Copysign:
-      case InterpreterOpcode::F64Eq:
-      case InterpreterOpcode::F64Ne:
-      case InterpreterOpcode::F64Lt:
-      case InterpreterOpcode::F64Le:
-      case InterpreterOpcode::F64Gt:
-      case InterpreterOpcode::F64Ge:
-        stream->Writef("%s %%[-2], %%[-1]\n",
-                       get_interpreter_opcode_name(opcode));
+      case Opcode::I32Add:
+      case Opcode::I32Sub:
+      case Opcode::I32Mul:
+      case Opcode::I32DivS:
+      case Opcode::I32DivU:
+      case Opcode::I32RemS:
+      case Opcode::I32RemU:
+      case Opcode::I32And:
+      case Opcode::I32Or:
+      case Opcode::I32Xor:
+      case Opcode::I32Shl:
+      case Opcode::I32ShrU:
+      case Opcode::I32ShrS:
+      case Opcode::I32Eq:
+      case Opcode::I32Ne:
+      case Opcode::I32LtS:
+      case Opcode::I32LeS:
+      case Opcode::I32LtU:
+      case Opcode::I32LeU:
+      case Opcode::I32GtS:
+      case Opcode::I32GeS:
+      case Opcode::I32GtU:
+      case Opcode::I32GeU:
+      case Opcode::I32Rotr:
+      case Opcode::I32Rotl:
+      case Opcode::F32Add:
+      case Opcode::F32Sub:
+      case Opcode::F32Mul:
+      case Opcode::F32Div:
+      case Opcode::F32Min:
+      case Opcode::F32Max:
+      case Opcode::F32Copysign:
+      case Opcode::F32Eq:
+      case Opcode::F32Ne:
+      case Opcode::F32Lt:
+      case Opcode::F32Le:
+      case Opcode::F32Gt:
+      case Opcode::F32Ge:
+      case Opcode::I64Add:
+      case Opcode::I64Sub:
+      case Opcode::I64Mul:
+      case Opcode::I64DivS:
+      case Opcode::I64DivU:
+      case Opcode::I64RemS:
+      case Opcode::I64RemU:
+      case Opcode::I64And:
+      case Opcode::I64Or:
+      case Opcode::I64Xor:
+      case Opcode::I64Shl:
+      case Opcode::I64ShrU:
+      case Opcode::I64ShrS:
+      case Opcode::I64Eq:
+      case Opcode::I64Ne:
+      case Opcode::I64LtS:
+      case Opcode::I64LeS:
+      case Opcode::I64LtU:
+      case Opcode::I64LeU:
+      case Opcode::I64GtS:
+      case Opcode::I64GeS:
+      case Opcode::I64GtU:
+      case Opcode::I64GeU:
+      case Opcode::I64Rotr:
+      case Opcode::I64Rotl:
+      case Opcode::F64Add:
+      case Opcode::F64Sub:
+      case Opcode::F64Mul:
+      case Opcode::F64Div:
+      case Opcode::F64Min:
+      case Opcode::F64Max:
+      case Opcode::F64Copysign:
+      case Opcode::F64Eq:
+      case Opcode::F64Ne:
+      case Opcode::F64Lt:
+      case Opcode::F64Le:
+      case Opcode::F64Gt:
+      case Opcode::F64Ge:
+        stream->Writef("%s %%[-2], %%[-1]\n", get_opcode_name(opcode));
         break;
 
-      case InterpreterOpcode::I32Clz:
-      case InterpreterOpcode::I32Ctz:
-      case InterpreterOpcode::I32Popcnt:
-      case InterpreterOpcode::I32Eqz:
-      case InterpreterOpcode::I64Clz:
-      case InterpreterOpcode::I64Ctz:
-      case InterpreterOpcode::I64Popcnt:
-      case InterpreterOpcode::I64Eqz:
-      case InterpreterOpcode::F32Abs:
-      case InterpreterOpcode::F32Neg:
-      case InterpreterOpcode::F32Ceil:
-      case InterpreterOpcode::F32Floor:
-      case InterpreterOpcode::F32Trunc:
-      case InterpreterOpcode::F32Nearest:
-      case InterpreterOpcode::F32Sqrt:
-      case InterpreterOpcode::F64Abs:
-      case InterpreterOpcode::F64Neg:
-      case InterpreterOpcode::F64Ceil:
-      case InterpreterOpcode::F64Floor:
-      case InterpreterOpcode::F64Trunc:
-      case InterpreterOpcode::F64Nearest:
-      case InterpreterOpcode::F64Sqrt:
-      case InterpreterOpcode::I32TruncSF32:
-      case InterpreterOpcode::I32TruncUF32:
-      case InterpreterOpcode::I64TruncSF32:
-      case InterpreterOpcode::I64TruncUF32:
-      case InterpreterOpcode::F64PromoteF32:
-      case InterpreterOpcode::I32ReinterpretF32:
-      case InterpreterOpcode::I32TruncSF64:
-      case InterpreterOpcode::I32TruncUF64:
-      case InterpreterOpcode::I64TruncSF64:
-      case InterpreterOpcode::I64TruncUF64:
-      case InterpreterOpcode::F32DemoteF64:
-      case InterpreterOpcode::I64ReinterpretF64:
-      case InterpreterOpcode::I32WrapI64:
-      case InterpreterOpcode::F32ConvertSI64:
-      case InterpreterOpcode::F32ConvertUI64:
-      case InterpreterOpcode::F64ConvertSI64:
-      case InterpreterOpcode::F64ConvertUI64:
-      case InterpreterOpcode::F64ReinterpretI64:
-      case InterpreterOpcode::I64ExtendSI32:
-      case InterpreterOpcode::I64ExtendUI32:
-      case InterpreterOpcode::F32ConvertSI32:
-      case InterpreterOpcode::F32ConvertUI32:
-      case InterpreterOpcode::F32ReinterpretI32:
-      case InterpreterOpcode::F64ConvertSI32:
-      case InterpreterOpcode::F64ConvertUI32:
-        stream->Writef("%s %%[-1]\n", get_interpreter_opcode_name(opcode));
+      case Opcode::I32Clz:
+      case Opcode::I32Ctz:
+      case Opcode::I32Popcnt:
+      case Opcode::I32Eqz:
+      case Opcode::I64Clz:
+      case Opcode::I64Ctz:
+      case Opcode::I64Popcnt:
+      case Opcode::I64Eqz:
+      case Opcode::F32Abs:
+      case Opcode::F32Neg:
+      case Opcode::F32Ceil:
+      case Opcode::F32Floor:
+      case Opcode::F32Trunc:
+      case Opcode::F32Nearest:
+      case Opcode::F32Sqrt:
+      case Opcode::F64Abs:
+      case Opcode::F64Neg:
+      case Opcode::F64Ceil:
+      case Opcode::F64Floor:
+      case Opcode::F64Trunc:
+      case Opcode::F64Nearest:
+      case Opcode::F64Sqrt:
+      case Opcode::I32TruncSF32:
+      case Opcode::I32TruncUF32:
+      case Opcode::I64TruncSF32:
+      case Opcode::I64TruncUF32:
+      case Opcode::F64PromoteF32:
+      case Opcode::I32ReinterpretF32:
+      case Opcode::I32TruncSF64:
+      case Opcode::I32TruncUF64:
+      case Opcode::I64TruncSF64:
+      case Opcode::I64TruncUF64:
+      case Opcode::F32DemoteF64:
+      case Opcode::I64ReinterpretF64:
+      case Opcode::I32WrapI64:
+      case Opcode::F32ConvertSI64:
+      case Opcode::F32ConvertUI64:
+      case Opcode::F64ConvertSI64:
+      case Opcode::F64ConvertUI64:
+      case Opcode::F64ReinterpretI64:
+      case Opcode::I64ExtendSI32:
+      case Opcode::I64ExtendUI32:
+      case Opcode::F32ConvertSI32:
+      case Opcode::F32ConvertUI32:
+      case Opcode::F32ReinterpretI32:
+      case Opcode::F64ConvertSI32:
+      case Opcode::F64ConvertUI32:
+        stream->Writef("%s %%[-1]\n", get_opcode_name(opcode));
         break;
 
-      case InterpreterOpcode::GrowMemory: {
+      case Opcode::GrowMemory: {
         Index memory_index = read_u32(&pc);
-        stream->Writef("%s $%" PRIindex ":%%[-1]\n",
-                       get_interpreter_opcode_name(opcode), memory_index);
+        stream->Writef("%s $%" PRIindex ":%%[-1]\n", get_opcode_name(opcode),
+                       memory_index);
         break;
       }
 
-      case InterpreterOpcode::Alloca:
-        stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
+      case Opcode::Alloca:
+        stream->Writef("%s $%u\n", get_opcode_name(opcode), read_u32(&pc));
+        break;
+
+      case Opcode::BrUnless:
+        stream->Writef("%s @%u, %%[-1]\n", get_opcode_name(opcode),
                        read_u32(&pc));
         break;
 
-      case InterpreterOpcode::BrUnless:
-        stream->Writef("%s @%u, %%[-1]\n", get_interpreter_opcode_name(opcode),
-                       read_u32(&pc));
-        break;
-
-      case InterpreterOpcode::DropKeep: {
+      case Opcode::DropKeep: {
         uint32_t drop = read_u32(&pc);
         uint8_t keep = *pc++;
-        stream->Writef("%s $%u $%u\n", get_interpreter_opcode_name(opcode),
-                       drop, keep);
+        stream->Writef("%s $%u $%u\n", get_opcode_name(opcode), drop, keep);
         break;
       }
 
-      case InterpreterOpcode::Data: {
+      case Opcode::Data: {
         uint32_t num_bytes = read_u32(&pc);
-        stream->Writef("%s $%u\n", get_interpreter_opcode_name(opcode),
-                       num_bytes);
+        stream->Writef("%s $%u\n", get_opcode_name(opcode), num_bytes);
         /* for now, the only reason this is emitted is for br_table, so display
          * it as a list of table entries */
         if (num_bytes % WABT_TABLE_ENTRY_SIZE == 0) {
@@ -2388,12 +2344,11 @@ void disassemble(InterpreterEnvironment* env,
   }
 }
 
-void disassemble_module(InterpreterEnvironment* env,
-                        Stream* stream,
-                        InterpreterModule* module) {
+void disassemble_module(Environment* env, Stream* stream, Module* module) {
   assert(!module->is_host);
   disassemble(env, stream, module->as_defined()->istream_start,
               module->as_defined()->istream_end);
 }
 
+}  // namespace interpreter
 }  // namespace wabt

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -23,8 +23,8 @@
 #include <vector>
 
 #include "binary-error-handler.h"
-#include "binary-reader.h"
 #include "binary-reader-interpreter.h"
+#include "binary-reader.h"
 #include "interpreter.h"
 #include "literal.h"
 #include "option-parser.h"
@@ -34,6 +34,7 @@
 #define PROGRAM_NAME "wasm-interp"
 
 using namespace wabt;
+using namespace wabt::interpreter;
 
 #define V(name, str) str,
 static const char* s_trap_strings[] = {FOREACH_INTERPRETER_RESULT(V)};
@@ -43,8 +44,7 @@ static int s_verbose;
 static const char* s_infile;
 static ReadBinaryOptions s_read_binary_options =
     WABT_READ_BINARY_OPTIONS_DEFAULT;
-static InterpreterThreadOptions s_thread_options =
-    WABT_INTERPRETER_THREAD_OPTIONS_DEFAULT;
+static ThreadOptions s_thread_options = WABT_INTERPRETER_THREAD_OPTIONS_DEFAULT;
 static bool s_trace;
 static bool s_spec;
 static bool s_run_all_exports;
@@ -70,7 +70,6 @@ enum {
   FLAG_RUN_ALL_EXPORTS,
   NUM_FLAGS
 };
-
 
 static const char s_description[] =
     "  read a file in the wasm binary format, and run in it a stack-based\n"
@@ -202,7 +201,7 @@ static StringSlice get_dirname(const char* s) {
 
 static void sprint_typed_value(char* buffer,
                                size_t size,
-                               const InterpreterTypedValue* tv) {
+                               const TypedValue* tv) {
   switch (tv->type) {
     case Type::I32:
       snprintf(buffer, size, "i32:%u", tv->value.i32);
@@ -232,14 +231,13 @@ static void sprint_typed_value(char* buffer,
   }
 }
 
-static void print_typed_value(const InterpreterTypedValue* tv) {
+static void print_typed_value(const TypedValue* tv) {
   char buffer[MAX_TYPED_VALUE_CHARS];
   sprint_typed_value(buffer, sizeof(buffer), tv);
   printf("%s", buffer);
 }
 
-static void print_typed_value_vector(
-    const std::vector<InterpreterTypedValue>& values) {
+static void print_typed_value_vector(const std::vector<TypedValue>& values) {
   for (size_t i = 0; i < values.size(); ++i) {
     print_typed_value(&values[i]);
     if (i != values.size() - 1)
@@ -248,21 +246,21 @@ static void print_typed_value_vector(
 }
 
 static void print_interpreter_result(const char* desc,
-                                     InterpreterResult iresult) {
+                                     interpreter::Result iresult) {
   printf("%s: %s\n", desc, s_trap_strings[static_cast<size_t>(iresult)]);
 }
 
 static void print_call(StringSlice module_name,
                        StringSlice func_name,
-                       const std::vector<InterpreterTypedValue>& args,
-                       const std::vector<InterpreterTypedValue>& results,
-                       InterpreterResult iresult) {
+                       const std::vector<TypedValue>& args,
+                       const std::vector<TypedValue>& results,
+                       interpreter::Result iresult) {
   if (module_name.length)
     printf(PRIstringslice ".", WABT_PRINTF_STRING_SLICE_ARG(module_name));
   printf(PRIstringslice "(", WABT_PRINTF_STRING_SLICE_ARG(func_name));
   print_typed_value_vector(args);
   printf(") =>");
-  if (iresult == InterpreterResult::Ok) {
+  if (iresult == interpreter::Result::Ok) {
     if (results.size() > 0) {
       printf(" ");
       print_typed_value_vector(results);
@@ -273,46 +271,45 @@ static void print_call(StringSlice module_name,
   }
 }
 
-static InterpreterResult run_defined_function(InterpreterThread* thread,
-                                              IstreamOffset offset) {
+static interpreter::Result run_defined_function(Thread* thread,
+                                                IstreamOffset offset) {
   thread->pc = offset;
-  InterpreterResult iresult = InterpreterResult::Ok;
+  interpreter::Result iresult = interpreter::Result::Ok;
   int quantum = s_trace ? 1 : INSTRUCTION_QUANTUM;
   IstreamOffset* call_stack_return_top = thread->call_stack_top;
-  while (iresult == InterpreterResult::Ok) {
+  while (iresult == interpreter::Result::Ok) {
     if (s_trace)
       trace_pc(thread, s_stdout_stream.get());
     iresult = run_interpreter(thread, quantum, call_stack_return_top);
   }
-  if (iresult != InterpreterResult::Returned)
+  if (iresult != interpreter::Result::Returned)
     return iresult;
   /* use OK instead of RETURNED for consistency */
-  return InterpreterResult::Ok;
+  return interpreter::Result::Ok;
 }
 
-static InterpreterResult push_args(
-    InterpreterThread* thread,
-    const InterpreterFuncSignature* sig,
-    const std::vector<InterpreterTypedValue>& args) {
+static interpreter::Result push_args(Thread* thread,
+                                     const FuncSignature* sig,
+                                     const std::vector<TypedValue>& args) {
   if (sig->param_types.size() != args.size())
-    return InterpreterResult::ArgumentTypeMismatch;
+    return interpreter::Result::ArgumentTypeMismatch;
 
   for (size_t i = 0; i < sig->param_types.size(); ++i) {
     if (sig->param_types[i] != args[i].type)
-      return InterpreterResult::ArgumentTypeMismatch;
+      return interpreter::Result::ArgumentTypeMismatch;
 
-    InterpreterResult iresult = push_thread_value(thread, args[i].value);
-    if (iresult != InterpreterResult::Ok) {
+    interpreter::Result iresult = push_thread_value(thread, args[i].value);
+    if (iresult != interpreter::Result::Ok) {
       thread->value_stack_top = thread->value_stack.data();
       return iresult;
     }
   }
-  return InterpreterResult::Ok;
+  return interpreter::Result::Ok;
 }
 
-static void copy_results(InterpreterThread* thread,
-                         const InterpreterFuncSignature* sig,
-                         std::vector<InterpreterTypedValue>* out_results) {
+static void copy_results(Thread* thread,
+                         const FuncSignature* sig,
+                         std::vector<TypedValue>* out_results) {
   size_t expected_results = sig->result_types.size();
   size_t value_stack_depth =
       thread->value_stack_top - thread->value_stack.data();
@@ -324,23 +321,22 @@ static void copy_results(InterpreterThread* thread,
     out_results->emplace_back(sig->result_types[i], thread->value_stack[i]);
 }
 
-static InterpreterResult run_function(
-    InterpreterThread* thread,
-    Index func_index,
-    const std::vector<InterpreterTypedValue>& args,
-    std::vector<InterpreterTypedValue>* out_results) {
+static interpreter::Result run_function(Thread* thread,
+                                        Index func_index,
+                                        const std::vector<TypedValue>& args,
+                                        std::vector<TypedValue>* out_results) {
   assert(func_index < thread->env->funcs.size());
-  InterpreterFunc* func = thread->env->funcs[func_index].get();
+  Func* func = thread->env->funcs[func_index].get();
   Index sig_index = func->sig_index;
   assert(sig_index < thread->env->sigs.size());
-  InterpreterFuncSignature* sig = &thread->env->sigs[sig_index];
+  FuncSignature* sig = &thread->env->sigs[sig_index];
 
-  InterpreterResult iresult = push_args(thread, sig, args);
-  if (iresult == InterpreterResult::Ok) {
+  interpreter::Result iresult = push_args(thread, sig, args);
+  if (iresult == interpreter::Result::Ok) {
     iresult = func->is_host
                   ? call_host(thread, func->as_host())
                   : run_defined_function(thread, func->as_defined()->offset);
-    if (iresult == InterpreterResult::Ok)
+    if (iresult == interpreter::Result::Ok)
       copy_results(thread, sig, out_results);
   }
 
@@ -350,26 +346,25 @@ static InterpreterResult run_function(
   return iresult;
 }
 
-static InterpreterResult run_start_function(InterpreterThread* thread,
-                                            DefinedInterpreterModule* module) {
+static interpreter::Result run_start_function(Thread* thread,
+                                              DefinedModule* module) {
   if (module->start_func_index == kInvalidIndex)
-    return InterpreterResult::Ok;
+    return interpreter::Result::Ok;
 
   if (s_trace)
     printf(">>> running start function:\n");
-  std::vector<InterpreterTypedValue> args;
-  std::vector<InterpreterTypedValue> results;
-  InterpreterResult iresult =
+  std::vector<TypedValue> args;
+  std::vector<TypedValue> results;
+  interpreter::Result iresult =
       run_function(thread, module->start_func_index, args, &results);
   assert(results.size() == 0);
   return iresult;
 }
 
-static InterpreterResult run_export(
-    InterpreterThread* thread,
-    const InterpreterExport* export_,
-    const std::vector<InterpreterTypedValue>& args,
-    std::vector<InterpreterTypedValue>* out_results) {
+static interpreter::Result run_export(Thread* thread,
+                                      const Export* export_,
+                                      const std::vector<TypedValue>& args,
+                                      std::vector<TypedValue>* out_results) {
   if (s_trace) {
     printf(">>> running export \"" PRIstringslice "\":\n",
            WABT_PRINTF_STRING_SLICE_ARG(export_->name));
@@ -379,56 +374,56 @@ static InterpreterResult run_export(
   return run_function(thread, export_->index, args, out_results);
 }
 
-static InterpreterResult run_export_by_name(
-    InterpreterThread* thread,
-    InterpreterModule* module,
+static interpreter::Result run_export_by_name(
+    Thread* thread,
+    Module* module,
     const StringSlice* name,
-    const std::vector<InterpreterTypedValue>& args,
-    std::vector<InterpreterTypedValue>* out_results,
+    const std::vector<TypedValue>& args,
+    std::vector<TypedValue>* out_results,
     RunVerbosity verbose) {
-  InterpreterExport* export_ = get_interpreter_export_by_name(module, name);
+  Export* export_ = get_export_by_name(module, name);
   if (!export_)
-    return InterpreterResult::UnknownExport;
+    return interpreter::Result::UnknownExport;
   if (export_->kind != ExternalKind::Func)
-    return InterpreterResult::ExportKindMismatch;
+    return interpreter::Result::ExportKindMismatch;
   return run_export(thread, export_, args, out_results);
 }
 
-static InterpreterResult get_global_export_by_name(
-    InterpreterThread* thread,
-    InterpreterModule* module,
+static interpreter::Result get_global_export_by_name(
+    Thread* thread,
+    Module* module,
     const StringSlice* name,
-    std::vector<InterpreterTypedValue>* out_results) {
-  InterpreterExport* export_ = get_interpreter_export_by_name(module, name);
+    std::vector<TypedValue>* out_results) {
+  Export* export_ = get_export_by_name(module, name);
   if (!export_)
-    return InterpreterResult::UnknownExport;
+    return interpreter::Result::UnknownExport;
   if (export_->kind != ExternalKind::Global)
-    return InterpreterResult::ExportKindMismatch;
+    return interpreter::Result::ExportKindMismatch;
 
-  InterpreterGlobal* global = &thread->env->globals[export_->index];
+  Global* global = &thread->env->globals[export_->index];
   out_results->clear();
   out_results->push_back(global->typed_value);
-  return InterpreterResult::Ok;
+  return interpreter::Result::Ok;
 }
 
-static void run_all_exports(InterpreterModule* module,
-                            InterpreterThread* thread,
+static void run_all_exports(Module* module,
+                            Thread* thread,
                             RunVerbosity verbose) {
-  std::vector<InterpreterTypedValue> args;
-  std::vector<InterpreterTypedValue> results;
-  for (const InterpreterExport& export_: module->exports) {
-    InterpreterResult iresult = run_export(thread, &export_, args, &results);
+  std::vector<TypedValue> args;
+  std::vector<TypedValue> results;
+  for (const Export& export_ : module->exports) {
+    interpreter::Result iresult = run_export(thread, &export_, args, &results);
     if (verbose == RunVerbosity::Verbose) {
       print_call(empty_string_slice(), export_.name, args, results, iresult);
     }
   }
 }
 
-static Result read_module(const char* module_filename,
-                          InterpreterEnvironment* env,
-                          BinaryErrorHandler* error_handler,
-                          DefinedInterpreterModule** out_module) {
-  Result result;
+static wabt::Result read_module(const char* module_filename,
+                                Environment* env,
+                                BinaryErrorHandler* error_handler,
+                                DefinedModule** out_module) {
+  wabt::Result result;
   char* data;
   size_t size;
 
@@ -448,25 +443,24 @@ static Result read_module(const char* module_filename,
   return result;
 }
 
-static Result default_host_callback(const HostInterpreterFunc* func,
-                                    const InterpreterFuncSignature* sig,
-                                    Index num_args,
-                                    InterpreterTypedValue* args,
-                                    Index num_results,
-                                    InterpreterTypedValue* out_results,
-                                    void* user_data) {
-  memset(out_results, 0, sizeof(InterpreterTypedValue) * num_results);
+static interpreter::Result default_host_callback(const HostFunc* func,
+                                                 const FuncSignature* sig,
+                                                 Index num_args,
+                                                 TypedValue* args,
+                                                 Index num_results,
+                                                 TypedValue* out_results,
+                                                 void* user_data) {
+  memset(out_results, 0, sizeof(TypedValue) * num_results);
   for (Index i = 0; i < num_results; ++i)
     out_results[i].type = sig->result_types[i];
 
-  std::vector<InterpreterTypedValue> vec_args(args, args + num_args);
-  std::vector<InterpreterTypedValue> vec_results(out_results,
-                                                 out_results + num_results);
+  std::vector<TypedValue> vec_args(args, args + num_args);
+  std::vector<TypedValue> vec_results(out_results, out_results + num_results);
 
   printf("called host ");
   print_call(func->module_name, func->field_name, vec_args, vec_results,
-             InterpreterResult::Ok);
-  return Result::Ok;
+             interpreter::Result::Ok);
+  return interpreter::Result::Ok;
 }
 
 #define PRIimport "\"" PRIstringslice "." PRIstringslice "\""
@@ -480,58 +474,58 @@ static void WABT_PRINTF_FORMAT(2, 3)
   callback.print_error(buffer, callback.user_data);
 }
 
-static Result spectest_import_func(InterpreterImport* import,
-                                   InterpreterFunc* func,
-                                   InterpreterFuncSignature* sig,
-                                   PrintErrorCallback callback,
-                                   void* user_data) {
+static wabt::Result spectest_import_func(Import* import,
+                                         Func* func,
+                                         FuncSignature* sig,
+                                         PrintErrorCallback callback,
+                                         void* user_data) {
   if (string_slice_eq_cstr(&import->field_name, "print")) {
     func->as_host()->callback = default_host_callback;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_error(callback, "unknown host function import " PRIimport,
                 PRINTF_IMPORT_ARG(*import));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static Result spectest_import_table(InterpreterImport* import,
-                                    InterpreterTable* table,
-                                    PrintErrorCallback callback,
-                                    void* user_data) {
+static wabt::Result spectest_import_table(Import* import,
+                                          Table* table,
+                                          PrintErrorCallback callback,
+                                          void* user_data) {
   if (string_slice_eq_cstr(&import->field_name, "table")) {
     table->limits.has_max = true;
     table->limits.initial = 10;
     table->limits.max = 20;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_error(callback, "unknown host table import " PRIimport,
                 PRINTF_IMPORT_ARG(*import));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static Result spectest_import_memory(InterpreterImport* import,
-                                     InterpreterMemory* memory,
-                                     PrintErrorCallback callback,
-                                     void* user_data) {
+static wabt::Result spectest_import_memory(Import* import,
+                                           Memory* memory,
+                                           PrintErrorCallback callback,
+                                           void* user_data) {
   if (string_slice_eq_cstr(&import->field_name, "memory")) {
     memory->page_limits.has_max = true;
     memory->page_limits.initial = 1;
     memory->page_limits.max = 2;
     memory->data.resize(memory->page_limits.initial * WABT_MAX_PAGES);
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_error(callback, "unknown host memory import " PRIimport,
                 PRINTF_IMPORT_ARG(*import));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static Result spectest_import_global(InterpreterImport* import,
-                                     InterpreterGlobal* global,
-                                     PrintErrorCallback callback,
-                                     void* user_data) {
+static wabt::Result spectest_import_global(Import* import,
+                                           Global* global,
+                                           PrintErrorCallback callback,
+                                           void* user_data) {
   if (string_slice_eq_cstr(&import->field_name, "global")) {
     switch (global->typed_value.type) {
       case Type::I32:
@@ -557,19 +551,19 @@ static Result spectest_import_global(InterpreterImport* import,
       default:
         print_error(callback, "bad type for host global import " PRIimport,
                     PRINTF_IMPORT_ARG(*import));
-        return Result::Error;
+        return wabt::Result::Error;
     }
 
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_error(callback, "unknown host global import " PRIimport,
                 PRINTF_IMPORT_ARG(*import));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static void init_environment(InterpreterEnvironment* env) {
-  HostInterpreterModule* host_module =
+static void init_environment(Environment* env) {
+  HostModule* host_module =
       append_host_module(env, string_slice_from_cstr("spectest"));
   host_module->import_delegate.import_func = spectest_import_func;
   host_module->import_delegate.import_table = spectest_import_table;
@@ -577,19 +571,19 @@ static void init_environment(InterpreterEnvironment* env) {
   host_module->import_delegate.import_global = spectest_import_global;
 }
 
-static Result read_and_run_module(const char* module_filename) {
-  Result result;
-  InterpreterEnvironment env;
-  DefinedInterpreterModule* module = nullptr;
-  InterpreterThread thread;
+static wabt::Result read_and_run_module(const char* module_filename) {
+  wabt::Result result;
+  Environment env;
+  DefinedModule* module = nullptr;
+  Thread thread;
   BinaryErrorHandlerFile error_handler;
 
   init_environment(&env);
-  init_interpreter_thread(&env, &thread, &s_thread_options);
+  init_thread(&env, &thread, &s_thread_options);
   result = read_module(module_filename, &env, &error_handler, &module);
   if (WABT_SUCCEEDED(result)) {
-    InterpreterResult iresult = run_start_function(&thread, module);
-    if (iresult == InterpreterResult::Ok) {
+    interpreter::Result iresult = run_start_function(&thread, module);
+    if (iresult == interpreter::Result::Ok) {
       if (s_run_all_exports)
         run_all_exports(module, &thread, RunVerbosity::Verbose);
     } else {
@@ -616,9 +610,9 @@ struct Context {
     WABT_ZERO_MEMORY(prev_loc);
   }
 
-  InterpreterEnvironment env;
-  InterpreterThread thread;
-  DefinedInterpreterModule* last_module;
+  Environment env;
+  Thread thread;
+  DefinedModule* last_module;
 
   /* Parsing info */
   char* json_data;
@@ -649,13 +643,13 @@ struct Action {
   ActionType type = ActionType::Invoke;
   StringSlice module_name;
   StringSlice field_name;
-  std::vector<InterpreterTypedValue> args;
+  std::vector<TypedValue> args;
 };
 
-#define CHECK_RESULT(x)     \
-  do {                      \
-    if (WABT_FAILED(x))     \
-      return Result::Error; \
+#define CHECK_RESULT(x)           \
+  do {                            \
+    if (WABT_FAILED(x))           \
+      return wabt::Result::Error; \
   } while (0)
 
 #define EXPECT(x) CHECK_RESULT(expect(ctx, x))
@@ -735,26 +729,26 @@ static bool match(Context* ctx, const char* s) {
   }
 }
 
-static Result expect(Context* ctx, const char* s) {
+static wabt::Result expect(Context* ctx, const char* s) {
   if (match(ctx, s)) {
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_parse_error(ctx, "expected %s", s);
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static Result expect_key(Context* ctx, const char* key) {
+static wabt::Result expect_key(Context* ctx, const char* key) {
   size_t keylen = strlen(key);
   size_t quoted_len = keylen + 2 + 1;
   char* quoted = static_cast<char*>(alloca(quoted_len));
   snprintf(quoted, quoted_len, "\"%s\"", key);
   EXPECT(quoted);
   EXPECT(":");
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_uint32(Context* ctx, uint32_t* out_int) {
+static wabt::Result parse_uint32(Context* ctx, uint32_t* out_int) {
   uint32_t result = 0;
   skip_whitespace(ctx);
   while (1) {
@@ -764,7 +758,7 @@ static Result parse_uint32(Context* ctx, uint32_t* out_int) {
       result = result * 10 + static_cast<uint32_t>(c - '0');
       if (result < last_result) {
         print_parse_error(ctx, "uint32 overflow");
-        return Result::Error;
+        return wabt::Result::Error;
       }
     } else {
       putback_char(ctx);
@@ -772,16 +766,16 @@ static Result parse_uint32(Context* ctx, uint32_t* out_int) {
     }
   }
   *out_int = result;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_string(Context* ctx, StringSlice* out_string) {
+static wabt::Result parse_string(Context* ctx, StringSlice* out_string) {
   WABT_ZERO_MEMORY(*out_string);
 
   skip_whitespace(ctx);
   if (read_char(ctx) != '"') {
     print_parse_error(ctx, "expected string");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   /* Modify json_data in-place so we can use the StringSlice directly
    * without having to allocate additional memory; this is only necessary when
@@ -799,7 +793,7 @@ static Result parse_string(Context* ctx, StringSlice* out_string) {
       c = read_char(ctx);
       if (c != 'u') {
         print_parse_error(ctx, "expected escape: \\uxxxx");
-        return Result::Error;
+        return wabt::Result::Error;
       }
       uint16_t code = 0;
       for (int i = 0; i < 4; ++i) {
@@ -813,7 +807,7 @@ static Result parse_string(Context* ctx, StringSlice* out_string) {
           cval = c - 'A' + 10;
         } else {
           print_parse_error(ctx, "expected hex char");
-          return Result::Error;
+          return wabt::Result::Error;
         }
         code = (code << 4) + cval;
       }
@@ -829,35 +823,35 @@ static Result parse_string(Context* ctx, StringSlice* out_string) {
     }
   }
   out_string->length = p - start;
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_key_string_value(Context* ctx,
-                                     const char* key,
-                                     StringSlice* out_string) {
+static wabt::Result parse_key_string_value(Context* ctx,
+                                           const char* key,
+                                           StringSlice* out_string) {
   WABT_ZERO_MEMORY(*out_string);
   EXPECT_KEY(key);
   return parse_string(ctx, out_string);
 }
 
-static Result parse_opt_name_string_value(Context* ctx,
-                                          StringSlice* out_string) {
+static wabt::Result parse_opt_name_string_value(Context* ctx,
+                                                StringSlice* out_string) {
   WABT_ZERO_MEMORY(*out_string);
   if (match(ctx, "\"name\"")) {
     EXPECT(":");
     CHECK_RESULT(parse_string(ctx, out_string));
     EXPECT(",");
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_line(Context* ctx) {
+static wabt::Result parse_line(Context* ctx) {
   EXPECT_KEY("line");
   CHECK_RESULT(parse_uint32(ctx, &ctx->command_line_number));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_type_object(Context* ctx, Type* out_type) {
+static wabt::Result parse_type_object(Context* ctx, Type* out_type) {
   StringSlice type_str;
   EXPECT("{");
   PARSE_KEY_STRING_VALUE("type", &type_str);
@@ -865,24 +859,24 @@ static Result parse_type_object(Context* ctx, Type* out_type) {
 
   if (string_slice_eq_cstr(&type_str, "i32")) {
     *out_type = Type::I32;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else if (string_slice_eq_cstr(&type_str, "f32")) {
     *out_type = Type::F32;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else if (string_slice_eq_cstr(&type_str, "i64")) {
     *out_type = Type::I64;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else if (string_slice_eq_cstr(&type_str, "f64")) {
     *out_type = Type::F64;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_parse_error(ctx, "unknown type: \"" PRIstringslice "\"",
                       WABT_PRINTF_STRING_SLICE_ARG(type_str));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static Result parse_type_vector(Context* ctx, TypeVector* out_types) {
+static wabt::Result parse_type_vector(Context* ctx, TypeVector* out_types) {
   out_types->clear();
   EXPECT("[");
   bool first = true;
@@ -894,10 +888,10 @@ static Result parse_type_vector(Context* ctx, TypeVector* out_types) {
     first = false;
     out_types->push_back(type);
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_const(Context* ctx, InterpreterTypedValue* out_value) {
+static wabt::Result parse_const(Context* ctx, TypedValue* out_value) {
   StringSlice type_str;
   StringSlice value_str;
   EXPECT("{");
@@ -915,53 +909,52 @@ static Result parse_const(Context* ctx, InterpreterTypedValue* out_value) {
                              ParseIntType::UnsignedOnly));
     out_value->type = Type::I32;
     out_value->value.i32 = value;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else if (string_slice_eq_cstr(&type_str, "f32")) {
     uint32_t value_bits;
     CHECK_RESULT(parse_int32(value_start, value_end, &value_bits,
                              ParseIntType::UnsignedOnly));
     out_value->type = Type::F32;
     out_value->value.f32_bits = value_bits;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else if (string_slice_eq_cstr(&type_str, "i64")) {
     uint64_t value;
     CHECK_RESULT(parse_int64(value_start, value_end, &value,
                              ParseIntType::UnsignedOnly));
     out_value->type = Type::I64;
     out_value->value.i64 = value;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else if (string_slice_eq_cstr(&type_str, "f64")) {
     uint64_t value_bits;
     CHECK_RESULT(parse_int64(value_start, value_end, &value_bits,
                              ParseIntType::UnsignedOnly));
     out_value->type = Type::F64;
     out_value->value.f64_bits = value_bits;
-    return Result::Ok;
+    return wabt::Result::Ok;
   } else {
     print_parse_error(ctx, "unknown type: \"" PRIstringslice "\"",
                       WABT_PRINTF_STRING_SLICE_ARG(type_str));
-    return Result::Error;
+    return wabt::Result::Error;
   }
 }
 
-static Result parse_const_vector(
-    Context* ctx,
-    std::vector<InterpreterTypedValue>* out_values) {
+static wabt::Result parse_const_vector(Context* ctx,
+                                       std::vector<TypedValue>* out_values) {
   out_values->clear();
   EXPECT("[");
   bool first = true;
   while (!match(ctx, "]")) {
     if (!first)
       EXPECT(",");
-    InterpreterTypedValue value;
+    TypedValue value;
     CHECK_RESULT(parse_const(ctx, &value));
     out_values->push_back(value);
     first = false;
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_action(Context* ctx, Action* out_action) {
+static wabt::Result parse_action(Context* ctx, Action* out_action) {
   EXPECT_KEY("action");
   EXPECT("{");
   EXPECT_KEY("type");
@@ -984,7 +977,7 @@ static Result parse_action(Context* ctx, Action* out_action) {
     CHECK_RESULT(parse_const_vector(ctx, &out_action->args));
   }
   EXPECT("}");
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 static char* create_module_path(Context* ctx, StringSlice filename) {
@@ -1005,30 +998,30 @@ static char* create_module_path(Context* ctx, StringSlice filename) {
   return path;
 }
 
-static Result on_module_command(Context* ctx,
-                                StringSlice filename,
-                                StringSlice name) {
+static wabt::Result on_module_command(Context* ctx,
+                                      StringSlice filename,
+                                      StringSlice name) {
   char* path = create_module_path(ctx, filename);
-  InterpreterEnvironmentMark mark = mark_interpreter_environment(&ctx->env);
+  EnvironmentMark mark = mark_environment(&ctx->env);
   BinaryErrorHandlerFile error_handler;
-  Result result =
+  wabt::Result result =
       read_module(path, &ctx->env, &error_handler, &ctx->last_module);
 
   if (WABT_FAILED(result)) {
-    reset_interpreter_environment_to_mark(&ctx->env, mark);
+    reset_environment_to_mark(&ctx->env, mark);
     print_command_error(ctx, "error reading module: \"%s\"", path);
     delete[] path;
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   delete[] path;
 
-  InterpreterResult iresult =
+  interpreter::Result iresult =
       run_start_function(&ctx->thread, ctx->last_module);
-  if (iresult != InterpreterResult::Ok) {
-    reset_interpreter_environment_to_mark(&ctx->env, mark);
+  if (iresult != interpreter::Result::Ok) {
+    reset_environment_to_mark(&ctx->env, mark);
     print_interpreter_result("error running start function", iresult);
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   if (!string_slice_is_empty(&name)) {
@@ -1036,14 +1029,14 @@ static Result on_module_command(Context* ctx,
     ctx->env.module_bindings.emplace(string_slice_to_string(name),
                                      Binding(ctx->env.modules.size() - 1));
   }
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result run_action(Context* ctx,
-                         Action* action,
-                         InterpreterResult* out_iresult,
-                         std::vector<InterpreterTypedValue>* out_results,
-                         RunVerbosity verbose) {
+static wabt::Result run_action(Context* ctx,
+                               Action* action,
+                               interpreter::Result* out_iresult,
+                               std::vector<TypedValue>* out_results,
+                               RunVerbosity verbose) {
   out_results->clear();
 
   int module_index;
@@ -1054,7 +1047,7 @@ static Result run_action(Context* ctx,
   }
 
   assert(module_index < static_cast<int>(ctx->env.modules.size()));
-  InterpreterModule* module = ctx->env.modules[module_index].get();
+  Module* module = ctx->env.modules[module_index].get();
 
   switch (action->type) {
     case ActionType::Invoke:
@@ -1065,35 +1058,35 @@ static Result run_action(Context* ctx,
         print_call(empty_string_slice(), action->field_name, action->args,
                    *out_results, *out_iresult);
       }
-      return Result::Ok;
+      return wabt::Result::Ok;
 
     case ActionType::Get: {
       *out_iresult = get_global_export_by_name(
           &ctx->thread, module, &action->field_name, out_results);
-      return Result::Ok;
+      return wabt::Result::Ok;
     }
 
     default:
       print_command_error(ctx, "invalid action type %d",
                           static_cast<int>(action->type));
-      return Result::Error;
+      return wabt::Result::Error;
   }
 }
 
-static Result on_action_command(Context* ctx, Action* action) {
-  std::vector<InterpreterTypedValue> results;
-  InterpreterResult iresult;
+static wabt::Result on_action_command(Context* ctx, Action* action) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
 
   ctx->total++;
-  Result result =
+  wabt::Result result =
       run_action(ctx, action, &iresult, &results, RunVerbosity::Verbose);
   if (WABT_SUCCEEDED(result)) {
-    if (iresult == InterpreterResult::Ok) {
+    if (iresult == interpreter::Result::Ok) {
       ctx->passed++;
     } else {
       print_command_error(ctx, "unexpected trap: %s",
                           s_trap_strings[static_cast<size_t>(iresult)]);
-      result = Result::Error;
+      result = wabt::Result::Error;
     }
   }
 
@@ -1113,32 +1106,32 @@ class BinaryErrorHandlerAssert : public BinaryErrorHandlerFile {
   }
 };
 
-static Result on_assert_malformed_command(Context* ctx,
-                                          StringSlice filename,
-                                          StringSlice text) {
+static wabt::Result on_assert_malformed_command(Context* ctx,
+                                                StringSlice filename,
+                                                StringSlice text) {
   BinaryErrorHandlerAssert error_handler(ctx, "assert_malformed");
-  InterpreterEnvironment env;
+  Environment env;
   init_environment(&env);
 
   ctx->total++;
   char* path = create_module_path(ctx, filename);
-  DefinedInterpreterModule* module;
-  Result result = read_module(path, &env, &error_handler, &module);
+  DefinedModule* module;
+  wabt::Result result = read_module(path, &env, &error_handler, &module);
   if (WABT_FAILED(result)) {
     ctx->passed++;
-    result = Result::Ok;
+    result = wabt::Result::Ok;
   } else {
     print_command_error(ctx, "expected module to be malformed: \"%s\"", path);
-    result = Result::Error;
+    result = wabt::Result::Error;
   }
 
   delete[] path;
   return result;
 }
 
-static Result on_register_command(Context* ctx,
-                                  StringSlice name,
-                                  StringSlice as) {
+static wabt::Result on_register_command(Context* ctx,
+                                        StringSlice name,
+                                        StringSlice as) {
   int module_index;
   if (!string_slice_is_empty(&name)) {
     /* The module names can be different than their registered names. We don't
@@ -1160,93 +1153,93 @@ static Result on_register_command(Context* ctx,
   if (module_index < 0 ||
       module_index >= static_cast<int>(ctx->env.modules.size())) {
     print_command_error(ctx, "unknown module in register");
-    return Result::Error;
+    return wabt::Result::Error;
   }
 
   ctx->env.registered_module_bindings.emplace(string_slice_to_string(as),
                                               Binding(module_index));
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result on_assert_unlinkable_command(Context* ctx,
-                                           StringSlice filename,
-                                           StringSlice text) {
+static wabt::Result on_assert_unlinkable_command(Context* ctx,
+                                                 StringSlice filename,
+                                                 StringSlice text) {
   BinaryErrorHandlerAssert error_handler(ctx, "assert_unlinkable");
 
   ctx->total++;
   char* path = create_module_path(ctx, filename);
-  DefinedInterpreterModule* module;
-  InterpreterEnvironmentMark mark = mark_interpreter_environment(&ctx->env);
-  Result result = read_module(path, &ctx->env, &error_handler, &module);
-  reset_interpreter_environment_to_mark(&ctx->env, mark);
+  DefinedModule* module;
+  EnvironmentMark mark = mark_environment(&ctx->env);
+  wabt::Result result = read_module(path, &ctx->env, &error_handler, &module);
+  reset_environment_to_mark(&ctx->env, mark);
 
   if (WABT_FAILED(result)) {
     ctx->passed++;
-    result = Result::Ok;
+    result = wabt::Result::Ok;
   } else {
     print_command_error(ctx, "expected module to be unlinkable: \"%s\"", path);
-    result = Result::Error;
+    result = wabt::Result::Error;
   }
 
   delete[] path;
   return result;
 }
 
-static Result on_assert_invalid_command(Context* ctx,
-                                        StringSlice filename,
-                                        StringSlice text) {
+static wabt::Result on_assert_invalid_command(Context* ctx,
+                                              StringSlice filename,
+                                              StringSlice text) {
   BinaryErrorHandlerAssert error_handler(ctx, "assert_invalid");
-  InterpreterEnvironment env;
+  Environment env;
   init_environment(&env);
 
   ctx->total++;
   char* path = create_module_path(ctx, filename);
-  DefinedInterpreterModule* module;
-  Result result = read_module(path, &env, &error_handler, &module);
+  DefinedModule* module;
+  wabt::Result result = read_module(path, &env, &error_handler, &module);
   if (WABT_FAILED(result)) {
     ctx->passed++;
-    result = Result::Ok;
+    result = wabt::Result::Ok;
   } else {
     print_command_error(ctx, "expected module to be invalid: \"%s\"", path);
-    result = Result::Error;
+    result = wabt::Result::Error;
   }
 
   delete[] path;
   return result;
 }
 
-static Result on_assert_uninstantiable_command(Context* ctx,
-                                               StringSlice filename,
-                                               StringSlice text) {
+static wabt::Result on_assert_uninstantiable_command(Context* ctx,
+                                                     StringSlice filename,
+                                                     StringSlice text) {
   BinaryErrorHandlerFile error_handler;
   ctx->total++;
   char* path = create_module_path(ctx, filename);
-  DefinedInterpreterModule* module;
-  InterpreterEnvironmentMark mark = mark_interpreter_environment(&ctx->env);
-  Result result = read_module(path, &ctx->env, &error_handler, &module);
+  DefinedModule* module;
+  EnvironmentMark mark = mark_environment(&ctx->env);
+  wabt::Result result = read_module(path, &ctx->env, &error_handler, &module);
 
   if (WABT_SUCCEEDED(result)) {
-    InterpreterResult iresult = run_start_function(&ctx->thread, module);
-    if (iresult == InterpreterResult::Ok) {
+    interpreter::Result iresult = run_start_function(&ctx->thread, module);
+    if (iresult == interpreter::Result::Ok) {
       print_command_error(ctx, "expected error running start function: \"%s\"",
                           path);
-      result = Result::Error;
+      result = wabt::Result::Error;
     } else {
       ctx->passed++;
-      result = Result::Ok;
+      result = wabt::Result::Ok;
     }
   } else {
     print_command_error(ctx, "error reading module: \"%s\"", path);
-    result = Result::Error;
+    result = wabt::Result::Error;
   }
 
-  reset_interpreter_environment_to_mark(&ctx->env, mark);
+  reset_environment_to_mark(&ctx->env, mark);
   delete[] path;
   return result;
 }
 
-static bool typed_values_are_equal(const InterpreterTypedValue* tv1,
-                                   const InterpreterTypedValue* tv2) {
+static bool typed_values_are_equal(const TypedValue* tv1,
+                                   const TypedValue* tv2) {
   if (tv1->type != tv2->type)
     return false;
 
@@ -1265,45 +1258,47 @@ static bool typed_values_are_equal(const InterpreterTypedValue* tv1,
   }
 }
 
-static Result on_assert_return_command(
+static wabt::Result on_assert_return_command(
     Context* ctx,
     Action* action,
-    const std::vector<InterpreterTypedValue>& expected) {
-  std::vector<InterpreterTypedValue> results;
-  InterpreterResult iresult;
+    const std::vector<TypedValue>& expected) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
 
   ctx->total++;
-  Result result =
+  wabt::Result result =
       run_action(ctx, action, &iresult, &results, RunVerbosity::Quiet);
 
   if (WABT_SUCCEEDED(result)) {
-    if (iresult == InterpreterResult::Ok) {
+    if (iresult == interpreter::Result::Ok) {
       if (results.size() == expected.size()) {
         for (size_t i = 0; i < results.size(); ++i) {
-          const InterpreterTypedValue* expected_tv = &expected[i];
-          const InterpreterTypedValue* actual_tv = &results[i];
+          const TypedValue* expected_tv = &expected[i];
+          const TypedValue* actual_tv = &results[i];
           if (!typed_values_are_equal(expected_tv, actual_tv)) {
             char expected_str[MAX_TYPED_VALUE_CHARS];
             char actual_str[MAX_TYPED_VALUE_CHARS];
             sprint_typed_value(expected_str, sizeof(expected_str), expected_tv);
             sprint_typed_value(actual_str, sizeof(actual_str), actual_tv);
-            print_command_error(ctx, "mismatch in result %" PRIzd
-                                     " of assert_return: expected %s, got %s",
+            print_command_error(ctx,
+                                "mismatch in result %" PRIzd
+                                " of assert_return: expected %s, got %s",
                                 i, expected_str, actual_str);
-            result = Result::Error;
+            result = wabt::Result::Error;
           }
         }
       } else {
         print_command_error(
-            ctx, "result length mismatch in assert_return: expected %" PRIzd
-                 ", got %" PRIzd,
+            ctx,
+            "result length mismatch in assert_return: expected %" PRIzd
+            ", got %" PRIzd,
             expected.size(), results.size());
-        result = Result::Error;
+        result = wabt::Result::Error;
       }
     } else {
       print_command_error(ctx, "unexpected trap: %s",
                           s_trap_strings[static_cast<size_t>(iresult)]);
-      result = Result::Error;
+      result = wabt::Result::Error;
     }
   }
 
@@ -1313,24 +1308,24 @@ static Result on_assert_return_command(
   return result;
 }
 
-static Result on_assert_return_nan_command(Context* ctx,
-                                           Action* action,
-                                           bool canonical) {
-  std::vector<InterpreterTypedValue> results;
-  InterpreterResult iresult;
+static wabt::Result on_assert_return_nan_command(Context* ctx,
+                                                 Action* action,
+                                                 bool canonical) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
 
   ctx->total++;
-  Result result =
+  wabt::Result result =
       run_action(ctx, action, &iresult, &results, RunVerbosity::Quiet);
   if (WABT_SUCCEEDED(result)) {
-    if (iresult == InterpreterResult::Ok) {
+    if (iresult == interpreter::Result::Ok) {
       if (results.size() != 1) {
         print_command_error(ctx, "expected one result, got %" PRIzd,
                             results.size());
-        result = Result::Error;
+        result = wabt::Result::Error;
       }
 
-      const InterpreterTypedValue& actual = results[0];
+      const TypedValue& actual = results[0];
       switch (actual.type) {
         case Type::F32: {
           typedef bool (*IsNanFunc)(uint32_t);
@@ -1341,7 +1336,7 @@ static Result on_assert_return_nan_command(Context* ctx,
             sprint_typed_value(actual_str, sizeof(actual_str), &actual);
             print_command_error(ctx, "expected result to be nan, got %s",
                                 actual_str);
-            result = Result::Error;
+            result = wabt::Result::Error;
           }
           break;
         }
@@ -1355,7 +1350,7 @@ static Result on_assert_return_nan_command(Context* ctx,
             sprint_typed_value(actual_str, sizeof(actual_str), &actual);
             print_command_error(ctx, "expected result to be nan, got %s",
                                 actual_str);
-            result = Result::Error;
+            result = wabt::Result::Error;
           }
           break;
         }
@@ -1364,65 +1359,65 @@ static Result on_assert_return_nan_command(Context* ctx,
           print_command_error(ctx,
                               "expected result type to be f32 or f64, got %s",
                               get_type_name(actual.type));
-          result = Result::Error;
+          result = wabt::Result::Error;
           break;
       }
     } else {
       print_command_error(ctx, "unexpected trap: %s",
                           s_trap_strings[static_cast<int>(iresult)]);
-      result = Result::Error;
+      result = wabt::Result::Error;
     }
   }
 
   if (WABT_SUCCEEDED(result))
     ctx->passed++;
 
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result on_assert_trap_command(Context* ctx,
-                                     Action* action,
-                                     StringSlice text) {
-  std::vector<InterpreterTypedValue> results;
-  InterpreterResult iresult;
+static wabt::Result on_assert_trap_command(Context* ctx,
+                                           Action* action,
+                                           StringSlice text) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
 
   ctx->total++;
-  Result result =
+  wabt::Result result =
       run_action(ctx, action, &iresult, &results, RunVerbosity::Quiet);
   if (WABT_SUCCEEDED(result)) {
-    if (iresult != InterpreterResult::Ok) {
+    if (iresult != interpreter::Result::Ok) {
       ctx->passed++;
     } else {
       print_command_error(ctx, "expected trap: \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG(text));
-      result = Result::Error;
+      result = wabt::Result::Error;
     }
   }
 
   return result;
 }
 
-static Result on_assert_exhaustion_command(Context* ctx, Action* action) {
-  std::vector<InterpreterTypedValue> results;
-  InterpreterResult iresult;
+static wabt::Result on_assert_exhaustion_command(Context* ctx, Action* action) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
 
   ctx->total++;
-  Result result =
+  wabt::Result result =
       run_action(ctx, action, &iresult, &results, RunVerbosity::Quiet);
   if (WABT_SUCCEEDED(result)) {
-    if (iresult == InterpreterResult::TrapCallStackExhausted ||
-        iresult == InterpreterResult::TrapValueStackExhausted) {
+    if (iresult == interpreter::Result::TrapCallStackExhausted ||
+        iresult == interpreter::Result::TrapValueStackExhausted) {
       ctx->passed++;
     } else {
       print_command_error(ctx, "expected call stack exhaustion");
-      result = Result::Error;
+      result = wabt::Result::Error;
     }
   }
 
   return result;
 }
 
-static Result parse_command(Context* ctx) {
+static wabt::Result parse_command(Context* ctx) {
   EXPECT("{");
   EXPECT_KEY("type");
   if (match(ctx, "\"module\"")) {
@@ -1508,7 +1503,7 @@ static Result parse_command(Context* ctx) {
     on_assert_uninstantiable_command(ctx, filename, text);
   } else if (match(ctx, "\"assert_return\"")) {
     Action action;
-    std::vector<InterpreterTypedValue> expected;
+    std::vector<TypedValue> expected;
 
     EXPECT(",");
     CHECK_RESULT(parse_line(ctx));
@@ -1568,13 +1563,13 @@ static Result parse_command(Context* ctx) {
     on_assert_exhaustion_command(ctx, &action);
   } else {
     print_command_error(ctx, "unknown command type");
-    return Result::Error;
+    return wabt::Result::Error;
   }
   EXPECT("}");
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
-static Result parse_commands(Context* ctx) {
+static wabt::Result parse_commands(Context* ctx) {
   EXPECT("{");
   PARSE_KEY_STRING_VALUE("source_filename", &ctx->source_filename);
   EXPECT(",");
@@ -1588,26 +1583,26 @@ static Result parse_commands(Context* ctx) {
     first = false;
   }
   EXPECT("}");
-  return Result::Ok;
+  return wabt::Result::Ok;
 }
 
 static void destroy_context(Context* ctx) {
   delete[] ctx->json_data;
 }
 
-static Result read_and_run_spec_json(const char* spec_json_filename) {
+static wabt::Result read_and_run_spec_json(const char* spec_json_filename) {
   Context ctx;
   ctx.loc.filename = spec_json_filename;
   ctx.loc.line = 1;
   ctx.loc.first_column = 1;
   init_environment(&ctx.env);
-  init_interpreter_thread(&ctx.env, &ctx.thread, &s_thread_options);
+  init_thread(&ctx.env, &ctx.thread, &s_thread_options);
 
   char* data;
   size_t size;
-  Result result = read_file(spec_json_filename, &data, &size);
+  wabt::Result result = read_file(spec_json_filename, &data, &size);
   if (WABT_FAILED(result))
-    return Result::Error;
+    return wabt::Result::Error;
 
   ctx.json_data = data;
   ctx.json_data_size = size;
@@ -1624,13 +1619,13 @@ int ProgramMain(int argc, char** argv) {
 
   s_stdout_stream = FileStream::CreateStdout();
 
-  Result result;
+  wabt::Result result;
   if (s_spec) {
     result = read_and_run_spec_json(s_infile);
   } else {
     result = read_and_run_module(s_infile);
   }
-  return result != Result::Ok;
+  return result != wabt::Result::Ok;
 }
 
 int main(int argc, char** argv) {


### PR DESCRIPTION
The only names that conflict are `wabt::Opcode` vs.
`interpreter::Opcode` and `wabt::Result` vs. `interpreter::Result`.
Other names would conflict too (e.g. `FuncSignature`) but those aren't
ever included in the interpreter-related code.