### PR TITLE
Improve display of data segments

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -45,7 +45,11 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
                       StringSlice section_name) override;
 
  protected:
-  const char* GetFunctionName(Index index);
+  const char* GetFunctionName(Index index) const;
+  void PrintRelocation(const Reloc& reloc, Offset offset) const;
+  Offset GetSectionStart(BinarySection section_code) const {
+    return section_starts[static_cast<size_t>(section_code)];
+  }
 
   ObjdumpOptions* options;
   ObjdumpState* objdump_state;
@@ -112,12 +116,32 @@ Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
   return Result::Ok;
 }
 
-const char* BinaryReaderObjdumpBase::GetFunctionName(Index index) {
+const char* BinaryReaderObjdumpBase::GetFunctionName(Index index) const {
   if (index >= objdump_state->function_names.size() ||
       objdump_state->function_names[index].empty())
     return nullptr;
 
   return objdump_state->function_names[index].c_str();
+}
+
+void BinaryReaderObjdumpBase::PrintRelocation(const Reloc& reloc,
+                                              Offset offset) const {
+  printf("           %06" PRIzx ": %-18s %" PRIindex "", offset,
+         get_reloc_type_name(reloc.type), reloc.index);
+  switch (reloc.type) {
+    case RelocType::GlobalAddressLEB:
+    case RelocType::GlobalAddressSLEB:
+    case RelocType::GlobalAddressI32:
+      printf(" + %d", reloc.addend);
+      break;
+    case RelocType::FuncIndexLEB:
+      if (const char* name = GetFunctionName(reloc.index)) {
+        printf(" <%s>", name);
+      }
+    default:
+      break;
+  }
+  printf("\n");
 }
 
 Result BinaryReaderObjdumpBase::OnRelocCount(Index count,
@@ -153,6 +177,8 @@ Result BinaryReaderObjdumpPrepass::OnReloc(RelocType type,
   BinaryReaderObjdumpBase::OnReloc(type, offset, index, addend);
   if (reloc_section == BinarySection::Code) {
     objdump_state->code_relocations.emplace_back(type, offset, index, addend);
+  } else if (reloc_section == BinarySection::Data) {
+    objdump_state->data_relocations.emplace_back(type, offset, index, addend);
   }
   return Result::Ok;
 }
@@ -216,9 +242,9 @@ Result BinaryReaderObjdumpDisassemble::OnOpcode(Opcode opcode) {
 #define IMMEDIATE_OCTET_COUNT 9
 
 void BinaryReaderObjdumpDisassemble::LogOpcode(const uint8_t* data,
-                                              size_t data_size,
-                                              const char* fmt,
-                                              ...) {
+                                               size_t data_size,
+                                               const char* fmt,
+                                               ...) {
   Offset offset = current_opcode_offset;
 
   // Print binary data
@@ -255,27 +281,11 @@ void BinaryReaderObjdumpDisassemble::LogOpcode(const uint8_t* data,
   last_opcode_end = current_opcode_offset + data_size;
 
   if (options->relocs && next_reloc < objdump_state->code_relocations.size()) {
-    Reloc* reloc = &objdump_state->code_relocations[next_reloc];
-    Offset code_start =
-        section_starts[static_cast<size_t>(BinarySection::Code)];
-    Offset abs_offset = code_start + reloc->offset;
+    const Reloc& reloc = objdump_state->code_relocations[next_reloc];
+    Offset code_start = GetSectionStart(BinarySection::Code);
+    Offset abs_offset = code_start + reloc.offset;
     if (last_opcode_end > abs_offset) {
-      printf("           %06" PRIzx ": %-18s %" PRIindex "", abs_offset,
-             get_reloc_type_name(reloc->type), reloc->index);
-      switch (reloc->type) {
-        case RelocType::GlobalAddressLEB:
-        case RelocType::GlobalAddressSLEB:
-        case RelocType::GlobalAddressI32:
-          printf(" + %d", reloc->addend);
-          break;
-        case RelocType::FuncIndexLEB:
-          if (const char* name = GetFunctionName(reloc->index)) {
-            printf(" <%s>", name);
-          }
-        default:
-          break;
-      }
-      printf("\n");
+      PrintRelocation(reloc, abs_offset);
       next_reloc++;
     }
   }
@@ -394,6 +404,25 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeBlockSig(Index num_types,
   return Result::Ok;
 }
 
+enum class InitExprType {
+  I32,
+  F32,
+  I64,
+  F64,
+  Global,
+};
+
+struct InitExpr {
+  InitExprType type;
+  union {
+    Index global;
+    uint32_t i32;
+    uint32_t f32;
+    uint64_t i64;
+    uint64_t f64;
+  } value;
+};
+
 class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
  public:
   BinaryReaderObjdump(const uint8_t* data,
@@ -465,6 +494,14 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnElemSegmentFunctionIndex(Index segment_index,
                                     Index func_index) override;
 
+  Result BeginDataSection(Offset size) override {
+    in_data_section_ = true;
+    return Result::Ok;
+  }
+  Result EndDataSection() override {
+    in_data_section_ = false;
+    return Result::Ok;
+  }
   Result OnDataSegmentCount(Index count) override;
   Result BeginDataSegment(Index index, Index memory_index) override;
   Result OnDataSegmentData(Index index,
@@ -498,10 +535,14 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
  private:
   bool ShouldPrintDetails();
   void PrintDetails(const char* fmt, ...);
+  void PrintInitExpr(const InitExpr &expr);
   Result OnCount(Index count);
 
   std::unique_ptr<FileStream> out_stream_;
   Index elem_index_ = 0;
+  Index next_data_reloc_ = 0;
+  bool in_data_section_ = false;
+  InitExpr data_init_expr_;
 };
 
 BinaryReaderObjdump::BinaryReaderObjdump(const uint8_t* data,
@@ -552,7 +593,7 @@ Result BinaryReaderObjdump::BeginSection(BinarySection section_code,
       if (section_match) {
         printf("\nContents of section %s:\n", name);
         out_stream_->WriteMemoryDump(data + state->offset, size, state->offset,
-                                     nullptr, nullptr, PrintChars::Yes);
+                                     PrintChars::Yes);
       }
       break;
     case ObjdumpMode::Prepass:
@@ -587,8 +628,15 @@ Result BinaryReaderObjdump::OnCount(Index count) {
 
 Result BinaryReaderObjdump::EndModule() {
   if (options->section_name && !section_found) {
-    printf("Section not found: %s\n", options->section_name);
+    fprintf(stderr, "Section not found: %s\n", options->section_name);
     return Result::Error;
+  }
+
+  if (options->relocs) {
+    if (next_data_reloc_ != objdump_state->data_relocations.size()) {
+      fprintf(stderr, "Data reloctions outside of segments\n");
+      return Result::Error;
+    }
   }
 
   return Result::Ok;
@@ -783,37 +831,94 @@ Result BinaryReaderObjdump::BeginGlobal(Index index, Type type, bool mutable_) {
   return Result::Ok;
 }
 
+void BinaryReaderObjdump::PrintInitExpr(const InitExpr& expr) {
+  switch (expr.type) {
+    case InitExprType::I32:
+      PrintDetails(" - init i32=%d\n", expr.value.i32);
+      break;
+    case InitExprType::I64:
+      PrintDetails(" - init i64=%" PRId64 "\n", expr.value.i64);
+      break;
+    case InitExprType::F64: {
+      char buffer[WABT_MAX_DOUBLE_HEX];
+      write_float_hex(buffer, sizeof(buffer), expr.value.f64);
+      PrintDetails(" - init f64=%s\n", buffer);
+      break;
+    }
+    case InitExprType::F32: {
+      char buffer[WABT_MAX_FLOAT_HEX];
+      write_float_hex(buffer, sizeof(buffer), expr.value.f32);
+      PrintDetails(" - init f32=%s\n", buffer);
+      break;
+    }
+    case InitExprType::Global:
+      PrintDetails(" - init global=%" PRIindex "\n", expr.value.global);
+      break;
+  }
+}
+
 Result BinaryReaderObjdump::OnInitExprF32ConstExpr(Index index,
                                                    uint32_t value) {
-  char buffer[WABT_MAX_FLOAT_HEX];
-  write_float_hex(buffer, sizeof(buffer), value);
-  PrintDetails(" - init f32=%s\n", buffer);
+  InitExpr expr;
+  expr.type = InitExprType::F32;
+  expr.value.f32 = value;
+  if (in_data_section_) {
+    data_init_expr_ = expr;
+  } else {
+    PrintInitExpr(expr);
+  }
   return Result::Ok;
 }
 
 Result BinaryReaderObjdump::OnInitExprF64ConstExpr(Index index,
                                                    uint64_t value) {
-  char buffer[WABT_MAX_DOUBLE_HEX];
-  write_float_hex(buffer, sizeof(buffer), value);
-  PrintDetails(" - init f64=%s\n", buffer);
+  InitExpr expr;
+  expr.type = InitExprType::F64;
+  expr.value.f64 = value;
+  if (in_data_section_) {
+    data_init_expr_ = expr;
+  } else {
+    PrintInitExpr(expr);
+  }
   return Result::Ok;
 }
 
 Result BinaryReaderObjdump::OnInitExprGetGlobalExpr(Index index,
                                                     Index global_index) {
-  PrintDetails(" - init global=%" PRIindex "\n", global_index);
+  InitExpr expr;
+  expr.type = InitExprType::Global;
+  expr.value.global = global_index;
+  if (in_data_section_) {
+    data_init_expr_ = expr;
+  } else {
+    PrintInitExpr(expr);
+  }
   return Result::Ok;
 }
 
 Result BinaryReaderObjdump::OnInitExprI32ConstExpr(Index index,
                                                    uint32_t value) {
-  PrintDetails(" - init i32=%d\n", value);
+  InitExpr expr;
+  expr.type = InitExprType::I32;
+  expr.value.i32 = value;
+  if (in_data_section_) {
+    data_init_expr_ = expr;
+  } else {
+    PrintInitExpr(expr);
+  }
   return Result::Ok;
 }
 
 Result BinaryReaderObjdump::OnInitExprI64ConstExpr(Index index,
                                                    uint64_t value) {
-  PrintDetails(" - init i64=%" PRId64 "\n", value);
+  InitExpr expr;
+  expr.type = InitExprType::I64;
+  expr.value.i64 = value;
+  if (in_data_section_) {
+    data_init_expr_ = expr;
+  } else {
+    PrintInitExpr(expr);
+  }
   return Result::Ok;
 }
 
@@ -839,17 +944,53 @@ Result BinaryReaderObjdump::OnDataSegmentCount(Index count) {
 }
 
 Result BinaryReaderObjdump::BeginDataSegment(Index index, Index memory_index) {
-  PrintDetails(" - memory[%" PRIindex "]", memory_index);
+  // TODO(sbc): Display memory_index once multiple memories become a thing
+  //PrintDetails(" - memory[%" PRIindex "]", memory_index);
   return Result::Ok;
 }
 
 Result BinaryReaderObjdump::OnDataSegmentData(Index index,
                                               const void* src_data,
                                               Address size) {
-  if (ShouldPrintDetails()) {
-    out_stream_->WriteMemoryDump(src_data, size, state->offset - size, "  - ",
-                                 nullptr, PrintChars::Yes);
+  if (!ShouldPrintDetails())
+    return Result::Ok;
+
+  PrintDetails(" - segment[%" PRIindex "] size=%" PRIaddress, index, size);
+  PrintInitExpr(data_init_expr_);
+
+  size_t offset = 0;
+  switch (data_init_expr_.type) {
+    case InitExprType::I32:
+      offset = data_init_expr_.value.i32;
+      break;
+    case InitExprType::I64:
+      offset = data_init_expr_.value.i64;
+      break;
+    case InitExprType::F32:
+    case InitExprType::F64:
+      fprintf(stderr, "Floating point value not valid for data segement offset");
+      return Result::Error;
+      break;
+    case InitExprType::Global:
+      break;
   }
+
+  out_stream_->WriteMemoryDump(src_data, size, offset, PrintChars::Yes, "  - ");
+
+  // Print relocations from this section.
+  if (!options->relocs)
+    return Result::Ok;
+
+  Offset data_start = GetSectionStart(BinarySection::Data);
+  while (next_data_reloc_ < objdump_state->data_relocations.size()) {
+    const Reloc& reloc = objdump_state->data_relocations[next_data_reloc_];
+    Offset abs_offset = data_start + reloc.offset;
+    if (abs_offset > state->offset)
+      break;
+    PrintRelocation(reloc, abs_offset);
+    next_data_reloc_++;
+  }
+
   return Result::Ok;
 }
 
@@ -865,8 +1006,7 @@ Result BinaryReaderObjdump::OnReloc(RelocType type,
                                     Offset offset,
                                     Index index,
                                     uint32_t addend) {
-  Offset total_offset =
-      section_starts[static_cast<size_t>(reloc_section)] + offset;
+  Offset total_offset = GetSectionStart(reloc_section) + offset;
   PrintDetails("   - %-18s offset=%#08" PRIoffset "(file=%#08" PRIoffset
                ") index=%" PRIindex,
                get_reloc_type_name(type), offset, total_offset, index);

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -963,15 +963,13 @@ Result BinaryReaderObjdump::OnDataSegmentData(Index index,
     case InitExprType::I32:
       voffset = data_init_expr_.value.i32;
       break;
-    case InitExprType::I64:
-      voffset = data_init_expr_.value.i64;
+    case InitExprType::Global:
       break;
+    case InitExprType::I64:
     case InitExprType::F32:
     case InitExprType::F64:
-      fprintf(stderr, "Floating point value not valid for data segement offset");
+      fprintf(stderr, "Segment offset must be an i32 init expr");
       return Result::Error;
-      break;
-    case InitExprType::Global:
       break;
   }
 

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -53,6 +53,7 @@ struct ObjdumpOptions {
 // and use it to display more useful information.
 struct ObjdumpState {
   std::vector<Reloc> code_relocations;
+  std::vector<Reloc> data_relocations;
   std::vector<std::string> function_names;
 };
 

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -42,7 +42,7 @@ void Stream::WriteDataAt(size_t at,
   if (WABT_FAILED(result_))
     return;
   if (log_stream_) {
-    log_stream_->WriteMemoryDump(src, size, at, nullptr, desc, print_chars);
+    log_stream_->WriteMemoryDump(src, size, at, print_chars, nullptr, desc);
   }
   result_ = writer_->WriteData(at, src, size);
 }
@@ -74,9 +74,9 @@ void Stream::Writef(const char* format, ...) {
 void Stream::WriteMemoryDump(const void* start,
                              size_t size,
                              size_t offset,
+                             PrintChars print_chars,
                              const char* prefix,
-                             const char* desc,
-                             PrintChars print_chars) {
+                             const char* desc) {
   const uint8_t* p = static_cast<const uint8_t*>(start);
   const uint8_t* end = p + size;
   while (p < end) {

--- a/src/stream.h
+++ b/src/stream.h
@@ -95,9 +95,9 @@ class Stream {
   void WriteMemoryDump(const void* start,
                        size_t size,
                        size_t offset = 0,
+                       PrintChars print_chars = PrintChars::No,
                        const char* prefix = nullptr,
-                       const char* desc = nullptr,
-                       PrintChars print_chars = PrintChars::No);
+                       const char* desc = nullptr);
 
   // Convenience functions for writing enums.
   template <typename T>

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -46,12 +46,12 @@ Section Details:
 Memory:
  - memory[0] pages: initial=1
 Data:
- - memory[0] - init i32=10
-  - 0000015: 6865 6c6c 6f                             hello
- - memory[0] - init i32=20
-  - 000001f: 676f 6f64 6279 652c 204c 6f72 656d 2069  goodbye, Lorem i
-  - 000002f: 7073 756d 2064 6f6c 6f72 2073 6974 2061  psum dolor sit a
-  - 000003f: 6d65 742c 2063 6f6e 7365 6374 6574 7572  met, consectetur
+ - segment[0] size=5 - init i32=10
+  - 000000a: 6865 6c6c 6f                             hello
+ - segment[1] size=48 - init i32=20
+  - 0000014: 676f 6f64 6279 652c 204c 6f72 656d 2069  goodbye, Lorem i
+  - 0000024: 7073 756d 2064 6f6c 6f72 2073 6974 2061  psum dolor sit a
+  - 0000034: 6d65 742c 2063 6f6e 7365 6374 6574 7572  met, consectetur
 
 Code Disassembly:
 

--- a/test/link/data.txt
+++ b/test/link/data.txt
@@ -24,14 +24,14 @@ Section Details:
 Memory:
  - memory[0] pages: initial=2 max=2
 Data:
- - memory[0] - init i32=0
-  - 000001e: 666f 6f                                  foo
- - memory[0] - init i32=10
-  - 0000026: 6261 72                                  bar
- - memory[0] - init i32=65536
-  - 0000030: 6865 6c6c 6f                             hello
- - memory[0] - init i32=65636
-  - 000003c: 776f 726c 64                             world
+ - segment[0] size=3 - init i32=0
+  - 0000000: 666f 6f                                  foo
+ - segment[1] size=3 - init i32=10
+  - 000000a: 6261 72                                  bar
+ - segment[2] size=5 - init i32=65536
+  - 0010000: 6865 6c6c 6f                             hello
+ - segment[3] size=5 - init i32=65636
+  - 0010064: 776f 726c 64                             world
 
 Code Disassembly:
 


### PR DESCRIPTION
Use the virtual address (init offset) when display
the data rather that the file offset.

Show the segment size in the header.