### PR TITLE
Clean up the interpreter

### DIFF
--- a/src/binary-reader-interpreter.h
+++ b/src/binary-reader-interpreter.h
@@ -24,7 +24,7 @@ namespace wabt {
 namespace interpreter {
 
 struct DefinedModule;
-struct Environment;
+class Environment;
 
 } // namespace interpreter
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -29,6 +29,8 @@ namespace wabt {
 struct OutputBuffer {
   Result WriteToFile(const char* filename) const;
 
+  size_t size() const { return data.size(); }
+
   std::vector<uint8_t> data;
 };
 


### PR DESCRIPTION
* Make interpreter::Thread and interpreter::Environment into C++ classes
* Move function running code into interpreter (was in wasm-interp)
* Move environment searching functions into interpreter (was in
  binary-reader-interpreter)
* Remove free functions, use member functions on Environment/Thread
  instead.