### PR TITLE
Explicitly initialize LexToken.value_ with 0

### DIFF
--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -96,10 +96,8 @@ namespace wabt {
 
 struct WastLexer::LexToken {
   Location loc_;
-  int value_;
+  int value_ = 0;
   Token lval_;
-
-  LexToken(void): value_(0) {}
 };
 
 struct WastLexer::Lookahead {


### PR DESCRIPTION
As suggested by Sam Clegg (@sbc100) this is a simpler solution to
my first solution, PR #530.