### PR TITLE
Correctly report the value of bad opcodes

### DIFF
--- a/src/opcode.h
+++ b/src/opcode.h
@@ -28,7 +28,7 @@ struct Opcode {
   //
   // NOTE: this enum does not match the binary encoding.
   //
-  enum Enum {
+  enum Enum : uint32_t {
 #define WABT_OPCODE(rtype, type1, type2, mem_size, prefix, code, Name, text) \
   Name,
 #include "src/opcode.def"
@@ -66,12 +66,15 @@ struct Opcode {
   // |opcode|, else return |alignment|.
   Address GetAlignment(Address alignment) const;
 
-  static bool IsPrefixByte(uint8_t byte) { return byte >= kFirstPrefix; }
+  static bool IsPrefixByte(uint8_t byte) {
+    return byte == kMathPrefix || byte == kThreadsPrefix;
+  }
 
   bool IsEnabled(const Features& features) const;
 
  private:
-  static const uint32_t kFirstPrefix = 0xfc;
+  static const uint32_t kMathPrefix = 0xfc;
+  static const uint32_t kThreadsPrefix = 0xfe;
 
   struct Info {
     const char* name;
@@ -90,9 +93,15 @@ struct Opcode {
     return (prefix << 8) | code;
   }
 
+  static void SplitPrefixCode(uint32_t prefix_code,
+                              uint8_t* out_prefix,
+                              uint32_t* out_code) {
+    *out_prefix = prefix_code >> 8;
+    *out_code = prefix_code & 0xff;
+  }
+
   Info GetInfo() const;
   static Info infos_[];
-  static Info invalid_info_;
 
   Enum enum_;
 };

--- a/test/binary/bad-opcode-prefix.txt
+++ b/test/binary/bad-opcode-prefix.txt
@@ -1,0 +1,23 @@
+;;; TOOL: run-gen-wasm
+;;; FLAGS: --objdump
+;;; ERROR: 1
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    invalid_op[0xfe 0x7f]
+  }
+}
+(;; STDERR ;;;
+Error running "wasm-objdump":
+*ERROR*: @0x0000001a: unexpected opcode: 254 127 (0xfe 0x7f)
+
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+bad-opcode-prefix.wasm:	file format wasm 0x1
+;;; STDOUT ;;)

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -1,0 +1,23 @@
+;;; TOOL: run-gen-wasm
+;;; FLAGS: --objdump
+;;; ERROR: 1
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    invalid_op[0xff]
+  }
+}
+(;; STDERR ;;;
+Error running "wasm-objdump":
+*ERROR*: @0x00000019: unexpected opcode: 255 (0xff)
+
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+bad-opcode.wasm:	file format wasm 0x1
+;;; STDOUT ;;)


### PR DESCRIPTION
Previously the opcode would always return 0.

Since `Opcode` only stores an enumeration, we represent invalid opcodes
as a negative number. This way `Opcode::GetInfo` can return the invalid
prefix and opcode number.

For now, these values are both 1-byte, but the current encoding can
be expanded to 2**24 opcodes.

This is a partial fix for #627.