### PR TITLE
Fix circular array to create/destroy elements.

### DIFF
--- a/src/circular-array.h
+++ b/src/circular-array.h
@@ -33,8 +33,13 @@ class CircularArray {
   typedef ptrdiff_t difference_type;
   CircularArray() : size_(0), front_(0), mask_(kCapacity - 1) {
     assert(kCapacity && ((kCapacity & (kCapacity - 1)) == 0));
+    for (size_t i = 0; i < kCapacity; ++i)
+      new (&contents_[i]) value_type();
   }
-  ~CircularArray() {}
+  ~CircularArray() {
+    for (size_t i = 0; i < kCapacity; ++i)
+      contents_[i].~T();
+  }
 
   reference at(size_type index) {
     assert(index < size_);

--- a/src/circular-array.h
+++ b/src/circular-array.h
@@ -17,6 +17,8 @@
 #ifndef WABT_CIRCULAR_ARRAY_H_
 #define WABT_CIRCULAR_ARRAY_H_
 
+#include <array>
+
 namespace wabt {
 
 // TODO(karlschimpf) Complete the API
@@ -33,12 +35,8 @@ class CircularArray {
   typedef ptrdiff_t difference_type;
   CircularArray() : size_(0), front_(0), mask_(kCapacity - 1) {
     assert(kCapacity && ((kCapacity & (kCapacity - 1)) == 0));
-    for (size_t i = 0; i < kCapacity; ++i)
-      new (&contents_[i]) value_type();
   }
   ~CircularArray() {
-    for (size_t i = 0; i < kCapacity; ++i)
-      contents_[i].~value_type();
   }
 
   reference at(size_type index) {
@@ -102,7 +100,7 @@ class CircularArray {
   }
 
  private:
-  T contents_[kCapacity];
+  std::array<T, kCapacity> contents_;
   size_type size_;
   size_type front_;
   size_type mask_;

--- a/src/circular-array.h
+++ b/src/circular-array.h
@@ -38,7 +38,7 @@ class CircularArray {
   }
   ~CircularArray() {
     for (size_t i = 0; i < kCapacity; ++i)
-      contents_[i].~T();
+      contents_[i].~value_type();
   }
 
   reference at(size_type index) {

--- a/src/circular-array.h
+++ b/src/circular-array.h
@@ -36,8 +36,6 @@ class CircularArray {
   CircularArray() : size_(0), front_(0), mask_(kCapacity - 1) {
     assert(kCapacity && ((kCapacity & (kCapacity - 1)) == 0));
   }
-  ~CircularArray() {
-  }
 
   reference at(size_type index) {
     assert(index < size_);

--- a/src/wast-parser-lexer-shared.h
+++ b/src/wast-parser-lexer-shared.h
@@ -60,6 +60,8 @@ union Token {
   Opcode opcode;
   Literal literal;
 
+  Token() {}
+
   /* non-terminals */
   /* some of these use pointers to keep the size of Token down; copying the
    tokens is a hotspot when parsing large files. */


### PR DESCRIPTION
The current implementation of a circular array did not construct/destruct the elements in its contents array. This PR fixes this problem.

Note: This problem was pointed out by @winksaville. He showed that if you compile with -Werror that you get warnings (converted to errors) about assigning to uninitialized data.

The fix is to use a placement new to construct the elements in the constructor, and to call the destructor on all elements in the destructor.