### PR TITLE
Add MoveAndDelete helper function to parser

### DIFF
--- a/src/prebuilt/wast-parser-gen.cc
+++ b/src/prebuilt/wast-parser-gen.cc
@@ -163,26 +163,22 @@
 
 namespace wabt {
 
-static bool is_power_of_two(uint32_t x) {
+static bool IsPowerOfTwo(uint32_t x) {
   return x && ((x & (x - 1)) == 0);
 }
 
-static Result parse_const(Type type,
-                          LiteralType literal_type,
-                          const char* s,
-                          const char* end,
-                          Const* out);
+Result ParseConst(Type type, const Literal& literal, Const* out);
 
-static void reverse_bindings(TypeVector*, BindingHash*);
+static void ReverseBindings(TypeVector*, BindingHash*);
 
-static bool is_empty_signature(const FuncSignature* sig);
+static bool IsEmptySignature(const FuncSignature* sig);
 
-static void check_import_ordering(Location* loc,
-                                  WastLexer* lexer,
-                                  WastParser* parser,
-                                  Module* module,
-                                  const ModuleFieldList&);
-static void append_module_fields(Module*, ModuleFieldList*);
+static void CheckImportOrdering(Location* loc,
+                                WastLexer* lexer,
+                                WastParser* parser,
+                                Module* module,
+                                const ModuleFieldList&);
+static void AppendModuleFields(Module*, ModuleFieldList&&);
 
 class BinaryErrorHandlerModule : public ErrorHandler {
  public:
@@ -263,12 +259,30 @@ void RemoveEscapes(const TextVector& texts, OutputIter out) {
     RemoveEscapes(text, out);
 }
 
+template <typename T>
+T MoveAndDelete(T* ptr) {
+  T result = std::move(*ptr);
+  delete ptr;
+  return result;
+}
+
+template <typename T, typename U>
+void PrependAndDelete(T& dest, U* source) {
+  dest.insert(dest.begin(), std::begin(*source), std::end(*source));
+  delete source;
+}
+
+template <typename T, typename U>
+void AppendAndDelete(T& dest, U* source) {
+  dest.insert(dest.end(), std::begin(*source), std::end(*source));
+  delete source;
+}
 
 #define wabt_wast_parser_lex(...) lexer->GetToken(__VA_ARGS__, parser)
 #define wabt_wast_parser_error wast_parser_error
 
 
-#line 272 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
+#line 286 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:339  */
 
 # ifndef YY_NULLPTR
 #  if defined __cplusplus && 201103L <= __cplusplus
@@ -423,7 +437,7 @@ int wabt_wast_parser_parse (::wabt::WastLexer* lexer, ::wabt::WastParser* parser
 
 /* Copy the second part of user declarations.  */
 
-#line 427 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
+#line 441 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:358  */
 
 #ifdef short
 # undef short
@@ -730,28 +744,28 @@ static const yytype_uint8 yytranslate[] =
   /* YYRLINE[YYN] -- Source line where rule number YYN was defined.  */
 static const yytype_uint16 yyrline[] =
 {
-       0,   317,   317,   321,   327,   328,   332,   341,   342,   348,
-     351,   356,   364,   368,   369,   374,   383,   384,   392,   398,
-     404,   409,   416,   422,   433,   436,   439,   445,   448,   453,
-     454,   461,   462,   465,   469,   470,   474,   475,   492,   493,
-     509,   513,   517,   521,   524,   527,   530,   533,   537,   541,
-     545,   548,   552,   556,   560,   564,   568,   572,   576,   579,
-     582,   593,   596,   599,   602,   605,   608,   611,   615,   622,
-     629,   636,   643,   652,   662,   665,   670,   677,   685,   693,
-     694,   698,   703,   710,   714,   719,   726,   733,   739,   749,
-     755,   765,   768,   774,   779,   787,   794,   797,   804,   810,
-     818,   825,   833,   843,   848,   854,   860,   861,   868,   869,
-     876,   881,   888,   895,   910,   917,   920,   929,   935,   944,
-     951,   952,   958,   968,   969,   978,   985,   986,   992,  1002,
-    1003,  1012,  1019,  1024,  1029,  1040,  1043,  1047,  1057,  1069,
-    1084,  1087,  1093,  1099,  1119,  1129,  1141,  1156,  1159,  1165,
-    1171,  1194,  1209,  1215,  1221,  1232,  1242,  1251,  1258,  1265,
-    1272,  1280,  1291,  1301,  1307,  1313,  1319,  1325,  1333,  1342,
-    1353,  1359,  1370,  1377,  1378,  1379,  1380,  1381,  1382,  1383,
-    1384,  1385,  1386,  1387,  1391,  1392,  1396,  1402,  1411,  1431,
-    1438,  1441,  1447,  1465,  1473,  1484,  1496,  1508,  1512,  1516,
-    1520,  1524,  1527,  1530,  1533,  1537,  1544,  1547,  1548,  1551,
-    1560,  1564,  1571,  1582,  1583,  1590,  1593,  1656,  1665
+       0,   331,   331,   335,   341,   342,   346,   355,   356,   362,
+     365,   370,   378,   382,   383,   387,   396,   397,   404,   410,
+     416,   421,   428,   434,   445,   448,   451,   457,   460,   465,
+     466,   472,   473,   476,   480,   481,   485,   486,   503,   504,
+     520,   524,   528,   532,   535,   538,   541,   544,   547,   550,
+     553,   556,   559,   562,   565,   568,   571,   574,   577,   580,
+     583,   593,   596,   599,   602,   605,   608,   611,   614,   620,
+     626,   632,   638,   645,   654,   657,   661,   667,   673,   680,
+     681,   685,   690,   697,   701,   706,   712,   718,   723,   732,
+     737,   746,   749,   755,   760,   768,   774,   777,   782,   787,
+     793,   799,   805,   814,   819,   825,   831,   832,   838,   839,
+     845,   850,   855,   862,   876,   882,   885,   893,   899,   908,
+     915,   916,   920,   929,   930,   937,   944,   945,   949,   958,
+     959,   966,   973,   977,   981,   992,   995,   999,  1006,  1016,
+    1030,  1033,  1039,  1045,  1064,  1071,  1081,  1095,  1098,  1104,
+    1110,  1132,  1146,  1151,  1157,  1168,  1176,  1183,  1189,  1195,
+    1201,  1209,  1218,  1226,  1231,  1236,  1241,  1246,  1253,  1261,
+    1271,  1276,  1285,  1291,  1292,  1293,  1294,  1295,  1296,  1297,
+    1298,  1299,  1300,  1301,  1305,  1306,  1310,  1315,  1323,  1343,
+    1350,  1353,  1359,  1376,  1382,  1391,  1400,  1410,  1413,  1416,
+    1419,  1422,  1425,  1428,  1431,  1434,  1440,  1443,  1444,  1447,
+    1454,  1458,  1465,  1475,  1476,  1483,  1486,  1548,  1557
 };
 #endif
 
@@ -1782,369 +1796,369 @@ yydestruct (const char *yymsg, int yytype, YYSTYPE *yyvaluep, YYLTYPE *yylocatio
   switch (yytype)
     {
           case 83: /* text_list  */
-#line 301 "src/wast-parser.y" /* yacc.c:1257  */
+#line 315 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).texts); }
-#line 1788 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1802 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 84: /* text_list_opt  */
-#line 301 "src/wast-parser.y" /* yacc.c:1257  */
+#line 315 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).texts); }
-#line 1794 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1808 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 85: /* quoted_text  */
-#line 300 "src/wast-parser.y" /* yacc.c:1257  */
+#line 314 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).string); }
-#line 1800 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1814 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 86: /* value_type_list  */
-#line 302 "src/wast-parser.y" /* yacc.c:1257  */
+#line 316 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1806 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1820 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 88: /* global_type  */
-#line 294 "src/wast-parser.y" /* yacc.c:1257  */
+#line 308 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).global); }
-#line 1812 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1826 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 89: /* func_type  */
-#line 293 "src/wast-parser.y" /* yacc.c:1257  */
+#line 307 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1818 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1832 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 90: /* func_sig  */
-#line 293 "src/wast-parser.y" /* yacc.c:1257  */
+#line 307 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1824 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1838 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 91: /* func_sig_result  */
-#line 293 "src/wast-parser.y" /* yacc.c:1257  */
+#line 307 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func_sig); }
-#line 1830 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1844 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 93: /* memory_sig  */
-#line 296 "src/wast-parser.y" /* yacc.c:1257  */
+#line 310 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).memory); }
-#line 1836 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1850 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 95: /* type_use  */
-#line 303 "src/wast-parser.y" /* yacc.c:1257  */
+#line 317 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 1842 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1856 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 98: /* var  */
-#line 303 "src/wast-parser.y" /* yacc.c:1257  */
+#line 317 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 1848 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1862 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 99: /* var_list  */
-#line 304 "src/wast-parser.y" /* yacc.c:1257  */
+#line 318 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).vars); }
-#line 1854 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1868 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 100: /* bind_var_opt  */
-#line 300 "src/wast-parser.y" /* yacc.c:1257  */
+#line 314 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).string); }
-#line 1860 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1874 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 101: /* bind_var  */
-#line 300 "src/wast-parser.y" /* yacc.c:1257  */
+#line 314 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).string); }
-#line 1866 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1880 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 102: /* labeling_opt  */
-#line 300 "src/wast-parser.y" /* yacc.c:1257  */
+#line 314 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).string); }
-#line 1872 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1886 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 105: /* instr  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1878 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1892 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 106: /* plain_instr  */
-#line 289 "src/wast-parser.y" /* yacc.c:1257  */
+#line 303 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1884 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1898 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 107: /* block_instr  */
-#line 289 "src/wast-parser.y" /* yacc.c:1257  */
+#line 303 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr); }
-#line 1890 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1904 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 108: /* block_sig  */
-#line 302 "src/wast-parser.y" /* yacc.c:1257  */
+#line 316 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).types); }
-#line 1896 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1910 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 109: /* block  */
-#line 284 "src/wast-parser.y" /* yacc.c:1257  */
+#line 298 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).block); }
-#line 1902 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1916 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 114: /* expr  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1908 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1922 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 115: /* expr1  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1914 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1928 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 119: /* if_block  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1920 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1934 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 120: /* if_  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1926 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1940 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 124: /* instr_list  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1932 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1946 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 125: /* expr_list  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1938 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1952 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 126: /* const_expr  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 1944 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1958 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 129: /* func  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 1950 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1964 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 130: /* func_fields  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 1956 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1970 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 131: /* func_fields_import  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1962 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1976 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 132: /* func_fields_import1  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1968 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1982 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 133: /* func_fields_import_result  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1974 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1988 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 134: /* func_fields_body  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1980 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 1994 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 135: /* func_fields_body1  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1986 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2000 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 136: /* func_result_body  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1992 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2006 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 137: /* func_body  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 1998 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2012 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 138: /* func_body1  */
-#line 292 "src/wast-parser.y" /* yacc.c:1257  */
+#line 306 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).func); }
-#line 2004 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2018 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 139: /* offset  */
-#line 290 "src/wast-parser.y" /* yacc.c:1257  */
+#line 304 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).expr_list); }
-#line 2010 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2024 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 141: /* table  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2016 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2030 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 142: /* table_fields  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2022 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2036 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 144: /* memory  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2028 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2042 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 145: /* memory_fields  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2034 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2048 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 146: /* global  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2040 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2054 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 147: /* global_fields  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2046 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2060 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 148: /* import_desc  */
-#line 295 "src/wast-parser.y" /* yacc.c:1257  */
+#line 309 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 2052 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2066 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 150: /* inline_import  */
-#line 295 "src/wast-parser.y" /* yacc.c:1257  */
+#line 309 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).import); }
-#line 2058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2072 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 151: /* export_desc  */
-#line 288 "src/wast-parser.y" /* yacc.c:1257  */
+#line 302 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 2064 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2078 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 153: /* inline_export  */
-#line 288 "src/wast-parser.y" /* yacc.c:1257  */
+#line 302 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).export_); }
-#line 2070 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2084 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 156: /* module_field  */
-#line 291 "src/wast-parser.y" /* yacc.c:1257  */
+#line 305 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module_fields); }
-#line 2076 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2090 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 157: /* module_fields_opt  */
-#line 297 "src/wast-parser.y" /* yacc.c:1257  */
+#line 311 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2082 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2096 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 158: /* module_fields  */
-#line 297 "src/wast-parser.y" /* yacc.c:1257  */
+#line 311 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2088 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2102 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 159: /* module  */
-#line 297 "src/wast-parser.y" /* yacc.c:1257  */
+#line 311 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2094 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2108 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 160: /* inline_module  */
-#line 297 "src/wast-parser.y" /* yacc.c:1257  */
+#line 311 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).module); }
-#line 2100 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2114 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 161: /* script_var_opt  */
-#line 303 "src/wast-parser.y" /* yacc.c:1257  */
+#line 317 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).var); }
-#line 2106 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2120 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 162: /* script_module  */
-#line 298 "src/wast-parser.y" /* yacc.c:1257  */
+#line 312 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script_module); }
-#line 2112 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2126 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 163: /* action  */
-#line 283 "src/wast-parser.y" /* yacc.c:1257  */
+#line 297 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).action); }
-#line 2118 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2132 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 164: /* assertion  */
-#line 285 "src/wast-parser.y" /* yacc.c:1257  */
+#line 299 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 2124 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2138 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 165: /* cmd  */
-#line 285 "src/wast-parser.y" /* yacc.c:1257  */
+#line 299 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).command); }
-#line 2130 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2144 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 166: /* cmd_list  */
-#line 286 "src/wast-parser.y" /* yacc.c:1257  */
+#line 300 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).commands); }
-#line 2136 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2150 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 168: /* const_list  */
-#line 287 "src/wast-parser.y" /* yacc.c:1257  */
+#line 301 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).consts); }
-#line 2142 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2156 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
     case 169: /* script  */
-#line 299 "src/wast-parser.y" /* yacc.c:1257  */
+#line 313 "src/wast-parser.y" /* yacc.c:1257  */
       { delete ((*yyvaluep).script); }
-#line 2148 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
+#line 2162 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1257  */
         break;
 
 
@@ -2436,168 +2450,166 @@ yyreduce:
   switch (yyn)
     {
         case 2:
-#line 317 "src/wast-parser.y" /* yacc.c:1646  */
+#line 331 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.texts) = new TextVector();
       (yyval.texts)->emplace_back((yyvsp[0].t_text).to_string());
     }
-#line 2445 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2459 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 3:
-#line 321 "src/wast-parser.y" /* yacc.c:1646  */
+#line 335 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.texts) = (yyvsp[-1].texts);
       (yyval.texts)->emplace_back((yyvsp[0].t_text).to_string());
     }
-#line 2454 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2468 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 4:
-#line 327 "src/wast-parser.y" /* yacc.c:1646  */
+#line 341 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.texts) = new TextVector(); }
-#line 2460 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2474 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 6:
-#line 332 "src/wast-parser.y" /* yacc.c:1646  */
+#line 346 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.string) = new std::string();
       RemoveEscapes((yyvsp[0].t_text).to_string_view(), std::back_inserter(*(yyval.string)));
     }
-#line 2469 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2483 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 7:
-#line 341 "src/wast-parser.y" /* yacc.c:1646  */
+#line 355 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = new TypeVector(); }
-#line 2475 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2489 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 8:
-#line 342 "src/wast-parser.y" /* yacc.c:1646  */
+#line 356 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.types) = (yyvsp[-1].types);
       (yyval.types)->push_back((yyvsp[0].t_type));
     }
-#line 2484 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2498 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 9:
-#line 348 "src/wast-parser.y" /* yacc.c:1646  */
+#line 362 "src/wast-parser.y" /* yacc.c:1646  */
     {}
-#line 2490 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2504 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 10:
-#line 351 "src/wast-parser.y" /* yacc.c:1646  */
+#line 365 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[0].t_type);
       (yyval.global)->mutable_ = false;
     }
-#line 2500 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2514 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 11:
-#line 356 "src/wast-parser.y" /* yacc.c:1646  */
+#line 370 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.global) = new Global();
       (yyval.global)->type = (yyvsp[-1].t_type);
       (yyval.global)->mutable_ = true;
     }
-#line 2510 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2524 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 12:
-#line 364 "src/wast-parser.y" /* yacc.c:1646  */
+#line 378 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = (yyvsp[-1].func_sig); }
-#line 2516 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2530 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 14:
-#line 369 "src/wast-parser.y" /* yacc.c:1646  */
+#line 383 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
-      (yyval.func_sig)->param_types.insert((yyval.func_sig)->param_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
+      PrependAndDelete((yyval.func_sig)->param_types, (yyvsp[-2].types));
     }
-#line 2526 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2539 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 15:
-#line 374 "src/wast-parser.y" /* yacc.c:1646  */
+#line 387 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
       (yyval.func_sig)->param_types.insert((yyval.func_sig)->param_types.begin(), (yyvsp[-2].t_type));
       // Ignore bind_var.
       delete (yyvsp[-3].string);
     }
-#line 2537 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2550 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 16:
-#line 383 "src/wast-parser.y" /* yacc.c:1646  */
+#line 396 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func_sig) = new FuncSignature(); }
-#line 2543 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2556 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 17:
-#line 384 "src/wast-parser.y" /* yacc.c:1646  */
+#line 397 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func_sig) = (yyvsp[0].func_sig);
-      (yyval.func_sig)->result_types.insert((yyval.func_sig)->result_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
+      PrependAndDelete((yyval.func_sig)->result_types, (yyvsp[-2].types));
     }
-#line 2553 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2565 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 18:
-#line 392 "src/wast-parser.y" /* yacc.c:1646  */
+#line 404 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.table) = new Table();
       (yyval.table)->elem_limits = (yyvsp[-1].limits);
     }
-#line 2562 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2574 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 19:
-#line 398 "src/wast-parser.y" /* yacc.c:1646  */
+#line 410 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.memory) = new Memory();
       (yyval.memory)->page_limits = (yyvsp[0].limits);
     }
-#line 2571 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2583 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 20:
-#line 404 "src/wast-parser.y" /* yacc.c:1646  */
+#line 416 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = false;
       (yyval.limits).initial = (yyvsp[0].u64);
       (yyval.limits).max = 0;
     }
-#line 2581 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2593 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 21:
-#line 409 "src/wast-parser.y" /* yacc.c:1646  */
+#line 421 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.limits).has_max = true;
       (yyval.limits).initial = (yyvsp[-1].u64);
       (yyval.limits).max = (yyvsp[0].u64);
     }
-#line 2591 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2603 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 22:
-#line 416 "src/wast-parser.y" /* yacc.c:1646  */
+#line 428 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.var) = (yyvsp[-1].var); }
-#line 2597 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2609 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 23:
-#line 422 "src/wast-parser.y" /* yacc.c:1646  */
+#line 434 "src/wast-parser.y" /* yacc.c:1646  */
     {
       string_view sv = (yyvsp[0].t_literal).text.to_string_view();
       if (Failed(parse_uint64(sv.begin(), sv.end(), &(yyval.u64)))) {
@@ -2606,91 +2618,90 @@ yyreduce:
                           WABT_PRINTF_STRING_VIEW_ARG(sv));
       }
     }
-#line 2610 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2622 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 24:
-#line 433 "src/wast-parser.y" /* yacc.c:1646  */
+#line 445 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal) = new Literal((yyvsp[0].t_literal));
     }
-#line 2618 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2630 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 25:
-#line 436 "src/wast-parser.y" /* yacc.c:1646  */
+#line 448 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal) = new Literal((yyvsp[0].t_literal));
     }
-#line 2626 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2638 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 26:
-#line 439 "src/wast-parser.y" /* yacc.c:1646  */
+#line 451 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.literal) = new Literal((yyvsp[0].t_literal));
     }
-#line 2634 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2646 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 27:
-#line 445 "src/wast-parser.y" /* yacc.c:1646  */
+#line 457 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var((yyvsp[0].u64), (yylsp[0]));
     }
-#line 2642 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2654 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 28:
-#line 448 "src/wast-parser.y" /* yacc.c:1646  */
+#line 460 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var((yyvsp[0].t_text).to_string_view(), (yylsp[0]));
     }
-#line 2650 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2662 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 29:
-#line 453 "src/wast-parser.y" /* yacc.c:1646  */
+#line 465 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.vars) = new VarVector(); }
-#line 2656 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2668 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 30:
-#line 454 "src/wast-parser.y" /* yacc.c:1646  */
+#line 466 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.vars) = (yyvsp[-1].vars);
-      (yyval.vars)->emplace_back(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.vars)->emplace_back(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2666 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2677 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 31:
-#line 461 "src/wast-parser.y" /* yacc.c:1646  */
+#line 472 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.string) = new std::string(); }
-#line 2672 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2683 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 33:
-#line 465 "src/wast-parser.y" /* yacc.c:1646  */
+#line 476 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.string) = new std::string((yyvsp[0].t_text).to_string()); }
-#line 2678 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2689 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 34:
-#line 469 "src/wast-parser.y" /* yacc.c:1646  */
+#line 480 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.string) = new std::string(); }
-#line 2684 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2695 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 36:
-#line 474 "src/wast-parser.y" /* yacc.c:1646  */
+#line 485 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u64) = 0; }
-#line 2690 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2701 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 37:
-#line 475 "src/wast-parser.y" /* yacc.c:1646  */
+#line 486 "src/wast-parser.y" /* yacc.c:1646  */
     {
       uint64_t offset64;
       string_view sv = (yyvsp[0].t_text).to_string_view();
@@ -2706,17 +2717,17 @@ yyreduce:
       }
       (yyval.u64) = static_cast<uint32_t>(offset64);
     }
-#line 2710 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2721 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 38:
-#line 492 "src/wast-parser.y" /* yacc.c:1646  */
+#line 503 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.u32) = USE_NATURAL_ALIGNMENT; }
-#line 2716 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2727 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 39:
-#line 493 "src/wast-parser.y" /* yacc.c:1646  */
+#line 504 "src/wast-parser.y" /* yacc.c:1646  */
     {
       string_view sv = (yyvsp[0].t_text).to_string_view();
       if (Failed(parse_int32(sv.begin(), sv.end(), &(yyval.u32),
@@ -2726,188 +2737,177 @@ yyreduce:
                           WABT_PRINTF_STRING_VIEW_ARG(sv));
       }
 
-      if ((yyval.u32) != WABT_USE_NATURAL_ALIGNMENT && !is_power_of_two((yyval.u32))) {
+      if ((yyval.u32) != WABT_USE_NATURAL_ALIGNMENT && !IsPowerOfTwo((yyval.u32))) {
         wast_parser_error(&(yylsp[0]), lexer, parser, "alignment must be power-of-two");
       }
     }
-#line 2734 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2745 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 40:
-#line 509 "src/wast-parser.y" /* yacc.c:1646  */
+#line 520 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = new ExprList((yyvsp[0].expr));
       (yyval.expr_list)->back().loc = (yylsp[0]);
     }
-#line 2743 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2754 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 41:
-#line 513 "src/wast-parser.y" /* yacc.c:1646  */
+#line 524 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = new ExprList((yyvsp[0].expr));
       (yyval.expr_list)->back().loc = (yylsp[0]);
     }
-#line 2752 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2763 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 43:
-#line 521 "src/wast-parser.y" /* yacc.c:1646  */
+#line 532 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new UnreachableExpr();
     }
-#line 2760 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2771 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 44:
-#line 524 "src/wast-parser.y" /* yacc.c:1646  */
+#line 535 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new NopExpr();
     }
-#line 2768 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2779 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 45:
-#line 527 "src/wast-parser.y" /* yacc.c:1646  */
+#line 538 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new DropExpr();
     }
-#line 2776 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2787 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 46:
-#line 530 "src/wast-parser.y" /* yacc.c:1646  */
+#line 541 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new SelectExpr();
     }
-#line 2784 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2795 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 47:
-#line 533 "src/wast-parser.y" /* yacc.c:1646  */
+#line 544 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new BrExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new BrExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2793 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2803 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 48:
-#line 537 "src/wast-parser.y" /* yacc.c:1646  */
+#line 547 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new BrIfExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
-    }
-#line 2802 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 49:
-#line 541 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.expr) = new BrTableExpr((yyvsp[-1].vars), std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new BrIfExpr(MoveAndDelete((yyvsp[0].var)));
     }
 #line 2811 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 50:
-#line 545 "src/wast-parser.y" /* yacc.c:1646  */
+  case 49:
+#line 550 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new ReturnExpr();
+      (yyval.expr) = new BrTableExpr((yyvsp[-1].vars), MoveAndDelete((yyvsp[0].var)));
     }
 #line 2819 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 51:
-#line 548 "src/wast-parser.y" /* yacc.c:1646  */
+  case 50:
+#line 553 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new CallExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new ReturnExpr();
     }
-#line 2828 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2827 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 51:
+#line 556 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.expr) = new CallExpr(MoveAndDelete((yyvsp[0].var)));
+    }
+#line 2835 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 52:
-#line 552 "src/wast-parser.y" /* yacc.c:1646  */
+#line 559 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new CallIndirectExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new CallIndirectExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2837 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2843 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 53:
-#line 556 "src/wast-parser.y" /* yacc.c:1646  */
+#line 562 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new GetLocalExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new GetLocalExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2846 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2851 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 54:
-#line 560 "src/wast-parser.y" /* yacc.c:1646  */
+#line 565 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new SetLocalExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new SetLocalExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2855 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2859 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 55:
-#line 564 "src/wast-parser.y" /* yacc.c:1646  */
+#line 568 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new TeeLocalExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new TeeLocalExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2867 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 56:
-#line 568 "src/wast-parser.y" /* yacc.c:1646  */
+#line 571 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new GetGlobalExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new GetGlobalExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2873 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2875 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 57:
-#line 572 "src/wast-parser.y" /* yacc.c:1646  */
+#line 574 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new SetGlobalExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new SetGlobalExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2882 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2883 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 58:
-#line 576 "src/wast-parser.y" /* yacc.c:1646  */
+#line 577 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new LoadExpr((yyvsp[-2].t_opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2890 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2891 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 59:
-#line 579 "src/wast-parser.y" /* yacc.c:1646  */
+#line 580 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr) = new StoreExpr((yyvsp[-2].t_opcode), (yyvsp[0].u32), (yyvsp[-1].u64));
     }
-#line 2898 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2899 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 60:
-#line 582 "src/wast-parser.y" /* yacc.c:1646  */
+#line 583 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Const const_;
       const_.loc = (yylsp[-1]);
-      string_view sv = (yyvsp[0].literal)->text;
-      if (Failed(parse_const((yyvsp[-1].t_type), (yyvsp[0].literal)->type, sv.begin(), sv.end(), &const_))) {
+      auto literal = MoveAndDelete((yyvsp[0].literal));
+      if (Failed(ParseConst((yyvsp[-1].t_type), literal, &const_))) {
         wast_parser_error(&(yylsp[0]), lexer, parser, "invalid literal \"%s\"",
-                          (yyvsp[0].literal)->text.c_str());
+                          literal.text.c_str());
       }
-      delete (yyvsp[0].literal);
       (yyval.expr) = new ConstExpr(const_);
     }
 #line 2914 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
@@ -2964,719 +2964,665 @@ yyreduce:
   case 67:
 #line 611 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new ThrowExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new ThrowExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2971 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2970 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 68:
-#line 615 "src/wast-parser.y" /* yacc.c:1646  */
+#line 614 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.expr) = new RethrowExpr(std::move(*(yyvsp[0].var)));
-      delete (yyvsp[0].var);
+      (yyval.expr) = new RethrowExpr(MoveAndDelete((yyvsp[0].var)));
     }
-#line 2980 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2978 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 69:
-#line 622 "src/wast-parser.y" /* yacc.c:1646  */
+#line 620 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new BlockExpr((yyvsp[-2].block));
-      expr->block->label = std::move(*(yyvsp[-3].string));
-      delete (yyvsp[-3].string);
+      expr->block->label = MoveAndDelete((yyvsp[-3].string));
       CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 2992 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 2989 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 70:
-#line 629 "src/wast-parser.y" /* yacc.c:1646  */
+#line 626 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new LoopExpr((yyvsp[-2].block));
-      expr->block->label = std::move(*(yyvsp[-3].string));
-      delete (yyvsp[-3].string);
+      expr->block->label = MoveAndDelete((yyvsp[-3].string));
       CHECK_END_LABEL((yylsp[0]), expr->block->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 3004 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3000 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 71:
-#line 636 "src/wast-parser.y" /* yacc.c:1646  */
+#line 632 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new IfExpr((yyvsp[-2].block));
-      expr->true_->label = std::move(*(yyvsp[-3].string));
-      delete (yyvsp[-3].string);
+      expr->true_->label = MoveAndDelete((yyvsp[-3].string));
       CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 3016 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3011 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 72:
-#line 643 "src/wast-parser.y" /* yacc.c:1646  */
+#line 638 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      auto expr = new IfExpr((yyvsp[-5].block), std::move(*(yyvsp[-2].expr_list)));
-      delete (yyvsp[-2].expr_list);
-      expr->true_->label = std::move(*(yyvsp[-6].string));
-      delete (yyvsp[-6].string);
+      auto expr = new IfExpr((yyvsp[-5].block), MoveAndDelete((yyvsp[-2].expr_list)));
+      expr->true_->label = MoveAndDelete((yyvsp[-6].string));
       CHECK_END_LABEL((yylsp[-3]), expr->true_->label, (yyvsp[-3].string));
       CHECK_END_LABEL((yylsp[0]), expr->true_->label, (yyvsp[0].string));
       (yyval.expr) = expr;
     }
-#line 3030 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3023 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 73:
-#line 652 "src/wast-parser.y" /* yacc.c:1646  */
+#line 645 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyvsp[-3].block)->label = std::move(*(yyvsp[-4].string));
-      delete (yyvsp[-4].string);
+      (yyvsp[-3].block)->label = MoveAndDelete((yyvsp[-4].string));
       (yyval.expr) = (yyvsp[-2].try_expr);
       cast<TryExpr>((yyval.expr))->block = (yyvsp[-3].block);
       CHECK_END_LABEL((yylsp[0]), (yyvsp[-3].block)->label, (yyvsp[0].string));
     }
-#line 3042 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3034 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 74:
-#line 662 "src/wast-parser.y" /* yacc.c:1646  */
+#line 654 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.types) = (yyvsp[-1].types); }
-#line 3048 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3040 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 75:
-#line 665 "src/wast-parser.y" /* yacc.c:1646  */
+#line 657 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.block) = (yyvsp[0].block);
-      (yyval.block)->sig.insert((yyval.block)->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
-      delete (yyvsp[-1].types);
+      AppendAndDelete((yyval.block)->sig, (yyvsp[-1].types));
     }
-#line 3058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3049 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 76:
-#line 670 "src/wast-parser.y" /* yacc.c:1646  */
+#line 661 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.block) = new Block(std::move(*(yyvsp[0].expr_list)));
-      delete (yyvsp[0].expr_list);
+      (yyval.block) = new Block(MoveAndDelete((yyvsp[0].expr_list)));
     }
-#line 3067 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3057 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 77:
-#line 677 "src/wast-parser.y" /* yacc.c:1646  */
+#line 667 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.catch_) = new Catch(std::move(*(yyvsp[-1].var)), std::move(*(yyvsp[0].expr_list)));
-      delete (yyvsp[-1].var);
-      delete (yyvsp[0].expr_list);
+      (yyval.catch_) = new Catch(MoveAndDelete((yyvsp[-1].var)), MoveAndDelete((yyvsp[0].expr_list)));
       (yyval.catch_)->loc = (yylsp[-2]);
     }
-#line 3078 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3066 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 78:
-#line 685 "src/wast-parser.y" /* yacc.c:1646  */
+#line 673 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.catch_) = new Catch(std::move(*(yyvsp[0].expr_list)));
-      delete (yyvsp[0].expr_list);
+      (yyval.catch_) = new Catch(MoveAndDelete((yyvsp[0].expr_list)));
       (yyval.catch_)->loc = (yylsp[-1]);
     }
-#line 3088 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3075 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 81:
-#line 698 "src/wast-parser.y" /* yacc.c:1646  */
+#line 685 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new TryExpr();
       expr->catches.push_back((yyvsp[0].catch_));
       (yyval.try_expr) = expr;
     }
-#line 3098 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3085 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 82:
-#line 703 "src/wast-parser.y" /* yacc.c:1646  */
+#line 690 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[-1].try_expr);
       cast<TryExpr>((yyval.try_expr))->catches.push_back((yyvsp[0].catch_));
     }
-#line 3107 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3094 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 83:
-#line 710 "src/wast-parser.y" /* yacc.c:1646  */
+#line 697 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = (yyvsp[-1].expr_list); }
-#line 3113 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3100 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 84:
-#line 714 "src/wast-parser.y" /* yacc.c:1646  */
+#line 701 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       (yyval.expr_list)->push_back((yyvsp[-1].expr));
       (yyvsp[-1].expr)->loc = (yylsp[-1]);
     }
-#line 3123 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3110 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 85:
-#line 719 "src/wast-parser.y" /* yacc.c:1646  */
+#line 706 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new BlockExpr((yyvsp[0].block));
-      expr->block->label = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      expr->block->label = MoveAndDelete((yyvsp[-1].string));
       expr->loc = (yylsp[-2]);
       (yyval.expr_list) = new ExprList(expr);
     }
-#line 3135 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3121 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 86:
-#line 726 "src/wast-parser.y" /* yacc.c:1646  */
+#line 712 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new LoopExpr((yyvsp[0].block));
-      expr->block->label = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      expr->block->label = MoveAndDelete((yyvsp[-1].string));
       expr->loc = (yylsp[-2]);
       (yyval.expr_list) = new ExprList(expr);
     }
-#line 3147 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3132 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 87:
-#line 733 "src/wast-parser.y" /* yacc.c:1646  */
+#line 718 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
       IfExpr* if_ = cast<IfExpr>(&(yyvsp[0].expr_list)->back());
-      if_->true_->label = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      if_->true_->label = MoveAndDelete((yyvsp[-1].string));
     }
-#line 3158 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3142 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 88:
-#line 739 "src/wast-parser.y" /* yacc.c:1646  */
+#line 723 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Block* block = (yyvsp[0].try_expr)->block;
-      block->label = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      block->label = MoveAndDelete((yyvsp[-1].string));
       (yyvsp[0].try_expr)->loc = (yylsp[-2]);
       (yyval.expr_list) = new ExprList((yyvsp[0].try_expr));
     }
-#line 3170 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3153 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 89:
-#line 749 "src/wast-parser.y" /* yacc.c:1646  */
+#line 732 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[0].try_expr);
       Block* block = (yyval.try_expr)->block;
-      block->sig.insert(block->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
-      delete (yyvsp[-1].types);
+      AppendAndDelete(block->sig, (yyvsp[-1].types));
     }
-#line 3181 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3163 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 90:
-#line 755 "src/wast-parser.y" /* yacc.c:1646  */
+#line 737 "src/wast-parser.y" /* yacc.c:1646  */
     {
       Block* block = new Block();
-      block->exprs = std::move(*(yyvsp[-1].expr_list));
-      delete (yyvsp[-1].expr_list);
+      block->exprs = MoveAndDelete((yyvsp[-1].expr_list));
       (yyval.try_expr) = (yyvsp[0].try_expr);
       (yyval.try_expr)->block = block;
     }
-#line 3193 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3174 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 91:
-#line 765 "src/wast-parser.y" /* yacc.c:1646  */
+#line 746 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = (yyvsp[-1].catch_);
     }
-#line 3201 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3182 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 92:
-#line 768 "src/wast-parser.y" /* yacc.c:1646  */
+#line 749 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.catch_) = (yyvsp[-1].catch_);
     }
-#line 3209 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3190 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 93:
-#line 774 "src/wast-parser.y" /* yacc.c:1646  */
+#line 755 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto expr = new TryExpr();
       expr->catches.push_back((yyvsp[0].catch_));
       (yyval.try_expr) = expr;
     }
-#line 3219 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3200 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 94:
-#line 779 "src/wast-parser.y" /* yacc.c:1646  */
+#line 760 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.try_expr) = (yyvsp[-1].try_expr);
       cast<TryExpr>((yyval.try_expr))->catches.push_back((yyvsp[0].catch_));
     }
-#line 3228 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3209 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 95:
-#line 787 "src/wast-parser.y" /* yacc.c:1646  */
+#line 768 "src/wast-parser.y" /* yacc.c:1646  */
     {
       IfExpr* if_ = cast<IfExpr>(&(yyvsp[0].expr_list)->back());
       (yyval.expr_list) = (yyvsp[0].expr_list);
       Block* true_ = if_->true_;
-      true_->sig.insert(true_->sig.end(), (yyvsp[-1].types)->begin(), (yyvsp[-1].types)->end());
-      delete (yyvsp[-1].types);
+      AppendAndDelete(true_->sig, (yyvsp[-1].types));
+    }
+#line 3220 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 97:
+#line 777 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      Expr* expr = new IfExpr(new Block(MoveAndDelete((yyvsp[-5].expr_list))), MoveAndDelete((yyvsp[-1].expr_list)));
+      expr->loc = (yylsp[-7]);
+      (yyval.expr_list) = new ExprList(expr);
+    }
+#line 3230 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 98:
+#line 782 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      Expr* expr = new IfExpr(new Block(MoveAndDelete((yyvsp[-1].expr_list))));
+      expr->loc = (yylsp[-3]);
+      (yyval.expr_list) = new ExprList(expr);
     }
 #line 3240 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 97:
-#line 797 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-5].expr_list))), std::move(*(yyvsp[-1].expr_list)));
-      delete (yyvsp[-5].expr_list);
-      delete (yyvsp[-1].expr_list);
-      expr->loc = (yylsp[-7]);
-      (yyval.expr_list) = new ExprList(expr);
-    }
-#line 3252 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 98:
-#line 804 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-1].expr_list))));
-      delete (yyvsp[-1].expr_list);
-      expr->loc = (yylsp[-3]);
-      (yyval.expr_list) = new ExprList(expr);
-    }
-#line 3263 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
   case 99:
-#line 810 "src/wast-parser.y" /* yacc.c:1646  */
+#line 787 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-5].expr_list))), std::move(*(yyvsp[-1].expr_list)));
-      delete (yyvsp[-5].expr_list);
-      delete (yyvsp[-1].expr_list);
+      Expr* expr = new IfExpr(new Block(MoveAndDelete((yyvsp[-5].expr_list))), MoveAndDelete((yyvsp[-1].expr_list)));
       expr->loc = (yylsp[-8]);
       (yyval.expr_list) = (yyvsp[-8].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3276 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3251 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 100:
-#line 818 "src/wast-parser.y" /* yacc.c:1646  */
+#line 793 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-1].expr_list))));
-      delete (yyvsp[-1].expr_list);
+      Expr* expr = new IfExpr(new Block(MoveAndDelete((yyvsp[-1].expr_list))));
       expr->loc = (yylsp[-4]);
       (yyval.expr_list) = (yyvsp[-4].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3288 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3262 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 101:
-#line 825 "src/wast-parser.y" /* yacc.c:1646  */
+#line 799 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[-1].expr_list))), std::move(*(yyvsp[0].expr_list)));
-      delete (yyvsp[-1].expr_list);
-      delete (yyvsp[0].expr_list);
+      Expr* expr = new IfExpr(new Block(MoveAndDelete((yyvsp[-1].expr_list))), MoveAndDelete((yyvsp[0].expr_list)));
       expr->loc = (yylsp[-2]);
       (yyval.expr_list) = (yyvsp[-2].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3301 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3273 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 102:
-#line 833 "src/wast-parser.y" /* yacc.c:1646  */
+#line 805 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      Expr* expr = new IfExpr(new Block(std::move(*(yyvsp[0].expr_list))));
-      delete (yyvsp[0].expr_list);
+      Expr* expr = new IfExpr(new Block(MoveAndDelete((yyvsp[0].expr_list))));
       expr->loc = (yylsp[-1]);
       (yyval.expr_list) = (yyvsp[-1].expr_list);
       (yyval.expr_list)->push_back(expr);
     }
-#line 3313 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3284 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 103:
-#line 843 "src/wast-parser.y" /* yacc.c:1646  */
+#line 814 "src/wast-parser.y" /* yacc.c:1646  */
     {
      CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "rethrow");
     }
-#line 3321 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3292 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 104:
-#line 848 "src/wast-parser.y" /* yacc.c:1646  */
+#line 819 "src/wast-parser.y" /* yacc.c:1646  */
     {
       CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "throw");
     }
-#line 3329 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3300 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 105:
-#line 854 "src/wast-parser.y" /* yacc.c:1646  */
+#line 825 "src/wast-parser.y" /* yacc.c:1646  */
     {
       CHECK_ALLOW_EXCEPTIONS(&(yylsp[0]), "try");
     }
-#line 3337 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3308 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 106:
-#line 860 "src/wast-parser.y" /* yacc.c:1646  */
+#line 831 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = new ExprList(); }
-#line 3343 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3314 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 107:
-#line 861 "src/wast-parser.y" /* yacc.c:1646  */
+#line 832 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
-      (yyval.expr_list)->splice((yyval.expr_list)->begin(), std::move(*(yyvsp[-1].expr_list)));
-      delete (yyvsp[-1].expr_list);
+      (yyval.expr_list)->splice((yyval.expr_list)->begin(), MoveAndDelete((yyvsp[-1].expr_list)));
     }
-#line 3353 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3323 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 108:
-#line 868 "src/wast-parser.y" /* yacc.c:1646  */
+#line 838 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.expr_list) = new ExprList(); }
-#line 3359 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3329 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 109:
-#line 869 "src/wast-parser.y" /* yacc.c:1646  */
+#line 839 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.expr_list) = (yyvsp[0].expr_list);
-      (yyval.expr_list)->splice((yyval.expr_list)->begin(), std::move(*(yyvsp[-1].expr_list)));
-      delete (yyvsp[-1].expr_list);
+      (yyval.expr_list)->splice((yyval.expr_list)->begin(), MoveAndDelete((yyvsp[-1].expr_list)));
     }
-#line 3369 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3338 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 111:
-#line 881 "src/wast-parser.y" /* yacc.c:1646  */
+#line 850 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.exception) = new Exception(*(yyvsp[-2].string), *(yyvsp[-1].types));
-      delete (yyvsp[-2].string);
-      delete (yyvsp[-1].types);
+      (yyval.exception) = new Exception(MoveAndDelete((yyvsp[-2].string)), MoveAndDelete((yyvsp[-1].types)));
     }
-#line 3379 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3346 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 112:
-#line 888 "src/wast-parser.y" /* yacc.c:1646  */
+#line 855 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_field) = new ExceptionModuleField((yyvsp[0].exception));
     }
-#line 3387 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3354 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 113:
-#line 895 "src/wast-parser.y" /* yacc.c:1646  */
+#line 862 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto func_field = dyn_cast<FuncModuleField>(main_field)) {
-        func_field->func->name = std::move(*(yyvsp[-2].string));
+        func_field->func->name = MoveAndDelete((yyvsp[-2].string));
       } else {
         cast<ImportModuleField>(main_field)->import->func->name =
-            std::move(*(yyvsp[-2].string));
+            MoveAndDelete((yyvsp[-2].string));
       }
-      delete (yyvsp[-2].string);
     }
-#line 3404 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3370 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 114:
-#line 910 "src/wast-parser.y" /* yacc.c:1646  */
+#line 876 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new FuncModuleField((yyvsp[0].func));
       field->func->decl.has_func_type = true;
-      field->func->decl.type_var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      field->func->decl.type_var = MoveAndDelete((yyvsp[-1].var));
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3416 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3381 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 115:
-#line 917 "src/wast-parser.y" /* yacc.c:1646  */
+#line 882 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = new ModuleFieldList(new FuncModuleField((yyvsp[0].func)));
     }
-#line 3424 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3389 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 116:
-#line 920 "src/wast-parser.y" /* yacc.c:1646  */
+#line 885 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-2].import), (yylsp[-2]));
       field->import->kind = ExternalKind::Func;
       field->import->func = (yyvsp[0].func);
       field->import->func->decl.has_func_type = true;
-      field->import->func->decl.type_var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      field->import->func->decl.type_var = MoveAndDelete((yyvsp[-1].var));
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3438 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3402 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 117:
-#line 929 "src/wast-parser.y" /* yacc.c:1646  */
+#line 893 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import), (yylsp[-1]));
       field->import->kind = ExternalKind::Func;
       field->import->func = (yyvsp[0].func);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3449 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3413 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 118:
-#line 935 "src/wast-parser.y" /* yacc.c:1646  */
+#line 899 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Func;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3460 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3424 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 119:
-#line 944 "src/wast-parser.y" /* yacc.c:1646  */
+#line 908 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
+      ReverseBindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
     }
-#line 3469 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3433 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 121:
-#line 952 "src/wast-parser.y" /* yacc.c:1646  */
+#line 916 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(),
-                                      (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
+      PrependAndDelete((yyval.func)->decl.sig.param_types, (yyvsp[-2].types));
     }
-#line 3480 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3442 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 122:
-#line 958 "src/wast-parser.y" /* yacc.c:1646  */
+#line 920 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->param_bindings.emplace(*(yyvsp[-3].string),
+      (yyval.func)->param_bindings.emplace(MoveAndDelete((yyvsp[-3].string)),
                                  Binding((yylsp[-3]), (yyval.func)->decl.sig.param_types.size()));
-      delete (yyvsp[-3].string);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(), (yyvsp[-2].t_type));
     }
-#line 3492 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3453 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 123:
-#line 968 "src/wast-parser.y" /* yacc.c:1646  */
+#line 929 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.func) = new Func(); }
-#line 3498 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3459 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 124:
-#line 969 "src/wast-parser.y" /* yacc.c:1646  */
+#line 930 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->decl.sig.result_types.insert((yyval.func)->decl.sig.result_types.begin(),
-                                       (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
+      PrependAndDelete((yyval.func)->decl.sig.result_types, (yyvsp[-2].types));
     }
-#line 3509 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3468 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 125:
-#line 978 "src/wast-parser.y" /* yacc.c:1646  */
+#line 937 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      reverse_bindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
+      ReverseBindings(&(yyval.func)->decl.sig.param_types, &(yyval.func)->param_bindings);
     }
-#line 3518 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3477 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 127:
-#line 986 "src/wast-parser.y" /* yacc.c:1646  */
+#line 945 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(),
-                                      (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
+      PrependAndDelete((yyval.func)->decl.sig.param_types, (yyvsp[-2].types));
     }
-#line 3529 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3486 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 128:
-#line 992 "src/wast-parser.y" /* yacc.c:1646  */
+#line 949 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->param_bindings.emplace(*(yyvsp[-3].string),
+      (yyval.func)->param_bindings.emplace(MoveAndDelete((yyvsp[-3].string)),
                                  Binding((yylsp[-3]), (yyval.func)->decl.sig.param_types.size()));
-      delete (yyvsp[-3].string);
       (yyval.func)->decl.sig.param_types.insert((yyval.func)->decl.sig.param_types.begin(), (yyvsp[-2].t_type));
     }
-#line 3541 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3497 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 130:
-#line 1003 "src/wast-parser.y" /* yacc.c:1646  */
+#line 959 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->decl.sig.result_types.insert((yyval.func)->decl.sig.result_types.begin(),
-                                       (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
+      PrependAndDelete((yyval.func)->decl.sig.result_types, (yyvsp[-2].types));
+    }
+#line 3506 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 131:
+#line 966 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.func) = (yyvsp[0].func);
+      ReverseBindings(&(yyval.func)->local_types, &(yyval.func)->local_bindings);
+    }
+#line 3515 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 132:
+#line 973 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.func) = new Func();
+      (yyval.func)->exprs = MoveAndDelete((yyvsp[0].expr_list));
+    }
+#line 3524 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 133:
+#line 977 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.func) = (yyvsp[0].func);
+      PrependAndDelete((yyval.func)->local_types, (yyvsp[-2].types));
+    }
+#line 3533 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 134:
+#line 981 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.func) = (yyvsp[0].func);
+      (yyval.func)->local_bindings.emplace(MoveAndDelete((yyvsp[-3].string)),
+                                 Binding((yylsp[-3]), (yyval.func)->local_types.size()));
+      (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].t_type));
+    }
+#line 3544 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 135:
+#line 992 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.expr_list) = (yyvsp[-1].expr_list);
     }
 #line 3552 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 131:
-#line 1012 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.func) = (yyvsp[0].func);
-      reverse_bindings(&(yyval.func)->local_types, &(yyval.func)->local_bindings);
-    }
-#line 3561 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 132:
-#line 1019 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.func) = new Func();
-      (yyval.func)->exprs = std::move(*(yyvsp[0].expr_list));
-      delete (yyvsp[0].expr_list);
-    }
-#line 3571 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 133:
-#line 1024 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].types)->begin(), (yyvsp[-2].types)->end());
-      delete (yyvsp[-2].types);
-    }
-#line 3581 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 134:
-#line 1029 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.func) = (yyvsp[0].func);
-      (yyval.func)->local_bindings.emplace(*(yyvsp[-3].string), Binding((yylsp[-3]), (yyval.func)->local_types.size()));
-      delete (yyvsp[-3].string);
-      (yyval.func)->local_types.insert((yyval.func)->local_types.begin(), (yyvsp[-2].t_type));
-    }
-#line 3592 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 135:
-#line 1040 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.expr_list) = (yyvsp[-1].expr_list);
-    }
-#line 3600 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
   case 137:
-#line 1047 "src/wast-parser.y" /* yacc.c:1646  */
+#line 999 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto elem_segment = new ElemSegment();
-      elem_segment->table_var = std::move(*(yyvsp[-3].var));
-      delete (yyvsp[-3].var);
-      elem_segment->offset = std::move(*(yyvsp[-2].expr_list));
-      delete (yyvsp[-2].expr_list);
-      elem_segment->vars = std::move(*(yyvsp[-1].vars));
-      delete (yyvsp[-1].vars);
+      elem_segment->table_var = MoveAndDelete((yyvsp[-3].var));
+      elem_segment->offset = MoveAndDelete((yyvsp[-2].expr_list));
+      elem_segment->vars = MoveAndDelete((yyvsp[-1].vars));
       (yyval.module_field) = new ElemSegmentModuleField(elem_segment, (yylsp[-4]));
     }
-#line 3615 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3564 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 138:
-#line 1057 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1006 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto elem_segment = new ElemSegment();
       elem_segment->table_var = Var(0, (yylsp[-3]));
-      elem_segment->offset = std::move(*(yyvsp[-2].expr_list));
-      delete (yyvsp[-2].expr_list);
-      elem_segment->vars = std::move(*(yyvsp[-1].vars));
-      delete (yyvsp[-1].vars);
+      elem_segment->offset = MoveAndDelete((yyvsp[-2].expr_list));
+      elem_segment->vars = MoveAndDelete((yyvsp[-1].vars));
       (yyval.module_field) = new ElemSegmentModuleField(elem_segment, (yylsp[-3]));
     }
-#line 3629 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3576 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 139:
-#line 1069 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1016 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto table_field = dyn_cast<TableModuleField>(main_field)) {
-        table_field->table->name = std::move(*(yyvsp[-2].string));
+        table_field->table->name = MoveAndDelete((yyvsp[-2].string));
       } else {
         cast<ImportModuleField>(main_field)->import->table->name =
-            std::move(*(yyvsp[-2].string));
+            MoveAndDelete((yyvsp[-2].string));
       }
-      delete (yyvsp[-2].string);
     }
-#line 3646 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3592 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 140:
-#line 1084 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1030 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = new ModuleFieldList(new TableModuleField((yyvsp[0].table)));
     }
-#line 3654 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3600 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 141:
-#line 1087 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1033 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Table;
       field->import->table = (yyvsp[0].table);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3665 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3611 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 142:
-#line 1093 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1039 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Table;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3676 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3622 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 143:
-#line 1099 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1045 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto table = new Table();
       table->elem_limits.initial = (yyvsp[-1].vars)->size();
@@ -3687,101 +3633,93 @@ yyreduce:
       elem_segment->table_var = Var(kInvalidIndex);
       elem_segment->offset.push_back(new ConstExpr(Const(Const::I32(), 0)));
       elem_segment->offset.back().loc = (yylsp[-2]);
-      elem_segment->vars = std::move(*(yyvsp[-1].vars));
-      delete (yyvsp[-1].vars);
+      elem_segment->vars = MoveAndDelete((yyvsp[-1].vars));
 
       (yyval.module_fields) = new ModuleFieldList();
       (yyval.module_fields)->push_back(new TableModuleField(table));
       (yyval.module_fields)->push_back(new ElemSegmentModuleField(elem_segment, (yylsp[-2])));
     }
-#line 3698 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3643 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 144:
-#line 1119 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1064 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto data_segment = new DataSegment();
-      data_segment->memory_var = std::move(*(yyvsp[-3].var));
-      delete (yyvsp[-3].var);
-      data_segment->offset = std::move(*(yyvsp[-2].expr_list));
-      delete (yyvsp[-2].expr_list);
-      RemoveEscapes(*(yyvsp[-1].texts), std::back_inserter(data_segment->data));
-      delete (yyvsp[-1].texts);
+      data_segment->memory_var = MoveAndDelete((yyvsp[-3].var));
+      data_segment->offset = MoveAndDelete((yyvsp[-2].expr_list));
+      RemoveEscapes(MoveAndDelete((yyvsp[-1].texts)), std::back_inserter(data_segment->data));
       (yyval.module_field) = new DataSegmentModuleField(data_segment, (yylsp[-4]));
     }
-#line 3713 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3655 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 145:
-#line 1129 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1071 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto data_segment = new DataSegment();
       data_segment->memory_var = Var(0, (yylsp[-3]));
-      data_segment->offset = std::move(*(yyvsp[-2].expr_list));
-      delete (yyvsp[-2].expr_list);
-      RemoveEscapes(*(yyvsp[-1].texts), std::back_inserter(data_segment->data));
-      delete (yyvsp[-1].texts);
+      data_segment->offset = MoveAndDelete((yyvsp[-2].expr_list));
+      RemoveEscapes(MoveAndDelete((yyvsp[-1].texts)), std::back_inserter(data_segment->data));
       (yyval.module_field) = new DataSegmentModuleField(data_segment, (yylsp[-3]));
     }
-#line 3727 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3667 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 146:
-#line 1141 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1081 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto memory_field = dyn_cast<MemoryModuleField>(main_field)) {
-        memory_field->memory->name = std::move(*(yyvsp[-2].string));
+        memory_field->memory->name = MoveAndDelete((yyvsp[-2].string));
       } else {
         cast<ImportModuleField>(main_field)->import->memory->name =
-            std::move(*(yyvsp[-2].string));
+            MoveAndDelete((yyvsp[-2].string));
       }
-      delete (yyvsp[-2].string);
     }
-#line 3744 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3683 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 147:
-#line 1156 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1095 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = new ModuleFieldList(new MemoryModuleField((yyvsp[0].memory)));
     }
-#line 3752 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3691 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 148:
-#line 1159 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1098 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Memory;
       field->import->memory = (yyvsp[0].memory);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3763 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3702 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 149:
-#line 1165 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1104 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Memory;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3774 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3713 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 150:
-#line 1171 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1110 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto data_segment = new DataSegment();
       data_segment->memory_var = Var(kInvalidIndex);
       data_segment->offset.push_back(new ConstExpr(Const(Const::I32(), 0)));
       data_segment->offset.back().loc = (yylsp[-2]);
-      RemoveEscapes(*(yyvsp[-1].texts), std::back_inserter(data_segment->data));
-      delete (yyvsp[-1].texts);
+      RemoveEscapes(MoveAndDelete((yyvsp[-1].texts)), std::back_inserter(data_segment->data));
 
       uint32_t byte_size = WABT_ALIGN_UP_TO_PAGE(data_segment->data.size());
       uint32_t page_size = WABT_BYTES_TO_PAGES(byte_size);
@@ -3795,340 +3733,314 @@ yyreduce:
       (yyval.module_fields)->push_back(new MemoryModuleField(memory));
       (yyval.module_fields)->push_back(new DataSegmentModuleField(data_segment, (yylsp[-2])));
     }
-#line 3799 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3737 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 151:
-#line 1194 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1132 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module_fields) = (yyvsp[-1].module_fields);
       ModuleField* main_field = &(yyval.module_fields)->front();
       main_field->loc = (yylsp[-3]);
       if (auto global_field = dyn_cast<GlobalModuleField>(main_field)) {
-        global_field->global->name = std::move(*(yyvsp[-2].string));
+        global_field->global->name = MoveAndDelete((yyvsp[-2].string));
       } else {
         cast<ImportModuleField>(main_field)->import->global->name =
-            std::move(*(yyvsp[-2].string));
+            MoveAndDelete((yyvsp[-2].string));
       }
-      delete (yyvsp[-2].string);
     }
-#line 3816 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3753 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 152:
-#line 1209 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1146 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new GlobalModuleField((yyvsp[-1].global));
-      field->global->init_expr = std::move(*(yyvsp[0].expr_list));
-      delete (yyvsp[0].expr_list);
+      field->global->init_expr = MoveAndDelete((yyvsp[0].expr_list));
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3827 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3763 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 153:
-#line 1215 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1151 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import));
       field->import->kind = ExternalKind::Global;
       field->import->global = (yyvsp[0].global);
       (yyval.module_fields) = new ModuleFieldList(field);
     }
-#line 3838 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3774 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 154:
-#line 1221 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1157 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-1]));
       field->export_->kind = ExternalKind::Global;
       (yyval.module_fields) = (yyvsp[0].module_fields);
       (yyval.module_fields)->push_back(field);
     }
-#line 3849 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3785 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 155:
-#line 1232 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1168 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
       (yyval.import)->func = new Func();
-      (yyval.import)->func->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      (yyval.import)->func->name = MoveAndDelete((yyvsp[-2].string));
       (yyval.import)->func->decl.has_func_type = true;
-      (yyval.import)->func->decl.type_var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      (yyval.import)->func->decl.type_var = MoveAndDelete((yyvsp[-1].var));
     }
-#line 3864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3798 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 156:
-#line 1242 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1176 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Func;
       (yyval.import)->func = new Func();
-      (yyval.import)->func->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
-      (yyval.import)->func->decl.sig = std::move(*(yyvsp[-1].func_sig));
-      delete (yyvsp[-1].func_sig);
+      (yyval.import)->func->name = MoveAndDelete((yyvsp[-2].string));
+      (yyval.import)->func->decl.sig = MoveAndDelete((yyvsp[-1].func_sig));
     }
-#line 3878 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3810 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 157:
-#line 1251 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1183 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Table;
       (yyval.import)->table = (yyvsp[-1].table);
-      (yyval.import)->table->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      (yyval.import)->table->name = MoveAndDelete((yyvsp[-2].string));
     }
-#line 3890 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3821 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 158:
-#line 1258 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1189 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Memory;
       (yyval.import)->memory = (yyvsp[-1].memory);
-      (yyval.import)->memory->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      (yyval.import)->memory->name = MoveAndDelete((yyvsp[-2].string));
     }
-#line 3902 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3832 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 159:
-#line 1265 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1195 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Global;
       (yyval.import)->global = (yyvsp[-1].global);
-      (yyval.import)->global->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      (yyval.import)->global->name = MoveAndDelete((yyvsp[-2].string));
     }
-#line 3914 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3843 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 160:
-#line 1272 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1201 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
       (yyval.import)->kind = ExternalKind::Except;
       (yyval.import)->except = (yyvsp[0].exception);
     }
-#line 3924 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3853 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 161:
-#line 1280 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1209 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ImportModuleField((yyvsp[-1].import), (yylsp[-4]));
-      field->import->module_name = std::move(*(yyvsp[-3].string));
-      delete (yyvsp[-3].string);
-      field->import->field_name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      field->import->module_name = MoveAndDelete((yyvsp[-3].string));
+      field->import->field_name = MoveAndDelete((yyvsp[-2].string));
       (yyval.module_field) = field;
     }
-#line 3937 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3864 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 162:
-#line 1291 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1218 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.import) = new Import();
-      (yyval.import)->module_name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
-      (yyval.import)->field_name = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      (yyval.import)->module_name = MoveAndDelete((yyvsp[-2].string));
+      (yyval.import)->field_name = MoveAndDelete((yyvsp[-1].string));
     }
-#line 3949 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3874 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 163:
-#line 1301 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1226 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Func;
-      (yyval.export_)->var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      (yyval.export_)->var = MoveAndDelete((yyvsp[-1].var));
     }
-#line 3960 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3884 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 164:
-#line 1307 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1231 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Table;
-      (yyval.export_)->var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      (yyval.export_)->var = MoveAndDelete((yyvsp[-1].var));
     }
-#line 3971 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3894 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 165:
-#line 1313 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1236 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Memory;
-      (yyval.export_)->var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      (yyval.export_)->var = MoveAndDelete((yyvsp[-1].var));
     }
-#line 3982 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3904 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 166:
-#line 1319 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1241 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Global;
-      (yyval.export_)->var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      (yyval.export_)->var = MoveAndDelete((yyvsp[-1].var));
     }
-#line 3993 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3914 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 167:
-#line 1325 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1246 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
       (yyval.export_)->kind = ExternalKind::Except;
-      (yyval.export_)->var = std::move(*(yyvsp[-1].var));
-      delete (yyvsp[-1].var);
+      (yyval.export_)->var = MoveAndDelete((yyvsp[-1].var));
     }
-#line 4004 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3924 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 168:
-#line 1333 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1253 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto field = new ExportModuleField((yyvsp[-1].export_), (yylsp[-3]));
-      field->export_->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      field->export_->name = MoveAndDelete((yyvsp[-2].string));
       (yyval.module_field) = field;
     }
-#line 4015 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3934 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 169:
-#line 1342 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1261 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.export_) = new Export();
-      (yyval.export_)->name = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      (yyval.export_)->name = MoveAndDelete((yyvsp[-1].string));
     }
-#line 4025 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3943 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 170:
-#line 1353 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1271 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto func_type = new FuncType();
-      func_type->sig = std::move(*(yyvsp[-1].func_sig));
-      delete (yyvsp[-1].func_sig);
+      func_type->sig = MoveAndDelete((yyvsp[-1].func_sig));
       (yyval.module_field) = new FuncTypeModuleField(func_type, (yylsp[-2]));
     }
-#line 4036 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3953 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 171:
-#line 1359 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1276 "src/wast-parser.y" /* yacc.c:1646  */
     {
       auto func_type = new FuncType();
-      func_type->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
-      func_type->sig = std::move(*(yyvsp[-1].func_sig));
-      delete (yyvsp[-1].func_sig);
+      func_type->name = MoveAndDelete((yyvsp[-2].string));
+      func_type->sig = MoveAndDelete((yyvsp[-1].func_sig));
       (yyval.module_field) = new FuncTypeModuleField(func_type, (yylsp[-3]));
     }
-#line 4049 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3964 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 172:
-#line 1370 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1285 "src/wast-parser.y" /* yacc.c:1646  */
     {
-      (yyval.module_field) = new StartModuleField(*(yyvsp[-1].var), (yylsp[-2]));
-      delete (yyvsp[-1].var);
+      (yyval.module_field) = new StartModuleField(MoveAndDelete((yyvsp[-1].var)), (yylsp[-2]));
     }
-#line 4058 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3972 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 173:
-#line 1377 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1291 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4064 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3978 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 178:
-#line 1382 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1296 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4070 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3984 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 179:
-#line 1383 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1297 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4076 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3990 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 180:
-#line 1384 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1298 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4082 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 3996 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 181:
-#line 1385 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1299 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4088 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4002 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 182:
-#line 1386 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1300 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4094 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4008 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 183:
-#line 1387 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1301 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module_fields) = new ModuleFieldList((yyvsp[0].module_field)); }
-#line 4100 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4014 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 184:
-#line 1391 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1305 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.module) = new Module(); }
-#line 4106 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4020 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 186:
-#line 1396 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1310 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = new Module();
-      check_import_ordering(&(yylsp[0]), lexer, parser, (yyval.module), *(yyvsp[0].module_fields));
-      append_module_fields((yyval.module), (yyvsp[0].module_fields));
-      delete (yyvsp[0].module_fields);
+      CheckImportOrdering(&(yylsp[0]), lexer, parser, (yyval.module), *(yyvsp[0].module_fields));
+      AppendModuleFields((yyval.module), MoveAndDelete((yyvsp[0].module_fields)));
     }
-#line 4117 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4030 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 187:
-#line 1402 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1315 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.module) = (yyvsp[-1].module);
-      check_import_ordering(&(yylsp[0]), lexer, parser, (yyval.module), *(yyvsp[0].module_fields));
-      append_module_fields((yyval.module), (yyvsp[0].module_fields));
-      delete (yyvsp[0].module_fields);
+      CheckImportOrdering(&(yylsp[0]), lexer, parser, (yyval.module), *(yyvsp[0].module_fields));
+      AppendModuleFields((yyval.module), MoveAndDelete((yyvsp[0].module_fields)));
     }
-#line 4128 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4040 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 188:
-#line 1411 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1323 "src/wast-parser.y" /* yacc.c:1646  */
     {
       if ((yyvsp[0].script_module)->type == ScriptModule::Type::Text) {
         (yyval.module) = (yyvsp[0].script_module)->text;
@@ -4146,38 +4058,37 @@ yyreduce:
       }
       delete (yyvsp[0].script_module);
     }
-#line 4150 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4062 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 190:
-#line 1438 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1350 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var(kInvalidIndex);
     }
-#line 4158 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4070 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 191:
-#line 1441 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1353 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.var) = new Var((yyvsp[0].t_text).to_string_view(), (yylsp[0]));
     }
-#line 4166 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4078 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 192:
-#line 1447 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1359 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script_module) = new ScriptModule(ScriptModule::Type::Text);
       (yyval.script_module)->text = (yyvsp[-1].module);
-      (yyval.script_module)->text->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      (yyval.script_module)->text->name = MoveAndDelete((yyvsp[-2].string));
       (yyval.script_module)->text->loc = (yylsp[-3]);
 
       // Resolve func type variables where the signature was not specified
       // explicitly.
       for (Func* func: (yyvsp[-1].module)->funcs) {
-        if (func->decl.has_func_type && is_empty_signature(&func->decl.sig)) {
+        if (func->decl.has_func_type && IsEmptySignature(&func->decl.sig)) {
           FuncType* func_type = (yyvsp[-1].module)->GetFuncType(func->decl.type_var);
           if (func_type) {
             func->decl.sig = func_type->sig;
@@ -4185,233 +4096,214 @@ yyreduce:
         }
       }
     }
-#line 4189 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4100 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 193:
-#line 1465 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1376 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script_module) = new ScriptModule(ScriptModule::Type::Binary);
-      (yyval.script_module)->binary.name = std::move(*(yyvsp[-3].string));
-      delete (yyvsp[-3].string);
+      (yyval.script_module)->binary.name = MoveAndDelete((yyvsp[-3].string));
       (yyval.script_module)->binary.loc = (yylsp[-4]);
-      RemoveEscapes(*(yyvsp[-1].texts), std::back_inserter((yyval.script_module)->binary.data));
-      delete (yyvsp[-1].texts);
+      RemoveEscapes(MoveAndDelete((yyvsp[-1].texts)), std::back_inserter((yyval.script_module)->binary.data));
     }
-#line 4202 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4111 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 194:
-#line 1473 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1382 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script_module) = new ScriptModule(ScriptModule::Type::Quoted);
-      (yyval.script_module)->quoted.name = std::move(*(yyvsp[-3].string));
-      delete (yyvsp[-3].string);
+      (yyval.script_module)->quoted.name = MoveAndDelete((yyvsp[-3].string));
       (yyval.script_module)->quoted.loc = (yylsp[-4]);
-      RemoveEscapes(*(yyvsp[-1].texts), std::back_inserter((yyval.script_module)->quoted.data));
-      delete (yyvsp[-1].texts);
+      RemoveEscapes(MoveAndDelete((yyvsp[-1].texts)), std::back_inserter((yyval.script_module)->quoted.data));
     }
-#line 4215 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4122 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 195:
-#line 1484 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1391 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-4]);
-      (yyval.action)->module_var = std::move(*(yyvsp[-3].var));
-      delete (yyvsp[-3].var);
+      (yyval.action)->module_var = MoveAndDelete((yyvsp[-3].var));
       (yyval.action)->type = ActionType::Invoke;
-      (yyval.action)->name = std::move(*(yyvsp[-2].string));
-      delete (yyvsp[-2].string);
+      (yyval.action)->name = MoveAndDelete((yyvsp[-2].string));
       (yyval.action)->invoke = new ActionInvoke();
-      (yyval.action)->invoke->args = std::move(*(yyvsp[-1].consts));
-      delete (yyvsp[-1].consts);
+      (yyval.action)->invoke->args = MoveAndDelete((yyvsp[-1].consts));
     }
-#line 4232 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4136 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 196:
-#line 1496 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1400 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.action) = new Action();
       (yyval.action)->loc = (yylsp[-3]);
-      (yyval.action)->module_var = std::move(*(yyvsp[-2].var));
-      delete (yyvsp[-2].var);
+      (yyval.action)->module_var = MoveAndDelete((yyvsp[-2].var));
       (yyval.action)->type = ActionType::Get;
-      (yyval.action)->name = std::move(*(yyvsp[-1].string));
-      delete (yyvsp[-1].string);
+      (yyval.action)->name = MoveAndDelete((yyvsp[-1].string));
+    }
+#line 4148 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 197:
+#line 1410 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertMalformedCommand((yyvsp[-2].script_module), MoveAndDelete((yyvsp[-1].string)));
+    }
+#line 4156 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 198:
+#line 1413 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertInvalidCommand((yyvsp[-2].script_module), MoveAndDelete((yyvsp[-1].string)));
+    }
+#line 4164 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 199:
+#line 1416 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertUnlinkableCommand((yyvsp[-2].script_module), MoveAndDelete((yyvsp[-1].string)));
+    }
+#line 4172 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 200:
+#line 1419 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertUninstantiableCommand((yyvsp[-2].script_module), MoveAndDelete((yyvsp[-1].string)));
+    }
+#line 4180 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 201:
+#line 1422 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertReturnCommand((yyvsp[-2].action), (yyvsp[-1].consts));
+    }
+#line 4188 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 202:
+#line 1425 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertReturnCanonicalNanCommand((yyvsp[-1].action));
+    }
+#line 4196 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 203:
+#line 1428 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertReturnArithmeticNanCommand((yyvsp[-1].action));
+    }
+#line 4204 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 204:
+#line 1431 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertTrapCommand((yyvsp[-2].action), MoveAndDelete((yyvsp[-1].string)));
+    }
+#line 4212 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 205:
+#line 1434 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new AssertExhaustionCommand((yyvsp[-2].action), MoveAndDelete((yyvsp[-1].string)));
+    }
+#line 4220 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 206:
+#line 1440 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new ActionCommand((yyvsp[0].action));
+    }
+#line 4228 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 208:
+#line 1444 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      (yyval.command) = new ModuleCommand((yyvsp[0].module));
+    }
+#line 4236 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+    break;
+
+  case 209:
+#line 1447 "src/wast-parser.y" /* yacc.c:1646  */
+    {
+      auto* command = new RegisterCommand(MoveAndDelete((yyvsp[-2].string)), MoveAndDelete((yyvsp[-1].var)));
+      command->var.loc = (yylsp[-1]);
+      (yyval.command) = command;
     }
 #line 4246 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
-  case 197:
-#line 1508 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertMalformedCommand((yyvsp[-2].script_module), std::move(*(yyvsp[-1].string)));
-      delete (yyvsp[-1].string);
-    }
-#line 4255 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 198:
-#line 1512 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertInvalidCommand((yyvsp[-2].script_module), std::move(*(yyvsp[-1].string)));
-      delete (yyvsp[-1].string);
-    }
-#line 4264 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 199:
-#line 1516 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertUnlinkableCommand((yyvsp[-2].script_module), std::move(*(yyvsp[-1].string)));
-      delete (yyvsp[-1].string);
-    }
-#line 4273 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 200:
-#line 1520 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertUninstantiableCommand((yyvsp[-2].script_module), std::move(*(yyvsp[-1].string)));
-      delete (yyvsp[-1].string);
-    }
-#line 4282 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 201:
-#line 1524 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertReturnCommand((yyvsp[-2].action), (yyvsp[-1].consts));
-    }
-#line 4290 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 202:
-#line 1527 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertReturnCanonicalNanCommand((yyvsp[-1].action));
-    }
-#line 4298 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 203:
-#line 1530 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertReturnArithmeticNanCommand((yyvsp[-1].action));
-    }
-#line 4306 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 204:
-#line 1533 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertTrapCommand((yyvsp[-2].action), std::move(*(yyvsp[-1].string)));
-      delete (yyvsp[-1].string);
-    }
-#line 4315 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 205:
-#line 1537 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new AssertExhaustionCommand((yyvsp[-2].action), std::move(*(yyvsp[-1].string)));
-      delete (yyvsp[-1].string);
-    }
-#line 4324 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 206:
-#line 1544 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new ActionCommand((yyvsp[0].action));
-    }
-#line 4332 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 208:
-#line 1548 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      (yyval.command) = new ModuleCommand((yyvsp[0].module));
-    }
-#line 4340 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
-  case 209:
-#line 1551 "src/wast-parser.y" /* yacc.c:1646  */
-    {
-      auto* command = new RegisterCommand(std::move(*(yyvsp[-2].string)), *(yyvsp[-1].var));
-      delete (yyvsp[-2].string);
-      delete (yyvsp[-1].var);
-      command->var.loc = (yylsp[-1]);
-      (yyval.command) = command;
-    }
-#line 4352 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
-    break;
-
   case 210:
-#line 1560 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1454 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = new CommandPtrVector();
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4361 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4255 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 211:
-#line 1564 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1458 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.commands) = (yyvsp[-1].commands);
       (yyval.commands)->emplace_back((yyvsp[0].command));
     }
-#line 4370 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4264 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 212:
-#line 1571 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1465 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.const_).loc = (yylsp[-2]);
-      string_view sv = (yyvsp[-1].literal)->text;
-      if (Failed(parse_const((yyvsp[-2].t_type), (yyvsp[-1].literal)->type, sv.begin(), sv.end(), &(yyval.const_)))) {
+      auto literal = MoveAndDelete((yyvsp[-1].literal));
+      if (Failed(ParseConst((yyvsp[-2].t_type), literal, &(yyval.const_)))) {
         wast_parser_error(&(yylsp[-1]), lexer, parser, "invalid literal \"%s\"",
-                          (yyvsp[-1].literal)->text.c_str());
+                          literal.text.c_str());
       }
-      delete (yyvsp[-1].literal);
     }
-#line 4384 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4277 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 213:
-#line 1582 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1475 "src/wast-parser.y" /* yacc.c:1646  */
     { (yyval.consts) = new ConstVector(); }
-#line 4390 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4283 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 214:
-#line 1583 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1476 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.consts) = (yyvsp[-1].consts);
       (yyval.consts)->push_back((yyvsp[0].const_));
     }
-#line 4399 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4292 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 215:
-#line 1590 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1483 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
     }
-#line 4407 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4300 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 216:
-#line 1593 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1486 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
-      (yyval.script)->commands = std::move(*(yyvsp[0].commands));
-      delete (yyvsp[0].commands);
+      (yyval.script)->commands = MoveAndDelete((yyvsp[0].commands));
 
       int last_module_index = -1;
       for (size_t i = 0; i < (yyval.script)->commands.size(); ++i) {
@@ -4471,26 +4363,26 @@ yyreduce:
         }
       }
     }
-#line 4475 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4367 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 217:
-#line 1656 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1548 "src/wast-parser.y" /* yacc.c:1646  */
     {
       (yyval.script) = new Script();
       (yyval.script)->commands.emplace_back(new ModuleCommand((yyvsp[0].module)));
     }
-#line 4484 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4376 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
   case 218:
-#line 1665 "src/wast-parser.y" /* yacc.c:1646  */
+#line 1557 "src/wast-parser.y" /* yacc.c:1646  */
     { parser->script = (yyvsp[0].script); }
-#line 4490 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4382 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
     break;
 
 
-#line 4494 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
+#line 4386 "src/prebuilt/wast-parser-gen.cc" /* yacc.c:1646  */
       default: break;
     }
   /* User semantic actions sometimes alter yychar, and that requires
@@ -4725,14 +4617,14 @@ yyreturn:
 #endif
   return yyresult;
 }
-#line 1668 "src/wast-parser.y" /* yacc.c:1906  */
+#line 1560 "src/wast-parser.y" /* yacc.c:1906  */
 
 
-Result parse_const(Type type,
-                   LiteralType literal_type,
-                   const char* s,
-                   const char* end,
-                   Const* out) {
+Result ParseConst(Type type, const Literal& literal, Const* out) {
+  string_view sv = literal.text;
+  const char* s = sv.begin();
+  const char* end = sv.end();
+
   out->type = type;
   switch (type) {
     case Type::I32:
@@ -4740,9 +4632,9 @@ Result parse_const(Type type,
     case Type::I64:
       return parse_int64(s, end, &out->u64, ParseIntType::SignedAndUnsigned);
     case Type::F32:
-      return parse_float(literal_type, s, end, &out->f32_bits);
+      return parse_float(literal.type, s, end, &out->f32_bits);
     case Type::F64:
-      return parse_double(literal_type, s, end, &out->f64_bits);
+      return parse_double(literal.type, s, end, &out->f64_bits);
     default:
       assert(0);
       break;
@@ -4750,13 +4642,13 @@ Result parse_const(Type type,
   return Result::Error;
 }
 
-void reverse_bindings(TypeVector* types, BindingHash* bindings) {
+void ReverseBindings(TypeVector* types, BindingHash* bindings) {
   for (auto& pair : *bindings) {
     pair.second.index = types->size() - pair.second.index - 1;
   }
 }
 
-bool is_empty_signature(const FuncSignature* sig) {
+bool IsEmptySignature(const FuncSignature* sig) {
   return sig->result_types.empty() && sig->param_types.empty();
 }
 
@@ -4774,8 +4666,8 @@ void append_implicit_func_declaration(Location* loc,
   }
 }
 
-void check_import_ordering(Location* loc, WastLexer* lexer, WastParser* parser,
-                           Module* module, const ModuleFieldList& fields) {
+void CheckImportOrdering(Location* loc, WastLexer* lexer, WastParser* parser,
+                         Module* module, const ModuleFieldList& fields) {
   for (const ModuleField& field: fields) {
     if (field.type == ModuleFieldType::Import) {
       if (module->funcs.size() != module->num_func_imports ||
@@ -4791,11 +4683,11 @@ void check_import_ordering(Location* loc, WastLexer* lexer, WastParser* parser,
   }
 }
 
-void append_module_fields(Module* module, ModuleFieldList* fields) {
-  ModuleField* main_field = &fields->front();
+void AppendModuleFields(Module* module, ModuleFieldList&& fields) {
+  ModuleField* main_field = &fields.front();
   Index main_index = kInvalidIndex;
 
-  for (ModuleField& field : *fields) {
+  for (ModuleField& field : fields) {
     std::string* name = nullptr;
     BindingHash* bindings = nullptr;
     Index index = kInvalidIndex;
@@ -4953,7 +4845,7 @@ void append_module_fields(Module* module, ModuleFieldList* fields) {
     }
   }
 
-  module->fields.splice(module->fields.end(), *fields);
+  module->fields.splice(module->fields.end(), fields);
 }
 
 Result parse_wast(WastLexer* lexer, Script** out_script,


### PR DESCRIPTION
This combines the std::move + delete behavior that was used throughout
wast-parser.y in a cleaner way.

I've also renamed the other helper functions to MixedCase, and added the
PrependAndDelete and AppendAndDelete helper functions too.