### PR TITLE
Fix handling of exception section.

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -406,6 +406,7 @@ Result BinaryReaderIR::OnImportException(Index import_index,
   Import* import = module->imports[import_index];
   import->kind = ExternalKind::Except;
   import->except = new Exception(sig);
+  module->excepts.push_back(import->except);
   return Result::Ok;
 }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1021,11 +1021,13 @@ Result BinaryWriter::WriteModule(const Module* module) {
     }
   }
 
-  if (module->excepts.size()) {
+  assert(module->excepts.size() >= module->num_except_imports);
+  Index num_exceptions = module->excepts.size() - module->num_except_imports;
+  if (num_exceptions) {
     BeginCustomSection("exception", LEB_SECTION_SIZE_GUESS);
-    write_u32_leb128(&stream_, module->excepts.size(), "exception count");
-    for (Exception* except : module->excepts) {
-      WriteExceptType(&except->sig);
+    write_u32_leb128(&stream_, num_exceptions, "exception count");
+    for (Index i = module->num_except_imports; i < num_exceptions; ++i) {
+      WriteExceptType(&module->excepts[i]->sig);
     }
     EndSection();
   }

--- a/test/exceptions/try-imports.txt
+++ b/test/exceptions/try-imports.txt
@@ -69,13 +69,4 @@
 0000035: 0b                                        ; end
 0000027: 0e                                        ; FIXUP func body size
 0000025: 10                                        ; FIXUP section size
-; section "exception"
-0000036: 00                                        ; custom section code
-0000037: 00                                        ; section size (guess)
-0000038: 09                                        ; string length
-0000039: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000042: 01                                        ; exception count
-0000043: 01                                        ; exception type count
-0000044: 7f                                        ; i32
-0000037: 0d                                        ; FIXUP section size
 ;;; STDOUT ;;)

--- a/test/roundtrip/try-imports.txt
+++ b/test/roundtrip/try-imports.txt
@@ -25,6 +25,5 @@
       nop
     catch_all
       rethrow 0 (;@1;)
-    end)
-  (except (;1;) i32))
+    end))
 ;;; STDOUT ;;)


### PR DESCRIPTION
According to the proposal for exception handling, only exceptions not imported should be defined in the exceptions section.

This PR fixes the code, which assumed all exceptions appear in the exception section.