### PR TITLE
Only allow parsing one module with wat2wasm

### DIFF
--- a/src/emscripten-helpers.cc
+++ b/src/emscripten-helpers.cc
@@ -66,7 +66,7 @@ WabtParseWastResult* wabt_parse_wast(wabt::WastLexer* lexer,
                                      wabt::ErrorHandlerBuffer* error_handler) {
   WabtParseWastResult* result = new WabtParseWastResult();
   std::unique_ptr<wabt::Script> script;
-  result->result = wabt::ParseWast(lexer, &script, error_handler);
+  result->result = wabt::ParseWastScript(lexer, &script, error_handler);
   result->script = std::move(script);
   return result;
 }

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -1014,7 +1014,7 @@ wabt::Result SpecJSONParser::ReadInvalidTextModule(
   std::unique_ptr<WastLexer> lexer =
       WastLexer::CreateFileLexer(module_filename);
   std::unique_ptr<Script> script;
-  wabt::Result result = ParseWast(lexer.get(), &script, error_handler);
+  wabt::Result result = ParseWastScript(lexer.get(), &script, error_handler);
   if (Succeeded(result)) {
     wabt::Module* module = script->GetFirstModule();
     result = ResolveNamesModule(lexer.get(), module, error_handler);

--- a/src/tools/wast-desugar.cc
+++ b/src/tools/wast-desugar.cc
@@ -88,8 +88,8 @@ int ProgramMain(int argc, char** argv) {
   ErrorHandlerFile error_handler(Location::Type::Text);
   std::unique_ptr<Script> script;
   WastParseOptions parse_wast_options(s_features);
-  Result result =
-      ParseWast(lexer.get(), &script, &error_handler, &parse_wast_options);
+  Result result = ParseWastScript(lexer.get(), &script, &error_handler,
+                                  &parse_wast_options);
 
   if (Succeeded(result)) {
     Module* module = script->GetFirstModule();

--- a/src/tools/wast2json.cc
+++ b/src/tools/wast2json.cc
@@ -101,8 +101,8 @@ int ProgramMain(int argc, char** argv) {
   ErrorHandlerFile error_handler(Location::Type::Text);
   std::unique_ptr<Script> script;
   WastParseOptions parse_wast_options(s_features);
-  Result result =
-      ParseWast(lexer.get(), &script, &error_handler, &parse_wast_options);
+  Result result = ParseWastScript(lexer.get(), &script, &error_handler,
+                                  &parse_wast_options);
 
   if (Succeeded(result)) {
     result = ResolveNamesScript(lexer.get(), script.get(), &error_handler);

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -43,7 +43,9 @@ class WastParser {
   WastParser(WastLexer*, ErrorHandler*, WastParseOptions*);
 
   void WABT_PRINTF_FORMAT(3, 4) Error(Location, const char* format, ...);
-  Result ParseScript();
+  Result ParseModule(std::unique_ptr<Module>* out_module);
+  Result ParseScript(std::unique_ptr<Script>* out_script);
+
   std::unique_ptr<Script> ReleaseScript();
 
  private:
@@ -168,8 +170,8 @@ class WastParser {
   template <typename T>
   Result ParsePlainInstrVar(Location, std::unique_ptr<Expr>*);
 
-  Result ParseCommandList(CommandPtrVector*);
-  Result ParseCommand(CommandPtr*);
+  Result ParseCommandList(Script*, CommandPtrVector*);
+  Result ParseCommand(Script*, CommandPtr*);
   Result ParseAssertExhaustionCommand(CommandPtr*);
   Result ParseAssertInvalidCommand(CommandPtr*);
   Result ParseAssertMalformedCommand(CommandPtr*);
@@ -179,7 +181,7 @@ class WastParser {
   Result ParseAssertTrapCommand(CommandPtr*);
   Result ParseAssertUnlinkableCommand(CommandPtr*);
   Result ParseActionCommand(CommandPtr*);
-  Result ParseModuleCommand(CommandPtr*);
+  Result ParseModuleCommand(Script*, CommandPtr*);
   Result ParseRegisterCommand(CommandPtr*);
 
   Result ParseAction(ActionPtr*);
@@ -197,7 +199,6 @@ class WastParser {
   void CheckImportOrdering(Module*);
 
   WastLexer* lexer_;
-  std::unique_ptr<Script> script_;
   Index last_module_index_ = kInvalidIndex;
   ErrorHandler* error_handler_;
   int errors_ = 0;
@@ -206,10 +207,15 @@ class WastParser {
   CircularArray<Token, 2> tokens_;
 };
 
-Result ParseWast(WastLexer* lexer,
-                 std::unique_ptr<Script>* out_script,
-                 ErrorHandler*,
-                 WastParseOptions* options = nullptr);
+Result ParseWatModule(WastLexer* lexer,
+                      std::unique_ptr<Module>* out_module,
+                      ErrorHandler*,
+                      WastParseOptions* options = nullptr);
+
+Result ParseWastScript(WastLexer* lexer,
+                       std::unique_ptr<Script>* out_script,
+                       ErrorHandler*,
+                       WastParseOptions* options = nullptr);
 
 }  // namespace wabt
 

--- a/test/parse/bad-crlf.txt
+++ b/test/parse/bad-crlf.txt
@@ -2,7 +2,7 @@
 modulez
 funcz
 (;; STDERR ;;;
-out/test/parse/bad-crlf.txt:2:1: error: unexpected token "modulez", expected a module field or a command.
+out/test/parse/bad-crlf.txt:2:1: error: unexpected token "modulez", expected a module field or a module.
 modulez
 ^^^^^^^
 out/test/parse/bad-crlf.txt:3:1: error: unexpected token funcz, expected EOF.

--- a/test/parse/bad-error-long-line.txt
+++ b/test/parse/bad-error-long-line.txt
@@ -1,7 +1,7 @@
 ;;; ERROR: 1
                                                                                                                                                                          whoops                      (; some text at the end of the line ;)
 (;; STDERR ;;;
-out/test/parse/bad-error-long-line.txt:2:170: error: unexpected token "whoops", expected a module field or a command.
+out/test/parse/bad-error-long-line.txt:2:170: error: unexpected token "whoops", expected a module field or a module.
 ...                                  whoops                      (; some text...
                                      ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/bad-error-long-token.txt
+++ b/test/parse/bad-error-long-token.txt
@@ -1,7 +1,7 @@
 ;;; ERROR: 1
               abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz                                                   
 (;; STDERR ;;;
-out/test/parse/bad-error-long-token.txt:2:15: error: unexpected token "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", expected a module field or a command.
+out/test/parse/bad-error-long-token.txt:2:15: error: unexpected token "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz", expected a module field or a module.
               abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/bad-single-semicolon.txt
+++ b/test/parse/bad-single-semicolon.txt
@@ -5,7 +5,7 @@
 out/test/parse/bad-single-semicolon.txt:2:1: error: unexpected char
 ; foo bar
 ^
-out/test/parse/bad-single-semicolon.txt:2:3: error: unexpected token "foo", expected a module field or a command.
+out/test/parse/bad-single-semicolon.txt:2:3: error: unexpected token "foo", expected a module field or a module.
 ; foo bar
   ^^^
 out/test/parse/bad-single-semicolon.txt:2:7: error: unexpected token bar, expected EOF.

--- a/test/parse/bad-toplevel.txt
+++ b/test/parse/bad-toplevel.txt
@@ -1,7 +1,7 @@
 ;;; ERROR: 1
 (foo bar)
 (;; STDERR ;;;
-out/test/parse/bad-toplevel.txt:2:2: error: unexpected token "foo", expected a module field or a command.
+out/test/parse/bad-toplevel.txt:2:2: error: unexpected token "foo", expected a module field or a module.
 (foo bar)
  ^^^
 out/test/parse/bad-toplevel.txt:2:6: error: unexpected token bar, expected EOF.

--- a/test/parse/empty-file.txt
+++ b/test/parse/empty-file.txt
@@ -1,5 +1,5 @@
 ;;; ERROR: 1
 ;; empty file
 (;; STDERR ;;;
-out/test/parse/empty-file.txt:3:2: error: unexpected token "EOF", expected a module field or a command.
+out/test/parse/empty-file.txt:3:2: error: unexpected token "EOF", expected a module field or a module.
 ;;; STDERR ;;)

--- a/test/parse/module/bad-module-multi.txt
+++ b/test/parse/module/bad-module-multi.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+(module (func))
+
+;; Can't have two modules in a .wat file.
+(module)
+(;; STDERR ;;;
+out/test/parse/module/bad-module-multi.txt:5:1: error: unexpected token (, expected EOF.
+(module)
+^
+;;; STDERR ;;)

--- a/test/parse/module/bad-module-with-assert.txt
+++ b/test/parse/module/bad-module-with-assert.txt
@@ -1,0 +1,10 @@
+;;; ERROR: 1
+(module (func (export "f")))
+
+;; Can't use assert_return when parsing a .wat file.
+(assert_return (invoke "f"))
+(;; STDERR ;;;
+out/test/parse/module/bad-module-with-assert.txt:5:1: error: unexpected token (, expected EOF.
+(assert_return (invoke "f"))
+^
+;;; STDERR ;;)


### PR DESCRIPTION
`.wat` files can only contain one module, and no assertions.

This fixes issue #621.