### PR TITLE
Always pass string_view by value

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -67,7 +67,7 @@ class NameApplier : public ExprVisitor::DelegateNop {
   void PushLabel(const std::string& label);
   void PopLabel();
   string_view FindLabelByVar(Var* var);
-  void UseNameForVar(const string_view& name, Var* var);
+  void UseNameForVar(string_view name, Var* var);
   Result UseNameForFuncTypeVar(Var* var);
   Result UseNameForFuncVar(Var* var);
   Result UseNameForGlobalVar(Var* var);
@@ -114,7 +114,7 @@ string_view NameApplier::FindLabelByVar(Var* var) {
   }
 }
 
-void NameApplier::UseNameForVar(const string_view& name, Var* var) {
+void NameApplier::UseNameForVar(string_view name, Var* var) {
   if (var->is_name()) {
     assert(name == var->name());
     return;

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -30,7 +30,7 @@
 
 namespace wabt {
 
-static string_view strip_extension(const string_view& s) {
+static string_view strip_extension(string_view s) {
   // Strip .json or .wasm, but leave other extensions, e.g.:
   //
   // s = "foo", => "foo"
@@ -45,7 +45,7 @@ static string_view strip_extension(const string_view& s) {
   return result;
 }
 
-static string_view get_basename(const string_view& s) {
+static string_view get_basename(string_view s) {
   // Strip everything up to and including the last slash, e.g.:
   //
   // s = "/foo/bar/baz", => "baz"
@@ -71,7 +71,7 @@ class BinaryWriterSpec {
   void WriteString(const char* s);
   void WriteKey(const char* key);
   void WriteSeparator();
-  void WriteEscapedString(const string_view&);
+  void WriteEscapedString(string_view);
   void WriteCommandType(const Command& command);
   void WriteLocation(const Location* loc);
   void WriteVar(const Var* var);
@@ -80,10 +80,10 @@ class BinaryWriterSpec {
   void WriteConstVector(const ConstVector& consts);
   void WriteAction(const Action* action);
   void WriteActionResultType(Script* script, const Action* action);
-  void WriteModule(const string_view& filename, const Module* module);
-  void WriteScriptModule(const string_view& filename,
+  void WriteModule(string_view filename, const Module* module);
+  void WriteScriptModule(string_view filename,
                          const ScriptModule* script_module);
-  void WriteInvalidModule(const ScriptModule* module, const string_view& text);
+  void WriteInvalidModule(const ScriptModule* module, string_view text);
   void WriteCommands(Script* script);
 
   MemoryStream json_stream_;
@@ -135,7 +135,7 @@ void BinaryWriterSpec::WriteSeparator() {
   json_stream_.Writef(", ");
 }
 
-void BinaryWriterSpec::WriteEscapedString(const string_view& s) {
+void BinaryWriterSpec::WriteEscapedString(string_view s) {
   json_stream_.WriteChar('"');
   for (size_t i = 0; i < s.length(); ++i) {
     uint8_t c = s[i];
@@ -302,8 +302,7 @@ void BinaryWriterSpec::WriteActionResultType(Script* script,
   json_stream_.Writef("]");
 }
 
-void BinaryWriterSpec::WriteModule(const string_view& filename,
-                                   const Module* module) {
+void BinaryWriterSpec::WriteModule(string_view filename, const Module* module) {
   MemoryStream memory_stream;
   result_ = write_binary_module(&memory_stream.writer(), module,
                                 &spec_options_->write_binary_options);
@@ -311,7 +310,7 @@ void BinaryWriterSpec::WriteModule(const string_view& filename,
     result_ = memory_stream.WriteToFile(filename);
 }
 
-void BinaryWriterSpec::WriteScriptModule(const string_view& filename,
+void BinaryWriterSpec::WriteScriptModule(string_view filename,
                                          const ScriptModule* script_module) {
   switch (script_module->type) {
     case ScriptModule::Type::Text:
@@ -347,7 +346,7 @@ void BinaryWriterSpec::WriteScriptModule(const string_view& filename,
 }
 
 void BinaryWriterSpec::WriteInvalidModule(const ScriptModule* module,
-                                          const string_view& text) {
+                                          string_view text) {
   const char* extension = "";
   const char* module_type = "";
   switch (module->type) {

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -134,7 +134,7 @@ static void write_i64_leb128(Stream* stream, int64_t value, const char* desc) {
 #undef LEB128_LOOP_UNTIL
 
 void write_str(Stream* stream,
-               const string_view& s,
+               string_view s,
                const char* desc,
                PrintChars print_chars) {
   write_u32_leb128(stream, s.length(), "string length");
@@ -157,9 +157,7 @@ void write_limits(Stream* stream, const Limits* limits) {
     write_u32_leb128(stream, limits->max, "limits: max");
 }
 
-void write_debug_name(Stream* stream,
-                      const string_view& name,
-                      const char* desc) {
+void write_debug_name(Stream* stream, string_view name, const char* desc) {
   string_view stripped_name = name;
   if (!stripped_name.empty()) {
     // Strip leading $ from name

--- a/src/binary-writer.h
+++ b/src/binary-writer.h
@@ -55,7 +55,7 @@ Offset write_fixed_u32_leb128_raw(uint8_t* data, uint8_t* end, uint32_t value);
 void write_type(Stream* stream, Type type);
 
 void write_str(Stream* stream,
-               const string_view& s,
+               string_view s,
                const char* desc,
                PrintChars print_chars = PrintChars::No);
 

--- a/src/binding-hash.h
+++ b/src/binding-hash.h
@@ -54,7 +54,7 @@ class BindingHash : public std::unordered_multimap<std::string, Binding> {
     return iter != end() ? iter->second.index : kInvalidIndex;
   }
 
-  Index FindIndex(const string_view& name) const {
+  Index FindIndex(string_view name) const {
     return FindIndex(name.to_string());
   }
 

--- a/src/common.h
+++ b/src/common.h
@@ -286,7 +286,7 @@ inline std::string string_slice_to_string(const StringSlice& ss) {
   return std::string(ss.start, ss.length);
 }
 
-inline StringSlice string_view_to_string_slice(const string_view& view) {
+inline StringSlice string_view_to_string_slice(string_view view) {
   StringSlice ss;
   ss.start = view.data();
   ss.length = view.length();

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -74,7 +74,7 @@ bool FuncSignature::operator==(const FuncSignature& rhs) const {
   return param_types == rhs.param_types && result_types == rhs.result_types;
 }
 
-const Export* Module::GetExport(const string_view& name) const {
+const Export* Module::GetExport(string_view name) const {
   Index index = export_bindings.FindIndex(name);
   if (index >= exports.size())
     return nullptr;
@@ -236,7 +236,7 @@ FuncType* Module::AppendImplicitFuncType(const Location& loc,
 Var::Var(Index index, const Location& loc)
     : loc(loc), type_(VarType::Index), index_(index) {}
 
-Var::Var(const string_view& name, const Location& loc)
+Var::Var(string_view name, const Location& loc)
     : loc(loc), type_(VarType::Name), name_(name) {}
 
 Var::Var(Var&& rhs) : Var(kInvalidIndex) {
@@ -283,7 +283,7 @@ void Var::set_name(std::string&& name) {
   new (&name_) std::string(std::move(name));
 }
 
-void Var::set_name(const string_view& name) {
+void Var::set_name(string_view name) {
   set_name(name.to_string());
 }
 

--- a/src/ir.h
+++ b/src/ir.h
@@ -40,7 +40,7 @@ enum class VarType {
 
 struct Var {
   explicit Var(Index index = kInvalidIndex, const Location& loc = Location());
-  explicit Var(const string_view& name, const Location& loc = Location());
+  explicit Var(string_view name, const Location& loc = Location());
   Var(Var&&);
   Var(const Var&);
   Var& operator =(const Var&);
@@ -56,7 +56,7 @@ struct Var {
 
   void set_index(Index);
   void set_name(std::string&&);
-  void set_name(const string_view&);
+  void set_name(string_view);
 
   Location loc;
 
@@ -292,8 +292,7 @@ typedef LoadStoreExpr<ExprType::Store> StoreExpr;
 struct Exception {
   Exception() = default;
   Exception(const TypeVector& sig) : sig(sig) {}
-  Exception(const string_view& name, const TypeVector& sig)
-      : name(name), sig(sig) {}
+  Exception(string_view name, const TypeVector& sig) : name(name), sig(sig) {}
 
   std::string name;
   TypeVector sig;
@@ -584,7 +583,7 @@ struct Module {
   Index GetGlobalIndex(const Var&) const;
   const Global* GetGlobal(const Var&) const;
   Global* GetGlobal(const Var&);
-  const Export* GetExport(const string_view&) const;
+  const Export* GetExport(string_view) const;
   Exception* GetExcept(const Var&) const;
   Index GetExceptIndex(const Var&) const;
 
@@ -746,7 +745,7 @@ typedef ActionCommandBase<CommandType::AssertReturnArithmeticNan>
 
 class RegisterCommand : public CommandMixin<CommandType::Register> {
  public:
-  RegisterCommand(const string_view& module_name, const Var& var)
+  RegisterCommand(string_view module_name, const Var& var)
       : module_name(module_name), var(var) {}
 
   std::string module_name;
@@ -769,7 +768,7 @@ class AssertReturnCommand : public CommandMixin<CommandType::AssertReturn> {
 template <CommandType TypeEnum>
 class AssertTrapCommandBase : public CommandMixin<TypeEnum> {
  public:
-  AssertTrapCommandBase(Action* action, const string_view& text)
+  AssertTrapCommandBase(Action* action, string_view text)
       : action(action), text(text) {}
   ~AssertTrapCommandBase() {
     delete action;
@@ -786,7 +785,7 @@ typedef AssertTrapCommandBase<CommandType::AssertExhaustion>
 template <CommandType TypeEnum>
 class AssertModuleCommand : public CommandMixin<TypeEnum> {
  public:
-  AssertModuleCommand(ScriptModule* module, const string_view& text)
+  AssertModuleCommand(ScriptModule* module, string_view text)
       : module(module), text(text) {}
   ~AssertModuleCommand() { delete module; }
 

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -114,7 +114,7 @@ void Stream::WriteMemoryDump(const void* start,
 
 MemoryStream::MemoryStream() : Stream(&writer_) {}
 
-FileStream::FileStream(const string_view& filename)
+FileStream::FileStream(string_view filename)
     : Stream(&writer_), writer_(filename) {}
 
 FileStream::FileStream(FILE* file) : Stream(&writer_), writer_(file) {}

--- a/src/stream.h
+++ b/src/stream.h
@@ -130,7 +130,7 @@ class MemoryStream : public Stream {
     return writer_.ReleaseOutputBuffer();
   }
 
-  Result WriteToFile(const string_view& filename) {
+  Result WriteToFile(string_view filename) {
     return writer_.output_buffer().WriteToFile(filename);
   }
 
@@ -140,7 +140,7 @@ class MemoryStream : public Stream {
 
 class FileStream : public Stream {
  public:
-  explicit FileStream(const string_view& filename);
+  explicit FileStream(string_view filename);
   explicit FileStream(FILE*);
 
   FileWriter& writer() { return writer_; }

--- a/src/test-string-view.cc
+++ b/src/test-string-view.cc
@@ -25,7 +25,7 @@ using namespace wabt;
 
 namespace {
 
-void assert_string_view_eq(const char* s, const string_view& sv) {
+void assert_string_view_eq(const char* s, string_view sv) {
   size_t len = std::strlen(s);
   ASSERT_EQ(len, sv.size());
   for (size_t i = 0; i < len; ++i) {

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -115,12 +115,10 @@ class WatWriter {
   void WriteCloseNewline();
   void WriteCloseSpace();
   void WriteString(const std::string& str, NextChar next_char);
-  void WriteName(const string_view& str, NextChar next_char);
-  void WriteNameOrIndex(const string_view& str,
-                        Index index,
-                        NextChar next_char);
+  void WriteName(string_view str, NextChar next_char);
+  void WriteNameOrIndex(string_view str, Index index, NextChar next_char);
   void WriteQuotedData(const void* data, size_t length);
-  void WriteQuotedString(const string_view& str, NextChar next_char);
+  void WriteQuotedString(string_view str, NextChar next_char);
   void WriteVar(const Var* var, NextChar next_char);
   void WriteBrVar(const Var* var, NextChar next_char);
   void WriteType(Type type, NextChar next_char);
@@ -305,14 +303,14 @@ void WatWriter::WriteString(const std::string& str, NextChar next_char) {
   WritePuts(str.c_str(), next_char);
 }
 
-void WatWriter::WriteName(const string_view& str, NextChar next_char) {
+void WatWriter::WriteName(string_view str, NextChar next_char) {
   // Debug names must begin with a $ for for wast file to be valid
   assert(!str.empty() && str.front() == '$');
   WriteDataWithNextChar(str.data(), str.length());
   next_char_ = next_char;
 }
 
-void WatWriter::WriteNameOrIndex(const string_view& str,
+void WatWriter::WriteNameOrIndex(string_view str,
                                  Index index,
                                  NextChar next_char) {
   if (!str.empty())
@@ -340,7 +338,7 @@ void WatWriter::WriteQuotedData(const void* data, size_t length) {
   next_char_ = NextChar::Space;
 }
 
-void WatWriter::WriteQuotedString(const string_view& str, NextChar next_char) {
+void WatWriter::WriteQuotedString(string_view str, NextChar next_char) {
   WriteQuotedData(str.data(), str.length());
   next_char_ = next_char;
 }

--- a/src/writer.cc
+++ b/src/writer.cc
@@ -28,7 +28,7 @@
 
 namespace wabt {
 
-Result OutputBuffer::WriteToFile(const string_view& filename) const {
+Result OutputBuffer::WriteToFile(string_view filename) const {
   std::string filename_str = filename.to_string();
   FILE* file = fopen(filename_str.c_str(), "wb");
   if (!file) {
@@ -95,7 +95,7 @@ Result MemoryWriter::MoveData(size_t dst_offset,
 FileWriter::FileWriter(FILE* file)
     : file_(file), offset_(0), should_close_(false) {}
 
-FileWriter::FileWriter(const string_view& filename)
+FileWriter::FileWriter(string_view filename)
     : file_(nullptr), offset_(0), should_close_(false) {
   std::string filename_str = filename.to_string();
   file_ = fopen(filename_str.c_str(), "wb");

--- a/src/writer.h
+++ b/src/writer.h
@@ -27,7 +27,7 @@
 namespace wabt {
 
 struct OutputBuffer {
-  Result WriteToFile(const string_view& filename) const;
+  Result WriteToFile(string_view filename) const;
 
   size_t size() const { return data.size(); }
 
@@ -62,7 +62,7 @@ class FileWriter : public Writer {
   WABT_DISALLOW_COPY_AND_ASSIGN(FileWriter);
 
  public:
-  explicit FileWriter(const string_view& filename);
+  explicit FileWriter(string_view filename);
   explicit FileWriter(FILE* file);
   FileWriter(FileWriter&&);
   FileWriter& operator=(FileWriter&&);


### PR DESCRIPTION
It's a value type, so it should be passed by value, just like int, etc.
For x64-clang linux ABI, it seems to be passed in two registers rather
than requiring indirection, so may be faster too.