### PR TITLE
Fix bug in BinaryReaderIR w/ debug names

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -822,10 +822,10 @@ Result BinaryReaderIR::OnFunctionName(Index index, StringSlice name) {
   if (string_slice_is_empty(&name))
     return Result::Ok;
 
-  module->func_bindings.emplace(string_slice_to_string(name), Binding(index));
   Func* func = module->funcs[index];
-  func->name = dup_string_slice(
-      string_to_string_slice(std::string("$") + string_slice_to_string(name)));
+  std::string dollar_name = std::string("$") + string_slice_to_string(name);
+  func->name = dup_string_slice(string_to_string_slice(dollar_name));
+  module->func_bindings.emplace(dollar_name, Binding(index));
   return Result::Ok;
 }
 

--- a/test/roundtrip/inline-export-func-name.txt
+++ b/test/roundtrip/inline-export-func-name.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --inline-export --debug-names
+(module
+  (func $foo
+    nop)
+  (export "foo" (func $foo)))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func $foo (export "foo") (type 0)
+    nop))
+;;; STDOUT ;;)


### PR DESCRIPTION
The debug name don't have a '$', and add it in when converting to IR.
This worked properly for func->name, but wasn't updated for the func
bindings.