### PR TITLE
Fix tee_local typechecking bug w/ polymorphic stack

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -528,10 +528,8 @@ Result TypeChecker::OnTryBlock(const TypeVector* sig) {
 
 Result TypeChecker::OnTeeLocal(Type type) {
   Result result = Result::Ok;
-  Type value = Type::Any;
-  COMBINE_RESULT(result, CheckTypeStackLimit(1, "tee_local"));
-  COMBINE_RESULT(result, TopType(&value));
-  COMBINE_RESULT(result, CheckType(value, type, "tee_local"));
+  COMBINE_RESULT(result, PopAndCheck1Type(type, "tee_local"));
+  PushType(type);
   return result;
 }
 

--- a/test/regress/regress-10.txt
+++ b/test/regress/regress-10.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+(module
+  (func
+    (local i32)
+    block
+      unreachable
+      tee_local 0
+    end))
+(;; STDERR ;;;
+out/test/regress/regress-10.txt:7:7: error: type stack at end of block is 1, expected 0
+      tee_local 0
+      ^^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
The previous type-checking code just made sure the value on the top of
the stack is the correct type. This isn't sufficient when the stack is
polymorphic, because the concrete type is not pushed onto the stack.

Fixes #586.