### PR TITLE
Enable all reader features in objdump

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1127,10 +1127,9 @@ Result ReadBinaryObjdump(const uint8_t* data,
                          size_t size,
                          ObjdumpOptions* options,
                          ObjdumpState* state) {
-  ReadBinaryOptions read_options;
-  read_options.read_debug_names = true;
-  read_options.log_stream = options->log_stream;
-  read_options.features = options->features;
+  Features features;
+  features.EnableAll();
+  ReadBinaryOptions read_options(features, options->log_stream, true);
 
   switch (options->mode) {
     case ObjdumpMode::Prepass: {

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -45,7 +45,6 @@ struct ObjdumpOptions {
   bool disassemble;
   bool debug;
   bool relocs;
-  Features features;
   ObjdumpMode mode;
   const char* filename;
   const char* section_name;

--- a/src/feature.h
+++ b/src/feature.h
@@ -27,6 +27,12 @@ class Features {
  public:
   void AddOptions(OptionParser*);
 
+  void EnableAll() {
+#define WABT_FEATURE(variable, flag, help) enable_##variable();
+#include "src/feature.def"
+#undef WABT_FEATURE
+  }
+
 #define WABT_FEATURE(variable, flag, help) \
   bool variable##_enabled() const { return variable##_enabled_; } \
   void enable_##variable() { variable##_enabled_ = true; }

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -19,7 +19,6 @@
 #include <cstring>
 
 #include "src/common.h"
-#include "src/feature.h"
 #include "src/option-parser.h"
 #include "src/stream.h"
 #include "src/binary-reader.h"
@@ -35,7 +34,6 @@ examples:
 )";
 
 static ObjdumpOptions s_objdump_options;
-static Features s_features;
 
 static std::vector<const char*> s_infiles;
 
@@ -58,7 +56,6 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
     s_objdump_options.log_stream = s_log_stream.get();
   });
-  s_features.AddOptions(&parser);
   parser.AddOption('x', "details", "Show section details",
                    []() { s_objdump_options.details = true; });
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",
@@ -81,7 +78,6 @@ Result dump_file(const char* filename) {
   // Perform serveral passed over the binary in order to print out different
   // types of information.
   s_objdump_options.filename = filename;
-  s_objdump_options.features = s_features;
   printf("\n");
 
   ObjdumpState state;

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -9,15 +9,12 @@ examples:
   $ wasm-objdump test.wasm
 
 options:
-  -h, --headers                               Print headers
-  -j, --section=SECTION                       Select just one section
-  -s, --full-contents                         Print raw section contents
-  -d, --disassemble                           Disassemble function bodies
-      --debug                                 Print extra debug information
-      --enable-exceptions                     Experimental exception handling
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-threads                        Threading support
-  -x, --details                               Show section details
-  -r, --reloc                                 Show relocations inline with disassembly
-  -h, --help                                  Print this help message
+  -h, --headers                Print headers
+  -j, --section=SECTION        Select just one section
+  -s, --full-contents          Print raw section contents
+  -d, --disassemble            Disassemble function bodies
+      --debug                  Print extra debug information
+  -x, --details                Show section details
+  -r, --reloc                  Show relocations inline with disassembly
+  -h, --help                   Print this help message
 ;;; STDOUT ;;)

--- a/test/run-objdump.py
+++ b/test/run-objdump.py
@@ -90,10 +90,6 @@ def main(args):
       find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
   wasm_objdump.AppendOptionalArgs({
-      '--enable-exceptions': options.enable_exceptions,
-      '--enable-saturating-float-to-int':
-          options.enable_saturating_float_to_int,
-      '--enable-threads': options.enable_threads,
       '-h': options.headers,
       '-x': options.dump_verbose,
       '--debug': options.dump_debug,


### PR DESCRIPTION
Objdump should really make a best effort to display
anything its given.  There are other tools that are
better suited for validation.

Partial fix for #627 