### PR TITLE
Error out of parse errors in gen-wasm.py

### DIFF
--- a/test/binary/gen-wasm-parse-error.txt
+++ b/test/binary/gen-wasm-parse-error.txt
@@ -1,0 +1,9 @@
+;;; ERROR: 1
+;;; TOOL: run-gen-wasm
+section(TYPE) { foo }
+(;; STDERR ;;;
+Error running "gen-wasm.py":
+Generating LALR tables
+3: syntax error, LexToken(RBRACE,'}',3,22)
+
+;;; STDERR ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -491,7 +491,7 @@ def p_data_empty(p):
 
 
 def p_error(p):
-  print('%d: syntax error, %s' % (p.lineno, p))
+  raise Error('%d: syntax error, %s' % (p.lineno, p))
 
 
 parser = yacc.yacc(tabmodule='gen_wasm', debugfile='gen_wasm_debug.txt',

--- a/test/run-gen-wasm.py
+++ b/test/run-gen-wasm.py
@@ -51,7 +51,8 @@ def main(args):
   options = parser.parse_args(args)
 
   gen_wasm = utils.Executable(sys.executable, GEN_WASM_PY,
-                              error_cmdline=options.error_cmdline)
+                              error_cmdline=options.error_cmdline,
+                              basename=os.path.basename(GEN_WASM_PY))
 
   wasm2wast = utils.Executable(
       find_exe.GetWasm2WastExecutable(options.bindir),

--- a/test/utils.py
+++ b/test/utils.py
@@ -54,8 +54,9 @@ class Executable(object):
     if self.verbose:
       print(cmd_str)
 
-    err_cmd_str = cmd_str.replace('.exe', '')
-    if not self.error_cmdline:
+    if self.error_cmdline:
+      err_cmd_str = cmd_str.replace('.exe', '')
+    else:
       err_cmd_str = self.basename
 
     stdout = ''


### PR DESCRIPTION
Previously gen-wasm.py would return 0 on parse errors
rather than bailing out and causing tests to fail.