### PR TITLE
Clean up errors messages for bad rethrow instruction.

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -548,8 +548,6 @@ void Validator::CheckExpr(const Expr* expr) {
       break;
 
     case ExprType::Rethrow:
-      if (try_contexts_.empty() || try_contexts_.back().catch_ == nullptr)
-        PrintError(&expr->loc, "Rethrow not in try catch block");
       typechecker_.OnRethrow(expr->As<RethrowExpr>()->var.index);
       break;
 

--- a/test/exceptions/rethrow-not-in-catch.txt
+++ b/test/exceptions/rethrow-not-in-catch.txt
@@ -17,7 +17,4 @@
 out/test/exceptions/rethrow-not-in-catch.txt:9:8: Rethrow not in try catch block
       (rethrow $try1)
        ^^^^^^^^^^^^^
-out/test/exceptions/rethrow-not-in-catch.txt:9:8: invalid rethrow depth: 0 (max 1)
-      (rethrow $try1)
-       ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/exceptions/rethrow-to-wrong-block.txt
+++ b/test/exceptions/rethrow-to-wrong-block.txt
@@ -14,7 +14,7 @@
   )
 ) 
 (;; STDERR ;;;
-out/test/exceptions/rethrow-to-wrong-block.txt:10:12: invalid rethrow depth: 1 (max 2)
+out/test/exceptions/rethrow-to-wrong-block.txt:10:12: invalid rethrow depth: 1 (catches: 0)
           (rethrow $b)
            ^^^^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
Cleans up the error messages for rethrows.

In particular, it only reports on valid depth values (associated with the catch they appear in).
