### PR TITLE
Support for CommonJS and AMD loaders in libwabt.js

### DIFF
--- a/src/wabt.post.js
+++ b/src/wabt.post.js
@@ -350,10 +350,17 @@ WasmModule.prototype.destroy = function() {
   Module._wabt_destroy_module(this.module_addr);
 };
 
-return {
+var exports = {
   ready: Promise.resolve(),
   parseWast: parseWast,
   readWasm: readWasm,
 };
+
+if (typeof module !== "undefined" && module && module.exports)
+  module.exports = exports;
+else if (typeof define === "function" && define.amd)
+  define(function() { return exports; });
+else
+  (typeof global !== "undefined" && global || typeof window !== "undefined" && window || this).wabt = exports;
 
 })();  // Call IIFE from wabt.pre.js.

--- a/src/wabt.pre.js
+++ b/src/wabt.pre.js
@@ -14,5 +14,5 @@
  * limitations under the License.
  */
 
-var wabt = (function() {
+(function() {
   "use strict";


### PR DESCRIPTION
It is currently necessary to postprocess libwabt.js to support different kinds of module loaders, especially CommonJS-style `require` and AMD-style `define`. This PR adds CommonJS and AMD module loader support directly to wabt.pre/post.js and exposes `wabt` as a global var only if neither is available.

Unfortunately, I haven't yet figured out where exactly libwabt.js is built with emscripten, so the new generated file is not included. In case you decide to merge the PR, I would appreciate if libwabt.js could be updated as well.