### PR TITLE
Fix location of error in wasm2wast

### DIFF
--- a/src/tools/wasm2wast.cc
+++ b/src/tools/wasm2wast.cc
@@ -105,16 +105,14 @@ int ProgramMain(int argc, char** argv) {
   size_t size;
   result = read_file(s_infile.c_str(), &data, &size);
   if (Succeeded(result)) {
-    ErrorHandlerFile binary_error_handler(Location::Type::Binary);
+    ErrorHandlerFile error_handler(Location::Type::Binary);
     Module module;
-    result =
-        read_binary_ir(s_infile.c_str(), data, size, &s_read_binary_options,
-                       &binary_error_handler, &module);
+    result = read_binary_ir(s_infile.c_str(), data, size,
+                            &s_read_binary_options, &error_handler, &module);
     if (Succeeded(result)) {
       if (Succeeded(result) && s_validate) {
-        ErrorHandlerFile text_error_handler(Location::Type::Text);
         WastLexer* lexer = nullptr;
-        result = validate_module(lexer, &module, &text_error_handler);
+        result = validate_module(lexer, &module, &error_handler);
       }
 
       if (s_generate_names)

--- a/test/binary/bad-typecheck-missing-drop.txt
+++ b/test/binary/bad-typecheck-missing-drop.txt
@@ -15,6 +15,6 @@ section(CODE) {
 }
 (;; STDERR ;;;
 Error running "wasm2wast":
-out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:28:0: error: type stack at end of function is 1, expected 0
+out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type stack at end of function is 1, expected 0
 
 ;;; STDERR ;;)


### PR DESCRIPTION
Errors are binary locations, not text.

See #557.