### PR TITLE
Add WAST highlighting to *.txt files in tests directories

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -17,3 +17,11 @@ demo/third_party/codemirror/codemirror.js binary
 # Mark this test as binary so git doesn't change the line endings, since this
 # test is testing \r\n.
 test/parse/bad-crlf.txt binary
+
+# Highlight tests like .wast files when displayed on GitHub.
+test/**/*.txt linguist-language=WebAssembly
+
+# Mark test-files as "vendored". This tells GitHub to exclude them when it
+# calculates the repository's languages summary, and preserves the current
+# classification as a C++ project. See https://git.io/vr2pO
+test/**/*.txt linguist-vendored

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This will build and install to the installation directory you provided above.
 
 So, for example, if you want to build the debug configuration on Visual Studio 2015:
 
-```
+```console
 > mkdir build
 > cd build
 > cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=..\bin -G "Visual Studio 14 2015"


### PR DESCRIPTION
This PR uses some [GitHub-specific gitattributes](https://github.com/github/linguist#overrides) to enable WAST's syntax highlighting for `*.txt` test-files. They're currently being highlighted as plain text, because `.txt` isn't listed as a [registered WebAssembly extension](https://github.com/github/linguist/blob/f75c570/lib/linguist/languages.yml#L4748-L4753).

I also made sure to keep the files from counting toward the repository's language summary. Data and prose-type languages are always excluded by default (which is why you're not seeing `Text` occupy 45% of the codebase)... but since WebAssembly is a programming language, the reclassification would make them all count toward the usage total, potentially replacing the project's status as a C++ project.

Excluding large, ancillary files in this manner is actually common practice, and GitHub [even excludes by default](https://github.com/github/linguist/blob/master/lib/linguist/vendor.yml) commonly-used filepaths which would otherwise threaten to grossly misidentify the language of a user's project.

If the explanation I added to `.gitattributes` regarding vendored files is too verbose, just let me know.