### PR TITLE
Use std::unique_ptr in intrusive-list API

### DIFF
--- a/src/cast.h
+++ b/src/cast.h
@@ -17,6 +17,7 @@
 #ifndef WABT_CAST_H_
 #define WABT_CAST_H_
 
+#include <memory>
 #include <type_traits>
 
 #include "src/common.h"
@@ -86,6 +87,21 @@ const Derived* dyn_cast(const Base* base) {
 template <typename Derived, typename Base>
 Derived* dyn_cast(Base* base) {
   return isa<Derived>(base) ? static_cast<Derived*>(base) : nullptr;
+};
+
+// Cast functionality for unique_ptr. isa and dyn_cast are not included because
+// they won't always pass ownership back to the caller.
+
+template <typename Derived, typename Base>
+std::unique_ptr<const Derived> cast(std::unique_ptr<const Base>&& base) {
+  assert(isa<Derived>(base.get()));
+  return std::unique_ptr<Derived>(static_cast<const Derived*>(base.release()));
+};
+
+template <typename Derived, typename Base>
+std::unique_ptr<Derived> cast(std::unique_ptr<Base>&& base) {
+  assert(isa<Derived>(base.get()));
+  return std::unique_ptr<Derived>(static_cast<Derived*>(base.release()));
 };
 
 } // namespace wabt

--- a/src/common.h
+++ b/src/common.h
@@ -32,6 +32,7 @@
 
 #include "config.h"
 
+#include "src/make-unique.h"
 #include "src/result.h"
 #include "src/string-view.h"
 
@@ -115,22 +116,6 @@ void Construct(T& placement, Args&&... args) {
 template <typename T>
 void Destruct(T& placement) {
   placement.~T();
-}
-
-// This is named MakeUnique instead of make_unique because make_unique has the
-// potential to conflict with std::make_unique if it is defined.
-//
-// On gcc/clang, we currently compile with c++11, which doesn't define
-// std::make_unique, but on MSVC the newest C++ version is always used, which
-// includes std::make_unique. If an argument from the std namespace is used, it
-// will cause ADL to find std::make_unique, and an unqualified call to
-// make_unique will be ambiguous. We can work around this by fully qualifying
-// the call (i.e. wabt::make_unique), but it's simpler to just use a different
-// name. It's also more consistent with other names in the wabt namespace,
-// which use CamelCase.
-template <typename T, typename... Args>
-std::unique_ptr<T> MakeUnique(Args&&... args) {
-  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
 }
 
 // Calls data() on vector, string, etc. but will return nullptr if the

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -191,59 +191,59 @@ Index Module::GetFuncTypeIndex(const FuncDeclaration& decl) const {
   }
 }
 
-void Module::AppendField(DataSegmentModuleField* field) {
-  fields.push_back(field);
+void Module::AppendField(std::unique_ptr<DataSegmentModuleField> field) {
   data_segments.push_back(&field->data_segment);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(ElemSegmentModuleField* field) {
-  fields.push_back(field);
+void Module::AppendField(std::unique_ptr<ElemSegmentModuleField> field) {
   elem_segments.push_back(&field->elem_segment);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(ExceptionModuleField* field) {
+void Module::AppendField(std::unique_ptr<ExceptionModuleField> field) {
   Exception& except = field->except;
   if (!except.name.empty())
     except_bindings.emplace(except.name, Binding(field->loc, excepts.size()));
   excepts.push_back(&except);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(ExportModuleField* field) {
+void Module::AppendField(std::unique_ptr<ExportModuleField> field) {
   // Exported names are allowed to be empty.
   Export& export_ = field->export_;
   export_bindings.emplace(export_.name, Binding(field->loc, exports.size()));
   exports.push_back(&export_);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(FuncModuleField* field) {
+void Module::AppendField(std::unique_ptr<FuncModuleField> field) {
   Func& func = field->func;
   if (!func.name.empty())
     func_bindings.emplace(func.name, Binding(field->loc, funcs.size()));
   funcs.push_back(&func);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(FuncTypeModuleField* field) {
+void Module::AppendField(std::unique_ptr<FuncTypeModuleField> field) {
   FuncType& func_type = field->func_type;
   if (!func_type.name.empty()) {
     func_type_bindings.emplace(func_type.name,
                                Binding(field->loc, func_types.size()));
   }
   func_types.push_back(&func_type);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(GlobalModuleField* field) {
+void Module::AppendField(std::unique_ptr<GlobalModuleField> field) {
   Global& global = field->global;
   if (!global.name.empty())
     global_bindings.emplace(global.name, Binding(field->loc, globals.size()));
   globals.push_back(&global);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(ImportModuleField* field) {
+void Module::AppendField(std::unique_ptr<ImportModuleField> field) {
   Import* import = field->import.get();
   const std::string* name = nullptr;
   BindingHash* bindings = nullptr;
@@ -305,81 +305,81 @@ void Module::AppendField(ImportModuleField* field) {
   if (!name->empty())
     bindings->emplace(*name, Binding(field->loc, index));
   imports.push_back(import);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(MemoryModuleField* field) {
+void Module::AppendField(std::unique_ptr<MemoryModuleField> field) {
   Memory& memory = field->memory;
   if (!memory.name.empty())
     memory_bindings.emplace(memory.name, Binding(field->loc, memories.size()));
   memories.push_back(&memory);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(StartModuleField* field) {
-  fields.push_back(field);
+void Module::AppendField(std::unique_ptr<StartModuleField> field) {
   start = &field->start;
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(TableModuleField* field) {
+void Module::AppendField(std::unique_ptr<TableModuleField> field) {
   Table& table = field->table;
   if (!table.name.empty())
     table_bindings.emplace(table.name, Binding(field->loc, tables.size()));
   tables.push_back(&table);
-  fields.push_back(field);
+  fields.push_back(std::move(field));
 }
 
-void Module::AppendField(ModuleField* field) {
+void Module::AppendField(std::unique_ptr<ModuleField> field) {
   switch (field->type()) {
     case ModuleFieldType::Func:
-      AppendField(dyn_cast<FuncModuleField>(field));
+      AppendField(cast<FuncModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Global:
-      AppendField(dyn_cast<GlobalModuleField>(field));
+      AppendField(cast<GlobalModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Import:
-      AppendField(dyn_cast<ImportModuleField>(field));
+      AppendField(cast<ImportModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Export:
-      AppendField(dyn_cast<ExportModuleField>(field));
+      AppendField(cast<ExportModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::FuncType:
-      AppendField(dyn_cast<FuncTypeModuleField>(field));
+      AppendField(cast<FuncTypeModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Table:
-      AppendField(dyn_cast<TableModuleField>(field));
+      AppendField(cast<TableModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::ElemSegment:
-      AppendField(dyn_cast<ElemSegmentModuleField>(field));
+      AppendField(cast<ElemSegmentModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Memory:
-      AppendField(dyn_cast<MemoryModuleField>(field));
+      AppendField(cast<MemoryModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::DataSegment:
-      AppendField(dyn_cast<DataSegmentModuleField>(field));
+      AppendField(cast<DataSegmentModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Start:
-      AppendField(dyn_cast<StartModuleField>(field));
+      AppendField(cast<StartModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Except:
-      AppendField(dyn_cast<ExceptionModuleField>(field));
+      AppendField(cast<ExceptionModuleField>(std::move(field)));
       break;
   }
 }
 
 void Module::AppendFields(ModuleFieldList* fields) {
   while (!fields->empty())
-    AppendField(fields->extract_front());
+    AppendField(std::unique_ptr<ModuleField>(fields->extract_front()));
 }
 
 const Module* Script::GetFirstModule() const {

--- a/src/ir.h
+++ b/src/ir.h
@@ -658,18 +658,18 @@ struct Module {
   Index GetExceptIndex(const Var&) const;
 
   // TODO(binji): move this into a builder class?
-  void AppendField(DataSegmentModuleField*);
-  void AppendField(ElemSegmentModuleField*);
-  void AppendField(ExceptionModuleField*);
-  void AppendField(ExportModuleField*);
-  void AppendField(FuncModuleField*);
-  void AppendField(FuncTypeModuleField*);
-  void AppendField(GlobalModuleField*);
-  void AppendField(ImportModuleField*);
-  void AppendField(MemoryModuleField*);
-  void AppendField(StartModuleField*);
-  void AppendField(TableModuleField*);
-  void AppendField(ModuleField*);
+  void AppendField(std::unique_ptr<DataSegmentModuleField>);
+  void AppendField(std::unique_ptr<ElemSegmentModuleField>);
+  void AppendField(std::unique_ptr<ExceptionModuleField>);
+  void AppendField(std::unique_ptr<ExportModuleField>);
+  void AppendField(std::unique_ptr<FuncModuleField>);
+  void AppendField(std::unique_ptr<FuncTypeModuleField>);
+  void AppendField(std::unique_ptr<GlobalModuleField>);
+  void AppendField(std::unique_ptr<ImportModuleField>);
+  void AppendField(std::unique_ptr<MemoryModuleField>);
+  void AppendField(std::unique_ptr<StartModuleField>);
+  void AppendField(std::unique_ptr<TableModuleField>);
+  void AppendField(std::unique_ptr<ModuleField>);
   void AppendFields(ModuleFieldList*);
 
   Location loc;

--- a/src/make-unique.h
+++ b/src/make-unique.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_MAKE_UNIQUE_H_
+#define WABT_MAKE_UNIQUE_H_
+
+#include <memory>
+
+namespace wabt {
+
+// This is named MakeUnique instead of make_unique because make_unique has the
+// potential to conflict with std::make_unique if it is defined.
+//
+// On gcc/clang, we currently compile with c++11, which doesn't define
+// std::make_unique, but on MSVC the newest C++ version is always used, which
+// includes std::make_unique. If an argument from the std namespace is used, it
+// will cause ADL to find std::make_unique, and an unqualified call to
+// make_unique will be ambiguous. We can work around this by fully qualifying
+// the call (i.e. wabt::make_unique), but it's simpler to just use a different
+// name. It's also more consistent with other names in the wabt namespace,
+// which use CamelCase.
+template <typename T, typename... Args>
+std::unique_ptr<T> MakeUnique(Args&&... args) {
+  return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
+} // namespace wabt
+
+#endif  // WABT_MAKE_UNIQUE_H_

--- a/src/test-intrusive-list.cc
+++ b/src/test-intrusive-list.cc
@@ -19,6 +19,7 @@
 #include <memory>
 
 #include "src/intrusive-list.h"
+#include "src/make-unique.h"
 
 using namespace wabt;
 
@@ -112,7 +113,7 @@ TEST_F(IntrusiveListTest, default_constructor) {
 }
 
 TEST_F(IntrusiveListTest, node_constructor) {
-  TestObjectList list(new TestObject(1));
+  TestObjectList list(MakeUnique<TestObject>(1));
   AssertListEq(list, {1});
 }
 
@@ -277,9 +278,9 @@ TEST_F(IntrusiveListTest, emplace_back) {
 TEST_F(IntrusiveListTest, push_front_pointer) {
   TestObjectList list;
 
-  list.push_front(new TestObject(1));
-  list.push_front(new TestObject(2));
-  list.push_front(new TestObject(3));
+  list.push_front(MakeUnique<TestObject>(1));
+  list.push_front(MakeUnique<TestObject>(2));
+  list.push_front(MakeUnique<TestObject>(3));
 
   AssertListEq(list, {3, 2, 1});
 }
@@ -287,9 +288,9 @@ TEST_F(IntrusiveListTest, push_front_pointer) {
 TEST_F(IntrusiveListTest, push_back_pointer) {
   TestObjectList list;
 
-  list.push_back(new TestObject(1));
-  list.push_back(new TestObject(2));
-  list.push_back(new TestObject(3));
+  list.push_back(MakeUnique<TestObject>(1));
+  list.push_back(MakeUnique<TestObject>(2));
+  list.push_back(MakeUnique<TestObject>(3));
 
   AssertListEq(list, {1, 2, 3});
 }
@@ -387,10 +388,10 @@ TEST_F(IntrusiveListTest, emplace) {
 TEST_F(IntrusiveListTest, insert_pointer) {
   TestObjectList list;
 
-  list.insert(list.begin(), new TestObject(2));
-  list.insert(list.end(), new TestObject(4));
-  list.insert(std::next(list.begin()), new TestObject(3));
-  list.insert(list.begin(), new TestObject(1));
+  list.insert(list.begin(), MakeUnique<TestObject>(2));
+  list.insert(list.end(), MakeUnique<TestObject>(4));
+  list.insert(std::next(list.begin()), MakeUnique<TestObject>(3));
+  list.insert(list.begin(), MakeUnique<TestObject>(1));
 
   AssertListEq(list, {1, 2, 3, 4});
 }


### PR DESCRIPTION
By using std::unique_ptr in more function signatures, we can avoid calls
to `std::unique_ptr<T>::release`.

This change also moves `wabt::MakeUnique` into `src/make-unique.h` so it
can be used in `intrusive-list.h` and `test-intrusive-list.cc` without
pulling in all of `common.h`.