### PR TITLE
Make wast-desugar work for exception handling.

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -108,6 +108,13 @@ Memory* Module::GetMemory(const Var& var) {
   return memories[index];
 }
 
+Exception* Module::GetExcept(const Var& var) const {
+  Index index = GetExceptIndex(var);
+  if (index >= excepts.size())
+    return nullptr;
+  return excepts[index];
+}
+
 const FuncType* Module::GetFuncType(const Var& var) const {
   return const_cast<Module*>(this)->GetFuncType(var);
 }

--- a/src/ir.h
+++ b/src/ir.h
@@ -507,6 +507,7 @@ struct Module {
   const Global* GetGlobal(const Var&) const;
   Global* GetGlobal(const Var&);
   const Export* GetExport(const StringSlice&) const;
+  Exception* GetExcept(const Var&) const;
   Index GetExceptIndex(const Var&) const;
 
   Location loc;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1165,6 +1165,7 @@ void WatWriter::BuildExportMaps() {
       }
 
       case ExternalKind::Except:
+        // TODO(karlschimpf): Build for inline exceptions.
         break;
     }
   }

--- a/test/desugar/try-exports.txt
+++ b/test/desugar/try-exports.txt
@@ -1,0 +1,19 @@
+;;; TOOL: wast-desugar
+;;; FLAGS: --future-exceptions
+(module
+  (except $ex i32)
+  (export "except" (except $ex))
+  (func (result i32)
+    (i32.const 7)
+    (throw $ex)
+  )
+)
+(;; STDOUT ;;;
+(module
+  (except $ex i32)
+  (export "except" (except $ex))
+  (type (;0;) (func (result i32)))
+  (func (;0;) (result i32)
+    i32.const 7
+    throw $ex))
+;;; STDOUT ;;)

--- a/test/desugar/try-import.txt
+++ b/test/desugar/try-import.txt
@@ -1,0 +1,31 @@
+;;; TOOL: wast-desugar
+;;; FLAGS: --future-exceptions
+(module
+  (import "c++" "except" (except $ex i32))
+  (func (result i32)
+    (try $try1 (result i32)
+      (nop)
+      (i32.const 7)
+      (catch $ex
+        (nop)
+      )
+      (catch_all
+        (rethrow $try1)
+      )
+    )
+  )
+)
+(;; STDOUT ;;;
+(module
+  (import "c++" "except" (except $ex i32))
+  (type (;0;) (func (result i32)))
+  (func (;0;) (result i32)
+    try $try1 (result i32)
+      nop
+      i32.const 7
+    catch $ex
+      nop
+    catch_all
+      rethrow $try1
+    end))
+;;; STDOUT ;;)

--- a/test/desugar/try.txt
+++ b/test/desugar/try.txt
@@ -1,0 +1,29 @@
+;;; TOOL: wast-desugar
+;;; FLAGS: --future-exceptions
+(module
+  (except $ex i32)
+  (func (result i32)
+    try $try1 (result i32)
+      nop
+      i32.const 7
+    catch $ex
+      nop
+    catch_all
+      rethrow $try1
+    end
+  )
+)
+(;; STDOUT ;;;
+(module
+  (except $ex i32)
+  (type (;0;) (func (result i32)))
+  (func (;0;) (result i32)
+    try $try1 (result i32)
+      nop
+      i32.const 7
+    catch $ex
+      nop
+    catch_all
+      rethrow $try1
+    end))
+;;; STDOUT ;;)


### PR DESCRIPTION
Updates generate/apply names, as well as the wat writer, allowing wast-desugar to work.

Also fixes the following nits:

* Fixes NameApplier::UseNameForVar() to not leak a string slice (i.e. don't override name if
  it exists).

* Removes unnecessary "Module" arguments in class NameApplier (it is already a field).