### PR TITLE
Fix parsing bug in ParseCommandList

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1658,7 +1658,7 @@ Result WastParser::ParseGlobalType(Global* global) {
 
 Result WastParser::ParseCommandList(CommandPtrVector* commands) {
   WABT_TRACE(ParseCommandList);
-  while (PeekMatch(TokenType::Lpar)) {
+  while (IsCommand(PeekPair())) {
     CommandPtr command;
     if (Succeeded(ParseCommand(&command))) {
       commands->push_back(std::move(command));

--- a/test/regress/regress-12.txt
+++ b/test/regress/regress-12.txt
@@ -1,0 +1,11 @@
+;;; ERROR: 1
+(module
+  (func)
+)
+
+(func))
+(;; STDERR ;;;
+out/test/regress/regress-12.txt:6:1: error: unexpected token (, expected EOF.
+(func))
+^
+;;; STDERR ;;)


### PR DESCRIPTION
This would previously fire an assert because it was attempting to
`ParseCommand` when `IsCommand` was false.