### PR TITLE
added missing function in emscripten export

### DIFF
--- a/src/emscripten-exported.json
+++ b/src/emscripten-exported.json
@@ -29,5 +29,6 @@
 "_wabt_write_module_result_release_log_output_buffer",
 "_wabt_write_module_result_release_output_buffer",
 "_wabt_write_text_module",
-"_wabt_new_text_error_handler_buffer"
+"_wabt_new_text_error_handler_buffer",
+"_wabt_new_binary_error_handler_buffer"
 ]

--- a/src/emscripten-exported.json
+++ b/src/emscripten-exported.json
@@ -28,5 +28,6 @@
 "_wabt_write_module_result_get_result",
 "_wabt_write_module_result_release_log_output_buffer",
 "_wabt_write_module_result_release_output_buffer",
-"_wabt_write_text_module"
+"_wabt_write_text_module",
+"_wabt_new_text_error_handler_buffer"
 ]


### PR DESCRIPTION
This commit added missing functions to the export table.  This functions used in `wabt.post.js`.