### PR TITLE
Remove uses of StringSlice from IR

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -22,6 +22,7 @@
 
 #include "expr-visitor.h"
 #include "ir.h"
+#include "string-view.h"
 
 #define CHECK_RESULT(expr)  \
   do {                      \
@@ -63,10 +64,10 @@ class NameApplier : public ExprVisitor::DelegateNop {
   Result OnRethrowExpr(RethrowExpr*) override;
 
  private:
-  void PushLabel(Label* label);
+  void PushLabel(const std::string& label);
   void PopLabel();
-  Label* FindLabelByVar(Var* var);
-  void UseNameForVar(StringSlice* name, Var* var);
+  string_view FindLabelByVar(Var* var);
+  void UseNameForVar(const string_view& name, Var* var);
   Result UseNameForFuncTypeVar(Var* var);
   Result UseNameForFuncVar(Var* var);
   Result UseNameForGlobalVar(Var* var);
@@ -85,12 +86,12 @@ class NameApplier : public ExprVisitor::DelegateNop {
   /* mapping from param index to its name, if any, for the current func */
   std::vector<std::string> param_index_to_name_;
   std::vector<std::string> local_index_to_name_;
-  std::vector<Label*> labels_;
+  std::vector<std::string> labels_;
 };
 
 NameApplier::NameApplier() : visitor_(this) {}
 
-void NameApplier::PushLabel(Label* label) {
+void NameApplier::PushLabel(const std::string& label) {
   labels_.push_back(label);
 }
 
@@ -98,37 +99,36 @@ void NameApplier::PopLabel() {
   labels_.pop_back();
 }
 
-Label* NameApplier::FindLabelByVar(Var* var) {
+string_view NameApplier::FindLabelByVar(Var* var) {
   if (var->is_name()) {
     for (int i = labels_.size() - 1; i >= 0; --i) {
-      Label* label = labels_[i];
-      if (string_slice_to_string(*label) == var->name())
+      const std::string& label = labels_[i];
+      if (label == var->name())
         return label;
     }
-    return nullptr;
+    return string_view();
   } else {
     if (var->index() >= labels_.size())
-      return nullptr;
+      return string_view();
     return labels_[labels_.size() - 1 - var->index()];
   }
 }
 
-void NameApplier::UseNameForVar(StringSlice* name, Var* var) {
+void NameApplier::UseNameForVar(const string_view& name, Var* var) {
   if (var->is_name()) {
-    assert(string_slice_to_string(*name) == var->name());
+    assert(name == var->name());
     return;
   }
 
-  if (name && name->start) {
-    var->set_name(string_slice_to_string(*name));
-  }
+  if (!name.empty())
+    var->set_name(name);
 }
 
 Result NameApplier::UseNameForFuncTypeVar(Var* var) {
   FuncType* func_type = module_->GetFuncType(*var);
   if (!func_type)
     return Result::Error;
-  UseNameForVar(&func_type->name, var);
+  UseNameForVar(func_type->name, var);
   return Result::Ok;
 }
 
@@ -136,7 +136,7 @@ Result NameApplier::UseNameForFuncVar(Var* var) {
   Func* func = module_->GetFunc(*var);
   if (!func)
     return Result::Error;
-  UseNameForVar(&func->name, var);
+  UseNameForVar(func->name, var);
   return Result::Ok;
 }
 
@@ -144,7 +144,7 @@ Result NameApplier::UseNameForGlobalVar(Var* var) {
   Global* global = module_->GetGlobal(*var);
   if (!global)
     return Result::Error;
-  UseNameForVar(&global->name, var);
+  UseNameForVar(global->name, var);
   return Result::Ok;
 }
 
@@ -152,7 +152,7 @@ Result NameApplier::UseNameForTableVar(Var* var) {
   Table* table = module_->GetTable(*var);
   if (!table)
     return Result::Error;
-  UseNameForVar(&table->name, var);
+  UseNameForVar(table->name, var);
   return Result::Ok;
 }
 
@@ -160,7 +160,7 @@ Result NameApplier::UseNameForMemoryVar(Var* var) {
   Memory* memory = module_->GetMemory(*var);
   if (!memory)
     return Result::Error;
-  UseNameForVar(&memory->name, var);
+  UseNameForVar(memory->name, var);
   return Result::Ok;
 }
 
@@ -168,7 +168,7 @@ Result NameApplier::UseNameForExceptVar(Var* var) {
   Exception* except = module_->GetExcept(*var);
   if (!except)
     return Result::Error;
-  UseNameForVar(&except->name, var);
+  UseNameForVar(except->name, var);
   return Result::Ok;
 }
 
@@ -202,7 +202,7 @@ Result NameApplier::UseNameForParamAndLocalVar(Func* func, Var* var) {
 }
 
 Result NameApplier::BeginBlockExpr(BlockExpr* expr) {
-  PushLabel(&expr->block->label);
+  PushLabel(expr->block->label);
   return Result::Ok;
 }
 
@@ -212,7 +212,7 @@ Result NameApplier::EndBlockExpr(BlockExpr* expr) {
 }
 
 Result NameApplier::BeginLoopExpr(LoopExpr* expr) {
-  PushLabel(&expr->block->label);
+  PushLabel(expr->block->label);
   return Result::Ok;
 }
 
@@ -222,13 +222,13 @@ Result NameApplier::EndLoopExpr(LoopExpr* expr) {
 }
 
 Result NameApplier::OnBrExpr(BrExpr* expr) {
-  Label* label = FindLabelByVar(&expr->var);
+  string_view label = FindLabelByVar(&expr->var);
   UseNameForVar(label, &expr->var);
   return Result::Ok;
 }
 
 Result NameApplier::OnBrIfExpr(BrIfExpr* expr) {
-  Label* label = FindLabelByVar(&expr->var);
+  string_view label = FindLabelByVar(&expr->var);
   UseNameForVar(label, &expr->var);
   return Result::Ok;
 }
@@ -236,17 +236,17 @@ Result NameApplier::OnBrIfExpr(BrIfExpr* expr) {
 Result NameApplier::OnBrTableExpr(BrTableExpr* expr) {
   VarVector& targets = *expr->targets;
   for (Var& target : targets) {
-    Label* label = FindLabelByVar(&target);
+    string_view label = FindLabelByVar(&target);
     UseNameForVar(label, &target);
   }
 
-  Label* label = FindLabelByVar(&expr->default_target);
+  string_view label = FindLabelByVar(&expr->default_target);
   UseNameForVar(label, &expr->default_target);
   return Result::Ok;
 }
 
 Result NameApplier::BeginTryExpr(TryExpr* expr) {
-  PushLabel(&expr->block->label);
+  PushLabel(expr->block->label);
   return Result::Ok;
 }
 
@@ -268,7 +268,7 @@ Result NameApplier::OnThrowExpr(ThrowExpr* expr) {
 }
 
 Result NameApplier::OnRethrowExpr(RethrowExpr* expr) {
-  Label* label = FindLabelByVar(&expr->var);
+  string_view label = FindLabelByVar(&expr->var);
   UseNameForVar(label, &expr->var);
   return Result::Ok;
 }
@@ -294,7 +294,7 @@ Result NameApplier::OnGetLocalExpr(GetLocalExpr* expr) {
 }
 
 Result NameApplier::BeginIfExpr(IfExpr* expr) {
-  PushLabel(&expr->true_->label);
+  PushLabel(expr->true_->label);
   return Result::Ok;
 }
 

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -323,8 +323,8 @@ Result BinaryReaderIR::OnImport(Index index,
                                  StringSlice module_name,
                                  StringSlice field_name) {
   auto import = new Import();
-  import->module_name = dup_string_slice(module_name);
-  import->field_name = dup_string_slice(field_name);
+  import->module_name = string_slice_to_string(module_name);
+  import->field_name = string_slice_to_string(field_name);
   module->imports.push_back(import);
   module->fields.push_back(new ImportModuleField(import, GetLocation()));
   return Result::Ok;
@@ -490,7 +490,7 @@ Result BinaryReaderIR::OnExport(Index index,
                                 Index item_index,
                                 StringSlice name) {
   auto export_ = new Export();
-  export_->name = dup_string_slice(name);
+  export_->name = string_slice_to_string(name);
   switch (kind) {
     case ExternalKind::Func:
       assert(item_index < module->funcs.size());
@@ -895,7 +895,7 @@ Result BinaryReaderIR::OnFunctionName(Index index, StringSlice name) {
   while (module->func_bindings.count(dollar_name) != 0) {
     dollar_name = orig_name + "." + std::to_string(counter++);
   }
-  func->name = dup_string_slice(string_to_string_slice(dollar_name));
+  func->name = dollar_name;
   module->func_bindings.emplace(dollar_name, Binding(index));
   return Result::Ok;
 }

--- a/src/binary-writer.h
+++ b/src/binary-writer.h
@@ -55,8 +55,7 @@ Offset write_fixed_u32_leb128_raw(uint8_t* data, uint8_t* end, uint32_t value);
 void write_type(Stream* stream, Type type);
 
 void write_str(Stream* stream,
-               const char* s,
-               size_t length,
+               const string_view& s,
                const char* desc,
                PrintChars print_chars = PrintChars::No);
 

--- a/src/binding-hash.h
+++ b/src/binding-hash.h
@@ -54,6 +54,10 @@ class BindingHash : public std::unordered_multimap<std::string, Binding> {
     return iter != end() ? iter->second.index : kInvalidIndex;
   }
 
+  Index FindIndex(const string_view& name) const {
+    return FindIndex(name.to_string());
+  }
+
   Index FindIndex(const StringSlice& name) const {
     return FindIndex(string_slice_to_string(name));
   }

--- a/src/common.cc
+++ b/src/common.cc
@@ -63,14 +63,6 @@ bool string_slice_eq_cstr(const StringSlice* s1, const char* s2) {
   return strncmp(s1->start, s2, s2_len) == 0;
 }
 
-bool string_slice_startswith(const StringSlice* s1, const char* s2) {
-  size_t s2_len = strlen(s2);
-  if (s2_len > s1->length)
-    return false;
-
-  return strncmp(s1->start, s2, s2_len) == 0;
-}
-
 StringSlice string_slice_from_cstr(const char* string) {
   StringSlice result;
   result.start = string;
@@ -81,12 +73,6 @@ StringSlice string_slice_from_cstr(const char* string) {
 bool string_slice_is_empty(const StringSlice* str) {
   assert(str);
   return !str->start || str->length == 0;
-}
-
-bool string_slices_are_equal(const StringSlice* a, const StringSlice* b) {
-  assert(a && b);
-  return a->start && b->start && a->length == b->length &&
-         memcmp(a->start, b->start, a->length) == 0;
 }
 
 void destroy_string_slice(StringSlice* str) {

--- a/src/common.h
+++ b/src/common.h
@@ -277,10 +277,8 @@ static WABT_INLINE StringSlice dup_string_slice(StringSlice str) {
 
 StringSlice empty_string_slice(void);
 bool string_slice_eq_cstr(const StringSlice* s1, const char* s2);
-bool string_slice_startswith(const StringSlice* s1, const char* s2);
 StringSlice string_slice_from_cstr(const char* string);
 bool string_slice_is_empty(const StringSlice*);
-bool string_slices_are_equal(const StringSlice*, const StringSlice*);
 void destroy_string_slice(StringSlice*);
 Result read_file(const char* filename, char** out_data, size_t* out_size);
 
@@ -292,13 +290,6 @@ inline StringSlice string_view_to_string_slice(const string_view& view) {
   StringSlice ss;
   ss.start = view.data();
   ss.length = view.length();
-  return ss;
-}
-
-inline StringSlice string_to_string_slice(const std::string& s) {
-  StringSlice ss;
-  ss.start = s.data();
-  ss.length = s.length();
   return ss;
 }
 

--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -121,7 +121,7 @@ struct Table {
 };
 
 struct Memory {
-  Memory() { ZeroMemory(page_limits); }
+  Memory() = default;
   explicit Memory(const Limits& limits)
       : page_limits(limits), data(limits.initial * WABT_PAGE_SIZE) {}
 

--- a/src/prebuilt/wast-parser-gen.cc
+++ b/src/prebuilt/wast-parser-gen.cc
@@ -136,22 +136,19 @@
     }                                                         \
   while (0)
 
-#define CHECK_END_LABEL(loc, begin_label, end_label)                       \
-  do {                                                                     \
-    if (!string_slice_is_empty(&(end_label))) {                            \
-      if (string_slice_is_empty(&(begin_label))) {                         \
-        wast_parser_error(&loc, lexer, parser,                             \
-                          "unexpected label \"" PRIstringslice "\"",       \
-                          WABT_PRINTF_STRING_SLICE_ARG(end_label));        \
-      } else if (!string_slices_are_equal(&(begin_label), &(end_label))) { \
-        wast_parser_error(&loc, lexer, parser,                             \
-                          "mismatching label \"" PRIstringslice            \
-                          "\" != \"" PRIstringslice "\"",                  \
-                          WABT_PRINTF_STRING_SLICE_ARG(begin_label),       \
-                          WABT_PRINTF_STRING_SLICE_ARG(end_label));        \
-      }                                                                    \
-      destroy_string_slice(&(end_label));                                  \
-    }                                                                      \
+#define CHECK_END_LABEL(loc, begin_label, end_label)                      \
+  do {                                                                    \
+    if (!end_label->empty()) {                                            \
+      if (begin_label.empty()) {                                          \
+        wast_parser_error(&loc, lexer, parser, "unexpected label \"%s\"", \
+                          end_label->c_str());                            \
+      } else if (begin_label != *end_label) {                             \
+        wast_parser_error(&loc, lexer, parser,                            \
+                          "mismatching label \"%s\" != \"%s\"",           \
+                          begin_label.c_str(), end_label->c_str());       \
+      }                                                                   \
+    }                                                                     \
+    delete (end_label);                                                   \
   } while (0)
 
 #define CHECK_ALLOW_EXCEPTIONS(loc, opcode_name)                      \
@@ -214,7 +211,7 @@ class BinaryErrorHandlerModule : public ErrorHandler {
 #define wabt_wast_parser_error wast_parser_error
 
 
-#line 218 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
+#line 215 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -369,7 +366,7 @@ int wabt_wast_parser_parse (::wabt::WastLexer* lexer, ::wabt::WastParser* parser
 
 /* Copy the second part of user declarations.  */
 
-#line 373 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
+#line 370 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -676,28 +673,28 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   267,   267,   273,   283,   284,   288,   306,   307,   313,
-     316,   321,   329,   333,   334,   339,   348,   349,   357,   363,
-     369,   374,   381,   387,   398,   402,   406,   413,   416,   421,
-     422,   429,   430,   433,   437,   438,   442,   443,   459,   460,
-     475,   479,   483,   487,   490,   493,   496,   499,   503,   507,
-     511,   514,   518,   522,   526,   530,   534,   538,   542,   545,
-     548,   560,   563,   566,   569,   572,   575,   578,   582,   589,
-     595,   601,   607,   615,   624,   627,   632,   639,   647,   655,
-     656,   660,   665,   672,   676,   681,   687,   693,   698,   707,
-     713,   723,   726,   732,   737,   745,   752,   755,   762,   768,
-     776,   783,   791,   801,   806,   812,   818,   819,   826,   827,
-     834,   839,   845,   852,   865,   872,   875,   884,   890,   899,
-     906,   907,   913,   923,   924,   933,   940,   941,   947,   957,
-     958,   967,   974,   979,   984,   996,   999,  1003,  1013,  1025,
-    1038,  1041,  1047,  1053,  1073,  1083,  1095,  1108,  1111,  1117,
-    1123,  1146,  1159,  1165,  1171,  1182,  1191,  1199,  1205,  1211,
-    1217,  1225,  1234,  1242,  1248,  1254,  1260,  1266,  1274,  1282,
-    1292,  1298,  1308,  1315,  1316,  1317,  1318,  1319,  1320,  1321,
-    1322,  1323,  1324,  1325,  1329,  1330,  1334,  1340,  1349,  1370,
-    1377,  1380,  1386,  1404,  1412,  1423,  1434,  1445,  1448,  1451,
-    1454,  1457,  1460,  1463,  1466,  1469,  1475,  1478,  1479,  1482,
-    1490,  1494,  1501,  1513,  1514,  1521,  1524,  1588,  1597
+       0,   266,   266,   272,   282,   283,   287,   305,   306,   312,
+     315,   320,   328,   332,   333,   338,   347,   348,   356,   362,
+     368,   373,   380,   386,   397,   401,   405,   412,   415,   420,
+     421,   428,   429,   432,   436,   437,   441,   442,   458,   459,
+     474,   478,   482,   486,   489,   492,   495,   498,   502,   506,
+     510,   513,   517,   521,   525,   529,   533,   537,   541,   544,
+     547,   559,   562,   565,   568,   571,   574,   577,   581,   588,
+     595,   602,   609,   618,   628,   631,   636,   643,   651,   659,
+     660,   664,   669,   676,   680,   685,   692,   699,   705,   715,
+     721,   731,   734,   740,   745,   753,   760,   763,   770,   776,
+     784,   791,   799,   809,   814,   820,   826,   827,   834,   835,
+     842,   847,   854,   861,   876,   883,   886,   895,   901,   910,
+     917,   918,   924,   934,   935,   944,   951,   952,   958,   968,
+     969,   978,   985,   990,   995,  1006,  1009,  1013,  1023,  1035,
+    1050,  1053,  1059,  1065,  1085,  1095,  1107,  1122,  1125,  1131,
+    1137,  1160,  1175,  1181,  1187,  1198,  1208,  1217,  1224,  1231,
+    1238,  1246,  1257,  1267,  1273,  1279,  1285,  1291,  1299,  1308,
+    1319,  1325,  1336,  1343,  1344,  1345,  1346,  1347,  1348,  1349,
+    1350,  1351,  1352,  1353,  1357,  1358,  1362,  1368,  1377,  1397,
+    1404,  1407,  1413,  1431,  1439,  1450,  1462,  1474,  1478,  1482,
+    1486,  1490,  1493,  1496,  1499,  1503,  1510,  1513,  1514,  1517,
+    1526,  1530,  1537,  1549,  1550,  1557,  1560,  1623,  1632
 };
 #endif
 
@@ -1728,417 +1725,417 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 5: /* NAT  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1734 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1731 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 6: /* INT  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1740 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1737 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 7: /* FLOAT  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1746 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1743 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 8: /* TEXT  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1752 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1749 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 9: /* VAR  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1758 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1755 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 41: /* OFFSET_EQ_NAT  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1764 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1761 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 42: /* ALIGN_EQ_NAT  */
-#line 231 "src/wast-parser.y" /* yacc.c:1257  */
+#line 229 "src/wast-parser.y" /* yacc.c:1257  */
       {}
-#line 1770 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1767 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 83: /* text_list  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1776 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1773 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 84: /* text_list_opt  */
-#line 251 "src/wast-parser.y" /* yacc.c:1257  */
+#line 250 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_text_list(&((*yyvaluep).text_list)); }
-#line 1782 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1779 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 85: /* quoted_text  */
-#line 232 "src/wast-parser.y" /* yacc.c:1257  */
+#line 230 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1788 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1785 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 86: /* value_type_list  */
-#line 252 "src/wast-parser.y" /* yacc.c:1257  */
+#line 251 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1794 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1791 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 88: /* global_type  */
-#line 245 "src/wast-parser.y" /* yacc.c:1257  */
+#line 243 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).global); }
-#line 1800 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1797 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 89: /* func_type  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 242 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1806 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1803 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 90: /* func_sig  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 242 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1812 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1809 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 91: /* func_sig_result  */
-#line 244 "src/wast-parser.y" /* yacc.c:1257  */
+#line 242 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1818 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1815 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 93: /* memory_sig  */
-#line 247 "src/wast-parser.y" /* yacc.c:1257  */
+#line 245 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).memory); }
-#line 1824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1821 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 95: /* type_use  */
-#line 253 "src/wast-parser.y" /* yacc.c:1257  */
+#line 252 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 1830 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1827 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 97: /* literal  */
-#line 233 "src/wast-parser.y" /* yacc.c:1257  */
+#line 231 "src/wast-parser.y" /* yacc.c:1257  */
       { destroy_string_slice(&((*yyvaluep).literal).text); }
-#line 1836 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1833 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 98: /* var  */
-#line 253 "src/wast-parser.y" /* yacc.c:1257  */
+#line 252 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 1842 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1839 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 99: /* var_list  */
-#line 254 "src/wast-parser.y" /* yacc.c:1257  */
+#line 253 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).vars); }
-#line 1848 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1845 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 100: /* bind_var_opt  */
-#line 232 "src/wast-parser.y" /* yacc.c:1257  */
-      { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1854 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+      { delete ((*yyvaluep).string); }
+#line 1851 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 101: /* bind_var  */
-#line 232 "src/wast-parser.y" /* yacc.c:1257  */
-      { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1860 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+      { delete ((*yyvaluep).string); }
+#line 1857 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 102: /* labeling_opt  */
-#line 232 "src/wast-parser.y" /* yacc.c:1257  */
-      { destroy_string_slice(&((*yyvaluep).text)); }
-#line 1866 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+      { delete ((*yyvaluep).string); }
+#line 1863 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 105: /* instr  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1872 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1869 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 106: /* plain_instr  */
-#line 240 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1878 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1875 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 107: /* block_instr  */
-#line 240 "src/wast-parser.y" /* yacc.c:1257  */
+#line 238 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1884 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1881 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 108: /* block_sig  */
-#line 252 "src/wast-parser.y" /* yacc.c:1257  */
+#line 251 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1890 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1887 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 109: /* block  */
-#line 235 "src/wast-parser.y" /* yacc.c:1257  */
+#line 233 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).block); }
-#line 1896 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1893 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 114: /* expr  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1902 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1899 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 115: /* expr1  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1908 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1905 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 119: /* if_block  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1914 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1911 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 120: /* if_  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1917 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 124: /* instr_list  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1926 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1923 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 125: /* expr_list  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1932 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1929 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 126: /* const_expr  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1938 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1935 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 129: /* func  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 1944 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1941 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 130: /* func_fields  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 1950 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1947 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 131: /* func_fields_import  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1956 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1953 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 132: /* func_fields_import1  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1962 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1959 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 133: /* func_fields_import_result  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1968 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1965 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 134: /* func_fields_body  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1974 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1971 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 135: /* func_fields_body1  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1980 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1977 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 136: /* func_result_body  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1986 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1983 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 137: /* func_body  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1992 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1989 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 138: /* func_body1  */
-#line 243 "src/wast-parser.y" /* yacc.c:1257  */
+#line 241 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1998 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1995 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 139: /* offset  */
-#line 241 "src/wast-parser.y" /* yacc.c:1257  */
+#line 239 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 2004 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2001 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 141: /* table  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2010 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2007 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 142: /* table_fields  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2016 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2013 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 144: /* memory  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2022 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2019 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 145: /* memory_fields  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2028 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2025 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 146: /* global  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2034 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2031 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 147: /* global_fields  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2040 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2037 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 148: /* import_desc  */
-#line 246 "src/wast-parser.y" /* yacc.c:1257  */
+#line 244 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 2046 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2043 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 150: /* inline_import  */
-#line 246 "src/wast-parser.y" /* yacc.c:1257  */
+#line 244 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 2052 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2049 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 151: /* export_desc  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 237 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 2058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2055 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 153: /* inline_export  */
-#line 239 "src/wast-parser.y" /* yacc.c:1257  */
+#line 237 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 2064 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2061 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 156: /* module_field  */
-#line 242 "src/wast-parser.y" /* yacc.c:1257  */
+#line 240 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2070 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2067 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 157: /* module_fields_opt  */
-#line 248 "src/wast-parser.y" /* yacc.c:1257  */
+#line 246 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2076 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2073 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 158: /* module_fields  */
-#line 248 "src/wast-parser.y" /* yacc.c:1257  */
+#line 246 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2082 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2079 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 159: /* module  */
-#line 248 "src/wast-parser.y" /* yacc.c:1257  */
+#line 246 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2088 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2085 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 160: /* inline_module  */
-#line 248 "src/wast-parser.y" /* yacc.c:1257  */
+#line 246 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2094 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2091 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 161: /* script_var_opt  */
-#line 253 "src/wast-parser.y" /* yacc.c:1257  */
+#line 252 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 2100 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2097 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 162: /* script_module  */
-#line 249 "src/wast-parser.y" /* yacc.c:1257  */
+#line 247 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script_module); }
-#line 2106 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2103 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 163: /* action  */
-#line 234 "src/wast-parser.y" /* yacc.c:1257  */
+#line 232 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).action); }
-#line 2112 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2109 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 164: /* assertion  */
-#line 236 "src/wast-parser.y" /* yacc.c:1257  */
+#line 234 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 2118 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2115 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 165: /* cmd  */
-#line 236 "src/wast-parser.y" /* yacc.c:1257  */
+#line 234 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 2124 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2121 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 166: /* cmd_list  */
-#line 237 "src/wast-parser.y" /* yacc.c:1257  */
+#line 235 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).commands); }
-#line 2130 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2127 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 168: /* const_list  */
-#line 238 "src/wast-parser.y" /* yacc.c:1257  */
+#line 236 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).consts); }
-#line 2136 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2133 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 169: /* script  */
-#line 250 "src/wast-parser.y" /* yacc.c:1257  */
+#line 248 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script); }
-#line 2142 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2139 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
 
@@ -2430,18 +2427,18 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 267 "src/wast-parser.y" /* yacc.c:1646  */
+#line 266 "src/wast-parser.y" /* yacc.c:1646  */
     {
       TextListNode* node = new TextListNode();
       DUPTEXT(node->text, (yyvsp[0].text));
       node->next = nullptr;
       (yyval.text_list).first = (yyval.text_list).last = node;
     }
-#line 2441 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2438 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 273 "src/wast-parser.y" /* yacc.c:1646  */
+#line 272 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.text_list) = (yyvsp[-1].text_list);
       TextListNode* node = new TextListNode();
@@ -2450,17 +2447,17 @@ yyreduce:
       (yyval.text_list).last->next = node;
       (yyval.text_list).last = node;
     }
-#line 2454 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2451 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 283 "src/wast-parser.y" /* yacc.c:1646  */
+#line 282 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.text_list).first = (yyval.text_list).last = nullptr; }
-#line 2460 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2457 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 288 "src/wast-parser.y" /* yacc.c:1646  */
+#line 287 "src/wast-parser.y" /* yacc.c:1646  */
     {
       TextListNode node;
       node.text = (yyvsp[0].text);
@@ -2474,139 +2471,139 @@ yyreduce:
       (yyval.text).start = data;
       (yyval.text).length = size;
     }
-#line 2478 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2475 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 306 "src/wast-parser.y" /* yacc.c:1646  */
+#line 305 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = new TypeVector(); }
-#line 2484 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2481 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 307 "src/wast-parser.y" /* yacc.c:1646  */
+#line 306 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.types) = (yyvsp[-1].types);
       (yyval.types)->push_back((yyvsp[0].type));
     }
-#line 2493 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2490 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 313 "src/wast-parser.y" /* yacc.c:1646  */
+#line 312 "src/wast-parser.y" /* yacc.c:1646  */
     {}
-#line 2499 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2496 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 316 "src/wast-parser.y" /* yacc.c:1646  */
+#line 315 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[0].type);
       (yyval.global)->mutable_ = false;
     }
-#line 2509 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2506 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 321 "src/wast-parser.y" /* yacc.c:1646  */
+#line 320 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[-1].type);
       (yyval.global)->mutable_ = true;
     }
-#line 2519 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2516 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 329 "src/wast-parser.y" /* yacc.c:1646  */
+#line 328 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = (yyvsp[-1].func_sig); }
-#line 2525 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2522 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 334 "src/wast-parser.y" /* yacc.c:1646  */
+#line 333 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->param_types.insert((yyval.func_sig)->param_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 2535 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2532 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 339 "src/wast-parser.y" /* yacc.c:1646  */
+#line 338 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->param_types.insert((yyval.func_sig)->param_types.begin(), (yyvsp[-2].type));
       // Ignore bind_var.
-      destroy_string_slice(&(yyvsp[-3].text));
+      delete (yyvsp[-3].string);
     }
-#line 2546 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2543 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 348 "src/wast-parser.y" /* yacc.c:1646  */
+#line 347 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = new FuncSignature(); }
-#line 2552 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2549 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 349 "src/wast-parser.y" /* yacc.c:1646  */
+#line 348 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->result_types.insert((yyval.func_sig)->result_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 2562 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2559 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 357 "src/wast-parser.y" /* yacc.c:1646  */
+#line 356 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.table) = new Table();
       (yyval.table)->elem_limits = (yyvsp[-1].limits);
     }
-#line 2571 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2568 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 363 "src/wast-parser.y" /* yacc.c:1646  */
+#line 362 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.memory) = new Memory();
       (yyval.memory)->page_limits = (yyvsp[0].limits);
     }
-#line 2580 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2577 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 369 "src/wast-parser.y" /* yacc.c:1646  */
+#line 368 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = false;
       (yyval.limits).initial = (yyvsp[0].u64);
       (yyval.limits).max = 0;
     }
-#line 2590 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2587 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 374 "src/wast-parser.y" /* yacc.c:1646  */
+#line 373 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = true;
       (yyval.limits).initial = (yyvsp[-1].u64);
       (yyval.limits).max = (yyvsp[0].u64);
     }
-#line 2600 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2597 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 381 "src/wast-parser.y" /* yacc.c:1646  */
+#line 380 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2606 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2603 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 387 "src/wast-parser.y" /* yacc.c:1646  */
+#line 386 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if (Failed(parse_uint64((yyvsp[0].literal).text.start,
                               (yyvsp[0].literal).text.start + (yyvsp[0].literal).text.length, &(yyval.u64)))) {
@@ -2615,94 +2612,94 @@ yyreduce:
                           WABT_PRINTF_STRING_SLICE_ARG((yyvsp[0].literal).text));
       }
     }
-#line 2619 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2616 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 398 "src/wast-parser.y" /* yacc.c:1646  */
+#line 397 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2628 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2625 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 402 "src/wast-parser.y" /* yacc.c:1646  */
+#line 401 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2637 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2634 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 406 "src/wast-parser.y" /* yacc.c:1646  */
+#line 405 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal).type = (yyvsp[0].literal).type;
       DUPTEXT((yyval.literal).text, (yyvsp[0].literal).text);
     }
-#line 2646 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2643 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 413 "src/wast-parser.y" /* yacc.c:1646  */
+#line 412 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var((yyvsp[0].u64), (yylsp[0]));
     }
-#line 2654 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2651 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 416 "src/wast-parser.y" /* yacc.c:1646  */
+#line 415 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var(string_view((yyvsp[0].text).start, (yyvsp[0].text).length), (yylsp[0]));
     }
-#line 2662 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2659 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 421 "src/wast-parser.y" /* yacc.c:1646  */
+#line 420 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.vars) = new VarVector(); }
-#line 2668 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2665 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 422 "src/wast-parser.y" /* yacc.c:1646  */
+#line 421 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.vars) = (yyvsp[-1].vars);
       (yyval.vars)->emplace_back(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2678 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2675 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 429 "src/wast-parser.y" /* yacc.c:1646  */
-    { ZeroMemory((yyval.text)); }
-#line 2684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 428 "src/wast-parser.y" /* yacc.c:1646  */
+    { (yyval.string) = new std::string(); }
+#line 2681 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 433 "src/wast-parser.y" /* yacc.c:1646  */
-    { DUPTEXT((yyval.text), (yyvsp[0].text)); }
-#line 2690 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 432 "src/wast-parser.y" /* yacc.c:1646  */
+    { (yyval.string) = new std::string(string_slice_to_string((yyvsp[0].text))); }
+#line 2687 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 437 "src/wast-parser.y" /* yacc.c:1646  */
-    { ZeroMemory((yyval.text)); }
-#line 2696 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 436 "src/wast-parser.y" /* yacc.c:1646  */
+    { (yyval.string) = new std::string(); }
+#line 2693 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 442 "src/wast-parser.y" /* yacc.c:1646  */
+#line 441 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u64) = 0; }
-#line 2702 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2699 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 443 "src/wast-parser.y" /* yacc.c:1646  */
+#line 442 "src/wast-parser.y" /* yacc.c:1646  */
     {
       uint64_t offset64;
       if (Failed(parse_int64((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &offset64,
@@ -2717,17 +2714,17 @@ yyreduce:
       }
       (yyval.u64) = static_cast<uint32_t>(offset64);
     }
-#line 2721 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2718 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 459 "src/wast-parser.y" /* yacc.c:1646  */
+#line 458 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u32) = USE_NATURAL_ALIGNMENT; }
-#line 2727 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2724 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 460 "src/wast-parser.y" /* yacc.c:1646  */
+#line 459 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if (Failed(parse_int32((yyvsp[0].text).start, (yyvsp[0].text).start + (yyvsp[0].text).length, &(yyval.u32),
                              ParseIntType::UnsignedOnly))) {
@@ -2740,175 +2737,175 @@ yyreduce:
         wast_parser_error(&(yylsp[0]), lexer, parser, "alignment must be power-of-two");
       }
     }
-#line 2744 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2741 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 475 "src/wast-parser.y" /* yacc.c:1646  */
+#line 474 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = new ExprList((yyvsp[0].expr));
       (yyval.expr_list)->back().loc = (yylsp[0]);
     }
-#line 2753 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2750 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 479 "src/wast-parser.y" /* yacc.c:1646  */
+#line 478 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = new ExprList((yyvsp[0].expr));
       (yyval.expr_list)->back().loc = (yylsp[0]);
     }
-#line 2762 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2759 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 487 "src/wast-parser.y" /* yacc.c:1646  */
+#line 486 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new UnreachableExpr();
     }
-#line 2770 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2767 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 490 "src/wast-parser.y" /* yacc.c:1646  */
+#line 489 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new NopExpr();
     }
-#line 2778 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2775 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 493 "src/wast-parser.y" /* yacc.c:1646  */
+#line 492 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new DropExpr();
     }
-#line 2786 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2783 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 496 "src/wast-parser.y" /* yacc.c:1646  */
+#line 495 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SelectExpr();
     }
-#line 2794 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2791 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 499 "src/wast-parser.y" /* yacc.c:1646  */
+#line 498 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BrExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2803 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2800 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 503 "src/wast-parser.y" /* yacc.c:1646  */
+#line 502 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BrIfExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2812 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2809 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 49:
-#line 507 "src/wast-parser.y" /* yacc.c:1646  */
+#line 506 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BrTableExpr((yyvsp[-1].vars), std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2821 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2818 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 50:
-#line 511 "src/wast-parser.y" /* yacc.c:1646  */
+#line 510 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new ReturnExpr();
     }
-#line 2829 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2826 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 51:
-#line 514 "src/wast-parser.y" /* yacc.c:1646  */
+#line 513 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CallExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2838 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2835 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 518 "src/wast-parser.y" /* yacc.c:1646  */
+#line 517 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CallIndirectExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2847 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2844 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 522 "src/wast-parser.y" /* yacc.c:1646  */
+#line 521 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new GetLocalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2856 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2853 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 526 "src/wast-parser.y" /* yacc.c:1646  */
+#line 525 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SetLocalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2865 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2862 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 530 "src/wast-parser.y" /* yacc.c:1646  */
+#line 529 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new TeeLocalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2874 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2871 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 534 "src/wast-parser.y" /* yacc.c:1646  */
+#line 533 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new GetGlobalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2883 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2880 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 538 "src/wast-parser.y" /* yacc.c:1646  */
+#line 537 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SetGlobalExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2892 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2889 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 542 "src/wast-parser.y" /* yacc.c:1646  */
+#line 541 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new LoadExpr((yyvsp[-2].opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2900 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2897 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 545 "src/wast-parser.y" /* yacc.c:1646  */
+#line 544 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new StoreExpr((yyvsp[-2].opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2908 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2905 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 548 "src/wast-parser.y" /* yacc.c:1646  */
+#line 547 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Const const_;
       const_.loc = (yylsp[-1]);
@@ -2921,269 +2918,278 @@ yyreduce:
       delete [] (yyvsp[0].literal).text.start;
       (yyval.expr) = new ConstExpr(const_);
     }
-#line 2925 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2922 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 61:
-#line 560 "src/wast-parser.y" /* yacc.c:1646  */
+#line 559 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new UnaryExpr((yyvsp[0].opcode));
     }
-#line 2933 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2930 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 62:
-#line 563 "src/wast-parser.y" /* yacc.c:1646  */
+#line 562 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new BinaryExpr((yyvsp[0].opcode));
     }
-#line 2941 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2938 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 63:
-#line 566 "src/wast-parser.y" /* yacc.c:1646  */
+#line 565 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CompareExpr((yyvsp[0].opcode));
     }
-#line 2949 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2946 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 64:
-#line 569 "src/wast-parser.y" /* yacc.c:1646  */
+#line 568 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new ConvertExpr((yyvsp[0].opcode));
     }
-#line 2957 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2954 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 65:
-#line 572 "src/wast-parser.y" /* yacc.c:1646  */
+#line 571 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new CurrentMemoryExpr();
     }
-#line 2965 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2962 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 66:
-#line 575 "src/wast-parser.y" /* yacc.c:1646  */
+#line 574 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new GrowMemoryExpr();
     }
-#line 2973 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2970 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 67:
-#line 578 "src/wast-parser.y" /* yacc.c:1646  */
+#line 577 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new ThrowExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2982 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2979 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 582 "src/wast-parser.y" /* yacc.c:1646  */
+#line 581 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new RethrowExpr(std::move(*(yyvsp[0].var)));
       delete (yyvsp[0].var);
     }
-#line 2991 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2988 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 589 "src/wast-parser.y" /* yacc.c:1646  */
+#line 588 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new BlockExpr((yyvsp[-2].block));
-      expr->block->label = (yyvsp[-3].text);
-      CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].text));
+      expr->block->label = std::move(*(yyvsp[-3].string));
+      delete (yyvsp[-3].string);
+      CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 3002 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3000 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 70:
 #line 595 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new LoopExpr((yyvsp[-2].block));
-      expr->block->label = (yyvsp[-3].text);
-      CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].text));
+      expr->block->label = std::move(*(yyvsp[-3].string));
+      delete (yyvsp[-3].string);
+      CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 3013 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3012 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 601 "src/wast-parser.y" /* yacc.c:1646  */
+#line 602 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new IfExpr((yyvsp[-2].block));
-      expr->true_->label = (yyvsp[-3].text);
-      CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].text));
+      expr->true_->label = std::move(*(yyvsp[-3].string));
+      delete (yyvsp[-3].string);
+      CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
 #line 3024 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 607 "src/wast-parser.y" /* yacc.c:1646  */
+#line 609 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new IfExpr((yyvsp[-5].block), std::move(*(yyvsp[-2].expr_list)));
       delete (yyvsp[-2].expr_list);
-      expr->true_->label = (yyvsp[-6].text);
-      CHECK_END_LABEL((yylsp[-3]), expr->true_->label, (yyvsp[-3].text));
-      CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].text));
+      expr->true_->label = std::move(*(yyvsp[-6].string));
+      delete (yyvsp[-6].string);
+      CHECK_END_LABEL((yylsp[-3]), expr->true_->label, (yyvsp[-3].string));
+      CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 3037 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3038 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 615 "src/wast-parser.y" /* yacc.c:1646  */
+#line 618 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyvsp[-3].block)->label = (yyvsp[-4].text);
+      (yyvsp[-3].block)->label = std::move(*(yyvsp[-4].string));
+      delete (yyvsp[-4].string);
       (yyval.expr) = (yyvsp[-2].try_expr);
       cast<TryExpr>((yyval.expr))->block = (yyvsp[-3].block);
-      CHECK_END_LABEL((yylsp[0]), (yyvsp[-3].block)->label, (yyvsp[0].text));
+      CHECK_END_LABEL((yylsp[0]), (yyvsp[-3].block)->label, (yyvsp[0].string));
     }
-#line 3048 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3050 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 624 "src/wast-parser.y" /* yacc.c:1646  */
+#line 628 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = (yyvsp[-1].types); }
-#line 3054 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3056 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 627 "src/wast-parser.y" /* yacc.c:1646  */
+#line 631 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.block) = (yyvsp[0].block);
       (yyval.block)->sig.insert((yyval.block)->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
       delete (yyvsp[-1].types);
     }
-#line 3064 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3066 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 632 "src/wast-parser.y" /* yacc.c:1646  */
+#line 636 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.block) = new Block(std::move(*(yyvsp[0].expr_list)));
       delete (yyvsp[0].expr_list);
     }
-#line 3073 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3075 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 639 "src/wast-parser.y" /* yacc.c:1646  */
+#line 643 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = new Catch(std::move(*(yyvsp[-1].var)), std::move(*(yyvsp[0].expr_list)));
       delete (yyvsp[-1].var);
       delete (yyvsp[0].expr_list);
       (yyval.catch_)->loc = (yylsp[-2]);
     }
-#line 3084 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3086 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 647 "src/wast-parser.y" /* yacc.c:1646  */
+#line 651 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = new Catch(std::move(*(yyvsp[0].expr_list)));
       delete (yyvsp[0].expr_list);
       (yyval.catch_)->loc = (yylsp[-1]);
     }
-#line 3094 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3096 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 660 "src/wast-parser.y" /* yacc.c:1646  */
+#line 664 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new TryExpr();
       expr->catches.push_back((yyvsp[0].catch_));
       (yyval.try_expr) = expr;
     }
-#line 3104 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3106 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 665 "src/wast-parser.y" /* yacc.c:1646  */
+#line 669 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[-1].try_expr);
       cast<TryExpr>((yyval.try_expr))->catches.push_back((yyvsp[0].catch_));
     }
-#line 3113 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3115 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 672 "src/wast-parser.y" /* yacc.c:1646  */
+#line 676 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[-1].expr_list); }
-#line 3119 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3121 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 676 "src/wast-parser.y" /* yacc.c:1646  */
+#line 680 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       (yyval.expr_list)->push_back((yyvsp[-1].expr));
       (yyvsp[-1].expr)->loc = (yylsp[-1]);
     }
-#line 3129 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3131 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 681 "src/wast-parser.y" /* yacc.c:1646  */
+#line 685 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new BlockExpr((yyvsp[0].block));
-      expr->block->label = (yyvsp[-1].text);
+      expr->block->label = std::move(*(yyvsp[-1].string));
+      delete (yyvsp[-1].string);
       expr->loc = (yylsp[-2]);
       (yyval.expr_list) = new ExprList(expr);
     }
-#line 3140 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3143 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 687 "src/wast-parser.y" /* yacc.c:1646  */
+#line 692 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new LoopExpr((yyvsp[0].block));
-      expr->block->label = (yyvsp[-1].text);
+      expr->block->label = std::move(*(yyvsp[-1].string));
+      delete (yyvsp[-1].string);
       expr->loc = (yylsp[-2]);
       (yyval.expr_list) = new ExprList(expr);
     }
-#line 3151 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3155 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 693 "src/wast-parser.y" /* yacc.c:1646  */
+#line 699 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       IfExpr* if_ = cast<IfExpr>(&(yyvsp[0].expr_list)->back());
-      if_->true_->label = (yyvsp[-1].text);
+      if_->true_->label = std::move(*(yyvsp[-1].string));
+      delete (yyvsp[-1].string);
     }
-#line 3161 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3166 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 698 "src/wast-parser.y" /* yacc.c:1646  */
+#line 705 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Block* block = (yyvsp[0].try_expr)->block;
-      block->label = (yyvsp[-1].text);
+      block->label = std::move(*(yyvsp[-1].string));
+      delete (yyvsp[-1].string);
       (yyvsp[0].try_expr)->loc = (yylsp[-2]);
       (yyval.expr_list) = new ExprList((yyvsp[0].try_expr));
     }
-#line 3172 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3178 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 707 "src/wast-parser.y" /* yacc.c:1646  */
+#line 715 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[0].try_expr);
       Block* block = (yyval.try_expr)->block;
       block->sig.insert(block->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
       delete (yyvsp[-1].types);
     }
-#line 3183 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3189 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 713 "src/wast-parser.y" /* yacc.c:1646  */
+#line 721 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Block* block = new Block();
       block->exprs = std::move(*(yyvsp[-1].expr_list));
@@ -3191,46 +3197,46 @@ yyreduce:
       (yyval.try_expr) = (yyvsp[0].try_expr);
       (yyval.try_expr)->block = block;
     }
-#line 3195 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3201 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 723 "src/wast-parser.y" /* yacc.c:1646  */
+#line 731 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = (yyvsp[-1].catch_);
     }
-#line 3203 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3209 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 726 "src/wast-parser.y" /* yacc.c:1646  */
+#line 734 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = (yyvsp[-1].catch_);
     }
-#line 3211 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3217 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 732 "src/wast-parser.y" /* yacc.c:1646  */
+#line 740 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new TryExpr();
       expr->catches.push_back((yyvsp[0].catch_));
       (yyval.try_expr) = expr;
     }
-#line 3221 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3227 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 737 "src/wast-parser.y" /* yacc.c:1646  */
+#line 745 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[-1].try_expr);
       cast<TryExpr>((yyval.try_expr))->catches.push_back((yyvsp[0].catch_));
     }
-#line 3230 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3236 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 745 "src/wast-parser.y" /* yacc.c:1646  */
+#line 753 "src/wast-parser.y" /* yacc.c:1646  */
     {
       IfExpr* if_ = cast<IfExpr>(&(yyvsp[0].expr_list)->back());
       (yyval.expr_list) = (yyvsp[0].expr_list);
@@ -3238,11 +3244,11 @@ yyreduce:
       true_->sig.insert(true_->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
       delete (yyvsp[-1].types);
     }
-#line 3242 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3248 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 97:
-#line 755 "src/wast-parser.y" /* yacc.c:1646  */
+#line 763 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-5].expr_list))), std::move(*(yyvsp[-1].expr_list)));
       delete (yyvsp[-5].expr_list);
@@ -3250,22 +3256,22 @@ yyreduce:
       expr->loc = (yylsp[-7]);
       (yyval.expr_list) = new ExprList(expr);
     }
-#line 3254 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3260 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 98:
-#line 762 "src/wast-parser.y" /* yacc.c:1646  */
+#line 770 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-1].expr_list))));
       delete (yyvsp[-1].expr_list);
       expr->loc = (yylsp[-3]);
       (yyval.expr_list) = new ExprList(expr);
     }
-#line 3265 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3271 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 99:
-#line 768 "src/wast-parser.y" /* yacc.c:1646  */
+#line 776 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-5].expr_list))), std::move(*(yyvsp[-1].expr_list)));
       delete (yyvsp[-5].expr_list);
@@ -3274,11 +3280,11 @@ yyreduce:
       (yyval.expr_list) = (yyvsp[-8].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3278 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3284 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 776 "src/wast-parser.y" /* yacc.c:1646  */
+#line 784 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-1].expr_list))));
       delete (yyvsp[-1].expr_list);
@@ -3286,11 +3292,11 @@ yyreduce:
       (yyval.expr_list) = (yyvsp[-4].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3290 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3296 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 783 "src/wast-parser.y" /* yacc.c:1646  */
+#line 791 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-1].expr_list))), std::move(*(yyvsp[0].expr_list)));
       delete (yyvsp[-1].expr_list);
@@ -3299,11 +3305,11 @@ yyreduce:
       (yyval.expr_list) = (yyvsp[-2].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3303 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3309 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 791 "src/wast-parser.y" /* yacc.c:1646  */
+#line 799 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[0].expr_list))));
       delete (yyvsp[0].expr_list);
@@ -3311,99 +3317,102 @@ yyreduce:
       (yyval.expr_list) = (yyvsp[-1].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3315 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3321 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 801 "src/wast-parser.y" /* yacc.c:1646  */
+#line 809 "src/wast-parser.y" /* yacc.c:1646  */
     {
      CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "rethrow");
     }
-#line 3323 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3329 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 806 "src/wast-parser.y" /* yacc.c:1646  */
+#line 814 "src/wast-parser.y" /* yacc.c:1646  */
     {
       CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "throw");
     }
-#line 3331 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3337 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 812 "src/wast-parser.y" /* yacc.c:1646  */
+#line 820 "src/wast-parser.y" /* yacc.c:1646  */
     {
       CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "try");
     }
-#line 3339 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 106:
-#line 818 "src/wast-parser.y" /* yacc.c:1646  */
-    { (yyval.expr_list) = new ExprList(); }
 #line 3345 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 107:
-#line 819 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.expr_list) = (yyvsp[0].expr_list);
-      (yyval.expr_list)->splice((yyval.expr_list)->begin(), std::move(*(yyvsp[-1].expr_list)));
-      delete (yyvsp[-1].expr_list);
-    }
-#line 3355 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 108:
+  case 106:
 #line 826 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = new ExprList(); }
-#line 3361 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3351 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 109:
+  case 107:
 #line 827 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       (yyval.expr_list)->splice((yyval.expr_list)->begin(), std::move(*(yyvsp[-1].expr_list)));
       delete (yyvsp[-1].expr_list);
     }
-#line 3371 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3361 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 108:
+#line 834 "src/wast-parser.y" /* yacc.c:1646  */
+    { (yyval.expr_list) = new ExprList(); }
+#line 3367 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 109:
+#line 835 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.expr_list) = (yyvsp[0].expr_list);
+      (yyval.expr_list)->splice((yyval.expr_list)->begin(), std::move(*(yyvsp[-1].expr_list)));
+      delete (yyvsp[-1].expr_list);
+    }
+#line 3377 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 839 "src/wast-parser.y" /* yacc.c:1646  */
+#line 847 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.exception) = new Exception((yyvsp[-2].text), *(yyvsp[-1].types));
+      (yyval.exception) = new Exception(*(yyvsp[-2].string), *(yyvsp[-1].types));
+      delete (yyvsp[-2].string);
       delete (yyvsp[-1].types);
     }
-#line 3380 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3387 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 845 "src/wast-parser.y" /* yacc.c:1646  */
+#line 854 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_field) = new ExceptionModuleField((yyvsp[0].exception));
     }
-#line 3388 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3395 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 852 "src/wast-parser.y" /* yacc.c:1646  */
+#line 861 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto func_field = dyn_cast<FuncModuleField>(main_field)) {
-        func_field->func->name = (yyvsp[-2].text);
+        func_field->func->name = std::move(*(yyvsp[-2].string));
       } else {
-        cast<ImportModuleField>(main_field)->import->func->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->func->name =
+            std::move(*(yyvsp[-2].string));
       }
+      delete (yyvsp[-2].string);
     }
-#line 3403 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3412 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 865 "src/wast-parser.y" /* yacc.c:1646  */
+#line 876 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new FuncModuleField((yyvsp[0].func));
       field->func->decl.has_func_type = true;
@@ -3411,19 +3420,19 @@ yyreduce:
       delete (yyvsp[-1].var);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3415 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3424 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 872 "src/wast-parser.y" /* yacc.c:1646  */
+#line 883 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = new ModuleFieldList(new FuncModuleField((yyvsp[0].func)));
     }
-#line 3423 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3432 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 875 "src/wast-parser.y" /* yacc.c:1646  */
+#line 886 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-2].import), (yylsp[-2]));
       field->import->kind = ExternalKind::Func;
@@ -3433,174 +3442,173 @@ yyreduce:
       delete (yyvsp[-1].var);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3437 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3446 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 884 "src/wast-parser.y" /* yacc.c:1646  */
+#line 895 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import), (yylsp[-1]));
       field->import->kind = ExternalKind::Func;
       field->import->func = (yyvsp[0].func);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3448 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3457 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 890 "src/wast-parser.y" /* yacc.c:1646  */
+#line 901 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Func;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3459 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3468 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 899 "src/wast-parser.y" /* yacc.c:1646  */
+#line 910 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
     }
-#line 3468 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3477 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 907 "src/wast-parser.y" /* yacc.c:1646  */
+#line 918 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(),
                                       (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3479 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3488 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 913 "src/wast-parser.y" /* yacc.c:1646  */
+#line 924 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->param_bindings.emplace(string_slice_to_string((yyvsp[-3].text)),
+      (yyval.func)->param_bindings.emplace(*(yyvsp[-3].string),
                                  Binding((yylsp[-3]), (yyval.func)->decl.sig.param_types.size()));
-      destroy_string_slice(&(yyvsp[-3].text));
+      delete (yyvsp[-3].string);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(), (yyvsp[-2].type));
     }
-#line 3491 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3500 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 923 "src/wast-parser.y" /* yacc.c:1646  */
+#line 934 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func) = new Func(); }
-#line 3497 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3506 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 924 "src/wast-parser.y" /* yacc.c:1646  */
+#line 935 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.result_types.insert((yyval.func)->decl.sig.result_types.begin(),
                                        (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
-    }
-#line 3508 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 125:
-#line 933 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.func) = (yyvsp[0].func);
-      reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
     }
 #line 3517 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
+  case 125:
+#line 944 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.func) = (yyvsp[0].func);
+      reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
+    }
+#line 3526 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
   case 127:
-#line 941 "src/wast-parser.y" /* yacc.c:1646  */
+#line 952 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(),
                                       (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3528 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3537 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 947 "src/wast-parser.y" /* yacc.c:1646  */
+#line 958 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->param_bindings.emplace(string_slice_to_string((yyvsp[-3].text)),
+      (yyval.func)->param_bindings.emplace(*(yyvsp[-3].string),
                                  Binding((yylsp[-3]), (yyval.func)->decl.sig.param_types.size()));
-      destroy_string_slice(&(yyvsp[-3].text));
+      delete (yyvsp[-3].string);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(), (yyvsp[-2].type));
     }
-#line 3540 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3549 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 130:
-#line 958 "src/wast-parser.y" /* yacc.c:1646  */
+#line 969 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->decl.sig.result_types.insert((yyval.func)->decl.sig.result_types.begin(),
                                        (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3551 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3560 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 131:
-#line 967 "src/wast-parser.y" /* yacc.c:1646  */
+#line 978 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       reverse_bindings(&(yyval.func)->local_types, &(yyval.func)->local_bindings);
     }
-#line 3560 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3569 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 132:
-#line 974 "src/wast-parser.y" /* yacc.c:1646  */
+#line 985 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = new Func();
       (yyval.func)->exprs = std::move(*(yyvsp[0].expr_list));
       delete (yyvsp[0].expr_list);
     }
-#line 3570 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3579 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 133:
-#line 979 "src/wast-parser.y" /* yacc.c:1646  */
+#line 990 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
       (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
       delete (yyvsp[-2].types);
     }
-#line 3580 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3589 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 134:
-#line 984 "src/wast-parser.y" /* yacc.c:1646  */
+#line 995 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->local_bindings.emplace(string_slice_to_string((yyvsp[-3].text)),
-                                 Binding((yylsp[-3]), (yyval.func)->local_types.size()));
-      destroy_string_slice(&(yyvsp[-3].text));
+      (yyval.func)->local_bindings.emplace(*(yyvsp[-3].string), Binding((yylsp[-3]), (yyval.func)->local_types.size()));
+      delete (yyvsp[-3].string);
       (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].type));
-    }
-#line 3592 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 135:
-#line 996 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.expr_list) = (yyvsp[-1].expr_list);
     }
 #line 3600 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
+  case 135:
+#line 1006 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.expr_list) = (yyvsp[-1].expr_list);
+    }
+#line 3608 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
   case 137:
-#line 1003 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1013 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto elem_segment = new ElemSegment();
       elem_segment->table_var = std::move(*(yyvsp[-3].var));
@@ -3611,11 +3619,11 @@ yyreduce:
       delete (yyvsp[-1].vars);
       (yyval.module_field) = new ElemSegmentModuleField(elem_segment, (yylsp[-4]));
     }
-#line 3615 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3623 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 1013 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1023 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto elem_segment = new ElemSegment();
       elem_segment->table_var = Var(0, (yylsp[-3]));
@@ -3625,56 +3633,58 @@ yyreduce:
       delete (yyvsp[-1].vars);
       (yyval.module_field) = new ElemSegmentModuleField(elem_segment, (yylsp[-3]));
     }
-#line 3629 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3637 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 1025 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1035 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto table_field = dyn_cast<TableModuleField>(main_field)) {
-        table_field->table->name = (yyvsp[-2].text);
+        table_field->table->name = std::move(*(yyvsp[-2].string));
       } else {
-        cast<ImportModuleField>(main_field)->import->table->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->table->name =
+            std::move(*(yyvsp[-2].string));
       }
+      delete (yyvsp[-2].string);
     }
-#line 3644 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3654 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 1038 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1050 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = new ModuleFieldList(new TableModuleField((yyvsp[0].table)));
     }
-#line 3652 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3662 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 1041 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1053 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Table;
       field->import->table = (yyvsp[0].table);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3663 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3673 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 1047 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1059 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Table;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3674 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 1053 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1065 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto table = new Table();
       table->elem_limits.initial = (yyvsp[-1].vars)->size();
@@ -3692,11 +3702,11 @@ yyreduce:
       (yyval.module_fields)->push_back(new TableModuleField(table));
       (yyval.module_fields)->push_back(new ElemSegmentModuleField(elem_segment, (yylsp[-2])));
     }
-#line 3696 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3706 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 1073 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1085 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto data_segment = new DataSegment();
       data_segment->memory_var = std::move(*(yyvsp[-3].var));
@@ -3707,11 +3717,11 @@ yyreduce:
       destroy_text_list(&(yyvsp[-1].text_list));
       (yyval.module_field) = new DataSegmentModuleField(data_segment, (yylsp[-4]));
     }
-#line 3711 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3721 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 1083 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1095 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto data_segment = new DataSegment();
       data_segment->memory_var = Var(0, (yylsp[-3]));
@@ -3721,56 +3731,58 @@ yyreduce:
       destroy_text_list(&(yyvsp[-1].text_list));
       (yyval.module_field) = new DataSegmentModuleField(data_segment, (yylsp[-3]));
     }
-#line 3725 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3735 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 1095 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1107 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto memory_field = dyn_cast<MemoryModuleField>(main_field)) {
-        memory_field->memory->name = (yyvsp[-2].text);
+        memory_field->memory->name = std::move(*(yyvsp[-2].string));
       } else {
-        cast<ImportModuleField>(main_field)->import->memory->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->memory->name =
+            std::move(*(yyvsp[-2].string));
       }
+      delete (yyvsp[-2].string);
     }
-#line 3740 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3752 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1108 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1122 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = new ModuleFieldList(new MemoryModuleField((yyvsp[0].memory)));
     }
-#line 3748 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3760 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1111 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1125 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Memory;
       field->import->memory = (yyvsp[0].memory);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3759 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3771 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1117 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1131 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Memory;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3770 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3782 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1123 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1137 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto data_segment = new DataSegment();
       data_segment->memory_var = Var(kInvalidIndex);
@@ -3791,326 +3803,340 @@ yyreduce:
       (yyval.module_fields)->push_back(new MemoryModuleField(memory));
       (yyval.module_fields)->push_back(new DataSegmentModuleField(data_segment, (yylsp[-2])));
     }
-#line 3795 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3807 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1146 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1160 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto global_field = dyn_cast<GlobalModuleField>(main_field)) {
-        global_field->global->name = (yyvsp[-2].text);
+        global_field->global->name = std::move(*(yyvsp[-2].string));
       } else {
-        cast<ImportModuleField>(main_field)->import->global->name = (yyvsp[-2].text);
+        cast<ImportModuleField>(main_field)->import->global->name =
+            std::move(*(yyvsp[-2].string));
       }
+      delete (yyvsp[-2].string);
     }
-#line 3810 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1159 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1175 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new GlobalModuleField((yyvsp[-1].global));
       field->global->init_expr = std::move(*(yyvsp[0].expr_list));
       delete (yyvsp[0].expr_list);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3821 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3835 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1165 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1181 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Global;
       field->import->global = (yyvsp[0].global);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3832 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3846 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1171 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1187 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Global;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3843 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3857 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1182 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1198 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
       (yyval.import)->func = new Func();
-      (yyval.import)->func->name = (yyvsp[-2].text);
+      (yyval.import)->func->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
       (yyval.import)->func->decl.has_func_type = true;
       (yyval.import)->func->decl.type_var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3857 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3872 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1191 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1208 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
       (yyval.import)->func = new Func();
-      (yyval.import)->func->name = (yyvsp[-2].text);
+      (yyval.import)->func->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
       (yyval.import)->func->decl.sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
     }
-#line 3870 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3886 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1199 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1217 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
-      (yyval.import)->table->name = (yyvsp[-2].text);
+      (yyval.import)->table->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
     }
-#line 3881 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3898 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1205 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1224 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
-      (yyval.import)->memory->name = (yyvsp[-2].text);
+      (yyval.import)->memory->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
     }
-#line 3892 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3910 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1211 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1231 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
-      (yyval.import)->global->name = (yyvsp[-2].text);
+      (yyval.import)->global->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
     }
-#line 3903 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3922 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1217 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1238 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Except;
       (yyval.import)->except = (yyvsp[0].exception);
     }
-#line 3913 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3932 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1225 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1246 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import), (yylsp[-4]));
-      field->import->module_name = (yyvsp[-3].text);
-      field->import->field_name = (yyvsp[-2].text);
+      field->import->module_name = string_slice_to_string((yyvsp[-3].text));
+      destroy_string_slice(&(yyvsp[-3].text));
+      field->import->field_name = string_slice_to_string((yyvsp[-2].text));
+      destroy_string_slice(&(yyvsp[-2].text));
       (yyval.module_field) = field;
     }
-#line 3924 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3945 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 162:
-#line 1234 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1257 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
-      (yyval.import)->module_name = (yyvsp[-2].text);
-      (yyval.import)->field_name = (yyvsp[-1].text);
+      (yyval.import)->module_name = string_slice_to_string((yyvsp[-2].text));
+      destroy_string_slice(&(yyvsp[-2].text));
+      (yyval.import)->field_name = string_slice_to_string((yyvsp[-1].text));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 3934 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3957 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 163:
-#line 1242 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1267 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Func;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3945 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3968 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1248 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1273 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Table;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3956 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3979 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1254 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1279 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Memory;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3967 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3990 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1260 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1285 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Global;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3978 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4001 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1266 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1291 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Except;
       (yyval.export_)->var = std::move(*(yyvsp[-1].var));
       delete (yyvsp[-1].var);
     }
-#line 3989 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4012 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1274 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1299 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-3]));
-      field->export_->name = (yyvsp[-2].text);
+      field->export_->name = string_slice_to_string((yyvsp[-2].text));
+      destroy_string_slice(&(yyvsp[-2].text));
       (yyval.module_field) = field;
     }
-#line 3999 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4023 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1282 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1308 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
-      (yyval.export_)->name = (yyvsp[-1].text);
+      (yyval.export_)->name = string_slice_to_string((yyvsp[-1].text));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4008 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4033 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1292 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1319 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto func_type = new FuncType();
       func_type->sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
       (yyval.module_field) = new FuncTypeModuleField(func_type, (yylsp[-2]));
     }
-#line 4019 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4044 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 171:
-#line 1298 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1325 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto func_type = new FuncType();
-      func_type->name = (yyvsp[-2].text);
+      func_type->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
       func_type->sig = std::move(*(yyvsp[-1].func_sig));
       delete (yyvsp[-1].func_sig);
       (yyval.module_field) = new FuncTypeModuleField(func_type, (yylsp[-3]));
     }
-#line 4031 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4057 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 172:
-#line 1308 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1336 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_field) = new StartModuleField(*(yyvsp[-1].var), (yylsp[-2]));
       delete (yyvsp[-1].var);
     }
-#line 4040 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4066 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 173:
-#line 1315 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1343 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4046 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4072 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 178:
-#line 1320 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1348 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4052 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4078 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 179:
-#line 1321 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1349 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4084 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 180:
-#line 1322 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1350 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4064 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4090 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 181:
-#line 1323 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1351 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4070 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4096 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 182:
-#line 1324 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1352 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4076 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4102 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 183:
-#line 1325 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1353 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4082 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4108 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 184:
-#line 1329 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1357 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module) = new Module(); }
-#line 4088 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4114 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 186:
-#line 1334 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1362 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new Module();
       check_import_ordering(&(yylsp[0]), lexer, parser, (yyval.module), *(yyvsp[0].module_fields));
       append_module_fields((yyval.module), (yyvsp[0].module_fields));
       delete (yyvsp[0].module_fields);
     }
-#line 4099 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4125 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 187:
-#line 1340 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1368 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
       check_import_ordering(&(yylsp[0]), lexer, parser, (yyval.module), *(yyvsp[0].module_fields));
       append_module_fields((yyval.module), (yyvsp[0].module_fields));
       delete (yyvsp[0].module_fields);
     }
-#line 4110 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4136 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 188:
-#line 1349 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1377 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].script_module)->type == ScriptModule::Type::Text) {
         (yyval.module) = (yyvsp[0].script_module)->text;
@@ -4125,36 +4151,35 @@ yyreduce:
                        &error_handler, (yyval.module));
         (yyval.module)->name = (yyvsp[0].script_module)->binary.name;
         (yyval.module)->loc = (yyvsp[0].script_module)->binary.loc;
-        ZeroMemory((yyvsp[0].script_module)->binary.name);
       }
       delete (yyvsp[0].script_module);
     }
-#line 4133 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4158 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 190:
-#line 1377 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1404 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var(kInvalidIndex);
     }
-#line 4141 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4166 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 191:
-#line 1380 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1407 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var(string_view((yyvsp[0].text).start, (yyvsp[0].text).length), (yylsp[0]));
     }
-#line 4149 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4174 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 192:
-#line 1386 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1413 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.script_module) = new ScriptModule();
-      (yyval.script_module)->type = ScriptModule::Type::Text;
+      (yyval.script_module) = new ScriptModule(ScriptModule::Type::Text);
       (yyval.script_module)->text = (yyvsp[-1].module);
-      (yyval.script_module)->text->name = (yyvsp[-2].text);
+      (yyval.script_module)->text->name = std::move(*(yyvsp[-2].string));
+      delete (yyvsp[-2].string);
       (yyval.script_module)->text->loc = (yylsp[-3]);
 
       // Resolve func type variables where the signature was not specified
@@ -4168,183 +4193,192 @@ yyreduce:
         }
       }
     }
-#line 4172 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4197 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 193:
-#line 1404 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1431 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.script_module) = new ScriptModule();
-      (yyval.script_module)->type = ScriptModule::Type::Binary;
-      (yyval.script_module)->binary.name = (yyvsp[-3].text);
+      (yyval.script_module) = new ScriptModule(ScriptModule::Type::Binary);
+      (yyval.script_module)->binary.name = std::move(*(yyvsp[-3].string));
+      delete (yyvsp[-3].string);
       (yyval.script_module)->binary.loc = (yylsp[-4]);
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.script_module)->binary.data, &(yyval.script_module)->binary.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 4185 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4210 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 194:
-#line 1412 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1439 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.script_module) = new ScriptModule();
-      (yyval.script_module)->type = ScriptModule::Type::Quoted;
-      (yyval.script_module)->quoted.name = (yyvsp[-3].text);
+      (yyval.script_module) = new ScriptModule(ScriptModule::Type::Quoted);
+      (yyval.script_module)->quoted.name = std::move(*(yyvsp[-3].string));
+      delete (yyvsp[-3].string);
       (yyval.script_module)->quoted.loc = (yylsp[-4]);
       dup_text_list(&(yyvsp[-1].text_list), &(yyval.script_module)->quoted.data, &(yyval.script_module)->quoted.size);
       destroy_text_list(&(yyvsp[-1].text_list));
     }
-#line 4198 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4223 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 195:
-#line 1423 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1450 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-4]);
       (yyval.action)->module_var = std::move(*(yyvsp[-3].var));
       delete (yyvsp[-3].var);
       (yyval.action)->type = ActionType::Invoke;
-      (yyval.action)->name = (yyvsp[-2].text);
+      (yyval.action)->name = string_slice_to_string((yyvsp[-2].text));
+      destroy_string_slice(&(yyvsp[-2].text));
       (yyval.action)->invoke = new ActionInvoke();
       (yyval.action)->invoke->args = std::move(*(yyvsp[-1].consts));
       delete (yyvsp[-1].consts);
     }
-#line 4214 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4240 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 196:
-#line 1434 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1462 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-3]);
       (yyval.action)->module_var = std::move(*(yyvsp[-2].var));
       delete (yyvsp[-2].var);
       (yyval.action)->type = ActionType::Get;
-      (yyval.action)->name = (yyvsp[-1].text);
+      (yyval.action)->name = string_slice_to_string((yyvsp[-1].text));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4227 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4254 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 197:
-#line 1445 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1474 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.command) = new AssertMalformedCommand((yyvsp[-2].script_module), (yyvsp[-1].text));
+      (yyval.command) = new AssertMalformedCommand((yyvsp[-2].script_module), string_slice_to_string((yyvsp[-1].text)));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4235 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4263 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 198:
-#line 1448 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1478 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.command) = new AssertInvalidCommand((yyvsp[-2].script_module), (yyvsp[-1].text));
+      (yyval.command) = new AssertInvalidCommand((yyvsp[-2].script_module), string_slice_to_string((yyvsp[-1].text)));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4243 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4272 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 199:
-#line 1451 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1482 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.command) = new AssertUnlinkableCommand((yyvsp[-2].script_module), (yyvsp[-1].text));
+      (yyval.command) = new AssertUnlinkableCommand((yyvsp[-2].script_module), string_slice_to_string((yyvsp[-1].text)));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4251 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4281 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 200:
-#line 1454 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1486 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.command) = new AssertUninstantiableCommand((yyvsp[-2].script_module), (yyvsp[-1].text));
+      (yyval.command) = new AssertUninstantiableCommand((yyvsp[-2].script_module), string_slice_to_string((yyvsp[-1].text)));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4259 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4290 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 201:
-#line 1457 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1490 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new AssertReturnCommand((yyvsp[-2].action), (yyvsp[-1].consts));
     }
-#line 4267 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4298 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 202:
-#line 1460 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1493 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new AssertReturnCanonicalNanCommand((yyvsp[-1].action));
     }
-#line 4275 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4306 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 203:
-#line 1463 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1496 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new AssertReturnArithmeticNanCommand((yyvsp[-1].action));
     }
-#line 4283 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4314 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 204:
-#line 1466 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1499 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.command) = new AssertTrapCommand((yyvsp[-2].action), (yyvsp[-1].text));
+      (yyval.command) = new AssertTrapCommand((yyvsp[-2].action), string_slice_to_string((yyvsp[-1].text)));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4291 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4323 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 205:
-#line 1469 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1503 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.command) = new AssertExhaustionCommand((yyvsp[-2].action), (yyvsp[-1].text));
+      (yyval.command) = new AssertExhaustionCommand((yyvsp[-2].action), string_slice_to_string((yyvsp[-1].text)));
+      destroy_string_slice(&(yyvsp[-1].text));
     }
-#line 4299 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4332 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 206:
-#line 1475 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1510 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new ActionCommand((yyvsp[0].action));
     }
-#line 4307 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4340 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 208:
-#line 1479 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1514 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.command) = new ModuleCommand((yyvsp[0].module));
     }
-#line 4315 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4348 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 209:
-#line 1482 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1517 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      auto* command = new RegisterCommand((yyvsp[-2].text), *(yyvsp[-1].var));
+      auto* command = new RegisterCommand(string_slice_to_string((yyvsp[-2].text)), *(yyvsp[-1].var));
+      destroy_string_slice(&(yyvsp[-2].text));
       delete (yyvsp[-1].var);
       command->var.loc = (yylsp[-1]);
       (yyval.command) = command;
     }
-#line 4326 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4360 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 210:
-#line 1490 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1526 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = new CommandPtrVector();
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4335 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4369 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 211:
-#line 1494 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1530 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4344 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4378 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 212:
-#line 1501 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1537 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
       if (Failed(parse_const((yyvsp[-2].type), (yyvsp[-1].literal).type, (yyvsp[-1].literal).text.start,
@@ -4355,34 +4389,34 @@ yyreduce:
       }
       delete [] (yyvsp[-1].literal).text.start;
     }
-#line 4359 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4393 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 213:
-#line 1513 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1549 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.consts) = new ConstVector(); }
-#line 4365 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4399 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 214:
-#line 1514 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1550 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       (yyval.consts)->push_back((yyvsp[0].const_));
     }
-#line 4374 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4408 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 215:
-#line 1521 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1557 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
     }
-#line 4382 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4416 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 216:
-#line 1524 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1560 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       (yyval.script)->commands = std::move(*(yyvsp[0].commands));
@@ -4398,11 +4432,10 @@ yyreduce:
 
             // Wire up module name bindings.
             Module* module = cast<ModuleCommand>(command)->module;
-            if (module->name.length == 0)
+            if (module->name.empty())
               continue;
 
-            (yyval.script)->module_bindings.emplace(string_slice_to_string(module->name),
-                                        Binding(module->loc, i));
+            (yyval.script)->module_bindings.emplace(module->name, Binding(module->loc, i));
             break;
           }
 
@@ -4447,26 +4480,26 @@ yyreduce:
         }
       }
     }
-#line 4451 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4484 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 217:
-#line 1588 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1623 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       (yyval.script)->commands.emplace_back(new ModuleCommand((yyvsp[0].module)));
     }
-#line 4460 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4493 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 218:
-#line 1597 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1632 "src/wast-parser.y" /* yacc.c:1646  */
     { parser->script = (yyvsp[0].script); }
-#line 4466 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4499 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4470 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4503 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4701,7 +4734,7 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1600 "src/wast-parser.y" /* yacc.c:1906  */
+#line 1635 "src/wast-parser.y" /* yacc.c:1906  */
 
 
 Result parse_const(Type type,
@@ -4846,7 +4879,7 @@ void append_module_fields(Module* module, ModuleFieldList* fields) {
   Index main_index = kInvalidIndex;
 
   for (ModuleField& field : *fields) {
-    StringSlice* name = nullptr;
+    std::string* name = nullptr;
     BindingHash* bindings = nullptr;
     Index index = kInvalidIndex;
 
@@ -4997,10 +5030,8 @@ void append_module_fields(Module* module, ModuleFieldList* fields) {
 
     if (name && bindings) {
       // Exported names are allowed to be empty; other names aren't.
-      if (bindings == &module->export_bindings ||
-          !string_slice_is_empty(name)) {
-        bindings->emplace(string_slice_to_string(*name),
-                          Binding(field.loc, index));
+      if (bindings == &module->export_bindings || !name->empty()) {
+        bindings->emplace(*name, Binding(field.loc, index));
       }
     }
   }

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -218,18 +218,8 @@ static void write_section_payload(Context* ctx, Section* sec) {
   ctx->stream.WriteData(payload, sec->payload_size, "section content");
 }
 
-static void write_c_str(Stream* stream, const char* str, const char* desc) {
-  write_str(stream, str, strlen(str), desc, PrintChars::Yes);
-}
-
 static void write_slice(Stream* stream, StringSlice str, const char* desc) {
-  write_str(stream, str.start, str.length, desc, PrintChars::Yes);
-}
-
-static void write_string(Stream* stream,
-                         const std::string& str,
-                         const char* desc) {
-  write_str(stream, str.data(), str.length(), desc, PrintChars::Yes);
+  write_str(stream, string_slice_to_string(str), desc, PrintChars::Yes);
 }
 
 #define WRITE_UNKNOWN_SIZE(STREAM)                            \
@@ -470,7 +460,7 @@ static void write_names_section(Context* ctx) {
   Stream* stream = &ctx->stream;
   stream->WriteU8Enum(BinarySection::Custom, "section code");
   WRITE_UNKNOWN_SIZE(stream);
-  write_c_str(stream, "name", "custom section name");
+  write_str(stream, "name", "custom section name");
 
   stream->WriteU8Enum(NameSectionSubsection::Function, "subsection code");
   WRITE_UNKNOWN_SIZE(stream);
@@ -484,7 +474,7 @@ static void write_names_section(Context* ctx) {
       if (binary->IsInactiveFunctionImport(i))
         continue;
       write_u32_leb128(stream, binary->RelocateFuncIndex(i), "function index");
-      write_string(stream, binary->debug_names[i], "function name");
+      write_str(stream, binary->debug_names[i], "function name");
     }
   }
 
@@ -494,7 +484,7 @@ static void write_names_section(Context* ctx) {
       if (binary->debug_names[i].empty() || binary->IsFunctionImport(i))
         continue;
       write_u32_leb128(stream, binary->RelocateFuncIndex(i), "function index");
-      write_string(stream, binary->debug_names[i], "function name");
+      write_str(stream, binary->debug_names[i], "function name");
     }
   }
 
@@ -522,7 +512,7 @@ static void write_reloc_section(Context* ctx,
   Stream* stream = &ctx->stream;
   stream->WriteU8Enum(BinarySection::Custom, "section code");
   WRITE_UNKNOWN_SIZE(stream);
-  write_c_str(stream, section_name, "reloc section name");
+  write_str(stream, section_name, "reloc section name");
   write_u32_leb128_enum(&ctx->stream, section_code, "reloc section");
   write_u32_leb128(&ctx->stream, total_relocs, "num relocs");
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -952,8 +952,8 @@ const TypeVector* Validator::CheckInvoke(const Action* action) {
 
   const Export* export_ = module->GetExport(action->name);
   if (!export_) {
-    PrintError(&action->loc, "unknown function export \"" PRIstringslice "\"",
-               WABT_PRINTF_STRING_SLICE_ARG(action->name));
+    PrintError(&action->loc, "unknown function export \"%s\"",
+               action->name.c_str());
     return nullptr;
   }
 
@@ -990,8 +990,8 @@ Result Validator::CheckGet(const Action* action, Type* out_type) {
 
   const Export* export_ = module->GetExport(action->name);
   if (!export_) {
-    PrintError(&action->loc, "unknown global export \"" PRIstringslice "\"",
-               WABT_PRINTF_STRING_SLICE_ARG(action->name));
+    PrintError(&action->loc, "unknown global export \"%s\"",
+               action->name.c_str());
     return Result::Error;
   }
 

--- a/src/wast-parser-lexer-shared.h
+++ b/src/wast-parser-lexer-shared.h
@@ -79,6 +79,7 @@ union Token {
   ModuleFieldList* module_fields;
   ScriptModule* script_module;
   Script* script;
+  std::string* string;
   Table* table;
   TextList text_list;
   TryExpr* try_expr;


### PR DESCRIPTION
All member variables are now std::string, and most parameters are
string_view. This allows us to remove many of the destructors.