### PR TITLE
Update the binary writer to handle try/catch/throw/rethrow instructions.

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -543,7 +543,7 @@ void BinaryWriter::WriteExpr(const Module* module,
       break;
     case ExprType::Rethrow:
       write_opcode(&stream_, Opcode::Rethrow);
-      write_u32_leb128(&stream_, GetExceptVarDepth(&expr->rethrow_.var),
+      write_u32_leb128(&stream_, GetLabelVarDepth(&expr->rethrow_.var),
                        "rethrow exception");
       break;
     case ExprType::Return:
@@ -588,11 +588,11 @@ void BinaryWriter::WriteExpr(const Module* module,
       WriteExprList(module, func, expr->try_block.block->first);
       for (Catch* catch_ : *expr->try_block.catches) {
         if (catch_->IsCatchAll()) {
+          write_opcode(&stream_, Opcode::CatchAll);
+        } else {
           write_opcode(&stream_, Opcode::Catch);
           write_u32_leb128(&stream_, GetExceptVarDepth(&catch_->var),
                            "catch exception");
-        } else {
-          write_opcode(&stream_, Opcode::CatchAll);
         }
         WriteExprList(module, func, catch_->first);
       }

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -544,7 +544,7 @@ void BinaryWriter::WriteExpr(const Module* module,
     case ExprType::Rethrow:
       write_opcode(&stream_, Opcode::Rethrow);
       write_u32_leb128(&stream_, GetLabelVarDepth(&expr->rethrow_.var),
-                       "rethrow exception");
+                       "rethrow depth");
       break;
     case ExprType::Return:
       write_opcode(&stream_, Opcode::Return);
@@ -999,6 +999,11 @@ Result BinaryWriter::WriteModule(const Module* module) {
     for (RelocSection& section : reloc_sections_) {
       WriteRelocSection(&section);
     }
+  }
+
+  if (module->excepts.size()) {
+    // TODO(karlschimpf) Define.
+    WABT_FATAL("write exception section not implemented");
   }
 
   return stream_.result();

--- a/test/exceptions/try-text.txt
+++ b/test/exceptions/try-text.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (except $ex i32)
@@ -15,5 +15,47 @@
   )
 )
 (;; STDERR ;;;
-TryBlock: Don't know how to write
+write exception section not implemented
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Code" (10)
+0000013: 0a                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num functions
+; function body 0
+0000016: 00                                        ; func body size (guess)
+0000017: 00                                        ; local decl count
+0000018: 06                                        ; try
+0000019: 7f                                        ; i32
+000001a: 01                                        ; nop
+000001b: 41                                        ; i32.const
+000001c: 07                                        ; i32 literal
+000001d: 07                                        ; catch
+000001e: 00                                        ; catch exception
+000001f: 01                                        ; nop
+0000020: 0a                                        ; catch_all
+0000021: 09                                        ; rethrow
+0000022: 00                                        ; rethrow depth
+0000023: 0b                                        ; end
+0000024: 0b                                        ; end
+0000016: 0e                                        ; FIXUP func body size
+0000014: 10                                        ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/exceptions/try.txt
+++ b/test/exceptions/try.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (except $ex i32)
@@ -17,5 +17,47 @@
   )
 ) 
 (;; STDERR ;;;
-TryBlock: Don't know how to write
+write exception section not implemented
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Code" (10)
+0000013: 0a                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num functions
+; function body 0
+0000016: 00                                        ; func body size (guess)
+0000017: 00                                        ; local decl count
+0000018: 06                                        ; try
+0000019: 7f                                        ; i32
+000001a: 01                                        ; nop
+000001b: 41                                        ; i32.const
+000001c: 07                                        ; i32 literal
+000001d: 07                                        ; catch
+000001e: 00                                        ; catch exception
+000001f: 01                                        ; nop
+0000020: 0a                                        ; catch_all
+0000021: 09                                        ; rethrow
+0000022: 00                                        ; rethrow depth
+0000023: 0b                                        ; end
+0000024: 0b                                        ; end
+0000016: 0e                                        ; FIXUP func body size
+0000014: 10                                        ; FIXUP section size
+;;; STDOUT ;;)


### PR DESCRIPTION
Defines how to write the contents of exception handling instructions.

Note: It doesn't yet handle exception declarations.