### PR TITLE
Remove WABT_ZERO_MEMORY WABT_FAILED and WABT_SUCCEEDED macros.

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -25,7 +25,7 @@
 
 #define CHECK_RESULT(expr)  \
   do {                      \
-    if (WABT_FAILED(expr))  \
+    if (Failed(expr))       \
       return Result::Error; \
   } while (0)
 

--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -30,7 +30,7 @@
 
 #define CHECK_RESULT(expr)        \
   do {                            \
-    if (WABT_FAILED(expr))        \
+    if (Failed(expr))             \
       return wabt::Result::Error; \
   } while (0)
 
@@ -474,8 +474,8 @@ wabt::Result BinaryReaderInterpreter::GetBrDropKeepCount(
 wabt::Result BinaryReaderInterpreter::GetReturnDropKeepCount(
     Index* out_drop_count,
     Index* out_keep_count) {
-  if (WABT_FAILED(GetBrDropKeepCount(label_stack.size() - 1, out_drop_count,
-                                     out_keep_count))) {
+  if (Failed(GetBrDropKeepCount(label_stack.size() - 1, out_drop_count,
+                                out_keep_count))) {
     return wabt::Result::Error;
   }
 
@@ -1458,7 +1458,7 @@ wabt::Result read_binary_interpreter(Environment* env,
   wabt::Result result = read_binary(data, size, &reader, options);
   env->SetIstream(reader.ReleaseOutputBuffer());
 
-  if (WABT_SUCCEEDED(result)) {
+  if (Succeeded(result)) {
     module->istream_start = istream_offset;
     module->istream_end = env->istream().size();
     *out_module = module;

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -29,10 +29,10 @@
 #include "common.h"
 #include "ir.h"
 
-#define CHECK_RESULT(expr) \
-  do {                     \
-    if (WABT_FAILED(expr)) \
-      return Result::Error;   \
+#define CHECK_RESULT(expr)  \
+  do {                      \
+    if (Failed(expr))       \
+      return Result::Error; \
   } while (0)
 
 namespace wabt {
@@ -263,7 +263,7 @@ Result BinaryReaderIR::AppendExpr(Expr* expr) {
   expr->loc = GetLocation();
 
   LabelNode* label;
-  if (WABT_FAILED(TopLabel(&label))) {
+  if (Failed(TopLabel(&label))) {
     delete expr;
     return Result::Error;
   }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -69,7 +69,7 @@ BinaryReaderObjdumpBase::BinaryReaderObjdumpBase(const uint8_t* data,
       objdump_state(objdump_state),
       data(data),
       size(size) {
-  WABT_ZERO_MEMORY(section_starts);
+  ZeroMemory(section_starts);
 }
 
 Result BinaryReaderObjdumpBase::BeginSection(BinarySection section_code,

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -36,7 +36,7 @@
 
 #define CHECK_RESULT(expr)  \
   do {                      \
-    if (WABT_FAILED(expr))  \
+    if (Failed(expr))       \
       return Result::Error; \
   } while (0)
 
@@ -48,13 +48,12 @@
     }                           \
   } while (0)
 
-#define CALLBACK0(member)                                   \
-  ERROR_UNLESS(WABT_SUCCEEDED(delegate_->member()), #member \
-               " callback "                                 \
-               "failed")
+#define CALLBACK0(member)                              \
+  ERROR_UNLESS(Succeeded(delegate_->member()), #member \
+               " callback failed")
 
-#define CALLBACK(member, ...)                                  \
-  ERROR_UNLESS(WABT_SUCCEEDED(delegate_->member(__VA_ARGS__)), \
+#define CALLBACK(member, ...)                             \
+  ERROR_UNLESS(Succeeded(delegate_->member(__VA_ARGS__)), \
                #member " callback failed")
 
 namespace wabt {
@@ -256,7 +255,7 @@ void WABT_PRINTF_FORMAT(2, 3) BinaryReader::PrintError(const char* format,
 
 Result BinaryReader::ReadOpcode(Opcode* out_value, const char* desc) {
   uint8_t value = 0;
-  if (WABT_FAILED(ReadU8(&value, desc))) {
+  if (Failed(ReadU8(&value, desc))) {
     return Result::Error;
   }
   *out_value = Opcode::FromCode(value);
@@ -1109,7 +1108,7 @@ Result BinaryReader::ReadRelocSection(Offset section_size) {
   uint32_t section;
   CHECK_RESULT(ReadU32Leb128(&section, "section"));
   StringSlice section_name;
-  WABT_ZERO_MEMORY(section_name);
+  ZeroMemory(section_name);
   if (static_cast<BinarySection>(section) == BinarySection::Custom)
     CHECK_RESULT(ReadStr(&section_name, "section name"));
   Index num_relocs;

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -329,7 +329,7 @@ void BinaryWriterSpec::WriteModule(char* filename, const Module* module) {
   MemoryStream memory_stream;
   result_ = write_binary_module(&memory_stream.writer(), module,
                                 &spec_options_->write_binary_options);
-  if (WABT_SUCCEEDED(result_) && write_modules_)
+  if (Succeeded(result_) && write_modules_)
     result_ = memory_stream.WriteToFile(filename);
 }
 

--- a/src/common.h
+++ b/src/common.h
@@ -33,10 +33,6 @@
 
 #define WABT_FATAL(...) fprintf(stderr, __VA_ARGS__), exit(1)
 #define WABT_ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
-#define WABT_ZERO_MEMORY(var)                                          \
-  WABT_STATIC_ASSERT(                                                  \
-      std::is_pod<std::remove_reference<decltype(var)>::type>::value); \
-  memset(static_cast<void*>(&(var)), 0, sizeof(var))
 
 #define WABT_USE(x) static_cast<void>(x)
 
@@ -103,8 +99,13 @@ enum class Result {
   Error,
 };
 
-#define WABT_SUCCEEDED(x) ((x) == ::wabt::Result::Ok)
-#define WABT_FAILED(x) ((x) == ::wabt::Result::Error)
+template<typename T>
+void ZeroMemory(T& v) {
+  memset(&v, 0, sizeof(v));
+}
+
+inline bool Succeeded(Result result) { return result == Result::Ok; }
+inline bool Failed(Result result) { return result == Result::Error; }
 
 inline std::string WABT_PRINTF_FORMAT(1, 2)
     string_printf(const char* format, ...) {

--- a/src/common.h
+++ b/src/common.h
@@ -101,6 +101,7 @@ enum class Result {
 
 template<typename T>
 void ZeroMemory(T& v) {
+  WABT_STATIC_ASSERT(std::is_pod<T>::value);
   memset(&v, 0, sizeof(v));
 }
 

--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -21,7 +21,7 @@
 
 #define CHECK_RESULT(expr)   \
   do {                       \
-    if (WABT_FAILED((expr))) \
+    if (Failed((expr)))      \
       return Result::Error;  \
   } while (0)
 

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -26,7 +26,7 @@
 
 #define CHECK_RESULT(expr)  \
   do {                      \
-    if (WABT_FAILED(expr))  \
+    if (Failed(expr))       \
       return Result::Error; \
   } while (0)
 

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -94,9 +94,9 @@ FuncSignature::FuncSignature(Index param_count,
       result_types(result_types, result_types + result_count) {}
 
 Import::Import() : kind(ExternalKind::Func) {
-  WABT_ZERO_MEMORY(module_name);
-  WABT_ZERO_MEMORY(field_name);
-  WABT_ZERO_MEMORY(func.sig_index);
+  ZeroMemory(module_name);
+  ZeroMemory(field_name);
+  ZeroMemory(func.sig_index);
 }
 
 Import::Import(Import&& other) {
@@ -106,9 +106,9 @@ Import::Import(Import&& other) {
 Import& Import::operator=(Import&& other) {
   kind = other.kind;
   module_name = other.module_name;
-  WABT_ZERO_MEMORY(other.module_name);
+  ZeroMemory(other.module_name);
   field_name = other.field_name;
-  WABT_ZERO_MEMORY(other.field_name);
+  ZeroMemory(other.field_name);
   switch (kind) {
     case ExternalKind::Func:
       func.sig_index = other.func.sig_index;
@@ -138,14 +138,14 @@ Import::~Import() {
 
 Export::Export(Export&& other)
     : name(other.name), kind(other.kind), index(other.index) {
-  WABT_ZERO_MEMORY(other.name);
+  ZeroMemory(other.name);
 }
 
 Export& Export::operator=(Export&& other) {
   name = other.name;
   kind = other.kind;
   index = other.index;
-  WABT_ZERO_MEMORY(other.name);
+  ZeroMemory(other.name);
   return *this;
 }
 
@@ -157,7 +157,7 @@ Module::Module(bool is_host)
     : memory_index(kInvalidIndex),
       table_index(kInvalidIndex),
       is_host(is_host) {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 Module::Module(const StringSlice& name, bool is_host)

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -121,7 +121,7 @@ struct Table {
 };
 
 struct Memory {
-  Memory() { WABT_ZERO_MEMORY(page_limits); }
+  Memory() { ZeroMemory(page_limits); }
   explicit Memory(const Limits& limits)
       : page_limits(limits), data(limits.initial * WABT_PAGE_SIZE) {}
 

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -327,11 +327,11 @@ Const::Const(F64, uint64_t value, const Location& loc_)
 
 
 Block::Block(): first(nullptr) {
-  WABT_ZERO_MEMORY(label);
+  ZeroMemory(label);
 }
 
 Block::Block(Expr* first) : first(first) {
-  WABT_ZERO_MEMORY(label);
+  ZeroMemory(label);
 }
 
 Block::~Block() {
@@ -364,7 +364,7 @@ Expr::Expr(ExprType type) : type(type), next(nullptr) {
 }
 
 FuncType::FuncType() {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 FuncType::~FuncType() {
@@ -377,7 +377,7 @@ FuncDeclaration::FuncDeclaration()
 FuncDeclaration::~FuncDeclaration() {}
 
 Func::Func() : first_expr(nullptr) {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 Func::~Func() {
@@ -386,7 +386,7 @@ Func::~Func() {
 }
 
 Global::Global() : type(Type::Void), mutable_(false), init_expr(nullptr) {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 Global::~Global() {
@@ -395,8 +395,8 @@ Global::~Global() {
 }
 
 Table::Table() {
-  WABT_ZERO_MEMORY(name);
-  WABT_ZERO_MEMORY(elem_limits);
+  ZeroMemory(name);
+  ZeroMemory(elem_limits);
 }
 
 Table::~Table() {
@@ -417,8 +417,8 @@ DataSegment::~DataSegment() {
 }
 
 Memory::Memory() {
-  WABT_ZERO_MEMORY(name);
-  WABT_ZERO_MEMORY(page_limits);
+  ZeroMemory(name);
+  ZeroMemory(page_limits);
 }
 
 Memory::~Memory() {
@@ -426,8 +426,8 @@ Memory::~Memory() {
 }
 
 Import::Import() : kind(ExternalKind::Func), func(nullptr) {
-  WABT_ZERO_MEMORY(module_name);
-  WABT_ZERO_MEMORY(field_name);
+  ZeroMemory(module_name);
+  ZeroMemory(field_name);
 }
 
 Import::~Import() {
@@ -453,7 +453,7 @@ Import::~Import() {
 }
 
 Export::Export() {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 Export::~Export() {
@@ -472,7 +472,7 @@ Module::Module()
       num_memory_imports(0),
       num_global_imports(0),
       start(0) {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 Module::~Module() {
@@ -507,7 +507,7 @@ ScriptModule::~ScriptModule() {
 ActionInvoke::ActionInvoke() {}
 
 Action::Action() : type(ActionType::Get), module_var(kInvalidIndex) {
-  WABT_ZERO_MEMORY(name);
+  ZeroMemory(name);
 }
 
 Action::~Action() {

--- a/src/lexer-source-line-finder.cc
+++ b/src/lexer-source-line-finder.cc
@@ -22,7 +22,7 @@
 
 #define CHECK_RESULT(expr)  \
   do {                      \
-    if (WABT_FAILED(expr))  \
+    if (Failed(expr))       \
       return Result::Error; \
   } while (0)
 

--- a/src/lexer-source.cc
+++ b/src/lexer-source.cc
@@ -20,7 +20,7 @@
 
 #define CHECK_RESULT(expr)  \
   do {                      \
-    if (WABT_FAILED(expr))  \
+    if (Failed(expr))       \
       return Result::Error; \
   } while (0)
 
@@ -40,7 +40,7 @@ std::unique_ptr<LexerSource> LexerSourceFile::Clone() {
   std::unique_ptr<LexerSourceFile> result(new LexerSourceFile(filename_));
 
   Offset offset = 0;
-  if (WABT_FAILED(Tell(&offset)) || WABT_FAILED(result->Seek(offset)))
+  if (Failed(Tell(&offset)) || Failed(result->Seek(offset)))
     result.reset();
 
   return std::move(result);

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -214,7 +214,7 @@ Result FloatParser<T>::ParseNan(const char* s,
 
     for (; s < end; ++s) {
       uint32_t digit;
-      if (WABT_FAILED(parse_hexdigit(*s, &digit)))
+      if (Failed(parse_hexdigit(*s, &digit)))
         return Result::Error;
       tag = tag * 16 + digit;
       // Check for overflow.
@@ -262,7 +262,7 @@ Result FloatParser<T>::ParseHex(const char* s,
     uint32_t digit;
     if (*s == '.') {
       seen_dot = true;
-    } else if (WABT_SUCCEEDED(parse_hexdigit(*s, &digit))) {
+    } else if (Succeeded(parse_hexdigit(*s, &digit))) {
       if (Traits::kBits - Clz(significand) <= Traits::kSigPlusOneBits) {
         significand = (significand << 4) + digit;
         if (seen_dot)
@@ -534,7 +534,7 @@ Result parse_uint64(const char* s, const char* end, uint64_t* out) {
       return Result::Error;
     for (; s < end; ++s) {
       uint32_t digit;
-      if (WABT_FAILED(parse_hexdigit(*s, &digit)))
+      if (Failed(parse_hexdigit(*s, &digit)))
         return Result::Error;
       uint64_t old_value = value;
       value = value * 16 + digit;
@@ -597,7 +597,7 @@ Result parse_int32(const char* s,
       has_sign = true;
     s++;
   }
-  if (WABT_FAILED(parse_uint64(s, end, &value)))
+  if (Failed(parse_uint64(s, end, &value)))
     return Result::Error;
 
   if (has_sign) {

--- a/src/prebuilt/wast-lexer-gen.cc
+++ b/src/prebuilt/wast-lexer-gen.cc
@@ -61,7 +61,7 @@
 #define BEGIN(c) cond = (c)
 #define FILL(n)                                \
   do {                                         \
-    if (WABT_FAILED(Fill(loc, parser, (n)))) { \
+    if (Failed(Fill(loc, parser, (n)))) {      \
       int value = NAME_TO_VALUE(EOF);          \
       SetToken(value);                         \
       return PopLookaheadToken(lval, loc);     \
@@ -98,10 +98,8 @@ namespace wabt {
 
 struct WastLexer::LexToken {
   Location loc_;
-  int value_;
+  int value_ = 0;
   Token lval_;
-
-  LexToken(void): value_(0) {}
 };
 
 struct WastLexer::Lookahead {
@@ -263,7 +261,7 @@ Result WastLexer::Fill(Location* loc, WastParser* parser, size_t need) {
 }
 
 int WastLexer::GetToken(Token* lval, Location* loc, WastParser* parser) {
-#line 267 "src/prebuilt/wast-lexer-gen.cc"
+#line 265 "src/prebuilt/wast-lexer-gen.cc"
 
 enum YYCONDTYPE {
 	YYCOND_i,
@@ -272,7 +270,7 @@ enum YYCONDTYPE {
 	YYCOND_BLOCK_COMMENT,
 };
 
-#line 264 "src/wast-lexer.cc"
+#line 262 "src/wast-lexer.cc"
   YYCONDTYPE cond = YYCOND_i;  // i is the initial state.
 
   if (!lookahead_->tokens_.empty()) {
@@ -284,7 +282,7 @@ enum YYCONDTYPE {
   for (;;) {
     next_pos_ = cursor_;
     
-#line 288 "src/prebuilt/wast-lexer-gen.cc"
+#line 286 "src/prebuilt/wast-lexer-gen.cc"
 {
 	unsigned char yych;
 	unsigned int yyaccept = 0;
@@ -329,29 +327,29 @@ YYCOND_BAD_TEXT:
 	}
 	++cursor_;
 yy4:
-#line 329 "src/wast-lexer.cc"
+#line 327 "src/wast-lexer.cc"
 	{ ERROR("illegal character in string");
                                   continue; }
-#line 336 "src/prebuilt/wast-lexer-gen.cc"
+#line 334 "src/prebuilt/wast-lexer-gen.cc"
 yy5:
 	++cursor_;
 	BEGIN(YYCOND_i);
-#line 322 "src/wast-lexer.cc"
+#line 320 "src/wast-lexer.cc"
 	{ ERROR("newline in string");
                                   NEWLINE;
                                   continue; }
-#line 344 "src/prebuilt/wast-lexer-gen.cc"
+#line 342 "src/prebuilt/wast-lexer-gen.cc"
 yy7:
 	++cursor_;
-#line 321 "src/wast-lexer.cc"
+#line 319 "src/wast-lexer.cc"
 	{ continue; }
-#line 349 "src/prebuilt/wast-lexer-gen.cc"
+#line 347 "src/prebuilt/wast-lexer-gen.cc"
 yy9:
 	++cursor_;
 	BEGIN(YYCOND_i);
-#line 328 "src/wast-lexer.cc"
+#line 326 "src/wast-lexer.cc"
 	{ SetText(); RETURN(TEXT); }
-#line 355 "src/prebuilt/wast-lexer-gen.cc"
+#line 353 "src/prebuilt/wast-lexer-gen.cc"
 yy11:
 	yyaccept = 0;
 	yych = *(marker_ = ++cursor_);
@@ -403,9 +401,9 @@ yy11:
 yy12:
 	++cursor_;
 yy13:
-#line 331 "src/wast-lexer.cc"
+#line 329 "src/wast-lexer.cc"
 	{ MAYBE_MALFORMED_UTF8(" in string"); }
-#line 409 "src/prebuilt/wast-lexer-gen.cc"
+#line 407 "src/prebuilt/wast-lexer-gen.cc"
 yy14:
 	yych = *++cursor_;
 	if (yych <= 0x7F) goto yy13;
@@ -444,11 +442,11 @@ yy19:
 yy20:
 	++cursor_;
 yy21:
-#line 325 "src/wast-lexer.cc"
+#line 323 "src/wast-lexer.cc"
 	{ ERROR("bad escape \"%.*s\"",
                                         static_cast<int>(yyleng), yytext);
                                   continue; }
-#line 452 "src/prebuilt/wast-lexer-gen.cc"
+#line 450 "src/prebuilt/wast-lexer-gen.cc"
 yy22:
 	yych = *++cursor_;
 	if (yych <= '@') {
@@ -534,14 +532,14 @@ YYCOND_BLOCK_COMMENT:
 yy34:
 	++cursor_;
 yy35:
-#line 560 "src/wast-lexer.cc"
+#line 558 "src/wast-lexer.cc"
 	{ continue; }
-#line 540 "src/prebuilt/wast-lexer-gen.cc"
+#line 538 "src/prebuilt/wast-lexer-gen.cc"
 yy36:
 	++cursor_;
-#line 559 "src/wast-lexer.cc"
+#line 557 "src/wast-lexer.cc"
 	{ NEWLINE; continue; }
-#line 545 "src/prebuilt/wast-lexer-gen.cc"
+#line 543 "src/prebuilt/wast-lexer-gen.cc"
 yy38:
 	yych = *++cursor_;
 	if (yych == ';') goto yy48;
@@ -553,9 +551,9 @@ yy39:
 yy40:
 	++cursor_;
 yy41:
-#line 561 "src/wast-lexer.cc"
+#line 559 "src/wast-lexer.cc"
 	{ MAYBE_MALFORMED_UTF8(" in block comment"); }
-#line 559 "src/prebuilt/wast-lexer-gen.cc"
+#line 557 "src/prebuilt/wast-lexer-gen.cc"
 yy42:
 	yych = *++cursor_;
 	if (yych <= 0x7F) goto yy41;
@@ -588,16 +586,16 @@ yy47:
 	goto yy41;
 yy48:
 	++cursor_;
-#line 555 "src/wast-lexer.cc"
+#line 553 "src/wast-lexer.cc"
 	{ COMMENT_NESTING++; continue; }
-#line 594 "src/prebuilt/wast-lexer-gen.cc"
+#line 592 "src/prebuilt/wast-lexer-gen.cc"
 yy50:
 	++cursor_;
-#line 556 "src/wast-lexer.cc"
+#line 554 "src/wast-lexer.cc"
 	{ if (--COMMENT_NESTING == 0)
                                     BEGIN(YYCOND_i);
                                   continue; }
-#line 601 "src/prebuilt/wast-lexer-gen.cc"
+#line 599 "src/prebuilt/wast-lexer-gen.cc"
 yy52:
 	yych = *++cursor_;
 	if (yych <= 0x7F) goto yy53;
@@ -686,21 +684,21 @@ yy57:
 			if (yych <= 0xF4) goto yy76;
 		}
 yy59:
-#line 553 "src/wast-lexer.cc"
+#line 551 "src/wast-lexer.cc"
 		{ continue; }
-#line 692 "src/prebuilt/wast-lexer-gen.cc"
+#line 690 "src/prebuilt/wast-lexer-gen.cc"
 yy60:
 		++cursor_;
 		BEGIN(YYCOND_i);
-#line 552 "src/wast-lexer.cc"
+#line 550 "src/wast-lexer.cc"
 		{ NEWLINE; continue; }
-#line 698 "src/prebuilt/wast-lexer-gen.cc"
+#line 696 "src/prebuilt/wast-lexer-gen.cc"
 yy62:
 		++cursor_;
 yy63:
-#line 568 "src/wast-lexer.cc"
+#line 566 "src/wast-lexer.cc"
 		{ MAYBE_MALFORMED_UTF8(""); }
-#line 704 "src/prebuilt/wast-lexer-gen.cc"
+#line 702 "src/prebuilt/wast-lexer-gen.cc"
 yy64:
 		yych = *++cursor_;
 		if (yych <= 0x7F) goto yy63;
@@ -921,9 +919,9 @@ YYCOND_i:
 yy79:
 		++cursor_;
 yy80:
-#line 567 "src/wast-lexer.cc"
+#line 565 "src/wast-lexer.cc"
 		{ ERROR("unexpected char"); continue; }
-#line 927 "src/prebuilt/wast-lexer-gen.cc"
+#line 925 "src/prebuilt/wast-lexer-gen.cc"
 yy81:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -931,14 +929,14 @@ yy81:
 		if (yybm[0+yych] & 4) {
 			goto yy81;
 		}
-#line 563 "src/wast-lexer.cc"
+#line 561 "src/wast-lexer.cc"
 		{ continue; }
-#line 937 "src/prebuilt/wast-lexer-gen.cc"
+#line 935 "src/prebuilt/wast-lexer-gen.cc"
 yy84:
 		++cursor_;
-#line 562 "src/wast-lexer.cc"
+#line 560 "src/wast-lexer.cc"
 		{ NEWLINE; continue; }
-#line 942 "src/prebuilt/wast-lexer-gen.cc"
+#line 940 "src/prebuilt/wast-lexer-gen.cc"
 yy86:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -948,11 +946,11 @@ yy87:
 			goto yy86;
 		}
 yy88:
-#line 564 "src/wast-lexer.cc"
+#line 562 "src/wast-lexer.cc"
 		{ ERROR("unexpected token \"%.*s\"",
                                         static_cast<int>(yyleng), yytext);
                                   continue; }
-#line 956 "src/prebuilt/wast-lexer-gen.cc"
+#line 954 "src/prebuilt/wast-lexer-gen.cc"
 yy89:
 		yyaccept = 0;
 		yych = *(marker_ = ++cursor_);
@@ -962,9 +960,9 @@ yy89:
 		if (yych <= 0xF4) goto yy129;
 yy90:
 		BEGIN(YYCOND_BAD_TEXT);
-#line 320 "src/wast-lexer.cc"
+#line 318 "src/wast-lexer.cc"
 		{ continue; }
-#line 968 "src/prebuilt/wast-lexer-gen.cc"
+#line 966 "src/prebuilt/wast-lexer-gen.cc"
 yy91:
 		yych = *++cursor_;
 		if (yych <= '\'') {
@@ -984,14 +982,14 @@ yy91:
 yy92:
 		++cursor_;
 		if ((yych = *cursor_) == ';') goto yy143;
-#line 311 "src/wast-lexer.cc"
+#line 309 "src/wast-lexer.cc"
 		{ LOOKAHEAD(LPAR); }
-#line 990 "src/prebuilt/wast-lexer-gen.cc"
+#line 988 "src/prebuilt/wast-lexer-gen.cc"
 yy94:
 		++cursor_;
-#line 312 "src/wast-lexer.cc"
+#line 310 "src/wast-lexer.cc"
 		{ RETURN(RPAR); }
-#line 995 "src/prebuilt/wast-lexer-gen.cc"
+#line 993 "src/prebuilt/wast-lexer-gen.cc"
 yy96:
 		yych = *++cursor_;
 		if (yych <= 'h') {
@@ -1034,9 +1032,9 @@ yy97:
 			}
 		}
 yy98:
-#line 313 "src/wast-lexer.cc"
+#line 311 "src/wast-lexer.cc"
 		{ LITERAL(Int); RETURN(NAT); }
-#line 1040 "src/prebuilt/wast-lexer-gen.cc"
+#line 1038 "src/prebuilt/wast-lexer-gen.cc"
 yy99:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
@@ -1206,9 +1204,9 @@ yy119:
 yy120:
 		++cursor_;
 yy121:
-#line 568 "src/wast-lexer.cc"
+#line 566 "src/wast-lexer.cc"
 		{ MAYBE_MALFORMED_UTF8(""); }
-#line 1212 "src/prebuilt/wast-lexer-gen.cc"
+#line 1210 "src/prebuilt/wast-lexer-gen.cc"
 yy122:
 		yych = *++cursor_;
 		if (yych <= 0x7F) goto yy121;
@@ -1278,9 +1276,9 @@ yy130:
 		}
 yy131:
 		++cursor_;
-#line 319 "src/wast-lexer.cc"
+#line 317 "src/wast-lexer.cc"
 		{ SetText(); RETURN(TEXT); }
-#line 1284 "src/prebuilt/wast-lexer-gen.cc"
+#line 1282 "src/prebuilt/wast-lexer-gen.cc"
 yy133:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -1375,15 +1373,15 @@ yy141:
 		if (yych <= ';') goto yy142;
 		if (yych <= '}') goto yy86;
 yy142:
-#line 549 "src/wast-lexer.cc"
+#line 547 "src/wast-lexer.cc"
 		{ SetText(); RETURN(VAR); }
-#line 1381 "src/prebuilt/wast-lexer-gen.cc"
+#line 1379 "src/prebuilt/wast-lexer-gen.cc"
 yy143:
 		++cursor_;
 		BEGIN(YYCOND_BLOCK_COMMENT);
-#line 554 "src/wast-lexer.cc"
+#line 552 "src/wast-lexer.cc"
 		{ COMMENT_NESTING = 1; continue; }
-#line 1387 "src/prebuilt/wast-lexer-gen.cc"
+#line 1385 "src/prebuilt/wast-lexer-gen.cc"
 yy145:
 		++cursor_;
 		if ((yych = *cursor_) <= '9') {
@@ -1418,9 +1416,9 @@ yy145:
 			}
 		}
 yy146:
-#line 314 "src/wast-lexer.cc"
+#line 312 "src/wast-lexer.cc"
 		{ LITERAL(Int); RETURN(INT); }
-#line 1424 "src/prebuilt/wast-lexer-gen.cc"
+#line 1422 "src/prebuilt/wast-lexer-gen.cc"
 yy147:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
@@ -1483,9 +1481,9 @@ yy151:
 			}
 		}
 yy153:
-#line 315 "src/wast-lexer.cc"
+#line 313 "src/wast-lexer.cc"
 		{ LITERAL(Float); RETURN(FLOAT); }
-#line 1489 "src/prebuilt/wast-lexer-gen.cc"
+#line 1487 "src/prebuilt/wast-lexer-gen.cc"
 yy154:
 		yych = *++cursor_;
 		if (yych <= ',') {
@@ -1506,9 +1504,9 @@ yy155:
 yy156:
 		++cursor_;
 		BEGIN(YYCOND_LINE_COMMENT);
-#line 551 "src/wast-lexer.cc"
+#line 549 "src/wast-lexer.cc"
 		{ continue; }
-#line 1512 "src/prebuilt/wast-lexer-gen.cc"
+#line 1510 "src/prebuilt/wast-lexer-gen.cc"
 yy158:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy212;
@@ -1547,9 +1545,9 @@ yy163:
 			}
 		}
 yy164:
-#line 344 "src/wast-lexer.cc"
+#line 342 "src/wast-lexer.cc"
 		{ RETURN(BR); }
-#line 1553 "src/prebuilt/wast-lexer-gen.cc"
+#line 1551 "src/prebuilt/wast-lexer-gen.cc"
 yy165:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy218;
@@ -1618,9 +1616,9 @@ yy180:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 340 "src/wast-lexer.cc"
+#line 338 "src/wast-lexer.cc"
 		{ RETURN(IF); }
-#line 1624 "src/prebuilt/wast-lexer-gen.cc"
+#line 1622 "src/prebuilt/wast-lexer-gen.cc"
 yy182:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy242;
@@ -1864,9 +1862,9 @@ yy225:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 350 "src/wast-lexer.cc"
+#line 348 "src/wast-lexer.cc"
 		{ RETURN(END); }
-#line 1870 "src/prebuilt/wast-lexer-gen.cc"
+#line 1868 "src/prebuilt/wast-lexer-gen.cc"
 yy227:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy297;
@@ -1894,9 +1892,9 @@ yy229:
 			}
 		}
 yy230:
-#line 334 "src/wast-lexer.cc"
+#line 332 "src/wast-lexer.cc"
 		{ TYPE(F32); RETURN(VALUE_TYPE); }
-#line 1900 "src/prebuilt/wast-lexer-gen.cc"
+#line 1898 "src/prebuilt/wast-lexer-gen.cc"
 yy231:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
@@ -1916,9 +1914,9 @@ yy231:
 			}
 		}
 yy232:
-#line 335 "src/wast-lexer.cc"
+#line 333 "src/wast-lexer.cc"
 		{ TYPE(F64); RETURN(VALUE_TYPE); }
-#line 1922 "src/prebuilt/wast-lexer-gen.cc"
+#line 1920 "src/prebuilt/wast-lexer-gen.cc"
 yy233:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy301;
@@ -1941,9 +1939,9 @@ yy234:
 			}
 		}
 yy235:
-#line 533 "src/wast-lexer.cc"
+#line 531 "src/wast-lexer.cc"
 		{ RETURN(GET); }
-#line 1947 "src/prebuilt/wast-lexer-gen.cc"
+#line 1945 "src/prebuilt/wast-lexer-gen.cc"
 yy236:
 		yych = *++cursor_;
 		if (yych == 'b') goto yy304;
@@ -1971,9 +1969,9 @@ yy238:
 			}
 		}
 yy239:
-#line 332 "src/wast-lexer.cc"
+#line 330 "src/wast-lexer.cc"
 		{ TYPE(I32); RETURN(VALUE_TYPE); }
-#line 1977 "src/prebuilt/wast-lexer-gen.cc"
+#line 1975 "src/prebuilt/wast-lexer-gen.cc"
 yy240:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
@@ -1993,9 +1991,9 @@ yy240:
 			}
 		}
 yy241:
-#line 333 "src/wast-lexer.cc"
+#line 331 "src/wast-lexer.cc"
 		{ TYPE(I64); RETURN(VALUE_TYPE); }
-#line 1999 "src/prebuilt/wast-lexer-gen.cc"
+#line 1997 "src/prebuilt/wast-lexer-gen.cc"
 yy242:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy308;
@@ -2005,9 +2003,9 @@ yy243:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 317 "src/wast-lexer.cc"
+#line 315 "src/wast-lexer.cc"
 		{ LITERAL(Infinity); RETURN(FLOAT); }
-#line 2011 "src/prebuilt/wast-lexer-gen.cc"
+#line 2009 "src/prebuilt/wast-lexer-gen.cc"
 yy245:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy309;
@@ -2033,9 +2031,9 @@ yy250:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 337 "src/wast-lexer.cc"
+#line 335 "src/wast-lexer.cc"
 		{ RETURN(MUT); }
-#line 2039 "src/prebuilt/wast-lexer-gen.cc"
+#line 2037 "src/prebuilt/wast-lexer-gen.cc"
 yy252:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
@@ -2055,17 +2053,17 @@ yy252:
 			}
 		}
 yy253:
-#line 318 "src/wast-lexer.cc"
+#line 316 "src/wast-lexer.cc"
 		{ LITERAL(Nan); RETURN(FLOAT); }
-#line 2061 "src/prebuilt/wast-lexer-gen.cc"
+#line 2059 "src/prebuilt/wast-lexer-gen.cc"
 yy254:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 338 "src/wast-lexer.cc"
+#line 336 "src/wast-lexer.cc"
 		{ RETURN(NOP); }
-#line 2069 "src/prebuilt/wast-lexer-gen.cc"
+#line 2067 "src/prebuilt/wast-lexer-gen.cc"
 yy256:
 		yych = *++cursor_;
 		if (yych == 's') goto yy316;
@@ -2124,9 +2122,9 @@ yy269:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 544 "src/wast-lexer.cc"
+#line 542 "src/wast-lexer.cc"
 		{ RETURN(TRY); }
-#line 2130 "src/prebuilt/wast-lexer-gen.cc"
+#line 2128 "src/prebuilt/wast-lexer-gen.cc"
 yy271:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy331;
@@ -2264,9 +2262,9 @@ yy285:
 			}
 		}
 yy286:
-#line 347 "src/wast-lexer.cc"
+#line 345 "src/wast-lexer.cc"
 		{ RETURN(CALL); }
-#line 2270 "src/prebuilt/wast-lexer-gen.cc"
+#line 2268 "src/prebuilt/wast-lexer-gen.cc"
 yy287:
 		yych = *++cursor_;
 		if (yych == 'h') goto yy348;
@@ -2280,33 +2278,33 @@ yy289:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 526 "src/wast-lexer.cc"
+#line 524 "src/wast-lexer.cc"
 		{ RETURN(DATA); }
-#line 2286 "src/prebuilt/wast-lexer-gen.cc"
+#line 2284 "src/prebuilt/wast-lexer-gen.cc"
 yy291:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 349 "src/wast-lexer.cc"
+#line 347 "src/wast-lexer.cc"
 		{ RETURN(DROP); }
-#line 2294 "src/prebuilt/wast-lexer-gen.cc"
+#line 2292 "src/prebuilt/wast-lexer-gen.cc"
 yy293:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 525 "src/wast-lexer.cc"
+#line 523 "src/wast-lexer.cc"
 		{ RETURN(ELEM); }
-#line 2302 "src/prebuilt/wast-lexer-gen.cc"
+#line 2300 "src/prebuilt/wast-lexer-gen.cc"
 yy295:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 342 "src/wast-lexer.cc"
+#line 340 "src/wast-lexer.cc"
 		{ RETURN(ELSE); }
-#line 2310 "src/prebuilt/wast-lexer-gen.cc"
+#line 2308 "src/prebuilt/wast-lexer-gen.cc"
 yy297:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy351;
@@ -2355,9 +2353,9 @@ yy301:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 514 "src/wast-lexer.cc"
+#line 512 "src/wast-lexer.cc"
 		{ RETURN(FUNC); }
-#line 2361 "src/prebuilt/wast-lexer-gen.cc"
+#line 2359 "src/prebuilt/wast-lexer-gen.cc"
 yy303:
 		yych = *++cursor_;
 		if (yych == 'g') goto yy378;
@@ -2427,9 +2425,9 @@ yy311:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 343 "src/wast-lexer.cc"
+#line 341 "src/wast-lexer.cc"
 		{ RETURN(LOOP); }
-#line 2433 "src/prebuilt/wast-lexer-gen.cc"
+#line 2431 "src/prebuilt/wast-lexer-gen.cc"
 yy313:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy415;
@@ -2496,9 +2494,9 @@ yy328:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 341 "src/wast-lexer.cc"
+#line 339 "src/wast-lexer.cc"
 		{ RETURN(THEN); }
-#line 2502 "src/prebuilt/wast-lexer-gen.cc"
+#line 2500 "src/prebuilt/wast-lexer-gen.cc"
 yy330:
 		yych = *++cursor_;
 		if (yych == 'w') goto yy435;
@@ -2508,9 +2506,9 @@ yy331:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 513 "src/wast-lexer.cc"
+#line 511 "src/wast-lexer.cc"
 		{ RETURN(TYPE); }
-#line 2514 "src/prebuilt/wast-lexer-gen.cc"
+#line 2512 "src/prebuilt/wast-lexer-gen.cc"
 yy333:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy437;
@@ -2541,9 +2539,9 @@ yy335:
 			}
 		}
 yy337:
-#line 316 "src/wast-lexer.cc"
+#line 314 "src/wast-lexer.cc"
 		{ LITERAL(Hexfloat); RETURN(FLOAT); }
-#line 2547 "src/prebuilt/wast-lexer-gen.cc"
+#line 2545 "src/prebuilt/wast-lexer-gen.cc"
 yy338:
 		yych = *++cursor_;
 		if (yych == '=') goto yy438;
@@ -2565,17 +2563,17 @@ yy342:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 339 "src/wast-lexer.cc"
+#line 337 "src/wast-lexer.cc"
 		{ RETURN(BLOCK); }
-#line 2571 "src/prebuilt/wast-lexer-gen.cc"
+#line 2569 "src/prebuilt/wast-lexer-gen.cc"
 yy344:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 345 "src/wast-lexer.cc"
+#line 343 "src/wast-lexer.cc"
 		{ RETURN(BR_IF); }
-#line 2579 "src/prebuilt/wast-lexer-gen.cc"
+#line 2577 "src/prebuilt/wast-lexer-gen.cc"
 yy346:
 		yych = *++cursor_;
 		if (yych == 'b') goto yy443;
@@ -2602,9 +2600,9 @@ yy348:
 			}
 		}
 yy349:
-#line 545 "src/wast-lexer.cc"
+#line 543 "src/wast-lexer.cc"
 		{ RETURN_LPAR(CATCH); }
-#line 2608 "src/prebuilt/wast-lexer-gen.cc"
+#line 2606 "src/prebuilt/wast-lexer-gen.cc"
 yy350:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy446;
@@ -2948,9 +2946,9 @@ yy413:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 517 "src/wast-lexer.cc"
+#line 515 "src/wast-lexer.cc"
 		{ RETURN(LOCAL); }
-#line 2954 "src/prebuilt/wast-lexer-gen.cc"
+#line 2952 "src/prebuilt/wast-lexer-gen.cc"
 yy415:
 		yych = *++cursor_;
 		if (yych == 'y') goto yy570;
@@ -2972,17 +2970,17 @@ yy419:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 515 "src/wast-lexer.cc"
+#line 513 "src/wast-lexer.cc"
 		{ RETURN(PARAM); }
-#line 2978 "src/prebuilt/wast-lexer-gen.cc"
+#line 2976 "src/prebuilt/wast-lexer-gen.cc"
 yy421:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 521 "src/wast-lexer.cc"
+#line 519 "src/wast-lexer.cc"
 		{ RETURN(QUOTE); }
-#line 2986 "src/prebuilt/wast-lexer-gen.cc"
+#line 2984 "src/prebuilt/wast-lexer-gen.cc"
 yy423:
 		yych = *++cursor_;
 		if (yych == 't') goto yy577;
@@ -3016,17 +3014,17 @@ yy430:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 524 "src/wast-lexer.cc"
+#line 522 "src/wast-lexer.cc"
 		{ RETURN(START); }
-#line 3022 "src/prebuilt/wast-lexer-gen.cc"
+#line 3020 "src/prebuilt/wast-lexer-gen.cc"
 yy432:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 522 "src/wast-lexer.cc"
+#line 520 "src/wast-lexer.cc"
 		{ RETURN(TABLE); }
-#line 3030 "src/prebuilt/wast-lexer-gen.cc"
+#line 3028 "src/prebuilt/wast-lexer-gen.cc"
 yy434:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy587;
@@ -3036,9 +3034,9 @@ yy435:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 547 "src/wast-lexer.cc"
+#line 545 "src/wast-lexer.cc"
 		{ RETURN(THROW); }
-#line 3042 "src/prebuilt/wast-lexer-gen.cc"
+#line 3040 "src/prebuilt/wast-lexer-gen.cc"
 yy437:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy588;
@@ -3062,9 +3060,9 @@ yy441:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 520 "src/wast-lexer.cc"
+#line 518 "src/wast-lexer.cc"
 		{ RETURN(BIN); }
-#line 3068 "src/prebuilt/wast-lexer-gen.cc"
+#line 3066 "src/prebuilt/wast-lexer-gen.cc"
 yy443:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy596;
@@ -3086,17 +3084,17 @@ yy447:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 530 "src/wast-lexer.cc"
+#line 528 "src/wast-lexer.cc"
 		{ RETURN(EXCEPT); }
-#line 3092 "src/prebuilt/wast-lexer-gen.cc"
+#line 3090 "src/prebuilt/wast-lexer-gen.cc"
 yy449:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 529 "src/wast-lexer.cc"
+#line 527 "src/wast-lexer.cc"
 		{ RETURN(EXPORT); }
-#line 3100 "src/prebuilt/wast-lexer-gen.cc"
+#line 3098 "src/prebuilt/wast-lexer-gen.cc"
 yy451:
 		yych = *++cursor_;
 		if (yych == 's') goto yy600;
@@ -3127,9 +3125,9 @@ yy457:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 472 "src/wast-lexer.cc"
+#line 470 "src/wast-lexer.cc"
 		{ OPCODE(F32Eq); RETURN(COMPARE); }
-#line 3133 "src/prebuilt/wast-lexer-gen.cc"
+#line 3131 "src/prebuilt/wast-lexer-gen.cc"
 yy459:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy610;
@@ -3139,25 +3137,25 @@ yy460:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 482 "src/wast-lexer.cc"
+#line 480 "src/wast-lexer.cc"
 		{ OPCODE(F32Ge); RETURN(COMPARE); }
-#line 3145 "src/prebuilt/wast-lexer-gen.cc"
+#line 3143 "src/prebuilt/wast-lexer-gen.cc"
 yy462:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 480 "src/wast-lexer.cc"
+#line 478 "src/wast-lexer.cc"
 		{ OPCODE(F32Gt); RETURN(COMPARE); }
-#line 3153 "src/prebuilt/wast-lexer-gen.cc"
+#line 3151 "src/prebuilt/wast-lexer-gen.cc"
 yy464:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 478 "src/wast-lexer.cc"
+#line 476 "src/wast-lexer.cc"
 		{ OPCODE(F32Le); RETURN(COMPARE); }
-#line 3161 "src/prebuilt/wast-lexer-gen.cc"
+#line 3159 "src/prebuilt/wast-lexer-gen.cc"
 yy466:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy611;
@@ -3167,9 +3165,9 @@ yy467:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 476 "src/wast-lexer.cc"
+#line 474 "src/wast-lexer.cc"
 		{ OPCODE(F32Lt); RETURN(COMPARE); }
-#line 3173 "src/prebuilt/wast-lexer-gen.cc"
+#line 3171 "src/prebuilt/wast-lexer-gen.cc"
 yy469:
 		yych = *++cursor_;
 		if (yych == 'x') goto yy612;
@@ -3202,9 +3200,9 @@ yy472:
 			}
 		}
 yy473:
-#line 474 "src/wast-lexer.cc"
+#line 472 "src/wast-lexer.cc"
 		{ OPCODE(F32Ne); RETURN(COMPARE); }
-#line 3208 "src/prebuilt/wast-lexer-gen.cc"
+#line 3206 "src/prebuilt/wast-lexer-gen.cc"
 yy474:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy621;
@@ -3251,9 +3249,9 @@ yy484:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 473 "src/wast-lexer.cc"
+#line 471 "src/wast-lexer.cc"
 		{ OPCODE(F64Eq); RETURN(COMPARE); }
-#line 3257 "src/prebuilt/wast-lexer-gen.cc"
+#line 3255 "src/prebuilt/wast-lexer-gen.cc"
 yy486:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy636;
@@ -3263,25 +3261,25 @@ yy487:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 483 "src/wast-lexer.cc"
+#line 481 "src/wast-lexer.cc"
 		{ OPCODE(F64Ge); RETURN(COMPARE); }
-#line 3269 "src/prebuilt/wast-lexer-gen.cc"
+#line 3267 "src/prebuilt/wast-lexer-gen.cc"
 yy489:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 481 "src/wast-lexer.cc"
+#line 479 "src/wast-lexer.cc"
 		{ OPCODE(F64Gt); RETURN(COMPARE); }
-#line 3277 "src/prebuilt/wast-lexer-gen.cc"
+#line 3275 "src/prebuilt/wast-lexer-gen.cc"
 yy491:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 479 "src/wast-lexer.cc"
+#line 477 "src/wast-lexer.cc"
 		{ OPCODE(F64Le); RETURN(COMPARE); }
-#line 3285 "src/prebuilt/wast-lexer-gen.cc"
+#line 3283 "src/prebuilt/wast-lexer-gen.cc"
 yy493:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy637;
@@ -3291,9 +3289,9 @@ yy494:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 477 "src/wast-lexer.cc"
+#line 475 "src/wast-lexer.cc"
 		{ OPCODE(F64Lt); RETURN(COMPARE); }
-#line 3297 "src/prebuilt/wast-lexer-gen.cc"
+#line 3295 "src/prebuilt/wast-lexer-gen.cc"
 yy496:
 		yych = *++cursor_;
 		if (yych == 'x') goto yy638;
@@ -3326,9 +3324,9 @@ yy499:
 			}
 		}
 yy500:
-#line 475 "src/wast-lexer.cc"
+#line 473 "src/wast-lexer.cc"
 		{ OPCODE(F64Ne); RETURN(COMPARE); }
-#line 3332 "src/prebuilt/wast-lexer-gen.cc"
+#line 3330 "src/prebuilt/wast-lexer-gen.cc"
 yy501:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy647;
@@ -3366,9 +3364,9 @@ yy509:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 518 "src/wast-lexer.cc"
+#line 516 "src/wast-lexer.cc"
 		{ RETURN(GLOBAL); }
-#line 3372 "src/prebuilt/wast-lexer-gen.cc"
+#line 3370 "src/prebuilt/wast-lexer-gen.cc"
 yy511:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy656;
@@ -3415,9 +3413,9 @@ yy518:
 			}
 		}
 yy519:
-#line 452 "src/wast-lexer.cc"
+#line 450 "src/wast-lexer.cc"
 		{ OPCODE(I32Eq); RETURN(COMPARE); }
-#line 3421 "src/prebuilt/wast-lexer-gen.cc"
+#line 3419 "src/prebuilt/wast-lexer-gen.cc"
 yy520:
 		yych = *++cursor_;
 		if (yych == '_') goto yy669;
@@ -3447,17 +3445,17 @@ yy526:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 454 "src/wast-lexer.cc"
+#line 452 "src/wast-lexer.cc"
 		{ OPCODE(I32Ne); RETURN(COMPARE); }
-#line 3453 "src/prebuilt/wast-lexer-gen.cc"
+#line 3451 "src/prebuilt/wast-lexer-gen.cc"
 yy528:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 424 "src/wast-lexer.cc"
+#line 422 "src/wast-lexer.cc"
 		{ OPCODE(I32Or); RETURN(BINARY); }
-#line 3461 "src/prebuilt/wast-lexer-gen.cc"
+#line 3459 "src/prebuilt/wast-lexer-gen.cc"
 yy530:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy676;
@@ -3538,9 +3536,9 @@ yy545:
 			}
 		}
 yy546:
-#line 453 "src/wast-lexer.cc"
+#line 451 "src/wast-lexer.cc"
 		{ OPCODE(I64Eq); RETURN(COMPARE); }
-#line 3544 "src/prebuilt/wast-lexer-gen.cc"
+#line 3542 "src/prebuilt/wast-lexer-gen.cc"
 yy547:
 		yych = *++cursor_;
 		if (yych == 't') goto yy702;
@@ -3574,17 +3572,17 @@ yy554:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 455 "src/wast-lexer.cc"
+#line 453 "src/wast-lexer.cc"
 		{ OPCODE(I64Ne); RETURN(COMPARE); }
-#line 3580 "src/prebuilt/wast-lexer-gen.cc"
+#line 3578 "src/prebuilt/wast-lexer-gen.cc"
 yy556:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 425 "src/wast-lexer.cc"
+#line 423 "src/wast-lexer.cc"
 		{ OPCODE(I64Or); RETURN(BINARY); }
-#line 3588 "src/prebuilt/wast-lexer-gen.cc"
+#line 3586 "src/prebuilt/wast-lexer-gen.cc"
 yy558:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy710;
@@ -3624,33 +3622,33 @@ yy566:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 528 "src/wast-lexer.cc"
+#line 526 "src/wast-lexer.cc"
 		{ RETURN(IMPORT); }
-#line 3630 "src/prebuilt/wast-lexer-gen.cc"
+#line 3628 "src/prebuilt/wast-lexer-gen.cc"
 yy568:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 532 "src/wast-lexer.cc"
+#line 530 "src/wast-lexer.cc"
 		{ RETURN(INVOKE); }
-#line 3638 "src/prebuilt/wast-lexer-gen.cc"
+#line 3636 "src/prebuilt/wast-lexer-gen.cc"
 yy570:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 523 "src/wast-lexer.cc"
+#line 521 "src/wast-lexer.cc"
 		{ RETURN(MEMORY); }
-#line 3646 "src/prebuilt/wast-lexer-gen.cc"
+#line 3644 "src/prebuilt/wast-lexer-gen.cc"
 yy572:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 519 "src/wast-lexer.cc"
+#line 517 "src/wast-lexer.cc"
 		{ RETURN(MODULE); }
-#line 3654 "src/prebuilt/wast-lexer-gen.cc"
+#line 3652 "src/prebuilt/wast-lexer-gen.cc"
 yy574:
 		yych = *++cursor_;
 		if (yych <= '@') {
@@ -3681,9 +3679,9 @@ yy575:
 			}
 		}
 yy576:
-#line 527 "src/wast-lexer.cc"
+#line 525 "src/wast-lexer.cc"
 		{ RETURN(OFFSET); }
-#line 3687 "src/prebuilt/wast-lexer-gen.cc"
+#line 3685 "src/prebuilt/wast-lexer-gen.cc"
 yy577:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy726;
@@ -3693,9 +3691,9 @@ yy578:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 516 "src/wast-lexer.cc"
+#line 514 "src/wast-lexer.cc"
 		{ RETURN(RESULT); }
-#line 3699 "src/prebuilt/wast-lexer-gen.cc"
+#line 3697 "src/prebuilt/wast-lexer-gen.cc"
 yy580:
 		yych = *++cursor_;
 		if (yych == 'w') goto yy727;
@@ -3705,17 +3703,17 @@ yy581:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 351 "src/wast-lexer.cc"
+#line 349 "src/wast-lexer.cc"
 		{ RETURN(RETURN); }
-#line 3711 "src/prebuilt/wast-lexer-gen.cc"
+#line 3709 "src/prebuilt/wast-lexer-gen.cc"
 yy583:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 509 "src/wast-lexer.cc"
+#line 507 "src/wast-lexer.cc"
 		{ RETURN(SELECT); }
-#line 3719 "src/prebuilt/wast-lexer-gen.cc"
+#line 3717 "src/prebuilt/wast-lexer-gen.cc"
 yy585:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy729;
@@ -3751,9 +3749,9 @@ yy589:
 			}
 		}
 yy590:
-#line 381 "src/wast-lexer.cc"
+#line 379 "src/wast-lexer.cc"
 		{ SetTextAt(6); RETURN(ALIGN_EQ_NAT); }
-#line 3757 "src/prebuilt/wast-lexer-gen.cc"
+#line 3755 "src/prebuilt/wast-lexer-gen.cc"
 yy591:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -3783,9 +3781,9 @@ yy593:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 336 "src/wast-lexer.cc"
+#line 334 "src/wast-lexer.cc"
 		{ RETURN(ANYFUNC); }
-#line 3789 "src/prebuilt/wast-lexer-gen.cc"
+#line 3787 "src/prebuilt/wast-lexer-gen.cc"
 yy595:
 		yych = *++cursor_;
 		switch (yych) {
@@ -3818,17 +3816,17 @@ yy600:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 396 "src/wast-lexer.cc"
+#line 394 "src/wast-lexer.cc"
 		{ OPCODE(F32Abs); RETURN(UNARY); }
-#line 3824 "src/prebuilt/wast-lexer-gen.cc"
+#line 3822 "src/prebuilt/wast-lexer-gen.cc"
 yy602:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 438 "src/wast-lexer.cc"
+#line 436 "src/wast-lexer.cc"
 		{ OPCODE(F32Add); RETURN(BINARY); }
-#line 3832 "src/prebuilt/wast-lexer-gen.cc"
+#line 3830 "src/prebuilt/wast-lexer-gen.cc"
 yy604:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy745;
@@ -3851,9 +3849,9 @@ yy608:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 444 "src/wast-lexer.cc"
+#line 442 "src/wast-lexer.cc"
 		{ OPCODE(F32Div); RETURN(BINARY); }
-#line 3857 "src/prebuilt/wast-lexer-gen.cc"
+#line 3855 "src/prebuilt/wast-lexer-gen.cc"
 yy610:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy751;
@@ -3867,25 +3865,25 @@ yy612:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 448 "src/wast-lexer.cc"
+#line 446 "src/wast-lexer.cc"
 		{ OPCODE(F32Max); RETURN(BINARY); }
-#line 3873 "src/prebuilt/wast-lexer-gen.cc"
+#line 3871 "src/prebuilt/wast-lexer-gen.cc"
 yy614:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 446 "src/wast-lexer.cc"
+#line 444 "src/wast-lexer.cc"
 		{ OPCODE(F32Min); RETURN(BINARY); }
-#line 3881 "src/prebuilt/wast-lexer-gen.cc"
+#line 3879 "src/prebuilt/wast-lexer-gen.cc"
 yy616:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 442 "src/wast-lexer.cc"
+#line 440 "src/wast-lexer.cc"
 		{ OPCODE(F32Mul); RETURN(BINARY); }
-#line 3889 "src/prebuilt/wast-lexer-gen.cc"
+#line 3887 "src/prebuilt/wast-lexer-gen.cc"
 yy618:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy754;
@@ -3895,9 +3893,9 @@ yy619:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 394 "src/wast-lexer.cc"
+#line 392 "src/wast-lexer.cc"
 		{ OPCODE(F32Neg); RETURN(UNARY); }
-#line 3901 "src/prebuilt/wast-lexer-gen.cc"
+#line 3899 "src/prebuilt/wast-lexer-gen.cc"
 yy621:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy755;
@@ -3915,9 +3913,9 @@ yy624:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 440 "src/wast-lexer.cc"
+#line 438 "src/wast-lexer.cc"
 		{ OPCODE(F32Sub); RETURN(BINARY); }
-#line 3921 "src/prebuilt/wast-lexer-gen.cc"
+#line 3919 "src/prebuilt/wast-lexer-gen.cc"
 yy626:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy759;
@@ -3927,17 +3925,17 @@ yy627:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 397 "src/wast-lexer.cc"
+#line 395 "src/wast-lexer.cc"
 		{ OPCODE(F64Abs); RETURN(UNARY); }
-#line 3933 "src/prebuilt/wast-lexer-gen.cc"
+#line 3931 "src/prebuilt/wast-lexer-gen.cc"
 yy629:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 439 "src/wast-lexer.cc"
+#line 437 "src/wast-lexer.cc"
 		{ OPCODE(F64Add); RETURN(BINARY); }
-#line 3941 "src/prebuilt/wast-lexer-gen.cc"
+#line 3939 "src/prebuilt/wast-lexer-gen.cc"
 yy631:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy760;
@@ -3956,9 +3954,9 @@ yy634:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 445 "src/wast-lexer.cc"
+#line 443 "src/wast-lexer.cc"
 		{ OPCODE(F64Div); RETURN(BINARY); }
-#line 3962 "src/prebuilt/wast-lexer-gen.cc"
+#line 3960 "src/prebuilt/wast-lexer-gen.cc"
 yy636:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy765;
@@ -3972,25 +3970,25 @@ yy638:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 449 "src/wast-lexer.cc"
+#line 447 "src/wast-lexer.cc"
 		{ OPCODE(F64Max); RETURN(BINARY); }
-#line 3978 "src/prebuilt/wast-lexer-gen.cc"
+#line 3976 "src/prebuilt/wast-lexer-gen.cc"
 yy640:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 447 "src/wast-lexer.cc"
+#line 445 "src/wast-lexer.cc"
 		{ OPCODE(F64Min); RETURN(BINARY); }
-#line 3986 "src/prebuilt/wast-lexer-gen.cc"
+#line 3984 "src/prebuilt/wast-lexer-gen.cc"
 yy642:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 443 "src/wast-lexer.cc"
+#line 441 "src/wast-lexer.cc"
 		{ OPCODE(F64Mul); RETURN(BINARY); }
-#line 3994 "src/prebuilt/wast-lexer-gen.cc"
+#line 3992 "src/prebuilt/wast-lexer-gen.cc"
 yy644:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy768;
@@ -4000,9 +3998,9 @@ yy645:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 395 "src/wast-lexer.cc"
+#line 393 "src/wast-lexer.cc"
 		{ OPCODE(F64Neg); RETURN(UNARY); }
-#line 4006 "src/prebuilt/wast-lexer-gen.cc"
+#line 4004 "src/prebuilt/wast-lexer-gen.cc"
 yy647:
 		yych = *++cursor_;
 		if (yych == 'm') goto yy769;
@@ -4024,9 +4022,9 @@ yy651:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 441 "src/wast-lexer.cc"
+#line 439 "src/wast-lexer.cc"
 		{ OPCODE(F64Sub); RETURN(BINARY); }
-#line 4030 "src/prebuilt/wast-lexer-gen.cc"
+#line 4028 "src/prebuilt/wast-lexer-gen.cc"
 yy653:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy774;
@@ -4048,25 +4046,25 @@ yy657:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 408 "src/wast-lexer.cc"
+#line 406 "src/wast-lexer.cc"
 		{ OPCODE(I32Add); RETURN(BINARY); }
-#line 4054 "src/prebuilt/wast-lexer-gen.cc"
+#line 4052 "src/prebuilt/wast-lexer-gen.cc"
 yy659:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 422 "src/wast-lexer.cc"
+#line 420 "src/wast-lexer.cc"
 		{ OPCODE(I32And); RETURN(BINARY); }
-#line 4062 "src/prebuilt/wast-lexer-gen.cc"
+#line 4060 "src/prebuilt/wast-lexer-gen.cc"
 yy661:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 388 "src/wast-lexer.cc"
+#line 386 "src/wast-lexer.cc"
 		{ OPCODE(I32Clz); RETURN(UNARY); }
-#line 4070 "src/prebuilt/wast-lexer-gen.cc"
+#line 4068 "src/prebuilt/wast-lexer-gen.cc"
 yy663:
 		yych = *++cursor_;
 		if (yych == 's') goto yy778;
@@ -4076,9 +4074,9 @@ yy664:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 390 "src/wast-lexer.cc"
+#line 388 "src/wast-lexer.cc"
 		{ OPCODE(I32Ctz); RETURN(UNARY); }
-#line 4082 "src/prebuilt/wast-lexer-gen.cc"
+#line 4080 "src/prebuilt/wast-lexer-gen.cc"
 yy666:
 		yych = *++cursor_;
 		if (yych == '_') goto yy779;
@@ -4088,9 +4086,9 @@ yy667:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 386 "src/wast-lexer.cc"
+#line 384 "src/wast-lexer.cc"
 		{ OPCODE(I32Eqz); RETURN(CONVERT); }
-#line 4094 "src/prebuilt/wast-lexer-gen.cc"
+#line 4092 "src/prebuilt/wast-lexer-gen.cc"
 yy669:
 		yych = *++cursor_;
 		if (yych == 's') goto yy780;
@@ -4120,9 +4118,9 @@ yy674:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 412 "src/wast-lexer.cc"
+#line 410 "src/wast-lexer.cc"
 		{ OPCODE(I32Mul); RETURN(BINARY); }
-#line 4126 "src/prebuilt/wast-lexer-gen.cc"
+#line 4124 "src/prebuilt/wast-lexer-gen.cc"
 yy676:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy798;
@@ -4145,9 +4143,9 @@ yy680:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 428 "src/wast-lexer.cc"
+#line 426 "src/wast-lexer.cc"
 		{ OPCODE(I32Shl); RETURN(BINARY); }
-#line 4151 "src/prebuilt/wast-lexer-gen.cc"
+#line 4149 "src/prebuilt/wast-lexer-gen.cc"
 yy682:
 		yych = *++cursor_;
 		if (yych == '_') goto yy805;
@@ -4161,9 +4159,9 @@ yy684:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 410 "src/wast-lexer.cc"
+#line 408 "src/wast-lexer.cc"
 		{ OPCODE(I32Sub); RETURN(BINARY); }
-#line 4167 "src/prebuilt/wast-lexer-gen.cc"
+#line 4165 "src/prebuilt/wast-lexer-gen.cc"
 yy686:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy807;
@@ -4177,33 +4175,33 @@ yy688:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 426 "src/wast-lexer.cc"
+#line 424 "src/wast-lexer.cc"
 		{ OPCODE(I32Xor); RETURN(BINARY); }
-#line 4183 "src/prebuilt/wast-lexer-gen.cc"
+#line 4181 "src/prebuilt/wast-lexer-gen.cc"
 yy690:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 409 "src/wast-lexer.cc"
+#line 407 "src/wast-lexer.cc"
 		{ OPCODE(I64Add); RETURN(BINARY); }
-#line 4191 "src/prebuilt/wast-lexer-gen.cc"
+#line 4189 "src/prebuilt/wast-lexer-gen.cc"
 yy692:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 423 "src/wast-lexer.cc"
+#line 421 "src/wast-lexer.cc"
 		{ OPCODE(I64And); RETURN(BINARY); }
-#line 4199 "src/prebuilt/wast-lexer-gen.cc"
+#line 4197 "src/prebuilt/wast-lexer-gen.cc"
 yy694:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 389 "src/wast-lexer.cc"
+#line 387 "src/wast-lexer.cc"
 		{ OPCODE(I64Clz); RETURN(UNARY); }
-#line 4207 "src/prebuilt/wast-lexer-gen.cc"
+#line 4205 "src/prebuilt/wast-lexer-gen.cc"
 yy696:
 		yych = *++cursor_;
 		if (yych == 's') goto yy809;
@@ -4213,9 +4211,9 @@ yy697:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 391 "src/wast-lexer.cc"
+#line 389 "src/wast-lexer.cc"
 		{ OPCODE(I64Ctz); RETURN(UNARY); }
-#line 4219 "src/prebuilt/wast-lexer-gen.cc"
+#line 4217 "src/prebuilt/wast-lexer-gen.cc"
 yy699:
 		yych = *++cursor_;
 		if (yych == '_') goto yy810;
@@ -4225,9 +4223,9 @@ yy700:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 387 "src/wast-lexer.cc"
+#line 385 "src/wast-lexer.cc"
 		{ OPCODE(I64Eqz); RETURN(CONVERT); }
-#line 4231 "src/prebuilt/wast-lexer-gen.cc"
+#line 4229 "src/prebuilt/wast-lexer-gen.cc"
 yy702:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy811;
@@ -4261,9 +4259,9 @@ yy708:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 413 "src/wast-lexer.cc"
+#line 411 "src/wast-lexer.cc"
 		{ OPCODE(I64Mul); RETURN(BINARY); }
-#line 4267 "src/prebuilt/wast-lexer-gen.cc"
+#line 4265 "src/prebuilt/wast-lexer-gen.cc"
 yy710:
 		yych = *++cursor_;
 		if (yych == 'c') goto yy830;
@@ -4286,9 +4284,9 @@ yy714:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 429 "src/wast-lexer.cc"
+#line 427 "src/wast-lexer.cc"
 		{ OPCODE(I64Shl); RETURN(BINARY); }
-#line 4292 "src/prebuilt/wast-lexer-gen.cc"
+#line 4290 "src/prebuilt/wast-lexer-gen.cc"
 yy716:
 		yych = *++cursor_;
 		if (yych == '_') goto yy837;
@@ -4302,9 +4300,9 @@ yy718:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 411 "src/wast-lexer.cc"
+#line 409 "src/wast-lexer.cc"
 		{ OPCODE(I64Sub); RETURN(BINARY); }
-#line 4308 "src/prebuilt/wast-lexer-gen.cc"
+#line 4306 "src/prebuilt/wast-lexer-gen.cc"
 yy720:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy839;
@@ -4314,9 +4312,9 @@ yy721:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 427 "src/wast-lexer.cc"
+#line 425 "src/wast-lexer.cc"
 		{ OPCODE(I64Xor); RETURN(BINARY); }
-#line 4320 "src/prebuilt/wast-lexer-gen.cc"
+#line 4318 "src/prebuilt/wast-lexer-gen.cc"
 yy723:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -4358,9 +4356,9 @@ yy727:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 548 "src/wast-lexer.cc"
+#line 546 "src/wast-lexer.cc"
 		{ RETURN(RETHROW); }
-#line 4364 "src/prebuilt/wast-lexer-gen.cc"
+#line 4362 "src/prebuilt/wast-lexer-gen.cc"
 yy729:
 		yych = *++cursor_;
 		if (yych == 'b') goto yy846;
@@ -4418,9 +4416,9 @@ yy740:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 346 "src/wast-lexer.cc"
+#line 344 "src/wast-lexer.cc"
 		{ RETURN(BR_TABLE); }
-#line 4424 "src/prebuilt/wast-lexer-gen.cc"
+#line 4422 "src/prebuilt/wast-lexer-gen.cc"
 yy742:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy858;
@@ -4438,9 +4436,9 @@ yy745:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 400 "src/wast-lexer.cc"
+#line 398 "src/wast-lexer.cc"
 		{ OPCODE(F32Ceil); RETURN(UNARY); }
-#line 4444 "src/prebuilt/wast-lexer-gen.cc"
+#line 4442 "src/prebuilt/wast-lexer-gen.cc"
 yy747:
 		yych = *++cursor_;
 		if (yych == 't') goto yy862;
@@ -4466,9 +4464,9 @@ yy752:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 359 "src/wast-lexer.cc"
+#line 357 "src/wast-lexer.cc"
 		{ OPCODE(F32Load); RETURN(LOAD); }
-#line 4472 "src/prebuilt/wast-lexer-gen.cc"
+#line 4470 "src/prebuilt/wast-lexer-gen.cc"
 yy754:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy869;
@@ -4482,9 +4480,9 @@ yy756:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 398 "src/wast-lexer.cc"
+#line 396 "src/wast-lexer.cc"
 		{ OPCODE(F32Sqrt); RETURN(UNARY); }
-#line 4488 "src/prebuilt/wast-lexer-gen.cc"
+#line 4486 "src/prebuilt/wast-lexer-gen.cc"
 yy758:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy871;
@@ -4498,9 +4496,9 @@ yy760:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 401 "src/wast-lexer.cc"
+#line 399 "src/wast-lexer.cc"
 		{ OPCODE(F64Ceil); RETURN(UNARY); }
-#line 4504 "src/prebuilt/wast-lexer-gen.cc"
+#line 4502 "src/prebuilt/wast-lexer-gen.cc"
 yy762:
 		yych = *++cursor_;
 		if (yych == 't') goto yy875;
@@ -4522,9 +4520,9 @@ yy766:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 360 "src/wast-lexer.cc"
+#line 358 "src/wast-lexer.cc"
 		{ OPCODE(F64Load); RETURN(LOAD); }
-#line 4528 "src/prebuilt/wast-lexer-gen.cc"
+#line 4526 "src/prebuilt/wast-lexer-gen.cc"
 yy768:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy881;
@@ -4542,9 +4540,9 @@ yy771:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 399 "src/wast-lexer.cc"
+#line 397 "src/wast-lexer.cc"
 		{ OPCODE(F64Sqrt); RETURN(UNARY); }
-#line 4548 "src/prebuilt/wast-lexer-gen.cc"
+#line 4546 "src/prebuilt/wast-lexer-gen.cc"
 yy773:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy884;
@@ -4579,49 +4577,49 @@ yy780:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 468 "src/wast-lexer.cc"
+#line 466 "src/wast-lexer.cc"
 		{ OPCODE(I32GeS); RETURN(COMPARE); }
-#line 4585 "src/prebuilt/wast-lexer-gen.cc"
+#line 4583 "src/prebuilt/wast-lexer-gen.cc"
 yy782:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 470 "src/wast-lexer.cc"
+#line 468 "src/wast-lexer.cc"
 		{ OPCODE(I32GeU); RETURN(COMPARE); }
-#line 4593 "src/prebuilt/wast-lexer-gen.cc"
+#line 4591 "src/prebuilt/wast-lexer-gen.cc"
 yy784:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 464 "src/wast-lexer.cc"
+#line 462 "src/wast-lexer.cc"
 		{ OPCODE(I32GtS); RETURN(COMPARE); }
-#line 4601 "src/prebuilt/wast-lexer-gen.cc"
+#line 4599 "src/prebuilt/wast-lexer-gen.cc"
 yy786:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 466 "src/wast-lexer.cc"
+#line 464 "src/wast-lexer.cc"
 		{ OPCODE(I32GtU); RETURN(COMPARE); }
-#line 4609 "src/prebuilt/wast-lexer-gen.cc"
+#line 4607 "src/prebuilt/wast-lexer-gen.cc"
 yy788:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 460 "src/wast-lexer.cc"
+#line 458 "src/wast-lexer.cc"
 		{ OPCODE(I32LeS); RETURN(COMPARE); }
-#line 4617 "src/prebuilt/wast-lexer-gen.cc"
+#line 4615 "src/prebuilt/wast-lexer-gen.cc"
 yy790:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 462 "src/wast-lexer.cc"
+#line 460 "src/wast-lexer.cc"
 		{ OPCODE(I32LeU); RETURN(COMPARE); }
-#line 4625 "src/prebuilt/wast-lexer-gen.cc"
+#line 4623 "src/prebuilt/wast-lexer-gen.cc"
 yy792:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
@@ -4642,25 +4640,25 @@ yy792:
 			}
 		}
 yy793:
-#line 357 "src/wast-lexer.cc"
+#line 355 "src/wast-lexer.cc"
 		{ OPCODE(I32Load); RETURN(LOAD); }
-#line 4648 "src/prebuilt/wast-lexer-gen.cc"
+#line 4646 "src/prebuilt/wast-lexer-gen.cc"
 yy794:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 456 "src/wast-lexer.cc"
+#line 454 "src/wast-lexer.cc"
 		{ OPCODE(I32LtS); RETURN(COMPARE); }
-#line 4656 "src/prebuilt/wast-lexer-gen.cc"
+#line 4654 "src/prebuilt/wast-lexer-gen.cc"
 yy796:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 458 "src/wast-lexer.cc"
+#line 456 "src/wast-lexer.cc"
 		{ OPCODE(I32LtU); RETURN(COMPARE); }
-#line 4664 "src/prebuilt/wast-lexer-gen.cc"
+#line 4662 "src/prebuilt/wast-lexer-gen.cc"
 yy798:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy900;
@@ -4679,17 +4677,17 @@ yy801:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 434 "src/wast-lexer.cc"
+#line 432 "src/wast-lexer.cc"
 		{ OPCODE(I32Rotl); RETURN(BINARY); }
-#line 4685 "src/prebuilt/wast-lexer-gen.cc"
+#line 4683 "src/prebuilt/wast-lexer-gen.cc"
 yy803:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 436 "src/wast-lexer.cc"
+#line 434 "src/wast-lexer.cc"
 		{ OPCODE(I32Rotr); RETURN(BINARY); }
-#line 4693 "src/prebuilt/wast-lexer-gen.cc"
+#line 4691 "src/prebuilt/wast-lexer-gen.cc"
 yy805:
 		yych = *++cursor_;
 		if (yych == 's') goto yy906;
@@ -4725,49 +4723,49 @@ yy812:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 469 "src/wast-lexer.cc"
+#line 467 "src/wast-lexer.cc"
 		{ OPCODE(I64GeS); RETURN(COMPARE); }
-#line 4731 "src/prebuilt/wast-lexer-gen.cc"
+#line 4729 "src/prebuilt/wast-lexer-gen.cc"
 yy814:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 471 "src/wast-lexer.cc"
+#line 469 "src/wast-lexer.cc"
 		{ OPCODE(I64GeU); RETURN(COMPARE); }
-#line 4739 "src/prebuilt/wast-lexer-gen.cc"
+#line 4737 "src/prebuilt/wast-lexer-gen.cc"
 yy816:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 465 "src/wast-lexer.cc"
+#line 463 "src/wast-lexer.cc"
 		{ OPCODE(I64GtS); RETURN(COMPARE); }
-#line 4747 "src/prebuilt/wast-lexer-gen.cc"
+#line 4745 "src/prebuilt/wast-lexer-gen.cc"
 yy818:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 467 "src/wast-lexer.cc"
+#line 465 "src/wast-lexer.cc"
 		{ OPCODE(I64GtU); RETURN(COMPARE); }
-#line 4755 "src/prebuilt/wast-lexer-gen.cc"
+#line 4753 "src/prebuilt/wast-lexer-gen.cc"
 yy820:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 461 "src/wast-lexer.cc"
+#line 459 "src/wast-lexer.cc"
 		{ OPCODE(I64LeS); RETURN(COMPARE); }
-#line 4763 "src/prebuilt/wast-lexer-gen.cc"
+#line 4761 "src/prebuilt/wast-lexer-gen.cc"
 yy822:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 463 "src/wast-lexer.cc"
+#line 461 "src/wast-lexer.cc"
 		{ OPCODE(I64LeU); RETURN(COMPARE); }
-#line 4771 "src/prebuilt/wast-lexer-gen.cc"
+#line 4769 "src/prebuilt/wast-lexer-gen.cc"
 yy824:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
@@ -4790,25 +4788,25 @@ yy824:
 			}
 		}
 yy825:
-#line 358 "src/wast-lexer.cc"
+#line 356 "src/wast-lexer.cc"
 		{ OPCODE(I64Load); RETURN(LOAD); }
-#line 4796 "src/prebuilt/wast-lexer-gen.cc"
+#line 4794 "src/prebuilt/wast-lexer-gen.cc"
 yy826:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 457 "src/wast-lexer.cc"
+#line 455 "src/wast-lexer.cc"
 		{ OPCODE(I64LtS); RETURN(COMPARE); }
-#line 4804 "src/prebuilt/wast-lexer-gen.cc"
+#line 4802 "src/prebuilt/wast-lexer-gen.cc"
 yy828:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 459 "src/wast-lexer.cc"
+#line 457 "src/wast-lexer.cc"
 		{ OPCODE(I64LtU); RETURN(COMPARE); }
-#line 4812 "src/prebuilt/wast-lexer-gen.cc"
+#line 4810 "src/prebuilt/wast-lexer-gen.cc"
 yy830:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy924;
@@ -4827,17 +4825,17 @@ yy833:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 435 "src/wast-lexer.cc"
+#line 433 "src/wast-lexer.cc"
 		{ OPCODE(I64Rotl); RETURN(BINARY); }
-#line 4833 "src/prebuilt/wast-lexer-gen.cc"
+#line 4831 "src/prebuilt/wast-lexer-gen.cc"
 yy835:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 437 "src/wast-lexer.cc"
+#line 435 "src/wast-lexer.cc"
 		{ OPCODE(I64Rotr); RETURN(BINARY); }
-#line 4841 "src/prebuilt/wast-lexer-gen.cc"
+#line 4839 "src/prebuilt/wast-lexer-gen.cc"
 yy837:
 		yych = *++cursor_;
 		if (yych == 's') goto yy930;
@@ -4870,9 +4868,9 @@ yy840:
 			}
 		}
 yy841:
-#line 380 "src/wast-lexer.cc"
+#line 378 "src/wast-lexer.cc"
 		{ SetTextAt(7); RETURN(OFFSET_EQ_NAT); }
-#line 4876 "src/prebuilt/wast-lexer-gen.cc"
+#line 4874 "src/prebuilt/wast-lexer-gen.cc"
 yy842:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -4902,9 +4900,9 @@ yy844:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 531 "src/wast-lexer.cc"
+#line 529 "src/wast-lexer.cc"
 		{ RETURN(REGISTER); }
-#line 4908 "src/prebuilt/wast-lexer-gen.cc"
+#line 4906 "src/prebuilt/wast-lexer-gen.cc"
 yy846:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy938;
@@ -4980,9 +4978,9 @@ yy859:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 546 "src/wast-lexer.cc"
+#line 544 "src/wast-lexer.cc"
 		{ RETURN_LPAR(CATCH_ALL); }
-#line 4986 "src/prebuilt/wast-lexer-gen.cc"
+#line 4984 "src/prebuilt/wast-lexer-gen.cc"
 yy861:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy951;
@@ -4992,9 +4990,9 @@ yy862:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 384 "src/wast-lexer.cc"
+#line 382 "src/wast-lexer.cc"
 		{ TYPE(F32); RETURN(CONST); }
-#line 4998 "src/prebuilt/wast-lexer-gen.cc"
+#line 4996 "src/prebuilt/wast-lexer-gen.cc"
 yy864:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy952;
@@ -5012,9 +5010,9 @@ yy867:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 402 "src/wast-lexer.cc"
+#line 400 "src/wast-lexer.cc"
 		{ OPCODE(F32Floor); RETURN(UNARY); }
-#line 5018 "src/prebuilt/wast-lexer-gen.cc"
+#line 5016 "src/prebuilt/wast-lexer-gen.cc"
 yy869:
 		yych = *++cursor_;
 		if (yych == 's') goto yy955;
@@ -5028,25 +5026,25 @@ yy871:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 363 "src/wast-lexer.cc"
+#line 361 "src/wast-lexer.cc"
 		{ OPCODE(F32Store); RETURN(STORE); }
-#line 5034 "src/prebuilt/wast-lexer-gen.cc"
+#line 5032 "src/prebuilt/wast-lexer-gen.cc"
 yy873:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 404 "src/wast-lexer.cc"
+#line 402 "src/wast-lexer.cc"
 		{ OPCODE(F32Trunc); RETURN(UNARY); }
-#line 5042 "src/prebuilt/wast-lexer-gen.cc"
+#line 5040 "src/prebuilt/wast-lexer-gen.cc"
 yy875:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 385 "src/wast-lexer.cc"
+#line 383 "src/wast-lexer.cc"
 		{ TYPE(F64); RETURN(CONST); }
-#line 5050 "src/prebuilt/wast-lexer-gen.cc"
+#line 5048 "src/prebuilt/wast-lexer-gen.cc"
 yy877:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy957;
@@ -5060,9 +5058,9 @@ yy879:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 403 "src/wast-lexer.cc"
+#line 401 "src/wast-lexer.cc"
 		{ OPCODE(F64Floor); RETURN(UNARY); }
-#line 5066 "src/prebuilt/wast-lexer-gen.cc"
+#line 5064 "src/prebuilt/wast-lexer-gen.cc"
 yy881:
 		yych = *++cursor_;
 		if (yych == 's') goto yy959;
@@ -5080,17 +5078,17 @@ yy884:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 364 "src/wast-lexer.cc"
+#line 362 "src/wast-lexer.cc"
 		{ OPCODE(F64Store); RETURN(STORE); }
-#line 5086 "src/prebuilt/wast-lexer-gen.cc"
+#line 5084 "src/prebuilt/wast-lexer-gen.cc"
 yy886:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 405 "src/wast-lexer.cc"
+#line 403 "src/wast-lexer.cc"
 		{ OPCODE(F64Trunc); RETURN(UNARY); }
-#line 5094 "src/prebuilt/wast-lexer-gen.cc"
+#line 5092 "src/prebuilt/wast-lexer-gen.cc"
 yy888:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy962;
@@ -5100,9 +5098,9 @@ yy889:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 352 "src/wast-lexer.cc"
+#line 350 "src/wast-lexer.cc"
 		{ RETURN(GET_LOCAL); }
-#line 5106 "src/prebuilt/wast-lexer-gen.cc"
+#line 5104 "src/prebuilt/wast-lexer-gen.cc"
 yy891:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy964;
@@ -5112,25 +5110,25 @@ yy892:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 382 "src/wast-lexer.cc"
+#line 380 "src/wast-lexer.cc"
 		{ TYPE(I32); RETURN(CONST); }
-#line 5118 "src/prebuilt/wast-lexer-gen.cc"
+#line 5116 "src/prebuilt/wast-lexer-gen.cc"
 yy894:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 414 "src/wast-lexer.cc"
+#line 412 "src/wast-lexer.cc"
 		{ OPCODE(I32DivS); RETURN(BINARY); }
-#line 5126 "src/prebuilt/wast-lexer-gen.cc"
+#line 5124 "src/prebuilt/wast-lexer-gen.cc"
 yy896:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 416 "src/wast-lexer.cc"
+#line 414 "src/wast-lexer.cc"
 		{ OPCODE(I32DivU); RETURN(BINARY); }
-#line 5134 "src/prebuilt/wast-lexer-gen.cc"
+#line 5132 "src/prebuilt/wast-lexer-gen.cc"
 yy898:
 		yych = *++cursor_;
 		if (yych == '6') goto yy965;
@@ -5152,33 +5150,33 @@ yy902:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 418 "src/wast-lexer.cc"
+#line 416 "src/wast-lexer.cc"
 		{ OPCODE(I32RemS); RETURN(BINARY); }
-#line 5158 "src/prebuilt/wast-lexer-gen.cc"
+#line 5156 "src/prebuilt/wast-lexer-gen.cc"
 yy904:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 420 "src/wast-lexer.cc"
+#line 418 "src/wast-lexer.cc"
 		{ OPCODE(I32RemU); RETURN(BINARY); }
-#line 5166 "src/prebuilt/wast-lexer-gen.cc"
+#line 5164 "src/prebuilt/wast-lexer-gen.cc"
 yy906:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 430 "src/wast-lexer.cc"
+#line 428 "src/wast-lexer.cc"
 		{ OPCODE(I32ShrS); RETURN(BINARY); }
-#line 5174 "src/prebuilt/wast-lexer-gen.cc"
+#line 5172 "src/prebuilt/wast-lexer-gen.cc"
 yy908:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 432 "src/wast-lexer.cc"
+#line 430 "src/wast-lexer.cc"
 		{ OPCODE(I32ShrU); RETURN(BINARY); }
-#line 5182 "src/prebuilt/wast-lexer-gen.cc"
+#line 5180 "src/prebuilt/wast-lexer-gen.cc"
 yy910:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
@@ -5199,9 +5197,9 @@ yy910:
 			}
 		}
 yy911:
-#line 361 "src/wast-lexer.cc"
+#line 359 "src/wast-lexer.cc"
 		{ OPCODE(I32Store); RETURN(STORE); }
-#line 5205 "src/prebuilt/wast-lexer-gen.cc"
+#line 5203 "src/prebuilt/wast-lexer-gen.cc"
 yy912:
 		yych = *++cursor_;
 		if (yych == '_') goto yy973;
@@ -5215,25 +5213,25 @@ yy914:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 383 "src/wast-lexer.cc"
+#line 381 "src/wast-lexer.cc"
 		{ TYPE(I64); RETURN(CONST); }
-#line 5221 "src/prebuilt/wast-lexer-gen.cc"
+#line 5219 "src/prebuilt/wast-lexer-gen.cc"
 yy916:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 415 "src/wast-lexer.cc"
+#line 413 "src/wast-lexer.cc"
 		{ OPCODE(I64DivS); RETURN(BINARY); }
-#line 5229 "src/prebuilt/wast-lexer-gen.cc"
+#line 5227 "src/prebuilt/wast-lexer-gen.cc"
 yy918:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 417 "src/wast-lexer.cc"
+#line 415 "src/wast-lexer.cc"
 		{ OPCODE(I64DivU); RETURN(BINARY); }
-#line 5237 "src/prebuilt/wast-lexer-gen.cc"
+#line 5235 "src/prebuilt/wast-lexer-gen.cc"
 yy920:
 		yych = *++cursor_;
 		if (yych == 'd') goto yy975;
@@ -5263,33 +5261,33 @@ yy926:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 419 "src/wast-lexer.cc"
+#line 417 "src/wast-lexer.cc"
 		{ OPCODE(I64RemS); RETURN(BINARY); }
-#line 5269 "src/prebuilt/wast-lexer-gen.cc"
+#line 5267 "src/prebuilt/wast-lexer-gen.cc"
 yy928:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 421 "src/wast-lexer.cc"
+#line 419 "src/wast-lexer.cc"
 		{ OPCODE(I64RemU); RETURN(BINARY); }
-#line 5277 "src/prebuilt/wast-lexer-gen.cc"
+#line 5275 "src/prebuilt/wast-lexer-gen.cc"
 yy930:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 431 "src/wast-lexer.cc"
+#line 429 "src/wast-lexer.cc"
 		{ OPCODE(I64ShrS); RETURN(BINARY); }
-#line 5285 "src/prebuilt/wast-lexer-gen.cc"
+#line 5283 "src/prebuilt/wast-lexer-gen.cc"
 yy932:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 433 "src/wast-lexer.cc"
+#line 431 "src/wast-lexer.cc"
 		{ OPCODE(I64ShrU); RETURN(BINARY); }
-#line 5293 "src/prebuilt/wast-lexer-gen.cc"
+#line 5291 "src/prebuilt/wast-lexer-gen.cc"
 yy934:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
@@ -5312,9 +5310,9 @@ yy934:
 			}
 		}
 yy935:
-#line 362 "src/wast-lexer.cc"
+#line 360 "src/wast-lexer.cc"
 		{ OPCODE(I64Store); RETURN(STORE); }
-#line 5318 "src/prebuilt/wast-lexer-gen.cc"
+#line 5316 "src/prebuilt/wast-lexer-gen.cc"
 yy936:
 		yych = *++cursor_;
 		if (yych == '_') goto yy986;
@@ -5340,17 +5338,17 @@ yy939:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 353 "src/wast-lexer.cc"
+#line 351 "src/wast-lexer.cc"
 		{ RETURN(SET_LOCAL); }
-#line 5346 "src/prebuilt/wast-lexer-gen.cc"
+#line 5344 "src/prebuilt/wast-lexer-gen.cc"
 yy941:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 354 "src/wast-lexer.cc"
+#line 352 "src/wast-lexer.cc"
 		{ RETURN(TEE_LOCAL); }
-#line 5354 "src/prebuilt/wast-lexer-gen.cc"
+#line 5352 "src/prebuilt/wast-lexer-gen.cc"
 yy943:
 		yych = *++cursor_;
 		if (yych == 'l') goto yy991;
@@ -5432,9 +5430,9 @@ yy962:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 355 "src/wast-lexer.cc"
+#line 353 "src/wast-lexer.cc"
 		{ RETURN(GET_GLOBAL); }
-#line 5438 "src/prebuilt/wast-lexer-gen.cc"
+#line 5436 "src/prebuilt/wast-lexer-gen.cc"
 yy964:
 		yych = *++cursor_;
 		if (yych == 'y') goto yy1013;
@@ -5453,9 +5451,9 @@ yy967:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 392 "src/wast-lexer.cc"
+#line 390 "src/wast-lexer.cc"
 		{ OPCODE(I32Popcnt); RETURN(UNARY); }
-#line 5459 "src/prebuilt/wast-lexer-gen.cc"
+#line 5457 "src/prebuilt/wast-lexer-gen.cc"
 yy969:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1020;
@@ -5469,9 +5467,9 @@ yy971:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 375 "src/wast-lexer.cc"
+#line 373 "src/wast-lexer.cc"
 		{ OPCODE(I32Store8); RETURN(STORE); }
-#line 5475 "src/prebuilt/wast-lexer-gen.cc"
+#line 5473 "src/prebuilt/wast-lexer-gen.cc"
 yy973:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1023;
@@ -5503,9 +5501,9 @@ yy979:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 393 "src/wast-lexer.cc"
+#line 391 "src/wast-lexer.cc"
 		{ OPCODE(I64Popcnt); RETURN(UNARY); }
-#line 5509 "src/prebuilt/wast-lexer-gen.cc"
+#line 5507 "src/prebuilt/wast-lexer-gen.cc"
 yy981:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1033;
@@ -5523,9 +5521,9 @@ yy984:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 376 "src/wast-lexer.cc"
+#line 374 "src/wast-lexer.cc"
 		{ OPCODE(I64Store8); RETURN(STORE); }
-#line 5529 "src/prebuilt/wast-lexer-gen.cc"
+#line 5527 "src/prebuilt/wast-lexer-gen.cc"
 yy986:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1038;
@@ -5562,9 +5560,9 @@ yy989:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 356 "src/wast-lexer.cc"
+#line 354 "src/wast-lexer.cc"
 		{ RETURN(SET_GLOBAL); }
-#line 5568 "src/prebuilt/wast-lexer-gen.cc"
+#line 5566 "src/prebuilt/wast-lexer-gen.cc"
 yy991:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy1040;
@@ -5590,9 +5588,9 @@ yy996:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 542 "src/wast-lexer.cc"
+#line 540 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_TRAP); }
-#line 5596 "src/prebuilt/wast-lexer-gen.cc"
+#line 5594 "src/prebuilt/wast-lexer-gen.cc"
 yy998:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy1046;
@@ -5622,9 +5620,9 @@ yy1004:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 406 "src/wast-lexer.cc"
+#line 404 "src/wast-lexer.cc"
 		{ OPCODE(F32Nearest); RETURN(UNARY); }
-#line 5628 "src/prebuilt/wast-lexer-gen.cc"
+#line 5626 "src/prebuilt/wast-lexer-gen.cc"
 yy1006:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy1053;
@@ -5642,9 +5640,9 @@ yy1009:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 407 "src/wast-lexer.cc"
+#line 405 "src/wast-lexer.cc"
 		{ OPCODE(F64Nearest); RETURN(UNARY); }
-#line 5648 "src/prebuilt/wast-lexer-gen.cc"
+#line 5646 "src/prebuilt/wast-lexer-gen.cc"
 yy1011:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1057;
@@ -5658,9 +5656,9 @@ yy1013:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 512 "src/wast-lexer.cc"
+#line 510 "src/wast-lexer.cc"
 		{ RETURN(GROW_MEMORY); }
-#line 5664 "src/prebuilt/wast-lexer-gen.cc"
+#line 5662 "src/prebuilt/wast-lexer-gen.cc"
 yy1015:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1059;
@@ -5671,17 +5669,17 @@ yy1016:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 365 "src/wast-lexer.cc"
+#line 363 "src/wast-lexer.cc"
 		{ OPCODE(I32Load8S); RETURN(LOAD); }
-#line 5677 "src/prebuilt/wast-lexer-gen.cc"
+#line 5675 "src/prebuilt/wast-lexer-gen.cc"
 yy1018:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 367 "src/wast-lexer.cc"
+#line 365 "src/wast-lexer.cc"
 		{ OPCODE(I32Load8U); RETURN(LOAD); }
-#line 5685 "src/prebuilt/wast-lexer-gen.cc"
+#line 5683 "src/prebuilt/wast-lexer-gen.cc"
 yy1020:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy1063;
@@ -5691,9 +5689,9 @@ yy1021:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 377 "src/wast-lexer.cc"
+#line 375 "src/wast-lexer.cc"
 		{ OPCODE(I32Store16); RETURN(STORE); }
-#line 5697 "src/prebuilt/wast-lexer-gen.cc"
+#line 5695 "src/prebuilt/wast-lexer-gen.cc"
 yy1023:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1064;
@@ -5726,17 +5724,17 @@ yy1029:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 366 "src/wast-lexer.cc"
+#line 364 "src/wast-lexer.cc"
 		{ OPCODE(I64Load8S); RETURN(LOAD); }
-#line 5732 "src/prebuilt/wast-lexer-gen.cc"
+#line 5730 "src/prebuilt/wast-lexer-gen.cc"
 yy1031:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 368 "src/wast-lexer.cc"
+#line 366 "src/wast-lexer.cc"
 		{ OPCODE(I64Load8U); RETURN(LOAD); }
-#line 5740 "src/prebuilt/wast-lexer-gen.cc"
+#line 5738 "src/prebuilt/wast-lexer-gen.cc"
 yy1033:
 		yych = *++cursor_;
 		if (yych == 'p') goto yy1078;
@@ -5746,17 +5744,17 @@ yy1034:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 378 "src/wast-lexer.cc"
+#line 376 "src/wast-lexer.cc"
 		{ OPCODE(I64Store16); RETURN(STORE); }
-#line 5752 "src/prebuilt/wast-lexer-gen.cc"
+#line 5750 "src/prebuilt/wast-lexer-gen.cc"
 yy1036:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 379 "src/wast-lexer.cc"
+#line 377 "src/wast-lexer.cc"
 		{ OPCODE(I64Store32); RETURN(STORE); }
-#line 5760 "src/prebuilt/wast-lexer-gen.cc"
+#line 5758 "src/prebuilt/wast-lexer-gen.cc"
 yy1038:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1079;
@@ -5770,9 +5768,9 @@ yy1040:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 510 "src/wast-lexer.cc"
+#line 508 "src/wast-lexer.cc"
 		{ RETURN(UNREACHABLE); }
-#line 5776 "src/prebuilt/wast-lexer-gen.cc"
+#line 5774 "src/prebuilt/wast-lexer-gen.cc"
 yy1042:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1081;
@@ -5811,9 +5809,9 @@ yy1050:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 450 "src/wast-lexer.cc"
+#line 448 "src/wast-lexer.cc"
 		{ OPCODE(F32Copysign); RETURN(BINARY); }
-#line 5817 "src/prebuilt/wast-lexer-gen.cc"
+#line 5815 "src/prebuilt/wast-lexer-gen.cc"
 yy1052:
 		yych = *++cursor_;
 		if (yych == '6') goto yy1092;
@@ -5832,9 +5830,9 @@ yy1055:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 451 "src/wast-lexer.cc"
+#line 449 "src/wast-lexer.cc"
 		{ OPCODE(F64Copysign); RETURN(BINARY); }
-#line 5838 "src/prebuilt/wast-lexer-gen.cc"
+#line 5836 "src/prebuilt/wast-lexer-gen.cc"
 yy1057:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy1096;
@@ -5848,17 +5846,17 @@ yy1059:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 369 "src/wast-lexer.cc"
+#line 367 "src/wast-lexer.cc"
 		{ OPCODE(I32Load16S); RETURN(LOAD); }
-#line 5854 "src/prebuilt/wast-lexer-gen.cc"
+#line 5852 "src/prebuilt/wast-lexer-gen.cc"
 yy1061:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 371 "src/wast-lexer.cc"
+#line 369 "src/wast-lexer.cc"
 		{ OPCODE(I32Load16U); RETURN(LOAD); }
-#line 5862 "src/prebuilt/wast-lexer-gen.cc"
+#line 5860 "src/prebuilt/wast-lexer-gen.cc"
 yy1063:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1098;
@@ -5876,9 +5874,9 @@ yy1066:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 486 "src/wast-lexer.cc"
+#line 484 "src/wast-lexer.cc"
 		{ OPCODE(I32WrapI64); RETURN(CONVERT); }
-#line 5882 "src/prebuilt/wast-lexer-gen.cc"
+#line 5880 "src/prebuilt/wast-lexer-gen.cc"
 yy1068:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1101;
@@ -5892,33 +5890,33 @@ yy1070:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 370 "src/wast-lexer.cc"
+#line 368 "src/wast-lexer.cc"
 		{ OPCODE(I64Load16S); RETURN(LOAD); }
-#line 5898 "src/prebuilt/wast-lexer-gen.cc"
+#line 5896 "src/prebuilt/wast-lexer-gen.cc"
 yy1072:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 372 "src/wast-lexer.cc"
+#line 370 "src/wast-lexer.cc"
 		{ OPCODE(I64Load16U); RETURN(LOAD); }
-#line 5906 "src/prebuilt/wast-lexer-gen.cc"
+#line 5904 "src/prebuilt/wast-lexer-gen.cc"
 yy1074:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 373 "src/wast-lexer.cc"
+#line 371 "src/wast-lexer.cc"
 		{ OPCODE(I64Load32S); RETURN(LOAD); }
-#line 5914 "src/prebuilt/wast-lexer-gen.cc"
+#line 5912 "src/prebuilt/wast-lexer-gen.cc"
 yy1076:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 374 "src/wast-lexer.cc"
+#line 372 "src/wast-lexer.cc"
 		{ OPCODE(I64Load32U); RETURN(LOAD); }
-#line 5922 "src/prebuilt/wast-lexer-gen.cc"
+#line 5920 "src/prebuilt/wast-lexer-gen.cc"
 yy1078:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1103;
@@ -5961,9 +5959,9 @@ yy1084:
 			}
 		}
 yy1085:
-#line 537 "src/wast-lexer.cc"
+#line 535 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_RETURN); }
-#line 5967 "src/prebuilt/wast-lexer-gen.cc"
+#line 5965 "src/prebuilt/wast-lexer-gen.cc"
 yy1086:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy1111;
@@ -5973,9 +5971,9 @@ yy1087:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 348 "src/wast-lexer.cc"
+#line 346 "src/wast-lexer.cc"
 		{ RETURN(CALL_INDIRECT); }
-#line 5979 "src/prebuilt/wast-lexer-gen.cc"
+#line 5977 "src/prebuilt/wast-lexer-gen.cc"
 yy1089:
 		yych = *++cursor_;
 		if (yych == 'y') goto yy1112;
@@ -6057,9 +6055,9 @@ yy1107:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 535 "src/wast-lexer.cc"
+#line 533 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_INVALID); }
-#line 6063 "src/prebuilt/wast-lexer-gen.cc"
+#line 6061 "src/prebuilt/wast-lexer-gen.cc"
 yy1109:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy1136;
@@ -6078,9 +6076,9 @@ yy1112:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 511 "src/wast-lexer.cc"
+#line 509 "src/wast-lexer.cc"
 		{ RETURN(CURRENT_MEMORY); }
-#line 6084 "src/prebuilt/wast-lexer-gen.cc"
+#line 6082 "src/prebuilt/wast-lexer-gen.cc"
 yy1114:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy1140;
@@ -6094,9 +6092,9 @@ yy1116:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 504 "src/wast-lexer.cc"
+#line 502 "src/wast-lexer.cc"
 		{ OPCODE(F32DemoteF64); RETURN(CONVERT); }
-#line 6100 "src/prebuilt/wast-lexer-gen.cc"
+#line 6098 "src/prebuilt/wast-lexer-gen.cc"
 yy1118:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1142;
@@ -6214,9 +6212,9 @@ yy1145:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 503 "src/wast-lexer.cc"
+#line 501 "src/wast-lexer.cc"
 		{ OPCODE(F64PromoteF32); RETURN(CONVERT); }
-#line 6220 "src/prebuilt/wast-lexer-gen.cc"
+#line 6218 "src/prebuilt/wast-lexer-gen.cc"
 yy1147:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1183;
@@ -6230,33 +6228,33 @@ yy1149:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 487 "src/wast-lexer.cc"
+#line 485 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncSF32); RETURN(CONVERT); }
-#line 6236 "src/prebuilt/wast-lexer-gen.cc"
+#line 6234 "src/prebuilt/wast-lexer-gen.cc"
 yy1151:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 489 "src/wast-lexer.cc"
+#line 487 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncSF64); RETURN(CONVERT); }
-#line 6244 "src/prebuilt/wast-lexer-gen.cc"
+#line 6242 "src/prebuilt/wast-lexer-gen.cc"
 yy1153:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 491 "src/wast-lexer.cc"
+#line 489 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncUF32); RETURN(CONVERT); }
-#line 6252 "src/prebuilt/wast-lexer-gen.cc"
+#line 6250 "src/prebuilt/wast-lexer-gen.cc"
 yy1155:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 493 "src/wast-lexer.cc"
+#line 491 "src/wast-lexer.cc"
 		{ OPCODE(I32TruncUF64); RETURN(CONVERT); }
-#line 6260 "src/prebuilt/wast-lexer-gen.cc"
+#line 6258 "src/prebuilt/wast-lexer-gen.cc"
 yy1157:
 		yych = *++cursor_;
 		if (yych == '2') goto yy1185;
@@ -6274,33 +6272,33 @@ yy1160:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 488 "src/wast-lexer.cc"
+#line 486 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncSF32); RETURN(CONVERT); }
-#line 6280 "src/prebuilt/wast-lexer-gen.cc"
+#line 6278 "src/prebuilt/wast-lexer-gen.cc"
 yy1162:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 490 "src/wast-lexer.cc"
+#line 488 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncSF64); RETURN(CONVERT); }
-#line 6288 "src/prebuilt/wast-lexer-gen.cc"
+#line 6286 "src/prebuilt/wast-lexer-gen.cc"
 yy1164:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 492 "src/wast-lexer.cc"
+#line 490 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncUF32); RETURN(CONVERT); }
-#line 6296 "src/prebuilt/wast-lexer-gen.cc"
+#line 6294 "src/prebuilt/wast-lexer-gen.cc"
 yy1166:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 494 "src/wast-lexer.cc"
+#line 492 "src/wast-lexer.cc"
 		{ OPCODE(I64TruncUF64); RETURN(CONVERT); }
-#line 6304 "src/prebuilt/wast-lexer-gen.cc"
+#line 6302 "src/prebuilt/wast-lexer-gen.cc"
 yy1168:
 		yych = *++cursor_;
 		if (yych == 'n') goto yy1190;
@@ -6310,9 +6308,9 @@ yy1169:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 534 "src/wast-lexer.cc"
+#line 532 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_MALFORMED); }
-#line 6316 "src/prebuilt/wast-lexer-gen.cc"
+#line 6314 "src/prebuilt/wast-lexer-gen.cc"
 yy1171:
 		yych = *++cursor_;
 		if (yych == 'i') goto yy1192;
@@ -6374,17 +6372,17 @@ yy1185:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 484 "src/wast-lexer.cc"
+#line 482 "src/wast-lexer.cc"
 		{ OPCODE(I64ExtendSI32); RETURN(CONVERT); }
-#line 6380 "src/prebuilt/wast-lexer-gen.cc"
+#line 6378 "src/prebuilt/wast-lexer-gen.cc"
 yy1187:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 485 "src/wast-lexer.cc"
+#line 483 "src/wast-lexer.cc"
 		{ OPCODE(I64ExtendUI32); RETURN(CONVERT); }
-#line 6388 "src/prebuilt/wast-lexer-gen.cc"
+#line 6386 "src/prebuilt/wast-lexer-gen.cc"
 yy1189:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy1215;
@@ -6394,9 +6392,9 @@ yy1190:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 543 "src/wast-lexer.cc"
+#line 541 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_EXHAUSTION); }
-#line 6400 "src/prebuilt/wast-lexer-gen.cc"
+#line 6398 "src/prebuilt/wast-lexer-gen.cc"
 yy1192:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1216;
@@ -6410,41 +6408,41 @@ yy1194:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 536 "src/wast-lexer.cc"
+#line 534 "src/wast-lexer.cc"
 		{ RETURN(ASSERT_UNLINKABLE); }
-#line 6416 "src/prebuilt/wast-lexer-gen.cc"
+#line 6414 "src/prebuilt/wast-lexer-gen.cc"
 yy1196:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 495 "src/wast-lexer.cc"
+#line 493 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertSI32); RETURN(CONVERT); }
-#line 6424 "src/prebuilt/wast-lexer-gen.cc"
+#line 6422 "src/prebuilt/wast-lexer-gen.cc"
 yy1198:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 497 "src/wast-lexer.cc"
+#line 495 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertSI64); RETURN(CONVERT); }
-#line 6432 "src/prebuilt/wast-lexer-gen.cc"
+#line 6430 "src/prebuilt/wast-lexer-gen.cc"
 yy1200:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 499 "src/wast-lexer.cc"
+#line 497 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertUI32); RETURN(CONVERT); }
-#line 6440 "src/prebuilt/wast-lexer-gen.cc"
+#line 6438 "src/prebuilt/wast-lexer-gen.cc"
 yy1202:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 501 "src/wast-lexer.cc"
+#line 499 "src/wast-lexer.cc"
 		{ OPCODE(F32ConvertUI64); RETURN(CONVERT); }
-#line 6448 "src/prebuilt/wast-lexer-gen.cc"
+#line 6446 "src/prebuilt/wast-lexer-gen.cc"
 yy1204:
 		yych = *++cursor_;
 		if (yych == '3') goto yy1218;
@@ -6454,33 +6452,33 @@ yy1205:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 496 "src/wast-lexer.cc"
+#line 494 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertSI32); RETURN(CONVERT); }
-#line 6460 "src/prebuilt/wast-lexer-gen.cc"
+#line 6458 "src/prebuilt/wast-lexer-gen.cc"
 yy1207:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 498 "src/wast-lexer.cc"
+#line 496 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertSI64); RETURN(CONVERT); }
-#line 6468 "src/prebuilt/wast-lexer-gen.cc"
+#line 6466 "src/prebuilt/wast-lexer-gen.cc"
 yy1209:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 500 "src/wast-lexer.cc"
+#line 498 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertUI32); RETURN(CONVERT); }
-#line 6476 "src/prebuilt/wast-lexer-gen.cc"
+#line 6474 "src/prebuilt/wast-lexer-gen.cc"
 yy1211:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 502 "src/wast-lexer.cc"
+#line 500 "src/wast-lexer.cc"
 		{ OPCODE(F64ConvertUI64); RETURN(CONVERT); }
-#line 6484 "src/prebuilt/wast-lexer-gen.cc"
+#line 6482 "src/prebuilt/wast-lexer-gen.cc"
 yy1213:
 		yych = *++cursor_;
 		if (yych == '6') goto yy1219;
@@ -6530,33 +6528,33 @@ yy1224:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 505 "src/wast-lexer.cc"
+#line 503 "src/wast-lexer.cc"
 		{ OPCODE(F32ReinterpretI32); RETURN(CONVERT); }
-#line 6536 "src/prebuilt/wast-lexer-gen.cc"
+#line 6534 "src/prebuilt/wast-lexer-gen.cc"
 yy1226:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 507 "src/wast-lexer.cc"
+#line 505 "src/wast-lexer.cc"
 		{ OPCODE(F64ReinterpretI64); RETURN(CONVERT); }
-#line 6544 "src/prebuilt/wast-lexer-gen.cc"
+#line 6542 "src/prebuilt/wast-lexer-gen.cc"
 yy1228:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 506 "src/wast-lexer.cc"
+#line 504 "src/wast-lexer.cc"
 		{ OPCODE(I32ReinterpretF32); RETURN(CONVERT); }
-#line 6552 "src/prebuilt/wast-lexer-gen.cc"
+#line 6550 "src/prebuilt/wast-lexer-gen.cc"
 yy1230:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 508 "src/wast-lexer.cc"
+#line 506 "src/wast-lexer.cc"
 		{ OPCODE(I64ReinterpretF64); RETURN(CONVERT); }
-#line 6560 "src/prebuilt/wast-lexer-gen.cc"
+#line 6558 "src/prebuilt/wast-lexer-gen.cc"
 yy1232:
 		yych = *++cursor_;
 		if (yych == 'e') goto yy1234;
@@ -6622,22 +6620,22 @@ yy1247:
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 538 "src/wast-lexer.cc"
+#line 536 "src/wast-lexer.cc"
 		{
                                   RETURN(ASSERT_RETURN_CANONICAL_NAN); }
-#line 6629 "src/prebuilt/wast-lexer-gen.cc"
+#line 6627 "src/prebuilt/wast-lexer-gen.cc"
 yy1249:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 540 "src/wast-lexer.cc"
+#line 538 "src/wast-lexer.cc"
 		{
                                   RETURN(ASSERT_RETURN_ARITHMETIC_NAN); }
-#line 6638 "src/prebuilt/wast-lexer-gen.cc"
+#line 6636 "src/prebuilt/wast-lexer-gen.cc"
 	}
 }
-#line 569 "src/wast-lexer.cc"
+#line 567 "src/wast-lexer.cc"
 
   }
 }

--- a/src/prebuilt/wast-parser-gen.cc
+++ b/src/prebuilt/wast-parser-gen.cc
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison implementation for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by
@@ -44,7 +44,7 @@
 #define YYBISON 1
 
 /* Bison version.  */
-#define YYBISON_VERSION "3.0.4"
+#define YYBISON_VERSION "3.0.2"
 
 /* Skeleton name.  */
 #define YYSKELETON_NAME "yacc.c"
@@ -2605,8 +2605,8 @@ yyreduce:
   case 23:
 #line 384 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      if (WABT_FAILED(parse_uint64((yyvsp[0].literal).text.start,
-                                        (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
+      if (Failed(parse_uint64((yyvsp[0].literal).text.start,
+                              (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
         wast_parser_error(&(yylsp[0]), lexer, parser,
                           "invalid int " PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
@@ -2680,7 +2680,7 @@ yyreduce:
 
   case 31:
 #line 430 "src/wast-parser.y" /* yacc.c:1646  */
-    { WABT_ZERO_MEMORY((yyval.text)); }
+    { ZeroMemory((yyval.text)); }
 #line 2685 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
@@ -2692,7 +2692,7 @@ yyreduce:
 
   case 34:
 #line 438 "src/wast-parser.y" /* yacc.c:1646  */
-    { WABT_ZERO_MEMORY((yyval.text)); }
+    { ZeroMemory((yyval.text)); }
 #line 2697 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
@@ -2706,8 +2706,8 @@ yyreduce:
 #line 444 "src/wast-parser.y" /* yacc.c:1646  */
     {
       uint64_t offset64;
-      if (WABT_FAILED(parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &offset64,
-                                  ParseIntType::SignedAndUnsigned))) {
+      if (Failed(parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &offset64,
+                             ParseIntType::SignedAndUnsigned))) {
         wast_parser_error(&(yylsp[0]), lexer, parser,
                           "invalid offset \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
@@ -2730,8 +2730,8 @@ yyreduce:
   case 39:
 #line 461 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      if (WABT_FAILED(parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
-                                  ParseIntType::UnsignedOnly))) {
+      if (Failed(parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
+                             ParseIntType::UnsignedOnly))) {
         wast_parser_error(&(yylsp[0]), lexer, parser,
                           "invalid alignment \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].text)));
@@ -2907,8 +2907,8 @@ yyreduce:
     {
       Const const_;
       const_.loc = (yylsp[-1]);
-      if (WABT_FAILED(parse_const((yyvsp[-1].type), (yyvsp[0].literal).type, (yyvsp[0].literal).text.start,
-                                  (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &const_))) {
+      if (Failed(parse_const((yyvsp[-1].type), (yyvsp[0].literal).type, (yyvsp[0].literal).text.start,
+                             (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &const_))) {
         wast_parser_error(&(yylsp[0]), lexer, parser,
                           "invalid literal \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
@@ -3307,7 +3307,7 @@ yyreduce:
 
   case 106:
 #line 785 "src/wast-parser.y" /* yacc.c:1646  */
-    { WABT_ZERO_MEMORY((yyval.expr_list)); }
+    { ZeroMemory((yyval.expr_list)); }
 #line 3312 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
@@ -3324,7 +3324,7 @@ yyreduce:
 
   case 108:
 #line 794 "src/wast-parser.y" /* yacc.c:1646  */
-    { WABT_ZERO_MEMORY((yyval.expr_list)); }
+    { ZeroMemory((yyval.expr_list)); }
 #line 3329 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
@@ -4095,7 +4095,7 @@ yyreduce:
                        &error_handler, (yyval.module));
         (yyval.module)->name = (yyvsp[0].script_module)->binary.name;
         (yyval.module)->loc = (yyvsp[0].script_module)->binary.loc;
-        WABT_ZERO_MEMORY((yyvsp[0].script_module)->binary.name);
+        ZeroMemory((yyvsp[0].script_module)->binary.name);
       }
       delete (yyvsp[0].script_module);
     }
@@ -4319,8 +4319,8 @@ yyreduce:
 #line 1473 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
-      if (WABT_FAILED(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
-                                  (yyvsp[-1].literal).text.start + (yyvsp[-1].literal).text.length, &(yyval.const_)))) {
+      if (Failed(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
+                             (yyvsp[-1].literal).text.start + (yyvsp[-1].literal).text.length, &(yyval.const_)))) {
         wast_parser_error(&(yylsp[-1]), lexer, parser,
                           "invalid literal \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[-1].literal).text));
@@ -4698,7 +4698,7 @@ void append_expr(ExprList* expr_list, Expr* expr) {
 
 ExprList join_exprs1(Location* loc, Expr* expr1) {
   ExprList result;
-  WABT_ZERO_MEMORY(result);
+  ZeroMemory(result);
   append_expr(&result, expr1);
   expr1->loc = *loc;
   return result;
@@ -4706,7 +4706,7 @@ ExprList join_exprs1(Location* loc, Expr* expr1) {
 
 ExprList join_exprs2(Location* loc, ExprList* expr1, Expr* expr2) {
   ExprList result;
-  WABT_ZERO_MEMORY(result);
+  ZeroMemory(result);
   append_expr_list(&result, expr1);
   append_expr(&result, expr2);
   expr2->loc = *loc;
@@ -4768,8 +4768,8 @@ size_t copy_string_contents(StringSlice* text, char* dest) {
           // sequence.
           uint32_t hi;
           uint32_t lo;
-          if (WABT_SUCCEEDED(parse_hexdigit(src[0], &hi)) &&
-              WABT_SUCCEEDED(parse_hexdigit(src[1], &lo))) {
+          if (Succeeded(parse_hexdigit(src[0], &hi)) &&
+              Succeeded(parse_hexdigit(src[1], &lo))) {
             *dest++ = (hi << 4) | lo;
           } else {
             assert(0);
@@ -5028,7 +5028,7 @@ Result parse_wast(WastLexer* lexer, Script** out_script,
                   SourceErrorHandler* error_handler,
                   WastParseOptions* options) {
   WastParser parser;
-  WABT_ZERO_MEMORY(parser);
+  ZeroMemory(parser);
   static WastParseOptions default_options;
   if (options == nullptr)
     options = &default_options;

--- a/src/prebuilt/wast-parser-gen.hh
+++ b/src/prebuilt/wast-parser-gen.hh
@@ -1,8 +1,8 @@
-/* A Bison parser, made by GNU Bison 3.0.4.  */
+/* A Bison parser, made by GNU Bison 3.0.2.  */
 
 /* Bison interface for Yacc-like parsers in C
 
-   Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+   Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
 
    This program is free software: you can redistribute it and/or modify
    it under the terms of the GNU General Public License as published by

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -39,7 +39,7 @@ void Stream::WriteDataAt(size_t at,
                          size_t size,
                          const char* desc,
                          PrintChars print_chars) {
-  if (WABT_FAILED(result_))
+  if (Failed(result_))
     return;
   if (log_stream_) {
     log_stream_->WriteMemoryDump(src, size, at, print_chars, nullptr, desc);
@@ -56,7 +56,7 @@ void Stream::WriteData(const void* src,
 }
 
 void Stream::MoveData(size_t dst_offset, size_t src_offset, size_t size) {
-  if (WABT_FAILED(result_))
+  if (Failed(result_))
     return;
   if (log_stream_) {
     log_stream_->Writef(

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -84,7 +84,7 @@ Section::Section()
       payload_offset(0),
       count(0),
       output_payload_offset(0) {
-  WABT_ZERO_MEMORY(data);
+  ZeroMemory(data);
 }
 
 Section::~Section() {
@@ -331,7 +331,7 @@ static void write_memory_section(Context* ctx,
   write_u32_leb128(stream, 1, "memory count");
 
   Limits limits;
-  WABT_ZERO_MEMORY(limits);
+  ZeroMemory(limits);
   limits.has_max = true;
   for (size_t i = 0; i < sections.size(); i++) {
     Section* sec = sections[i];
@@ -795,7 +795,7 @@ static Result perform_link(Context* ctx) {
   dump_reloc_offsets(ctx);
   write_binary(ctx);
 
-  if (WABT_FAILED(ctx->stream.WriteToFile(s_outfile))) {
+  if (Failed(ctx->stream.WriteToFile(s_outfile))) {
     WABT_FATAL("error writing linked output to file\n");
   }
 
@@ -816,7 +816,7 @@ int ProgramMain(int argc, char** argv) {
     char* data;
     size_t size;
     result = read_file(input_filename.c_str(), &data, &size);
-    if (WABT_FAILED(result))
+    if (Failed(result))
       return result != Result::Ok;
     LinkerInputBinary* b = new LinkerInputBinary(
         input_filename.c_str(), reinterpret_cast<uint8_t*>(data), size);
@@ -825,7 +825,7 @@ int ProgramMain(int argc, char** argv) {
     if (s_debug)
       options.log_stream = s_log_stream.get();
     result = read_binary_linker(b, &options);
-    if (WABT_FAILED(result))
+    if (Failed(result))
       WABT_FATAL("error parsing file: %s\n", input_filename.c_str());
   }
 

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -73,7 +73,7 @@ Result dump_file(const char* filename) {
   char* char_data;
   size_t size;
   Result result = read_file(filename, &char_data, &size);
-  if (WABT_FAILED(result))
+  if (Failed(result))
     return result;
 
   uint8_t* data = reinterpret_cast<uint8_t*>(char_data);
@@ -88,7 +88,7 @@ Result dump_file(const char* filename) {
   // Pass 0: Prepass
   s_objdump_options.mode = ObjdumpMode::Prepass;
   result = read_binary_objdump(data, size, &s_objdump_options, &state);
-  if (WABT_FAILED(result))
+  if (Failed(result))
     goto done;
   s_objdump_options.log_stream = nullptr;
 
@@ -96,7 +96,7 @@ Result dump_file(const char* filename) {
   if (s_objdump_options.headers) {
     s_objdump_options.mode = ObjdumpMode::Headers;
     result = read_binary_objdump(data, size, &s_objdump_options, &state);
-    if (WABT_FAILED(result))
+    if (Failed(result))
       goto done;
   }
 
@@ -104,7 +104,7 @@ Result dump_file(const char* filename) {
   if (s_objdump_options.details) {
     s_objdump_options.mode = ObjdumpMode::Details;
     result = read_binary_objdump(data, size, &s_objdump_options, &state);
-    if (WABT_FAILED(result))
+    if (Failed(result))
       goto done;
   }
 
@@ -112,7 +112,7 @@ Result dump_file(const char* filename) {
   if (s_objdump_options.disassemble) {
     s_objdump_options.mode = ObjdumpMode::Disassemble;
     result = read_binary_objdump(data, size, &s_objdump_options, &state);
-    if (WABT_FAILED(result))
+    if (Failed(result))
       goto done;
   }
 
@@ -142,7 +142,7 @@ int ProgramMain(int argc, char** argv) {
   }
 
   for (const char* filename: s_infiles) {
-    if (WABT_FAILED(dump_file(filename))) {
+    if (Failed(dump_file(filename))) {
       return 1;
     }
   }

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -221,7 +221,7 @@ int ProgramMain(int argc, char** argv) {
   char* data;
   size_t size;
   Result result = read_file(s_infile, &data, &size);
-  if (WABT_FAILED(result)) {
+  if (Failed(result)) {
     const char* input_name = s_infile ? s_infile : "stdin";
     ERROR("Unable to parse: %s", input_name);
     delete[] data;
@@ -233,10 +233,10 @@ int ProgramMain(int argc, char** argv) {
       ERROR("fopen \"%s\" failed, errno=%d\n", s_outfile, errno);
     result = Result::Error;
   }
-  if (WABT_SUCCEEDED(result)) {
+  if (Succeeded(result)) {
     OpcntData opcnt_data;
     result = read_binary_opcnt(data, size, &s_read_binary_options, &opcnt_data);
-    if (WABT_SUCCEEDED(result)) {
+    if (Succeeded(result)) {
       display_sorted_int_counter_vector(
           out, "Opcode counts:", opcnt_data.opcode_vec, opcode_counter_gt,
           display_opcode_name, nullptr);

--- a/src/tools/wasm2wast.cc
+++ b/src/tools/wasm2wast.cc
@@ -101,13 +101,13 @@ int ProgramMain(int argc, char** argv) {
   char* data;
   size_t size;
   result = read_file(s_infile.c_str(), &data, &size);
-  if (WABT_SUCCEEDED(result)) {
+  if (Succeeded(result)) {
     BinaryErrorHandlerFile error_handler;
     Module module;
     result = read_binary_ir(s_infile.c_str(), data, size,
                             &s_read_binary_options, &error_handler, &module);
-    if (WABT_SUCCEEDED(result)) {
-      if (WABT_SUCCEEDED(result) && s_validate) {
+    if (Succeeded(result)) {
+      if (Succeeded(result) && s_validate) {
         // TODO(binji): Would be nicer to use a builder pattern for an option
         // struct here, e.g.:
         //
@@ -123,14 +123,14 @@ int ProgramMain(int argc, char** argv) {
       if (s_generate_names)
         result = generate_names(&module);
 
-      if (WABT_SUCCEEDED(result)) {
+      if (Succeeded(result)) {
         /* TODO(binji): This shouldn't fail; if a name can't be applied
          * (because the index is invalid, say) it should just be skipped. */
         Result dummy_result = apply_names(&module);
         WABT_USE(dummy_result);
       }
 
-      if (WABT_SUCCEEDED(result)) {
+      if (Succeeded(result)) {
         FileWriter writer(!s_outfile.empty() ? FileWriter(s_outfile.c_str())
                                              : FileWriter(stdout));
         result = write_wat(&writer, &module, &s_write_wat_options);

--- a/src/tools/wast-desugar.cc
+++ b/src/tools/wast-desugar.cc
@@ -90,7 +90,7 @@ int ProgramMain(int argc, char** argv) {
   Result result = parse_wast(lexer.get(), &script, &error_handler,
                              &s_parse_options);
 
-  if (WABT_SUCCEEDED(result)) {
+  if (Succeeded(result)) {
     Module* module = script->GetFirstModule();
     if (!module)
       WABT_FATAL("no module in file.\n");
@@ -98,10 +98,10 @@ int ProgramMain(int argc, char** argv) {
     if (s_generate_names)
       result = generate_names(module);
 
-    if (WABT_SUCCEEDED(result))
+    if (Succeeded(result))
       result = apply_names(module);
 
-    if (WABT_SUCCEEDED(result)) {
+    if (Succeeded(result)) {
       FileWriter writer(s_outfile ? FileWriter(s_outfile) : FileWriter(stdout));
       result = write_wat(&writer, module, &s_write_wat_options);
     }

--- a/src/tools/wast2wasm.cc
+++ b/src/tools/wast2wasm.cc
@@ -140,13 +140,13 @@ int ProgramMain(int argc, char** argv) {
   Result result = parse_wast(lexer.get(), &script, &error_handler,
                              &s_parse_options);
 
-  if (WABT_SUCCEEDED(result)) {
+  if (Succeeded(result)) {
     result = resolve_names_script(lexer.get(), script, &error_handler);
 
-    if (WABT_SUCCEEDED(result) && s_validate)
+    if (Succeeded(result) && s_validate)
       result = validate_script(lexer.get(), script, &error_handler);
 
-    if (WABT_SUCCEEDED(result)) {
+    if (Succeeded(result)) {
       if (s_spec) {
         s_write_binary_spec_options.json_filename = s_outfile;
         s_write_binary_spec_options.write_binary_options =
@@ -163,7 +163,7 @@ int ProgramMain(int argc, char** argv) {
           WABT_FATAL("no module found\n");
         }
 
-        if (WABT_SUCCEEDED(result))
+        if (Succeeded(result))
           write_buffer_to_file(s_outfile, writer.output_buffer());
       }
     }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -18,7 +18,7 @@
 
 #define CHECK_RESULT(expr)  \
   do {                      \
-    if (WABT_FAILED(expr))  \
+    if (Failed(expr))       \
       return Result::Error; \
   } while (0)
 
@@ -66,7 +66,7 @@ Result TypeChecker::TopLabel(Label** out_label) {
 
 bool TypeChecker::IsUnreachable() {
   Label* label;
-  if (WABT_FAILED(TopLabel(&label)))
+  if (Failed(TopLabel(&label)))
     return true;
   return label->unreachable;
 }

--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -59,7 +59,7 @@
 #define BEGIN(c) cond = (c)
 #define FILL(n)                                \
   do {                                         \
-    if (WABT_FAILED(Fill(loc, parser, (n)))) { \
+    if (Failed(Fill(loc, parser, (n)))) {      \
       int value = NAME_TO_VALUE(EOF);          \
       SetToken(value);                         \
       return PopLookaheadToken(lval, loc);     \

--- a/src/wast-parser-lexer-shared.cc
+++ b/src/wast-parser-lexer-shared.cc
@@ -55,7 +55,7 @@ void wast_format_error(SourceErrorHandler* error_handler,
     size_t source_line_max_length = error_handler->source_line_max_length();
     Result result = lexer->line_finder().GetSourceLine(
         *loc, source_line_max_length, &source_line);
-    if (WABT_FAILED(result)) {
+    if (Failed(result)) {
       // If this fails, it means that we've probably screwed up the lexer. Blow
       // up.
       WABT_FATAL("error getting the source line.\n");

--- a/src/wast-parser.y
+++ b/src/wast-parser.y
@@ -382,8 +382,8 @@ type_use :
 
 nat :
     NAT {
-      if (WABT_FAILED(parse_uint64($1.text.start,
-                                        $1.text.start + $1.text.length, &$$))) {
+      if (Failed(parse_uint64($1.text.start,
+                              $1.text.start + $1.text.length, &$$))) {
         wast_parser_error(&@1, lexer, parser,
                           "invalid int " PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG($1.text));
@@ -427,7 +427,7 @@ var_list :
     }
 ;
 bind_var_opt :
-    /* empty */ { WABT_ZERO_MEMORY($$); }
+    /* empty */ { ZeroMemory($$); }
   | bind_var
 ;
 bind_var :
@@ -435,7 +435,7 @@ bind_var :
 ;
 
 labeling_opt :
-    /* empty */ %prec LOW { WABT_ZERO_MEMORY($$); }
+    /* empty */ %prec LOW { ZeroMemory($$); }
   | bind_var
 ;
 
@@ -443,8 +443,8 @@ offset_opt :
     /* empty */ { $$ = 0; }
   | OFFSET_EQ_NAT {
       uint64_t offset64;
-      if (WABT_FAILED(parse_int64($1.start, $1.start + $1.length, &offset64,
-                                  ParseIntType::SignedAndUnsigned))) {
+      if (Failed(parse_int64($1.start, $1.start + $1.length, &offset64,
+                             ParseIntType::SignedAndUnsigned))) {
         wast_parser_error(&@1, lexer, parser,
                           "invalid offset \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG($1));
@@ -459,8 +459,8 @@ offset_opt :
 align_opt :
     /* empty */ { $$ = USE_NATURAL_ALIGNMENT; }
   | ALIGN_EQ_NAT {
-      if (WABT_FAILED(parse_int32($1.start, $1.start + $1.length, &$$,
-                                  ParseIntType::UnsignedOnly))) {
+      if (Failed(parse_int32($1.start, $1.start + $1.length, &$$,
+                             ParseIntType::UnsignedOnly))) {
         wast_parser_error(&@1, lexer, parser,
                           "invalid alignment \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG($1));
@@ -543,8 +543,8 @@ plain_instr :
   | CONST literal {
       Const const_;
       const_.loc = @1;
-      if (WABT_FAILED(parse_const($1, $2.type, $2.text.start,
-                                  $2.text.start + $2.text.length, &const_))) {
+      if (Failed(parse_const($1, $2.type, $2.text.start,
+                             $2.text.start + $2.text.length, &const_))) {
         wast_parser_error(&@2, lexer, parser,
                           "invalid literal \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG($2.text));
@@ -782,7 +782,7 @@ try_check :
   ;
 
 instr_list :
-    /* empty */ { WABT_ZERO_MEMORY($$); }
+    /* empty */ { ZeroMemory($$); }
   | instr instr_list {
       $$.first = $1.first;
       $1.last->next = $2.first;
@@ -791,7 +791,7 @@ instr_list :
     }
 ;
 expr_list :
-    /* empty */ { WABT_ZERO_MEMORY($$); }
+    /* empty */ { ZeroMemory($$); }
   | expr expr_list {
       $$.first = $1.first;
       $1.last->next = $2.first;
@@ -1330,7 +1330,7 @@ module :
                        &error_handler, $$);
         $$->name = $1->binary.name;
         $$->loc = $1->binary.loc;
-        WABT_ZERO_MEMORY($1->binary.name);
+        ZeroMemory($1->binary.name);
       }
       delete $1;
     }
@@ -1472,8 +1472,8 @@ cmd_list :
 const :
     LPAR CONST literal RPAR {
       $$.loc = @2;
-      if (WABT_FAILED(parse_const($2, $3.type, $3.text.start,
-                                  $3.text.start + $3.text.length, &$$))) {
+      if (Failed(parse_const($2, $3.type, $3.text.start,
+                             $3.text.start + $3.text.length, &$$))) {
         wast_parser_error(&@3, lexer, parser,
                           "invalid literal \"" PRIstringslice "\"",
                           WABT_PRINTF_STRING_SLICE_ARG($3.text));
@@ -1593,7 +1593,7 @@ void append_expr(ExprList* expr_list, Expr* expr) {
 
 ExprList join_exprs1(Location* loc, Expr* expr1) {
   ExprList result;
-  WABT_ZERO_MEMORY(result);
+  ZeroMemory(result);
   append_expr(&result, expr1);
   expr1->loc = *loc;
   return result;
@@ -1601,7 +1601,7 @@ ExprList join_exprs1(Location* loc, Expr* expr1) {
 
 ExprList join_exprs2(Location* loc, ExprList* expr1, Expr* expr2) {
   ExprList result;
-  WABT_ZERO_MEMORY(result);
+  ZeroMemory(result);
   append_expr_list(&result, expr1);
   append_expr(&result, expr2);
   expr2->loc = *loc;
@@ -1663,8 +1663,8 @@ size_t copy_string_contents(StringSlice* text, char* dest) {
           // sequence.
           uint32_t hi;
           uint32_t lo;
-          if (WABT_SUCCEEDED(parse_hexdigit(src[0], &hi)) &&
-              WABT_SUCCEEDED(parse_hexdigit(src[1], &lo))) {
+          if (Succeeded(parse_hexdigit(src[0], &hi)) &&
+              Succeeded(parse_hexdigit(src[1], &lo))) {
             *dest++ = (hi << 4) | lo;
           } else {
             assert(0);
@@ -1923,7 +1923,7 @@ Result parse_wast(WastLexer* lexer, Script** out_script,
                   SourceErrorHandler* error_handler,
                   WastParseOptions* options) {
   WastParser parser;
-  WABT_ZERO_MEMORY(parser);
+  ZeroMemory(parser);
   static WastParseOptions default_options;
   if (options == nullptr)
     options = &default_options;


### PR DESCRIPTION
Changed these macros to inline functions.

This change was prompted by the difficulty of using WABT_ZERO_MEMORY to clear the contents of this in a constructor.