### PR TITLE
Return unique_ptr<Script> from parser

### DIFF
--- a/src/emscripten-helpers.cc
+++ b/src/emscripten-helpers.cc
@@ -66,9 +66,9 @@ wabt::WastLexer* wabt_new_wast_buffer_lexer(const char* filename,
 WabtParseWastResult* wabt_parse_wast(wabt::WastLexer* lexer,
                                      wabt::ErrorHandlerBuffer* error_handler) {
   WabtParseWastResult* result = new WabtParseWastResult();
-  wabt::Script* script = nullptr;
+  std::unique_ptr<wabt::Script> script;
   result->result = wabt::ParseWast(lexer, &script, error_handler);
-  result->script.reset(script);
+  result->script = std::move(script);
   return result;
 }
 
@@ -91,31 +91,31 @@ WabtReadBinaryResult* wabt_read_binary(
   return result;
 }
 
-wabt::Result wabt_resolve_names_script(
+wabt::Result::Enum wabt_resolve_names_script(
     wabt::WastLexer* lexer,
     wabt::Script* script,
     wabt::ErrorHandlerBuffer* error_handler) {
   return ResolveNamesScript(lexer, script, error_handler);
 }
 
-wabt::Result wabt_resolve_names_module(
+wabt::Result::Enum wabt_resolve_names_module(
     wabt::WastLexer* lexer,
     wabt::Module* module,
     wabt::ErrorHandlerBuffer* error_handler) {
   return ResolveNamesModule(lexer, module, error_handler);
 }
 
-wabt::Result wabt_validate_script(wabt::WastLexer* lexer,
+wabt::Result::Enum wabt_validate_script(wabt::WastLexer* lexer,
                                   wabt::Script* script,
                                   wabt::ErrorHandlerBuffer* error_handler) {
   return ValidateScript(lexer, script, error_handler);
 }
 
-wabt::Result wabt_apply_names_module(wabt::Module* module) {
+wabt::Result::Enum wabt_apply_names_module(wabt::Module* module) {
   return ApplyNames(module);
 }
 
-wabt::Result wabt_generate_names_module(wabt::Module* module) {
+wabt::Result::Enum wabt_generate_names_module(wabt::Module* module) {
   return GenerateNames(module);
 }
 
@@ -199,7 +199,8 @@ void wabt_destroy_error_handler_buffer(
 }
 
 // WabtParseWastResult
-wabt::Result wabt_parse_wast_result_get_result(WabtParseWastResult* result) {
+wabt::Result::Enum wabt_parse_wast_result_get_result(
+    WabtParseWastResult* result) {
   return result->result;
 }
 
@@ -213,7 +214,8 @@ void wabt_destroy_parse_wast_result(WabtParseWastResult* result) {
 }
 
 // WabtReadBinaryResult
-wabt::Result wabt_read_binary_result_get_result(WabtReadBinaryResult* result) {
+wabt::Result::Enum wabt_read_binary_result_get_result(
+    WabtReadBinaryResult* result) {
   return result->result;
 }
 
@@ -227,7 +229,7 @@ void wabt_destroy_read_binary_result(WabtReadBinaryResult* result) {
 }
 
 // WabtWriteModuleResult
-wabt::Result wabt_write_module_result_get_result(
+wabt::Result::Enum wabt_write_module_result_get_result(
     WabtWriteModuleResult* result) {
   return result->result;
 }

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -1012,8 +1012,8 @@ wabt::Result SpecJSONParser::ReadInvalidTextModule(
     ErrorHandler* error_handler) {
   std::unique_ptr<WastLexer> lexer =
       WastLexer::CreateFileLexer(module_filename);
-  wabt::Result result = ParseWast(lexer.get(), nullptr, error_handler);
-  return result;
+  std::unique_ptr<Script> script;
+  return ParseWast(lexer.get(), &script, error_handler);
 }
 
 wabt::Result SpecJSONParser::ReadInvalidModule(const char* module_filename,

--- a/src/tools/wast-desugar.cc
+++ b/src/tools/wast-desugar.cc
@@ -87,7 +87,7 @@ int ProgramMain(int argc, char** argv) {
     WABT_FATAL("unable to read %s\n", s_infile);
 
   ErrorHandlerFile error_handler(Location::Type::Text);
-  Script* script;
+  std::unique_ptr<Script> script;
   WastParseOptions parse_wast_options(s_features);
   Result result =
       ParseWast(lexer.get(), &script, &error_handler, &parse_wast_options);
@@ -109,7 +109,6 @@ int ProgramMain(int argc, char** argv) {
     }
   }
 
-  delete script;
   return result != Result::Ok;
 }
 

--- a/src/tools/wast2wasm.cc
+++ b/src/tools/wast2wasm.cc
@@ -135,24 +135,24 @@ int ProgramMain(int argc, char** argv) {
     WABT_FATAL("unable to read file: %s\n", s_infile);
 
   ErrorHandlerFile error_handler(Location::Type::Text);
-  Script* script;
+  std::unique_ptr<Script> script;
   WastParseOptions parse_wast_options(s_features);
   Result result =
       ParseWast(lexer.get(), &script, &error_handler, &parse_wast_options);
 
   if (Succeeded(result)) {
-    result = ResolveNamesScript(lexer.get(), script, &error_handler);
+    result = ResolveNamesScript(lexer.get(), script.get(), &error_handler);
 
     if (Succeeded(result) && s_validate)
-      result = ValidateScript(lexer.get(), script, &error_handler);
+      result = ValidateScript(lexer.get(), script.get(), &error_handler);
 
     if (Succeeded(result)) {
       if (s_spec) {
         WriteBinarySpecOptions write_binary_spec_options;
         write_binary_spec_options.json_filename = s_outfile;
         write_binary_spec_options.write_binary_options = s_write_binary_options;
-        result =
-            WriteBinarySpecScript(script, s_infile, &write_binary_spec_options);
+        result = WriteBinarySpecScript(script.get(), s_infile,
+                                       &write_binary_spec_options);
       } else {
         MemoryWriter writer;
         const Module* module = script->GetFirstModule();
@@ -168,7 +168,6 @@ int ProgramMain(int argc, char** argv) {
     }
   }
 
-  delete script;
   return result != Result::Ok;
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -20,6 +20,7 @@
 #include "src/binary-reader-ir.h"
 #include "src/cast.h"
 #include "src/error-handler.h"
+#include "src/make-unique.h"
 #include "src/wast-parser-lexer-shared.h"
 
 #define WABT_TRACING 0
@@ -629,9 +630,9 @@ Result WastParser::ParseNat(uint64_t* out_nat) {
   return Result::Ok;
 }
 
-Result WastParser::ParseScript(Script* script) {
+Result WastParser::ParseScript() {
   WABT_TRACE(ParseScript);
-  script_ = script;
+  script_ = MakeUnique<Script>();
 
   // Don't consume the Lpar yet, even though it is required. This way the
   // sub-parser functions (e.g. ParseFuncModuleField) can consume it and keep
@@ -641,9 +642,9 @@ Result WastParser::ParseScript(Script* script) {
     auto command = MakeUnique<ModuleCommand>();
     command->module.loc = GetLocation();
     CHECK_RESULT(ParseModuleFieldList(&command->module));
-    script->commands.emplace_back(std::move(command));
+    script_->commands.emplace_back(std::move(command));
   } else if (IsCommand(PeekPair())) {
-    CHECK_RESULT(ParseCommandList(&script->commands));
+    CHECK_RESULT(ParseCommandList(&script_->commands));
   } else {
     ConsumeIfLpar();
     ErrorExpected({"a module field", "a command"});
@@ -1978,17 +1979,18 @@ void WastParser::CheckImportOrdering(Module* module) {
   }
 }
 
+std::unique_ptr<Script> WastParser::ReleaseScript() {
+  return std::move(script_);
+}
+
 Result ParseWast(WastLexer* lexer,
-                 Script** out_script,
+                 std::unique_ptr<Script>* out_script,
                  ErrorHandler* error_handler,
                  WastParseOptions* options) {
-  auto script = MakeUnique<Script>();
+  assert(out_script != nullptr);
   WastParser parser(lexer, error_handler, options);
-  Result result = parser.ParseScript(script.get());
-
-  if (out_script)
-    *out_script = script.release();
-
+  Result result = parser.ParseScript();
+  *out_script = parser.ReleaseScript();
   return result;
 }
 

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -43,7 +43,8 @@ class WastParser {
   WastParser(WastLexer*, ErrorHandler*, WastParseOptions*);
 
   void WABT_PRINTF_FORMAT(3, 4) Error(Location, const char* format, ...);
-  Result ParseScript(Script*);
+  Result ParseScript();
+  std::unique_ptr<Script> ReleaseScript();
 
  private:
   void ErrorUnlessOpcodeEnabled(const Token&);
@@ -196,7 +197,7 @@ class WastParser {
   void CheckImportOrdering(Module*);
 
   WastLexer* lexer_;
-  Script* script_ = nullptr;
+  std::unique_ptr<Script> script_;
   Index last_module_index_ = kInvalidIndex;
   ErrorHandler* error_handler_;
   int errors_ = 0;
@@ -206,7 +207,7 @@ class WastParser {
 };
 
 Result ParseWast(WastLexer* lexer,
-                 Script** out_script,
+                 std::unique_ptr<Script>* out_script,
                  ErrorHandler*,
                  WastParseOptions* options = nullptr);
 


### PR DESCRIPTION
This removes a few more places we were using `delete`. I also checked
the emscripten build and found that the previous change to
`wabt::Result` broke this, so I fixed those too.