### PR TITLE
Refactor interpreter imports

### DIFF
--- a/src/interpreter.h
+++ b/src/interpreter.h
@@ -172,26 +172,54 @@ struct Global {
 };
 
 struct Import {
-  Import();
-  Import(Import&&);
-  Import& operator=(Import&&);
-  ~Import() = default;
+  explicit Import(ExternalKind kind) : kind(kind) {}
+  Import(ExternalKind kind, string_view module_name, string_view field_name)
+      : kind(kind),
+        module_name(module_name.to_string()),
+        field_name(field_name.to_string()) {}
 
+  ExternalKind kind;
   std::string module_name;
   std::string field_name;
-  ExternalKind kind;
-  union {
-    struct {
-      Index sig_index;
-    } func;
-    struct {
-      Limits limits;
-    } table, memory;
-    struct {
-      Type type;
-      bool mutable_;
-    } global;
-  };
+};
+
+struct FuncImport : Import {
+  FuncImport() : Import(ExternalKind::Func) {}
+  FuncImport(string_view module_name, string_view field_name)
+      : Import(ExternalKind::Func, module_name, field_name) {}
+
+  Index sig_index = kInvalidIndex;
+};
+
+struct TableImport : Import {
+  TableImport() : Import(ExternalKind::Table) { ZeroMemory(limits); }
+  TableImport(string_view module_name, string_view field_name)
+      : Import(ExternalKind::Table, module_name, field_name) {}
+
+  Limits limits;
+};
+
+struct MemoryImport : Import {
+  MemoryImport() : Import(ExternalKind::Memory) { ZeroMemory(limits); }
+  MemoryImport(string_view module_name, string_view field_name)
+      : Import(ExternalKind::Memory, module_name, field_name) {}
+
+  Limits limits;
+};
+
+struct GlobalImport : Import {
+  GlobalImport() : Import(ExternalKind::Global) {}
+  GlobalImport(string_view module_name, string_view field_name)
+      : Import(ExternalKind::Global, module_name, field_name) {}
+
+  Type type = Type::Void;
+  bool mutable_ = false;
+};
+
+struct ExceptImport : Import {
+  ExceptImport() : Import(ExternalKind::Except) {}
+  ExceptImport(string_view module_name, string_view field_name)
+      : Import(ExternalKind::Except, module_name, field_name) {}
 };
 
 struct Func;
@@ -210,9 +238,6 @@ struct Func {
       : sig_index(sig_index), is_host(is_host) {}
   virtual ~Func() {}
 
-  inline struct DefinedFunc* as_defined();
-  inline struct HostFunc* as_host();
-
   Index sig_index;
   bool is_host;
 };
@@ -223,6 +248,8 @@ struct DefinedFunc : Func {
         offset(kInvalidIstreamOffset),
         local_decl_count(0),
         local_count(0) {}
+
+  static bool classof(const Func* func) { return !func->is_host; }
 
   IstreamOffset offset;
   Index local_decl_count;
@@ -236,21 +263,13 @@ struct HostFunc : Func {
         module_name(module_name.to_string()),
         field_name(field_name.to_string()) {}
 
+  static bool classof(const Func* func) { return func->is_host; }
+
   std::string module_name;
   std::string field_name;
   HostFuncCallback callback;
   void* user_data;
 };
-
-DefinedFunc* Func::as_defined() {
-  assert(!is_host);
-  return static_cast<DefinedFunc*>(this);
-}
-
-HostFunc* Func::as_host() {
-  assert(is_host);
-  return static_cast<HostFunc*>(this);
-}
 
 struct Export {
   Export(string_view name, ExternalKind kind, Index index)
@@ -266,13 +285,19 @@ class HostImportDelegate {
   typedef std::function<void(const char* msg)> ErrorCallback;
 
   virtual ~HostImportDelegate() {}
-  virtual wabt::Result ImportFunc(Import*,
+  virtual wabt::Result ImportFunc(FuncImport*,
                                   Func*,
                                   FuncSignature*,
                                   const ErrorCallback&) = 0;
-  virtual wabt::Result ImportTable(Import*, Table*, const ErrorCallback&) = 0;
-  virtual wabt::Result ImportMemory(Import*, Memory*, const ErrorCallback&) = 0;
-  virtual wabt::Result ImportGlobal(Import*, Global*, const ErrorCallback&) = 0;
+  virtual wabt::Result ImportTable(TableImport*,
+                                   Table*,
+                                   const ErrorCallback&) = 0;
+  virtual wabt::Result ImportMemory(MemoryImport*,
+                                    Memory*,
+                                    const ErrorCallback&) = 0;
+  virtual wabt::Result ImportGlobal(GlobalImport*,
+                                    Global*,
+                                    const ErrorCallback&) = 0;
 };
 
 struct Module {
@@ -280,9 +305,6 @@ struct Module {
   explicit Module(bool is_host);
   Module(string_view name, bool is_host);
   virtual ~Module() = default;
-
-  inline struct DefinedModule* as_defined();
-  inline struct HostModule* as_host();
 
   Export* GetExport(string_view name);
 
@@ -296,8 +318,13 @@ struct Module {
 
 struct DefinedModule : Module {
   DefinedModule();
+  static bool classof(const Module* module) { return !module->is_host; }
 
-  std::vector<Import> imports;
+  std::vector<FuncImport> func_imports;
+  std::vector<TableImport> table_imports;
+  std::vector<MemoryImport> memory_imports;
+  std::vector<GlobalImport> global_imports;
+  std::vector<ExceptImport> except_imports;
   Index start_func_index; /* kInvalidIndex if not defined */
   IstreamOffset istream_start;
   IstreamOffset istream_end;
@@ -305,19 +332,10 @@ struct DefinedModule : Module {
 
 struct HostModule : Module {
   explicit HostModule(string_view name);
+  static bool classof(const Module* module) { return module->is_host; }
 
   std::unique_ptr<HostImportDelegate> import_delegate;
 };
-
-DefinedModule* Module::as_defined() {
-  assert(!is_host);
-  return static_cast<DefinedModule*>(this);
-}
-
-HostModule* Module::as_host() {
-  assert(is_host);
-  return static_cast<HostModule*>(this);
-}
 
 class Environment {
  public:

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -25,6 +25,7 @@
 
 #include "binary-reader-interpreter.h"
 #include "binary-reader.h"
+#include "cast.h"
 #include "error-handler.h"
 #include "feature.h"
 #include "interpreter.h"
@@ -344,12 +345,12 @@ static interpreter::Result DefaultHostCallback(
 
 class SpectestHostImportDelegate : public HostImportDelegate {
  public:
-  wabt::Result ImportFunc(interpreter::Import* import,
+  wabt::Result ImportFunc(interpreter::FuncImport* import,
                           interpreter::Func* func,
                           interpreter::FuncSignature* func_sig,
                           const ErrorCallback& callback) override {
     if (import->field_name == "print") {
-      func->as_host()->callback = DefaultHostCallback;
+      cast<HostFunc>(func)->callback = DefaultHostCallback;
       return wabt::Result::Ok;
     } else {
       PrintError(callback, "unknown host function import " PRIimport,
@@ -358,7 +359,7 @@ class SpectestHostImportDelegate : public HostImportDelegate {
     }
   }
 
-  wabt::Result ImportTable(interpreter::Import* import,
+  wabt::Result ImportTable(interpreter::TableImport* import,
                            interpreter::Table* table,
                            const ErrorCallback& callback) override {
     if (import->field_name == "table") {
@@ -373,7 +374,7 @@ class SpectestHostImportDelegate : public HostImportDelegate {
     }
   }
 
-  wabt::Result ImportMemory(interpreter::Import* import,
+  wabt::Result ImportMemory(interpreter::MemoryImport* import,
                             interpreter::Memory* memory,
                             const ErrorCallback& callback) override {
     if (import->field_name == "memory") {
@@ -389,7 +390,7 @@ class SpectestHostImportDelegate : public HostImportDelegate {
     }
   }
 
-  wabt::Result ImportGlobal(interpreter::Import* import,
+  wabt::Result ImportGlobal(interpreter::GlobalImport* import,
                             interpreter::Global* global,
                             const ErrorCallback& callback) override {
     if (import->field_name == "global") {

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -6,10 +6,10 @@ out/third_party/testsuite/globals.wast:50: assert_invalid passed:
   0000026: error: OnSetGlobalExpr callback failed
 out/third_party/testsuite/globals.wast:55: assert_invalid passed:
   error: unknown import module "m"
-  0000012: error: OnImport callback failed
+  0000012: error: OnImportGlobal callback failed
 out/third_party/testsuite/globals.wast:60: assert_invalid passed:
   error: unknown import module "m"
-  0000012: error: OnImport callback failed
+  0000012: error: OnImportGlobal callback failed
 out/third_party/testsuite/globals.wast:65: assert_invalid passed:
   error: mutable globals cannot be exported
   000001a: error: OnExport callback failed

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -13,7 +13,7 @@ called host spectest.print(f64:24.000000) =>
 called host spectest.print(f64:24.000000) =>
 out/third_party/testsuite/imports.wast:99: assert_unlinkable passed:
   error: unknown module field "unknown"
-  0000020: error: OnImport callback failed
+  0000020: error: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:103: assert_unlinkable passed:
   error: unknown host function import "spectest.unknown"
   0000024: error: OnImportFunc callback failed
@@ -85,7 +85,7 @@ out/third_party/testsuite/imports.wast:193: assert_unlinkable passed:
   0000023: error: OnImportFunc callback failed
 out/third_party/testsuite/imports.wast:227: assert_unlinkable passed:
   error: unknown module field "unknown"
-  000001b: error: OnImport callback failed
+  000001b: error: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:231: assert_unlinkable passed:
   error: unknown host global import "spectest.unknown"
   000001f: error: OnImportGlobal callback failed
@@ -109,15 +109,15 @@ out/third_party/testsuite/imports.wast:256: assert_unlinkable passed:
   000001e: error: OnImportGlobal callback failed
 out/third_party/testsuite/imports.wast:298: assert_invalid passed:
   error: unknown import module ""
-  0000011: error: OnImport callback failed
+  0000011: error: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:302: assert_invalid passed:
   error: unknown import module ""
-  0000011: error: OnImport callback failed
+  0000011: error: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:306: assert_invalid passed:
   000000b: error: table count (2) must be 0 or 1
 out/third_party/testsuite/imports.wast:323: assert_unlinkable passed:
   error: unknown module field "unknown"
-  000001c: error: OnImport callback failed
+  000001c: error: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:327: assert_unlinkable passed:
   error: unknown host table import "spectest.unknown"
   0000020: error: OnImportTable callback failed
@@ -147,15 +147,15 @@ out/third_party/testsuite/imports.wast:361: assert_unlinkable passed:
   000001e: error: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:393: assert_invalid passed:
   error: unknown import module ""
-  0000010: error: OnImport callback failed
+  0000010: error: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:397: assert_invalid passed:
   error: unknown import module ""
-  0000010: error: OnImport callback failed
+  0000010: error: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:401: assert_invalid passed:
   000000b: error: memory count must be 0 or 1
 out/third_party/testsuite/imports.wast:416: assert_unlinkable passed:
   error: unknown module field "unknown"
-  000001b: error: OnImport callback failed
+  000001b: error: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:420: assert_unlinkable passed:
   error: unknown host memory import "spectest.unknown"
   000001f: error: OnImportMemory callback failed

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -12,7 +12,7 @@ out/third_party/testsuite/linking.wast:166: assert_unlinkable passed:
   0000029: error: OnElemSegmentFunctionIndex callback failed
 out/third_party/testsuite/linking.wast:175: assert_unlinkable passed:
   error: unknown module field "mem"
-  0000027: error: OnImport callback failed
+  0000027: error: OnImportMemory callback failed
 out/third_party/testsuite/linking.wast:187: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 12 >= max value 10
   0000030: error: OnElemSegmentFunctionIndex callback failed
@@ -25,7 +25,7 @@ out/third_party/testsuite/linking.wast:258: assert_unlinkable passed:
 out/third_party/testsuite/linking.wast:283: assert_unlinkable passed:
   error: duplicate export "print"
   error: unknown module field "tab"
-  0000037: error: OnImport callback failed
+  0000037: error: OnImportTable callback failed
 out/third_party/testsuite/linking.wast:294: assert_unlinkable passed:
   error: data segment is out of bounds: [327680, 327681) >= max value 327680
   0000028: error: OnDataSegmentData callback failed


### PR DESCRIPTION
* Create Import derived classes instead of using union
* Use cast/dyn_cast for interpreter Func and Module (Defined vs. Host)
* Remove OnImport callback in BinaryReaderInterpreter; do all the work
  in the kind-specific callbacks (e.g. OnImportFunc)