### PR TITLE
Change default tools path from 'out' to 'bin'

### DIFF
--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -30,7 +30,7 @@ EXECUTABLES = [
 
 
 def GetDefaultPath():
-  return os.path.join(REPO_ROOT_DIR, 'out')
+  return os.path.join(REPO_ROOT_DIR, 'bin')
 
 
 def GetDefaultExe(basename):


### PR DESCRIPTION
This is where 'make install' will put stuff by default.