### PR TITLE
Move Result to its own file (result.h)

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -24,12 +24,6 @@
 #include "ir.h"
 #include "string-view.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 namespace wabt {
 
 namespace {

--- a/src/binary-reader-interpreter.cc
+++ b/src/binary-reader-interpreter.cc
@@ -29,12 +29,6 @@
 #include "type-checker.h"
 #include "writer.h"
 
-#define CHECK_RESULT(expr)        \
-  do {                            \
-    if (Failed(expr))             \
-      return wabt::Result::Error; \
-  } while (0)
-
 namespace wabt {
 
 using namespace interpreter;
@@ -473,11 +467,8 @@ wabt::Result BinaryReaderInterpreter::GetBrDropKeepCount(
 wabt::Result BinaryReaderInterpreter::GetReturnDropKeepCount(
     Index* out_drop_count,
     Index* out_keep_count) {
-  if (Failed(GetBrDropKeepCount(label_stack.size() - 1, out_drop_count,
-                                out_keep_count))) {
-    return wabt::Result::Error;
-  }
-
+  CHECK_RESULT(GetBrDropKeepCount(label_stack.size() - 1, out_drop_count,
+                                  out_keep_count));
   *out_drop_count += current_func->param_and_local_types.size();
   return wabt::Result::Ok;
 }

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -29,12 +29,6 @@
 #include "error-handler.h"
 #include "ir.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 namespace wabt {
 
 namespace {
@@ -274,9 +268,7 @@ Result BinaryReaderIR::TopLabel(LabelNode** label) {
 
 Result BinaryReaderIR::AppendExpr(std::unique_ptr<Expr> expr) {
   LabelNode* label;
-  if (Failed(TopLabel(&label))) {
-    return Result::Error;
-  }
+  CHECK_RESULT(TopLabel(&label));
   label->exprs->push_back(expr.release());
   return Result::Ok;
 }

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -34,12 +34,6 @@
 #include <alloca.h>
 #endif
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 #define ERROR_UNLESS(expr, ...) \
   do {                          \
     if (!(expr)) {              \

--- a/src/common.h
+++ b/src/common.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "config.h"
+#include "result.h"
 #include "string-view.h"
 
 #define WABT_FATAL(...) fprintf(stderr, __VA_ARGS__), exit(1)
@@ -97,11 +98,6 @@ static const Address kInvalidAddress = ~0;
 static const Index kInvalidIndex = ~0;
 static const Offset kInvalidOffset = ~0;
 
-enum class Result {
-  Ok,
-  Error,
-};
-
 template<typename T>
 void ZeroMemory(T& v) {
   WABT_STATIC_ASSERT(std::is_pod<T>::value);
@@ -144,9 +140,6 @@ template <typename T>
 typename T::value_type* DataOrNull(T& container) {
   return container.empty() ? nullptr : container.data();
 }
-
-inline bool Succeeded(Result result) { return result == Result::Ok; }
-inline bool Failed(Result result) { return result == Result::Error; }
 
 inline std::string WABT_PRINTF_FORMAT(1, 2)
     StringPrintf(const char* format, ...) {
@@ -338,6 +331,6 @@ inline void ConvertBackslashToSlash(std::string* s) {
   ConvertBackslashToSlash(s->begin(), s->end());
 }
 
-}  // end anonymous namespace
+}  // namespace wabt
 
-#endif /* WABT_COMMON_H_ */
+#endif // WABT_COMMON_H_

--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -19,12 +19,6 @@
 #include "cast.h"
 #include "ir.h"
 
-#define CHECK_RESULT(expr)   \
-  do {                       \
-    if (Failed((expr)))      \
-      return Result::Error;  \
-  } while (0)
-
 namespace wabt {
 
 ExprVisitor::ExprVisitor(Delegate* delegate) : delegate_(delegate) {}

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -24,12 +24,6 @@
 #include "expr-visitor.h"
 #include "ir.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 namespace wabt {
 
 namespace {

--- a/src/interpreter.cc
+++ b/src/interpreter.cc
@@ -39,6 +39,9 @@ static const char* s_opcode_name[] = {
   "<invalid>",
 };
 
+// Differs from the normal CHECK_RESULT because this one is meant to return the
+// interpreter Result type.
+#undef CHECK_RESULT
 #define CHECK_RESULT(expr)  \
   do {                      \
     if (WABT_FAILED(expr))  \

--- a/src/lexer-source-line-finder.cc
+++ b/src/lexer-source-line-finder.cc
@@ -20,12 +20,6 @@
 
 #include "lexer-source.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 namespace wabt {
 
 LexerSourceLineFinder::LexerSourceLineFinder(

--- a/src/lexer-source.cc
+++ b/src/lexer-source.cc
@@ -18,12 +18,6 @@
 
 #include <algorithm>
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 namespace wabt {
 
 LexerSourceFile::LexerSourceFile(const std::string& filename)

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -225,8 +225,7 @@ Result FloatParser<T>::ParseNan(const char* s,
 
     for (; s < end; ++s) {
       uint32_t digit;
-      if (Failed(ParseHexdigit(*s, &digit)))
-        return Result::Error;
+      CHECK_RESULT(ParseHexdigit(*s, &digit));
       tag = tag * 16 + digit;
       // Check for overflow.
       if (tag > Traits::kSigMask)
@@ -552,8 +551,7 @@ Result ParseUint64(const char* s, const char* end, uint64_t* out) {
       uint32_t digit;
       if (*s == '_')
         continue;
-      if (Failed(ParseHexdigit(*s, &digit)))
-        return Result::Error;
+      CHECK_RESULT(ParseHexdigit(*s, &digit));
       uint64_t old_value = value;
       value = value * 16 + digit;
       // Check for overflow.
@@ -617,8 +615,7 @@ Result ParseInt32(const char* s,
       has_sign = true;
     s++;
   }
-  if (Failed(ParseUint64(s, end, &value)))
-    return Result::Error;
+  CHECK_RESULT(ParseUint64(s, end, &value));
 
   if (has_sign) {
     // abs(INT32_MIN) == INT32_MAX + 1.

--- a/src/result.h
+++ b/src/result.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_RESULT_H_
+#define WABT_RESULT_H_
+
+namespace wabt {
+
+struct Result {
+  enum Enum {
+    Ok,
+    Error,
+  };
+
+  Result() : Result(Ok) {}
+  Result(Enum e) : enum_(e) {}
+  operator Enum() const { return enum_; }
+  Result& operator|=(Result rhs);
+
+ private:
+  Enum enum_;
+};
+
+inline Result operator|(Result lhs, Result rhs) {
+  return (lhs == Result::Error || rhs == Result::Error) ? Result::Error
+                                                        : Result::Ok;
+}
+
+inline Result& Result::operator|=(Result rhs) {
+  enum_ = *this | rhs;
+  return *this;
+}
+
+inline bool Succeeded(Result result) { return result == Result::Ok; }
+inline bool Failed(Result result) { return result == Result::Error; }
+
+#define CHECK_RESULT(expr)          \
+  do {                              \
+    if (Failed(expr))               \
+      return ::wabt::Result::Error; \
+  } while (0)
+
+}  // namespace wabt
+
+#endif  // WABT_RESULT_H_

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -561,12 +561,6 @@ class SpecJSONParser {
   int total_ = 0;
 };
 
-#define CHECK_RESULT(x)           \
-  do {                            \
-    if (Failed(x))                \
-      return wabt::Result::Error; \
-  } while (0)
-
 #define EXPECT(x) CHECK_RESULT(Expect(x))
 #define EXPECT_KEY(x) CHECK_RESULT(ExpectKey(x))
 #define PARSE_KEY_STRING_VALUE(key, value) \

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -74,9 +74,7 @@ static void ParseOptions(int argc, char** argv) {
 
 Result dump_file(const char* filename) {
   std::vector<uint8_t> file_data;
-  Result result = ReadFile(filename, &file_data);
-  if (Failed(result))
-    return result;
+  CHECK_RESULT(ReadFile(filename, &file_data));
 
   uint8_t* data = DataOrNull(file_data);
   size_t size = file_data.size();
@@ -91,42 +89,34 @@ Result dump_file(const char* filename) {
 
   // Pass 0: Prepass
   s_objdump_options.mode = ObjdumpMode::Prepass;
-  result = ReadBinaryObjdump(data, size, &s_objdump_options, &state);
-  if (Failed(result))
-    return result;
+  CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
   s_objdump_options.log_stream = nullptr;
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {
     s_objdump_options.mode = ObjdumpMode::Headers;
-    result = ReadBinaryObjdump(data, size, &s_objdump_options, &state);
-    if (Failed(result))
-      return result;
+    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
   }
 
   // Pass 2: Print extra information based on section type
   if (s_objdump_options.details) {
     s_objdump_options.mode = ObjdumpMode::Details;
-    result = ReadBinaryObjdump(data, size, &s_objdump_options, &state);
-    if (Failed(result))
-      return result;
+    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
   }
 
   // Pass 3: Disassemble code section
   if (s_objdump_options.disassemble) {
     s_objdump_options.mode = ObjdumpMode::Disassemble;
-    result = ReadBinaryObjdump(data, size, &s_objdump_options, &state);
-    if (Failed(result))
-      return result;
+    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
   }
 
   // Pass 4: Dump to raw contents of the sections
   if (s_objdump_options.raw) {
     s_objdump_options.mode = ObjdumpMode::RawData;
-    result = ReadBinaryObjdump(data, size, &s_objdump_options, &state);
+    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
   }
 
-  return result;
+  return Result::Ok;
 }
 
 int ProgramMain(int argc, char** argv) {

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -16,18 +16,6 @@
 
 #include "type-checker.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
-#define COMBINE_RESULT(result_var, result)                            \
-  do {                                                                \
-    (result_var) = static_cast<Result>(static_cast<int>(result_var) | \
-                                       static_cast<int>(result));     \
-  } while (0)
-
 namespace wabt {
 
 TypeChecker::Label::Label(LabelType label_type,
@@ -179,35 +167,32 @@ Result TypeChecker::CheckType(Type actual, Type expected, const char* desc) {
 }
 
 Result TypeChecker::CheckSignature(const TypeVector& sig, const char* desc) {
-  Result result = Result::Ok;
-  COMBINE_RESULT(result, CheckTypeStackLimit(sig.size(), desc));
+  Result result = CheckTypeStackLimit(sig.size(), desc);
   for (size_t i = 0; i < sig.size(); ++i) {
     Type actual = Type::Any;
-    COMBINE_RESULT(result, PeekType(sig.size() - i - 1, &actual));
-    COMBINE_RESULT(result, CheckType(actual, sig[i], desc));
+    result |= PeekType(sig.size() - i - 1, &actual);
+    result |= CheckType(actual, sig[i], desc);
   }
   return result;
 }
 
 Result TypeChecker::PopAndCheckSignature(const TypeVector& sig,
                                          const char* desc) {
-  Result result = Result::Ok;
-  COMBINE_RESULT(result, CheckSignature(sig, desc));
-  COMBINE_RESULT(result, DropTypes(sig.size()));
+  Result result = CheckSignature(sig, desc);
+  result |= DropTypes(sig.size());
   return result;
 }
 
 Result TypeChecker::PopAndCheckCall(const TypeVector& param_types,
                                     const TypeVector& result_types,
                                     const char* desc) {
-  Result result = Result::Ok;
-  COMBINE_RESULT(result, CheckTypeStackLimit(param_types.size(), desc));
+  Result result = CheckTypeStackLimit(param_types.size(), desc);
   for (size_t i = 0; i < param_types.size(); ++i) {
     Type actual = Type::Any;
-    COMBINE_RESULT(result, PeekType(param_types.size() - i - 1, &actual));
-    COMBINE_RESULT(result, CheckType(actual, param_types[i], desc));
+    result |= PeekType(param_types.size() - i - 1, &actual);
+    result |= CheckType(actual, param_types[i], desc);
   }
-  COMBINE_RESULT(result, DropTypes(param_types.size()));
+  result |= DropTypes(param_types.size());
   PushTypes(result_types);
   return result;
 }
@@ -215,9 +200,9 @@ Result TypeChecker::PopAndCheckCall(const TypeVector& param_types,
 Result TypeChecker::PopAndCheck1Type(Type expected, const char* desc) {
   Result result = Result::Ok;
   Type actual = Type::Any;
-  COMBINE_RESULT(result, CheckTypeStackLimit(1, desc));
-  COMBINE_RESULT(result, PopType(&actual));
-  COMBINE_RESULT(result, CheckType(actual, expected, desc));
+  result |= CheckTypeStackLimit(1, desc);
+  result |= PopType(&actual);
+  result |= CheckType(actual, expected, desc);
   return result;
 }
 
@@ -227,11 +212,11 @@ Result TypeChecker::PopAndCheck2Types(Type expected1,
   Result result = Result::Ok;
   Type actual1 = Type::Any;
   Type actual2 = Type::Any;
-  COMBINE_RESULT(result, CheckTypeStackLimit(2, desc));
-  COMBINE_RESULT(result, PopType(&actual2));
-  COMBINE_RESULT(result, PopType(&actual1));
-  COMBINE_RESULT(result, CheckType(actual1, expected1, desc));
-  COMBINE_RESULT(result, CheckType(actual2, expected2, desc));
+  result |= CheckTypeStackLimit(2, desc);
+  result |= PopType(&actual2);
+  result |= PopType(&actual1);
+  result |= CheckType(actual1, expected1, desc);
+  result |= CheckType(actual2, expected2, desc);
   return result;
 }
 
@@ -240,10 +225,10 @@ Result TypeChecker::PopAndCheck2TypesAreEqual(Type* out_type,
   Result result = Result::Ok;
   Type right = Type::Any;
   Type left = Type::Any;
-  COMBINE_RESULT(result, CheckTypeStackLimit(2, desc));
-  COMBINE_RESULT(result, PopType(&right));
-  COMBINE_RESULT(result, PopType(&left));
-  COMBINE_RESULT(result, CheckType(left, right, desc));
+  result |= CheckTypeStackLimit(2, desc);
+  result |= PopType(&right);
+  result |= PopType(&left);
+  result |= CheckType(left, right, desc);
   *out_type = right;
   return result;
 }
@@ -282,18 +267,17 @@ Result TypeChecker::OnBr(Index depth) {
   Label* label;
   CHECK_RESULT(GetLabel(depth, &label));
   if (label->label_type != LabelType::Loop)
-    COMBINE_RESULT(result, CheckSignature(label->sig, "br"));
+    result |= CheckSignature(label->sig, "br");
   CHECK_RESULT(SetUnreachable());
   return result;
 }
 
 Result TypeChecker::OnBrIf(Index depth) {
-  Result result = Result::Ok;
-  COMBINE_RESULT(result, PopAndCheck1Type(Type::I32, "br_if"));
+  Result result = PopAndCheck1Type(Type::I32, "br_if");
   Label* label;
   CHECK_RESULT(GetLabel(depth, &label));
   if (label->label_type != LabelType::Loop) {
-    COMBINE_RESULT(result, PopAndCheckSignature(label->sig, "br_if"));
+    result |= PopAndCheckSignature(label->sig, "br_if");
     PushTypes(label->sig);
   }
   return result;
@@ -316,11 +300,11 @@ Result TypeChecker::OnBrTableTarget(Index depth) {
     label_sig = label->sig.size() == 0 ? Type::Void : label->sig[0];
   }
 
-  COMBINE_RESULT(result, CheckType(br_table_sig_, label_sig, "br_table"));
+  result |= CheckType(br_table_sig_, label_sig, "br_table");
   br_table_sig_ = label_sig;
 
   if (label->label_type != LabelType::Loop)
-    COMBINE_RESULT(result, CheckSignature(label->sig, "br_table"));
+    result |= CheckSignature(label->sig, "br_table");
   return result;
 }
 
@@ -335,10 +319,8 @@ Result TypeChecker::OnCall(const TypeVector* param_types,
 
 Result TypeChecker::OnCallIndirect(const TypeVector* param_types,
                                    const TypeVector* result_types) {
-  Result result = Result::Ok;
-  COMBINE_RESULT(result, PopAndCheck1Type(Type::I32, "call_indirect"));
-  COMBINE_RESULT(result,
-                 PopAndCheckCall(*param_types, *result_types, "call_indirect"));
+  Result result = PopAndCheck1Type(Type::I32, "call_indirect");
+  result |= PopAndCheckCall(*param_types, *result_types, "call_indirect");
   return result;
 }
 
@@ -355,9 +337,9 @@ Result TypeChecker::OnCatchBlock(const TypeVector* sig) {
   Result result = Result::Ok;
   Label* label;
   CHECK_RESULT(TopLabel(&label));
-  COMBINE_RESULT(result, CheckLabelType(label, LabelType::Try));
-  COMBINE_RESULT(result, PopAndCheckSignature(label->sig, "try block"));
-  COMBINE_RESULT(result, CheckTypeStackEnd("try block"));
+  result |= CheckLabelType(label, LabelType::Try);
+  result |= PopAndCheckSignature(label->sig, "try block");
+  result |= CheckTypeStackEnd("try block");
   ResetTypeStackToLabel(label);
   label->label_type = LabelType::Catch;
   label->unreachable = false;
@@ -381,8 +363,8 @@ Result TypeChecker::OnCurrentMemory() {
 Result TypeChecker::OnDrop() {
   Result result = Result::Ok;
   Type type = Type::Any;
-  COMBINE_RESULT(result, CheckTypeStackLimit(1, "drop"));
-  COMBINE_RESULT(result, PopType(&type));
+  result |= CheckTypeStackLimit(1, "drop");
+  result |= PopType(&type);
   return result;
 }
 
@@ -390,9 +372,9 @@ Result TypeChecker::OnElse() {
   Result result = Result::Ok;
   Label* label;
   CHECK_RESULT(TopLabel(&label));
-  COMBINE_RESULT(result, CheckLabelType(label, LabelType::If));
-  COMBINE_RESULT(result, PopAndCheckSignature(label->sig, "if true branch"));
-  COMBINE_RESULT(result, CheckTypeStackEnd("if true branch"));
+  result |= CheckLabelType(label, LabelType::If);
+  result |= PopAndCheckSignature(label->sig, "if true branch");
+  result |= CheckTypeStackEnd("if true branch");
   ResetTypeStackToLabel(label);
   label->label_type = LabelType::Else;
   label->unreachable = false;
@@ -403,8 +385,8 @@ Result TypeChecker::OnEnd(Label* label,
                           const char* sig_desc,
                           const char* end_desc) {
   Result result = Result::Ok;
-  COMBINE_RESULT(result, PopAndCheckSignature(label->sig, sig_desc));
-  COMBINE_RESULT(result, CheckTypeStackEnd(end_desc));
+  result |= PopAndCheckSignature(label->sig, sig_desc);
+  result |= CheckTypeStackEnd(end_desc);
   ResetTypeStackToLabel(label);
   PushTypes(label->sig);
   PopLabel();
@@ -427,7 +409,7 @@ Result TypeChecker::OnEnd() {
     }
   }
   const char* desc = s_label_type_name[static_cast<int>(label->label_type)];
-  COMBINE_RESULT(result, OnEnd(label, desc, desc));
+  result |= OnEnd(label, desc, desc);
   return result;
 }
 
@@ -488,7 +470,7 @@ Result TypeChecker::OnRethrow(Index depth) {
 
 Result TypeChecker::OnThrow(const TypeVector* sig) {
   Result result = Result::Ok;
-  COMBINE_RESULT(result, PopAndCheckSignature(*sig, "throw"));
+  result |= PopAndCheckSignature(*sig, "throw");
   CHECK_RESULT(SetUnreachable());
   return result;
 }
@@ -497,16 +479,16 @@ Result TypeChecker::OnReturn() {
   Result result = Result::Ok;
   Label* func_label;
   CHECK_RESULT(GetLabel(label_stack_.size() - 1, &func_label));
-  COMBINE_RESULT(result, PopAndCheckSignature(func_label->sig, "return"));
+  result |= PopAndCheckSignature(func_label->sig, "return");
   CHECK_RESULT(SetUnreachable());
   return result;
 }
 
 Result TypeChecker::OnSelect() {
   Result result = Result::Ok;
-  COMBINE_RESULT(result, PopAndCheck1Type(Type::I32, "select"));
+  result |= PopAndCheck1Type(Type::I32, "select");
   Type type = Type::Any;
-  COMBINE_RESULT(result, PopAndCheck2TypesAreEqual(&type, "select"));
+  result |= PopAndCheck2TypesAreEqual(&type, "select");
   PushType(type);
   return result;
 }
@@ -530,7 +512,7 @@ Result TypeChecker::OnTryBlock(const TypeVector* sig) {
 
 Result TypeChecker::OnTeeLocal(Type type) {
   Result result = Result::Ok;
-  COMBINE_RESULT(result, PopAndCheck1Type(type, "tee_local"));
+  result |= PopAndCheck1Type(type, "tee_local");
   PushType(type);
   return result;
 }
@@ -547,8 +529,8 @@ Result TypeChecker::EndFunction() {
   Result result = Result::Ok;
   Label* label;
   CHECK_RESULT(TopLabel(&label));
-  COMBINE_RESULT(result, CheckLabelType(label, LabelType::Func));
-  COMBINE_RESULT(result, OnEnd(label, "implicit return", "function"));
+  result |= CheckLabelType(label, LabelType::Func);
+  result |= OnEnd(label, "implicit return", "function");
   return result;
 }
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -200,11 +200,7 @@ Result Validator::CheckVar(Index max_index,
 
 Result Validator::CheckFuncVar(const Var* var, const Func** out_func) {
   Index index;
-  if (Failed(
-          CheckVar(current_module_->funcs.size(), var, "function", &index))) {
-    return Result::Error;
-  }
-
+  CHECK_RESULT(CheckVar(current_module_->funcs.size(), var, "function", &index));
   if (out_func)
     *out_func = current_module_->funcs[index];
   return Result::Ok;
@@ -214,11 +210,8 @@ Result Validator::CheckGlobalVar(const Var* var,
                                  const Global** out_global,
                                  Index* out_global_index) {
   Index index;
-  if (Failed(
-          CheckVar(current_module_->globals.size(), var, "global", &index))) {
-    return Result::Error;
-  }
-
+  CHECK_RESULT(
+      CheckVar(current_module_->globals.size(), var, "global", &index));
   if (out_global)
     *out_global = current_module_->globals[index];
   if (out_global_index)
@@ -236,11 +229,8 @@ Type Validator::GetGlobalVarTypeOrAny(const Var* var) {
 Result Validator::CheckFuncTypeVar(const Var* var,
                                    const FuncType** out_func_type) {
   Index index;
-  if (Failed(CheckVar(current_module_->func_types.size(), var,
-                      "function type", &index))) {
-    return Result::Error;
-  }
-
+  CHECK_RESULT(CheckVar(current_module_->func_types.size(), var,
+                        "function type", &index));
   if (out_func_type)
     *out_func_type = current_module_->func_types[index];
   return Result::Ok;
@@ -248,10 +238,7 @@ Result Validator::CheckFuncTypeVar(const Var* var,
 
 Result Validator::CheckTableVar(const Var* var, const Table** out_table) {
   Index index;
-  if (Failed(CheckVar(current_module_->tables.size(), var, "table", &index))) {
-    return Result::Error;
-  }
-
+  CHECK_RESULT(CheckVar(current_module_->tables.size(), var, "table", &index));
   if (out_table)
     *out_table = current_module_->tables[index];
   return Result::Ok;
@@ -259,11 +246,8 @@ Result Validator::CheckTableVar(const Var* var, const Table** out_table) {
 
 Result Validator::CheckMemoryVar(const Var* var, const Memory** out_memory) {
   Index index;
-  if (Failed(
-          CheckVar(current_module_->memories.size(), var, "memory", &index))) {
-    return Result::Error;
-  }
-
+  CHECK_RESULT(
+      CheckVar(current_module_->memories.size(), var, "memory", &index));
   if (out_memory)
     *out_memory = current_module_->memories[index];
   return Result::Ok;
@@ -745,12 +729,11 @@ void Validator::CheckElemSegments(const Module* module) {
     if (auto elem_segment_field = dyn_cast<ElemSegmentModuleField>(&field)) {
       auto&& elem_segment = elem_segment_field->elem_segment;
       const Table* table;
-      if (!Succeeded(CheckTableVar(&elem_segment.table_var, &table)))
+      if (Failed(CheckTableVar(&elem_segment.table_var, &table)))
         continue;
 
       for (const Var& var : elem_segment.vars) {
-        if (!Succeeded(CheckFuncVar(&var, nullptr)))
-          continue;
+        CheckFuncVar(&var, nullptr);
       }
 
       CheckConstInitExpr(&field.loc, elem_segment.offset, Type::I32,
@@ -770,7 +753,7 @@ void Validator::CheckDataSegments(const Module* module) {
     if (auto data_segment_field = dyn_cast<DataSegmentModuleField>(&field)) {
       auto&& data_segment = data_segment_field->data_segment;
       const Memory* memory;
-      if (!Succeeded(CheckMemoryVar(&data_segment.memory_var, &memory)))
+      if (Failed(CheckMemoryVar(&data_segment.memory_var, &memory)))
         continue;
 
       CheckConstInitExpr(&field.loc, data_segment.offset, Type::I32,
@@ -1003,10 +986,8 @@ Result Validator::CheckGet(const GetAction* action, Type* out_type) {
 
 Result Validator::CheckExceptVar(const Var* var, const Exception** out_except) {
   Index index;
-  if (Failed(
-          CheckVar(current_module_->excepts.size(), var, "except", &index))) {
-    return Result::Error;
-  }
+  CHECK_RESULT(
+      CheckVar(current_module_->excepts.size(), var, "except", &index));
   if (out_except)
     *out_except = current_module_->excepts[index];
   return Result::Ok;

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -25,12 +25,6 @@
 #define WABT_TRACING 0
 #include "tracing.h"
 
-#define CHECK_RESULT(expr)  \
-  do {                      \
-    if (Failed(expr))       \
-      return Result::Error; \
-  } while (0)
-
 #define EXPECT(token_type) CHECK_RESULT(Expect(TokenType::token_type))
 
 namespace wabt {


### PR DESCRIPTION
* Unify all uses of `CHECK_RESULT`
* Use `CHECK_RESULT` in a few more places
* Add `operator|` and `operator|=` to `Result`, use it instead of
  `COMBINE_RESULT`
* Change a few occurrences of `!Succeeded` to `Failed`