### PR TITLE
Fix assert in wasm2wast with invalid br var

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -356,9 +356,12 @@ void WatWriter::WriteVar(const Var* var, NextChar next_char) {
 
 void WatWriter::WriteBrVar(const Var* var, NextChar next_char) {
   if (var->type == VarType::Index) {
-    assert(var->index < GetLabelStackSize());
-    Writef("%" PRIindex " (;@%" PRIindex ";)", var->index,
-           GetLabelStackSize() - var->index - 1);
+    if (var->index < GetLabelStackSize()) {
+      Writef("%" PRIindex " (;@%" PRIindex ";)", var->index,
+             GetLabelStackSize() - var->index - 1);
+    } else {
+      Writef("%" PRIindex " (; INVALID ;)", var->index);
+    }
     next_char_ = next_char;
   } else {
     WriteStringSlice(&var->name, next_char);

--- a/test/roundtrip/invalid-br-var.txt
+++ b/test/roundtrip/invalid-br-var.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --no-check
+(module
+  (func
+    br 1))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    br 1 (; INVALID ;)))
+;;; STDOUT ;;)


### PR DESCRIPTION
WatWriter can't rely on the module having been previously validated.

Fixes #468.