### PR TITLE
Rename read_file -> ReadFile; now returns vector

### DIFF
--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -288,8 +288,8 @@ Result read_binary_linker(LinkerInputBinary* input_info, LinkOptions* options) {
   ReadBinaryOptions read_options;
   read_options.read_debug_names = true;
   read_options.log_stream = options->log_stream;
-  return read_binary(input_info->data.data(), input_info->data.size(), &reader,
-                     &read_options);
+  return read_binary(DataOrNull(input_info->data), input_info->data.size(),
+                     &reader, &read_options);
 }
 
 }  // namespace link

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -185,8 +185,9 @@ Result BinaryReaderLinker::BeginSection(BinarySection section_code,
 
   if (sec->section_code != BinarySection::Custom &&
       sec->section_code != BinarySection::Start) {
-    size_t bytes_read = read_u32_leb128(
-        &binary_->data[sec->offset], &binary_->data[binary_->size], &sec->count);
+    size_t bytes_read =
+        read_u32_leb128(&binary_->data[sec->offset],
+                        &binary_->data[binary_->data.size()], &sec->count);
     if (bytes_read == 0)
       WABT_FATAL("error reading section element count\n");
     sec->payload_offset = sec->offset + bytes_read;
@@ -287,7 +288,7 @@ Result read_binary_linker(LinkerInputBinary* input_info, LinkOptions* options) {
   ReadBinaryOptions read_options;
   read_options.read_debug_names = true;
   read_options.log_stream = options->log_stream;
-  return read_binary(input_info->data, input_info->size, &reader,
+  return read_binary(input_info->data.data(), input_info->data.size(), &reader,
                      &read_options);
 }
 

--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -185,9 +185,10 @@ Result BinaryReaderLinker::BeginSection(BinarySection section_code,
 
   if (sec->section_code != BinarySection::Custom &&
       sec->section_code != BinarySection::Start) {
-    size_t bytes_read =
-        read_u32_leb128(&binary_->data[sec->offset],
-                        &binary_->data[binary_->data.size()], &sec->count);
+    const uint8_t* start = &binary_->data[sec->offset];
+    // Must point to one-past-the-end, but we can't dereference end().
+    const uint8_t* end = &binary_->data.back() + 1;
+    size_t bytes_read = read_u32_leb128(start, end, &sec->count);
     if (bytes_read == 0)
       WABT_FATAL("error reading section element count\n");
     sec->payload_offset = sec->offset + bytes_read;

--- a/src/common.cc
+++ b/src/common.cc
@@ -80,7 +80,7 @@ void destroy_string_slice(StringSlice* str) {
   delete [] str->start;
 }
 
-Result read_file(const char* filename, char** out_data, size_t* out_size) {
+Result ReadFile(const char* filename, std::vector<uint8_t>* out_data) {
   FILE* infile = fopen(filename, "rb");
   if (!infile) {
     const char format[] = "unable to read file %s";
@@ -92,28 +92,30 @@ Result read_file(const char* filename, char** out_data, size_t* out_size) {
 
   if (fseek(infile, 0, SEEK_END) < 0) {
     perror("fseek to end failed");
+    fclose(infile);
     return Result::Error;
   }
 
   long size = ftell(infile);
   if (size < 0) {
     perror("ftell failed");
+    fclose(infile);
     return Result::Error;
   }
 
   if (fseek(infile, 0, SEEK_SET) < 0) {
     perror("fseek to beginning failed");
+    fclose(infile);
     return Result::Error;
   }
 
-  char* data = new char [size];
-  if (size != 0 && fread(data, size, 1, infile) != 1) {
+  out_data->resize(size);
+  if (size != 0 && fread(out_data->data(), size, 1, infile) != 1) {
     perror("fread failed");
+    fclose(infile);
     return Result::Error;
   }
 
-  *out_data = data;
-  *out_size = size;
   fclose(infile);
   return Result::Ok;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -122,6 +122,15 @@ void Destruct(T& placement) {
   placement.~T();
 }
 
+// Calls data() on vector, string, etc. but will return nullptr if the
+// container is empty.
+// TODO(binji): this should probably be removed when there is a more direct way
+// to represent a memory slice (e.g. something similar to GSL's span)
+template <typename T>
+typename T::value_type* DataOrNull(T& container) {
+  return container.empty() ? nullptr : container.data();
+}
+
 inline bool Succeeded(Result result) { return result == Result::Ok; }
 inline bool Failed(Result result) { return result == Result::Error; }
 

--- a/src/common.h
+++ b/src/common.h
@@ -292,7 +292,6 @@ bool string_slice_eq_cstr(const StringSlice* s1, const char* s2);
 StringSlice string_slice_from_cstr(const char* string);
 bool string_slice_is_empty(const StringSlice*);
 void destroy_string_slice(StringSlice*);
-Result read_file(const char* filename, char** out_data, size_t* out_size);
 
 inline std::string string_slice_to_string(const StringSlice& ss) {
   return std::string(ss.start, ss.length);
@@ -304,6 +303,8 @@ inline StringSlice string_view_to_string_slice(string_view view) {
   ss.length = view.length();
   return ss;
 }
+
+Result ReadFile(const char* filename, std::vector<uint8_t>* out_data);
 
 void init_stdio();
 

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -305,9 +305,9 @@ static wabt::Result read_module(const char* module_filename,
 
   result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
-    result = read_binary_interpreter(env, file_data.data(), file_data.size(),
-                                     &s_read_binary_options, error_handler,
-                                     out_module);
+    result = read_binary_interpreter(env, DataOrNull(file_data),
+                                     file_data.size(), &s_read_binary_options,
+                                     error_handler, out_module);
 
     if (Succeeded(result)) {
       if (s_verbose)

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -299,21 +299,20 @@ static wabt::Result read_module(const char* module_filename,
                                 ErrorHandler* error_handler,
                                 DefinedModule** out_module) {
   wabt::Result result;
-  char* data;
-  size_t size;
+  std::vector<uint8_t> file_data;
 
   *out_module = nullptr;
 
-  result = read_file(module_filename, &data, &size);
+  result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
-    result = read_binary_interpreter(env, data, size, &s_read_binary_options,
-                                     error_handler, out_module);
+    result = read_binary_interpreter(env, file_data.data(), file_data.size(),
+                                     &s_read_binary_options, error_handler,
+                                     out_module);
 
     if (Succeeded(result)) {
       if (s_verbose)
         env->DisassembleModule(s_stdout_stream.get(), *out_module);
     }
-    delete[] data;
   }
   return result;
 }
@@ -468,8 +467,6 @@ struct Context {
   Context()
       : thread(&env, s_thread_options),
         last_module(nullptr),
-        json_data(nullptr),
-        json_data_size(0),
         json_offset(0),
         has_prev_loc(0),
         command_line_number(0),
@@ -481,8 +478,7 @@ struct Context {
   DefinedModule* last_module;
 
   /* Parsing info */
-  char* json_data;
-  size_t json_data_size;
+  std::vector<uint8_t> json_data;
   std::string source_filename;
   size_t json_offset;
   Location loc;
@@ -541,7 +537,7 @@ static void putback_char(Context* ctx) {
 }
 
 static int read_char(Context* ctx) {
-  if (ctx->json_offset >= ctx->json_data_size)
+  if (ctx->json_offset >= ctx->json_data.size())
     return -1;
   ctx->prev_loc = ctx->loc;
   char c = ctx->json_data[ctx->json_offset++];
@@ -1463,10 +1459,6 @@ static wabt::Result parse_commands(Context* ctx) {
   return wabt::Result::Ok;
 }
 
-static void destroy_context(Context* ctx) {
-  delete[] ctx->json_data;
-}
-
 static wabt::Result read_and_run_spec_json(const char* spec_json_filename) {
   Context ctx;
   ctx.loc.filename = spec_json_filename;
@@ -1474,18 +1466,12 @@ static wabt::Result read_and_run_spec_json(const char* spec_json_filename) {
   ctx.loc.first_column = 1;
   init_environment(&ctx.env);
 
-  char* data;
-  size_t size;
-  wabt::Result result = read_file(spec_json_filename, &data, &size);
+  wabt::Result result = ReadFile(spec_json_filename, &ctx.json_data);
   if (Failed(result))
     return wabt::Result::Error;
 
-  ctx.json_data = data;
-  ctx.json_data_size = size;
-
   result = parse_commands(&ctx);
   printf("%d/%d tests passed.\n", ctx.passed, ctx.total);
-  destroy_context(&ctx);
   return result;
 }
 

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -94,11 +94,9 @@ Section::~Section() {
 }
 
 LinkerInputBinary::LinkerInputBinary(const char* filename,
-                                     uint8_t* data,
-                                     size_t size)
+                                     const std::vector<uint8_t>& data)
     : filename(filename),
       data(data),
-      size(size),
       active_function_imports(0),
       active_global_imports(0),
       type_index_offset(0),
@@ -108,10 +106,6 @@ LinkerInputBinary::LinkerInputBinary(const char* filename,
       memory_page_count(0),
       memory_page_offset(0),
       table_elem_count(0) {}
-
-LinkerInputBinary::~LinkerInputBinary() {
-  delete[] data;
-}
 
 bool LinkerInputBinary::IsFunctionImport(Index index) {
   assert(IsValidFunctionIndex(index));
@@ -803,13 +797,12 @@ int ProgramMain(int argc, char** argv) {
   for (size_t i = 0; i < s_infiles.size(); i++) {
     const std::string& input_filename = s_infiles[i];
     LOG_DEBUG("reading file: %s\n", input_filename.c_str());
-    char* data;
-    size_t size;
-    result = read_file(input_filename.c_str(), &data, &size);
+    std::vector<uint8_t> file_data;
+    result = ReadFile(input_filename.c_str(), &file_data);
     if (Failed(result))
       return result != Result::Ok;
-    LinkerInputBinary* b = new LinkerInputBinary(
-        input_filename.c_str(), reinterpret_cast<uint8_t*>(data), size);
+    LinkerInputBinary* b =
+        new LinkerInputBinary(input_filename.c_str(), file_data);
     context.inputs.emplace_back(b);
     LinkOptions options = { NULL };
     if (s_debug)

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -79,7 +79,7 @@ Result dump_file(const char* filename) {
   if (Failed(result))
     return result;
 
-  uint8_t* data = file_data.data();
+  uint8_t* data = DataOrNull(file_data);
   size_t size = file_data.size();
 
   // Perform serveral passed over the binary in order to print out different

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -218,13 +218,11 @@ int ProgramMain(int argc, char** argv) {
   init_stdio();
   parse_options(argc, argv);
 
-  char* data;
-  size_t size;
-  Result result = read_file(s_infile, &data, &size);
+  std::vector<uint8_t> file_data;
+  Result result = ReadFile(s_infile, &file_data);
   if (Failed(result)) {
     const char* input_name = s_infile ? s_infile : "stdin";
     ERROR("Unable to parse: %s", input_name);
-    delete[] data;
   }
   FILE* out = stdout;
   if (s_outfile) {
@@ -235,7 +233,8 @@ int ProgramMain(int argc, char** argv) {
   }
   if (Succeeded(result)) {
     OpcntData opcnt_data;
-    result = read_binary_opcnt(data, size, &s_read_binary_options, &opcnt_data);
+    result = read_binary_opcnt(file_data.data(), file_data.size(),
+                               &s_read_binary_options, &opcnt_data);
     if (Succeeded(result)) {
       display_sorted_int_counter_vector(
           out, "Opcode counts:", opcnt_data.opcode_vec, opcode_counter_gt,
@@ -260,7 +259,6 @@ int ProgramMain(int argc, char** argv) {
           display_intmax, display_intmax, Opcode::I32Store_Opcode.GetName());
     }
   }
-  delete[] data;
   return result != Result::Ok;
 }
 

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -233,7 +233,7 @@ int ProgramMain(int argc, char** argv) {
   }
   if (Succeeded(result)) {
     OpcntData opcnt_data;
-    result = read_binary_opcnt(file_data.data(), file_data.size(),
+    result = read_binary_opcnt(DataOrNull(file_data), file_data.size(),
                                &s_read_binary_options, &opcnt_data);
     if (Succeeded(result)) {
       display_sorted_int_counter_vector(

--- a/src/tools/wasm2wast.cc
+++ b/src/tools/wasm2wast.cc
@@ -101,14 +101,14 @@ int ProgramMain(int argc, char** argv) {
   init_stdio();
   parse_options(argc, argv);
 
-  char* data;
-  size_t size;
-  result = read_file(s_infile.c_str(), &data, &size);
+  std::vector<uint8_t> file_data;
+  result = ReadFile(s_infile.c_str(), &file_data);
   if (Succeeded(result)) {
     ErrorHandlerFile error_handler(Location::Type::Binary);
     Module module;
-    result = read_binary_ir(s_infile.c_str(), data, size,
-                            &s_read_binary_options, &error_handler, &module);
+    result =
+        read_binary_ir(s_infile.c_str(), file_data.data(), file_data.size(),
+                       &s_read_binary_options, &error_handler, &module);
     if (Succeeded(result)) {
       if (Succeeded(result) && s_validate) {
         WastLexer* lexer = nullptr;
@@ -131,7 +131,6 @@ int ProgramMain(int argc, char** argv) {
         result = write_wat(&writer, &module, &s_write_wat_options);
       }
     }
-    delete[] data;
   }
   return result != Result::Ok;
 }

--- a/src/tools/wasm2wast.cc
+++ b/src/tools/wasm2wast.cc
@@ -106,9 +106,9 @@ int ProgramMain(int argc, char** argv) {
   if (Succeeded(result)) {
     ErrorHandlerFile error_handler(Location::Type::Binary);
     Module module;
-    result =
-        read_binary_ir(s_infile.c_str(), file_data.data(), file_data.size(),
-                       &s_read_binary_options, &error_handler, &module);
+    result = read_binary_ir(s_infile.c_str(), DataOrNull(file_data),
+                            file_data.size(), &s_read_binary_options,
+                            &error_handler, &module);
     if (Succeeded(result)) {
       if (Succeeded(result) && s_validate) {
         WastLexer* lexer = nullptr;

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -101,8 +101,7 @@ typedef std::vector<Section*> SectionPtrVector;
 class LinkerInputBinary {
  public:
   WABT_DISALLOW_COPY_AND_ASSIGN(LinkerInputBinary);
-  LinkerInputBinary(const char* filename, uint8_t* data, size_t size);
-  ~LinkerInputBinary();
+  LinkerInputBinary(const char* filename, const std::vector<uint8_t>& data);
 
   Index RelocateFuncIndex(Index findex);
   Index RelocateTypeIndex(Index index);
@@ -113,8 +112,7 @@ class LinkerInputBinary {
   bool IsInactiveFunctionImport(Index index);
 
   const char* filename;
-  uint8_t* data;
-  size_t size;
+  std::vector<uint8_t> data;
   std::vector<std::unique_ptr<Section>> sections;
   std::vector<Export> exports;
 


### PR DESCRIPTION
It would be nicer to have the various read_* functions not take a void*,
size_t pair either, but that's work for another PR (perhaps introducing
a span-like API?)

I've also been considering having ReadFile return a wrapper object
instead, so this could just mmap the file.

Fixes #570.