### PR TITLE
Move exception section to just before code section.

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -916,6 +916,17 @@ Result BinaryWriter::WriteModule(const Module* module) {
     EndSection();
   }
 
+  assert(module->excepts.size() >= module->num_except_imports);
+  Index num_exceptions = module->excepts.size() - module->num_except_imports;
+  if (num_exceptions) {
+    BeginCustomSection("exception", LEB_SECTION_SIZE_GUESS);
+    write_u32_leb128(&stream_, num_exceptions, "exception count");
+    for (Index i = module->num_except_imports; i < num_exceptions; ++i) {
+      WriteExceptType(&module->excepts[i]->sig);
+    }
+    EndSection();
+  }
+
   if (num_funcs) {
     BeginKnownSection(BinarySection::Code, LEB_SECTION_SIZE_GUESS);
     write_u32_leb128(&stream_, num_funcs, "num functions");
@@ -1021,16 +1032,6 @@ Result BinaryWriter::WriteModule(const Module* module) {
     }
   }
 
-  assert(module->excepts.size() >= module->num_except_imports);
-  Index num_exceptions = module->excepts.size() - module->num_except_imports;
-  if (num_exceptions) {
-    BeginCustomSection("exception", LEB_SECTION_SIZE_GUESS);
-    write_u32_leb128(&stream_, num_exceptions, "exception count");
-    for (Index i = module->num_except_imports; i < num_exceptions; ++i) {
-      WriteExceptType(&module->excepts[i]->sig);
-    }
-    EndSection();
-  }
 
   return stream_.result();
 }

--- a/test/dump/try-details.txt
+++ b/test/dump/try-details.txt
@@ -24,14 +24,14 @@ Custom:
  - name: "exception"
  - except[0] (i32)
 Code Disassembly:
-000016 func[0]:
- 000018: 06 7f                      | try i32
- 00001a: 01                         |   nop
- 00001b: 41 07                      |   i32.const 7
- 00001d: 07 00                      | catch 0
- 00001f: 01                         |   nop
- 000020: 0a                         | catch_all
- 000021: 09 00                      |   rethrow 0
- 000023: 0b                         | end
- 000024: 0b                         | end
+000025 func[0]:
+ 000027: 06 7f                      | try i32
+ 000029: 01                         |   nop
+ 00002a: 41 07                      |   i32.const 7
+ 00002c: 07 00                      | catch 0
+ 00002e: 01                         |   nop
+ 00002f: 0a                         | catch_all
+ 000030: 09 00                      |   rethrow 0
+ 000032: 0b                         | end
+ 000033: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/try-exports-details.txt
+++ b/test/dump/try-exports-details.txt
@@ -21,8 +21,8 @@ Custom:
  - name: "exception"
  - except[0] (i32)
 Code Disassembly:
-000022 func[0]:
- 000024: 41 07                      | i32.const 7
- 000026: 08 00                      | throw 0
- 000028: 0b                         | end
+000031 func[0]:
+ 000033: 41 07                      | i32.const 7
+ 000035: 08 00                      | throw 0
+ 000037: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/try-exports.txt
+++ b/test/dump/try-exports.txt
@@ -36,40 +36,40 @@
 000001d: 04                                        ; export kind
 000001e: 00                                        ; export exception index
 0000014: 0a                                        ; FIXUP section size
-; section "Code" (10)
-000001f: 0a                                        ; section code
-0000020: 00                                        ; section size (guess)
-0000021: 01                                        ; num functions
-; function body 0
-0000022: 00                                        ; func body size (guess)
-0000023: 00                                        ; local decl count
-0000024: 41                                        ; i32.const
-0000025: 07                                        ; i32 literal
-0000026: 08                                        ; throw
-0000027: 00                                        ; throw exception
-0000028: 0b                                        ; end
-0000022: 06                                        ; FIXUP func body size
-0000020: 08                                        ; FIXUP section size
 ; section "exception"
-0000029: 00                                        ; custom section code
-000002a: 00                                        ; section size (guess)
-000002b: 09                                        ; string length
-000002c: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000035: 01                                        ; exception count
-0000036: 01                                        ; exception type count
-0000037: 7f                                        ; i32
-000002a: 0d                                        ; FIXUP section size
+000001f: 00                                        ; custom section code
+0000020: 00                                        ; section size (guess)
+0000021: 09                                        ; string length
+0000022: 6578 6365 7074 696f 6e                   exception  ; custom section name
+000002b: 01                                        ; exception count
+000002c: 01                                        ; exception type count
+000002d: 7f                                        ; i32
+0000020: 0d                                        ; FIXUP section size
+; section "Code" (10)
+000002e: 0a                                        ; section code
+000002f: 00                                        ; section size (guess)
+0000030: 01                                        ; num functions
+; function body 0
+0000031: 00                                        ; func body size (guess)
+0000032: 00                                        ; local decl count
+0000033: 41                                        ; i32.const
+0000034: 07                                        ; i32 literal
+0000035: 08                                        ; throw
+0000036: 00                                        ; throw exception
+0000037: 0b                                        ; end
+0000031: 06                                        ; FIXUP func body size
+000002f: 08                                        ; FIXUP section size
 try-exports.wasm:	file format wasm 0x1
 Sections:
      Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
  Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
    Export start=0x00000015 end=0x0000001f (size=0x0000000a) count: 1
-     Code start=0x00000021 end=0x00000029 (size=0x00000008) count: 1
-   Custom start=0x0000002b end=0x00000038 (size=0x0000000d) "exception"
+   Custom start=0x00000021 end=0x0000002e (size=0x0000000d) "exception"
 count: 1
+     Code start=0x00000030 end=0x00000038 (size=0x00000008) count: 1
 Code Disassembly:
-000022 func[0]:
- 000024: 41 07                      | i32.const 7
- 000026: 08 00                      | throw 0
- 000028: 0b                         | end
+000031 func[0]:
+ 000033: 41 07                      | i32.const 7
+ 000035: 08 00                      | throw 0
+ 000037: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/try.txt
+++ b/test/dump/try.txt
@@ -32,53 +32,53 @@
 0000011: 01                                        ; num functions
 0000012: 00                                        ; function 0 signature index
 0000010: 02                                        ; FIXUP section size
-; section "Code" (10)
-0000013: 0a                                        ; section code
-0000014: 00                                        ; section size (guess)
-0000015: 01                                        ; num functions
-; function body 0
-0000016: 00                                        ; func body size (guess)
-0000017: 00                                        ; local decl count
-0000018: 06                                        ; try
-0000019: 7f                                        ; i32
-000001a: 01                                        ; nop
-000001b: 41                                        ; i32.const
-000001c: 07                                        ; i32 literal
-000001d: 07                                        ; catch
-000001e: 00                                        ; catch exception
-000001f: 01                                        ; nop
-0000020: 0a                                        ; catch_all
-0000021: 09                                        ; rethrow
-0000022: 00                                        ; rethrow depth
-0000023: 0b                                        ; end
-0000024: 0b                                        ; end
-0000016: 0e                                        ; FIXUP func body size
-0000014: 10                                        ; FIXUP section size
 ; section "exception"
-0000025: 00                                        ; custom section code
-0000026: 00                                        ; section size (guess)
-0000027: 09                                        ; string length
-0000028: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000031: 01                                        ; exception count
-0000032: 01                                        ; exception type count
-0000033: 7f                                        ; i32
-0000026: 0d                                        ; FIXUP section size
+0000013: 00                                        ; custom section code
+0000014: 00                                        ; section size (guess)
+0000015: 09                                        ; string length
+0000016: 6578 6365 7074 696f 6e                   exception  ; custom section name
+000001f: 01                                        ; exception count
+0000020: 01                                        ; exception type count
+0000021: 7f                                        ; i32
+0000014: 0d                                        ; FIXUP section size
+; section "Code" (10)
+0000022: 0a                                        ; section code
+0000023: 00                                        ; section size (guess)
+0000024: 01                                        ; num functions
+; function body 0
+0000025: 00                                        ; func body size (guess)
+0000026: 00                                        ; local decl count
+0000027: 06                                        ; try
+0000028: 7f                                        ; i32
+0000029: 01                                        ; nop
+000002a: 41                                        ; i32.const
+000002b: 07                                        ; i32 literal
+000002c: 07                                        ; catch
+000002d: 00                                        ; catch exception
+000002e: 01                                        ; nop
+000002f: 0a                                        ; catch_all
+0000030: 09                                        ; rethrow
+0000031: 00                                        ; rethrow depth
+0000032: 0b                                        ; end
+0000033: 0b                                        ; end
+0000025: 0e                                        ; FIXUP func body size
+0000023: 10                                        ; FIXUP section size
 try.wasm:	file format wasm 0x1
 Sections:
      Type start=0x0000000a end=0x0000000f (size=0x00000005) count: 1
  Function start=0x00000011 end=0x00000013 (size=0x00000002) count: 1
-     Code start=0x00000015 end=0x00000025 (size=0x00000010) count: 1
-   Custom start=0x00000027 end=0x00000034 (size=0x0000000d) "exception"
+   Custom start=0x00000015 end=0x00000022 (size=0x0000000d) "exception"
 count: 1
+     Code start=0x00000024 end=0x00000034 (size=0x00000010) count: 1
 Code Disassembly:
-000016 func[0]:
- 000018: 06 7f                      | try i32
- 00001a: 01                         |   nop
- 00001b: 41 07                      |   i32.const 7
- 00001d: 07 00                      | catch 0
- 00001f: 01                         |   nop
- 000020: 0a                         | catch_all
- 000021: 09 00                      |   rethrow 0
- 000023: 0b                         | end
- 000024: 0b                         | end
+000025 func[0]:
+ 000027: 06 7f                      | try i32
+ 000029: 01                         |   nop
+ 00002a: 41 07                      |   i32.const 7
+ 00002c: 07 00                      | catch 0
+ 00002e: 01                         |   nop
+ 00002f: 0a                         | catch_all
+ 000030: 09 00                      |   rethrow 0
+ 000032: 0b                         | end
+ 000033: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/exceptions/try-exports.txt
+++ b/test/exceptions/try-exports.txt
@@ -36,27 +36,27 @@
 000001d: 04                                        ; export kind
 000001e: 00                                        ; export exception index
 0000014: 0a                                        ; FIXUP section size
-; section "Code" (10)
-000001f: 0a                                        ; section code
-0000020: 00                                        ; section size (guess)
-0000021: 01                                        ; num functions
-; function body 0
-0000022: 00                                        ; func body size (guess)
-0000023: 00                                        ; local decl count
-0000024: 41                                        ; i32.const
-0000025: 07                                        ; i32 literal
-0000026: 08                                        ; throw
-0000027: 00                                        ; throw exception
-0000028: 0b                                        ; end
-0000022: 06                                        ; FIXUP func body size
-0000020: 08                                        ; FIXUP section size
 ; section "exception"
-0000029: 00                                        ; custom section code
-000002a: 00                                        ; section size (guess)
-000002b: 09                                        ; string length
-000002c: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000035: 01                                        ; exception count
-0000036: 01                                        ; exception type count
-0000037: 7f                                        ; i32
-000002a: 0d                                        ; FIXUP section size
+000001f: 00                                        ; custom section code
+0000020: 00                                        ; section size (guess)
+0000021: 09                                        ; string length
+0000022: 6578 6365 7074 696f 6e                   exception  ; custom section name
+000002b: 01                                        ; exception count
+000002c: 01                                        ; exception type count
+000002d: 7f                                        ; i32
+0000020: 0d                                        ; FIXUP section size
+; section "Code" (10)
+000002e: 0a                                        ; section code
+000002f: 00                                        ; section size (guess)
+0000030: 01                                        ; num functions
+; function body 0
+0000031: 00                                        ; func body size (guess)
+0000032: 00                                        ; local decl count
+0000033: 41                                        ; i32.const
+0000034: 07                                        ; i32 literal
+0000035: 08                                        ; throw
+0000036: 00                                        ; throw exception
+0000037: 0b                                        ; end
+0000031: 06                                        ; FIXUP func body size
+000002f: 08                                        ; FIXUP section size
 ;;; STDOUT ;;)

--- a/test/exceptions/try-text.txt
+++ b/test/exceptions/try-text.txt
@@ -32,35 +32,35 @@
 0000011: 01                                        ; num functions
 0000012: 00                                        ; function 0 signature index
 0000010: 02                                        ; FIXUP section size
-; section "Code" (10)
-0000013: 0a                                        ; section code
-0000014: 00                                        ; section size (guess)
-0000015: 01                                        ; num functions
-; function body 0
-0000016: 00                                        ; func body size (guess)
-0000017: 00                                        ; local decl count
-0000018: 06                                        ; try
-0000019: 7f                                        ; i32
-000001a: 01                                        ; nop
-000001b: 41                                        ; i32.const
-000001c: 07                                        ; i32 literal
-000001d: 07                                        ; catch
-000001e: 00                                        ; catch exception
-000001f: 01                                        ; nop
-0000020: 0a                                        ; catch_all
-0000021: 09                                        ; rethrow
-0000022: 00                                        ; rethrow depth
-0000023: 0b                                        ; end
-0000024: 0b                                        ; end
-0000016: 0e                                        ; FIXUP func body size
-0000014: 10                                        ; FIXUP section size
 ; section "exception"
-0000025: 00                                        ; custom section code
-0000026: 00                                        ; section size (guess)
-0000027: 09                                        ; string length
-0000028: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000031: 01                                        ; exception count
-0000032: 01                                        ; exception type count
-0000033: 7f                                        ; i32
-0000026: 0d                                        ; FIXUP section size
+0000013: 00                                        ; custom section code
+0000014: 00                                        ; section size (guess)
+0000015: 09                                        ; string length
+0000016: 6578 6365 7074 696f 6e                   exception  ; custom section name
+000001f: 01                                        ; exception count
+0000020: 01                                        ; exception type count
+0000021: 7f                                        ; i32
+0000014: 0d                                        ; FIXUP section size
+; section "Code" (10)
+0000022: 0a                                        ; section code
+0000023: 00                                        ; section size (guess)
+0000024: 01                                        ; num functions
+; function body 0
+0000025: 00                                        ; func body size (guess)
+0000026: 00                                        ; local decl count
+0000027: 06                                        ; try
+0000028: 7f                                        ; i32
+0000029: 01                                        ; nop
+000002a: 41                                        ; i32.const
+000002b: 07                                        ; i32 literal
+000002c: 07                                        ; catch
+000002d: 00                                        ; catch exception
+000002e: 01                                        ; nop
+000002f: 0a                                        ; catch_all
+0000030: 09                                        ; rethrow
+0000031: 00                                        ; rethrow depth
+0000032: 0b                                        ; end
+0000033: 0b                                        ; end
+0000025: 0e                                        ; FIXUP func body size
+0000023: 10                                        ; FIXUP section size
 ;;; STDOUT ;;)

--- a/test/exceptions/try.txt
+++ b/test/exceptions/try.txt
@@ -34,35 +34,35 @@
 0000011: 01                                        ; num functions
 0000012: 00                                        ; function 0 signature index
 0000010: 02                                        ; FIXUP section size
-; section "Code" (10)
-0000013: 0a                                        ; section code
-0000014: 00                                        ; section size (guess)
-0000015: 01                                        ; num functions
-; function body 0
-0000016: 00                                        ; func body size (guess)
-0000017: 00                                        ; local decl count
-0000018: 06                                        ; try
-0000019: 7f                                        ; i32
-000001a: 01                                        ; nop
-000001b: 41                                        ; i32.const
-000001c: 07                                        ; i32 literal
-000001d: 07                                        ; catch
-000001e: 00                                        ; catch exception
-000001f: 01                                        ; nop
-0000020: 0a                                        ; catch_all
-0000021: 09                                        ; rethrow
-0000022: 00                                        ; rethrow depth
-0000023: 0b                                        ; end
-0000024: 0b                                        ; end
-0000016: 0e                                        ; FIXUP func body size
-0000014: 10                                        ; FIXUP section size
 ; section "exception"
-0000025: 00                                        ; custom section code
-0000026: 00                                        ; section size (guess)
-0000027: 09                                        ; string length
-0000028: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000031: 01                                        ; exception count
-0000032: 01                                        ; exception type count
-0000033: 7f                                        ; i32
-0000026: 0d                                        ; FIXUP section size
+0000013: 00                                        ; custom section code
+0000014: 00                                        ; section size (guess)
+0000015: 09                                        ; string length
+0000016: 6578 6365 7074 696f 6e                   exception  ; custom section name
+000001f: 01                                        ; exception count
+0000020: 01                                        ; exception type count
+0000021: 7f                                        ; i32
+0000014: 0d                                        ; FIXUP section size
+; section "Code" (10)
+0000022: 0a                                        ; section code
+0000023: 00                                        ; section size (guess)
+0000024: 01                                        ; num functions
+; function body 0
+0000025: 00                                        ; func body size (guess)
+0000026: 00                                        ; local decl count
+0000027: 06                                        ; try
+0000028: 7f                                        ; i32
+0000029: 01                                        ; nop
+000002a: 41                                        ; i32.const
+000002b: 07                                        ; i32 literal
+000002c: 07                                        ; catch
+000002d: 00                                        ; catch exception
+000002e: 01                                        ; nop
+000002f: 0a                                        ; catch_all
+0000030: 09                                        ; rethrow
+0000031: 00                                        ; rethrow depth
+0000032: 0b                                        ; end
+0000033: 0b                                        ; end
+0000025: 0e                                        ; FIXUP func body size
+0000023: 10                                        ; FIXUP section size
 ;;; STDOUT ;;)


### PR DESCRIPTION
When looking at the V8 compiler, and wasm-interp, the details of exceptions must be known before the code section is processed (i.e. translated). This PR moves the (named) exception section to immediately before the code section.
