### PR TITLE
Allow duplicate names in the name section

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -824,12 +824,10 @@ Result BinaryReaderIR::OnFunctionName(Index index, StringSlice name) {
 
   Func* func = module->funcs[index];
   std::string dollar_name = std::string("$") + string_slice_to_string(name);
-  if (module->func_bindings.count(dollar_name) != 0) {
-    std::string orig_name = dollar_name;
-    int counter = 1;
-    do {
-      dollar_name = orig_name + "." + std::to_string(counter++);
-    } while (module->func_bindings.count(dollar_name) != 0);
+  int counter = 1;
+  std::string orig_name = dollar_name;
+  while (module->func_bindings.count(dollar_name) != 0) {
+    dollar_name = orig_name + "." + std::to_string(counter++);
   }
   func->name = dup_string_slice(string_to_string_slice(dollar_name));
   module->func_bindings.emplace(dollar_name, Binding(index));

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -824,6 +824,13 @@ Result BinaryReaderIR::OnFunctionName(Index index, StringSlice name) {
 
   Func* func = module->funcs[index];
   std::string dollar_name = std::string("$") + string_slice_to_string(name);
+  if (module->func_bindings.count(dollar_name) != 0) {
+    std::string orig_name = dollar_name;
+    int counter = 1;
+    do {
+      dollar_name = orig_name + "." + std::to_string(counter++);
+    } while (module->func_bindings.count(dollar_name) != 0);
+  }
   func->name = dup_string_slice(string_to_string_slice(dollar_name));
   module->func_bindings.emplace(dollar_name, Binding(index));
   return Result::Ok;

--- a/test/binary/duplicate-names.txt
+++ b/test/binary/duplicate-names.txt
@@ -1,0 +1,27 @@
+;;; TOOL: run-gen-wasm
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[3] type[0] type[0] type[0] }
+section(CODE) {
+  count[3]
+  func { locals[decl_count[0]] }
+  func { locals[decl_count[0]] }
+  func { locals[decl_count[0]] }
+}
+section("name") {
+  subsection[1]
+  length[13]
+  func_count[3]
+
+  index[0] str("F1")
+  index[1] str("F1")
+  index[2] str("F1")
+}
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func $F1 (type 0))
+  (func $F1.1 (type 0))
+  (func $F1.2 (type 0)))
+;;; STDOUT ;;)


### PR DESCRIPTION
While this was previously allowed, it would result
in an invalid wast file since mutliple functions
would end up with the same name.

When generating labels we now add a unique numeric
suffix (.1, .2 etc) a la llvm-link.

We could add magic behaviour to strip these out
again when producing the name sectio in wast2wasm
which would allow for cleaner roundtrip, but might
cuase confusion/issues for those who might want
to legitametly name thier functions with such
suffixes.