### PR TITLE
Refactor wasm-opcodecnt.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
-      compiler: clang
       # ubsan requires a newer clang for blacklisting to work.
       addons:
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: c
 before_install:
+  - eval "${MATRIX_EVAL}"
   - scripts/travis-before-install.sh
 script:
   - scripts/travis-build.sh
@@ -37,6 +38,7 @@ matrix:
     - os: linux
       dist: trusty
       sudo: required
+      compiler: clang
       # ubsan requires a newer clang for blacklisting to work.
       addons:
         apt:
@@ -45,7 +47,8 @@ matrix:
             - llvm-toolchain-precise-3.6
           packages:
             - clang-3.6
-      env: SANITIZER=ubsan CC=clang-3.6 CC=clang++-3.6
+          env:
+            - SANITIZER=ubsan MATRIX_EVAL="CC=clang-3.6 && CC=clang++-3.6"
     - os: osx
       compiler: clang
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,15 @@ matrix:
       dist: trusty
       sudo: required
       compiler: clang
-      env: SANITIZER=ubsan
+      # ubsan requires a newer clang for blacklisting to work.
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+            - llvm-toolchain-precise-3.6
+          packages:
+            - clang-3.6
+      env: SANITIZER=ubsan CC=clang-3.6 CC=clang++-3.6
     - os: osx
       compiler: clang
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -182,7 +182,9 @@ endfunction()
 SANITIZER(USE_ASAN "-fsanitize=address")
 SANITIZER(USE_MSAN "-fsanitize=memory")
 SANITIZER(USE_LSAN "-fsanitize=leak")
-SANITIZER(USE_UBSAN "-fsanitize=undefined -fno-sanitize-recover")
+
+set(UBSAN_BLACKLIST ${WABT_SOURCE_DIR}/ubsan.blacklist)
+SANITIZER(USE_UBSAN "-fsanitize=undefined -fno-sanitize-recover -fsanitize-blacklist=${UBSAN_BLACKLIST}")
 
 find_package(BISON)
 if (RUN_BISON AND BISON_FOUND AND (NOT ${BISON_VERSION} VERSION_LESS "3.0"))

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -49,6 +49,10 @@ OpcodeInfo::OpcodeInfo(Opcode opcode, Kind kind, T* data, size_t count, T extra)
 
 template <typename T>
 std::pair<const T*, size_t> OpcodeInfo::GetDataArray() const {
+  if (data_.empty()) {
+    return std::pair<const T*, size_t>(nullptr, 0);
+  }
+
   assert(data_.size() % sizeof(T) == 0);
   return std::make_pair(reinterpret_cast<const T*>(data_.data()),
                         data_.size() / sizeof(T));

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -24,100 +24,234 @@
 
 #include "binary-reader-nop.h"
 #include "common.h"
+#include "stream.h"
 
 namespace wabt {
+
+OpcodeInfo::OpcodeInfo(Opcode opcode, Kind kind)
+    : opcode_(opcode), kind_(kind) {}
+
+template <typename T>
+OpcodeInfo::OpcodeInfo(Opcode opcode, Kind kind, T* data, size_t count)
+    : OpcodeInfo(opcode, kind) {
+  data_.resize(sizeof(T) * count);
+  memcpy(data_.data(), data, data_.size());
+}
+
+template <typename T>
+OpcodeInfo::OpcodeInfo(Opcode opcode, Kind kind, T* data, size_t count, T extra)
+    : OpcodeInfo(opcode, kind, data, count) {
+  data_.resize(data_.size() + sizeof(T));
+  memcpy(data_.data() + data_.size() - sizeof(T), &extra, sizeof(T));
+}
+
+template <typename T>
+std::pair<const T*, size_t> OpcodeInfo::GetDataArray() const {
+  assert(data_.size() % sizeof(T) == 0);
+  return std::make_pair(reinterpret_cast<const T*>(data_.data()),
+                        data_.size() / sizeof(T));
+}
+
+template <typename T>
+const T* OpcodeInfo::GetData(size_t expected_size) const {
+  auto pair = GetDataArray<T>();
+  assert(pair.second == expected_size);
+  return pair.first;
+}
+
+template <typename T, typename F>
+void OpcodeInfo::WriteArray(Stream& stream, F&& write_func) {
+  auto pair = GetDataArray<T>();
+  for (size_t i = 0; i < pair.second; ++i) {
+    // Write an initial space (to separate from the opcode name) first, then
+    // comma-separate.
+    stream.Writef("%s", i == 0 ? " " : ", ");
+    write_func(pair.first[i]);
+  }
+}
+
+void OpcodeInfo::Write(Stream& stream) {
+  stream.Writef("%s", opcode_.GetName());
+
+  switch (kind_) {
+    case Kind::Bare:
+      break;
+
+    case Kind::Uint32:
+      stream.Writef(" %u", *GetData<uint32_t>());
+      break;
+
+    case Kind::Uint64:
+      stream.Writef(" %" PRIu64, *GetData<uint64_t>());
+      break;
+
+    case Kind::Index:
+      stream.Writef(" %" PRIindex, *GetData<Index>());
+      break;
+
+    case Kind::Float32:
+      stream.Writef(" %g", *GetData<float>());
+      break;
+
+    case Kind::Float64:
+      stream.Writef(" %g", *GetData<double>());
+      break;
+
+    case Kind::Uint32Uint32:
+      WriteArray<uint32_t>(
+          stream, [&stream](uint32_t value) { stream.Writef("%u", value); });
+      break;
+
+    case Kind::BlockSig:
+      WriteArray<Type>(stream, [&stream](Type type) {
+        stream.Writef("%s", GetTypeName(type));
+      });
+      break;
+
+    case Kind::BrTable: {
+      WriteArray<Index>(stream, [&stream](Index index) {
+        stream.Writef("%" PRIindex, index);
+      });
+      break;
+    }
+  }
+}
+
+bool operator==(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
+  return lhs.opcode_ == rhs.opcode_ || lhs.kind_ == rhs.kind_ ||
+         lhs.data_ == rhs.data_;
+}
+
+bool operator!=(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
+  return !(lhs == rhs);
+}
+
+bool operator<(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
+  if (lhs.opcode_ < rhs.opcode_) return true;
+  if (lhs.opcode_ > rhs.opcode_) return false;
+  if (lhs.kind_ < rhs.kind_) return true;
+  if (lhs.kind_ > rhs.kind_) return false;
+  if (lhs.data_ < rhs.data_) return true;
+  if (lhs.data_ > rhs.data_) return false;
+  return false;
+}
+
+bool operator<=(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
+  return lhs < rhs || lhs == rhs;
+}
+
+bool operator>(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
+  return !(lhs <= rhs);
+}
+
+bool operator>=(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
+  return !(lhs < rhs);
+}
 
 namespace {
 
 class BinaryReaderOpcnt : public BinaryReaderNop {
  public:
-  explicit BinaryReaderOpcnt(OpcntData* data);
+  explicit BinaryReaderOpcnt(OpcodeInfoCounts* counts);
 
   Result OnOpcode(Opcode opcode) override;
-  Result OnI32ConstExpr(uint32_t value) override;
-  Result OnGetLocalExpr(Index local_index) override;
-  Result OnSetLocalExpr(Index local_index) override;
-  Result OnTeeLocalExpr(Index local_index) override;
-  Result OnLoadExpr(Opcode opcode,
-                    uint32_t alignment_log2,
-                    Address offset) override;
-  Result OnStoreExpr(Opcode opcode,
-                     uint32_t alignment_log2,
-                     Address offset) override;
+  Result OnOpcodeBare() override;
+  Result OnOpcodeUint32(uint32_t value) override;
+  Result OnOpcodeIndex(Index value) override;
+  Result OnOpcodeUint32Uint32(uint32_t value, uint32_t value2) override;
+  Result OnOpcodeUint64(uint64_t value) override;
+  Result OnOpcodeF32(uint32_t value) override;
+  Result OnOpcodeF64(uint64_t value) override;
+  Result OnOpcodeBlockSig(Index num_types, Type* sig_types) override;
+  Result OnBrTableExpr(Index num_targets,
+                       Index* target_depths,
+                       Index default_target_depth) override;
+  Result OnEndExpr() override;
+  Result OnEndFunc() override;
 
  private:
-  OpcntData* opcnt_data;
+  template <typename... Args>
+  void Emplace(Args&&... args);
+
+  OpcodeInfoCounts* opcode_counts_;
+  Opcode current_opcode_;
 };
 
-static Result AddIntCounterValue(IntCounterVector* vec, intmax_t value) {
-  for (IntCounter& counter : *vec) {
-    if (counter.value == value) {
-      ++counter.count;
-      return Result::Ok;
-    }
-  }
-  vec->emplace_back(value, 1);
-  return Result::Ok;
+template <typename... Args>
+void BinaryReaderOpcnt::Emplace(Args&&... args) {
+  auto pair = opcode_counts_->emplace(
+      std::piecewise_construct, std::make_tuple(std::forward<Args>(args)...),
+      std::make_tuple(0));
+
+  auto& count = pair.first->second;
+  count++;
 }
 
-static Result AddIntPairCounterValue(IntPairCounterVector* vec,
-                                     intmax_t first,
-                                     intmax_t second) {
-  for (IntPairCounter& pair : *vec) {
-    if (pair.first == first && pair.second == second) {
-      ++pair.count;
-      return Result::Ok;
-    }
-  }
-  vec->emplace_back(first, second, 1);
-  return Result::Ok;
-}
-
-BinaryReaderOpcnt::BinaryReaderOpcnt(OpcntData* data) : opcnt_data(data) {}
+BinaryReaderOpcnt::BinaryReaderOpcnt(OpcodeInfoCounts* counts)
+    : opcode_counts_(counts) {}
 
 Result BinaryReaderOpcnt::OnOpcode(Opcode opcode) {
-  IntCounterVector& opcnt_vec = opcnt_data->opcode_vec;
-  while (opcode >= opcnt_vec.size()) {
-    opcnt_vec.emplace_back(opcnt_vec.size(), 0);
-  }
-  ++opcnt_vec[opcode].count;
+  current_opcode_ = opcode;
   return Result::Ok;
 }
 
-Result BinaryReaderOpcnt::OnI32ConstExpr(uint32_t value) {
-  return AddIntCounterValue(&opcnt_data->i32_const_vec,
-                            static_cast<int32_t>(value));
-}
-
-Result BinaryReaderOpcnt::OnGetLocalExpr(Index local_index) {
-  return AddIntCounterValue(&opcnt_data->get_local_vec, local_index);
-}
-
-Result BinaryReaderOpcnt::OnSetLocalExpr(Index local_index) {
-  return AddIntCounterValue(&opcnt_data->set_local_vec, local_index);
-}
-
-Result BinaryReaderOpcnt::OnTeeLocalExpr(Index local_index) {
-  return AddIntCounterValue(&opcnt_data->tee_local_vec, local_index);
-}
-
-Result BinaryReaderOpcnt::OnLoadExpr(Opcode opcode,
-                                     uint32_t alignment_log2,
-                                     Address offset) {
-  if (opcode == Opcode::I32Load) {
-    return AddIntPairCounterValue(&opcnt_data->i32_load_vec, alignment_log2,
-                                  offset);
-  }
+Result BinaryReaderOpcnt::OnOpcodeBare() {
+  Emplace(current_opcode_, OpcodeInfo::Kind::Bare);
   return Result::Ok;
 }
 
-Result BinaryReaderOpcnt::OnStoreExpr(Opcode opcode,
-                                      uint32_t alignment_log2,
-                                      Address offset) {
-  if (opcode == Opcode::I32Store) {
-    return AddIntPairCounterValue(&opcnt_data->i32_store_vec, alignment_log2,
-                                  offset);
-  }
+Result BinaryReaderOpcnt::OnOpcodeUint32(uint32_t value) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::Uint32, &value);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnOpcodeIndex(Index value) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::Index, &value);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnOpcodeUint32Uint32(uint32_t value0,
+                                               uint32_t value1) {
+  uint32_t array[2] = {value0, value1};
+  Emplace(current_opcode_, OpcodeInfo::Kind::Uint32Uint32, array, 2);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnOpcodeUint64(uint64_t value) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::Uint64, &value);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnOpcodeF32(uint32_t value) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::Float32, &value);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnOpcodeF64(uint64_t value) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::Float64, &value);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnOpcodeBlockSig(Index num_types, Type* sig_types) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::BlockSig, sig_types, num_types);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnBrTableExpr(Index num_targets,
+                                        Index* target_depths,
+                                        Index default_target_depth) {
+  Emplace(current_opcode_, OpcodeInfo::Kind::BrTable, target_depths,
+          num_targets, default_target_depth);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnEndExpr() {
+  Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
+  return Result::Ok;
+}
+
+Result BinaryReaderOpcnt::OnEndFunc() {
+  Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
   return Result::Ok;
 }
 
@@ -126,8 +260,8 @@ Result BinaryReaderOpcnt::OnStoreExpr(Opcode opcode,
 Result ReadBinaryOpcnt(const void* data,
                        size_t size,
                        const struct ReadBinaryOptions* options,
-                       OpcntData* opcnt_data) {
-  BinaryReaderOpcnt reader(opcnt_data);
+                       OpcodeInfoCounts* counts) {
+  BinaryReaderOpcnt reader(counts);
   return ReadBinary(data, size, &reader, options);
 }
 

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -34,8 +34,10 @@ OpcodeInfo::OpcodeInfo(Opcode opcode, Kind kind)
 template <typename T>
 OpcodeInfo::OpcodeInfo(Opcode opcode, Kind kind, T* data, size_t count)
     : OpcodeInfo(opcode, kind) {
-  data_.resize(sizeof(T) * count);
-  memcpy(data_.data(), data, data_.size());
+  if (count > 0) {
+    data_.resize(sizeof(T) * count);
+    memcpy(data_.data(), data, data_.size());
+  }
 }
 
 template <typename T>
@@ -118,7 +120,7 @@ void OpcodeInfo::Write(Stream& stream) {
 }
 
 bool operator==(const OpcodeInfo& lhs, const OpcodeInfo& rhs) {
-  return lhs.opcode_ == rhs.opcode_ || lhs.kind_ == rhs.kind_ ||
+  return lhs.opcode_ == rhs.opcode_ && lhs.kind_ == rhs.kind_ &&
          lhs.data_ == rhs.data_;
 }
 

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -177,20 +177,21 @@ class BinaryReaderOpcnt : public BinaryReaderNop {
 
  private:
   template <typename... Args>
-  void Emplace(Args&&... args);
+  Result Emplace(Args&&... args);
 
   OpcodeInfoCounts* opcode_counts_;
   Opcode current_opcode_;
 };
 
 template <typename... Args>
-void BinaryReaderOpcnt::Emplace(Args&&... args) {
+Result BinaryReaderOpcnt::Emplace(Args&&... args) {
   auto pair = opcode_counts_->emplace(
       std::piecewise_construct, std::make_tuple(std::forward<Args>(args)...),
       std::make_tuple(0));
 
   auto& count = pair.first->second;
   count++;
+  return Result::Ok;
 }
 
 BinaryReaderOpcnt::BinaryReaderOpcnt(OpcodeInfoCounts* counts)
@@ -202,63 +203,53 @@ Result BinaryReaderOpcnt::OnOpcode(Opcode opcode) {
 }
 
 Result BinaryReaderOpcnt::OnOpcodeBare() {
-  Emplace(current_opcode_, OpcodeInfo::Kind::Bare);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Bare);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeUint32(uint32_t value) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::Uint32, &value);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Uint32, &value);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeIndex(Index value) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::Index, &value);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Index, &value);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeUint32Uint32(uint32_t value0,
                                                uint32_t value1) {
   uint32_t array[2] = {value0, value1};
-  Emplace(current_opcode_, OpcodeInfo::Kind::Uint32Uint32, array, 2);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Uint32Uint32, array, 2);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeUint64(uint64_t value) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::Uint64, &value);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Uint64, &value);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeF32(uint32_t value) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::Float32, &value);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Float32, &value);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeF64(uint64_t value) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::Float64, &value);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::Float64, &value);
 }
 
 Result BinaryReaderOpcnt::OnOpcodeBlockSig(Index num_types, Type* sig_types) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::BlockSig, sig_types, num_types);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::BlockSig, sig_types,
+                 num_types);
 }
 
 Result BinaryReaderOpcnt::OnBrTableExpr(Index num_targets,
                                         Index* target_depths,
                                         Index default_target_depth) {
-  Emplace(current_opcode_, OpcodeInfo::Kind::BrTable, target_depths,
-          num_targets, default_target_depth);
-  return Result::Ok;
+  return Emplace(current_opcode_, OpcodeInfo::Kind::BrTable, target_depths,
+                 num_targets, default_target_depth);
 }
 
 Result BinaryReaderOpcnt::OnEndExpr() {
-  Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
-  return Result::Ok;
+  return Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
 }
 
 Result BinaryReaderOpcnt::OnEndFunc() {
-  Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
-  return Result::Ok;
+  return Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
 }
 
 }  // end anonymous namespace

--- a/src/binary-reader-opcnt.h
+++ b/src/binary-reader-opcnt.h
@@ -17,50 +17,76 @@
 #ifndef WABT_BINARY_READER_OPCNT_H_
 #define WABT_BINARY_READER_OPCNT_H_
 
-#include "common.h"
-
+#include <map>
 #include <vector>
+
+#include "common.h"
+#include "opcode.h"
 
 namespace wabt {
 
 struct Module;
 struct ReadBinaryOptions;
+class Stream;
 
-struct IntCounter {
-  IntCounter(intmax_t value, size_t count) : value(value), count(count) {}
+class OpcodeInfo {
+ public:
+  enum class Kind {
+    Bare,
+    Uint32,
+    Uint64,
+    Index,
+    Float32,
+    Float64,
+    Uint32Uint32,
+    BlockSig,
+    BrTable,
+  };
 
-  intmax_t value;
-  size_t count;
+  explicit OpcodeInfo(Opcode, Kind);
+  template <typename T>
+  OpcodeInfo(Opcode, Kind, T* data, size_t count = 1);
+  template <typename T>
+  OpcodeInfo(Opcode, Kind, T* data, size_t count, T extra);
+
+  Opcode opcode() const { return opcode_; }
+
+  void Write(Stream&);
+
+ private:
+  template <typename T>
+  std::pair<const T*, size_t> GetDataArray() const;
+  template <typename T>
+  const T* GetData(size_t expected_size = 1) const;
+
+  template <typename T, typename F>
+  void WriteArray(Stream& stream, F&& write_func);
+
+  Opcode opcode_;
+  Kind kind_;
+  std::vector<uint8_t> data_;
+
+  friend bool operator==(const OpcodeInfo&, const OpcodeInfo&);
+  friend bool operator!=(const OpcodeInfo&, const OpcodeInfo&);
+  friend bool operator<(const OpcodeInfo&, const OpcodeInfo&);
+  friend bool operator<=(const OpcodeInfo&, const OpcodeInfo&);
+  friend bool operator>(const OpcodeInfo&, const OpcodeInfo&);
+  friend bool operator>=(const OpcodeInfo&, const OpcodeInfo&);
 };
-typedef std::vector<IntCounter> IntCounterVector;
 
-struct IntPairCounter {
-  IntPairCounter(intmax_t first, intmax_t second, size_t count)
-      : first(first), second(second), count(count) {}
+bool operator==(const OpcodeInfo&, const OpcodeInfo&);
+bool operator!=(const OpcodeInfo&, const OpcodeInfo&);
+bool operator<(const OpcodeInfo&, const OpcodeInfo&);
+bool operator<=(const OpcodeInfo&, const OpcodeInfo&);
+bool operator>(const OpcodeInfo&, const OpcodeInfo&);
+bool operator>=(const OpcodeInfo&, const OpcodeInfo&);
 
-  intmax_t first;
-  intmax_t second;
-  size_t count;
-};
-typedef std::vector<IntPairCounter> IntPairCounterVector;
-
-struct OpcntData {
-  IntCounterVector opcode_vec;
-  IntCounterVector i32_const_vec;
-  IntCounterVector get_local_vec;
-  IntCounterVector set_local_vec;
-  IntCounterVector tee_local_vec;
-  IntPairCounterVector i32_load_vec;
-  IntPairCounterVector i32_store_vec;
-};
-
-void init_opcnt_data(OpcntData* data);
-void destroy_opcnt_data(OpcntData* data);
+typedef std::map<OpcodeInfo, size_t> OpcodeInfoCounts;
 
 Result ReadBinaryOpcnt(const void* data,
                        size_t size,
                        const struct ReadBinaryOptions* options,
-                       OpcntData* opcnt_data);
+                       OpcodeInfoCounts* opcode_counts);
 
 }  // namespace wabt
 

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -119,6 +119,14 @@ FileStream::FileStream(string_view filename)
 
 FileStream::FileStream(FILE* file) : Stream(&writer_), writer_(file) {}
 
+FileStream::FileStream(FileStream&& other)
+    : Stream(&writer_), writer_(std::move(other.writer_)) {}
+
+FileStream& FileStream::operator=(FileStream&& other) {
+  writer_ = std::move(other.writer_);
+  return *this;
+}
+
 // static
 std::unique_ptr<FileStream> FileStream::CreateStdout() {
   return std::unique_ptr<FileStream>(new FileStream(stdout));

--- a/src/stream.h
+++ b/src/stream.h
@@ -132,6 +132,7 @@ class Stream {
 
 class MemoryStream : public Stream {
  public:
+  WABT_DISALLOW_COPY_AND_ASSIGN(MemoryStream);
   MemoryStream();
 
   MemoryWriter& writer() { return writer_; }
@@ -150,8 +151,11 @@ class MemoryStream : public Stream {
 
 class FileStream : public Stream {
  public:
+  WABT_DISALLOW_COPY_AND_ASSIGN(FileStream);
   explicit FileStream(string_view filename);
   explicit FileStream(FILE*);
+  FileStream(FileStream&&);
+  FileStream& operator=(FileStream&&);
 
   FileWriter& writer() { return writer_; }
 

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -81,9 +81,7 @@ static void ParseOptions(int argc, char** argv) {
 template <typename T>
 struct SortByCountDescending {
   bool operator()(const T& lhs, const T& rhs) const {
-    if (lhs.second > rhs.second) return true;
-    if (lhs.second < rhs.second) return false;
-    return lhs.first > rhs.first;
+    return lhs.second > rhs.second;
   }
 };
 
@@ -108,8 +106,10 @@ void WriteCounts(Stream& stream, const OpcodeInfoCounts& info_counts) {
   std::copy_if(counts.begin(), counts.end(), std::back_inserter(sorted),
                WithinCutoff<OpcodeCountPair>());
 
-  std::sort(sorted.begin(), sorted.end(),
-            SortByCountDescending<OpcodeCountPair>());
+  // Use a stable sort to keep the elements with the same count in opcode
+  // order (since the Opcode map is sorted).
+  std::stable_sort(sorted.begin(), sorted.end(),
+                   SortByCountDescending<OpcodeCountPair>());
 
   for (auto& pair : sorted) {
     Opcode opcode = pair.first;
@@ -129,8 +129,10 @@ void WriteCountsWithImmediates(Stream& stream,
   std::copy_if(counts.begin(), counts.end(), std::back_inserter(sorted),
                WithinCutoff<OpcodeInfoCountPair>());
 
-  std::sort(sorted.begin(), sorted.end(),
-            SortByCountDescending<OpcodeInfoCountPair>());
+  // Use a stable sort to keep the elements with the same count in opcode info
+  // order (since the OpcodeInfoCounts map is sorted).
+  std::stable_sort(sorted.begin(), sorted.end(),
+                   SortByCountDescending<OpcodeInfoCountPair>());
 
   for (auto& pair : sorted) {
     auto&& info = pair.first;

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -20,6 +20,8 @@
 #include <cinttypes>
 #include <cstdio>
 #include <cstdlib>
+#include <map>
+#include <vector>
 
 #include "binary-reader.h"
 #include "binary-reader-opcnt.h"
@@ -76,142 +78,66 @@ static void ParseOptions(int argc, char** argv) {
   parser.Parse(argc, argv);
 }
 
-typedef int(int_counter_lt_fcn)(const IntCounter&, const IntCounter&);
+template <typename T>
+struct SortByCountDescending {
+  bool operator()(const T& lhs, const T& rhs) const {
+    if (lhs.second > rhs.second) return true;
+    if (lhs.second < rhs.second) return false;
+    return lhs.first > rhs.first;
+  }
+};
 
-typedef int(int_pair_counter_lt_fcn)(const IntPairCounter&,
-                                     const IntPairCounter&);
+template <typename T>
+struct WithinCutoff {
+  bool operator()(const T& pair) const {
+    return pair.second >= s_cutoff;
+  }
+};
 
-typedef void (*display_name_fcn)(FILE* out, intmax_t value);
+void WriteCounts(Stream& stream, const OpcodeInfoCounts& info_counts) {
+  typedef std::pair<Opcode, size_t> OpcodeCountPair;
 
-static void DisplayOpcodeName(FILE* out, intmax_t opcode) {
-  fprintf(out, "%s", Opcode(Opcode::Enum(opcode)).GetName());
-}
+  std::map<Opcode, size_t> counts;
+  for (auto& info_count_pair: info_counts) {
+    Opcode opcode = info_count_pair.first.opcode();
+    size_t count = info_count_pair.second;
+    counts[opcode] += count;
+  }
 
-static void DisplayIntmax(FILE* out, intmax_t value) {
-  fprintf(out, "%" PRIdMAX, value);
-}
+  std::vector<OpcodeCountPair> sorted;
+  std::copy_if(counts.begin(), counts.end(), std::back_inserter(sorted),
+               WithinCutoff<OpcodeCountPair>());
 
-static void DisplayIntCounterVector(FILE* out,
-                                    const IntCounterVector& vec,
-                                    display_name_fcn display_fcn,
-                                    const char* opcode_name) {
-  for (const IntCounter& counter : vec) {
-    if (counter.count == 0)
-      continue;
-    if (opcode_name)
-      fprintf(out, "(%s ", opcode_name);
-    display_fcn(out, counter.value);
-    if (opcode_name)
-      fprintf(out, ")");
-    fprintf(out, "%s%" PRIzd "\n", s_separator, counter.count);
+  std::sort(sorted.begin(), sorted.end(),
+            SortByCountDescending<OpcodeCountPair>());
+
+  for (auto& pair : sorted) {
+    Opcode opcode = pair.first;
+    size_t count = pair.second;
+    stream.Writef("%s%s%" PRIzd "\n", opcode.GetName(), s_separator, count);
   }
 }
 
-static void DisplayIntPairCounterVector(FILE* out,
-                                        const IntPairCounterVector& vec,
-                                        display_name_fcn display_first_fcn,
-                                        display_name_fcn display_second_fcn,
-                                        const char* opcode_name) {
-  for (const IntPairCounter& pair : vec) {
-    if (pair.count == 0)
-      continue;
-    if (opcode_name)
-      fprintf(out, "(%s ", opcode_name);
-    display_first_fcn(out, pair.first);
-    fputc(' ', out);
-    display_second_fcn(out, pair.second);
-    if (opcode_name)
-      fprintf(out, ")");
-    fprintf(out, "%s%" PRIzd "\n", s_separator, pair.count);
+void WriteCountsWithImmediates(Stream& stream,
+                               const OpcodeInfoCounts& counts) {
+  // Remove const from the key type so we can sort below.
+  typedef std::pair<std::remove_const<OpcodeInfoCounts::key_type>::type,
+                    OpcodeInfoCounts::mapped_type>
+      OpcodeInfoCountPair;
+
+  std::vector<OpcodeInfoCountPair> sorted;
+  std::copy_if(counts.begin(), counts.end(), std::back_inserter(sorted),
+               WithinCutoff<OpcodeInfoCountPair>());
+
+  std::sort(sorted.begin(), sorted.end(),
+            SortByCountDescending<OpcodeInfoCountPair>());
+
+  for (auto& pair : sorted) {
+    auto&& info = pair.first;
+    size_t count = pair.second;
+    info.Write(stream);
+    stream.Writef("%s%" PRIzd "\n", s_separator, count);
   }
-}
-
-static int OpcodeCounterGt(const IntCounter& counter_1,
-                           const IntCounter& counter_2) {
-  if (counter_1.count > counter_2.count)
-    return 1;
-  if (counter_1.count < counter_2.count)
-    return 0;
-  const char* name_1 = Opcode(Opcode::Enum(counter_1.value)).GetName();
-  const char* name_2 = Opcode(Opcode::Enum(counter_2.value)).GetName();
-  int diff = strcmp(name_1, name_2);
-  if (diff > 0)
-    return 1;
-  return 0;
-}
-
-static int IntCounterGt(const IntCounter& counter_1,
-                        const IntCounter& counter_2) {
-  if (counter_1.count < counter_2.count)
-    return 0;
-  if (counter_1.count > counter_2.count)
-    return 1;
-  if (counter_1.value < counter_2.value)
-    return 0;
-  if (counter_1.value > counter_2.value)
-    return 1;
-  return 0;
-}
-
-static int IntPairCounterGt(const IntPairCounter& counter_1,
-                            const IntPairCounter& counter_2) {
-  if (counter_1.count < counter_2.count)
-    return 0;
-  if (counter_1.count > counter_2.count)
-    return 1;
-  if (counter_1.first < counter_2.first)
-    return 0;
-  if (counter_1.first > counter_2.first)
-    return 1;
-  if (counter_1.second < counter_2.second)
-    return 0;
-  if (counter_1.second > counter_2.second)
-    return 1;
-  return 0;
-}
-
-static void DisplaySortedIntCounterVector(FILE* out,
-                                          const char* title,
-                                          const IntCounterVector& vec,
-                                          int_counter_lt_fcn lt_fcn,
-                                          display_name_fcn display_fcn,
-                                          const char* opcode_name) {
-  if (vec.size() == 0)
-    return;
-
-  /* First filter out values less than cutoff. This speeds up sorting. */
-  IntCounterVector filtered_vec;
-  for (const IntCounter& counter: vec) {
-    if (counter.count < s_cutoff)
-      continue;
-    filtered_vec.push_back(counter);
-  }
-  std::sort(filtered_vec.begin(), filtered_vec.end(), lt_fcn);
-  fprintf(out, "%s\n", title);
-  DisplayIntCounterVector(out, filtered_vec, display_fcn, opcode_name);
-}
-
-static void DisplaySortedIntPairCounterVector(
-    FILE* out,
-    const char* title,
-    const IntPairCounterVector& vec,
-    int_pair_counter_lt_fcn lt_fcn,
-    display_name_fcn display_first_fcn,
-    display_name_fcn display_second_fcn,
-    const char* opcode_name) {
-  if (vec.size() == 0)
-    return;
-
-  IntPairCounterVector filtered_vec;
-  for (const IntPairCounter& pair : vec) {
-    if (pair.count < s_cutoff)
-      continue;
-    filtered_vec.push_back(pair);
-  }
-  std::sort(filtered_vec.begin(), filtered_vec.end(), lt_fcn);
-  fprintf(out, "%s\n", title);
-  DisplayIntPairCounterVector(out, filtered_vec, display_first_fcn,
-                              display_second_fcn, opcode_name);
 }
 
 int ProgramMain(int argc, char** argv) {
@@ -223,42 +149,24 @@ int ProgramMain(int argc, char** argv) {
   if (Failed(result)) {
     const char* input_name = s_infile ? s_infile : "stdin";
     ERROR("Unable to parse: %s", input_name);
+    return 1;
   }
-  FILE* out = stdout;
-  if (s_outfile) {
-    out = fopen(s_outfile, "w");
-    if (!out)
-      ERROR("fopen \"%s\" failed, errno=%d\n", s_outfile, errno);
-    result = Result::Error;
-  }
+
+  FileStream stream(s_outfile ? FileStream(s_outfile) : FileStream(stdout));
+
   if (Succeeded(result)) {
-    OpcntData opcnt_data;
+    OpcodeInfoCounts counts;
     result = ReadBinaryOpcnt(DataOrNull(file_data), file_data.size(),
-                             &s_read_binary_options, &opcnt_data);
+                             &s_read_binary_options, &counts);
     if (Succeeded(result)) {
-      DisplaySortedIntCounterVector(
-          out, "Opcode counts:", opcnt_data.opcode_vec, OpcodeCounterGt,
-          DisplayOpcodeName, nullptr);
-      DisplaySortedIntCounterVector(
-          out, "\ni32.const:", opcnt_data.i32_const_vec, IntCounterGt,
-          DisplayIntmax, Opcode::I32Const_Opcode.GetName());
-      DisplaySortedIntCounterVector(
-          out, "\nget_local:", opcnt_data.get_local_vec, IntCounterGt,
-          DisplayIntmax, Opcode::GetLocal_Opcode.GetName());
-      DisplaySortedIntCounterVector(
-          out, "\nset_local:", opcnt_data.set_local_vec, IntCounterGt,
-          DisplayIntmax, Opcode::SetLocal_Opcode.GetName());
-      DisplaySortedIntCounterVector(
-          out, "\ntee_local:", opcnt_data.tee_local_vec, IntCounterGt,
-          DisplayIntmax, Opcode::TeeLocal_Opcode.GetName());
-      DisplaySortedIntPairCounterVector(
-          out, "\ni32.load:", opcnt_data.i32_load_vec, IntPairCounterGt,
-          DisplayIntmax, DisplayIntmax, Opcode::I32Load_Opcode.GetName());
-      DisplaySortedIntPairCounterVector(
-          out, "\ni32.store:", opcnt_data.i32_store_vec, IntPairCounterGt,
-          DisplayIntmax, DisplayIntmax, Opcode::I32Store_Opcode.GetName());
+      stream.Writef("Opcode counts:\n");
+      WriteCounts(stream, counts);
+
+      stream.Writef("\nOpcode counts with immediates:\n");
+      WriteCountsWithImmediates(stream, counts);
     }
   }
+
   return result != Result::Ok;
 }
 

--- a/test/opcodecnt/basic.txt
+++ b/test/opcodecnt/basic.txt
@@ -24,20 +24,21 @@ Opcode counts:
 get_local: 5
 i32.const: 3
 f32.const: 2
-end: 2
 br: 2
-i32.load: 1
+end: 2
 f32.add: 1
+i32.load: 1
 
-i32.const:
-(i32.const 2): 1
-(i32.const 1): 1
-(i32.const 0): 1
-
-get_local:
-(get_local 0): 3
-(get_local 1): 2
-
-i32.load:
-(i32.load 2 0): 1
+Opcode counts with immediates:
+get_local 0: 3
+br 0: 2
+get_local 1: 2
+end: 2
+f32.add: 1
+f32.const 2: 1
+f32.const 1: 1
+i32.const 0: 1
+i32.const 1: 1
+i32.const 2: 1
+i32.load 2, 0: 1
 ;;; STDOUT ;;)

--- a/test/opcodecnt/basic.txt
+++ b/test/opcodecnt/basic.txt
@@ -23,22 +23,22 @@
 Opcode counts:
 get_local: 5
 i32.const: 3
-f32.const: 2
-br: 2
 end: 2
-f32.add: 1
+br: 2
+f32.const: 2
 i32.load: 1
+f32.add: 1
 
 Opcode counts with immediates:
 get_local 0: 3
+end: 2
 br 0: 2
 get_local 1: 2
-end: 2
-f32.add: 1
-f32.const 2: 1
-f32.const 1: 1
+i32.load 2, 0: 1
 i32.const 0: 1
 i32.const 1: 1
 i32.const 2: 1
-i32.load 2, 0: 1
+f32.const 2: 1
+f32.const 1: 1
+f32.add: 1
 ;;; STDOUT ;;)

--- a/test/opcodecnt/cutoff.txt
+++ b/test/opcodecnt/cutoff.txt
@@ -1,0 +1,21 @@
+;;; TOOL: run-opcodecnt
+;;; FLAGS: --cutoff 3
+(module
+  (func
+    i32.const 1
+    i32.const 2
+    i32.const 3
+    i32.const 4
+    i32.const 5
+    f32.const 6
+    f32.const 7
+    f32.const 8
+    f64.const 9
+    return))
+(;; STDOUT ;;;
+Opcode counts:
+i32.const: 5
+f32.const: 3
+
+Opcode counts with immediates:
+;;; STDOUT ;;)

--- a/test/opcodecnt/immediates.txt
+++ b/test/opcodecnt/immediates.txt
@@ -1,0 +1,67 @@
+;;; TOOL: run-opcodecnt
+(module
+  (memory 1)
+  (func
+    ;; constants
+    i32.const 1
+    i64.const 2
+    f32.const 3.125
+    f64.const 4.5
+
+    ;; load
+    i32.const 0
+    i32.load offset=1 align=4
+
+    ;; store
+    i32.const 0
+    i32.const 0
+    i32.store offset=3 align=4
+
+    ;; bare block
+    block
+    end
+
+    ;; block with signature
+    block (result i64)
+      unreachable
+    end
+
+    ;; br
+    br 0
+
+    ;; br_table
+    i32.const 0
+    br_table 0 0 0 0 0 0
+
+    return))
+(;; STDOUT ;;;
+Opcode counts:
+i32.const: 5
+end: 3
+block: 2
+f64.const: 1
+f32.const: 1
+i64.const: 1
+i32.store: 1
+i32.load: 1
+return: 1
+br_table: 1
+br: 1
+unreachable: 1
+
+Opcode counts with immediates:
+i32.const 0: 4
+end: 3
+f64.const 4.5: 1
+f32.const 3.125: 1
+i64.const 2: 1
+i32.const 1: 1
+i32.load 2, 1: 1
+i32.store 2, 3: 1
+br_table 0, 0, 0, 0, 0, 0: 1
+br 0: 1
+block i64: 1
+unreachable: 1
+block: 1
+return: 1
+;;; STDOUT ;;)

--- a/test/opcodecnt/immediates.txt
+++ b/test/opcodecnt/immediates.txt
@@ -39,29 +39,29 @@ Opcode counts:
 i32.const: 5
 end: 3
 block: 2
-f64.const: 1
-f32.const: 1
-i64.const: 1
-i32.store: 1
-i32.load: 1
-return: 1
-br_table: 1
-br: 1
 unreachable: 1
+br: 1
+br_table: 1
+return: 1
+i32.load: 1
+i32.store: 1
+i64.const: 1
+f32.const: 1
+f64.const: 1
 
 Opcode counts with immediates:
 i32.const 0: 4
 end: 3
-f64.const 4.5: 1
-f32.const 3.125: 1
-i64.const 2: 1
-i32.const 1: 1
-i32.load 2, 1: 1
-i32.store 2, 3: 1
-br_table 0, 0, 0, 0, 0, 0: 1
-br 0: 1
-block i64: 1
 unreachable: 1
 block: 1
+block i64: 1
+br 0: 1
+br_table 0, 0, 0, 0, 0, 0: 1
 return: 1
+i32.load 2, 1: 1
+i32.store 2, 3: 1
+i32.const 1: 1
+i64.const 2: 1
+f32.const 3.125: 1
+f64.const 4.5: 1
 ;;; STDOUT ;;)

--- a/test/run-opcodecnt.py
+++ b/test/run-opcodecnt.py
@@ -42,6 +42,7 @@ def main(args):
                       action='store_false')
   parser.add_argument('--print-cmd', help='print the commands that are run.',
                       action='store_true')
+  parser.add_argument('-c', '--cutoff', type=int, default=0)
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
 
@@ -62,7 +63,7 @@ def main(args):
   with utils.TempDirectory(options.out_dir, 'run-opcodecnt-') as out_dir:
     out_file = utils.ChangeDir(utils.ChangeExt(options.file, '.wasm'), out_dir)
     wast2wasm.RunWithArgs(options.file, '-o', out_file)
-    wasm_opcodecnt.RunWithArgs(out_file)
+    wasm_opcodecnt.RunWithArgs(out_file, '-c', str(options.cutoff))
 
   return 0
 

--- a/ubsan.blacklist
+++ b/ubsan.blacklist
@@ -1,0 +1,5 @@
+# Work around libstdc++ bug: https://llvm.org/bugs/show_bug.cgi?id=18156
+# Also see: http://lists.llvm.org/pipermail/cfe-dev/2015-January/040945.html
+src:*/ios_base.h
+# Work around another libstdc++ bug: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60734
+src:*/stl_tree.h


### PR DESCRIPTION
Simplify some of the code using map instead of vector. Also added the
ability to count immediates of any opcode.