### PR TITLE
Correctly report the value of bad opcodes

### DIFF
--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -37,9 +37,6 @@ Opcode::Info Opcode::infos_[] = {
 #undef WABT_OPCODE
 
 // static
-Opcode::Info Opcode::invalid_info_ = {
-    "<invalid>", Type::Void, Type::Void, Type::Void, 0, 0, 0, 0,
-};
 
 // static
 Opcode Opcode::FromCode(uint32_t code) {
@@ -62,7 +59,9 @@ Opcode Opcode::FromCode(uint8_t prefix, uint32_t code) {
 }
 
 Opcode::Info Opcode::GetInfo() const {
-  return enum_ < Invalid ? infos_[enum_] : invalid_info_;
+  if (enum_ >= Invalid)
+    return { "<invalid>", Type::Void, Type::Void, Type::Void, 0, 0, enum_, 0 };
+  return infos_[enum_];
 }
 
 bool Opcode::IsNaturallyAligned(Address alignment) const {

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -1,0 +1,23 @@
+;;; TOOL: run-gen-wasm
+;;; FLAGS: --objdump
+;;; ERROR: 1
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    invalid_op[0xff]
+  }
+}
+(;; STDERR ;;;
+Error running "wasm-objdump":
+*ERROR*: @0x0000001a: unexpected opcode: 195 (0xc3)
+
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+bad-opcode.wasm:	file format wasm 0x1
+;;; STDOUT ;;)


### PR DESCRIPTION
Previously we were always reporting 0.

Partial fix for #627