### PR TITLE
Add virtual destructor to Stream

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -34,7 +34,8 @@ enum class PrintChars {
 
 class Stream {
  public:
-  Stream(Stream* log_stream = nullptr);
+  explicit Stream(Stream* log_stream = nullptr);
+  virtual ~Stream() = default;
 
   size_t offset() { return offset_; }
   Result result() { return result_; }


### PR DESCRIPTION
Seems to be causing a warning on some builds; I didn't see it on Travis,
though.