### PR TITLE
Clean up BinaryWriterSpec::GetModuleFilename

### DIFF
--- a/src/stream.cc
+++ b/src/stream.cc
@@ -114,7 +114,7 @@ void Stream::WriteMemoryDump(const void* start,
 
 MemoryStream::MemoryStream() : Stream(&writer_) {}
 
-FileStream::FileStream(const char* filename)
+FileStream::FileStream(const string_view& filename)
     : Stream(&writer_), writer_(filename) {}
 
 FileStream::FileStream(FILE* file) : Stream(&writer_), writer_(file) {}

--- a/src/stream.h
+++ b/src/stream.h
@@ -130,7 +130,7 @@ class MemoryStream : public Stream {
     return writer_.ReleaseOutputBuffer();
   }
 
-  Result WriteToFile(const char* filename) {
+  Result WriteToFile(const string_view& filename) {
     return writer_.output_buffer().WriteToFile(filename);
   }
 
@@ -140,7 +140,7 @@ class MemoryStream : public Stream {
 
 class FileStream : public Stream {
  public:
-  explicit FileStream(const char* filename);
+  explicit FileStream(const string_view& filename);
   explicit FileStream(FILE*);
 
   FileWriter& writer() { return writer_; }

--- a/src/writer.cc
+++ b/src/writer.cc
@@ -28,10 +28,11 @@
 
 namespace wabt {
 
-Result OutputBuffer::WriteToFile(const char* filename) const {
-  FILE* file = fopen(filename, "wb");
+Result OutputBuffer::WriteToFile(const string_view& filename) const {
+  std::string filename_str = filename.to_string();
+  FILE* file = fopen(filename_str.c_str(), "wb");
   if (!file) {
-    ERROR("unable to open %s for writing\n", filename);
+    ERROR("unable to open %s for writing\n", filename_str.c_str());
     return Result::Error;
   }
 
@@ -41,7 +42,8 @@ Result OutputBuffer::WriteToFile(const char* filename) const {
 
   ssize_t bytes = fwrite(data.data(), 1, data.size(), file);
   if (bytes < 0 || static_cast<size_t>(bytes) != data.size()) {
-    ERROR("failed to write %" PRIzd " bytes to %s\n", data.size(), filename);
+    ERROR("failed to write %" PRIzd " bytes to %s\n", data.size(),
+          filename_str.c_str());
     return Result::Error;
   }
 
@@ -93,15 +95,16 @@ Result MemoryWriter::MoveData(size_t dst_offset,
 FileWriter::FileWriter(FILE* file)
     : file_(file), offset_(0), should_close_(false) {}
 
-FileWriter::FileWriter(const char* filename)
+FileWriter::FileWriter(const string_view& filename)
     : file_(nullptr), offset_(0), should_close_(false) {
-  file_ = fopen(filename, "wb");
+  std::string filename_str = filename.to_string();
+  file_ = fopen(filename_str.c_str(), "wb");
 
   // TODO(binji): this is pretty cheesy, should come up with a better API.
   if (file_) {
     should_close_ = true;
   } else {
-    ERROR("fopen name=\"%s\" failed, errno=%d\n", filename, errno);
+    ERROR("fopen name=\"%s\" failed, errno=%d\n", filename_str.c_str(), errno);
   }
 }
 

--- a/src/writer.h
+++ b/src/writer.h
@@ -27,7 +27,7 @@
 namespace wabt {
 
 struct OutputBuffer {
-  Result WriteToFile(const char* filename) const;
+  Result WriteToFile(const string_view& filename) const;
 
   size_t size() const { return data.size(); }
 
@@ -62,7 +62,7 @@ class FileWriter : public Writer {
   WABT_DISALLOW_COPY_AND_ASSIGN(FileWriter);
 
  public:
-  explicit FileWriter(const char* filename);
+  explicit FileWriter(const string_view& filename);
   explicit FileWriter(FILE* file);
   FileWriter(FileWriter&&);
   FileWriter& operator=(FileWriter&&);


### PR DESCRIPTION
This previously had an upper limit to the extension length.

I've also taken this opportunity to modify the Writer and Stream APIs to
take `string_view` instead of `const char*` for filenames.