### PR TITLE
Reduced link error test case (#447)

### DIFF
--- a/test/link/function_calls_nested.txt
+++ b/test/link/function_calls_nested.txt
@@ -1,0 +1,128 @@
+;;; TOOL: run-wasm-link
+;;; FLAGS: -r
+(module
+ (memory $0 1)
+ (export "b" (func $b))
+ (func $a (result i32)
+  (i32.const 0)
+ )
+ (func $b (param $0 i32) (param $1 i32) (param $2 i32) (param $3 i32) (result i32)
+  (local $4 i32)
+  (local $5 i32)
+  (local $6 i32)
+  (local $7 i32)
+  (local $8 i32)
+  (local $9 i32)
+  (block $label$0
+   (block $label$1
+    (block $label$2
+     (if
+      (i32.load
+       (i32.const 484)
+      )
+      (block
+       (br_if $label$2
+        (i32.eqz
+         (get_local $3)
+        )
+       )
+       (br $label$1)
+      )
+     )
+     (call $a)
+     (drop)
+     (br_if $label$1
+      (get_local $3)
+     )
+    )
+    (if
+     (get_local $0)
+     (block
+      (set_local $9
+       (select
+        (i32.const 16)
+        (i32.and
+         (i32.add
+          (tee_local $4
+           (i32.shl
+            (get_local $0)
+            (i32.const 2)
+           )
+          )
+          (i32.const 11)
+         )
+         (i32.const -8)
+        )
+        (i32.lt_u
+         (get_local $4)
+         (i32.const 11)
+        )
+       )
+      )
+      (br $label$0)
+     )
+    )
+   )
+   (br_if $label$0
+    (get_local $0)
+   )
+   (return
+    (get_local $3)
+   )
+  )
+  (block $label$5
+   (if
+    (i32.eqz
+     (i32.and
+      (get_local $2)
+      (i32.const 1)
+     )
+    )
+    (block
+     (loop $label$7
+      (br_if $label$5
+       (i32.eqz
+        (get_local $4)
+       )
+      )
+      (br $label$7)
+     )
+    )
+   )
+  )
+  (block $label$8
+   (block $label$9
+    (if
+     (tee_local $4
+      (i32.const 0)
+     )
+     (block
+      (set_local $6
+       (i32.and
+        (i32.load
+         (i32.add
+          (get_local $4)
+          (i32.const -4)
+         )
+        )
+        (i32.const -8)
+       )
+      )
+      (br_if $label$9
+       (i32.eqz
+        (get_local $3)
+       )
+      )
+      (br $label$8)
+     )
+    )
+    (return
+     (i32.const 0)
+    )
+   )
+  )
+  (get_local $3)
+ )
+)
+(;; STDOUT ;;;
+;;; STDOUT ;;)


### PR DESCRIPTION
Here's the test case from #447.

It seems to be hitting this invalid assertion:

```
Assertion failed: (IsValidFunctionIndex(index)), function IsFunctionImport, file /Users/guybedford/projects/wabt/src/tools/wasm-link.cc, line 158.
```

Just let me know if I can do anything further to assist.