### PR TITLE
Add type check to data segment offset

### DIFF
--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -973,11 +973,7 @@ wabt::Result BinaryReaderInterpreter::OnStartFunction(Index func_index) {
 }
 
 wabt::Result BinaryReaderInterpreter::EndElemSegmentInitExpr(Index index) {
-  if (init_expr_value.type != Type::I32) {
-    PrintError("type mismatch in elem segment, expected i32 but got %s",
-               GetTypeName(init_expr_value.type));
-    return wabt::Result::Error;
-  }
+  assert(init_expr_value.type == Type::I32);
   table_offset = init_expr_value.value.i32;
   return wabt::Result::Ok;
 }
@@ -1010,11 +1006,7 @@ wabt::Result BinaryReaderInterpreter::OnDataSegmentData(Index index,
                                                         Address size) {
   assert(module->memory_index != kInvalidIndex);
   Memory* memory = env->GetMemory(module->memory_index);
-  if (init_expr_value.type != Type::I32) {
-    PrintError("type mismatch in data segment, expected i32 but got %s",
-               GetTypeName(init_expr_value.type));
-    return wabt::Result::Error;
-  }
+  assert(init_expr_value.type == Type::I32);
   Address address = init_expr_value.value.i32;
   uint64_t end_address =
       static_cast<uint64_t>(address) + static_cast<uint64_t>(size);

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -176,7 +176,7 @@ class BinaryReader {
   Index NumTotalMemories();
   Index NumTotalGlobals();
 
-  Result ReadInitExpr(Index index) WABT_WARN_UNUSED;
+  Result ReadInitExpr(Index index, bool require_i32 = false) WABT_WARN_UNUSED;
   Result ReadTable(Type* out_elem_type,
                    Limits* out_elem_limits) WABT_WARN_UNUSED;
   Result ReadMemory(Limits* out_page_limits) WABT_WARN_UNUSED;
@@ -492,9 +492,10 @@ Index BinaryReader::NumTotalGlobals() {
   return num_global_imports_ + num_globals_;
 }
 
-Result BinaryReader::ReadInitExpr(Index index) {
+Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
   Opcode opcode;
   CHECK_RESULT(ReadOpcode(&opcode, "opcode"));
+
   switch (opcode) {
     case Opcode::I32Const: {
       uint32_t value = 0;
@@ -536,6 +537,12 @@ Result BinaryReader::ReadInitExpr(Index index) {
 
     default:
       return ReportUnexpectedOpcode(opcode, "in initializer expression");
+  }
+
+  if (require_i32 && opcode != Opcode::I32Const &&
+      opcode != Opcode::GetGlobal) {
+    PrintError("expected i32 init_expr");
+    return Result::Error;
   }
 
   CHECK_RESULT(ReadOpcode(&opcode, "opcode"));
@@ -1647,7 +1654,7 @@ Result BinaryReader::ReadDataSection(Offset section_size) {
     CHECK_RESULT(ReadIndex(&memory_index, "data segment memory index"));
     CALLBACK(BeginDataSegment, i, memory_index);
     CALLBACK(BeginDataSegmentInitExpr, i);
-    CHECK_RESULT(ReadInitExpr(i));
+    CHECK_RESULT(ReadInitExpr(i, true/*require_i32*/));
     CALLBACK(EndDataSegmentInitExpr, i);
 
     Address data_size;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -176,6 +176,7 @@ class BinaryReader {
   Index NumTotalMemories();
   Index NumTotalGlobals();
 
+  Result ReadI32InitExpr(Index index) WABT_WARN_UNUSED;
   Result ReadInitExpr(Index index, bool require_i32 = false) WABT_WARN_UNUSED;
   Result ReadTable(Type* out_elem_type,
                    Limits* out_elem_limits) WABT_WARN_UNUSED;
@@ -490,6 +491,10 @@ Index BinaryReader::NumTotalMemories() {
 
 Index BinaryReader::NumTotalGlobals() {
   return num_global_imports_ + num_globals_;
+}
+
+Result BinaryReader::ReadI32InitExpr(Index index) {
+  return ReadInitExpr(index, true);
 }
 
 Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
@@ -1588,7 +1593,7 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
     CHECK_RESULT(ReadIndex(&table_index, "elem segment table index"));
     CALLBACK(BeginElemSegment, i, table_index);
     CALLBACK(BeginElemSegmentInitExpr, i);
-    CHECK_RESULT(ReadInitExpr(i));
+    CHECK_RESULT(ReadI32InitExpr(i));
     CALLBACK(EndElemSegmentInitExpr, i);
 
     Index num_function_indexes;
@@ -1654,7 +1659,7 @@ Result BinaryReader::ReadDataSection(Offset section_size) {
     CHECK_RESULT(ReadIndex(&memory_index, "data segment memory index"));
     CALLBACK(BeginDataSegment, i, memory_index);
     CALLBACK(BeginDataSegmentInitExpr, i);
-    CHECK_RESULT(ReadInitExpr(i, true/*require_i32*/));
+    CHECK_RESULT(ReadI32InitExpr(i));
     CALLBACK(EndDataSegmentInitExpr, i);
 
     Address data_size;

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -8,8 +8,7 @@ out/third_party/testsuite/func_ptrs.wast:32: assert_invalid passed:
 out/third_party/testsuite/func_ptrs.wast:33: assert_invalid passed:
   0000015: error: elem section without table section
 out/third_party/testsuite/func_ptrs.wast:36: assert_invalid passed:
-  error: type mismatch in elem segment, expected i32 but got i64
-  0000015: error: EndElemSegmentInitExpr callback failed
+  0000014: error: expected i32 init_expr
 out/third_party/testsuite/func_ptrs.wast:40: assert_invalid passed:
   0000015: error: expected END opcode after initializer expression
 out/third_party/testsuite/func_ptrs.wast:44: assert_invalid passed:

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -31,8 +31,7 @@ out/third_party/testsuite/memory.wast:54: assert_invalid passed:
   error: grow_memory requires an imported or defined memory.
   000001b: error: OnGrowMemoryExpr callback failed
 out/third_party/testsuite/memory.wast:59: assert_invalid passed:
-  error: type mismatch in data segment, expected i32 but got i64
-  0000015: error: OnDataSegmentData callback failed
+  0000013: error: expected i32 init_expr
 out/third_party/testsuite/memory.wast:63: assert_invalid passed:
   0000014: error: expected END opcode after initializer expression
 out/third_party/testsuite/memory.wast:67: assert_invalid passed:


### PR DESCRIPTION
This is a conservative check that we can do in the binary
reader itself.  More extensive checking is still done in the
interpreter (i.e. vefiying the type of the global).