### PR TITLE
Fix binary writer to handle exception declarations.

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -224,6 +224,7 @@ class BinaryWriter {
   void WriteTable(const Table* table);
   void WriteMemory(const Memory* memory);
   void WriteGlobalHeader(const Global* global);
+  void WriteExceptType(const TypeVector* except_types);
   void WriteRelocSection(const RelocSection* reloc_section);
 
   Stream stream_;
@@ -683,6 +684,12 @@ void BinaryWriter::WriteGlobalHeader(const Global* global) {
   stream_.WriteU8(global->mutable_, "global mutability");
 }
 
+void BinaryWriter::WriteExceptType(const TypeVector* except_types) {
+  write_u32_leb128(&stream_, except_types->size(), "exception type count");
+  for (Type ty : *except_types)
+    write_type(&stream_, ty);
+}
+
 void BinaryWriter::WriteRelocSection(const RelocSection* reloc_section) {
   char section_name[128];
   wabt_snprintf(section_name, sizeof(section_name), "%s.%s",
@@ -765,8 +772,7 @@ Result BinaryWriter::WriteModule(const Module* module) {
           WriteGlobalHeader(import->global);
           break;
         case ExternalKind::Except:
-          // TODO(karlschimpf) Define.
-          WABT_FATAL("write import except not implemented\n");
+          WriteExceptType(&import->except->sig);
           break;
       }
     }
@@ -858,10 +864,11 @@ Result BinaryWriter::WriteModule(const Module* module) {
           write_u32_leb128(&stream_, index, "export global index");
           break;
         }
-        case ExternalKind::Except:
-          // TODO(karlschimpf) Define.
-          WABT_FATAL("write export except not implemented\n");
+        case ExternalKind::Except: {
+          Index index = module->GetExceptIndex(export_->var);
+          write_u32_leb128(&stream_, index, "export exception index");
           break;
+        }
       }
     }
     EndSection();
@@ -1002,8 +1009,12 @@ Result BinaryWriter::WriteModule(const Module* module) {
   }
 
   if (module->excepts.size()) {
-    // TODO(karlschimpf) Define.
-    WABT_FATAL("write exception section not implemented");
+    BeginCustomSection("exception", LEB_SECTION_SIZE_GUESS);
+    write_u32_leb128(&stream_, module->excepts.size(), "exception count");
+    for (Exception* except : module->excepts) {
+      WriteExceptType(&except->sig);
+    }
+    EndSection();
   }
 
   return stream_.result();

--- a/test/exceptions/try-exports.txt
+++ b/test/exceptions/try-exports.txt
@@ -9,6 +9,55 @@
     (throw $ex)
   )
 )
-(;; STDERR ;;;
-write export except not implemented
-;;; STDERR ;;)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Export" (7)
+0000013: 07                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num exports
+0000016: 06                                        ; string length
+0000017: 6578 6365 7074                           except  ; export name
+000001d: 04                                        ; export kind
+000001e: 00                                        ; export exception index
+0000014: 0a                                        ; FIXUP section size
+; section "Code" (10)
+000001f: 0a                                        ; section code
+0000020: 00                                        ; section size (guess)
+0000021: 01                                        ; num functions
+; function body 0
+0000022: 00                                        ; func body size (guess)
+0000023: 00                                        ; local decl count
+0000024: 41                                        ; i32.const
+0000025: 07                                        ; i32 literal
+0000026: 08                                        ; throw
+0000027: 00                                        ; throw exception
+0000028: 0b                                        ; end
+0000022: 06                                        ; FIXUP func body size
+0000020: 08                                        ; FIXUP section size
+; section "exception"
+0000029: 00                                        ; custom section code
+000002a: 00                                        ; section size (guess)
+000002b: 09                                        ; string length
+000002c: 6578 6365 7074 696f 6e                   exception  ; custom section name
+0000035: 01                                        ; exception count
+0000036: 01                                        ; exception type count
+0000037: 7f                                        ; i32
+000002a: 0d                                        ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/exceptions/try-exports.txt
+++ b/test/exceptions/try-exports.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: wast2wasm
 ;;; FLAGS: --future-exceptions -v
-;;; ERROR: 1
 (module
   (except $ex i32)
   (export "except" (except $ex))
@@ -35,7 +34,6 @@
 0000016: 06                                        ; string length
 0000017: 6578 6365 7074                           except  ; export name
 000001d: 04                                        ; export kind
-<<<<<<< HEAD
 000001e: 00                                        ; export exception index
 0000014: 0a                                        ; FIXUP section size
 ; section "Code" (10)
@@ -61,6 +59,4 @@
 0000036: 01                                        ; exception type count
 0000037: 7f                                        ; i32
 000002a: 0d                                        ; FIXUP section size
-=======
->>>>>>> master
 ;;; STDOUT ;;)

--- a/test/exceptions/try-imports.txt
+++ b/test/exceptions/try-imports.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: wast2wasm
 ;;; FLAGS: --future-exceptions -v
-;;; ERROR: 1
 (module
   (import "c++" "except" (except $ex i32))
   (func (result i32)
@@ -39,7 +38,6 @@
 0000016: 06                                        ; string length
 0000017: 6578 6365 7074                           except  ; import field name
 000001d: 04                                        ; import kind
-<<<<<<< HEAD
 000001e: 01                                        ; exception type count
 000001f: 7f                                        ; i32
 0000010: 0f                                        ; FIXUP section size
@@ -80,6 +78,4 @@
 0000043: 01                                        ; exception type count
 0000044: 7f                                        ; i32
 0000037: 0d                                        ; FIXUP section size
-=======
->>>>>>> master
 ;;; STDOUT ;;)

--- a/test/exceptions/try-imports.txt
+++ b/test/exceptions/try-imports.txt
@@ -16,6 +16,67 @@
     )
   )
 )
-(;; STDERR ;;;
-write import except not implemented
-;;; STDERR ;;)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Import" (2)
+000000f: 02                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num imports
+; import header 0
+0000012: 03                                        ; string length
+0000013: 632b 2b                                  c++  ; import module name
+0000016: 06                                        ; string length
+0000017: 6578 6365 7074                           except  ; import field name
+000001d: 04                                        ; import kind
+000001e: 01                                        ; exception type count
+000001f: 7f                                        ; i32
+0000010: 0f                                        ; FIXUP section size
+; section "Function" (3)
+0000020: 03                                        ; section code
+0000021: 00                                        ; section size (guess)
+0000022: 01                                        ; num functions
+0000023: 00                                        ; function 0 signature index
+0000021: 02                                        ; FIXUP section size
+; section "Code" (10)
+0000024: 0a                                        ; section code
+0000025: 00                                        ; section size (guess)
+0000026: 01                                        ; num functions
+; function body 0
+0000027: 00                                        ; func body size (guess)
+0000028: 00                                        ; local decl count
+0000029: 06                                        ; try
+000002a: 7f                                        ; i32
+000002b: 01                                        ; nop
+000002c: 41                                        ; i32.const
+000002d: 07                                        ; i32 literal
+000002e: 07                                        ; catch
+000002f: 00                                        ; catch exception
+0000030: 01                                        ; nop
+0000031: 0a                                        ; catch_all
+0000032: 09                                        ; rethrow
+0000033: 00                                        ; rethrow depth
+0000034: 0b                                        ; end
+0000035: 0b                                        ; end
+0000027: 0e                                        ; FIXUP func body size
+0000025: 10                                        ; FIXUP section size
+; section "exception"
+0000036: 00                                        ; custom section code
+0000037: 00                                        ; section size (guess)
+0000038: 09                                        ; string length
+0000039: 6578 6365 7074 696f 6e                   exception  ; custom section name
+0000042: 01                                        ; exception count
+0000043: 01                                        ; exception type count
+0000044: 7f                                        ; i32
+0000037: 0d                                        ; FIXUP section size
+;;; STDOUT ;;)

--- a/test/exceptions/try-text.txt
+++ b/test/exceptions/try-text.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: wast2wasm
 ;;; FLAGS: --future-exceptions -v
-;;; ERROR: 1
 (module
   (except $ex i32)
   (func (result i32)
@@ -14,9 +13,6 @@
     end
   )
 )
-(;; STDERR ;;;
-write exception section not implemented
-;;; STDERR ;;)
 (;; STDOUT ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION

--- a/test/exceptions/try-text.txt
+++ b/test/exceptions/try-text.txt
@@ -58,4 +58,13 @@ write exception section not implemented
 0000024: 0b                                        ; end
 0000016: 0e                                        ; FIXUP func body size
 0000014: 10                                        ; FIXUP section size
+; section "exception"
+0000025: 00                                        ; custom section code
+0000026: 00                                        ; section size (guess)
+0000027: 09                                        ; string length
+0000028: 6578 6365 7074 696f 6e                   exception  ; custom section name
+0000031: 01                                        ; exception count
+0000032: 01                                        ; exception type count
+0000033: 7f                                        ; i32
+0000026: 0d                                        ; FIXUP section size
 ;;; STDOUT ;;)

--- a/test/exceptions/try.txt
+++ b/test/exceptions/try.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: wast2wasm
 ;;; FLAGS: --future-exceptions -v
-;;; ERROR: 1
 (module
   (except $ex i32)
   (func (result i32)

--- a/test/exceptions/try.txt
+++ b/test/exceptions/try.txt
@@ -16,9 +16,6 @@
     )
   )
 ) 
-(;; STDERR ;;;
-write exception section not implemented
-;;; STDERR ;;)
 (;; STDOUT ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
@@ -60,4 +57,13 @@ write exception section not implemented
 0000024: 0b                                        ; end
 0000016: 0e                                        ; FIXUP func body size
 0000014: 10                                        ; FIXUP section size
+; section "exception"
+0000025: 00                                        ; custom section code
+0000026: 00                                        ; section size (guess)
+0000027: 09                                        ; string length
+0000028: 6578 6365 7074 696f 6e                   exception  ; custom section name
+0000031: 01                                        ; exception count
+0000032: 01                                        ; exception type count
+0000033: 7f                                        ; i32
+0000026: 0d                                        ; FIXUP section size
 ;;; STDOUT ;;)


### PR DESCRIPTION
Generate exception section, imported exceptions, and exported exceptions. At this point, we can successfully convert wast files with exceptions to their corresponding wasm files.

Also updates exceptions to reflect the changes.