### PR TITLE
Fix type-checking bug in br_if w/ polymorphic stack

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -292,8 +292,10 @@ Result TypeChecker::OnBrIf(Index depth) {
   COMBINE_RESULT(result, PopAndCheck1Type(Type::I32, "br_if"));
   Label* label;
   CHECK_RESULT(GetLabel(depth, &label));
-  if (label->label_type != LabelType::Loop)
-    COMBINE_RESULT(result, CheckSignature(label->sig, "br_if"));
+  if (label->label_type != LabelType::Loop) {
+    COMBINE_RESULT(result, PopAndCheckSignature(label->sig, "br_if"));
+    PushTypes(label->sig);
+  }
   return result;
 }
 

--- a/test/regress/regress-11.txt
+++ b/test/regress/regress-11.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+(module
+  (func (result i32)
+    block (result i32)
+      block
+        unreachable
+        br_if 1
+      end
+      i32.const 1
+    end))

--- a/test/regress/regress-11.txt
+++ b/test/regress/regress-11.txt
@@ -8,3 +8,8 @@
       end
       i32.const 1
     end))
+(;; STDERR ;;;
+out/test/regress/regress-11.txt:7:9: error: type stack at end of block is 1, expected 0
+        br_if 1
+        ^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
Similar to issue #586, it is necessary to pop and re-push the type on
the top of the stack when validating br_if, because otherwise the
concerete type is not pushed on the stack (i.e. the top remains
polymorphic).

Fixes #588.