### PR TITLE
Fix the wat writer to be able to fold exception handling constructs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ add_library(libwabt STATIC
   src/literal.cc
   src/option-parser.cc
   src/stream.cc
+  src/tracing.cc
   src/utf8.cc
   src/writer.cc
 )

--- a/src/cast.h
+++ b/src/cast.h
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_CAST_H_
+#define WABT_CAST_H_
+
+#include <type_traits>
+
+#include "common.h"
+
+// Modeled after LLVM's dynamic casts:
+// http://llvm.org/docs/ProgrammersManual.html#the-isa-cast-and-dyn-cast-templates
+//
+// Use isa<T>(foo) to check whether foo is a T*:
+//
+//     if (isa<Minivan>(car)) {
+//        ...
+//     }
+//
+// Use cast<T>(foo) when you know that foo is a T* -- it will assert that the
+// type matches:
+//
+//     switch (car.type) {
+//       case CarType::Minivan: {
+//         auto minivan = cast<Minivan>(car);
+//         ...
+//       }
+//     }
+//
+// Use dyn_cast<T>(foo) as a combination if isa and cast, it will return
+// nullptr if the type doesn't match:
+//
+//     if (auto minivan = dyn_cast<Minivan>(car)) {
+//       ...
+//     }
+//
+//
+// To use these classes in a type hierarchy, you must implement classof:
+//
+//     enum CarType { Minivan, ... };
+//     struct Car { CarType type; ... };
+//     struct Minivan : Car {
+//       static bool classof(const Car* car) { return car->type == Minivan; }
+//       ...
+//     };
+//
+
+namespace wabt {
+
+template <typename Derived, typename Base>
+bool isa(const Base* base) {
+  WABT_STATIC_ASSERT((std::is_base_of<Base, Derived>::value));
+  return Derived::classof(base);
+}
+
+template <typename Derived, typename Base>
+const Derived* cast(const Base* base) {
+  assert(isa<Derived>(base));
+  return static_cast<const Derived*>(base);
+};
+
+template <typename Derived, typename Base>
+Derived* cast(Base* base) {
+  assert(isa<Derived>(base));
+  return static_cast<Derived*>(base);
+};
+
+template <typename Derived, typename Base>
+const Derived* dyn_cast(const Base* base) {
+  return isa<Derived>(base) ? static_cast<const Derived*>(base) : nullptr;
+};
+
+template <typename Derived, typename Base>
+Derived* dyn_cast(Base* base) {
+  return isa<Derived>(base) ? static_cast<Derived*>(base) : nullptr;
+};
+
+} // namespace wabt
+
+#endif // WABT_CAST_H_

--- a/src/common.cc
+++ b/src/common.cc
@@ -31,6 +31,12 @@
 
 namespace wabt {
 
+Location EmptyLocation() {
+  Location result;
+  WABT_ZERO_MEMORY(result);
+  return result;
+}
+
 Reloc::Reloc(RelocType type, Offset offset, Index index, int32_t addend)
     : type(type), offset(offset), index(index), addend(addend) {}
 

--- a/src/common.h
+++ b/src/common.h
@@ -164,6 +164,10 @@ struct Location {
   };
 };
 
+// TODO(binji): This should be a default constructor, but can't currently; see
+// comment above.
+Location EmptyLocation();
+
 /* matches binary format, do not change */
 enum class Type {
   I32 = -0x01,

--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -16,6 +16,7 @@
 
 #include "expr-visitor.h"
 
+#include "cast.h"
 #include "ir.h"
 
 #define CHECK_RESULT(expr)   \
@@ -31,11 +32,11 @@ ExprVisitor::ExprVisitor(Delegate* delegate) : delegate_(delegate) {}
 Result ExprVisitor::VisitExpr(Expr* expr) {
   switch (expr->type) {
     case ExprType::Binary:
-      CHECK_RESULT(delegate_->OnBinaryExpr(expr->As<BinaryExpr>()));
+      CHECK_RESULT(delegate_->OnBinaryExpr(cast<BinaryExpr>(expr)));
       break;
 
     case ExprType::Block: {
-      auto block_expr = expr->As<BlockExpr>();
+      auto block_expr = cast<BlockExpr>(expr);
       CHECK_RESULT(delegate_->BeginBlockExpr(block_expr));
       CHECK_RESULT(VisitExprList(block_expr->block->first));
       CHECK_RESULT(delegate_->EndBlockExpr(block_expr));
@@ -43,60 +44,60 @@ Result ExprVisitor::VisitExpr(Expr* expr) {
     }
 
     case ExprType::Br:
-      CHECK_RESULT(delegate_->OnBrExpr(expr->As<BrExpr>()));
+      CHECK_RESULT(delegate_->OnBrExpr(cast<BrExpr>(expr)));
       break;
 
     case ExprType::BrIf:
-      CHECK_RESULT(delegate_->OnBrIfExpr(expr->As<BrIfExpr>()));
+      CHECK_RESULT(delegate_->OnBrIfExpr(cast<BrIfExpr>(expr)));
       break;
 
     case ExprType::BrTable:
-      CHECK_RESULT(delegate_->OnBrTableExpr(expr->As<BrTableExpr>()));
+      CHECK_RESULT(delegate_->OnBrTableExpr(cast<BrTableExpr>(expr)));
       break;
 
     case ExprType::Call:
-      CHECK_RESULT(delegate_->OnCallExpr(expr->As<CallExpr>()));
+      CHECK_RESULT(delegate_->OnCallExpr(cast<CallExpr>(expr)));
       break;
 
     case ExprType::CallIndirect:
-      CHECK_RESULT(delegate_->OnCallIndirectExpr(expr->As<CallIndirectExpr>()));
+      CHECK_RESULT(delegate_->OnCallIndirectExpr(cast<CallIndirectExpr>(expr)));
       break;
 
     case ExprType::Compare:
-      CHECK_RESULT(delegate_->OnCompareExpr(expr->As<CompareExpr>()));
+      CHECK_RESULT(delegate_->OnCompareExpr(cast<CompareExpr>(expr)));
       break;
 
     case ExprType::Const:
-      CHECK_RESULT(delegate_->OnConstExpr(expr->As<ConstExpr>()));
+      CHECK_RESULT(delegate_->OnConstExpr(cast<ConstExpr>(expr)));
       break;
 
     case ExprType::Convert:
-      CHECK_RESULT(delegate_->OnConvertExpr(expr->As<ConvertExpr>()));
+      CHECK_RESULT(delegate_->OnConvertExpr(cast<ConvertExpr>(expr)));
       break;
 
     case ExprType::CurrentMemory:
       CHECK_RESULT(
-          delegate_->OnCurrentMemoryExpr(expr->As<CurrentMemoryExpr>()));
+          delegate_->OnCurrentMemoryExpr(cast<CurrentMemoryExpr>(expr)));
       break;
 
     case ExprType::Drop:
-      CHECK_RESULT(delegate_->OnDropExpr(expr->As<DropExpr>()));
+      CHECK_RESULT(delegate_->OnDropExpr(cast<DropExpr>(expr)));
       break;
 
     case ExprType::GetGlobal:
-      CHECK_RESULT(delegate_->OnGetGlobalExpr(expr->As<GetGlobalExpr>()));
+      CHECK_RESULT(delegate_->OnGetGlobalExpr(cast<GetGlobalExpr>(expr)));
       break;
 
     case ExprType::GetLocal:
-      CHECK_RESULT(delegate_->OnGetLocalExpr(expr->As<GetLocalExpr>()));
+      CHECK_RESULT(delegate_->OnGetLocalExpr(cast<GetLocalExpr>(expr)));
       break;
 
     case ExprType::GrowMemory:
-      CHECK_RESULT(delegate_->OnGrowMemoryExpr(expr->As<GrowMemoryExpr>()));
+      CHECK_RESULT(delegate_->OnGrowMemoryExpr(cast<GrowMemoryExpr>(expr)));
       break;
 
     case ExprType::If: {
-      auto if_expr = expr->As<IfExpr>();
+      auto if_expr = cast<IfExpr>(expr);
       CHECK_RESULT(delegate_->BeginIfExpr(if_expr));
       CHECK_RESULT(VisitExprList(if_expr->true_->first));
       CHECK_RESULT(delegate_->AfterIfTrueExpr(if_expr));
@@ -106,11 +107,11 @@ Result ExprVisitor::VisitExpr(Expr* expr) {
     }
 
     case ExprType::Load:
-      CHECK_RESULT(delegate_->OnLoadExpr(expr->As<LoadExpr>()));
+      CHECK_RESULT(delegate_->OnLoadExpr(cast<LoadExpr>(expr)));
       break;
 
     case ExprType::Loop: {
-      auto loop_expr = expr->As<LoopExpr>();
+      auto loop_expr = cast<LoopExpr>(expr);
       CHECK_RESULT(delegate_->BeginLoopExpr(loop_expr));
       CHECK_RESULT(VisitExprList(loop_expr->block->first));
       CHECK_RESULT(delegate_->EndLoopExpr(loop_expr));
@@ -118,43 +119,43 @@ Result ExprVisitor::VisitExpr(Expr* expr) {
     }
 
     case ExprType::Nop:
-      CHECK_RESULT(delegate_->OnNopExpr(expr->As<NopExpr>()));
+      CHECK_RESULT(delegate_->OnNopExpr(cast<NopExpr>(expr)));
       break;
 
     case ExprType::Rethrow:
-      CHECK_RESULT(delegate_->OnRethrowExpr(expr->As<RethrowExpr>()));
+      CHECK_RESULT(delegate_->OnRethrowExpr(cast<RethrowExpr>(expr)));
       break;
 
     case ExprType::Return:
-      CHECK_RESULT(delegate_->OnReturnExpr(expr->As<ReturnExpr>()));
+      CHECK_RESULT(delegate_->OnReturnExpr(cast<ReturnExpr>(expr)));
       break;
 
     case ExprType::Select:
-      CHECK_RESULT(delegate_->OnSelectExpr(expr->As<SelectExpr>()));
+      CHECK_RESULT(delegate_->OnSelectExpr(cast<SelectExpr>(expr)));
       break;
 
     case ExprType::SetGlobal:
-      CHECK_RESULT(delegate_->OnSetGlobalExpr(expr->As<SetGlobalExpr>()));
+      CHECK_RESULT(delegate_->OnSetGlobalExpr(cast<SetGlobalExpr>(expr)));
       break;
 
     case ExprType::SetLocal:
-      CHECK_RESULT(delegate_->OnSetLocalExpr(expr->As<SetLocalExpr>()));
+      CHECK_RESULT(delegate_->OnSetLocalExpr(cast<SetLocalExpr>(expr)));
       break;
 
     case ExprType::Store:
-      CHECK_RESULT(delegate_->OnStoreExpr(expr->As<StoreExpr>()));
+      CHECK_RESULT(delegate_->OnStoreExpr(cast<StoreExpr>(expr)));
       break;
 
     case ExprType::TeeLocal:
-      CHECK_RESULT(delegate_->OnTeeLocalExpr(expr->As<TeeLocalExpr>()));
+      CHECK_RESULT(delegate_->OnTeeLocalExpr(cast<TeeLocalExpr>(expr)));
       break;
 
     case ExprType::Throw:
-      CHECK_RESULT(delegate_->OnThrowExpr(expr->As<ThrowExpr>()));
+      CHECK_RESULT(delegate_->OnThrowExpr(cast<ThrowExpr>(expr)));
       break;
 
     case ExprType::TryBlock: {
-      auto try_expr = expr->As<TryExpr>();
+      auto try_expr = cast<TryExpr>(expr);
       CHECK_RESULT(delegate_->BeginTryExpr(try_expr));
       CHECK_RESULT(VisitExprList(try_expr->block->first));
       for (Catch* catch_ : try_expr->catches) {
@@ -166,11 +167,11 @@ Result ExprVisitor::VisitExpr(Expr* expr) {
     }
 
     case ExprType::Unary:
-      CHECK_RESULT(delegate_->OnUnaryExpr(expr->As<UnaryExpr>()));
+      CHECK_RESULT(delegate_->OnUnaryExpr(cast<UnaryExpr>(expr)));
       break;
 
     case ExprType::Unreachable:
-      CHECK_RESULT(delegate_->OnUnreachableExpr(expr->As<UnreachableExpr>()));
+      CHECK_RESULT(delegate_->OnUnreachableExpr(cast<UnreachableExpr>(expr)));
       break;
   }
 

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -21,7 +21,7 @@
 
 namespace {
 
-const char* ExprTypeName[size_t(wabt::ExprType::Unreachable) + 1] = {
+const char* ExprTypeName[] = {
   "Binary",
   "Block",
   "Br",
@@ -59,8 +59,7 @@ const char* ExprTypeName[size_t(wabt::ExprType::Unreachable) + 1] = {
 namespace wabt {
 
 const char* GetExprTypeName(ExprType type) {
-  static_assert(size_t(ExprType::Unreachable) + 1
-                == WABT_ARRAY_SIZE(ExprTypeName),
+  static_assert(WABT_ENUM_COUNT(ExprType) == WABT_ARRAY_SIZE(ExprTypeName),
                 "Malformed ExprTypeName array");
   return ExprTypeName[size_t(type)];
 }

--- a/src/ir.h
+++ b/src/ir.h
@@ -119,7 +119,10 @@ enum class ExprType {
   Throw,
   TryBlock,
   Unary,
-  Unreachable,  // Unreachable must appear last
+  Unreachable,
+
+  First = Binary,
+  Last = Unreachable
 };
 
 const char* GetExprTypeName(ExprType type);

--- a/src/prebuilt/wast-lexer-gen.cc
+++ b/src/prebuilt/wast-lexer-gen.cc
@@ -100,6 +100,8 @@ struct WastLexer::LexToken {
   Location loc_;
   int value_;
   Token lval_;
+
+  LexToken(void): value_(0) {}
 };
 
 struct WastLexer::Lookahead {
@@ -261,7 +263,7 @@ Result WastLexer::Fill(Location* loc, WastParser* parser, size_t need) {
 }
 
 int WastLexer::GetToken(Token* lval, Location* loc, WastParser* parser) {
-#line 265 "src/prebuilt/wast-lexer-gen.cc"
+#line 267 "src/prebuilt/wast-lexer-gen.cc"
 
 enum YYCONDTYPE {
 	YYCOND_i,
@@ -270,7 +272,7 @@ enum YYCONDTYPE {
 	YYCOND_BLOCK_COMMENT,
 };
 
-#line 262 "src/wast-lexer.cc"
+#line 264 "src/wast-lexer.cc"
   YYCONDTYPE cond = YYCOND_i;  // i is the initial state.
 
   if (!lookahead_->tokens_.empty()) {
@@ -282,7 +284,7 @@ enum YYCONDTYPE {
   for (;;) {
     next_pos_ = cursor_;
     
-#line 286 "src/prebuilt/wast-lexer-gen.cc"
+#line 288 "src/prebuilt/wast-lexer-gen.cc"
 {
 	unsigned char yych;
 	unsigned int yyaccept = 0;
@@ -327,29 +329,29 @@ YYCOND_BAD_TEXT:
 	}
 	++cursor_;
 yy4:
-#line 327 "src/wast-lexer.cc"
+#line 329 "src/wast-lexer.cc"
 	{ ERROR("illegal character in string");
                                   continue; }
-#line 334 "src/prebuilt/wast-lexer-gen.cc"
+#line 336 "src/prebuilt/wast-lexer-gen.cc"
 yy5:
 	++cursor_;
 	BEGIN(YYCOND_i);
-#line 320 "src/wast-lexer.cc"
+#line 322 "src/wast-lexer.cc"
 	{ ERROR("newline in string");
                                   NEWLINE;
                                   continue; }
-#line 342 "src/prebuilt/wast-lexer-gen.cc"
+#line 344 "src/prebuilt/wast-lexer-gen.cc"
 yy7:
 	++cursor_;
-#line 319 "src/wast-lexer.cc"
+#line 321 "src/wast-lexer.cc"
 	{ continue; }
-#line 347 "src/prebuilt/wast-lexer-gen.cc"
+#line 349 "src/prebuilt/wast-lexer-gen.cc"
 yy9:
 	++cursor_;
 	BEGIN(YYCOND_i);
-#line 326 "src/wast-lexer.cc"
+#line 328 "src/wast-lexer.cc"
 	{ SetText(); RETURN(TEXT); }
-#line 353 "src/prebuilt/wast-lexer-gen.cc"
+#line 355 "src/prebuilt/wast-lexer-gen.cc"
 yy11:
 	yyaccept = 0;
 	yych = *(marker_ = ++cursor_);
@@ -401,9 +403,9 @@ yy11:
 yy12:
 	++cursor_;
 yy13:
-#line 329 "src/wast-lexer.cc"
+#line 331 "src/wast-lexer.cc"
 	{ MAYBE_MALFORMED_UTF8(" in string"); }
-#line 407 "src/prebuilt/wast-lexer-gen.cc"
+#line 409 "src/prebuilt/wast-lexer-gen.cc"
 yy14:
 	yych = *++cursor_;
 	if (yych <= 0x7F) goto yy13;
@@ -442,11 +444,11 @@ yy19:
 yy20:
 	++cursor_;
 yy21:
-#line 323 "src/wast-lexer.cc"
+#line 325 "src/wast-lexer.cc"
 	{ ERROR("bad escape \"%.*s\"",
                                         static_cast<int>(yyleng), yytext);
                                   continue; }
-#line 450 "src/prebuilt/wast-lexer-gen.cc"
+#line 452 "src/prebuilt/wast-lexer-gen.cc"
 yy22:
 	yych = *++cursor_;
 	if (yych <= '@') {
@@ -532,14 +534,14 @@ YYCOND_BLOCK_COMMENT:
 yy34:
 	++cursor_;
 yy35:
-#line 558 "src/wast-lexer.cc"
+#line 560 "src/wast-lexer.cc"
 	{ continue; }
-#line 538 "src/prebuilt/wast-lexer-gen.cc"
+#line 540 "src/prebuilt/wast-lexer-gen.cc"
 yy36:
 	++cursor_;
-#line 557 "src/wast-lexer.cc"
+#line 559 "src/wast-lexer.cc"
 	{ NEWLINE; continue; }
-#line 543 "src/prebuilt/wast-lexer-gen.cc"
+#line 545 "src/prebuilt/wast-lexer-gen.cc"
 yy38:
 	yych = *++cursor_;
 	if (yych == ';') goto yy48;
@@ -551,9 +553,9 @@ yy39:
 yy40:
 	++cursor_;
 yy41:
-#line 559 "src/wast-lexer.cc"
+#line 561 "src/wast-lexer.cc"
 	{ MAYBE_MALFORMED_UTF8(" in block comment"); }
-#line 557 "src/prebuilt/wast-lexer-gen.cc"
+#line 559 "src/prebuilt/wast-lexer-gen.cc"
 yy42:
 	yych = *++cursor_;
 	if (yych <= 0x7F) goto yy41;
@@ -586,16 +588,16 @@ yy47:
 	goto yy41;
 yy48:
 	++cursor_;
-#line 553 "src/wast-lexer.cc"
+#line 555 "src/wast-lexer.cc"
 	{ COMMENT_NESTING++; continue; }
-#line 592 "src/prebuilt/wast-lexer-gen.cc"
+#line 594 "src/prebuilt/wast-lexer-gen.cc"
 yy50:
 	++cursor_;
-#line 554 "src/wast-lexer.cc"
+#line 556 "src/wast-lexer.cc"
 	{ if (--COMMENT_NESTING == 0)
                                     BEGIN(YYCOND_i);
                                   continue; }
-#line 599 "src/prebuilt/wast-lexer-gen.cc"
+#line 601 "src/prebuilt/wast-lexer-gen.cc"
 yy52:
 	yych = *++cursor_;
 	if (yych <= 0x7F) goto yy53;
@@ -684,21 +686,21 @@ yy57:
 			if (yych <= 0xF4) goto yy76;
 		}
 yy59:
-#line 551 "src/wast-lexer.cc"
+#line 553 "src/wast-lexer.cc"
 		{ continue; }
-#line 690 "src/prebuilt/wast-lexer-gen.cc"
+#line 692 "src/prebuilt/wast-lexer-gen.cc"
 yy60:
 		++cursor_;
 		BEGIN(YYCOND_i);
-#line 550 "src/wast-lexer.cc"
+#line 552 "src/wast-lexer.cc"
 		{ NEWLINE; continue; }
-#line 696 "src/prebuilt/wast-lexer-gen.cc"
+#line 698 "src/prebuilt/wast-lexer-gen.cc"
 yy62:
 		++cursor_;
 yy63:
-#line 566 "src/wast-lexer.cc"
+#line 568 "src/wast-lexer.cc"
 		{ MAYBE_MALFORMED_UTF8(""); }
-#line 702 "src/prebuilt/wast-lexer-gen.cc"
+#line 704 "src/prebuilt/wast-lexer-gen.cc"
 yy64:
 		yych = *++cursor_;
 		if (yych <= 0x7F) goto yy63;
@@ -919,9 +921,9 @@ YYCOND_i:
 yy79:
 		++cursor_;
 yy80:
-#line 565 "src/wast-lexer.cc"
+#line 567 "src/wast-lexer.cc"
 		{ ERROR("unexpected char"); continue; }
-#line 925 "src/prebuilt/wast-lexer-gen.cc"
+#line 927 "src/prebuilt/wast-lexer-gen.cc"
 yy81:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -929,14 +931,14 @@ yy81:
 		if (yybm[0+yych] & 4) {
 			goto yy81;
 		}
-#line 561 "src/wast-lexer.cc"
+#line 563 "src/wast-lexer.cc"
 		{ continue; }
-#line 935 "src/prebuilt/wast-lexer-gen.cc"
+#line 937 "src/prebuilt/wast-lexer-gen.cc"
 yy84:
 		++cursor_;
-#line 560 "src/wast-lexer.cc"
+#line 562 "src/wast-lexer.cc"
 		{ NEWLINE; continue; }
-#line 940 "src/prebuilt/wast-lexer-gen.cc"
+#line 942 "src/prebuilt/wast-lexer-gen.cc"
 yy86:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -946,11 +948,11 @@ yy87:
 			goto yy86;
 		}
 yy88:
-#line 562 "src/wast-lexer.cc"
+#line 564 "src/wast-lexer.cc"
 		{ ERROR("unexpected token \"%.*s\"",
                                         static_cast<int>(yyleng), yytext);
                                   continue; }
-#line 954 "src/prebuilt/wast-lexer-gen.cc"
+#line 956 "src/prebuilt/wast-lexer-gen.cc"
 yy89:
 		yyaccept = 0;
 		yych = *(marker_ = ++cursor_);
@@ -960,9 +962,9 @@ yy89:
 		if (yych <= 0xF4) goto yy129;
 yy90:
 		BEGIN(YYCOND_BAD_TEXT);
-#line 318 "src/wast-lexer.cc"
+#line 320 "src/wast-lexer.cc"
 		{ continue; }
-#line 966 "src/prebuilt/wast-lexer-gen.cc"
+#line 968 "src/prebuilt/wast-lexer-gen.cc"
 yy91:
 		yych = *++cursor_;
 		if (yych <= '\'') {
@@ -982,14 +984,14 @@ yy91:
 yy92:
 		++cursor_;
 		if ((yych = *cursor_) == ';') goto yy143;
-#line 309 "src/wast-lexer.cc"
+#line 311 "src/wast-lexer.cc"
 		{ LOOKAHEAD(LPAR); }
-#line 988 "src/prebuilt/wast-lexer-gen.cc"
+#line 990 "src/prebuilt/wast-lexer-gen.cc"
 yy94:
 		++cursor_;
-#line 310 "src/wast-lexer.cc"
+#line 312 "src/wast-lexer.cc"
 		{ RETURN(RPAR); }
-#line 993 "src/prebuilt/wast-lexer-gen.cc"
+#line 995 "src/prebuilt/wast-lexer-gen.cc"
 yy96:
 		yych = *++cursor_;
 		if (yych <= 'h') {
@@ -1032,9 +1034,9 @@ yy97:
 			}
 		}
 yy98:
-#line 311 "src/wast-lexer.cc"
+#line 313 "src/wast-lexer.cc"
 		{ LITERAL(Int); RETURN(NAT); }
-#line 1038 "src/prebuilt/wast-lexer-gen.cc"
+#line 1040 "src/prebuilt/wast-lexer-gen.cc"
 yy99:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
@@ -1204,9 +1206,9 @@ yy119:
 yy120:
 		++cursor_;
 yy121:
-#line 566 "src/wast-lexer.cc"
+#line 568 "src/wast-lexer.cc"
 		{ MAYBE_MALFORMED_UTF8(""); }
-#line 1210 "src/prebuilt/wast-lexer-gen.cc"
+#line 1212 "src/prebuilt/wast-lexer-gen.cc"
 yy122:
 		yych = *++cursor_;
 		if (yych <= 0x7F) goto yy121;
@@ -1276,9 +1278,9 @@ yy130:
 		}
 yy131:
 		++cursor_;
-#line 317 "src/wast-lexer.cc"
+#line 319 "src/wast-lexer.cc"
 		{ SetText(); RETURN(TEXT); }
-#line 1282 "src/prebuilt/wast-lexer-gen.cc"
+#line 1284 "src/prebuilt/wast-lexer-gen.cc"
 yy133:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -1373,15 +1375,15 @@ yy141:
 		if (yych <= ';') goto yy142;
 		if (yych <= '}') goto yy86;
 yy142:
-#line 547 "src/wast-lexer.cc"
+#line 549 "src/wast-lexer.cc"
 		{ SetText(); RETURN(VAR); }
-#line 1379 "src/prebuilt/wast-lexer-gen.cc"
+#line 1381 "src/prebuilt/wast-lexer-gen.cc"
 yy143:
 		++cursor_;
 		BEGIN(YYCOND_BLOCK_COMMENT);
-#line 552 "src/wast-lexer.cc"
+#line 554 "src/wast-lexer.cc"
 		{ COMMENT_NESTING = 1; continue; }
-#line 1385 "src/prebuilt/wast-lexer-gen.cc"
+#line 1387 "src/prebuilt/wast-lexer-gen.cc"
 yy145:
 		++cursor_;
 		if ((yych = *cursor_) <= '9') {
@@ -1416,9 +1418,9 @@ yy145:
 			}
 		}
 yy146:
-#line 312 "src/wast-lexer.cc"
+#line 314 "src/wast-lexer.cc"
 		{ LITERAL(Int); RETURN(INT); }
-#line 1422 "src/prebuilt/wast-lexer-gen.cc"
+#line 1424 "src/prebuilt/wast-lexer-gen.cc"
 yy147:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
@@ -1481,9 +1483,9 @@ yy151:
 			}
 		}
 yy153:
-#line 313 "src/wast-lexer.cc"
+#line 315 "src/wast-lexer.cc"
 		{ LITERAL(Float); RETURN(FLOAT); }
-#line 1487 "src/prebuilt/wast-lexer-gen.cc"
+#line 1489 "src/prebuilt/wast-lexer-gen.cc"
 yy154:
 		yych = *++cursor_;
 		if (yych <= ',') {
@@ -1504,9 +1506,9 @@ yy155:
 yy156:
 		++cursor_;
 		BEGIN(YYCOND_LINE_COMMENT);
-#line 549 "src/wast-lexer.cc"
+#line 551 "src/wast-lexer.cc"
 		{ continue; }
-#line 1510 "src/prebuilt/wast-lexer-gen.cc"
+#line 1512 "src/prebuilt/wast-lexer-gen.cc"
 yy158:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy212;
@@ -1545,9 +1547,9 @@ yy163:
 			}
 		}
 yy164:
-#line 342 "src/wast-lexer.cc"
+#line 344 "src/wast-lexer.cc"
 		{ RETURN(BR); }
-#line 1551 "src/prebuilt/wast-lexer-gen.cc"
+#line 1553 "src/prebuilt/wast-lexer-gen.cc"
 yy165:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy218;
@@ -1616,9 +1618,9 @@ yy180:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 338 "src/wast-lexer.cc"
+#line 340 "src/wast-lexer.cc"
 		{ RETURN(IF); }
-#line 1622 "src/prebuilt/wast-lexer-gen.cc"
+#line 1624 "src/prebuilt/wast-lexer-gen.cc"
 yy182:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy242;
@@ -1862,9 +1864,9 @@ yy225:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 348 "src/wast-lexer.cc"
+#line 350 "src/wast-lexer.cc"
 		{ RETURN(END); }
-#line 1868 "src/prebuilt/wast-lexer-gen.cc"
+#line 1870 "src/prebuilt/wast-lexer-gen.cc"
 yy227:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy297;
@@ -1892,9 +1894,9 @@ yy229:
 			}
 		}
 yy230:
-#line 332 "src/wast-lexer.cc"
+#line 334 "src/wast-lexer.cc"
 		{ TYPE(F32); RETURN(VALUE_TYPE); }
-#line 1898 "src/prebuilt/wast-lexer-gen.cc"
+#line 1900 "src/prebuilt/wast-lexer-gen.cc"
 yy231:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
@@ -1914,9 +1916,9 @@ yy231:
 			}
 		}
 yy232:
-#line 333 "src/wast-lexer.cc"
+#line 335 "src/wast-lexer.cc"
 		{ TYPE(F64); RETURN(VALUE_TYPE); }
-#line 1920 "src/prebuilt/wast-lexer-gen.cc"
+#line 1922 "src/prebuilt/wast-lexer-gen.cc"
 yy233:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy301;
@@ -1939,9 +1941,9 @@ yy234:
 			}
 		}
 yy235:
-#line 531 "src/wast-lexer.cc"
+#line 533 "src/wast-lexer.cc"
 		{ RETURN(GET); }
-#line 1945 "src/prebuilt/wast-lexer-gen.cc"
+#line 1947 "src/prebuilt/wast-lexer-gen.cc"
 yy236:
 		yych = *++cursor_;
 		if (yych == 'b') goto yy304;
@@ -1969,9 +1971,9 @@ yy238:
 			}
 		}
 yy239:
-#line 330 "src/wast-lexer.cc"
+#line 332 "src/wast-lexer.cc"
 		{ TYPE(I32); RETURN(VALUE_TYPE); }
-#line 1975 "src/prebuilt/wast-lexer-gen.cc"
+#line 1977 "src/prebuilt/wast-lexer-gen.cc"
 yy240:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
@@ -1991,9 +1993,9 @@ yy240:
 			}
 		}
 yy241:
-#line 331 "src/wast-lexer.cc"
+#line 333 "src/wast-lexer.cc"
 		{ TYPE(I64); RETURN(VALUE_TYPE); }
-#line 1997 "src/prebuilt/wast-lexer-gen.cc"
+#line 1999 "src/prebuilt/wast-lexer-gen.cc"
 yy242:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy308;
@@ -2003,9 +2005,9 @@ yy243:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 315 "src/wast-lexer.cc"
+#line 317 "src/wast-lexer.cc"
 		{ LITERAL(Infinity); RETURN(FLOAT); }
-#line 2009 "src/prebuilt/wast-lexer-gen.cc"
+#line 2011 "src/prebuilt/wast-lexer-gen.cc"
 yy245:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy309;
@@ -2031,9 +2033,9 @@ yy250:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 335 "src/wast-lexer.cc"
+#line 337 "src/wast-lexer.cc"
 		{ RETURN(MUT); }
-#line 2037 "src/prebuilt/wast-lexer-gen.cc"
+#line 2039 "src/prebuilt/wast-lexer-gen.cc"
 yy252:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
@@ -2053,17 +2055,17 @@ yy252:
 			}
 		}
 yy253:
-#line 316 "src/wast-lexer.cc"
+#line 318 "src/wast-lexer.cc"
 		{ LITERAL(Nan); RETURN(FLOAT); }
-#line 2059 "src/prebuilt/wast-lexer-gen.cc"
+#line 2061 "src/prebuilt/wast-lexer-gen.cc"
 yy254:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 336 "src/wast-lexer.cc"
+#line 338 "src/wast-lexer.cc"
 		{ RETURN(NOP); }
-#line 2067 "src/prebuilt/wast-lexer-gen.cc"
+#line 2069 "src/prebuilt/wast-lexer-gen.cc"
 yy256:
 		yych = *++cursor_;
 		if (yych == 's') goto yy316;
@@ -2122,9 +2124,9 @@ yy269:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 542 "src/wast-lexer.cc"
+#line 544 "src/wast-lexer.cc"
 		{ RETURN(TRY); }
-#line 2128 "src/prebuilt/wast-lexer-gen.cc"
+#line 2130 "src/prebuilt/wast-lexer-gen.cc"
 yy271:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy331;
@@ -2262,9 +2264,9 @@ yy285:
 			}
 		}
 yy286:
-#line 345 "src/wast-lexer.cc"
+#line 347 "src/wast-lexer.cc"
 		{ RETURN(CALL); }
-#line 2268 "src/prebuilt/wast-lexer-gen.cc"
+#line 2270 "src/prebuilt/wast-lexer-gen.cc"
 yy287:
 		yych = *++cursor_;
 		if (yych == 'h') goto yy348;
@@ -2278,33 +2280,33 @@ yy289:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 524 "src/wast-lexer.cc"
+#line 526 "src/wast-lexer.cc"
 		{ RETURN(DATA); }
-#line 2284 "src/prebuilt/wast-lexer-gen.cc"
+#line 2286 "src/prebuilt/wast-lexer-gen.cc"
 yy291:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 347 "src/wast-lexer.cc"
+#line 349 "src/wast-lexer.cc"
 		{ RETURN(DROP); }
-#line 2292 "src/prebuilt/wast-lexer-gen.cc"
+#line 2294 "src/prebuilt/wast-lexer-gen.cc"
 yy293:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 523 "src/wast-lexer.cc"
+#line 525 "src/wast-lexer.cc"
 		{ RETURN(ELEM); }
-#line 2300 "src/prebuilt/wast-lexer-gen.cc"
+#line 2302 "src/prebuilt/wast-lexer-gen.cc"
 yy295:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 340 "src/wast-lexer.cc"
+#line 342 "src/wast-lexer.cc"
 		{ RETURN(ELSE); }
-#line 2308 "src/prebuilt/wast-lexer-gen.cc"
+#line 2310 "src/prebuilt/wast-lexer-gen.cc"
 yy297:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy351;
@@ -2353,9 +2355,9 @@ yy301:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 512 "src/wast-lexer.cc"
+#line 514 "src/wast-lexer.cc"
 		{ RETURN(FUNC); }
-#line 2359 "src/prebuilt/wast-lexer-gen.cc"
+#line 2361 "src/prebuilt/wast-lexer-gen.cc"
 yy303:
 		yych = *++cursor_;
 		if (yych == 'g') goto yy378;
@@ -2425,9 +2427,9 @@ yy311:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 341 "src/wast-lexer.cc"
+#line 343 "src/wast-lexer.cc"
 		{ RETURN(LOOP); }
-#line 2431 "src/prebuilt/wast-lexer-gen.cc"
+#line 2433 "src/prebuilt/wast-lexer-gen.cc"
 yy313:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy415;
@@ -2494,9 +2496,9 @@ yy328:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 339 "src/wast-lexer.cc"
+#line 341 "src/wast-lexer.cc"
 		{ RETURN(THEN); }
-#line 2500 "src/prebuilt/wast-lexer-gen.cc"
+#line 2502 "src/prebuilt/wast-lexer-gen.cc"
 yy330:
 		yych = *++cursor_;
 		if (yych == 'w') goto yy435;
@@ -2506,9 +2508,9 @@ yy331:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 511 "src/wast-lexer.cc"
+#line 513 "src/wast-lexer.cc"
 		{ RETURN(TYPE); }
-#line 2512 "src/prebuilt/wast-lexer-gen.cc"
+#line 2514 "src/prebuilt/wast-lexer-gen.cc"
 yy333:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy437;
@@ -2539,9 +2541,9 @@ yy335:
 			}
 		}
 yy337:
-#line 314 "src/wast-lexer.cc"
+#line 316 "src/wast-lexer.cc"
 		{ LITERAL(Hexfloat); RETURN(FLOAT); }
-#line 2545 "src/prebuilt/wast-lexer-gen.cc"
+#line 2547 "src/prebuilt/wast-lexer-gen.cc"
 yy338:
 		yych = *++cursor_;
 		if (yych == '=') goto yy438;
@@ -2563,17 +2565,17 @@ yy342:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 337 "src/wast-lexer.cc"
+#line 339 "src/wast-lexer.cc"
 		{ RETURN(BLOCK); }
-#line 2569 "src/prebuilt/wast-lexer-gen.cc"
+#line 2571 "src/prebuilt/wast-lexer-gen.cc"
 yy344:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 343 "src/wast-lexer.cc"
+#line 345 "src/wast-lexer.cc"
 		{ RETURN(BR_IF); }
-#line 2577 "src/prebuilt/wast-lexer-gen.cc"
+#line 2579 "src/prebuilt/wast-lexer-gen.cc"
 yy346:
 		yych = *++cursor_;
 		if (yych == 'b') goto yy443;
@@ -2600,9 +2602,9 @@ yy348:
 			}
 		}
 yy349:
-#line 543 "src/wast-lexer.cc"
+#line 545 "src/wast-lexer.cc"
 		{ RETURN_LPAR(CATCH); }
-#line 2606 "src/prebuilt/wast-lexer-gen.cc"
+#line 2608 "src/prebuilt/wast-lexer-gen.cc"
 yy350:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy446;
@@ -2946,9 +2948,9 @@ yy413:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 515 "src/wast-lexer.cc"
+#line 517 "src/wast-lexer.cc"
 		{ RETURN(LOCAL); }
-#line 2952 "src/prebuilt/wast-lexer-gen.cc"
+#line 2954 "src/prebuilt/wast-lexer-gen.cc"
 yy415:
 		yych = *++cursor_;
 		if (yych == 'y') goto yy570;
@@ -2970,17 +2972,17 @@ yy419:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 513 "src/wast-lexer.cc"
+#line 515 "src/wast-lexer.cc"
 		{ RETURN(PARAM); }
-#line 2976 "src/prebuilt/wast-lexer-gen.cc"
+#line 2978 "src/prebuilt/wast-lexer-gen.cc"
 yy421:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 519 "src/wast-lexer.cc"
+#line 521 "src/wast-lexer.cc"
 		{ RETURN(QUOTE); }
-#line 2984 "src/prebuilt/wast-lexer-gen.cc"
+#line 2986 "src/prebuilt/wast-lexer-gen.cc"
 yy423:
 		yych = *++cursor_;
 		if (yych == 't') goto yy577;
@@ -3014,17 +3016,17 @@ yy430:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 522 "src/wast-lexer.cc"
+#line 524 "src/wast-lexer.cc"
 		{ RETURN(START); }
-#line 3020 "src/prebuilt/wast-lexer-gen.cc"
+#line 3022 "src/prebuilt/wast-lexer-gen.cc"
 yy432:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 520 "src/wast-lexer.cc"
+#line 522 "src/wast-lexer.cc"
 		{ RETURN(TABLE); }
-#line 3028 "src/prebuilt/wast-lexer-gen.cc"
+#line 3030 "src/prebuilt/wast-lexer-gen.cc"
 yy434:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy587;
@@ -3034,9 +3036,9 @@ yy435:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 545 "src/wast-lexer.cc"
+#line 547 "src/wast-lexer.cc"
 		{ RETURN(THROW); }
-#line 3040 "src/prebuilt/wast-lexer-gen.cc"
+#line 3042 "src/prebuilt/wast-lexer-gen.cc"
 yy437:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy588;
@@ -3060,9 +3062,9 @@ yy441:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 518 "src/wast-lexer.cc"
+#line 520 "src/wast-lexer.cc"
 		{ RETURN(BIN); }
-#line 3066 "src/prebuilt/wast-lexer-gen.cc"
+#line 3068 "src/prebuilt/wast-lexer-gen.cc"
 yy443:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy596;
@@ -3084,17 +3086,17 @@ yy447:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 528 "src/wast-lexer.cc"
+#line 530 "src/wast-lexer.cc"
 		{ RETURN(EXCEPT); }
-#line 3090 "src/prebuilt/wast-lexer-gen.cc"
+#line 3092 "src/prebuilt/wast-lexer-gen.cc"
 yy449:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 527 "src/wast-lexer.cc"
+#line 529 "src/wast-lexer.cc"
 		{ RETURN(EXPORT); }
-#line 3098 "src/prebuilt/wast-lexer-gen.cc"
+#line 3100 "src/prebuilt/wast-lexer-gen.cc"
 yy451:
 		yych = *++cursor_;
 		if (yych == 's') goto yy600;
@@ -3125,9 +3127,9 @@ yy457:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 470 "src/wast-lexer.cc"
+#line 472 "src/wast-lexer.cc"
 		{ OPCODE(F32Eq); RETURN(COMPARE); }
-#line 3131 "src/prebuilt/wast-lexer-gen.cc"
+#line 3133 "src/prebuilt/wast-lexer-gen.cc"
 yy459:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy610;
@@ -3137,25 +3139,25 @@ yy460:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 480 "src/wast-lexer.cc"
+#line 482 "src/wast-lexer.cc"
 		{ OPCODE(F32Ge); RETURN(COMPARE); }
-#line 3143 "src/prebuilt/wast-lexer-gen.cc"
+#line 3145 "src/prebuilt/wast-lexer-gen.cc"
 yy462:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 478 "src/wast-lexer.cc"
+#line 480 "src/wast-lexer.cc"
 		{ OPCODE(F32Gt); RETURN(COMPARE); }
-#line 3151 "src/prebuilt/wast-lexer-gen.cc"
+#line 3153 "src/prebuilt/wast-lexer-gen.cc"
 yy464:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 476 "src/wast-lexer.cc"
+#line 478 "src/wast-lexer.cc"
 		{ OPCODE(F32Le); RETURN(COMPARE); }
-#line 3159 "src/prebuilt/wast-lexer-gen.cc"
+#line 3161 "src/prebuilt/wast-lexer-gen.cc"
 yy466:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy611;
@@ -3165,9 +3167,9 @@ yy467:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 474 "src/wast-lexer.cc"
+#line 476 "src/wast-lexer.cc"
 		{ OPCODE(F32Lt); RETURN(COMPARE); }
-#line 3171 "src/prebuilt/wast-lexer-gen.cc"
+#line 3173 "src/prebuilt/wast-lexer-gen.cc"
 yy469:
 		yych = *++cursor_;
 		if (yych == 'x') goto yy612;
@@ -3200,9 +3202,9 @@ yy472:
 			}
 		}
 yy473:
-#line 472 "src/wast-lexer.cc"
+#line 474 "src/wast-lexer.cc"
 		{ OPCODE(F32Ne); RETURN(COMPARE); }
-#line 3206 "src/prebuilt/wast-lexer-gen.cc"
+#line 3208 "src/prebuilt/wast-lexer-gen.cc"
 yy474:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy621;
@@ -3249,9 +3251,9 @@ yy484:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 471 "src/wast-lexer.cc"
+#line 473 "src/wast-lexer.cc"
 		{ OPCODE(F64Eq); RETURN(COMPARE); }
-#line 3255 "src/prebuilt/wast-lexer-gen.cc"
+#line 3257 "src/prebuilt/wast-lexer-gen.cc"
 yy486:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy636;
@@ -3261,25 +3263,25 @@ yy487:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 481 "src/wast-lexer.cc"
+#line 483 "src/wast-lexer.cc"
 		{ OPCODE(F64Ge); RETURN(COMPARE); }
-#line 3267 "src/prebuilt/wast-lexer-gen.cc"
+#line 3269 "src/prebuilt/wast-lexer-gen.cc"
 yy489:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 479 "src/wast-lexer.cc"
+#line 481 "src/wast-lexer.cc"
 		{ OPCODE(F64Gt); RETURN(COMPARE); }
-#line 3275 "src/prebuilt/wast-lexer-gen.cc"
+#line 3277 "src/prebuilt/wast-lexer-gen.cc"
 yy491:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 477 "src/wast-lexer.cc"
+#line 479 "src/wast-lexer.cc"
 		{ OPCODE(F64Le); RETURN(COMPARE); }
-#line 3283 "src/prebuilt/wast-lexer-gen.cc"
+#line 3285 "src/prebuilt/wast-lexer-gen.cc"
 yy493:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy637;
@@ -3289,9 +3291,9 @@ yy494:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 475 "src/wast-lexer.cc"
+#line 477 "src/wast-lexer.cc"
 		{ OPCODE(F64Lt); RETURN(COMPARE); }
-#line 3295 "src/prebuilt/wast-lexer-gen.cc"
+#line 3297 "src/prebuilt/wast-lexer-gen.cc"
 yy496:
 		yych = *++cursor_;
 		if (yych == 'x') goto yy638;
@@ -3324,9 +3326,9 @@ yy499:
 			}
 		}
 yy500:
-#line 473 "src/wast-lexer.cc"
+#line 475 "src/wast-lexer.cc"
 		{ OPCODE(F64Ne); RETURN(COMPARE); }
-#line 3330 "src/prebuilt/wast-lexer-gen.cc"
+#line 3332 "src/prebuilt/wast-lexer-gen.cc"
 yy501:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy647;
@@ -3364,9 +3366,9 @@ yy509:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 516 "src/wast-lexer.cc"
+#line 518 "src/wast-lexer.cc"
 		{ RETURN(GLOBAL); }
-#line 3370 "src/prebuilt/wast-lexer-gen.cc"
+#line 3372 "src/prebuilt/wast-lexer-gen.cc"
 yy511:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy656;
@@ -3413,9 +3415,9 @@ yy518:
 			}
 		}
 yy519:
-#line 450 "src/wast-lexer.cc"
+#line 452 "src/wast-lexer.cc"
 		{ OPCODE(I32Eq); RETURN(COMPARE); }
-#line 3419 "src/prebuilt/wast-lexer-gen.cc"
+#line 3421 "src/prebuilt/wast-lexer-gen.cc"
 yy520:
 		yych = *++cursor_;
 		if (yych == '_') goto yy669;
@@ -3445,17 +3447,17 @@ yy526:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 452 "src/wast-lexer.cc"
+#line 454 "src/wast-lexer.cc"
 		{ OPCODE(I32Ne); RETURN(COMPARE); }
-#line 3451 "src/prebuilt/wast-lexer-gen.cc"
+#line 3453 "src/prebuilt/wast-lexer-gen.cc"
 yy528:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 422 "src/wast-lexer.cc"
+#line 424 "src/wast-lexer.cc"
 		{ OPCODE(I32Or); RETURN(BINARY); }
-#line 3459 "src/prebuilt/wast-lexer-gen.cc"
+#line 3461 "src/prebuilt/wast-lexer-gen.cc"
 yy530:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy676;
@@ -3536,9 +3538,9 @@ yy545:
 			}
 		}
 yy546:
-#line 451 "src/wast-lexer.cc"
+#line 453 "src/wast-lexer.cc"
 		{ OPCODE(I64Eq); RETURN(COMPARE); }
-#line 3542 "src/prebuilt/wast-lexer-gen.cc"
+#line 3544 "src/prebuilt/wast-lexer-gen.cc"
 yy547:
 		yych = *++cursor_;
 		if (yych == 't') goto yy702;
@@ -3572,17 +3574,17 @@ yy554:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 453 "src/wast-lexer.cc"
+#line 455 "src/wast-lexer.cc"
 		{ OPCODE(I64Ne); RETURN(COMPARE); }
-#line 3578 "src/prebuilt/wast-lexer-gen.cc"
+#line 3580 "src/prebuilt/wast-lexer-gen.cc"
 yy556:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 423 "src/wast-lexer.cc"
+#line 425 "src/wast-lexer.cc"
 		{ OPCODE(I64Or); RETURN(BINARY); }
-#line 3586 "src/prebuilt/wast-lexer-gen.cc"
+#line 3588 "src/prebuilt/wast-lexer-gen.cc"
 yy558:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy710;
@@ -3622,33 +3624,33 @@ yy566:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 526 "src/wast-lexer.cc"
+#line 528 "src/wast-lexer.cc"
 		{ RETURN(IMPORT); }
-#line 3628 "src/prebuilt/wast-lexer-gen.cc"
+#line 3630 "src/prebuilt/wast-lexer-gen.cc"
 yy568:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 530 "src/wast-lexer.cc"
+#line 532 "src/wast-lexer.cc"
 		{ RETURN(INVOKE); }
-#line 3636 "src/prebuilt/wast-lexer-gen.cc"
+#line 3638 "src/prebuilt/wast-lexer-gen.cc"
 yy570:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 521 "src/wast-lexer.cc"
+#line 523 "src/wast-lexer.cc"
 		{ RETURN(MEMORY); }
-#line 3644 "src/prebuilt/wast-lexer-gen.cc"
+#line 3646 "src/prebuilt/wast-lexer-gen.cc"
 yy572:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 517 "src/wast-lexer.cc"
+#line 519 "src/wast-lexer.cc"
 		{ RETURN(MODULE); }
-#line 3652 "src/prebuilt/wast-lexer-gen.cc"
+#line 3654 "src/prebuilt/wast-lexer-gen.cc"
 yy574:
 		yych = *++cursor_;
 		if (yych <= '@') {
@@ -3679,9 +3681,9 @@ yy575:
 			}
 		}
 yy576:
-#line 525 "src/wast-lexer.cc"
+#line 527 "src/wast-lexer.cc"
 		{ RETURN(OFFSET); }
-#line 3685 "src/prebuilt/wast-lexer-gen.cc"
+#line 3687 "src/prebuilt/wast-lexer-gen.cc"
 yy577:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy726;
@@ -3691,9 +3693,9 @@ yy578:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 514 "src/wast-lexer.cc"
+#line 516 "src/wast-lexer.cc"
 		{ RETURN(RESULT); }
-#line 3697 "src/prebuilt/wast-lexer-gen.cc"
+#line 3699 "src/prebuilt/wast-lexer-gen.cc"
 yy580:
 		yych = *++cursor_;
 		if (yych == 'w') goto yy727;
@@ -3703,17 +3705,17 @@ yy581:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 349 "src/wast-lexer.cc"
+#line 351 "src/wast-lexer.cc"
 		{ RETURN(RETURN); }
-#line 3709 "src/prebuilt/wast-lexer-gen.cc"
+#line 3711 "src/prebuilt/wast-lexer-gen.cc"
 yy583:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 507 "src/wast-lexer.cc"
+#line 509 "src/wast-lexer.cc"
 		{ RETURN(SELECT); }
-#line 3717 "src/prebuilt/wast-lexer-gen.cc"
+#line 3719 "src/prebuilt/wast-lexer-gen.cc"
 yy585:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy729;
@@ -3749,9 +3751,9 @@ yy589:
 			}
 		}
 yy590:
-#line 379 "src/wast-lexer.cc"
+#line 381 "src/wast-lexer.cc"
 		{ SetTextAt(6); RETURN(ALIGN_EQ_NAT); }
-#line 3755 "src/prebuilt/wast-lexer-gen.cc"
+#line 3757 "src/prebuilt/wast-lexer-gen.cc"
 yy591:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -3781,9 +3783,9 @@ yy593:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 334 "src/wast-lexer.cc"
+#line 336 "src/wast-lexer.cc"
 		{ RETURN(ANYFUNC); }
-#line 3787 "src/prebuilt/wast-lexer-gen.cc"
+#line 3789 "src/prebuilt/wast-lexer-gen.cc"
 yy595:
 		yych = *++cursor_;
 		switch (yych) {
@@ -3816,17 +3818,17 @@ yy600:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 394 "src/wast-lexer.cc"
+#line 396 "src/wast-lexer.cc"
 		{ OPCODE(F32Abs); RETURN(UNARY); }
-#line 3822 "src/prebuilt/wast-lexer-gen.cc"
+#line 3824 "src/prebuilt/wast-lexer-gen.cc"
 yy602:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 436 "src/wast-lexer.cc"
+#line 438 "src/wast-lexer.cc"
 		{ OPCODE(F32Add); RETURN(BINARY); }
-#line 3830 "src/prebuilt/wast-lexer-gen.cc"
+#line 3832 "src/prebuilt/wast-lexer-gen.cc"
 yy604:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy745;
@@ -3849,9 +3851,9 @@ yy608:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 442 "src/wast-lexer.cc"
+#line 444 "src/wast-lexer.cc"
 		{ OPCODE(F32Div); RETURN(BINARY); }
-#line 3855 "src/prebuilt/wast-lexer-gen.cc"
+#line 3857 "src/prebuilt/wast-lexer-gen.cc"
 yy610:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy751;
@@ -3865,25 +3867,25 @@ yy612:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 446 "src/wast-lexer.cc"
+#line 448 "src/wast-lexer.cc"
 		{ OPCODE(F32Max); RETURN(BINARY); }
-#line 3871 "src/prebuilt/wast-lexer-gen.cc"
+#line 3873 "src/prebuilt/wast-lexer-gen.cc"
 yy614:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 444 "src/wast-lexer.cc"
+#line 446 "src/wast-lexer.cc"
 		{ OPCODE(F32Min); RETURN(BINARY); }
-#line 3879 "src/prebuilt/wast-lexer-gen.cc"
+#line 3881 "src/prebuilt/wast-lexer-gen.cc"
 yy616:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 440 "src/wast-lexer.cc"
+#line 442 "src/wast-lexer.cc"
 		{ OPCODE(F32Mul); RETURN(BINARY); }
-#line 3887 "src/prebuilt/wast-lexer-gen.cc"
+#line 3889 "src/prebuilt/wast-lexer-gen.cc"
 yy618:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy754;
@@ -3893,9 +3895,9 @@ yy619:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 392 "src/wast-lexer.cc"
+#line 394 "src/wast-lexer.cc"
 		{ OPCODE(F32Neg); RETURN(UNARY); }
-#line 3899 "src/prebuilt/wast-lexer-gen.cc"
+#line 3901 "src/prebuilt/wast-lexer-gen.cc"
 yy621:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy755;
@@ -3913,9 +3915,9 @@ yy624:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 438 "src/wast-lexer.cc"
+#line 440 "src/wast-lexer.cc"
 		{ OPCODE(F32Sub); RETURN(BINARY); }
-#line 3919 "src/prebuilt/wast-lexer-gen.cc"
+#line 3921 "src/prebuilt/wast-lexer-gen.cc"
 yy626:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy759;
@@ -3925,17 +3927,17 @@ yy627:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 395 "src/wast-lexer.cc"
+#line 397 "src/wast-lexer.cc"
 		{ OPCODE(F64Abs); RETURN(UNARY); }
-#line 3931 "src/prebuilt/wast-lexer-gen.cc"
+#line 3933 "src/prebuilt/wast-lexer-gen.cc"
 yy629:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 437 "src/wast-lexer.cc"
+#line 439 "src/wast-lexer.cc"
 		{ OPCODE(F64Add); RETURN(BINARY); }
-#line 3939 "src/prebuilt/wast-lexer-gen.cc"
+#line 3941 "src/prebuilt/wast-lexer-gen.cc"
 yy631:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy760;
@@ -3954,9 +3956,9 @@ yy634:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 443 "src/wast-lexer.cc"
+#line 445 "src/wast-lexer.cc"
 		{ OPCODE(F64Div); RETURN(BINARY); }
-#line 3960 "src/prebuilt/wast-lexer-gen.cc"
+#line 3962 "src/prebuilt/wast-lexer-gen.cc"
 yy636:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy765;
@@ -3970,25 +3972,25 @@ yy638:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 447 "src/wast-lexer.cc"
+#line 449 "src/wast-lexer.cc"
 		{ OPCODE(F64Max); RETURN(BINARY); }
-#line 3976 "src/prebuilt/wast-lexer-gen.cc"
+#line 3978 "src/prebuilt/wast-lexer-gen.cc"
 yy640:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 445 "src/wast-lexer.cc"
+#line 447 "src/wast-lexer.cc"
 		{ OPCODE(F64Min); RETURN(BINARY); }
-#line 3984 "src/prebuilt/wast-lexer-gen.cc"
+#line 3986 "src/prebuilt/wast-lexer-gen.cc"
 yy642:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 441 "src/wast-lexer.cc"
+#line 443 "src/wast-lexer.cc"
 		{ OPCODE(F64Mul); RETURN(BINARY); }
-#line 3992 "src/prebuilt/wast-lexer-gen.cc"
+#line 3994 "src/prebuilt/wast-lexer-gen.cc"
 yy644:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy768;
@@ -3998,9 +4000,9 @@ yy645:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 393 "src/wast-lexer.cc"
+#line 395 "src/wast-lexer.cc"
 		{ OPCODE(F64Neg); RETURN(UNARY); }
-#line 4004 "src/prebuilt/wast-lexer-gen.cc"
+#line 4006 "src/prebuilt/wast-lexer-gen.cc"
 yy647:
 		yych = *++cursor_;
 		if (yych == 'm') goto yy769;
@@ -4022,9 +4024,9 @@ yy651:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 439 "src/wast-lexer.cc"
+#line 441 "src/wast-lexer.cc"
 		{ OPCODE(F64Sub); RETURN(BINARY); }
-#line 4028 "src/prebuilt/wast-lexer-gen.cc"
+#line 4030 "src/prebuilt/wast-lexer-gen.cc"
 yy653:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy774;
@@ -4046,25 +4048,25 @@ yy657:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 406 "src/wast-lexer.cc"
+#line 408 "src/wast-lexer.cc"
 		{ OPCODE(I32Add); RETURN(BINARY); }
-#line 4052 "src/prebuilt/wast-lexer-gen.cc"
+#line 4054 "src/prebuilt/wast-lexer-gen.cc"
 yy659:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 420 "src/wast-lexer.cc"
+#line 422 "src/wast-lexer.cc"
 		{ OPCODE(I32And); RETURN(BINARY); }
-#line 4060 "src/prebuilt/wast-lexer-gen.cc"
+#line 4062 "src/prebuilt/wast-lexer-gen.cc"
 yy661:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 386 "src/wast-lexer.cc"
+#line 388 "src/wast-lexer.cc"
 		{ OPCODE(I32Clz); RETURN(UNARY); }
-#line 4068 "src/prebuilt/wast-lexer-gen.cc"
+#line 4070 "src/prebuilt/wast-lexer-gen.cc"
 yy663:
 		yych = *++cursor_;
 		if (yych == 's') goto yy778;
@@ -4074,9 +4076,9 @@ yy664:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 388 "src/wast-lexer.cc"
+#line 390 "src/wast-lexer.cc"
 		{ OPCODE(I32Ctz); RETURN(UNARY); }
-#line 4080 "src/prebuilt/wast-lexer-gen.cc"
+#line 4082 "src/prebuilt/wast-lexer-gen.cc"
 yy666:
 		yych = *++cursor_;
 		if (yych == '_') goto yy779;
@@ -4086,9 +4088,9 @@ yy667:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 384 "src/wast-lexer.cc"
+#line 386 "src/wast-lexer.cc"
 		{ OPCODE(I32Eqz); RETURN(CONVERT); }
-#line 4092 "src/prebuilt/wast-lexer-gen.cc"
+#line 4094 "src/prebuilt/wast-lexer-gen.cc"
 yy669:
 		yych = *++cursor_;
 		if (yych == 's') goto yy780;
@@ -4118,9 +4120,9 @@ yy674:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 410 "src/wast-lexer.cc"
+#line 412 "src/wast-lexer.cc"
 		{ OPCODE(I32Mul); RETURN(BINARY); }
-#line 4124 "src/prebuilt/wast-lexer-gen.cc"
+#line 4126 "src/prebuilt/wast-lexer-gen.cc"
 yy676:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy798;
@@ -4143,9 +4145,9 @@ yy680:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 426 "src/wast-lexer.cc"
+#line 428 "src/wast-lexer.cc"
 		{ OPCODE(I32Shl); RETURN(BINARY); }
-#line 4149 "src/prebuilt/wast-lexer-gen.cc"
+#line 4151 "src/prebuilt/wast-lexer-gen.cc"
 yy682:
 		yych = *++cursor_;
 		if (yych == '_') goto yy805;
@@ -4159,9 +4161,9 @@ yy684:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 408 "src/wast-lexer.cc"
+#line 410 "src/wast-lexer.cc"
 		{ OPCODE(I32Sub); RETURN(BINARY); }
-#line 4165 "src/prebuilt/wast-lexer-gen.cc"
+#line 4167 "src/prebuilt/wast-lexer-gen.cc"
 yy686:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy807;
@@ -4175,33 +4177,33 @@ yy688:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 424 "src/wast-lexer.cc"
+#line 426 "src/wast-lexer.cc"
 		{ OPCODE(I32Xor); RETURN(BINARY); }
-#line 4181 "src/prebuilt/wast-lexer-gen.cc"
+#line 4183 "src/prebuilt/wast-lexer-gen.cc"
 yy690:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 407 "src/wast-lexer.cc"
+#line 409 "src/wast-lexer.cc"
 		{ OPCODE(I64Add); RETURN(BINARY); }
-#line 4189 "src/prebuilt/wast-lexer-gen.cc"
+#line 4191 "src/prebuilt/wast-lexer-gen.cc"
 yy692:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 421 "src/wast-lexer.cc"
+#line 423 "src/wast-lexer.cc"
 		{ OPCODE(I64And); RETURN(BINARY); }
-#line 4197 "src/prebuilt/wast-lexer-gen.cc"
+#line 4199 "src/prebuilt/wast-lexer-gen.cc"
 yy694:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 387 "src/wast-lexer.cc"
+#line 389 "src/wast-lexer.cc"
 		{ OPCODE(I64Clz); RETURN(UNARY); }
-#line 4205 "src/prebuilt/wast-lexer-gen.cc"
+#line 4207 "src/prebuilt/wast-lexer-gen.cc"
 yy696:
 		yych = *++cursor_;
 		if (yych == 's') goto yy809;
@@ -4211,9 +4213,9 @@ yy697:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 389 "src/wast-lexer.cc"
+#line 391 "src/wast-lexer.cc"
 		{ OPCODE(I64Ctz); RETURN(UNARY); }
-#line 4217 "src/prebuilt/wast-lexer-gen.cc"
+#line 4219 "src/prebuilt/wast-lexer-gen.cc"
 yy699:
 		yych = *++cursor_;
 		if (yych == '_') goto yy810;
@@ -4223,9 +4225,9 @@ yy700:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 385 "src/wast-lexer.cc"
+#line 387 "src/wast-lexer.cc"
 		{ OPCODE(I64Eqz); RETURN(CONVERT); }
-#line 4229 "src/prebuilt/wast-lexer-gen.cc"
+#line 4231 "src/prebuilt/wast-lexer-gen.cc"
 yy702:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy811;
@@ -4259,9 +4261,9 @@ yy708:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 411 "src/wast-lexer.cc"
+#line 413 "src/wast-lexer.cc"
 		{ OPCODE(I64Mul); RETURN(BINARY); }
-#line 4265 "src/prebuilt/wast-lexer-gen.cc"
+#line 4267 "src/prebuilt/wast-lexer-gen.cc"
 yy710:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy830;
@@ -4284,9 +4286,9 @@ yy714:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 427 "src/wast-lexer.cc"
+#line 429 "src/wast-lexer.cc"
 		{ OPCODE(I64Shl); RETURN(BINARY); }
-#line 4290 "src/prebuilt/wast-lexer-gen.cc"
+#line 4292 "src/prebuilt/wast-lexer-gen.cc"
 yy716:
 		yych = *++cursor_;
 		if (yych == '_') goto yy837;
@@ -4300,9 +4302,9 @@ yy718:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 409 "src/wast-lexer.cc"
+#line 411 "src/wast-lexer.cc"
 		{ OPCODE(I64Sub); RETURN(BINARY); }
-#line 4306 "src/prebuilt/wast-lexer-gen.cc"
+#line 4308 "src/prebuilt/wast-lexer-gen.cc"
 yy720:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy839;
@@ -4312,9 +4314,9 @@ yy721:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 425 "src/wast-lexer.cc"
+#line 427 "src/wast-lexer.cc"
 		{ OPCODE(I64Xor); RETURN(BINARY); }
-#line 4318 "src/prebuilt/wast-lexer-gen.cc"
+#line 4320 "src/prebuilt/wast-lexer-gen.cc"
 yy723:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -4356,9 +4358,9 @@ yy727:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 546 "src/wast-lexer.cc"
+#line 548 "src/wast-lexer.cc"
 		{ RETURN(RETHROW); }
-#line 4362 "src/prebuilt/wast-lexer-gen.cc"
+#line 4364 "src/prebuilt/wast-lexer-gen.cc"
 yy729:
 		yych = *++cursor_;
 		if (yych == 'b') goto yy846;
@@ -4416,9 +4418,9 @@ yy740:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 344 "src/wast-lexer.cc"
+#line 346 "src/wast-lexer.cc"
 		{ RETURN(BR_TABLE); }
-#line 4422 "src/prebuilt/wast-lexer-gen.cc"
+#line 4424 "src/prebuilt/wast-lexer-gen.cc"
 yy742:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy858;
@@ -4436,9 +4438,9 @@ yy745:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 398 "src/wast-lexer.cc"
+#line 400 "src/wast-lexer.cc"
 		{ OPCODE(F32Ceil); RETURN(UNARY); }
-#line 4442 "src/prebuilt/wast-lexer-gen.cc"
+#line 4444 "src/prebuilt/wast-lexer-gen.cc"
 yy747:
 		yych = *++cursor_;
 		if (yych == 't') goto yy862;
@@ -4464,9 +4466,9 @@ yy752:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 357 "src/wast-lexer.cc"
+#line 359 "src/wast-lexer.cc"
 		{ OPCODE(F32Load); RETURN(LOAD); }
-#line 4470 "src/prebuilt/wast-lexer-gen.cc"
+#line 4472 "src/prebuilt/wast-lexer-gen.cc"
 yy754:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy869;
@@ -4480,9 +4482,9 @@ yy756:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 396 "src/wast-lexer.cc"
+#line 398 "src/wast-lexer.cc"
 		{ OPCODE(F32Sqrt); RETURN(UNARY); }
-#line 4486 "src/prebuilt/wast-lexer-gen.cc"
+#line 4488 "src/prebuilt/wast-lexer-gen.cc"
 yy758:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy871;
@@ -4496,9 +4498,9 @@ yy760:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 399 "src/wast-lexer.cc"
+#line 401 "src/wast-lexer.cc"
 		{ OPCODE(F64Ceil); RETURN(UNARY); }
-#line 4502 "src/prebuilt/wast-lexer-gen.cc"
+#line 4504 "src/prebuilt/wast-lexer-gen.cc"
 yy762:
 		yych = *++cursor_;
 		if (yych == 't') goto yy875;
@@ -4520,9 +4522,9 @@ yy766:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 358 "src/wast-lexer.cc"
+#line 360 "src/wast-lexer.cc"
 		{ OPCODE(F64Load); RETURN(LOAD); }
-#line 4526 "src/prebuilt/wast-lexer-gen.cc"
+#line 4528 "src/prebuilt/wast-lexer-gen.cc"
 yy768:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy881;
@@ -4540,9 +4542,9 @@ yy771:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 397 "src/wast-lexer.cc"
+#line 399 "src/wast-lexer.cc"
 		{ OPCODE(F64Sqrt); RETURN(UNARY); }
-#line 4546 "src/prebuilt/wast-lexer-gen.cc"
+#line 4548 "src/prebuilt/wast-lexer-gen.cc"
 yy773:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy884;
@@ -4577,49 +4579,49 @@ yy780:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 466 "src/wast-lexer.cc"
+#line 468 "src/wast-lexer.cc"
 		{ OPCODE(I32GeS); RETURN(COMPARE); }
-#line 4583 "src/prebuilt/wast-lexer-gen.cc"
+#line 4585 "src/prebuilt/wast-lexer-gen.cc"
 yy782:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 468 "src/wast-lexer.cc"
+#line 470 "src/wast-lexer.cc"
 		{ OPCODE(I32GeU); RETURN(COMPARE); }
-#line 4591 "src/prebuilt/wast-lexer-gen.cc"
+#line 4593 "src/prebuilt/wast-lexer-gen.cc"
 yy784:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 462 "src/wast-lexer.cc"
+#line 464 "src/wast-lexer.cc"
 		{ OPCODE(I32GtS); RETURN(COMPARE); }
-#line 4599 "src/prebuilt/wast-lexer-gen.cc"
+#line 4601 "src/prebuilt/wast-lexer-gen.cc"
 yy786:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 464 "src/wast-lexer.cc"
+#line 466 "src/wast-lexer.cc"
 		{ OPCODE(I32GtU); RETURN(COMPARE); }
-#line 4607 "src/prebuilt/wast-lexer-gen.cc"
+#line 4609 "src/prebuilt/wast-lexer-gen.cc"
 yy788:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 458 "src/wast-lexer.cc"
+#line 460 "src/wast-lexer.cc"
 		{ OPCODE(I32LeS); RETURN(COMPARE); }
-#line 4615 "src/prebuilt/wast-lexer-gen.cc"
+#line 4617 "src/prebuilt/wast-lexer-gen.cc"
 yy790:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 460 "src/wast-lexer.cc"
+#line 462 "src/wast-lexer.cc"
 		{ OPCODE(I32LeU); RETURN(COMPARE); }
-#line 4623 "src/prebuilt/wast-lexer-gen.cc"
+#line 4625 "src/prebuilt/wast-lexer-gen.cc"
 yy792:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
@@ -4640,25 +4642,25 @@ yy792:
 			}
 		}
 yy793:
-#line 355 "src/wast-lexer.cc"
+#line 357 "src/wast-lexer.cc"
 		{ OPCODE(I32Load); RETURN(LOAD); }
-#line 4646 "src/prebuilt/wast-lexer-gen.cc"
+#line 4648 "src/prebuilt/wast-lexer-gen.cc"
 yy794:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 454 "src/wast-lexer.cc"
+#line 456 "src/wast-lexer.cc"
 		{ OPCODE(I32LtS); RETURN(COMPARE); }
-#line 4654 "src/prebuilt/wast-lexer-gen.cc"
+#line 4656 "src/prebuilt/wast-lexer-gen.cc"
 yy796:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 456 "src/wast-lexer.cc"
+#line 458 "src/wast-lexer.cc"
 		{ OPCODE(I32LtU); RETURN(COMPARE); }
-#line 4662 "src/prebuilt/wast-lexer-gen.cc"
+#line 4664 "src/prebuilt/wast-lexer-gen.cc"
 yy798:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy900;
@@ -4677,17 +4679,17 @@ yy801:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 432 "src/wast-lexer.cc"
+#line 434 "src/wast-lexer.cc"
 		{ OPCODE(I32Rotl); RETURN(BINARY); }
-#line 4683 "src/prebuilt/wast-lexer-gen.cc"
+#line 4685 "src/prebuilt/wast-lexer-gen.cc"
 yy803:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 434 "src/wast-lexer.cc"
+#line 436 "src/wast-lexer.cc"
 		{ OPCODE(I32Rotr); RETURN(BINARY); }
-#line 4691 "src/prebuilt/wast-lexer-gen.cc"
+#line 4693 "src/prebuilt/wast-lexer-gen.cc"
 yy805:
 		yych = *++cursor_;
 		if (yych == 's') goto yy906;
@@ -4723,49 +4725,49 @@ yy812:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 467 "src/wast-lexer.cc"
+#line 469 "src/wast-lexer.cc"
 		{ OPCODE(I64GeS); RETURN(COMPARE); }
-#line 4729 "src/prebuilt/wast-lexer-gen.cc"
+#line 4731 "src/prebuilt/wast-lexer-gen.cc"
 yy814:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 469 "src/wast-lexer.cc"
+#line 471 "src/wast-lexer.cc"
 		{ OPCODE(I64GeU); RETURN(COMPARE); }
-#line 4737 "src/prebuilt/wast-lexer-gen.cc"
+#line 4739 "src/prebuilt/wast-lexer-gen.cc"
 yy816:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 463 "src/wast-lexer.cc"
+#line 465 "src/wast-lexer.cc"
 		{ OPCODE(I64GtS); RETURN(COMPARE); }
-#line 4745 "src/prebuilt/wast-lexer-gen.cc"
+#line 4747 "src/prebuilt/wast-lexer-gen.cc"
 yy818:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 465 "src/wast-lexer.cc"
+#line 467 "src/wast-lexer.cc"
 		{ OPCODE(I64GtU); RETURN(COMPARE); }
-#line 4753 "src/prebuilt/wast-lexer-gen.cc"
+#line 4755 "src/prebuilt/wast-lexer-gen.cc"
 yy820:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 459 "src/wast-lexer.cc"
+#line 461 "src/wast-lexer.cc"
 		{ OPCODE(I64LeS); RETURN(COMPARE); }
-#line 4761 "src/prebuilt/wast-lexer-gen.cc"
+#line 4763 "src/prebuilt/wast-lexer-gen.cc"
 yy822:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 461 "src/wast-lexer.cc"
+#line 463 "src/wast-lexer.cc"
 		{ OPCODE(I64LeU); RETURN(COMPARE); }
-#line 4769 "src/prebuilt/wast-lexer-gen.cc"
+#line 4771 "src/prebuilt/wast-lexer-gen.cc"
 yy824:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
@@ -4788,25 +4790,25 @@ yy824:
 			}
 		}
 yy825:
-#line 356 "src/wast-lexer.cc"
+#line 358 "src/wast-lexer.cc"
 		{ OPCODE(I64Load); RETURN(LOAD); }
-#line 4794 "src/prebuilt/wast-lexer-gen.cc"
+#line 4796 "src/prebuilt/wast-lexer-gen.cc"
 yy826:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 455 "src/wast-lexer.cc"
+#line 457 "src/wast-lexer.cc"
 		{ OPCODE(I64LtS); RETURN(COMPARE); }
-#line 4802 "src/prebuilt/wast-lexer-gen.cc"
+#line 4804 "src/prebuilt/wast-lexer-gen.cc"
 yy828:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 457 "src/wast-lexer.cc"
+#line 459 "src/wast-lexer.cc"
 		{ OPCODE(I64LtU); RETURN(COMPARE); }
-#line 4810 "src/prebuilt/wast-lexer-gen.cc"
+#line 4812 "src/prebuilt/wast-lexer-gen.cc"
 yy830:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy924;
@@ -4825,17 +4827,17 @@ yy833:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 433 "src/wast-lexer.cc"
+#line 435 "src/wast-lexer.cc"
 		{ OPCODE(I64Rotl); RETURN(BINARY); }
-#line 4831 "src/prebuilt/wast-lexer-gen.cc"
+#line 4833 "src/prebuilt/wast-lexer-gen.cc"
 yy835:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 435 "src/wast-lexer.cc"
+#line 437 "src/wast-lexer.cc"
 		{ OPCODE(I64Rotr); RETURN(BINARY); }
-#line 4839 "src/prebuilt/wast-lexer-gen.cc"
+#line 4841 "src/prebuilt/wast-lexer-gen.cc"
 yy837:
 		yych = *++cursor_;
 		if (yych == 's') goto yy930;
@@ -4868,9 +4870,9 @@ yy840:
 			}
 		}
 yy841:
-#line 378 "src/wast-lexer.cc"
+#line 380 "src/wast-lexer.cc"
 		{ SetTextAt(7); RETURN(OFFSET_EQ_NAT); }
-#line 4874 "src/prebuilt/wast-lexer-gen.cc"
+#line 4876 "src/prebuilt/wast-lexer-gen.cc"
 yy842:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -4900,9 +4902,9 @@ yy844:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 529 "src/wast-lexer.cc"
+#line 531 "src/wast-lexer.cc"
 		{ RETURN(REGISTER); }
-#line 4906 "src/prebuilt/wast-lexer-gen.cc"
+#line 4908 "src/prebuilt/wast-lexer-gen.cc"
 yy846:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy938;
@@ -4978,9 +4980,9 @@ yy859:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 544 "src/wast-lexer.cc"
+#line 546 "src/wast-lexer.cc"
 		{ RETURN_LPAR(CATCH_ALL); }
-#line 4984 "src/prebuilt/wast-lexer-gen.cc"
+#line 4986 "src/prebuilt/wast-lexer-gen.cc"
 yy861:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy951;
@@ -4990,9 +4992,9 @@ yy862:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 382 "src/wast-lexer.cc"
+#line 384 "src/wast-lexer.cc"
 		{ TYPE(F32); RETURN(CONST); }
-#line 4996 "src/prebuilt/wast-lexer-gen.cc"
+#line 4998 "src/prebuilt/wast-lexer-gen.cc"
 yy864:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy952;
@@ -5010,9 +5012,9 @@ yy867:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 400 "src/wast-lexer.cc"
+#line 402 "src/wast-lexer.cc"
 		{ OPCODE(F32Floor); RETURN(UNARY); }
-#line 5016 "src/prebuilt/wast-lexer-gen.cc"
+#line 5018 "src/prebuilt/wast-lexer-gen.cc"
 yy869:
 		yych = *++cursor_;
 		if (yych == 's') goto yy955;
@@ -5026,25 +5028,25 @@ yy871:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 361 "src/wast-lexer.cc"
+#line 363 "src/wast-lexer.cc"
 		{ OPCODE(F32Store); RETURN(STORE); }
-#line 5032 "src/prebuilt/wast-lexer-gen.cc"
+#line 5034 "src/prebuilt/wast-lexer-gen.cc"
 yy873:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 402 "src/wast-lexer.cc"
+#line 404 "src/wast-lexer.cc"
 		{ OPCODE(F32Trunc); RETURN(UNARY); }
-#line 5040 "src/prebuilt/wast-lexer-gen.cc"
+#line 5042 "src/prebuilt/wast-lexer-gen.cc"
 yy875:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 383 "src/wast-lexer.cc"
+#line 385 "src/wast-lexer.cc"
 		{ TYPE(F64); RETURN(CONST); }
-#line 5048 "src/prebuilt/wast-lexer-gen.cc"
+#line 5050 "src/prebuilt/wast-lexer-gen.cc"
 yy877:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy957;
@@ -5058,9 +5060,9 @@ yy879:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 401 "src/wast-lexer.cc"
+#line 403 "src/wast-lexer.cc"
 		{ OPCODE(F64Floor); RETURN(UNARY); }
-#line 5064 "src/prebuilt/wast-lexer-gen.cc"
+#line 5066 "src/prebuilt/wast-lexer-gen.cc"
 yy881:
 		yych = *++cursor_;
 		if (yych == 's') goto yy959;
@@ -5078,17 +5080,17 @@ yy884:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 362 "src/wast-lexer.cc"
+#line 364 "src/wast-lexer.cc"
 		{ OPCODE(F64Store); RETURN(STORE); }
-#line 5084 "src/prebuilt/wast-lexer-gen.cc"
+#line 5086 "src/prebuilt/wast-lexer-gen.cc"
 yy886:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 403 "src/wast-lexer.cc"
+#line 405 "src/wast-lexer.cc"
 		{ OPCODE(F64Trunc); RETURN(UNARY); }
-#line 5092 "src/prebuilt/wast-lexer-gen.cc"
+#line 5094 "src/prebuilt/wast-lexer-gen.cc"
 yy888:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy962;
@@ -5098,9 +5100,9 @@ yy889:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 350 "src/wast-lexer.cc"
+#line 352 "src/wast-lexer.cc"
 		{ RETURN(GET_LOCAL); }
-#line 5104 "src/prebuilt/wast-lexer-gen.cc"
+#line 5106 "src/prebuilt/wast-lexer-gen.cc"
 yy891:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy964;
@@ -5110,25 +5112,25 @@ yy892:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 380 "src/wast-lexer.cc"
+#line 382 "src/wast-lexer.cc"
 		{ TYPE(I32); RETURN(CONST); }
-#line 5116 "src/prebuilt/wast-lexer-gen.cc"
+#line 5118 "src/prebuilt/wast-lexer-gen.cc"
 yy894:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 412 "src/wast-lexer.cc"
+#line 414 "src/wast-lexer.cc"
 		{ OPCODE(I32DivS); RETURN(BINARY); }
-#line 5124 "src/prebuilt/wast-lexer-gen.cc"
+#line 5126 "src/prebuilt/wast-lexer-gen.cc"
 yy896:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 414 "src/wast-lexer.cc"
+#line 416 "src/wast-lexer.cc"
 		{ OPCODE(I32DivU); RETURN(BINARY); }
-#line 5132 "src/prebuilt/wast-lexer-gen.cc"
+#line 5134 "src/prebuilt/wast-lexer-gen.cc"
 yy898:
 		yych = *++cursor_;
 		if (yych == '6') goto yy965;
@@ -5150,33 +5152,33 @@ yy902:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 416 "src/wast-lexer.cc"
+#line 418 "src/wast-lexer.cc"
 		{ OPCODE(I32RemS); RETURN(BINARY); }
-#line 5156 "src/prebuilt/wast-lexer-gen.cc"
+#line 5158 "src/prebuilt/wast-lexer-gen.cc"
 yy904:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 418 "src/wast-lexer.cc"
+#line 420 "src/wast-lexer.cc"
 		{ OPCODE(I32RemU); RETURN(BINARY); }
-#line 5164 "src/prebuilt/wast-lexer-gen.cc"
+#line 5166 "src/prebuilt/wast-lexer-gen.cc"
 yy906:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 428 "src/wast-lexer.cc"
+#line 430 "src/wast-lexer.cc"
 		{ OPCODE(I32ShrS); RETURN(BINARY); }
-#line 5172 "src/prebuilt/wast-lexer-gen.cc"
+#line 5174 "src/prebuilt/wast-lexer-gen.cc"
 yy908:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 430 "src/wast-lexer.cc"
+#line 432 "src/wast-lexer.cc"
 		{ OPCODE(I32ShrU); RETURN(BINARY); }
-#line 5180 "src/prebuilt/wast-lexer-gen.cc"
+#line 5182 "src/prebuilt/wast-lexer-gen.cc"
 yy910:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
@@ -5197,9 +5199,9 @@ yy910:
 			}
 		}
 yy911:
-#line 359 "src/wast-lexer.cc"
+#line 361 "src/wast-lexer.cc"
 		{ OPCODE(I32Store); RETURN(STORE); }
-#line 5203 "src/prebuilt/wast-lexer-gen.cc"
+#line 5205 "src/prebuilt/wast-lexer-gen.cc"
 yy912:
 		yych = *++cursor_;
 		if (yych == '_') goto yy973;
@@ -5213,25 +5215,25 @@ yy914:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 381 "src/wast-lexer.cc"
+#line 383 "src/wast-lexer.cc"
 		{ TYPE(I64); RETURN(CONST); }
-#line 5219 "src/prebuilt/wast-lexer-gen.cc"
+#line 5221 "src/prebuilt/wast-lexer-gen.cc"
 yy916:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 413 "src/wast-lexer.cc"
+#line 415 "src/wast-lexer.cc"
 		{ OPCODE(I64DivS); RETURN(BINARY); }
-#line 5227 "src/prebuilt/wast-lexer-gen.cc"
+#line 5229 "src/prebuilt/wast-lexer-gen.cc"
 yy918:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 415 "src/wast-lexer.cc"
+#line 417 "src/wast-lexer.cc"
 		{ OPCODE(I64DivU); RETURN(BINARY); }
-#line 5235 "src/prebuilt/wast-lexer-gen.cc"
+#line 5237 "src/prebuilt/wast-lexer-gen.cc"
 yy920:
 		yych = *++cursor_;
 		if (yych == 'd') goto yy975;
@@ -5261,33 +5263,33 @@ yy926:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 417 "src/wast-lexer.cc"
+#line 419 "src/wast-lexer.cc"
 		{ OPCODE(I64RemS); RETURN(BINARY); }
-#line 5267 "src/prebuilt/wast-lexer-gen.cc"
+#line 5269 "src/prebuilt/wast-lexer-gen.cc"
 yy928:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 419 "src/wast-lexer.cc"
+#line 421 "src/wast-lexer.cc"
 		{ OPCODE(I64RemU); RETURN(BINARY); }
-#line 5275 "src/prebuilt/wast-lexer-gen.cc"
+#line 5277 "src/prebuilt/wast-lexer-gen.cc"
 yy930:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 429 "src/wast-lexer.cc"
+#line 431 "src/wast-lexer.cc"
 		{ OPCODE(I64ShrS); RETURN(BINARY); }
-#line 5283 "src/prebuilt/wast-lexer-gen.cc"
+#line 5285 "src/prebuilt/wast-lexer-gen.cc"
 yy932:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 431 "src/wast-lexer.cc"
+#line 433 "src/wast-lexer.cc"
 		{ OPCODE(I64ShrU); RETURN(BINARY); }
-#line 5291 "src/prebuilt/wast-lexer-gen.cc"
+#line 5293 "src/prebuilt/wast-lexer-gen.cc"
 yy934:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
@@ -5310,9 +5312,9 @@ yy934:
 			}
 		}
 yy935:
-#line 360 "src/wast-lexer.cc"
+#line 362 "src/wast-lexer.cc"
 		{ OPCODE(I64Store); RETURN(STORE); }
-#line 5316 "src/prebuilt/wast-lexer-gen.cc"
+#line 5318 "src/prebuilt/wast-lexer-gen.cc"
 yy936:
 		yych = *++cursor_;
 		if (yych == '_') goto yy986;
@@ -5338,17 +5340,17 @@ yy939:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 351 "src/wast-lexer.cc"
+#line 353 "src/wast-lexer.cc"
 		{ RETURN(SET_LOCAL); }
-#line 5344 "src/prebuilt/wast-lexer-gen.cc"
+#line 5346 "src/prebuilt/wast-lexer-gen.cc"
 yy941:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 352 "src/wast-lexer.cc"
+#line 354 "src/wast-lexer.cc"
 		{ RETURN(TEE_LOCAL); }
-#line 5352 "src/prebuilt/wast-lexer-gen.cc"
+#line 5354 "src/prebuilt/wast-lexer-gen.cc"
 yy943:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy991;
@@ -5430,9 +5432,9 @@ yy962:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 353 "src/wast-lexer.cc"
+#line 355 "src/wast-lexer.cc"
 		{ RETURN(GET_GLOBAL); }
-#line 5436 "src/prebuilt/wast-lexer-gen.cc"
+#line 5438 "src/prebuilt/wast-lexer-gen.cc"
 yy964:
 		yych = *++cursor_;
 		if (yych == 'y') goto yy1013;
@@ -5451,9 +5453,9 @@ yy967:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 390 "src/wast-lexer.cc"
+#line 392 "src/wast-lexer.cc"
 		{ OPCODE(I32Popcnt); RETURN(UNARY); }
-#line 5457 "src/prebuilt/wast-lexer-gen.cc"
+#line 5459 "src/prebuilt/wast-lexer-gen.cc"
 yy969:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1020;
@@ -5467,9 +5469,9 @@ yy971:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 373 "src/wast-lexer.cc"
+#line 375 "src/wast-lexer.cc"
 		{ OPCODE(I32Store8); RETURN(STORE); }
-#line 5473 "src/prebuilt/wast-lexer-gen.cc"
+#line 5475 "src/prebuilt/wast-lexer-gen.cc"
 yy973:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1023;
@@ -5501,9 +5503,9 @@ yy979:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 391 "src/wast-lexer.cc"
+#line 393 "src/wast-lexer.cc"
 		{ OPCODE(I64Popcnt); RETURN(UNARY); }
-#line 5507 "src/prebuilt/wast-lexer-gen.cc"
+#line 5509 "src/prebuilt/wast-lexer-gen.cc"
 yy981:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1033;
@@ -5521,9 +5523,9 @@ yy984:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 374 "src/wast-lexer.cc"
+#line 376 "src/wast-lexer.cc"
 		{ OPCODE(I64Store8); RETURN(STORE); }
-#line 5527 "src/prebuilt/wast-lexer-gen.cc"
+#line 5529 "src/prebuilt/wast-lexer-gen.cc"
 yy986:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1038;
@@ -5560,9 +5562,9 @@ yy989:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 354 "src/wast-lexer.cc"
+#line 356 "src/wast-lexer.cc"
 		{ RETURN(SET_GLOBAL); }
-#line 5566 "src/prebuilt/wast-lexer-gen.cc"
+#line 5568 "src/prebuilt/wast-lexer-gen.cc"
 yy991:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy1040;
@@ -5588,9 +5590,9 @@ yy996:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 540 "src/wast-lexer.cc"
+#line 542 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_TRAP); }
-#line 5594 "src/prebuilt/wast-lexer-gen.cc"
+#line 5596 "src/prebuilt/wast-lexer-gen.cc"
 yy998:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy1046;
@@ -5620,9 +5622,9 @@ yy1004:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 404 "src/wast-lexer.cc"
+#line 406 "src/wast-lexer.cc"
 		{ OPCODE(F32Nearest); RETURN(UNARY); }
-#line 5626 "src/prebuilt/wast-lexer-gen.cc"
+#line 5628 "src/prebuilt/wast-lexer-gen.cc"
 yy1006:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy1053;
@@ -5640,9 +5642,9 @@ yy1009:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 405 "src/wast-lexer.cc"
+#line 407 "src/wast-lexer.cc"
 		{ OPCODE(F64Nearest); RETURN(UNARY); }
-#line 5646 "src/prebuilt/wast-lexer-gen.cc"
+#line 5648 "src/prebuilt/wast-lexer-gen.cc"
 yy1011:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1057;
@@ -5656,9 +5658,9 @@ yy1013:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 510 "src/wast-lexer.cc"
+#line 512 "src/wast-lexer.cc"
 		{ RETURN(GROW_MEMORY); }
-#line 5662 "src/prebuilt/wast-lexer-gen.cc"
+#line 5664 "src/prebuilt/wast-lexer-gen.cc"
 yy1015:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1059;
@@ -5669,17 +5671,17 @@ yy1016:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 363 "src/wast-lexer.cc"
+#line 365 "src/wast-lexer.cc"
 		{ OPCODE(I32Load8S); RETURN(LOAD); }
-#line 5675 "src/prebuilt/wast-lexer-gen.cc"
+#line 5677 "src/prebuilt/wast-lexer-gen.cc"
 yy1018:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 365 "src/wast-lexer.cc"
+#line 367 "src/wast-lexer.cc"
 		{ OPCODE(I32Load8U); RETURN(LOAD); }
-#line 5683 "src/prebuilt/wast-lexer-gen.cc"
+#line 5685 "src/prebuilt/wast-lexer-gen.cc"
 yy1020:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy1063;
@@ -5689,9 +5691,9 @@ yy1021:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 375 "src/wast-lexer.cc"
+#line 377 "src/wast-lexer.cc"
 		{ OPCODE(I32Store16); RETURN(STORE); }
-#line 5695 "src/prebuilt/wast-lexer-gen.cc"
+#line 5697 "src/prebuilt/wast-lexer-gen.cc"
 yy1023:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1064;
@@ -5724,17 +5726,17 @@ yy1029:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 364 "src/wast-lexer.cc"
+#line 366 "src/wast-lexer.cc"
 		{ OPCODE(I64Load8S); RETURN(LOAD); }
-#line 5730 "src/prebuilt/wast-lexer-gen.cc"
+#line 5732 "src/prebuilt/wast-lexer-gen.cc"
 yy1031:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 366 "src/wast-lexer.cc"
+#line 368 "src/wast-lexer.cc"
 		{ OPCODE(I64Load8U); RETURN(LOAD); }
-#line 5738 "src/prebuilt/wast-lexer-gen.cc"
+#line 5740 "src/prebuilt/wast-lexer-gen.cc"
 yy1033:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy1078;
@@ -5744,17 +5746,17 @@ yy1034:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 376 "src/wast-lexer.cc"
+#line 378 "src/wast-lexer.cc"
 		{ OPCODE(I64Store16); RETURN(STORE); }
-#line 5750 "src/prebuilt/wast-lexer-gen.cc"
+#line 5752 "src/prebuilt/wast-lexer-gen.cc"
 yy1036:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 377 "src/wast-lexer.cc"
+#line 379 "src/wast-lexer.cc"
 		{ OPCODE(I64Store32); RETURN(STORE); }
-#line 5758 "src/prebuilt/wast-lexer-gen.cc"
+#line 5760 "src/prebuilt/wast-lexer-gen.cc"
 yy1038:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1079;
@@ -5768,9 +5770,9 @@ yy1040:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 508 "src/wast-lexer.cc"
+#line 510 "src/wast-lexer.cc"
 		{ RETURN(UNREACHABLE); }
-#line 5774 "src/prebuilt/wast-lexer-gen.cc"
+#line 5776 "src/prebuilt/wast-lexer-gen.cc"
 yy1042:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1081;
@@ -5809,9 +5811,9 @@ yy1050:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 448 "src/wast-lexer.cc"
+#line 450 "src/wast-lexer.cc"
 		{ OPCODE(F32Copysign); RETURN(BINARY); }
-#line 5815 "src/prebuilt/wast-lexer-gen.cc"
+#line 5817 "src/prebuilt/wast-lexer-gen.cc"
 yy1052:
 		yych = *++cursor_;
 		if (yych == '6') goto yy1092;
@@ -5830,9 +5832,9 @@ yy1055:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 449 "src/wast-lexer.cc"
+#line 451 "src/wast-lexer.cc"
 		{ OPCODE(F64Copysign); RETURN(BINARY); }
-#line 5836 "src/prebuilt/wast-lexer-gen.cc"
+#line 5838 "src/prebuilt/wast-lexer-gen.cc"
 yy1057:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy1096;
@@ -5846,17 +5848,17 @@ yy1059:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 367 "src/wast-lexer.cc"
+#line 369 "src/wast-lexer.cc"
 		{ OPCODE(I32Load16S); RETURN(LOAD); }
-#line 5852 "src/prebuilt/wast-lexer-gen.cc"
+#line 5854 "src/prebuilt/wast-lexer-gen.cc"
 yy1061:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 369 "src/wast-lexer.cc"
+#line 371 "src/wast-lexer.cc"
 		{ OPCODE(I32Load16U); RETURN(LOAD); }
-#line 5860 "src/prebuilt/wast-lexer-gen.cc"
+#line 5862 "src/prebuilt/wast-lexer-gen.cc"
 yy1063:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1098;
@@ -5874,9 +5876,9 @@ yy1066:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 484 "src/wast-lexer.cc"
+#line 486 "src/wast-lexer.cc"
 		{ OPCODE(I32WrapI64); RETURN(CONVERT); }
-#line 5880 "src/prebuilt/wast-lexer-gen.cc"
+#line 5882 "src/prebuilt/wast-lexer-gen.cc"
 yy1068:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1101;
@@ -5890,33 +5892,33 @@ yy1070:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 368 "src/wast-lexer.cc"
+#line 370 "src/wast-lexer.cc"
 		{ OPCODE(I64Load16S); RETURN(LOAD); }
-#line 5896 "src/prebuilt/wast-lexer-gen.cc"
+#line 5898 "src/prebuilt/wast-lexer-gen.cc"
 yy1072:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 370 "src/wast-lexer.cc"
+#line 372 "src/wast-lexer.cc"
 		{ OPCODE(I64Load16U); RETURN(LOAD); }
-#line 5904 "src/prebuilt/wast-lexer-gen.cc"
+#line 5906 "src/prebuilt/wast-lexer-gen.cc"
 yy1074:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 371 "src/wast-lexer.cc"
+#line 373 "src/wast-lexer.cc"
 		{ OPCODE(I64Load32S); RETURN(LOAD); }
-#line 5912 "src/prebuilt/wast-lexer-gen.cc"
+#line 5914 "src/prebuilt/wast-lexer-gen.cc"
 yy1076:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 372 "src/wast-lexer.cc"
+#line 374 "src/wast-lexer.cc"
 		{ OPCODE(I64Load32U); RETURN(LOAD); }
-#line 5920 "src/prebuilt/wast-lexer-gen.cc"
+#line 5922 "src/prebuilt/wast-lexer-gen.cc"
 yy1078:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1103;
@@ -5959,9 +5961,9 @@ yy1084:
 			}
 		}
 yy1085:
-#line 535 "src/wast-lexer.cc"
+#line 537 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_RETURN); }
-#line 5965 "src/prebuilt/wast-lexer-gen.cc"
+#line 5967 "src/prebuilt/wast-lexer-gen.cc"
 yy1086:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy1111;
@@ -5971,9 +5973,9 @@ yy1087:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 346 "src/wast-lexer.cc"
+#line 348 "src/wast-lexer.cc"
 		{ RETURN(CALL_INDIRECT); }
-#line 5977 "src/prebuilt/wast-lexer-gen.cc"
+#line 5979 "src/prebuilt/wast-lexer-gen.cc"
 yy1089:
 		yych = *++cursor_;
 		if (yych == 'y') goto yy1112;
@@ -6055,9 +6057,9 @@ yy1107:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 533 "src/wast-lexer.cc"
+#line 535 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_INVALID); }
-#line 6061 "src/prebuilt/wast-lexer-gen.cc"
+#line 6063 "src/prebuilt/wast-lexer-gen.cc"
 yy1109:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy1136;
@@ -6076,9 +6078,9 @@ yy1112:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 509 "src/wast-lexer.cc"
+#line 511 "src/wast-lexer.cc"
 		{ RETURN(CURRENT_MEMORY); }
-#line 6082 "src/prebuilt/wast-lexer-gen.cc"
+#line 6084 "src/prebuilt/wast-lexer-gen.cc"
 yy1114:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy1140;
@@ -6092,9 +6094,9 @@ yy1116:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 502 "src/wast-lexer.cc"
+#line 504 "src/wast-lexer.cc"
 		{ OPCODE(F32DemoteF64); RETURN(CONVERT); }
-#line 6098 "src/prebuilt/wast-lexer-gen.cc"
+#line 6100 "src/prebuilt/wast-lexer-gen.cc"
 yy1118:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1142;
@@ -6212,9 +6214,9 @@ yy1145:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 501 "src/wast-lexer.cc"
+#line 503 "src/wast-lexer.cc"
 		{ OPCODE(F64PromoteF32); RETURN(CONVERT); }
-#line 6218 "src/prebuilt/wast-lexer-gen.cc"
+#line 6220 "src/prebuilt/wast-lexer-gen.cc"
 yy1147:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1183;
@@ -6228,33 +6230,33 @@ yy1149:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 485 "src/wast-lexer.cc"
+#line 487 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncSF32); RETURN(CONVERT); }
-#line 6234 "src/prebuilt/wast-lexer-gen.cc"
+#line 6236 "src/prebuilt/wast-lexer-gen.cc"
 yy1151:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 487 "src/wast-lexer.cc"
+#line 489 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncSF64); RETURN(CONVERT); }
-#line 6242 "src/prebuilt/wast-lexer-gen.cc"
+#line 6244 "src/prebuilt/wast-lexer-gen.cc"
 yy1153:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 489 "src/wast-lexer.cc"
+#line 491 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncUF32); RETURN(CONVERT); }
-#line 6250 "src/prebuilt/wast-lexer-gen.cc"
+#line 6252 "src/prebuilt/wast-lexer-gen.cc"
 yy1155:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 491 "src/wast-lexer.cc"
+#line 493 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncUF64); RETURN(CONVERT); }
-#line 6258 "src/prebuilt/wast-lexer-gen.cc"
+#line 6260 "src/prebuilt/wast-lexer-gen.cc"
 yy1157:
 		yych = *++cursor_;
 		if (yych == '2') goto yy1185;
@@ -6272,33 +6274,33 @@ yy1160:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 486 "src/wast-lexer.cc"
+#line 488 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncSF32); RETURN(CONVERT); }
-#line 6278 "src/prebuilt/wast-lexer-gen.cc"
+#line 6280 "src/prebuilt/wast-lexer-gen.cc"
 yy1162:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 488 "src/wast-lexer.cc"
+#line 490 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncSF64); RETURN(CONVERT); }
-#line 6286 "src/prebuilt/wast-lexer-gen.cc"
+#line 6288 "src/prebuilt/wast-lexer-gen.cc"
 yy1164:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 490 "src/wast-lexer.cc"
+#line 492 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncUF32); RETURN(CONVERT); }
-#line 6294 "src/prebuilt/wast-lexer-gen.cc"
+#line 6296 "src/prebuilt/wast-lexer-gen.cc"
 yy1166:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 492 "src/wast-lexer.cc"
+#line 494 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncUF64); RETURN(CONVERT); }
-#line 6302 "src/prebuilt/wast-lexer-gen.cc"
+#line 6304 "src/prebuilt/wast-lexer-gen.cc"
 yy1168:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy1190;
@@ -6308,9 +6310,9 @@ yy1169:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 532 "src/wast-lexer.cc"
+#line 534 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_MALFORMED); }
-#line 6314 "src/prebuilt/wast-lexer-gen.cc"
+#line 6316 "src/prebuilt/wast-lexer-gen.cc"
 yy1171:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy1192;
@@ -6372,17 +6374,17 @@ yy1185:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 482 "src/wast-lexer.cc"
+#line 484 "src/wast-lexer.cc"
 		{ OPCODE(I64ExtendSI32); RETURN(CONVERT); }
-#line 6378 "src/prebuilt/wast-lexer-gen.cc"
+#line 6380 "src/prebuilt/wast-lexer-gen.cc"
 yy1187:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 483 "src/wast-lexer.cc"
+#line 485 "src/wast-lexer.cc"
 		{ OPCODE(I64ExtendUI32); RETURN(CONVERT); }
-#line 6386 "src/prebuilt/wast-lexer-gen.cc"
+#line 6388 "src/prebuilt/wast-lexer-gen.cc"
 yy1189:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy1215;
@@ -6392,9 +6394,9 @@ yy1190:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 541 "src/wast-lexer.cc"
+#line 543 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_EXHAUSTION); }
-#line 6398 "src/prebuilt/wast-lexer-gen.cc"
+#line 6400 "src/prebuilt/wast-lexer-gen.cc"
 yy1192:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1216;
@@ -6408,41 +6410,41 @@ yy1194:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 534 "src/wast-lexer.cc"
+#line 536 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_UNLINKABLE); }
-#line 6414 "src/prebuilt/wast-lexer-gen.cc"
+#line 6416 "src/prebuilt/wast-lexer-gen.cc"
 yy1196:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 493 "src/wast-lexer.cc"
+#line 495 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertSI32); RETURN(CONVERT); }
-#line 6422 "src/prebuilt/wast-lexer-gen.cc"
+#line 6424 "src/prebuilt/wast-lexer-gen.cc"
 yy1198:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 495 "src/wast-lexer.cc"
+#line 497 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertSI64); RETURN(CONVERT); }
-#line 6430 "src/prebuilt/wast-lexer-gen.cc"
+#line 6432 "src/prebuilt/wast-lexer-gen.cc"
 yy1200:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 497 "src/wast-lexer.cc"
+#line 499 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertUI32); RETURN(CONVERT); }
-#line 6438 "src/prebuilt/wast-lexer-gen.cc"
+#line 6440 "src/prebuilt/wast-lexer-gen.cc"
 yy1202:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 499 "src/wast-lexer.cc"
+#line 501 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertUI64); RETURN(CONVERT); }
-#line 6446 "src/prebuilt/wast-lexer-gen.cc"
+#line 6448 "src/prebuilt/wast-lexer-gen.cc"
 yy1204:
 		yych = *++cursor_;
 		if (yych == '3') goto yy1218;
@@ -6452,33 +6454,33 @@ yy1205:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 494 "src/wast-lexer.cc"
+#line 496 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertSI32); RETURN(CONVERT); }
-#line 6458 "src/prebuilt/wast-lexer-gen.cc"
+#line 6460 "src/prebuilt/wast-lexer-gen.cc"
 yy1207:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 496 "src/wast-lexer.cc"
+#line 498 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertSI64); RETURN(CONVERT); }
-#line 6466 "src/prebuilt/wast-lexer-gen.cc"
+#line 6468 "src/prebuilt/wast-lexer-gen.cc"
 yy1209:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 498 "src/wast-lexer.cc"
+#line 500 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertUI32); RETURN(CONVERT); }
-#line 6474 "src/prebuilt/wast-lexer-gen.cc"
+#line 6476 "src/prebuilt/wast-lexer-gen.cc"
 yy1211:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 500 "src/wast-lexer.cc"
+#line 502 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertUI64); RETURN(CONVERT); }
-#line 6482 "src/prebuilt/wast-lexer-gen.cc"
+#line 6484 "src/prebuilt/wast-lexer-gen.cc"
 yy1213:
 		yych = *++cursor_;
 		if (yych == '6') goto yy1219;
@@ -6528,33 +6530,33 @@ yy1224:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 503 "src/wast-lexer.cc"
+#line 505 "src/wast-lexer.cc"
 		{ OPCODE(F32ReinterpretI32); RETURN(CONVERT); }
-#line 6534 "src/prebuilt/wast-lexer-gen.cc"
+#line 6536 "src/prebuilt/wast-lexer-gen.cc"
 yy1226:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 505 "src/wast-lexer.cc"
+#line 507 "src/wast-lexer.cc"
 		{ OPCODE(F64ReinterpretI64); RETURN(CONVERT); }
-#line 6542 "src/prebuilt/wast-lexer-gen.cc"
+#line 6544 "src/prebuilt/wast-lexer-gen.cc"
 yy1228:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 504 "src/wast-lexer.cc"
+#line 506 "src/wast-lexer.cc"
 		{ OPCODE(I32ReinterpretF32); RETURN(CONVERT); }
-#line 6550 "src/prebuilt/wast-lexer-gen.cc"
+#line 6552 "src/prebuilt/wast-lexer-gen.cc"
 yy1230:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 506 "src/wast-lexer.cc"
+#line 508 "src/wast-lexer.cc"
 		{ OPCODE(I64ReinterpretF64); RETURN(CONVERT); }
-#line 6558 "src/prebuilt/wast-lexer-gen.cc"
+#line 6560 "src/prebuilt/wast-lexer-gen.cc"
 yy1232:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy1234;
@@ -6620,22 +6622,22 @@ yy1247:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 536 "src/wast-lexer.cc"
+#line 538 "src/wast-lexer.cc"
 		{
                                   RETURN(ASSERT_RETURN_CANONICAL_NAN); }
-#line 6627 "src/prebuilt/wast-lexer-gen.cc"
+#line 6629 "src/prebuilt/wast-lexer-gen.cc"
 yy1249:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 538 "src/wast-lexer.cc"
+#line 540 "src/wast-lexer.cc"
 		{
                                   RETURN(ASSERT_RETURN_ARITHMETIC_NAN); }
-#line 6636 "src/prebuilt/wast-lexer-gen.cc"
+#line 6638 "src/prebuilt/wast-lexer-gen.cc"
 	}
 }
-#line 567 "src/wast-lexer.cc"
+#line 569 "src/wast-lexer.cc"
 
   }
 }

--- a/src/prebuilt/wast-parser-gen.cc
+++ b/src/prebuilt/wast-parser-gen.cc
@@ -82,6 +82,7 @@
 #include "binary-error-handler.h"
 #include "binary-reader.h"
 #include "binary-reader-ir.h"
+#include "cast.h"
 #include "literal.h"
 #include "wast-parser.h"
 #include "wast-parser-lexer-shared.h"
@@ -210,7 +211,7 @@ class BinaryErrorHandlerModule : public BinaryErrorHandler {
 #define wabt_wast_parser_error wast_parser_error
 
 
-#line 214 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
+#line 215 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -365,7 +366,7 @@ int wabt_wast_parser_parse (::wabt::WastLexer* lexer, ::wabt::WastParser* parser
 
 /* Copy the second part of user declarations.  */
 
-#line 369 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
+#line 370 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -672,28 +673,28 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   263,   263,   269,   279,   280,   284,   302,   303,   309,
-     312,   317,   325,   329,   330,   335,   344,   345,   353,   359,
-     365,   370,   377,   383,   394,   398,   402,   409,   413,   421,
-     422,   429,   430,   433,   437,   438,   442,   443,   459,   460,
-     475,   476,   477,   481,   484,   487,   490,   493,   497,   501,
-     505,   508,   512,   516,   520,   524,   528,   532,   536,   539,
-     542,   555,   558,   561,   564,   567,   570,   573,   577,   584,
-     590,   596,   602,   609,   618,   621,   626,   633,   640,   647,
-     648,   652,   657,   664,   668,   671,   676,   681,   686,   694,
-     700,   709,   712,   718,   723,   731,   738,   741,   745,   749,
-     753,   757,   761,   768,   773,   779,   785,   786,   794,   795,
-     803,   808,   816,   825,   839,   847,   852,   863,   871,   882,
-     889,   890,   896,   906,   907,   916,   923,   924,   930,   940,
-     941,   950,   957,   961,   966,   978,   981,   985,   995,  1009,
-    1023,  1029,  1037,  1045,  1065,  1075,  1089,  1103,  1108,  1116,
-    1124,  1148,  1162,  1168,  1176,  1189,  1198,  1206,  1212,  1218,
-    1224,  1232,  1242,  1250,  1256,  1262,  1268,  1274,  1282,  1291,
-    1301,  1308,  1319,  1328,  1329,  1330,  1331,  1332,  1333,  1334,
-    1335,  1336,  1337,  1338,  1342,  1343,  1347,  1352,  1360,  1381,
-    1388,  1391,  1399,  1417,  1425,  1436,  1447,  1458,  1464,  1470,
-    1476,  1482,  1488,  1493,  1498,  1504,  1513,  1518,  1519,  1524,
-    1534,  1538,  1545,  1557,  1558,  1565,  1568,  1628,  1640
+       0,   264,   264,   270,   280,   281,   285,   303,   304,   310,
+     313,   318,   326,   330,   331,   336,   345,   346,   354,   360,
+     366,   371,   378,   384,   395,   399,   403,   410,   414,   422,
+     423,   430,   431,   434,   438,   439,   443,   444,   460,   461,
+     476,   477,   478,   482,   485,   488,   491,   494,   498,   502,
+     506,   509,   513,   517,   521,   525,   529,   533,   537,   540,
+     543,   556,   559,   562,   565,   568,   571,   574,   578,   585,
+     591,   597,   603,   610,   619,   622,   627,   634,   641,   648,
+     649,   653,   658,   665,   669,   672,   677,   682,   687,   695,
+     701,   710,   713,   719,   724,   732,   739,   742,   746,   750,
+     754,   758,   762,   769,   774,   780,   786,   787,   795,   796,
+     804,   809,   817,   824,   837,   844,   848,   857,   863,   872,
+     879,   880,   886,   896,   897,   906,   913,   914,   920,   930,
+     931,   940,   947,   951,   956,   968,   971,   975,   984,   997,
+    1010,  1014,  1020,  1026,  1046,  1055,  1068,  1081,  1085,  1091,
+    1097,  1120,  1133,  1138,  1144,  1155,  1164,  1172,  1178,  1184,
+    1190,  1198,  1207,  1215,  1221,  1227,  1233,  1239,  1247,  1255,
+    1265,  1271,  1281,  1288,  1289,  1290,  1291,  1292,  1293,  1294,
+    1295,  1296,  1297,  1298,  1302,  1303,  1307,  1312,  1320,  1341,
+    1348,  1351,  1359,  1377,  1385,  1396,  1407,  1418,  1424,  1430,
+    1436,  1442,  1448,  1453,  1458,  1464,  1473,  1478,  1479,  1484,
+    1494,  1498,  1505,  1517,  1518,  1525,  1528,  1588,  1600
 };
 #endif
 
@@ -1724,417 +1725,417 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 5: /* NAT  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1730 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1731 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 6: /* INT  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1736 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1737 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 7: /* FLOAT  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1742 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1743 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 8: /* TEXT  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1748 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1749 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 9: /* VAR  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1754 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1755 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 41: /* OFFSET_EQ_NAT  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1760 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1761 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 42: /* ALIGN_EQ_NAT  */
-#line 227 "src/wast-parser.y" /* yacc.c:1257  */
+#line 228 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1766 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1767 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 83: /* text_list  */
-#line 247 "src/wast-parser.y" /* yacc.c:1257  */
+#line 248 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1772 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1773 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 84: /* text_list_opt  */
-#line 247 "src/wast-parser.y" /* yacc.c:1257  */
+#line 248 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1778 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1779 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 85: /* quoted_text  */
-#line 228 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1784 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1785 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 86: /* value_type_list  */
-#line 248 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1790 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1791 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 88: /* global_type  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 242 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).global); }
-#line 1796 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1797 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 89: /* func_type  */
-#line 240 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1802 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1803 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 90: /* func_sig  */
-#line 240 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1808 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1809 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 91: /* func_sig_result  */
-#line 240 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1814 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1815 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 93: /* memory_sig  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 244 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).memory); }
-#line 1820 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1821 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 95: /* type_use  */
-#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 1826 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1827 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 97: /* literal  */
-#line 229 "src/wast-parser.y" /* yacc.c:1257  */
+#line 230 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).literal).text); }
-#line 1832 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1833 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 98: /* var  */
-#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 1838 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1839 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 99: /* var_list  */
-#line 250 "src/wast-parser.y" /* yacc.c:1257  */
+#line 251 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).vars); }
-#line 1844 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1845 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 100: /* bind_var_opt  */
-#line 228 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1850 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1851 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 101: /* bind_var  */
-#line 228 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1856 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1857 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 102: /* labeling_opt  */
-#line 228 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1862 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1863 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 105: /* instr  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1868 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1869 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 106: /* plain_instr  */
-#line 236 "src/wast-parser.y" /* yacc.c:1257  */
+#line 237 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1874 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1875 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 107: /* block_instr  */
-#line 236 "src/wast-parser.y" /* yacc.c:1257  */
+#line 237 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1880 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1881 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 108: /* block_sig  */
-#line 248 "src/wast-parser.y" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1886 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1887 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 109: /* block  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 232 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).block); }
-#line 1892 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1893 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 114: /* expr  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1898 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1899 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 115: /* expr1  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1904 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1905 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 119: /* if_block  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1910 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1911 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 120: /* if_  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1916 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1917 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 124: /* instr_list  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1922 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1923 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 125: /* expr_list  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1928 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1929 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 126: /* const_expr  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 1934 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1935 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 129: /* func  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 1940 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1941 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 130: /* func_fields  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 1946 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1947 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 131: /* func_fields_import  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1952 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1953 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 132: /* func_fields_import1  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1958 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1959 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 133: /* func_fields_import_result  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1964 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1965 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 134: /* func_fields_body  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1970 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1971 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 135: /* func_fields_body1  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1976 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1977 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 136: /* func_result_body  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1982 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1983 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 137: /* func_body  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1988 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1989 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 138: /* func_body1  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1994 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1995 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 139: /* offset  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { DestroyExprList(((*yyvaluep).expr_list).first); }
-#line 2000 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2001 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 141: /* table  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2006 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2007 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 142: /* table_fields  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2012 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2013 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 144: /* memory  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2018 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2019 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 145: /* memory_fields  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2024 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2025 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 146: /* global  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2030 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2031 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 147: /* global_fields  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2036 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2037 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 148: /* import_desc  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 243 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 2042 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2043 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 150: /* inline_import  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 243 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 2048 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2049 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 151: /* export_desc  */
-#line 235 "src/wast-parser.y" /* yacc.c:1257  */
+#line 236 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 2054 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2055 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 153: /* inline_export  */
-#line 235 "src/wast-parser.y" /* yacc.c:1257  */
+#line 236 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 2060 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2061 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 156: /* module_field  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_module_field_list(&((*yyvaluep).module_fields)); }
-#line 2066 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2067 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 157: /* module_fields_opt  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 245 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2072 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2073 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 158: /* module_fields  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 245 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2078 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2079 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 159: /* module  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 245 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2084 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2085 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 160: /* inline_module  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 245 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2090 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2091 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 161: /* script_var_opt  */
-#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 2096 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2097 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 162: /* script_module  */
-#line 245 "src/wast-parser.y" /* yacc.c:1257  */
+#line 246 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script_module); }
-#line 2102 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2103 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 163: /* action  */
-#line 230 "src/wast-parser.y" /* yacc.c:1257  */
+#line 231 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).action); }
-#line 2108 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2109 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 164: /* assertion  */
-#line 232 "src/wast-parser.y" /* yacc.c:1257  */
+#line 233 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 2114 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2115 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 165: /* cmd  */
-#line 232 "src/wast-parser.y" /* yacc.c:1257  */
+#line 233 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 2120 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2121 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 166: /* cmd_list  */
-#line 233 "src/wast-parser.y" /* yacc.c:1257  */
+#line 234 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).commands); }
-#line 2126 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2127 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 168: /* const_list  */
-#line 234 "src/wast-parser.y" /* yacc.c:1257  */
+#line 235 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).consts); }
-#line 2132 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2133 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 169: /* script  */
-#line 246 "src/wast-parser.y" /* yacc.c:1257  */
+#line 247 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script); }
-#line 2138 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2139 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
 
@@ -2426,18 +2427,18 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 263 "src/wast-parser.y" /* yacc.c:1646  */
+#line 264 "src/wast-parser.y" /* yacc.c:1646  */
     {
       TextListNode* node = new TextListNode();
       DUPTEXT(node->text, (yyvsp[0].text));
       node->next = nullptr;
       (yyval.text_list).first = (yyval.text_list).last = node;
     }
-#line 2437 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2438 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 269 "src/wast-parser.y" /* yacc.c:1646  */
+#line 270 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.text_list) = (yyvsp[-1].text_list);
       TextListNode* node = new TextListNode();
@@ -2446,17 +2447,17 @@ yyreduce:
       (yyval.text_list).last->next = node;
       (yyval.text_list).last = node;
     }
-#line 2450 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2451 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 279 "src/wast-parser.y" /* yacc.c:1646  */
+#line 280 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.text_list).first = (yyval.text_list).last = nullptr; }
-#line 2456 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2457 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 284 "src/wast-parser.y" /* yacc.c:1646  */
+#line 285 "src/wast-parser.y" /* yacc.c:1646  */
     {
       TextListNode node;
       node.text = (yyvsp[0].text);
@@ -2470,139 +2471,139 @@ yyreduce:
       (yyval.text).start = data;
       (yyval.text).length = size;
     }
-#line 2474 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2475 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 302 "src/wast-parser.y" /* yacc.c:1646  */
+#line 303 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = new TypeVector(); }
-#line 2480 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2481 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 303 "src/wast-parser.y" /* yacc.c:1646  */
+#line 304 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.types) = (yyvsp[-1].types);
       (yyval.types)->push_back((yyvsp[0].type));
     }
-#line 2489 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2490 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 309 "src/wast-parser.y" /* yacc.c:1646  */
+#line 310 "src/wast-parser.y" /* yacc.c:1646  */
     {}
-#line 2495 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2496 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 312 "src/wast-parser.y" /* yacc.c:1646  */
+#line 313 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[0].type);
       (yyval.global)->mutable_ = false;
     }
-#line 2505 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2506 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 317 "src/wast-parser.y" /* yacc.c:1646  */
+#line 318 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[-1].type);
       (yyval.global)->mutable_ = true;
     }
-#line 2515 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2516 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 325 "src/wast-parser.y" /* yacc.c:1646  */
+#line 326 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = (yyvsp[-1].func_sig); }
-#line 2521 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2522 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 330 "src/wast-parser.y" /* yacc.c:1646  */
+#line 331 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->param_types.insert((yyval.func_sig)->param_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 2531 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2532 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 335 "src/wast-parser.y" /* yacc.c:1646  */
+#line 336 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->param_types.insert((yyval.func_sig)->param_types.begin(), (yyvsp[-2].type));
       // Ignore bind_var.
       destroy_string_slice(&(yyvsp[-3].text));
     }
-#line 2542 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2543 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 344 "src/wast-parser.y" /* yacc.c:1646  */
+#line 345 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = new FuncSignature(); }
-#line 2548 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2549 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 345 "src/wast-parser.y" /* yacc.c:1646  */
+#line 346 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->result_types.insert((yyval.func_sig)->result_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 2558 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2559 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 353 "src/wast-parser.y" /* yacc.c:1646  */
+#line 354 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.table) = new Table();
       (yyval.table)->elem_limits = (yyvsp[-1].limits);
     }
-#line 2567 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2568 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 359 "src/wast-parser.y" /* yacc.c:1646  */
+#line 360 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.memory) = new Memory();
       (yyval.memory)->page_limits = (yyvsp[0].limits);
     }
-#line 2576 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2577 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 365 "src/wast-parser.y" /* yacc.c:1646  */
+#line 366 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = false;
       (yyval.limits).initial = (yyvsp[0].u64);
       (yyval.limits).max = 0;
     }
-#line 2586 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2587 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 370 "src/wast-parser.y" /* yacc.c:1646  */
+#line 371 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = true;
       (yyval.limits).initial = (yyvsp[-1].u64);
       (yyval.limits).max = (yyvsp[0].u64);
     }
-#line 2596 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2597 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 377 "src/wast-parser.y" /* yacc.c:1646  */
+#line 378 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2602 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2603 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 383 "src/wast-parser.y" /* yacc.c:1646  */
+#line 384 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if (WABT_FAILED(parse_uint64((yyvsp[0].literal).text.start,
                                         (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
@@ -2611,98 +2612,98 @@ yyreduce:
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2615 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2616 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 394 "src/wast-parser.y" /* yacc.c:1646  */
+#line 395 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2624 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2625 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 398 "src/wast-parser.y" /* yacc.c:1646  */
+#line 399 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2633 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2634 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 402 "src/wast-parser.y" /* yacc.c:1646  */
+#line 403 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2642 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2643 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 409 "src/wast-parser.y" /* yacc.c:1646  */
+#line 410 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var((yyvsp[0].u64));
       (yyval.var)->loc = (yylsp[0]);
     }
-#line 2651 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2652 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 413 "src/wast-parser.y" /* yacc.c:1646  */
+#line 414 "src/wast-parser.y" /* yacc.c:1646  */
     {
       StringSlice name;
       DUPTEXT(name, (yyvsp[0].text));
       (yyval.var) = new Var(name);
       (yyval.var)->loc = (yylsp[0]);
     }
-#line 2662 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2663 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 421 "src/wast-parser.y" /* yacc.c:1646  */
+#line 422 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.vars) = new VarVector(); }
-#line 2668 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2669 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 422 "src/wast-parser.y" /* yacc.c:1646  */
+#line 423 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.vars) = (yyvsp[-1].vars);
       (yyval.vars)->emplace_back(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2678 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2679 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 429 "src/wast-parser.y" /* yacc.c:1646  */
+#line 430 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.text)); }
-#line 2684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2685 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 433 "src/wast-parser.y" /* yacc.c:1646  */
+#line 434 "src/wast-parser.y" /* yacc.c:1646  */
     { DUPTEXT((yyval.text), (yyvsp[0].text)); }
-#line 2690 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2691 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 437 "src/wast-parser.y" /* yacc.c:1646  */
+#line 438 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.text)); }
-#line 2696 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2697 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 442 "src/wast-parser.y" /* yacc.c:1646  */
+#line 443 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u64) = 0; }
-#line 2702 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2703 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 443 "src/wast-parser.y" /* yacc.c:1646  */
+#line 444 "src/wast-parser.y" /* yacc.c:1646  */
     {
       uint64_t offset64;
       if (WABT_FAILED(parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &offset64,
@@ -2717,17 +2718,17 @@ yyreduce:
       }
       (yyval.u64) = static_cast<uint32_t>(offset64);
     }
-#line 2721 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2722 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 459 "src/wast-parser.y" /* yacc.c:1646  */
+#line 460 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u32) = USE_NATURAL_ALIGNMENT; }
-#line 2727 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2728 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 460 "src/wast-parser.y" /* yacc.c:1646  */
+#line 461 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if (WABT_FAILED(parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
                                   ParseIntType::UnsignedOnly))) {
@@ -2740,169 +2741,169 @@ yyreduce:
         wast_parser_error(&(yylsp[0]), lexer, parser, "alignment must be power-of-two");
       }
     }
-#line 2744 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2745 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 475 "src/wast-parser.y" /* yacc.c:1646  */
+#line 476 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = join_exprs1(&(yylsp[0]), (yyvsp[0].expr)); }
-#line 2750 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2751 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 476 "src/wast-parser.y" /* yacc.c:1646  */
+#line 477 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = join_exprs1(&(yylsp[0]), (yyvsp[0].expr)); }
-#line 2756 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2757 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 481 "src/wast-parser.y" /* yacc.c:1646  */
+#line 482 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new UnreachableExpr();
     }
-#line 2764 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2765 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 484 "src/wast-parser.y" /* yacc.c:1646  */
+#line 485 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new NopExpr();
     }
-#line 2772 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2773 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 487 "src/wast-parser.y" /* yacc.c:1646  */
+#line 488 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new DropExpr();
     }
-#line 2780 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2781 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 490 "src/wast-parser.y" /* yacc.c:1646  */
+#line 491 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SelectExpr();
     }
-#line 2788 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2789 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 493 "src/wast-parser.y" /* yacc.c:1646  */
+#line 494 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BrExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2797 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2798 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 497 "src/wast-parser.y" /* yacc.c:1646  */
+#line 498 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BrIfExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2806 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2807 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 501 "src/wast-parser.y" /* yacc.c:1646  */
+#line 502 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BrTableExpr((yyvsp[-1].vars), std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2815 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2816 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 505 "src/wast-parser.y" /* yacc.c:1646  */
+#line 506 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new ReturnExpr();
     }
-#line 2823 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 508 "src/wast-parser.y" /* yacc.c:1646  */
+#line 509 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CallExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2832 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2833 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 512 "src/wast-parser.y" /* yacc.c:1646  */
+#line 513 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CallIndirectExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2841 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2842 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 516 "src/wast-parser.y" /* yacc.c:1646  */
+#line 517 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new GetLocalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2850 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2851 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 520 "src/wast-parser.y" /* yacc.c:1646  */
+#line 521 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SetLocalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2859 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2860 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 524 "src/wast-parser.y" /* yacc.c:1646  */
+#line 525 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new TeeLocalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2868 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2869 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 528 "src/wast-parser.y" /* yacc.c:1646  */
+#line 529 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new GetGlobalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2877 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2878 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 532 "src/wast-parser.y" /* yacc.c:1646  */
+#line 533 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SetGlobalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2886 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2887 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 536 "src/wast-parser.y" /* yacc.c:1646  */
+#line 537 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new LoadExpr((yyvsp[-2].opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2894 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2895 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 539 "src/wast-parser.y" /* yacc.c:1646  */
+#line 540 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new StoreExpr((yyvsp[-2].opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2902 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2903 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 542 "src/wast-parser.y" /* yacc.c:1646  */
+#line 543 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Const const_;
       WABT_ZERO_MEMORY(const_);
@@ -2916,110 +2917,110 @@ yyreduce:
       delete [] (yyvsp[0].literal).text.start;
       (yyval.expr) = new ConstExpr(const_);
     }
-#line 2920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2921 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 555 "src/wast-parser.y" /* yacc.c:1646  */
+#line 556 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new UnaryExpr((yyvsp[0].opcode));
     }
-#line 2928 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2929 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 558 "src/wast-parser.y" /* yacc.c:1646  */
+#line 559 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BinaryExpr((yyvsp[0].opcode));
     }
-#line 2936 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2937 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 561 "src/wast-parser.y" /* yacc.c:1646  */
+#line 562 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CompareExpr((yyvsp[0].opcode));
     }
-#line 2944 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2945 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 564 "src/wast-parser.y" /* yacc.c:1646  */
+#line 565 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new ConvertExpr((yyvsp[0].opcode));
     }
-#line 2952 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2953 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 567 "src/wast-parser.y" /* yacc.c:1646  */
+#line 568 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CurrentMemoryExpr();
     }
-#line 2960 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2961 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 570 "src/wast-parser.y" /* yacc.c:1646  */
+#line 571 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new GrowMemoryExpr();
     }
-#line 2968 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2969 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 573 "src/wast-parser.y" /* yacc.c:1646  */
+#line 574 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new ThrowExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2977 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2978 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 577 "src/wast-parser.y" /* yacc.c:1646  */
+#line 578 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new RethrowExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2986 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2987 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 584 "src/wast-parser.y" /* yacc.c:1646  */
+#line 585 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new BlockExpr((yyvsp[-2].block));
       expr->block->label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].text));
       (yyval.expr) = expr;
     }
-#line 2997 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2998 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 590 "src/wast-parser.y" /* yacc.c:1646  */
+#line 591 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new LoopExpr((yyvsp[-2].block));
       expr->block->label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].text));
       (yyval.expr) = expr;
     }
-#line 3008 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3009 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 596 "src/wast-parser.y" /* yacc.c:1646  */
+#line 597 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new IfExpr((yyvsp[-2].block), nullptr);
       expr->true_->label = (yyvsp[-3].text);
       CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].text));
       (yyval.expr) = expr;
     }
-#line 3019 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3020 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 602 "src/wast-parser.y" /* yacc.c:1646  */
+#line 603 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new IfExpr((yyvsp[-5].block), (yyvsp[-2].expr_list).first);
       expr->true_->label = (yyvsp[-6].text);
@@ -3027,384 +3028,377 @@ yyreduce:
       CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].text));
       (yyval.expr) = expr;
     }
-#line 3031 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3032 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 609 "src/wast-parser.y" /* yacc.c:1646  */
+#line 610 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyvsp[-3].block)->label = (yyvsp[-4].text);
       (yyval.expr) = (yyvsp[-2].try_expr);
-      (yyval.expr)->As<TryExpr>()->block = (yyvsp[-3].block);
+      cast<TryExpr>((yyval.expr))->block = (yyvsp[-3].block);
       CHECK_END_LABEL((yylsp[0]), (yyvsp[-3].block)->label, (yyvsp[0].text));
     }
-#line 3042 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3043 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 618 "src/wast-parser.y" /* yacc.c:1646  */
+#line 619 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = (yyvsp[-1].types); }
-#line 3048 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3049 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 621 "src/wast-parser.y" /* yacc.c:1646  */
+#line 622 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.block) = (yyvsp[0].block);
       (yyval.block)->sig.insert((yyval.block)->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
       delete (yyvsp[-1].types);
     }
-#line 3058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3059 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 626 "src/wast-parser.y" /* yacc.c:1646  */
+#line 627 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.block) = new Block();
       (yyval.block)->first = (yyvsp[0].expr_list).first;
     }
-#line 3067 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3068 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 633 "src/wast-parser.y" /* yacc.c:1646  */
+#line 634 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = new Catch(std::move(*(yyvsp[-1].var)), (yyvsp[0].expr_list).first);
       (yyval.catch_)->loc = (yylsp[-2]);
       delete (yyvsp[-1].var);
     }
-#line 3077 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3078 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 640 "src/wast-parser.y" /* yacc.c:1646  */
+#line 641 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = new Catch((yyvsp[0].expr_list).first);
       (yyval.catch_)->loc = (yylsp[-1]);
     }
-#line 3086 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3087 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 652 "src/wast-parser.y" /* yacc.c:1646  */
+#line 653 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new TryExpr();
       expr->catches.push_back((yyvsp[0].catch_));
       (yyval.try_expr) = expr;
     }
-#line 3096 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3097 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 657 "src/wast-parser.y" /* yacc.c:1646  */
+#line 658 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[-1].try_expr);
-      (yyval.try_expr)->As<TryExpr>()->catches.push_back((yyvsp[0].catch_));
+      cast<TryExpr>((yyval.try_expr))->catches.push_back((yyvsp[0].catch_));
     }
-#line 3105 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3106 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 664 "src/wast-parser.y" /* yacc.c:1646  */
+#line 665 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[-1].expr_list); }
-#line 3111 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3112 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 668 "src/wast-parser.y" /* yacc.c:1646  */
+#line 669 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = join_exprs2(&(yylsp[-1]), &(yyvsp[0].expr_list), (yyvsp[-1].expr));
     }
-#line 3119 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3120 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 671 "src/wast-parser.y" /* yacc.c:1646  */
+#line 672 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new BlockExpr((yyvsp[0].block));
       expr->block->label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), expr);
     }
-#line 3129 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3130 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 676 "src/wast-parser.y" /* yacc.c:1646  */
+#line 677 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new LoopExpr((yyvsp[0].block));
       expr->block->label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), expr);
     }
-#line 3139 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3140 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 681 "src/wast-parser.y" /* yacc.c:1646  */
+#line 682 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
-      IfExpr* if_ = (yyvsp[0].expr_list).last->As<IfExpr>();
+      IfExpr* if_ = cast<IfExpr>((yyvsp[0].expr_list).last);
       if_->true_->label = (yyvsp[-1].text);
     }
-#line 3149 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3150 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 686 "src/wast-parser.y" /* yacc.c:1646  */
+#line 687 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Block* block = (yyvsp[0].try_expr)->block;
       block->label = (yyvsp[-1].text);
       (yyval.expr_list) = join_exprs1(&(yylsp[-2]), (yyvsp[0].try_expr));
     }
-#line 3159 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3160 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 694 "src/wast-parser.y" /* yacc.c:1646  */
+#line 695 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[0].try_expr);
       Block* block = (yyval.try_expr)->block;
       block->sig.insert(block->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
       delete (yyvsp[-1].types);
     }
-#line 3170 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3171 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 700 "src/wast-parser.y" /* yacc.c:1646  */
+#line 701 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Block* block = new Block();
       block->first = (yyvsp[-1].expr_list).first;
       (yyval.try_expr) = (yyvsp[0].try_expr);
       (yyval.try_expr)->block = block;
     }
-#line 3181 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3182 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 709 "src/wast-parser.y" /* yacc.c:1646  */
+#line 710 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = (yyvsp[-1].catch_);
     }
-#line 3189 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3190 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 712 "src/wast-parser.y" /* yacc.c:1646  */
+#line 713 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = (yyvsp[-1].catch_);
     }
-#line 3197 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3198 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 718 "src/wast-parser.y" /* yacc.c:1646  */
+#line 719 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new TryExpr();
       expr->catches.push_back((yyvsp[0].catch_));
       (yyval.try_expr) = expr;
     }
-#line 3207 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3208 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 723 "src/wast-parser.y" /* yacc.c:1646  */
+#line 724 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[-1].try_expr);
-      (yyval.try_expr)->As<TryExpr>()->catches.push_back((yyvsp[0].catch_));
+      cast<TryExpr>((yyval.try_expr))->catches.push_back((yyvsp[0].catch_));
     }
-#line 3216 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3217 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 731 "src/wast-parser.y" /* yacc.c:1646  */
+#line 732 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      IfExpr* if_ = (yyvsp[0].expr_list).last->As<IfExpr>();
+      IfExpr* if_ = cast<IfExpr>((yyvsp[0].expr_list).last);
       (yyval.expr_list) = (yyvsp[0].expr_list);
       Block* true_ = if_->true_;
       true_->sig.insert(true_->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
       delete (yyvsp[-1].types);
     }
-#line 3228 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3229 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 741 "src/wast-parser.y" /* yacc.c:1646  */
+#line 742 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block((yyvsp[-5].expr_list).first), (yyvsp[-1].expr_list).first);
       (yyval.expr_list) = join_exprs1(&(yylsp[-7]), expr);
     }
-#line 3237 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3238 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 745 "src/wast-parser.y" /* yacc.c:1646  */
+#line 746 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block((yyvsp[-1].expr_list).first), nullptr);
       (yyval.expr_list) = join_exprs1(&(yylsp[-3]), expr);
     }
-#line 3246 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3247 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 749 "src/wast-parser.y" /* yacc.c:1646  */
+#line 750 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block((yyvsp[-5].expr_list).first), (yyvsp[-1].expr_list).first);
       (yyval.expr_list) = join_exprs2(&(yylsp[-8]), &(yyvsp[-8].expr_list), expr);
     }
-#line 3255 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3256 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 753 "src/wast-parser.y" /* yacc.c:1646  */
+#line 754 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block((yyvsp[-1].expr_list).first), nullptr);
       (yyval.expr_list) = join_exprs2(&(yylsp[-4]), &(yyvsp[-4].expr_list), expr);
     }
-#line 3264 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3265 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 757 "src/wast-parser.y" /* yacc.c:1646  */
+#line 758 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block((yyvsp[-1].expr_list).first), (yyvsp[0].expr_list).first);
       (yyval.expr_list) = join_exprs2(&(yylsp[-2]), &(yyvsp[-2].expr_list), expr);
     }
-#line 3273 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3274 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 761 "src/wast-parser.y" /* yacc.c:1646  */
+#line 762 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block((yyvsp[0].expr_list).first), nullptr);
       (yyval.expr_list) = join_exprs2(&(yylsp[-1]), &(yyvsp[-1].expr_list), expr);
     }
-#line 3282 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3283 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 768 "src/wast-parser.y" /* yacc.c:1646  */
+#line 769 "src/wast-parser.y" /* yacc.c:1646  */
     {
      CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "rethrow");
     }
-#line 3290 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3291 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 773 "src/wast-parser.y" /* yacc.c:1646  */
+#line 774 "src/wast-parser.y" /* yacc.c:1646  */
     {
       CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "throw");
     }
-#line 3298 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3299 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 779 "src/wast-parser.y" /* yacc.c:1646  */
+#line 780 "src/wast-parser.y" /* yacc.c:1646  */
     {
       CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "try");
     }
-#line 3306 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3307 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 785 "src/wast-parser.y" /* yacc.c:1646  */
+#line 786 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.expr_list)); }
-#line 3312 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3313 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 786 "src/wast-parser.y" /* yacc.c:1646  */
+#line 787 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyvsp[-1].expr_list).first;
       (yyvsp[-1].expr_list).last->next = (yyvsp[0].expr_list).first;
       (yyval.expr_list).last = (yyvsp[0].expr_list).last ? (yyvsp[0].expr_list).last : (yyvsp[-1].expr_list).last;
       (yyval.expr_list).size = (yyvsp[-1].expr_list).size + (yyvsp[0].expr_list).size;
     }
-#line 3323 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3324 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 794 "src/wast-parser.y" /* yacc.c:1646  */
+#line 795 "src/wast-parser.y" /* yacc.c:1646  */
     { WABT_ZERO_MEMORY((yyval.expr_list)); }
-#line 3329 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3330 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 795 "src/wast-parser.y" /* yacc.c:1646  */
+#line 796 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list).first = (yyvsp[-1].expr_list).first;
       (yyvsp[-1].expr_list).last->next = (yyvsp[0].expr_list).first;
       (yyval.expr_list).last = (yyvsp[0].expr_list).last ? (yyvsp[0].expr_list).last : (yyvsp[-1].expr_list).last;
       (yyval.expr_list).size = (yyvsp[-1].expr_list).size + (yyvsp[0].expr_list).size;
     }
-#line 3340 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3341 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 808 "src/wast-parser.y" /* yacc.c:1646  */
+#line 809 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.exception) = new Exception();
       (yyval.exception)->name = (yyvsp[-2].text);
       (yyval.exception)->sig = std::move(*(yyvsp[-1].types));
       delete (yyvsp[-1].types);
     }
-#line 3351 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3352 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 816 "src/wast-parser.y" /* yacc.c:1646  */
+#line 817 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::Except);
-      (yyval.module_field)->loc = (yylsp[0]);
-      (yyval.module_field)->except = (yyvsp[0].exception);
+      (yyval.module_field) = new ExceptionModuleField((yyvsp[0].exception));
     }
-#line 3361 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3360 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 825 "src/wast-parser.y" /* yacc.c:1646  */
+#line 824 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
-      ModuleField* main = (yyval.module_fields).first;
-      main->loc = (yylsp[-3]);
-      if (main->type == ModuleFieldType::Func) {
-        main->func->name = (yyvsp[-2].text);
+      ModuleField* main_field = (yyval.module_fields).first;
+      main_field->loc = (yylsp[-3]);
+      if (auto func_field = dyn_cast<FuncModuleField>(main_field)) {
+        func_field->func->name = (yyvsp[-2].text);
       } else {
-        assert(main->type == ModuleFieldType::Import);
-        main->import->func->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->func->name = (yyvsp[-2].text);
       }
     }
-#line 3377 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3375 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 839 "src/wast-parser.y" /* yacc.c:1646  */
+#line 837 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Func);
-      field->func = (yyvsp[0].func);
+      auto field = new FuncModuleField((yyvsp[0].func));
       field->func->decl.has_func_type = true;
       field->func->decl.type_var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3390 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3387 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 847 "src/wast-parser.y" /* yacc.c:1646  */
+#line 844 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Func);
-      field->func = (yyvsp[0].func);
+      auto field = new FuncModuleField((yyvsp[0].func));
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3400 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3396 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 852 "src/wast-parser.y" /* yacc.c:1646  */
+#line 848 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Import);
-      field->loc = (yylsp[-2]);
-      field->import = (yyvsp[-2].import);
+      auto field = new ImportModuleField((yyvsp[-2].import), (yylsp[-2]));
       field->import->kind = ExternalKind::Func;
       field->import->func = (yyvsp[0].func);
       field->import->func->decl.has_func_type = true;
@@ -3412,57 +3406,53 @@ yyreduce:
       delete (yyvsp[-1].var);
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3416 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3410 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 863 "src/wast-parser.y" /* yacc.c:1646  */
+#line 857 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Import);
-      field->loc = (yylsp[-1]);
-      field->import = (yyvsp[-1].import);
+      auto field = new ImportModuleField((yyvsp[-1].import), (yylsp[-1]));
       field->import->kind = ExternalKind::Func;
       field->import->func = (yyvsp[0].func);
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3429 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3421 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 871 "src/wast-parser.y" /* yacc.c:1646  */
+#line 863 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Export);
-      field->loc = (yylsp[-1]);
-      field->export_ = (yyvsp[-1].export_);
+      auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Func;
       (yyval.module_fields).first = (yyvsp[0].module_fields).first;
       (yyval.module_fields).last = (yyvsp[0].module_fields).last->next = field;
     }
-#line 3442 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3432 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 882 "src/wast-parser.y" /* yacc.c:1646  */
+#line 872 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
     }
-#line 3451 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3441 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 890 "src/wast-parser.y" /* yacc.c:1646  */
+#line 880 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(),
                                       (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3462 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3452 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 896 "src/wast-parser.y" /* yacc.c:1646  */
+#line 886 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->param_bindings.emplace(string_slice_to_string((yyvsp[-3].text)),
@@ -3470,48 +3460,48 @@ yyreduce:
       destroy_string_slice(&(yyvsp[-3].text));
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(), (yyvsp[-2].type));
     }
-#line 3474 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3464 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 906 "src/wast-parser.y" /* yacc.c:1646  */
+#line 896 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func) = new Func(); }
-#line 3480 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3470 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 907 "src/wast-parser.y" /* yacc.c:1646  */
+#line 897 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.result_types.insert((yyval.func)->decl.sig.result_types.begin(),
                                        (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3491 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3481 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 916 "src/wast-parser.y" /* yacc.c:1646  */
+#line 906 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
     }
-#line 3500 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3490 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 127:
-#line 924 "src/wast-parser.y" /* yacc.c:1646  */
+#line 914 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(),
                                       (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3511 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3501 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 930 "src/wast-parser.y" /* yacc.c:1646  */
+#line 920 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->param_bindings.emplace(string_slice_to_string((yyvsp[-3].text)),
@@ -3519,50 +3509,50 @@ yyreduce:
       destroy_string_slice(&(yyvsp[-3].text));
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(), (yyvsp[-2].type));
     }
-#line 3523 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3513 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 130:
-#line 941 "src/wast-parser.y" /* yacc.c:1646  */
+#line 931 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.result_types.insert((yyval.func)->decl.sig.result_types.begin(),
                                        (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3534 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3524 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 950 "src/wast-parser.y" /* yacc.c:1646  */
+#line 940 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       reverse_bindings(&(yyval.func)->local_types, &(yyval.func)->local_bindings);
     }
-#line 3543 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3533 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 957 "src/wast-parser.y" /* yacc.c:1646  */
+#line 947 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = new Func();
       (yyval.func)->first_expr = (yyvsp[0].expr_list).first;
     }
-#line 3552 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3542 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 961 "src/wast-parser.y" /* yacc.c:1646  */
+#line 951 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3562 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3552 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 966 "src/wast-parser.y" /* yacc.c:1646  */
+#line 956 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->local_bindings.emplace(string_slice_to_string((yyvsp[-3].text)),
@@ -3570,287 +3560,263 @@ yyreduce:
       destroy_string_slice(&(yyvsp[-3].text));
       (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].type));
     }
-#line 3574 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3564 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 135:
-#line 978 "src/wast-parser.y" /* yacc.c:1646  */
+#line 968 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[-1].expr_list);
     }
-#line 3582 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3572 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 137:
-#line 985 "src/wast-parser.y" /* yacc.c:1646  */
+#line 975 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::ElemSegment);
-      (yyval.module_field)->loc = (yylsp[-4]);
-      (yyval.module_field)->elem_segment = new ElemSegment();
-      (yyval.module_field)->elem_segment->table_var = std::move(*(yyvsp[-3].var));
+      auto elem_segment = new ElemSegment();
+      elem_segment->table_var = std::move(*(yyvsp[-3].var));
       delete (yyvsp[-3].var);
-      (yyval.module_field)->elem_segment->offset = (yyvsp[-2].expr_list).first;
-      (yyval.module_field)->elem_segment->vars = std::move(*(yyvsp[-1].vars));
+      elem_segment->offset = (yyvsp[-2].expr_list).first;
+      elem_segment->vars = std::move(*(yyvsp[-1].vars));
       delete (yyvsp[-1].vars);
+      (yyval.module_field) = new ElemSegmentModuleField(elem_segment, (yylsp[-4]));
     }
-#line 3597 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3586 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 995 "src/wast-parser.y" /* yacc.c:1646  */
+#line 984 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::ElemSegment);
-      (yyval.module_field)->loc = (yylsp[-3]);
-      (yyval.module_field)->elem_segment = new ElemSegment();
-      (yyval.module_field)->elem_segment->table_var.loc = (yylsp[-3]);
-      (yyval.module_field)->elem_segment->table_var.type = VarType::Index;
-      (yyval.module_field)->elem_segment->table_var.index = 0;
-      (yyval.module_field)->elem_segment->offset = (yyvsp[-2].expr_list).first;
-      (yyval.module_field)->elem_segment->vars = std::move(*(yyvsp[-1].vars));
+      auto elem_segment = new ElemSegment();
+      elem_segment->table_var.loc = (yylsp[-3]);
+      elem_segment->table_var.type = VarType::Index;
+      elem_segment->table_var.index = 0;
+      elem_segment->offset = (yyvsp[-2].expr_list).first;
+      elem_segment->vars = std::move(*(yyvsp[-1].vars));
       delete (yyvsp[-1].vars);
+      (yyval.module_field) = new ElemSegmentModuleField(elem_segment, (yylsp[-3]));
     }
-#line 3613 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3601 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 1009 "src/wast-parser.y" /* yacc.c:1646  */
+#line 997 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
-      ModuleField* main = (yyval.module_fields).first;
-      main->loc = (yylsp[-3]);
-      if (main->type == ModuleFieldType::Table) {
-        main->table->name = (yyvsp[-2].text);
+      ModuleField* main_field = (yyval.module_fields).first;
+      main_field->loc = (yylsp[-3]);
+      if (auto table_field = dyn_cast<TableModuleField>(main_field)) {
+        table_field->table->name = (yyvsp[-2].text);
       } else {
-        assert(main->type == ModuleFieldType::Import);
-        main->import->table->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->table->name = (yyvsp[-2].text);
       }
     }
-#line 3629 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3616 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 1023 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1010 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Table);
-      field->loc = (yylsp[0]);
-      field->table = (yyvsp[0].table);
+      auto field = new TableModuleField((yyvsp[0].table));
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3640 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3625 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 1029 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1014 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Import);
-      field->loc = (yylsp[-1]);
-      field->import = (yyvsp[-1].import);
+      auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Table;
       field->import->table = (yyvsp[0].table);
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3653 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3636 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 1037 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1020 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Export);
-      field->loc = (yylsp[-1]);
-      field->export_ = (yyvsp[-1].export_);
+      auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Table;
       (yyval.module_fields).first = (yyvsp[0].module_fields).first;
       (yyval.module_fields).last = (yyvsp[0].module_fields).last->next = field;
     }
-#line 3666 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3647 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 1045 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1026 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* table_field = new ModuleField(ModuleFieldType::Table);
-      Table* table = table_field->table = new Table();
+      auto table = new Table();
       table->elem_limits.initial = (yyvsp[-1].vars)->size();
       table->elem_limits.max = (yyvsp[-1].vars)->size();
       table->elem_limits.has_max = true;
-      ModuleField* elem_field = new ModuleField(ModuleFieldType::ElemSegment);
-      elem_field->loc = (yylsp[-2]);
-      ElemSegment* elem_segment = elem_field->elem_segment = new ElemSegment();
+      auto table_field = new TableModuleField(table);
+
+      auto elem_segment = new ElemSegment();
       elem_segment->table_var = Var(kInvalidIndex);
       elem_segment->offset = new ConstExpr(Const(Const::I32(), 0));
       elem_segment->offset->loc = (yylsp[-2]);
       elem_segment->vars = std::move(*(yyvsp[-1].vars));
       delete (yyvsp[-1].vars);
+      auto elem_field = new ElemSegmentModuleField(elem_segment, (yylsp[-2]));
       (yyval.module_fields).first = table_field;
       (yyval.module_fields).last = table_field->next = elem_field;
     }
-#line 3688 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3669 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 1065 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1046 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::DataSegment);
-      (yyval.module_field)->loc = (yylsp[-4]);
-      (yyval.module_field)->data_segment = new DataSegment();
-      (yyval.module_field)->data_segment->memory_var = std::move(*(yyvsp[-3].var));
+      auto data_segment = new DataSegment();
+      data_segment->memory_var = std::move(*(yyvsp[-3].var));
       delete (yyvsp[-3].var);
-      (yyval.module_field)->data_segment->offset = (yyvsp[-2].expr_list).first;
-      dup_text_list(&(yyvsp[-1].text_list), &(yyval.module_field)->data_segment->data, &(yyval.module_field)->data_segment->size);
+      data_segment->offset = (yyvsp[-2].expr_list).first;
+      dup_text_list(&(yyvsp[-1].text_list), &data_segment->data, &data_segment->size);
       destroy_text_list(&(yyvsp[-1].text_list));
+      (yyval.module_field) = new DataSegmentModuleField(data_segment, (yylsp[-4]));
     }
-#line 3703 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3683 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 1075 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1055 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::DataSegment);
-      (yyval.module_field)->loc = (yylsp[-3]);
-      (yyval.module_field)->data_segment = new DataSegment();
-      (yyval.module_field)->data_segment->memory_var.loc = (yylsp[-3]);
-      (yyval.module_field)->data_segment->memory_var.type = VarType::Index;
-      (yyval.module_field)->data_segment->memory_var.index = 0;
-      (yyval.module_field)->data_segment->offset = (yyvsp[-2].expr_list).first;
-      dup_text_list(&(yyvsp[-1].text_list), &(yyval.module_field)->data_segment->data, &(yyval.module_field)->data_segment->size);
+      auto data_segment = new DataSegment();
+      data_segment->memory_var.loc = (yylsp[-3]);
+      data_segment->memory_var.type = VarType::Index;
+      data_segment->memory_var.index = 0;
+      data_segment->offset = (yyvsp[-2].expr_list).first;
+      dup_text_list(&(yyvsp[-1].text_list), &data_segment->data, &data_segment->size);
       destroy_text_list(&(yyvsp[-1].text_list));
+      (yyval.module_field) = new DataSegmentModuleField(data_segment, (yylsp[-3]));
     }
-#line 3719 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3698 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 1089 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1068 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
-      ModuleField* main = (yyval.module_fields).first;
-      main->loc = (yylsp[-3]);
-      if (main->type == ModuleFieldType::Memory) {
-        main->memory->name = (yyvsp[-2].text);
+      ModuleField* main_field = (yyval.module_fields).first;
+      main_field->loc = (yylsp[-3]);
+      if (auto memory_field = dyn_cast<MemoryModuleField>(main_field)) {
+        memory_field->memory->name = (yyvsp[-2].text);
       } else {
-        assert(main->type == ModuleFieldType::Import);
-        main->import->memory->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->memory->name = (yyvsp[-2].text);
       }
     }
-#line 3735 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3713 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1103 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1081 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Memory);
-      field->memory = (yyvsp[0].memory);
+      auto field = new MemoryModuleField((yyvsp[0].memory));
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3745 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3722 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1108 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1085 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Import);
-      field->loc = (yylsp[-1]);
-      field->import = (yyvsp[-1].import);
+      auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Memory;
       field->import->memory = (yyvsp[0].memory);
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3758 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3733 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1116 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1091 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Export);
-      field->loc = (yylsp[-1]);
-      field->export_ = (yyvsp[-1].export_);
+      auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Memory;
       (yyval.module_fields).first = (yyvsp[0].module_fields).first;
       (yyval.module_fields).last = (yyvsp[0].module_fields).last->next = field;
     }
-#line 3771 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3744 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1124 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1097 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* data_field = new ModuleField(ModuleFieldType::DataSegment);
-      data_field->loc = (yylsp[-2]);
-      DataSegment* data_segment = data_field->data_segment = new DataSegment();
+      auto data_segment = new DataSegment();
       data_segment->memory_var = Var(kInvalidIndex);
       data_segment->offset = new ConstExpr(Const(Const::I32(), 0));
       data_segment->offset->loc = (yylsp[-2]);
       dup_text_list(&(yyvsp[-1].text_list), &data_segment->data, &data_segment->size);
       destroy_text_list(&(yyvsp[-1].text_list));
+      auto data_field = new DataSegmentModuleField(data_segment, (yylsp[-2]));
+
       uint32_t byte_size = WABT_ALIGN_UP_TO_PAGE(data_segment->size);
       uint32_t page_size = WABT_BYTES_TO_PAGES(byte_size);
 
-      ModuleField* memory_field = new ModuleField(ModuleFieldType::Memory);
-      memory_field->loc = (yylsp[-2]);
-      Memory* memory = memory_field->memory = new Memory();
+      auto memory = new Memory();
       memory->page_limits.initial = page_size;
       memory->page_limits.max = page_size;
       memory->page_limits.has_max = true;
+      auto memory_field = new MemoryModuleField(memory);
       (yyval.module_fields).first = memory_field;
       (yyval.module_fields).last = memory_field->next = data_field;
     }
-#line 3797 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3769 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1148 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1120 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
-      ModuleField* main = (yyval.module_fields).first;
-      main->loc = (yylsp[-3]);
-      if (main->type == ModuleFieldType::Global) {
-        main->global->name = (yyvsp[-2].text);
+      ModuleField* main_field = (yyval.module_fields).first;
+      main_field->loc = (yylsp[-3]);
+      if (auto global_field = dyn_cast<GlobalModuleField>(main_field)) {
+        global_field->global->name = (yyvsp[-2].text);
       } else {
-        assert(main->type == ModuleFieldType::Import);
-        main->import->global->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->global->name = (yyvsp[-2].text);
       }
     }
-#line 3813 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3784 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1162 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1133 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Global);
-      field->global = (yyvsp[-1].global);
+      auto field = new GlobalModuleField((yyvsp[-1].global));
       field->global->init_expr = (yyvsp[0].expr_list).first;
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3794 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1168 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1138 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Import);
-      field->loc = (yylsp[-1]);
-      field->import = (yyvsp[-1].import);
+      auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Global;
       field->import->global = (yyvsp[0].global);
       (yyval.module_fields).first = (yyval.module_fields).last = field;
     }
-#line 3837 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3805 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1176 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1144 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      ModuleField* field = new ModuleField(ModuleFieldType::Export);
-      field->loc = (yylsp[-1]);
-      field->export_ = (yyvsp[-1].export_);
+      auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Global;
       (yyval.module_fields).first = (yyvsp[0].module_fields).first;
       (yyval.module_fields).last = (yyvsp[0].module_fields).last->next = field;
     }
-#line 3850 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3816 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1189 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1155 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
@@ -3860,11 +3826,11 @@ yyreduce:
       (yyval.import)->func->decl.type_var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3830 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1198 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1164 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
@@ -3873,255 +3839,249 @@ yyreduce:
       (yyval.import)->func->decl.sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
     }
-#line 3877 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3843 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1206 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1172 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
       (yyval.import)->table->name = (yyvsp[-2].text);
     }
-#line 3888 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3854 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1212 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1178 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
       (yyval.import)->memory->name = (yyvsp[-2].text);
     }
-#line 3899 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3865 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1218 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1184 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
       (yyval.import)->global->name = (yyvsp[-2].text);
     }
-#line 3910 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3876 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1224 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1190 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Except;
       (yyval.import)->except = (yyvsp[0].exception);
     }
-#line 3920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3886 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1232 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1198 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::Import);
-      (yyval.module_field)->loc = (yylsp[-4]);
-      (yyval.module_field)->import = (yyvsp[-1].import);
-      (yyval.module_field)->import->module_name = (yyvsp[-3].text);
-      (yyval.module_field)->import->field_name = (yyvsp[-2].text);
+      auto field = new ImportModuleField((yyvsp[-1].import), (yylsp[-4]));
+      field->import->module_name = (yyvsp[-3].text);
+      field->import->field_name = (yyvsp[-2].text);
+      (yyval.module_field) = field;
     }
-#line 3932 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3897 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 162:
-#line 1242 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1207 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->module_name = (yyvsp[-2].text);
       (yyval.import)->field_name = (yyvsp[-1].text);
     }
-#line 3942 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3907 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 163:
-#line 1250 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1215 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Func;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3953 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3918 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1256 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1221 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Table;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3964 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3929 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1262 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1227 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Memory;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3975 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3940 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1268 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1233 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Global;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3986 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3951 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1274 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1239 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Except;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3997 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3962 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1282 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1247 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::Export);
-      (yyval.module_field)->loc = (yylsp[-3]);
-      (yyval.module_field)->export_ = (yyvsp[-1].export_);
-      (yyval.module_field)->export_->name = (yyvsp[-2].text);
+      auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-3]));
+      field->export_->name = (yyvsp[-2].text);
+      (yyval.module_field) = field;
     }
-#line 4008 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3972 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1291 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1255 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->name = (yyvsp[-1].text);
     }
-#line 4017 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3981 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1301 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1265 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::FuncType);
-      (yyval.module_field)->loc = (yylsp[-2]);
-      (yyval.module_field)->func_type = new FuncType();
-      (yyval.module_field)->func_type->sig = std::move(*(yyvsp[-1].func_sig));
+      auto func_type = new FuncType();
+      func_type->sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
+      (yyval.module_field) = new FuncTypeModuleField(func_type, (yylsp[-2]));
     }
-#line 4029 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3992 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 171:
-#line 1308 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1271 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::FuncType);
-      (yyval.module_field)->loc = (yylsp[-3]);
-      (yyval.module_field)->func_type = new FuncType();
-      (yyval.module_field)->func_type->name = (yyvsp[-2].text);
-      (yyval.module_field)->func_type->sig = std::move(*(yyvsp[-1].func_sig));
+      auto func_type = new FuncType();
+      func_type->name = (yyvsp[-2].text);
+      func_type->sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
+      (yyval.module_field) = new FuncTypeModuleField(func_type, (yylsp[-3]));
     }
-#line 4042 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4004 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 172:
-#line 1319 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1281 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new ModuleField(ModuleFieldType::Start);
-      (yyval.module_field)->loc = (yylsp[-2]);
-      (yyval.module_field)->start = std::move(*(yyvsp[-1].var));
+      (yyval.module_field) = new StartModuleField(*(yyvsp[-1].var), (yylsp[-2]));
       delete (yyvsp[-1].var);
     }
-#line 4053 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4013 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 173:
-#line 1328 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1288 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4059 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4019 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 178:
-#line 1333 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1293 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4065 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4025 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 179:
-#line 1334 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1294 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4071 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4031 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 180:
-#line 1335 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1295 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4077 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4037 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 181:
-#line 1336 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1296 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4083 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4043 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 182:
-#line 1337 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1297 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4089 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4049 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 183:
-#line 1338 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1298 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields).first = (yyval.module_fields).last = (yyvsp[0].module_field); }
-#line 4095 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4055 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 184:
-#line 1342 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1302 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module) = new Module(); }
-#line 4101 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4061 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 186:
-#line 1347 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1307 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new Module();
       check_import_ordering(&(yylsp[0]), lexer, parser, (yyval.module), (yyvsp[0].module_fields).first);
       append_module_fields((yyval.module), (yyvsp[0].module_fields).first);
     }
-#line 4111 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4071 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 187:
-#line 1352 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1312 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       check_import_ordering(&(yylsp[0]), lexer, parser, (yyval.module), (yyvsp[0].module_fields).first);
       append_module_fields((yyval.module), (yyvsp[0].module_fields).first);
     }
-#line 4121 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4081 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 188:
-#line 1360 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1320 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].script_module)->type == ScriptModule::Type::Text) {
         (yyval.module) = (yyvsp[0].script_module)->text;
@@ -4140,29 +4100,29 @@ yyreduce:
       }
       delete (yyvsp[0].script_module);
     }
-#line 4144 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4104 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 190:
-#line 1388 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1348 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var(kInvalidIndex);
     }
-#line 4152 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4112 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 191:
-#line 1391 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1351 "src/wast-parser.y" /* yacc.c:1646  */
     {
       StringSlice name;
       DUPTEXT(name, (yyvsp[0].text));
       (yyval.var) = new Var(name);
     }
-#line 4162 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4122 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 192:
-#line 1399 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1359 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script_module) = new ScriptModule();
       (yyval.script_module)->type = ScriptModule::Type::Text;
@@ -4181,11 +4141,11 @@ yyreduce:
         }
       }
     }
-#line 4185 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4145 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 193:
-#line 1417 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1377 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script_module) = new ScriptModule();
       (yyval.script_module)->type = ScriptModule::Type::Binary;
@@ -4194,11 +4154,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.script_module)->binary.data, &(yyval.script_module)->binary.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 4198 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4158 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 194:
-#line 1425 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1385 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script_module) = new ScriptModule();
       (yyval.script_module)->type = ScriptModule::Type::Quoted;
@@ -4207,11 +4167,11 @@ yyreduce:
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.script_module)->quoted.data, &(yyval.script_module)->quoted.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 4211 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4171 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 195:
-#line 1436 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1396 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-4]);
@@ -4223,11 +4183,11 @@ yyreduce:
       (yyval.action)->invoke->args = std::move(*(yyvsp[-1].consts));
       delete (yyvsp[-1].consts);
     }
-#line 4227 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4187 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 196:
-#line 1447 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1407 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-3]);
@@ -4236,128 +4196,128 @@ yyreduce:
       (yyval.action)->type = ActionType::Get;
       (yyval.action)->name = (yyvsp[-1].text);
     }
-#line 4240 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4200 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 197:
-#line 1458 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1418 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertMalformed;
       (yyval.command)->assert_malformed.module = (yyvsp[-2].script_module);
       (yyval.command)->assert_malformed.text = (yyvsp[-1].text);
     }
-#line 4251 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4211 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 198:
-#line 1464 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1424 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertInvalid;
       (yyval.command)->assert_invalid.module = (yyvsp[-2].script_module);
       (yyval.command)->assert_invalid.text = (yyvsp[-1].text);
     }
-#line 4262 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4222 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 199:
-#line 1470 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1430 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertUnlinkable;
       (yyval.command)->assert_unlinkable.module = (yyvsp[-2].script_module);
       (yyval.command)->assert_unlinkable.text = (yyvsp[-1].text);
     }
-#line 4273 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4233 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 200:
-#line 1476 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1436 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertUninstantiable;
       (yyval.command)->assert_uninstantiable.module = (yyvsp[-2].script_module);
       (yyval.command)->assert_uninstantiable.text = (yyvsp[-1].text);
     }
-#line 4284 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4244 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 201:
-#line 1482 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1442 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertReturn;
       (yyval.command)->assert_return.action = (yyvsp[-2].action);
       (yyval.command)->assert_return.expected = (yyvsp[-1].consts);
     }
-#line 4295 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4255 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 202:
-#line 1488 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1448 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertReturnCanonicalNan;
       (yyval.command)->assert_return_canonical_nan.action = (yyvsp[-1].action);
     }
-#line 4305 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4265 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 203:
-#line 1493 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1453 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertReturnArithmeticNan;
       (yyval.command)->assert_return_arithmetic_nan.action = (yyvsp[-1].action);
     }
-#line 4315 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4275 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 204:
-#line 1498 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1458 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertTrap;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 4326 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4286 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 205:
-#line 1504 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1464 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::AssertExhaustion;
       (yyval.command)->assert_trap.action = (yyvsp[-2].action);
       (yyval.command)->assert_trap.text = (yyvsp[-1].text);
     }
-#line 4337 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4297 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 206:
-#line 1513 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1473 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::Action;
       (yyval.command)->action = (yyvsp[0].action);
     }
-#line 4347 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4307 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 208:
-#line 1519 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1479 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::Module;
       (yyval.command)->module = (yyvsp[0].module);
     }
-#line 4357 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4317 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 209:
-#line 1524 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1484 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new Command();
       (yyval.command)->type = CommandType::Register;
@@ -4366,29 +4326,29 @@ yyreduce:
       delete (yyvsp[-1].var);
       (yyval.command)->register_.var.loc = (yylsp[-1]);
     }
-#line 4370 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4330 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 210:
-#line 1534 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1494 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = new CommandPtrVector();
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4379 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4339 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 211:
-#line 1538 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1498 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4388 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4348 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 212:
-#line 1545 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1505 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (WABT_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -4399,34 +4359,34 @@ yyreduce:
       }
       delete [] (yyvsp[-1].literal).text.start;
     }
-#line 4403 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4363 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 213:
-#line 1557 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1517 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.consts) = new ConstVector(); }
-#line 4409 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4369 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 214:
-#line 1558 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1518 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       (yyval.consts)->push_back((yyvsp[0].const_));
     }
-#line 4418 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4378 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 215:
-#line 1565 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1525 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
     }
-#line 4426 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4386 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 216:
-#line 1568 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1528 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       (yyval.script)->commands = std::move(*(yyvsp[0].commands));
@@ -4487,11 +4447,11 @@ yyreduce:
         }
       }
     }
-#line 4491 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4451 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 217:
-#line 1628 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1588 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       Command* command = new Command();
@@ -4499,17 +4459,17 @@ yyreduce:
       command->module = (yyvsp[0].module);
       (yyval.script)->commands.emplace_back(command);
     }
-#line 4503 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4463 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 218:
-#line 1640 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1600 "src/wast-parser.y" /* yacc.c:1646  */
     { parser->script = (yyvsp[0].script); }
-#line 4509 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4469 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4513 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4473 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4744,7 +4704,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1643 "src/wast-parser.y" /* yacc.c:1906  */
+#line 1603 "src/wast-parser.y" /* yacc.c:1906  */
 
 
 void append_expr_list(ExprList* expr_list, ExprList* expr) {
@@ -4931,125 +4891,147 @@ void append_module_fields(Module* module, ModuleField* first) {
     Index index = kInvalidIndex;
 
     switch (field->type) {
-      case ModuleFieldType::Func:
-        append_implicit_func_declaration(&field->loc, module,
-                                         &field->func->decl);
-        name = &field->func->name;
+      case ModuleFieldType::Func: {
+        Func* func = cast<FuncModuleField>(field)->func;
+        append_implicit_func_declaration(&field->loc, module, &func->decl);
+        name = &func->name;
         bindings = &module->func_bindings;
         index = module->funcs.size();
-        module->funcs.push_back(field->func);
+        module->funcs.push_back(func);
         break;
+      }
 
-      case ModuleFieldType::Global:
-        name = &field->global->name;
+      case ModuleFieldType::Global: {
+        Global* global = cast<GlobalModuleField>(field)->global;
+        name = &global->name;
         bindings = &module->global_bindings;
         index = module->globals.size();
-        module->globals.push_back(field->global);
+        module->globals.push_back(global);
         break;
+      }
 
-      case ModuleFieldType::Import:
-        switch (field->import->kind) {
+      case ModuleFieldType::Import: {
+        Import* import = cast<ImportModuleField>(field)->import;
+
+        switch (import->kind) {
           case ExternalKind::Func:
             append_implicit_func_declaration(&field->loc, module,
-                                             &field->import->func->decl);
-            name = &field->import->func->name;
+                                             &import->func->decl);
+            name = &import->func->name;
             bindings = &module->func_bindings;
             index = module->funcs.size();
-            module->funcs.push_back(field->import->func);
+            module->funcs.push_back(import->func);
             ++module->num_func_imports;
             break;
           case ExternalKind::Table:
-            name = &field->import->table->name;
+            name = &import->table->name;
             bindings = &module->table_bindings;
             index = module->tables.size();
-            module->tables.push_back(field->import->table);
+            module->tables.push_back(import->table);
             ++module->num_table_imports;
             break;
           case ExternalKind::Memory:
-            name = &field->import->memory->name;
+            name = &import->memory->name;
             bindings = &module->memory_bindings;
             index = module->memories.size();
-            module->memories.push_back(field->import->memory);
+            module->memories.push_back(import->memory);
             ++module->num_memory_imports;
             break;
           case ExternalKind::Global:
-            name = &field->import->global->name;
+            name = &import->global->name;
             bindings = &module->global_bindings;
             index = module->globals.size();
-            module->globals.push_back(field->import->global);
+            module->globals.push_back(import->global);
             ++module->num_global_imports;
             break;
           case ExternalKind::Except:
-            name = &field->import->except->name;
+            name = &import->except->name;
             bindings = &module->except_bindings;
             index = module->excepts.size();
-            module->excepts.push_back(field->import->except);
+            module->excepts.push_back(import->except);
             ++module->num_except_imports;
             break;
         }
-        module->imports.push_back(field->import);
+        module->imports.push_back(import);
         break;
+      }
 
-      case ModuleFieldType::Export:
+      case ModuleFieldType::Export: {
+        Export* export_ = cast<ExportModuleField>(field)->export_;
         if (field != main_field) {
           // If this is not the main field, it must be an inline export.
-          field->export_->var.type = VarType::Index;
-          field->export_->var.index = main_index;
+          export_->var.type = VarType::Index;
+          export_->var.index = main_index;
         }
-        name = &field->export_->name;
+        name = &export_->name;
         bindings = &module->export_bindings;
         index = module->exports.size();
-        module->exports.push_back(field->export_);
+        module->exports.push_back(export_);
         break;
+      }
 
-      case ModuleFieldType::FuncType:
-        name = &field->func_type->name;
+      case ModuleFieldType::FuncType: {
+        FuncType* func_type = cast<FuncTypeModuleField>(field)->func_type;
+        name = &func_type->name;
         bindings = &module->func_type_bindings;
         index = module->func_types.size();
-        module->func_types.push_back(field->func_type);
+        module->func_types.push_back(func_type);
         break;
+      }
 
-      case ModuleFieldType::Table:
-        name = &field->table->name;
+      case ModuleFieldType::Table: {
+        Table* table = cast<TableModuleField>(field)->table;
+        name = &table->name;
         bindings = &module->table_bindings;
         index = module->tables.size();
-        module->tables.push_back(field->table);
+        module->tables.push_back(table);
         break;
+      }
 
-      case ModuleFieldType::ElemSegment:
+      case ModuleFieldType::ElemSegment: {
+        ElemSegment* elem_segment =
+            cast<ElemSegmentModuleField>(field)->elem_segment;
         if (field != main_field) {
           // If this is not the main field, it must be an inline elem segment.
-          field->elem_segment->table_var.type = VarType::Index;
-          field->elem_segment->table_var.index = main_index;
+          elem_segment->table_var.type = VarType::Index;
+          elem_segment->table_var.index = main_index;
         }
-        module->elem_segments.push_back(field->elem_segment);
+        module->elem_segments.push_back(elem_segment);
         break;
+      }
 
-      case ModuleFieldType::Memory:
-        name = &field->memory->name;
+      case ModuleFieldType::Memory: {
+        Memory* memory = cast<MemoryModuleField>(field)->memory;
+        name = &memory->name;
         bindings = &module->memory_bindings;
         index = module->memories.size();
-        module->memories.push_back(field->memory);
+        module->memories.push_back(memory);
         break;
+      }
 
-      case ModuleFieldType::DataSegment:
+      case ModuleFieldType::DataSegment: {
+        DataSegment* data_segment =
+            cast<DataSegmentModuleField>(field)->data_segment;
         if (field != main_field) {
           // If this is not the main field, it must be an inline data segment.
-          field->data_segment->memory_var.type = VarType::Index;
-          field->data_segment->memory_var.index = main_index;
+          data_segment->memory_var.type = VarType::Index;
+          data_segment->memory_var.index = main_index;
         }
-        module->data_segments.push_back(field->data_segment);
+        module->data_segments.push_back(data_segment);
         break;
+      }
 
-      case ModuleFieldType::Except:
-        name = &field->except->name;
+      case ModuleFieldType::Except: {
+        Exception* except = cast<ExceptionModuleField>(field)->except;
+        name = &except->name;
         bindings = &module->except_bindings;
         index = module->excepts.size();
-        module->excepts.push_back(field->except);
+        module->excepts.push_back(except);
         break;
+      }
 
       case ModuleFieldType::Start:
-        module->start = &field->start;
+        module->start = &cast<StartModuleField>(field)->start;
         break;
     }
 

--- a/src/tracing.cc
+++ b/src/tracing.cc
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define WABT_TRACING 1
+#include "tracing.h"
+
+namespace {
+
+size_t indent = 0;
+const char* indent_text = "  ";
+
+void Fill() {
+  for (size_t i = 0; i < indent; ++i)
+    fputs(indent_text, stderr);
+}
+
+void Indent() {
+  Fill();
+  ++indent;
+}
+
+void Dedent() {
+  if (indent)
+    --indent;
+  Fill();
+}
+
+}  // end of anonymous namespace
+
+namespace wabt {
+
+// static
+
+TraceScope::TraceScope(const char* method) : method_(method) {
+  PrintEnter(method);
+  PrintNewline();
+}
+
+TraceScope::~TraceScope() {
+  Dedent();
+  fputs("<- ", stderr);
+  fputs(method_, stderr);
+  fputc('\n', stderr);
+}
+
+void TraceScope::PrintEnter(const char* method) {
+  Indent();
+  fputs("-> ", stderr);
+  fputs(method, stderr);
+  fputs("(", stderr);
+}
+
+void TraceScope::PrintNewline() {
+  fputs(")\n", stderr);
+}
+
+}  // end of namespace wabt

--- a/src/tracing.h
+++ b/src/tracing.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_WAT_TRACING_H_
+#define WABT_WAT_TRACING_H_
+
+// Provides a simple tracing class that automatically generates enter/exit
+// messages using the scope of the instance.
+//
+// It also assumes that this file is only included in .cc files.
+// Immediately before the inclusion of this file, there is a define of
+// for WABT_TRACING, defining whether tracing should be compiled in for
+// that source file.
+
+#ifndef WABT_TRACING
+#define WABT_TRACING 0
+#endif
+
+#include "common.h"
+
+namespace wabt {
+
+#if WABT_TRACING
+
+// Scoped class that automatically prints enter("->") and exit("<-")
+// lines, indented by trace level.
+struct TraceScope {
+  WABT_DISALLOW_COPY_AND_ASSIGN(TraceScope);
+  TraceScope() = delete;
+  TraceScope(const char* method);
+  template<typename... Args>
+  TraceScope(const char* method, const char* format, Args... args)
+      : method_(method) {
+    PrintEnter(method);
+    fprintf(stderr, format, args...);
+    PrintNewline();
+  }
+  ~TraceScope();
+
+ private:
+  const char* method_;
+  void PrintEnter(const char* method);
+  void PrintNewline();
+};
+
+#define WABT_TRACE(method_name) TraceScope _trace_##method_name##_(#method_name);
+
+#define WABT_TRACE_ARGS(method_name, format, ...) \
+  TraceScope trace_##method_name##_(#method_name, format, __VA_ARGS__);
+
+#else
+
+#define WABT_TRACE(method)
+#define WABT_TRACE_ARGS(method_name, format, ...)
+
+#endif
+
+}  // end namespace wabt
+
+#endif // WABT_WAT_TRACING_H_

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -23,6 +23,7 @@
 #include <cstdio>
 
 #include "binary-reader.h"
+#include "cast.h"
 #include "source-error-handler.h"
 #include "type-checker.h"
 #include "wast-parser-lexer-shared.h"
@@ -424,11 +425,11 @@ void Validator::CheckExpr(const Expr* expr) {
 
   switch (expr->type) {
     case ExprType::Binary:
-      typechecker_.OnBinary(expr->As<BinaryExpr>()->opcode);
+      typechecker_.OnBinary(cast<BinaryExpr>(expr)->opcode);
       break;
 
     case ExprType::Block: {
-      auto block_expr = expr->As<BlockExpr>();
+      auto block_expr = cast<BlockExpr>(expr);
       CheckBlockSig(&block_expr->loc, Opcode::Block, &block_expr->block->sig);
       typechecker_.OnBlock(&block_expr->block->sig);
       CheckExprList(&block_expr->loc, block_expr->block->first);
@@ -437,15 +438,15 @@ void Validator::CheckExpr(const Expr* expr) {
     }
 
     case ExprType::Br:
-      typechecker_.OnBr(expr->As<BrExpr>()->var.index);
+      typechecker_.OnBr(cast<BrExpr>(expr)->var.index);
       break;
 
     case ExprType::BrIf:
-      typechecker_.OnBrIf(expr->As<BrIfExpr>()->var.index);
+      typechecker_.OnBrIf(cast<BrIfExpr>(expr)->var.index);
       break;
 
     case ExprType::BrTable: {
-      auto br_table_expr = expr->As<BrTableExpr>();
+      auto br_table_expr = cast<BrTableExpr>(expr);
       typechecker_.BeginBrTable();
       for (Var& var : *br_table_expr->targets) {
         typechecker_.OnBrTableTarget(var.index);
@@ -457,7 +458,7 @@ void Validator::CheckExpr(const Expr* expr) {
 
     case ExprType::Call: {
       const Func* callee;
-      if (WABT_SUCCEEDED(CheckFuncVar(&expr->As<CallExpr>()->var, &callee))) {
+      if (WABT_SUCCEEDED(CheckFuncVar(&cast<CallExpr>(expr)->var, &callee))) {
         typechecker_.OnCall(&callee->decl.sig.param_types,
                             &callee->decl.sig.result_types);
       }
@@ -469,7 +470,7 @@ void Validator::CheckExpr(const Expr* expr) {
       if (current_module_->tables.size() == 0) {
         PrintError(&expr->loc, "found call_indirect operator, but no table");
       }
-      if (WABT_SUCCEEDED(CheckFuncTypeVar(&expr->As<CallIndirectExpr>()->var,
+      if (WABT_SUCCEEDED(CheckFuncTypeVar(&cast<CallIndirectExpr>(expr)->var,
                                           &func_type))) {
         typechecker_.OnCallIndirect(&func_type->sig.param_types,
                                     &func_type->sig.result_types);
@@ -478,15 +479,15 @@ void Validator::CheckExpr(const Expr* expr) {
     }
 
     case ExprType::Compare:
-      typechecker_.OnCompare(expr->As<CompareExpr>()->opcode);
+      typechecker_.OnCompare(cast<CompareExpr>(expr)->opcode);
       break;
 
     case ExprType::Const:
-      typechecker_.OnConst(expr->As<ConstExpr>()->const_.type);
+      typechecker_.OnConst(cast<ConstExpr>(expr)->const_.type);
       break;
 
     case ExprType::Convert:
-      typechecker_.OnConvert(expr->As<ConvertExpr>()->opcode);
+      typechecker_.OnConvert(cast<ConvertExpr>(expr)->opcode);
       break;
 
     case ExprType::Drop:
@@ -495,12 +496,12 @@ void Validator::CheckExpr(const Expr* expr) {
 
     case ExprType::GetGlobal:
       typechecker_.OnGetGlobal(
-          GetGlobalVarTypeOrAny(&expr->As<GetGlobalExpr>()->var));
+          GetGlobalVarTypeOrAny(&cast<GetGlobalExpr>(expr)->var));
       break;
 
     case ExprType::GetLocal:
       typechecker_.OnGetLocal(
-          GetLocalVarTypeOrAny(&expr->As<GetLocalExpr>()->var));
+          GetLocalVarTypeOrAny(&cast<GetLocalExpr>(expr)->var));
       break;
 
     case ExprType::GrowMemory:
@@ -509,7 +510,7 @@ void Validator::CheckExpr(const Expr* expr) {
       break;
 
     case ExprType::If: {
-      auto if_expr = expr->As<IfExpr>();
+      auto if_expr = cast<IfExpr>(expr);
       CheckBlockSig(&if_expr->loc, Opcode::If, &if_expr->true_->sig);
       typechecker_.OnIf(&if_expr->true_->sig);
       CheckExprList(&if_expr->loc, if_expr->true_->first);
@@ -522,7 +523,7 @@ void Validator::CheckExpr(const Expr* expr) {
     }
 
     case ExprType::Load: {
-      auto load_expr = expr->As<LoadExpr>();
+      auto load_expr = cast<LoadExpr>(expr);
       CheckHasMemory(&load_expr->loc, load_expr->opcode);
       CheckAlign(&load_expr->loc, load_expr->align,
                  get_opcode_natural_alignment(load_expr->opcode));
@@ -531,7 +532,7 @@ void Validator::CheckExpr(const Expr* expr) {
     }
 
     case ExprType::Loop: {
-      auto loop_expr = expr->As<LoopExpr>();
+      auto loop_expr = cast<LoopExpr>(expr);
       CheckBlockSig(&loop_expr->loc, Opcode::Loop, &loop_expr->block->sig);
       typechecker_.OnLoop(&loop_expr->block->sig);
       CheckExprList(&loop_expr->loc, loop_expr->block->first);
@@ -548,7 +549,7 @@ void Validator::CheckExpr(const Expr* expr) {
       break;
 
     case ExprType::Rethrow:
-      typechecker_.OnRethrow(expr->As<RethrowExpr>()->var.index);
+      typechecker_.OnRethrow(cast<RethrowExpr>(expr)->var.index);
       break;
 
     case ExprType::Return:
@@ -561,16 +562,16 @@ void Validator::CheckExpr(const Expr* expr) {
 
     case ExprType::SetGlobal:
       typechecker_.OnSetGlobal(
-          GetGlobalVarTypeOrAny(&expr->As<SetGlobalExpr>()->var));
+          GetGlobalVarTypeOrAny(&cast<SetGlobalExpr>(expr)->var));
       break;
 
     case ExprType::SetLocal:
       typechecker_.OnSetLocal(
-          GetLocalVarTypeOrAny(&expr->As<SetLocalExpr>()->var));
+          GetLocalVarTypeOrAny(&cast<SetLocalExpr>(expr)->var));
       break;
 
     case ExprType::Store: {
-      auto store_expr = expr->As<StoreExpr>();
+      auto store_expr = cast<StoreExpr>(expr);
       CheckHasMemory(&store_expr->loc, store_expr->opcode);
       CheckAlign(&store_expr->loc, store_expr->align,
                  get_opcode_natural_alignment(store_expr->opcode));
@@ -580,19 +581,19 @@ void Validator::CheckExpr(const Expr* expr) {
 
     case ExprType::TeeLocal:
       typechecker_.OnTeeLocal(
-          GetLocalVarTypeOrAny(&expr->As<TeeLocalExpr>()->var));
+          GetLocalVarTypeOrAny(&cast<TeeLocalExpr>(expr)->var));
       break;
 
     case ExprType::Throw:
       const Exception* except;
       if (WABT_SUCCEEDED(
-              CheckExceptVar(&expr->As<ThrowExpr>()->var, &except))) {
+              CheckExceptVar(&cast<ThrowExpr>(expr)->var, &except))) {
         typechecker_.OnThrow(&except->sig);
       }
       break;
 
     case ExprType::TryBlock: {
-      auto try_expr = expr->As<TryExpr>();
+      auto try_expr = cast<TryExpr>(expr);
       TryContext context;
       context.try_ = try_expr;
       try_contexts_.push_back(context);
@@ -625,7 +626,7 @@ void Validator::CheckExpr(const Expr* expr) {
     }
 
     case ExprType::Unary:
-      typechecker_.OnUnary(expr->As<UnaryExpr>()->opcode);
+      typechecker_.OnUnary(cast<UnaryExpr>(expr)->opcode);
       break;
 
     case ExprType::Unreachable:
@@ -684,13 +685,13 @@ void Validator::CheckConstInitExpr(const Location* loc,
 
     switch (expr->type) {
       case ExprType::Const:
-        type = expr->As<ConstExpr>()->const_.type;
+        type = cast<ConstExpr>(expr)->const_.type;
         break;
 
       case ExprType::GetGlobal: {
         const Global* ref_global = nullptr;
         Index ref_global_index;
-        if (WABT_FAILED(CheckGlobalVar(&expr->As<GetGlobalExpr>()->var,
+        if (WABT_FAILED(CheckGlobalVar(&cast<GetGlobalExpr>(expr)->var,
                                        &ref_global, &ref_global_index))) {
           return;
         }
@@ -754,21 +755,20 @@ void Validator::CheckTable(const Location* loc, const Table* table) {
 
 void Validator::CheckElemSegments(const Module* module) {
   for (ModuleField* field = module->first_field; field; field = field->next) {
-    if (field->type != ModuleFieldType::ElemSegment)
-      continue;
-
-    ElemSegment* elem_segment = field->elem_segment;
-    const Table* table;
-    if (!WABT_SUCCEEDED(CheckTableVar(&elem_segment->table_var, &table)))
-      continue;
-
-    for (const Var& var : elem_segment->vars) {
-      if (!WABT_SUCCEEDED(CheckFuncVar(&var, nullptr)))
+    if (auto elem_segment_field = dyn_cast<ElemSegmentModuleField>(field)) {
+      ElemSegment* elem_segment = elem_segment_field->elem_segment;
+      const Table* table;
+      if (!WABT_SUCCEEDED(CheckTableVar(&elem_segment->table_var, &table)))
         continue;
-    }
 
-    CheckConstInitExpr(&field->loc, elem_segment->offset, Type::I32,
-                       "elem segment offset");
+      for (const Var& var : elem_segment->vars) {
+        if (!WABT_SUCCEEDED(CheckFuncVar(&var, nullptr)))
+          continue;
+      }
+
+      CheckConstInitExpr(&field->loc, elem_segment->offset, Type::I32,
+                         "elem segment offset");
+    }
   }
 }
 
@@ -780,16 +780,15 @@ void Validator::CheckMemory(const Location* loc, const Memory* memory) {
 
 void Validator::CheckDataSegments(const Module* module) {
   for (ModuleField* field = module->first_field; field; field = field->next) {
-    if (field->type != ModuleFieldType::DataSegment)
-      continue;
+    if (auto data_segment_field = dyn_cast<DataSegmentModuleField>(field)) {
+      DataSegment* data_segment = data_segment_field->data_segment;
+      const Memory* memory;
+      if (!WABT_SUCCEEDED(CheckMemoryVar(&data_segment->memory_var, &memory)))
+        continue;
 
-    DataSegment* data_segment = field->data_segment;
-    const Memory* memory;
-    if (!WABT_SUCCEEDED(CheckMemoryVar(&data_segment->memory_var, &memory)))
-      continue;
-
-    CheckConstInitExpr(&field->loc, data_segment->offset, Type::I32,
-                       "data segment offset");
+      CheckConstInitExpr(&field->loc, data_segment->offset, Type::I32,
+                         "data segment offset");
+    }
   }
 }
 
@@ -872,28 +871,28 @@ Result Validator::CheckModule(const Module* module) {
     switch (field->type) {
       case ModuleFieldType::Except:
         ++current_except_index_;
-        CheckExcept(&field->loc, field->except);
+        CheckExcept(&field->loc, cast<ExceptionModuleField>(field)->except);
         break;
 
       case ModuleFieldType::Func:
-        CheckFunc(&field->loc, field->func);
+        CheckFunc(&field->loc, cast<FuncModuleField>(field)->func);
         break;
 
       case ModuleFieldType::Global:
-        CheckGlobal(&field->loc, field->global);
+        CheckGlobal(&field->loc, cast<GlobalModuleField>(field)->global);
         current_global_index_++;
         break;
 
       case ModuleFieldType::Import:
-        CheckImport(&field->loc, field->import);
+        CheckImport(&field->loc, cast<ImportModuleField>(field)->import);
         break;
 
       case ModuleFieldType::Export:
-        CheckExport(&field->loc, field->export_);
+        CheckExport(&field->loc, cast<ExportModuleField>(field)->export_);
         break;
 
       case ModuleFieldType::Table:
-        CheckTable(&field->loc, field->table);
+        CheckTable(&field->loc, cast<TableModuleField>(field)->table);
         current_table_index_++;
         break;
 
@@ -902,7 +901,7 @@ Result Validator::CheckModule(const Module* module) {
         break;
 
       case ModuleFieldType::Memory:
-        CheckMemory(&field->loc, field->memory);
+        CheckMemory(&field->loc, cast<MemoryModuleField>(field)->memory);
         current_memory_index_++;
         break;
 
@@ -919,7 +918,7 @@ Result Validator::CheckModule(const Module* module) {
         }
 
         const Func* start_func = nullptr;
-        CheckFuncVar(&field->start, &start_func);
+        CheckFuncVar(&cast<StartModuleField>(field)->start, &start_func);
         if (start_func) {
           if (start_func->GetNumParams() != 0) {
             PrintError(&field->loc, "start function must be nullary");

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -26,6 +26,7 @@
 #include <string>
 #include <vector>
 
+#include "cast.h"
 #include "common.h"
 #include "ir.h"
 #include "literal.h"
@@ -466,52 +467,52 @@ void WatWriter::WriteConst(const Const* const_) {
 void WatWriter::WriteExpr(const Expr* expr) {
   switch (expr->type) {
     case ExprType::Binary:
-      WritePutsNewline(expr->As<BinaryExpr>()->opcode.GetName());
+      WritePutsNewline(cast<BinaryExpr>(expr)->opcode.GetName());
       break;
 
     case ExprType::Block:
-      WriteBlock(LabelType::Block, expr->As<BlockExpr>()->block,
+      WriteBlock(LabelType::Block, cast<BlockExpr>(expr)->block,
                  Opcode::Block_Opcode.GetName());
       break;
 
     case ExprType::Br:
       WritePutsSpace(Opcode::Br_Opcode.GetName());
-      WriteBrVar(&expr->As<BrExpr>()->var, NextChar::Newline);
+      WriteBrVar(&cast<BrExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::BrIf:
       WritePutsSpace(Opcode::BrIf_Opcode.GetName());
-      WriteBrVar(&expr->As<BrIfExpr>()->var, NextChar::Newline);
+      WriteBrVar(&cast<BrIfExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::BrTable: {
       WritePutsSpace(Opcode::BrTable_Opcode.GetName());
-      for (const Var& var : *expr->As<BrTableExpr>()->targets)
+      for (const Var& var : *cast<BrTableExpr>(expr)->targets)
         WriteBrVar(&var, NextChar::Space);
-      WriteBrVar(&expr->As<BrTableExpr>()->default_target, NextChar::Newline);
+      WriteBrVar(&cast<BrTableExpr>(expr)->default_target, NextChar::Newline);
       break;
     }
 
     case ExprType::Call:
       WritePutsSpace(Opcode::Call_Opcode.GetName());
-      WriteVar(&expr->As<CallExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<CallExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::CallIndirect:
       WritePutsSpace(Opcode::CallIndirect_Opcode.GetName());
-      WriteVar(&expr->As<CallIndirectExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<CallIndirectExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::Compare:
-      WritePutsNewline(expr->As<CompareExpr>()->opcode.GetName());
+      WritePutsNewline(cast<CompareExpr>(expr)->opcode.GetName());
       break;
 
     case ExprType::Const:
-      WriteConst(&expr->As<ConstExpr>()->const_);
+      WriteConst(&cast<ConstExpr>(expr)->const_);
       break;
 
     case ExprType::Convert:
-      WritePutsNewline(expr->As<ConvertExpr>()->opcode.GetName());
+      WritePutsNewline(cast<ConvertExpr>(expr)->opcode.GetName());
       break;
 
     case ExprType::Drop:
@@ -520,12 +521,12 @@ void WatWriter::WriteExpr(const Expr* expr) {
 
     case ExprType::GetGlobal:
       WritePutsSpace(Opcode::GetGlobal_Opcode.GetName());
-      WriteVar(&expr->As<GetGlobalExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<GetGlobalExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::GetLocal:
       WritePutsSpace(Opcode::GetLocal_Opcode.GetName());
-      WriteVar(&expr->As<GetLocalExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<GetLocalExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::GrowMemory:
@@ -533,7 +534,7 @@ void WatWriter::WriteExpr(const Expr* expr) {
       break;
 
     case ExprType::If: {
-      auto if_expr = expr->As<IfExpr>();
+      auto if_expr = cast<IfExpr>(expr);
       WriteBeginBlock(LabelType::If, if_expr->true_,
                       Opcode::If_Opcode.GetName());
       WriteExprList(if_expr->true_->first);
@@ -549,7 +550,7 @@ void WatWriter::WriteExpr(const Expr* expr) {
     }
 
     case ExprType::Load: {
-      auto load_expr = expr->As<LoadExpr>();
+      auto load_expr = cast<LoadExpr>(expr);
       WritePutsSpace(load_expr->opcode.GetName());
       if (load_expr->offset)
         Writef("offset=%u", load_expr->offset);
@@ -560,7 +561,7 @@ void WatWriter::WriteExpr(const Expr* expr) {
     }
 
     case ExprType::Loop:
-      WriteBlock(LabelType::Loop, expr->As<LoopExpr>()->block,
+      WriteBlock(LabelType::Loop, cast<LoopExpr>(expr)->block,
                  Opcode::Loop_Opcode.GetName());
       break;
 
@@ -574,7 +575,7 @@ void WatWriter::WriteExpr(const Expr* expr) {
 
     case ExprType::Rethrow:
       WritePutsSpace(Opcode::Rethrow_Opcode.GetName());
-      WriteBrVar(&expr->As<RethrowExpr>()->var, NextChar::Newline);
+      WriteBrVar(&cast<RethrowExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::Return:
@@ -587,16 +588,16 @@ void WatWriter::WriteExpr(const Expr* expr) {
 
     case ExprType::SetGlobal:
       WritePutsSpace(Opcode::SetGlobal_Opcode.GetName());
-      WriteVar(&expr->As<SetGlobalExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<SetGlobalExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::SetLocal:
       WritePutsSpace(Opcode::SetLocal_Opcode.GetName());
-      WriteVar(&expr->As<SetLocalExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<SetLocalExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::Store: {
-      auto store_expr = expr->As<StoreExpr>();
+      auto store_expr = cast<StoreExpr>(expr);
       WritePutsSpace(store_expr->opcode.GetName());
       if (store_expr->offset)
         Writef("offset=%u", store_expr->offset);
@@ -608,16 +609,16 @@ void WatWriter::WriteExpr(const Expr* expr) {
 
     case ExprType::TeeLocal:
       WritePutsSpace(Opcode::TeeLocal_Opcode.GetName());
-      WriteVar(&expr->As<TeeLocalExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<TeeLocalExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::Throw:
       WritePutsSpace(Opcode::Throw_Opcode.GetName());
-      WriteVar(&expr->As<ThrowExpr>()->var, NextChar::Newline);
+      WriteVar(&cast<ThrowExpr>(expr)->var, NextChar::Newline);
       break;
 
     case ExprType::TryBlock: {
-      auto try_ = expr->As<TryExpr>();
+      auto try_ = cast<TryExpr>(expr);
       WriteBeginBlock(LabelType::Try, try_->block,
                       Opcode::Try_Opcode.GetName());
       WriteExprList(try_->block->first);
@@ -638,7 +639,7 @@ void WatWriter::WriteExpr(const Expr* expr) {
     }
 
     case ExprType::Unary:
-      WritePutsNewline(expr->As<UnaryExpr>()->opcode.GetName());
+      WritePutsNewline(cast<UnaryExpr>(expr)->opcode.GetName());
       break;
 
     case ExprType::Unreachable:
@@ -706,32 +707,32 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
       break;
 
     case ExprType::Block:
-      PushExpr(expr, 0, expr->As<BlockExpr>()->block->sig.size());
+      PushExpr(expr, 0, cast<BlockExpr>(expr)->block->sig.size());
       break;
 
     case ExprType::Br:
-      PushExpr(expr, GetLabelArity(&expr->As<BrExpr>()->var), 1);
+      PushExpr(expr, GetLabelArity(&cast<BrExpr>(expr)->var), 1);
       break;
 
     case ExprType::BrIf: {
-      Index arity = GetLabelArity(&expr->As<BrIfExpr>()->var);
+      Index arity = GetLabelArity(&cast<BrIfExpr>(expr)->var);
       PushExpr(expr, arity + 1, arity);
       break;
     }
 
     case ExprType::BrTable:
       PushExpr(expr,
-               GetLabelArity(&expr->As<BrTableExpr>()->default_target) + 1, 1);
+               GetLabelArity(&cast<BrTableExpr>(expr)->default_target) + 1, 1);
       break;
 
     case ExprType::Call: {
-      const Var& var = expr->As<CallExpr>()->var;
+      const Var& var = cast<CallExpr>(expr)->var;
       PushExpr(expr, GetFuncParamCount(&var), GetFuncResultCount(&var));
       break;
     }
 
     case ExprType::CallIndirect: {
-      const Var& var = expr->As<CallIndirectExpr>()->var;
+      const Var& var = cast<CallIndirectExpr>(expr)->var;
       PushExpr(expr, GetFuncSigParamCount(&var) + 1,
                GetFuncSigResultCount(&var));
       break;
@@ -760,11 +761,11 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
       break;
 
     case ExprType::If:
-      PushExpr(expr, 1, expr->As<IfExpr>()->true_->sig.size());
+      PushExpr(expr, 1, cast<IfExpr>(expr)->true_->sig.size());
       break;
 
     case ExprType::Loop:
-      PushExpr(expr, 0, expr->As<LoopExpr>()->block->sig.size());
+      PushExpr(expr, 0, cast<LoopExpr>(expr)->block->sig.size());
       break;
 
     case ExprType::Nop:
@@ -813,24 +814,24 @@ void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
   switch (expr_tree.expr->type) {
     case ExprType::Block:
       WritePuts("(", NextChar::None);
-      WriteBeginBlock(LabelType::Block, expr_tree.expr->As<BlockExpr>()->block,
+      WriteBeginBlock(LabelType::Block, cast<BlockExpr>(expr_tree.expr)->block,
                       Opcode::Block_Opcode.GetName());
-      WriteFoldedExprList(expr_tree.expr->As<BlockExpr>()->block->first);
+      WriteFoldedExprList(cast<BlockExpr>(expr_tree.expr)->block->first);
       FlushExprTreeStack();
       WriteCloseNewline();
       break;
 
     case ExprType::Loop:
       WritePuts("(", NextChar::None);
-      WriteBeginBlock(LabelType::Loop, expr_tree.expr->As<LoopExpr>()->block,
+      WriteBeginBlock(LabelType::Loop, cast<LoopExpr>(expr_tree.expr)->block,
                       Opcode::Loop_Opcode.GetName());
-      WriteFoldedExprList(expr_tree.expr->As<LoopExpr>()->block->first);
+      WriteFoldedExprList(cast<LoopExpr>(expr_tree.expr)->block->first);
       FlushExprTreeStack();
       WriteCloseNewline();
       break;
 
     case ExprType::If: {
-      auto if_expr = expr_tree.expr->As<IfExpr>();
+      auto if_expr = cast<IfExpr>(expr_tree.expr);
       WritePuts("(", NextChar::None);
       WriteBeginBlock(LabelType::If, if_expr->true_,
                       Opcode::If_Opcode.GetName());
@@ -1088,37 +1089,37 @@ Result WatWriter::WriteModule(const Module* module) {
        field = field->next) {
     switch (field->type) {
       case ModuleFieldType::Func:
-        WriteFunc(module, field->func);
+        WriteFunc(module, cast<FuncModuleField>(field)->func);
         break;
       case ModuleFieldType::Global:
-        WriteGlobal(field->global);
+        WriteGlobal(cast<GlobalModuleField>(field)->global);
         break;
       case ModuleFieldType::Import:
-        WriteImport(field->import);
+        WriteImport(cast<ImportModuleField>(field)->import);
         break;
       case ModuleFieldType::Except:
-        WriteException(field->except);
+        WriteException(cast<ExceptionModuleField>(field)->except);
         break;
       case ModuleFieldType::Export:
-        WriteExport(field->export_);
+        WriteExport(cast<ExportModuleField>(field)->export_);
         break;
       case ModuleFieldType::Table:
-        WriteTable(field->table);
+        WriteTable(cast<TableModuleField>(field)->table);
         break;
       case ModuleFieldType::ElemSegment:
-        WriteElemSegment(field->elem_segment);
+        WriteElemSegment(cast<ElemSegmentModuleField>(field)->elem_segment);
         break;
       case ModuleFieldType::Memory:
-        WriteMemory(field->memory);
+        WriteMemory(cast<MemoryModuleField>(field)->memory);
         break;
       case ModuleFieldType::DataSegment:
-        WriteDataSegment(field->data_segment);
+        WriteDataSegment(cast<DataSegmentModuleField>(field)->data_segment);
         break;
       case ModuleFieldType::FuncType:
-        WriteFuncType(field->func_type);
+        WriteFuncType(cast<FuncTypeModuleField>(field)->func_type);
         break;
       case ModuleFieldType::Start:
-        WriteStartFunction(&field->start);
+        WriteStartFunction(&cast<StartModuleField>(field)->start);
         break;
     }
   }

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -821,7 +821,7 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
       break;
 
     case ExprType::Throw: {
-      auto throw_ = expr->As<ThrowExpr>();
+      auto throw_ = cast<ThrowExpr>(expr);
       Index operand_count = 0;
       if (Exception* except = module_->GetExcept(throw_->var)) {
         operand_count = except->sig.size();
@@ -831,7 +831,7 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
     }
 
     case ExprType::TryBlock:
-      PushExpr(expr, 0, expr->As<TryExpr>()->block->sig.size());
+      PushExpr(expr, 0, cast<TryExpr>(expr)->block->sig.size());
       break;
 
     default:
@@ -952,7 +952,7 @@ void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
     }
 
     case ExprType::TryBlock: {
-      auto try_ = expr_tree.expr->As<TryExpr>();
+      auto try_ = cast<TryExpr>(expr_tree.expr);
       WritePuts("(", NextChar::None);
       WriteBeginBlock(LabelType::Try, try_->block,
                       Opcode::Try_Opcode.GetName());

--- a/test/desugar/fold-catch.txt
+++ b/test/desugar/fold-catch.txt
@@ -21,7 +21,8 @@
     (try $try1 (result i32)
       (nop)
       (i32.const 7)
-      (catch $ex (i32.const 9))
+      (catch $ex
+        (i32.const 9))
       (catch_all
         (i32.const 11)))))
 ;;; STDOUT ;;)

--- a/test/desugar/fold-try-as-argument.txt
+++ b/test/desugar/fold-try-as-argument.txt
@@ -28,7 +28,8 @@
         (try $try1 (result i32)
           (nop)
           (i32.const 7)
-          (catch $ex (nop))
+          (catch $ex
+            (nop))
           (catch_all
             (rethrow $try1))))
       (i32.const 8))))

--- a/test/desugar/fold-try.txt
+++ b/test/desugar/fold-try.txt
@@ -21,7 +21,8 @@
     (try $try1 (result i32)
       (nop)
       (i32.const 7)
-      (catch $ex (nop))
+      (catch $ex
+        (nop))
       (catch_all
         (rethrow $try1)))))
 ;;; STDOUT ;;)

--- a/test/desugar/fold_try_as_argument.txt
+++ b/test/desugar/fold_try_as_argument.txt
@@ -1,0 +1,35 @@
+;;; TOOL: wast-desugar
+;;; FLAGS: --future-exceptions --fold-expr
+(module
+  (except $ex i32)
+  (func (result i32)
+    i32.const 1
+    try $try1 (result i32)
+      nop
+      i32.const 7
+    catch $ex
+      nop
+    catch_all
+      rethrow $try1
+    end
+    i32.add
+    i32.const 8
+    i32.sub
+  )
+)
+(;; STDOUT ;;;
+(module
+  (except $ex i32)
+  (type (;0;) (func (result i32)))
+  (func (;0;) (result i32)
+    (i32.sub
+      (i32.add
+        (i32.const 1)
+        (try $try1 (result i32)
+          (nop)
+          (i32.const 7)
+          (catch $ex (nop))
+          (catch_all
+            (rethrow $try1))))
+      (i32.const 8))))
+;;; STDOUT ;;)


### PR DESCRIPTION
Implements expression folding for exception handling constructs in the wat writer.

Also adds the following for debugging:

1) Names to  the enum ExprType.

2) Adds (compile-time) conditional debugging trace code to wat-writer.cc, making it easier to see how the IR is being translated.