### PR TITLE
Fix dereference of null pointer in validator.

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -597,8 +597,9 @@ void Validator::CheckExpr(const Expr* expr) {
           if (found_catch_all)
             PrintError(&catch_->loc, "Appears after catch all block");
           const Exception* except = nullptr;
-          CheckExceptVar(&catch_->var, &except);
-          typechecker_.OnCatch(&except->sig);
+          if (WABT_SUCCEEDED(CheckExceptVar(&catch_->var, &except))) {
+            typechecker_.OnCatch(&except->sig);
+          }
         }
         CheckExprList(&catch_->loc, catch_->first);
       }

--- a/test/exceptions/bad-throw.txt
+++ b/test/exceptions/bad-throw.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (except $ex i32)

--- a/test/exceptions/catch-all-not-last.txt
+++ b/test/exceptions/catch-all-not-last.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (except $ex i32)

--- a/test/exceptions/rethrow-not-in-catch.txt
+++ b/test/exceptions/rethrow-not-in-catch.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (except $ex i32)

--- a/test/exceptions/rethrow-to-wrong-block.txt
+++ b/test/exceptions/rethrow-to-wrong-block.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (func (result i32)

--- a/test/exceptions/try-exports.txt
+++ b/test/exceptions/try-exports.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (except $ex i32)
@@ -12,3 +12,30 @@
 (;; STDERR ;;;
 write export except not implemented
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Export" (7)
+0000013: 07                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num exports
+0000016: 06                                        ; string length
+0000017: 6578 6365 7074                           except  ; export name
+000001d: 04                                        ; export kind
+;;; STDOUT ;;)

--- a/test/exceptions/try-imports.txt
+++ b/test/exceptions/try-imports.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wast2wasm
-;;; FLAGS: --future-exceptions
+;;; FLAGS: --future-exceptions -v
 ;;; ERROR: 1
 (module
   (import "c++" "except" (except $ex i32))
@@ -19,3 +19,27 @@
 (;; STDERR ;;;
 write import except not implemented
 ;;; STDERR ;;)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Import" (2)
+000000f: 02                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num imports
+; import header 0
+0000012: 03                                        ; string length
+0000013: 632b 2b                                  c++  ; import module name
+0000016: 06                                        ; string length
+0000017: 6578 6365 7074                           except  ; import field name
+000001d: 04                                        ; import kind
+;;; STDOUT ;;)


### PR DESCRIPTION
Discovered that one of the exception tests was failing because of a null pointer dereference. This CL fixes the problem.

It also adds -v to exception test files (with exceptions) so that we are capturing how the constructs are being compiled into the binary form.