### PR TITLE
[wasm-objdump] Continue reading sections on error

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -37,6 +37,8 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
                           ObjdumpOptions* options,
                           ObjdumpState* state);
 
+  bool OnError(const char* message) override;
+
   Result BeginModule(uint32_t version) override;
   Result BeginSection(BinarySection section_type, Offset size) override;
 
@@ -76,6 +78,13 @@ Result BinaryReaderObjdumpBase::BeginSection(BinarySection section_code,
                                              Offset size) {
   section_starts_[static_cast<size_t>(section_code)] = state->offset;
   return Result::Ok;
+}
+
+bool BinaryReaderObjdumpBase::OnError(const char* message) {
+  // Tell the BinaryReader that this error is "handled" for all passes other
+  // than the prepass. When the error is handled the default message will be
+  // suppressed.
+  return options_->mode != ObjdumpMode::Prepass;
 }
 
 Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
@@ -1129,7 +1138,10 @@ Result ReadBinaryObjdump(const uint8_t* data,
                          ObjdumpState* state) {
   Features features;
   features.EnableAll();
-  ReadBinaryOptions read_options(features, options->log_stream, true);
+  const bool kReadDebugNames = true;
+  const bool kStopOnFirstError = false;
+  ReadBinaryOptions read_options(features, options->log_stream, kReadDebugNames,
+                                 kStopOnFirstError);
 
   switch (options->mode) {
     case ObjdumpMode::Prepass: {

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -34,14 +34,17 @@ struct ReadBinaryOptions {
   ReadBinaryOptions() = default;
   ReadBinaryOptions(const Features& features,
                     Stream* log_stream,
-                    bool read_debug_names)
+                    bool read_debug_names,
+                    bool stop_on_first_error)
       : features(features),
         log_stream(log_stream),
-        read_debug_names(read_debug_names) {}
+        read_debug_names(read_debug_names),
+        stop_on_first_error(stop_on_first_error) {}
 
   Features features;
   Stream* log_stream = nullptr;
   bool read_debug_names = false;
+  bool stop_on_first_error = true;
 };
 
 class BinaryReaderDelegate {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -305,8 +305,10 @@ static wabt::Result ReadModule(const char* module_filename,
 
   result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
-    ReadBinaryOptions options(s_features, s_log_stream.get(),
-                              true /* read_debug_names */);
+    const bool kReadDebugNames = true;
+    const bool kStopOnFirstError = true;
+    ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
+                              kStopOnFirstError);
     result = ReadBinaryInterpreter(env, DataOrNull(file_data), file_data.size(),
                                    &options, error_handler, out_module);
 

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -82,36 +82,38 @@ Result dump_file(const char* filename) {
 
   ObjdumpState state;
 
+  Result result = Result::Ok;
+
   // Pass 0: Prepass
   s_objdump_options.mode = ObjdumpMode::Prepass;
-  CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
+  result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
   s_objdump_options.log_stream = nullptr;
 
   // Pass 1: Print the section headers
   if (s_objdump_options.headers) {
     s_objdump_options.mode = ObjdumpMode::Headers;
-    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
+    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
   }
 
   // Pass 2: Print extra information based on section type
   if (s_objdump_options.details) {
     s_objdump_options.mode = ObjdumpMode::Details;
-    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
+    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
   }
 
   // Pass 3: Disassemble code section
   if (s_objdump_options.disassemble) {
     s_objdump_options.mode = ObjdumpMode::Disassemble;
-    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
+    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
   }
 
   // Pass 4: Dump to raw contents of the sections
   if (s_objdump_options.raw) {
     s_objdump_options.mode = ObjdumpMode::RawData;
-    CHECK_RESULT(ReadBinaryObjdump(data, size, &s_objdump_options, &state));
+    result |= ReadBinaryObjdump(data, size, &s_objdump_options, &state);
   }
 
-  return Result::Ok;
+  return result;
 }
 
 int ProgramMain(int argc, char** argv) {

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -103,8 +103,9 @@ int ProgramMain(int argc, char** argv) {
   if (Succeeded(result)) {
     ErrorHandlerFile error_handler(Location::Type::Binary);
     Module module;
+    const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
-                              s_read_debug_names);
+                              s_read_debug_names, kStopOnFirstError);
     result = ReadBinaryIr(s_infile.c_str(), DataOrNull(file_data),
                           file_data.size(), &options, &error_handler, &module);
     if (Succeeded(result)) {

--- a/test/binary/bad-opcode-prefix.txt
+++ b/test/binary/bad-opcode-prefix.txt
@@ -20,4 +20,11 @@ Error running "wasm-objdump":
 (;; STDOUT ;;;
 
 bad-opcode-prefix.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type:
+ - type[0] () -> i32
+Function:
+ - func[0] sig=0
 ;;; STDOUT ;;)

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -20,4 +20,11 @@ Error running "wasm-objdump":
 (;; STDOUT ;;;
 
 bad-opcode.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type:
+ - type[0] () -> i32
+Function:
+ - func[0] sig=0
 ;;; STDOUT ;;)


### PR DESCRIPTION
wasm-objdump wants to always try to read as much of the binary as
possible. This change adds a new `BinaryReader` option called
`stop_on_first_error` which can be set to `false` to enable this
behavior.

Currently this will bail on any error in a section, but will try to read
the next section. We may expand the error-handling behavior to try and
recover inside of a section as well, but it's probably best to keep it
simple for now.

Because `wasm-objdump` does multiple passes over the binary, the errors
would normally be displayed multiple times. We also add a `OnError`
override which will suppress the error message for all passes other than
the first.

I took this opportunity to clean up a `binary-reader.cc` a little too:

* Remove IN_SIZE macro and use a template instead
* Change C comments to C++ comments