### PR TITLE
Remove uses of StringSlice from wasm-link

### DIFF
--- a/src/binary-reader-linker.cc
+++ b/src/binary-reader-linker.cc
@@ -135,8 +135,8 @@ Result BinaryReaderLinker::OnImportFunc(Index import_index,
                                         Index sig_index) {
   binary_->function_imports.emplace_back();
   FunctionImport* import = &binary_->function_imports.back();
-  import->module_name = string_view_to_string_slice(module_name);
-  import->name = string_view_to_string_slice(field_name);
+  import->module_name = module_name.to_string();
+  import->name = field_name.to_string();
   import->sig_index = sig_index;
   import->active = true;
   binary_->active_function_imports++;
@@ -151,8 +151,8 @@ Result BinaryReaderLinker::OnImportGlobal(Index import_index,
                                           bool mutable_) {
   binary_->global_imports.emplace_back();
   GlobalImport* import = &binary_->global_imports.back();
-  import->module_name = string_view_to_string_slice(module_name);
-  import->name = string_view_to_string_slice(field_name);
+  import->module_name = module_name.to_string();
+  import->name = field_name.to_string();
   import->type = type;
   import->mutable_ = mutable_;
   binary_->active_global_imports++;
@@ -264,7 +264,7 @@ Result BinaryReaderLinker::OnExport(Index index,
   }
   binary_->exports.emplace_back();
   Export* export_ = &binary_->exports.back();
-  export_->name = string_view_to_string_slice(name);
+  export_->name = name.to_string();
   export_->kind = kind;
   export_->index = item_index;
   return Result::Ok;

--- a/src/wasm-link.h
+++ b/src/wasm-link.h
@@ -29,8 +29,8 @@ namespace link {
 class LinkerInputBinary;
 
 struct FunctionImport {
-  StringSlice module_name;
-  StringSlice name;
+  std::string module_name;
+  std::string name;
   Index sig_index;
   bool active; /* Is this import present in the linked binary */
   Index relocated_function_index;
@@ -39,8 +39,8 @@ struct FunctionImport {
 };
 
 struct GlobalImport {
-  StringSlice module_name;
-  StringSlice name;
+  std::string module_name;
+  std::string name;
   Type type;
   bool mutable_;
 };
@@ -54,13 +54,8 @@ struct DataSegment {
 
 struct Export {
   ExternalKind kind;
-  StringSlice name;
+  std::string name;
   Index index;
-};
-
-struct SectionDataCustom {
-  /* Reference to string data stored in the containing InputBinary */
-  StringSlice name;
 };
 
 struct Section {
@@ -83,8 +78,6 @@ struct Section {
   Index count;
 
   union {
-    /* CUSTOM section data */
-    SectionDataCustom custom;
     /* DATA section data */
     std::vector<DataSegment>* data_segments;
     /* MEMORY section data */


### PR DESCRIPTION
Also remove SectionDataCustom from wasm-link.h; it doesn't seem to be
used.