### PR TITLE
Adds the concept of exceptions to wasm-objdump

### DIFF
--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -94,7 +94,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
                            StringSlice field_name,
                            Index except_index,
                            TypeVector& sig) override {
-    return Result::Error;
+    return AllowIfFutureExceptions();
   }
   Result EndImportSection() override { return Result::Ok; }
 
@@ -188,8 +188,12 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   }
   Result OnCallExpr(Index func_index) override { return Result::Ok; }
   Result OnCallIndirectExpr(Index sig_index) override { return Result::Ok; }
-  Result OnCatchExpr(Index except_index) override { return Result::Error; }
-  Result OnCatchAllExpr() override { return Result::Error; }
+  Result OnCatchExpr(Index except_index) override {
+    return AllowIfFutureExceptions();
+  }
+  Result OnCatchAllExpr() override {
+    return AllowIfFutureExceptions();
+  }
   Result OnCompareExpr(Opcode opcode) override { return Result::Ok; }
   Result OnConvertExpr(Opcode opcode) override { return Result::Ok; }
   Result OnCurrentMemoryExpr() override { return Result::Ok; }
@@ -216,7 +220,9 @@ class BinaryReaderNop : public BinaryReaderDelegate {
     return Result::Ok;
   }
   Result OnNopExpr() override { return Result::Ok; }
-  Result OnRethrowExpr(Index depth) override { return Result::Error; }
+  Result OnRethrowExpr(Index depth) override {
+    return AllowIfFutureExceptions();
+  }
   Result OnReturnExpr() override { return Result::Ok; }
   Result OnSelectExpr() override { return Result::Ok; }
   Result OnSetGlobalExpr(Index global_index) override { return Result::Ok; }
@@ -227,9 +233,11 @@ class BinaryReaderNop : public BinaryReaderDelegate {
     return Result::Ok;
   }
   Result OnTeeLocalExpr(Index local_index) override { return Result::Ok; }
-  Result OnThrowExpr(Index depth) override { return Result::Error; }
+  Result OnThrowExpr(Index depth) override {
+    return AllowIfFutureExceptions();
+  }
   Result OnTryExpr(Index num_types, Type* sig_types) override {
-    return Result::Error;
+    return AllowIfFutureExceptions();
   }
   Result OnUnaryExpr(Opcode opcode) override { return Result::Ok; }
   Result OnUnreachableExpr() override { return Result::Ok; }
@@ -318,12 +326,18 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result EndRelocSection() override { return Result::Ok; }
 
   /* Exception section */
-  Result BeginExceptionSection(Offset size) override { return Result::Error; }
-  Result OnExceptionCount(Index count) override { return Result::Error; }
-  Result OnExceptionType(Index index, TypeVector& sig) override {
-    return Result::Error;
+  Result BeginExceptionSection(Offset size) override {
+    return AllowIfFutureExceptions();
   }
-  Result EndExceptionSection() override { return Result::Error; }
+  Result OnExceptionCount(Index count) override {
+    return AllowIfFutureExceptions();
+  }
+  Result OnExceptionType(Index index, TypeVector& sig) override {
+    return AllowIfFutureExceptions();
+  }
+  Result EndExceptionSection() override {
+    return AllowIfFutureExceptions();
+  }
 
   /* Linking section */
   Result BeginLinkingSection(Offset size) override { return Result::Ok; }
@@ -350,6 +364,13 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   }
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override {
     return Result::Ok;
+  }
+
+  bool allow_future_exceptions = false;
+
+ private:
+  Result AllowIfFutureExceptions() const {
+    return allow_future_exceptions ? Result::Ok : Result::Error;
   }
 };
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1051,18 +1051,22 @@ Result read_binary_objdump(const uint8_t* data,
   ReadBinaryOptions read_options;
   read_options.read_debug_names = true;
   read_options.log_stream = options->log_stream;
+  read_options.allow_future_exceptions = options->allow_future_exceptions;
 
   switch (options->mode) {
     case ObjdumpMode::Prepass: {
       BinaryReaderObjdumpPrepass reader(data, size, options, state);
+      reader.allow_future_exceptions = options->allow_future_exceptions;
       return read_binary(data, size, &reader, &read_options);
     }
     case ObjdumpMode::Disassemble: {
       BinaryReaderObjdumpDisassemble reader(data, size, options, state);
+      reader.allow_future_exceptions = options->allow_future_exceptions;
       return read_binary(data, size, &reader, &read_options);
     }
     default: {
       BinaryReaderObjdump reader(data, size, options, state);
+      reader.allow_future_exceptions = options->allow_future_exceptions;
       return read_binary(data, size, &reader, &read_options);
     }
   }

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -44,6 +44,7 @@ struct ObjdumpOptions {
   bool disassemble;
   bool debug;
   bool relocs;
+  bool allow_future_exceptions = false;
   ObjdumpMode mode;
   const char* filename;
   const char* section_name;

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1021,11 +1021,13 @@ Result BinaryWriter::WriteModule(const Module* module) {
     }
   }
 
-  if (module->excepts.size()) {
+  assert(module->excepts.size() >= module->num_except_imports);
+  Index num_exceptions = module->excepts.size() - module->num_except_imports;
+  if (num_exceptions) {
     BeginCustomSection("exception", LEB_SECTION_SIZE_GUESS);
-    write_u32_leb128(&stream_, module->excepts.size(), "exception count");
-    for (Exception* except : module->excepts) {
-      WriteExceptType(&except->sig);
+    write_u32_leb128(&stream_, num_exceptions, "exception count");
+    for (Index i = module->num_except_imports; i < num_exceptions; ++i) {
+      WriteExceptType(&module->excepts[i]->sig);
     }
     EndSection();
   }

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -57,6 +57,10 @@ static void parse_options(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
     s_objdump_options.log_stream = s_log_stream.get();
   });
+  parser.AddOption("future-exceptions",
+                   "Test future extension for exception handling",
+                   []() { s_objdump_options.allow_future_exceptions = true;
+                   });
   parser.AddOption('x', "details", "Show section details",
                    []() { s_objdump_options.details = true; });
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",

--- a/test/dump/try-exports.txt
+++ b/test/dump/try-exports.txt
@@ -1,0 +1,75 @@
+;;; TOOL: run-objdump
+;;; FLAGS: -v --headers --future-exceptions
+(module
+  (except $ex i32)
+  (export "except" (except $ex))
+  (func (result i32)
+    (i32.const 7)
+    (throw $ex)
+  )
+)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Export" (7)
+0000013: 07                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num exports
+0000016: 06                                        ; string length
+0000017: 6578 6365 7074                           except  ; export name
+000001d: 04                                        ; export kind
+000001e: 00                                        ; export exception index
+0000014: 0a                                        ; FIXUP section size
+; section "Code" (10)
+000001f: 0a                                        ; section code
+0000020: 00                                        ; section size (guess)
+0000021: 01                                        ; num functions
+; function body 0
+0000022: 00                                        ; func body size (guess)
+0000023: 00                                        ; local decl count
+0000024: 41                                        ; i32.const
+0000025: 07                                        ; i32 literal
+0000026: 08                                        ; throw
+0000027: 00                                        ; throw exception
+0000028: 0b                                        ; end
+0000022: 06                                        ; FIXUP func body size
+0000020: 08                                        ; FIXUP section size
+; section "exception"
+0000029: 00                                        ; custom section code
+000002a: 00                                        ; section size (guess)
+000002b: 09                                        ; string length
+000002c: 6578 6365 7074 696f 6e                   exception  ; custom section name
+0000035: 01                                        ; exception count
+0000036: 01                                        ; exception type count
+0000037: 7f                                        ; i32
+000002a: 0d                                        ; FIXUP section size
+try-exports.wasm:	file format wasm 0x1
+Sections:
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+ Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
+   Export start=0x00000015 end=0x0000001f (size=0x0000000a) count: 1
+     Code start=0x00000021 end=0x00000029 (size=0x00000008) count: 1
+   Custom start=0x0000002b end=0x00000038 (size=0x0000000d) "exception"
+count: 1
+Code Disassembly:
+000022 func[0]:
+ 000024: 41 07                      | i32.const 7
+ 000026: 08 00                      | throw 0
+ 000028: 0b                         | end
+;;; STDOUT ;;)

--- a/test/dump/try-imports.txt
+++ b/test/dump/try-imports.txt
@@ -1,0 +1,89 @@
+;;; TOOL: run-objdump
+;;; FLAGS: -v --headers --future-exceptions
+(module
+  (import "c++" "except" (except $ex i32))
+  (func (result i32)
+    (try $try1 (result i32)
+      (nop)
+      (i32.const 7)
+      (catch $ex
+        (nop)
+      )
+      (catch_all
+        (rethrow $try1)
+      )
+    )
+  )
+)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Import" (2)
+000000f: 02                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num imports
+; import header 0
+0000012: 03                                        ; string length
+0000013: 632b 2b                                  c++  ; import module name
+0000016: 06                                        ; string length
+0000017: 6578 6365 7074                           except  ; import field name
+000001d: 04                                        ; import kind
+000001e: 01                                        ; exception type count
+000001f: 7f                                        ; i32
+0000010: 0f                                        ; FIXUP section size
+; section "Function" (3)
+0000020: 03                                        ; section code
+0000021: 00                                        ; section size (guess)
+0000022: 01                                        ; num functions
+0000023: 00                                        ; function 0 signature index
+0000021: 02                                        ; FIXUP section size
+; section "Code" (10)
+0000024: 0a                                        ; section code
+0000025: 00                                        ; section size (guess)
+0000026: 01                                        ; num functions
+; function body 0
+0000027: 00                                        ; func body size (guess)
+0000028: 00                                        ; local decl count
+0000029: 06                                        ; try
+000002a: 7f                                        ; i32
+000002b: 01                                        ; nop
+000002c: 41                                        ; i32.const
+000002d: 07                                        ; i32 literal
+000002e: 07                                        ; catch
+000002f: 00                                        ; catch exception
+0000030: 01                                        ; nop
+0000031: 0a                                        ; catch_all
+0000032: 09                                        ; rethrow
+0000033: 00                                        ; rethrow depth
+0000034: 0b                                        ; end
+0000035: 0b                                        ; end
+0000027: 0e                                        ; FIXUP func body size
+0000025: 10                                        ; FIXUP section size
+try-imports.wasm:	file format wasm 0x1
+Sections:
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+   Import start=0x00000011 end=0x00000020 (size=0x0000000f) count: 1
+ Function start=0x00000022 end=0x00000024 (size=0x00000002) count: 1
+     Code start=0x00000026 end=0x00000036 (size=0x00000010) count: 1
+Code Disassembly:
+000027 func[0]:
+ 000029: 06 7f                      | try i32
+ 00002b: 01                         |   nop
+ 00002c: 41 07                      |   i32.const 7
+ 00002e: 07 00                      | catch 0
+ 000030: 01                         |   nop
+ 000031: 0a                         | catch_all
+ 000032: 09 00                      |   rethrow 0
+ 000034: 0b                         | end
+ 000035: 0b                         | end
+;;; STDOUT ;;)

--- a/test/dump/try.txt
+++ b/test/dump/try.txt
@@ -1,0 +1,84 @@
+;;; TOOL: run-objdump
+;;; FLAGS: -v --headers --future-exceptions
+(module
+  (except $ex i32)
+  (func (result i32)
+    try $try1 (result i32)
+      nop
+      i32.const 7
+    catch $ex
+      nop
+    catch_all
+      rethrow $try1
+    end
+  )
+)
+(;; STDOUT ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 01                                        ; num results
+000000e: 7f                                        ; i32
+0000009: 05                                        ; FIXUP section size
+; section "Function" (3)
+000000f: 03                                        ; section code
+0000010: 00                                        ; section size (guess)
+0000011: 01                                        ; num functions
+0000012: 00                                        ; function 0 signature index
+0000010: 02                                        ; FIXUP section size
+; section "Code" (10)
+0000013: 0a                                        ; section code
+0000014: 00                                        ; section size (guess)
+0000015: 01                                        ; num functions
+; function body 0
+0000016: 00                                        ; func body size (guess)
+0000017: 00                                        ; local decl count
+0000018: 06                                        ; try
+0000019: 7f                                        ; i32
+000001a: 01                                        ; nop
+000001b: 41                                        ; i32.const
+000001c: 07                                        ; i32 literal
+000001d: 07                                        ; catch
+000001e: 00                                        ; catch exception
+000001f: 01                                        ; nop
+0000020: 0a                                        ; catch_all
+0000021: 09                                        ; rethrow
+0000022: 00                                        ; rethrow depth
+0000023: 0b                                        ; end
+0000024: 0b                                        ; end
+0000016: 0e                                        ; FIXUP func body size
+0000014: 10                                        ; FIXUP section size
+; section "exception"
+0000025: 00                                        ; custom section code
+0000026: 00                                        ; section size (guess)
+0000027: 09                                        ; string length
+0000028: 6578 6365 7074 696f 6e                   exception  ; custom section name
+0000031: 01                                        ; exception count
+0000032: 01                                        ; exception type count
+0000033: 7f                                        ; i32
+0000026: 0d                                        ; FIXUP section size
+try.wasm:	file format wasm 0x1
+Sections:
+     Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
+ Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
+     Code start=0x00000015 end=0x00000025 (size=0x00000010) count: 1
+   Custom start=0x00000027 end=0x00000034 (size=0x0000000d) "exception"
+count: 1
+Code Disassembly:
+000016 func[0]:
+ 000018: 06 7f                      | try i32
+ 00001a: 01                         |   nop
+ 00001b: 41 07                      |   i32.const 7
+ 00001d: 07 00                      | catch 0
+ 00001f: 01                         |   nop
+ 000020: 0a                         | catch_all
+ 000021: 09 00                      |   rethrow 0
+ 000023: 0b                         | end
+ 000024: 0b                         | end
+;;; STDOUT ;;)

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -9,12 +9,13 @@ examples:
   $ wasm-objdump test.wasm
 
 options:
-  -h, --headers                Print headers
-  -j, --section=SECTION        Select just one section
-  -s, --full-contents          Print raw section contents
-  -d, --disassemble            Disassemble function bodies
-      --debug                  Print extra debug information
-  -x, --details                Show section details
-  -r, --reloc                  Show relocations inline with disassembly
-  -h, --help                   Print this help message
+  -h, --headers                  Print headers
+  -j, --section=SECTION          Select just one section
+  -s, --full-contents            Print raw section contents
+  -d, --disassemble              Disassemble function bodies
+      --debug                    Print extra debug information
+      --future-exceptions        Test future extension for exception handling
+  -x, --details                  Show section details
+  -r, --reloc                    Show relocations inline with disassembly
+  -h, --help                     Print this help message
 ;;; STDOUT ;;)

--- a/test/run-objdump.py
+++ b/test/run-objdump.py
@@ -47,6 +47,7 @@ def main(args):
   parser.add_argument('-c', '--compile-only', action='store_true')
   parser.add_argument('--dump-verbose', action='store_true')
   parser.add_argument('--dump-debug', action='store_true')
+  parser.add_argument('--future-exceptions', action='store_true')
   parser.add_argument('--gen-wasm', action='store_true',
                       help='parse with gen-wasm')
   parser.add_argument('--spec', action='store_true')
@@ -67,6 +68,7 @@ def main(args):
       error_cmdline=options.error_cmdline)
   wast2wasm.AppendOptionalArgs({
       '--debug-names': options.debug_names,
+      '--future-exceptions': options.future_exceptions,
       '--no-check': options.no_check,
       '--no-canonicalize-leb128s': options.no_canonicalize_leb128s,
       '--spec': options.spec,
@@ -79,6 +81,7 @@ def main(args):
       find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_objdump.AppendOptionalArgs({
+      '--future-exceptions': options.future_exceptions,
       '-h': options.headers,
       '-x': options.dump_verbose,
       '--debug': options.dump_debug,


### PR DESCRIPTION
Modifies the wasm objdump code to understand exceptions.

Adds command-line argument --future-exceptions to wasm-objdump and run-objdump.py.

Modifies class BinaryReaderNop so that its default behavior can be defined by a flag that defines if
exception handling should be accepted.