### PR TITLE
Removed duplicate initialization of EMSCRIPTEN_DIR var in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,6 @@ GCC_DIR := gcc/
 GCC_I686_DIR := gcc-i686/
 GCC_FUZZ_DIR := gcc-fuzz/
 CLANG_DIR := clang/
-EMSCRIPTEN_DIR := emscripten/
 DEBUG_DIR := Debug/
 RELEASE_DIR := Release/
 NORMAL_DIR :=


### PR DESCRIPTION
Should now allow overriding the variable with a custom emscripten location.

For reference, EMSCRIPTEN_DIR is already conditionally set [here](https://github.com/WebAssembly/wabt/blob/master/Makefile#L26).