### PR TITLE
Fix ununitailzed value_ in LexToken

### DIFF
--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -98,6 +98,8 @@ struct WastLexer::LexToken {
   Location loc_;
   int value_;
   Token lval_;
+
+  LexToken(void): value_(0) {}
 };
 
 struct WastLexer::Lookahead {


### PR DESCRIPTION
This fixes an uninitialized warning/error when compiling with c++ 7.1.1.