### PR TITLE
Use add add_custom_command rather than add_custom_target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,10 +283,9 @@ if (NOT EMSCRIPTEN)
     list(APPEND WABT_EXECUTABLES ${name})
     set(WABT_EXECUTABLES ${WABT_EXECUTABLES} PARENT_SCOPE)
 
-    add_custom_target(${name}-copy-to-bin ALL
+    add_custom_command(TARGET ${name} POST_BUILD
       COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
       COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${name}> ${WABT_SOURCE_DIR}/bin
-      DEPENDS ${name}
     )
   endfunction()
 


### PR DESCRIPTION
add_custom_target means that build is alwasy dirty and will
always execute the copy commands.  add_custom_command means
the copy will only be trigged if the binaries get rebuilt.

This means the ninja build will report nothing to do if
it is re-run without changing any inputs.