### PR TITLE
Use custom command to copy to bin/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -274,6 +274,7 @@ if (NOT EMSCRIPTEN)
     # ARGV contains all arguments; remove the first one, ${name}, so it's just
     # a list of sources.
     list(REMOVE_AT ARGV 0)
+
     add_executable(${name} ${ARGV})
     add_dependencies(everything ${name})
     target_link_libraries(${name} libwabt)
@@ -281,6 +282,12 @@ if (NOT EMSCRIPTEN)
     set_property(TARGET ${name} PROPERTY CXX_STANDARD_REQUIRED ON)
     list(APPEND WABT_EXECUTABLES ${name})
     set(WABT_EXECUTABLES ${WABT_EXECUTABLES} PARENT_SCOPE)
+
+    add_custom_target(${name}-copy-to-bin ALL
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
+      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${name}> ${WABT_SOURCE_DIR}/bin
+      DEPENDS ${name}
+    )
   endfunction()
 
   # wast2wasm
@@ -308,23 +315,6 @@ if (NOT EMSCRIPTEN)
 
   # wast-desugar
   wabt_executable(wast-desugar src/tools/wast-desugar.cc)
-
-  # symlinks for wast2wasm and wasm2wast
-  if (NOT WIN32)
-    add_custom_command(
-      TARGET wast2wasm
-      POST_BUILD
-      COMMAND ln -sf wast2wasm sexpr-wasm
-    )
-    add_custom_command(
-      TARGET wasm2wast
-      POST_BUILD
-      COMMAND ln -sf wasm2wast wasm-wast
-    )
-  endif ()
-  set_property(
-    DIRECTORY APPEND PROPERTY ADDITIONAL_MAKE_CLEAN_FILES
-    "sexpr-wasm" "wasm-wast")
 
   find_package(Threads)
   if (BUILD_TESTS)

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ $(call CMAKE_DIR,$(1),$(2),$(3)):
 
 $(call CMAKE_DIR,$(1),$(2),$(3))$$(BUILD_FILE): | $(call CMAKE_DIR,$(1),$(2),$(3))
 	cd $(call CMAKE_DIR,$(1),$(2),$(3)) && \
-	$$(CMAKE_CMD) -G $$(GENERATOR) -DCMAKE_INSTALL_PREFIX=$$(ROOT_DIR) $$(ROOT_DIR) $$($(1)_FLAG) $$($(2)_FLAG) $$($(3)_FLAG)
+	$$(CMAKE_CMD) -G $$(GENERATOR) $$(ROOT_DIR) $$($(1)_FLAG) $$($(2)_FLAG) $$($(3)_FLAG)
 endef
 
 define BUILD
@@ -117,7 +117,7 @@ endef
 
 define INSTALL
 .PHONY: $(call INSTALL_TARGET,$(1),$(2),$(3))
-$(call INSTALL_TARGET,$(1),$(2),$(3)): $(call BUILD_TARGET,$(1),$(2),$(3))
+$(call INSTALL_TARGET,$(1),$(2),$(3)): $(call CMAKE_DIR,$(1),$(2),$(3))$$(BUILD_FILE)
 	$$(BUILD_CMD) -C $(call CMAKE_DIR,$(1),$(2),$(3)) install
 endef
 


### PR DESCRIPTION
The last build will always be in the bin directory. This also means that
`make install` will install to the "normal" place for that OS, e.g.
`/usr/local/bin`.

Fixes #495.