### PR TITLE
Fix bug in string_view::rfind

### DIFF
--- a/src/string-view.cc
+++ b/src/string-view.cc
@@ -123,9 +123,9 @@ string_view::size_type string_view::find(const char* s, size_type pos) const {
 
 string_view::size_type string_view::rfind(string_view s, size_type pos) const
     noexcept {
-  pos = std::min(pos, size_  - s.size_);
-  reverse_iterator iter = std::search(reverse_iterator(begin() + pos + s.size_),
-                                      rend(), s.rbegin(), s.rend());
+  pos = std::min(std::min(pos, size_  - s.size_) + s.size_, size_);
+  reverse_iterator iter = std::search(reverse_iterator(begin() + pos), rend(),
+                                      s.rbegin(), s.rend());
   return iter == rend() ? npos : (rend() - iter - s.size_);
 }
 

--- a/src/test-string-view.cc
+++ b/src/test-string-view.cc
@@ -299,6 +299,7 @@ TEST(string_view, rfind0) {
   ASSERT_EQ(5U, string_view("find fins").rfind(string_view("fin")));
   ASSERT_EQ(0U, string_view("find fins").rfind(string_view("fin"), 4));
   ASSERT_EQ(npos, string_view("find fins").rfind(string_view("no")));
+  ASSERT_EQ(npos, string_view("foo").rfind(string_view("foobar")));
 }
 
 TEST(string_view, rfind1) {
@@ -311,12 +312,14 @@ TEST(string_view, rfind2) {
   ASSERT_EQ(6U, string_view("012340123").rfind("12345", npos, 2));
   ASSERT_EQ(1U, string_view("012340123").rfind("12345", 4, 2));
   ASSERT_EQ(npos, string_view("012340123").rfind("12345", npos, 5));
+  ASSERT_EQ(npos, string_view("012").rfind("12345", npos, 5));
 }
 
 TEST(string_view, rfind3) {
   ASSERT_EQ(6U, string_view("012340123").rfind("12"));
   ASSERT_EQ(1U, string_view("012340123").rfind("12", 2));
   ASSERT_EQ(npos, string_view("012340123").rfind("12", 0));
+  ASSERT_EQ(npos, string_view("012").rfind("12345"));
 }
 
 TEST(string_view, find_first_of0) {


### PR DESCRIPTION
The position needs to be clamped when the needle is larger than the
haystack.