### PR TITLE
Add spectest-interp tool; split from wasm-interp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,6 +299,12 @@ if (NOT EMSCRIPTEN)
     target_link_libraries(wasm-interp m)
   endif ()
 
+  # spectest-interp
+  wabt_executable(spectest-interp src/tools/spectest-interp.cc)
+  if (COMPILER_IS_CLANG OR COMPILER_IS_GNU)
+    target_link_libraries(spectest-interp m)
+  endif ()
+
   # wat-desugar
   wabt_executable(wat-desugar src/tools/wat-desugar.cc)
 

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1,0 +1,1470 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <cassert>
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "src/binary-reader-interpreter.h"
+#include "src/binary-reader.h"
+#include "src/cast.h"
+#include "src/error-handler.h"
+#include "src/feature.h"
+#include "src/interpreter.h"
+#include "src/literal.h"
+#include "src/option-parser.h"
+#include "src/resolve-names.h"
+#include "src/stream.h"
+#include "src/validator.h"
+#include "src/wast-lexer.h"
+#include "src/wast-parser.h"
+
+using namespace wabt;
+using namespace wabt::interpreter;
+
+#define V(name, str) str,
+static const char* s_trap_strings[] = {FOREACH_INTERPRETER_RESULT(V)};
+#undef V
+
+static int s_verbose;
+static const char* s_infile;
+static Thread::Options s_thread_options;
+static bool s_trace;
+static Features s_features;
+
+static std::unique_ptr<FileStream> s_log_stream;
+static std::unique_ptr<FileStream> s_stdout_stream;
+
+enum class RunVerbosity {
+  Quiet = 0,
+  Verbose = 1,
+};
+
+static const char s_description[] =
+R"(  read a Spectest JSON file, and run its tests in the interpreter.
+
+examples:
+  # parse test.json and run the spec tests
+  $ spectest-interp test.json
+)";
+
+static void ParseOptions(int argc, char** argv) {
+  OptionParser parser("spectest-interp", s_description);
+
+  parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
+    s_verbose++;
+    s_log_stream = FileStream::CreateStdout();
+  });
+  parser.AddHelpOption();
+  s_features.AddOptions(&parser);
+  parser.AddOption('V', "value-stack-size", "SIZE",
+                   "Size in elements of the value stack",
+                   [](const std::string& argument) {
+                     // TODO(binji): validate.
+                     s_thread_options.value_stack_size = atoi(argument.c_str());
+                   });
+  parser.AddOption('C', "call-stack-size", "SIZE",
+                   "Size in elements of the call stack",
+                   [](const std::string& argument) {
+                     // TODO(binji): validate.
+                     s_thread_options.call_stack_size = atoi(argument.c_str());
+                   });
+  parser.AddOption('t', "trace", "Trace execution", []() { s_trace = true; });
+
+  parser.AddArgument("filename", OptionParser::ArgumentCount::One,
+                     [](const char* argument) { s_infile = argument; });
+  parser.Parse(argc, argv);
+}
+
+enum class ModuleType {
+  Text,
+  Binary,
+};
+
+static string_view GetDirname(string_view path) {
+  // Strip everything after and including the last slash (or backslash), e.g.:
+  //
+  // s = "foo/bar/baz", => "foo/bar"
+  // s = "/usr/local/include/stdio.h", => "/usr/local/include"
+  // s = "foo.bar", => ""
+  // s = "some\windows\directory", => "some\windows"
+  size_t last_slash = path.find_last_of('/');
+  size_t last_backslash = path.find_last_of('\\');
+  if (last_slash == string_view::npos)
+    last_slash = 0;
+  if (last_backslash == string_view::npos)
+    last_backslash = 0;
+
+  return path.substr(0, std::max(last_slash, last_backslash));
+}
+
+/* Not sure, but 100 chars is probably safe */
+#define MAX_TYPED_VALUE_CHARS 100
+
+static void SPrintTypedValue(char* buffer, size_t size, const TypedValue* tv) {
+  switch (tv->type) {
+    case Type::I32:
+      snprintf(buffer, size, "i32:%u", tv->value.i32);
+      break;
+
+    case Type::I64:
+      snprintf(buffer, size, "i64:%" PRIu64, tv->value.i64);
+      break;
+
+    case Type::F32: {
+      float value;
+      memcpy(&value, &tv->value.f32_bits, sizeof(float));
+      snprintf(buffer, size, "f32:%f", value);
+      break;
+    }
+
+    case Type::F64: {
+      double value;
+      memcpy(&value, &tv->value.f64_bits, sizeof(double));
+      snprintf(buffer, size, "f64:%f", value);
+      break;
+    }
+
+    default:
+      WABT_UNREACHABLE;
+  }
+}
+
+static void PrintTypedValue(const TypedValue* tv) {
+  char buffer[MAX_TYPED_VALUE_CHARS];
+  SPrintTypedValue(buffer, sizeof(buffer), tv);
+  printf("%s", buffer);
+}
+
+static void PrintTypedValueVector(const std::vector<TypedValue>& values) {
+  for (size_t i = 0; i < values.size(); ++i) {
+    PrintTypedValue(&values[i]);
+    if (i != values.size() - 1)
+      printf(", ");
+  }
+}
+
+static void PrintInterpreterResult(const char* desc,
+                                   interpreter::Result iresult) {
+  printf("%s: %s\n", desc, s_trap_strings[static_cast<size_t>(iresult)]);
+}
+
+static void PrintCall(string_view module_name,
+                      string_view func_name,
+                      const std::vector<TypedValue>& args,
+                      const std::vector<TypedValue>& results,
+                      interpreter::Result iresult) {
+  if (!module_name.empty())
+    printf(PRIstringview ".", WABT_PRINTF_STRING_VIEW_ARG(module_name));
+  printf(PRIstringview "(", WABT_PRINTF_STRING_VIEW_ARG(func_name));
+  PrintTypedValueVector(args);
+  printf(") =>");
+  if (iresult == interpreter::Result::Ok) {
+    if (results.size() > 0) {
+      printf(" ");
+      PrintTypedValueVector(results);
+    }
+    printf("\n");
+  } else {
+    PrintInterpreterResult(" error", iresult);
+  }
+}
+
+static interpreter::Result RunFunction(Thread* thread,
+                                       Index func_index,
+                                       const std::vector<TypedValue>& args,
+                                       std::vector<TypedValue>* out_results) {
+  return s_trace ? thread->TraceFunction(func_index, s_stdout_stream.get(),
+                                         args, out_results)
+                 : thread->RunFunction(func_index, args, out_results);
+}
+
+static interpreter::Result RunStartFunction(Thread* thread,
+                                            DefinedModule* module) {
+  if (module->start_func_index == kInvalidIndex)
+    return interpreter::Result::Ok;
+
+  if (s_trace)
+    printf(">>> running start function:\n");
+  std::vector<TypedValue> args;
+  std::vector<TypedValue> results;
+  interpreter::Result iresult =
+      RunFunction(thread, module->start_func_index, args, &results);
+  assert(results.size() == 0);
+  return iresult;
+}
+
+static interpreter::Result RunExport(Thread* thread,
+                                     const interpreter::Export* export_,
+                                     const std::vector<TypedValue>& args,
+                                     std::vector<TypedValue>* out_results) {
+  if (s_trace) {
+    printf(">>> running export \"" PRIstringview "\":\n",
+           WABT_PRINTF_STRING_VIEW_ARG(export_->name));
+  }
+
+  assert(export_->kind == ExternalKind::Func);
+  return RunFunction(thread, export_->index, args, out_results);
+}
+
+static interpreter::Result RunExportByName(Thread* thread,
+                                           interpreter::Module* module,
+                                           string_view name,
+                                           const std::vector<TypedValue>& args,
+                                           std::vector<TypedValue>* out_results,
+                                           RunVerbosity verbose) {
+  interpreter::Export* export_ = module->GetExport(name);
+  if (!export_)
+    return interpreter::Result::UnknownExport;
+  if (export_->kind != ExternalKind::Func)
+    return interpreter::Result::ExportKindMismatch;
+  return RunExport(thread, export_, args, out_results);
+}
+
+static interpreter::Result GetGlobalExportByName(
+    Thread* thread,
+    interpreter::Module* module,
+    string_view name,
+    std::vector<TypedValue>* out_results) {
+  interpreter::Export* export_ = module->GetExport(name);
+  if (!export_)
+    return interpreter::Result::UnknownExport;
+  if (export_->kind != ExternalKind::Global)
+    return interpreter::Result::ExportKindMismatch;
+
+  interpreter::Global* global = thread->env()->GetGlobal(export_->index);
+  out_results->clear();
+  out_results->push_back(global->typed_value);
+  return interpreter::Result::Ok;
+}
+
+static wabt::Result ReadModule(const char* module_filename,
+                               Environment* env,
+                               ErrorHandler* error_handler,
+                               DefinedModule** out_module) {
+  wabt::Result result;
+  std::vector<uint8_t> file_data;
+
+  *out_module = nullptr;
+
+  result = ReadFile(module_filename, &file_data);
+  if (Succeeded(result)) {
+    const bool kReadDebugNames = true;
+    const bool kStopOnFirstError = true;
+    ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
+                              kStopOnFirstError);
+    result = ReadBinaryInterpreter(env, DataOrNull(file_data), file_data.size(),
+                                   &options, error_handler, out_module);
+
+    if (Succeeded(result)) {
+      if (s_verbose)
+        env->DisassembleModule(s_stdout_stream.get(), *out_module);
+    }
+  }
+  return result;
+}
+
+static interpreter::Result DefaultHostCallback(
+    const HostFunc* func,
+    const interpreter::FuncSignature* sig,
+    Index num_args,
+    TypedValue* args,
+    Index num_results,
+    TypedValue* out_results,
+    void* user_data) {
+  memset(out_results, 0, sizeof(TypedValue) * num_results);
+  for (Index i = 0; i < num_results; ++i)
+    out_results[i].type = sig->result_types[i];
+
+  std::vector<TypedValue> vec_args(args, args + num_args);
+  std::vector<TypedValue> vec_results(out_results, out_results + num_results);
+
+  printf("called host ");
+  PrintCall(func->module_name, func->field_name, vec_args, vec_results,
+            interpreter::Result::Ok);
+  return interpreter::Result::Ok;
+}
+
+#define PRIimport "\"" PRIstringview "." PRIstringview "\""
+#define PRINTF_IMPORT_ARG(x)                    \
+  WABT_PRINTF_STRING_VIEW_ARG((x).module_name) \
+  , WABT_PRINTF_STRING_VIEW_ARG((x).field_name)
+
+class SpectestHostImportDelegate : public HostImportDelegate {
+ public:
+  wabt::Result ImportFunc(interpreter::FuncImport* import,
+                          interpreter::Func* func,
+                          interpreter::FuncSignature* func_sig,
+                          const ErrorCallback& callback) override {
+    if (import->field_name == "print") {
+      cast<HostFunc>(func)->callback = DefaultHostCallback;
+      return wabt::Result::Ok;
+    } else {
+      PrintError(callback, "unknown host function import " PRIimport,
+                 PRINTF_IMPORT_ARG(*import));
+      return wabt::Result::Error;
+    }
+  }
+
+  wabt::Result ImportTable(interpreter::TableImport* import,
+                           interpreter::Table* table,
+                           const ErrorCallback& callback) override {
+    if (import->field_name == "table") {
+      table->limits.has_max = true;
+      table->limits.initial = 10;
+      table->limits.max = 20;
+      return wabt::Result::Ok;
+    } else {
+      PrintError(callback, "unknown host table import " PRIimport,
+                 PRINTF_IMPORT_ARG(*import));
+      return wabt::Result::Error;
+    }
+  }
+
+  wabt::Result ImportMemory(interpreter::MemoryImport* import,
+                            interpreter::Memory* memory,
+                            const ErrorCallback& callback) override {
+    if (import->field_name == "memory") {
+      memory->page_limits.has_max = true;
+      memory->page_limits.initial = 1;
+      memory->page_limits.max = 2;
+      memory->data.resize(memory->page_limits.initial * WABT_MAX_PAGES);
+      return wabt::Result::Ok;
+    } else {
+      PrintError(callback, "unknown host memory import " PRIimport,
+                 PRINTF_IMPORT_ARG(*import));
+      return wabt::Result::Error;
+    }
+  }
+
+  wabt::Result ImportGlobal(interpreter::GlobalImport* import,
+                            interpreter::Global* global,
+                            const ErrorCallback& callback) override {
+    if (import->field_name == "global") {
+      switch (global->typed_value.type) {
+        case Type::I32:
+          global->typed_value.value.i32 = 666;
+          break;
+
+        case Type::F32: {
+          float value = 666.6f;
+          memcpy(&global->typed_value.value.f32_bits, &value, sizeof(value));
+          break;
+        }
+
+        case Type::I64:
+          global->typed_value.value.i64 = 666;
+          break;
+
+        case Type::F64: {
+          double value = 666.6;
+          memcpy(&global->typed_value.value.f64_bits, &value, sizeof(value));
+          break;
+        }
+
+        default:
+          PrintError(callback, "bad type for host global import " PRIimport,
+                     PRINTF_IMPORT_ARG(*import));
+          return wabt::Result::Error;
+      }
+
+      return wabt::Result::Ok;
+    } else {
+      PrintError(callback, "unknown host global import " PRIimport,
+                 PRINTF_IMPORT_ARG(*import));
+      return wabt::Result::Error;
+    }
+  }
+
+ private:
+  void PrintError(const ErrorCallback& callback, const char* format, ...) {
+    WABT_SNPRINTF_ALLOCA(buffer, length, format);
+    callback(buffer);
+  }
+};
+
+static void InitEnvironment(Environment* env) {
+  HostModule* host_module = env->AppendHostModule("spectest");
+  host_module->import_delegate.reset(new SpectestHostImportDelegate());
+}
+
+enum class ActionType {
+  Invoke,
+  Get,
+};
+
+struct Action {
+  ::ActionType type = ::ActionType::Invoke;
+  std::string module_name;
+  std::string field_name;
+  std::vector<TypedValue> args;
+};
+
+// An extremely simple JSON parser that only knows how to parse the expected
+// format from wat2wasm.
+class SpecJSONParser {
+ public:
+  SpecJSONParser() : thread_(&env_, s_thread_options) {}
+
+  wabt::Result ReadFile(const char* spec_json_filename);
+  wabt::Result ParseCommands();
+
+  int passed() const { return passed_; }
+  int total() const { return total_; }
+
+ private:
+  void WABT_PRINTF_FORMAT(2, 3) PrintParseError(const char* format, ...);
+  void WABT_PRINTF_FORMAT(2, 3) PrintCommandError(const char* format, ...);
+
+  void PutbackChar();
+  int ReadChar();
+  void SkipWhitespace();
+  bool Match(const char* s);
+  wabt::Result Expect(const char* s);
+  wabt::Result ExpectKey(const char* key);
+  wabt::Result ParseUint32(uint32_t* out_int);
+  wabt::Result ParseString(std::string* out_string);
+  wabt::Result ParseKeyStringValue(const char* key, std::string* out_string);
+  wabt::Result ParseOptNameStringValue(std::string* out_string);
+  wabt::Result ParseLine();
+  wabt::Result ParseTypeObject(Type* out_type);
+  wabt::Result ParseTypeVector(TypeVector* out_types);
+  wabt::Result ParseConst(TypedValue* out_value);
+  wabt::Result ParseConstVector(std::vector<TypedValue>* out_values);
+  wabt::Result ParseAction(::Action* out_action);
+  wabt::Result ParseModuleType(ModuleType* out_type);
+
+  std::string CreateModulePath(string_view filename);
+
+  wabt::Result OnModuleCommand(string_view filename, string_view name);
+  wabt::Result RunAction(::Action* action,
+                         interpreter::Result* out_iresult,
+                         std::vector<TypedValue>* out_results,
+                         RunVerbosity verbose);
+  wabt::Result OnActionCommand(::Action* action);
+  wabt::Result ReadInvalidTextModule(const char* module_filename,
+                                     Environment* env,
+                                     ErrorHandler* error_handler);
+  wabt::Result ReadInvalidModule(const char* module_filename,
+                                 Environment* env,
+                                 ModuleType module_type,
+                                 const char* desc);
+  wabt::Result OnAssertMalformedCommand(string_view filename,
+                                        string_view text,
+                                        ModuleType module_type);
+  wabt::Result OnRegisterCommand(string_view name, string_view as);
+  wabt::Result OnAssertUnlinkableCommand(string_view filename,
+                                         string_view text,
+                                         ModuleType module_type);
+  wabt::Result OnAssertInvalidCommand(string_view filename,
+                                      string_view text,
+                                      ModuleType module_type);
+  wabt::Result OnAssertUninstantiableCommand(string_view filename,
+                                             string_view text,
+                                             ModuleType module_type);
+  wabt::Result OnAssertReturnCommand(::Action* action,
+                                     const std::vector<TypedValue>& expected);
+  wabt::Result OnAssertReturnNanCommand(::Action* action, bool canonical);
+  wabt::Result OnAssertTrapCommand(::Action* action, string_view text);
+  wabt::Result OnAssertExhaustionCommand(::Action* action);
+  wabt::Result ParseCommand();
+
+  Environment env_;
+  Thread thread_;
+  DefinedModule* last_module_ = nullptr;
+
+  // Parsing info.
+  std::vector<uint8_t> json_data_;
+  std::string source_filename_;
+  size_t json_offset_ = 0;
+  Location loc_;
+  Location prev_loc_;
+  bool has_prev_loc_ = false;
+  uint32_t command_line_number_ = 0;
+
+  // Test info.
+  int passed_ = 0;
+  int total_ = 0;
+};
+
+#define EXPECT(x) CHECK_RESULT(Expect(x))
+#define EXPECT_KEY(x) CHECK_RESULT(ExpectKey(x))
+#define PARSE_KEY_STRING_VALUE(key, value) \
+  CHECK_RESULT(ParseKeyStringValue(key, value))
+
+wabt::Result SpecJSONParser::ReadFile(const char* spec_json_filename) {
+  loc_.filename = spec_json_filename;
+  loc_.line = 1;
+  loc_.first_column = 1;
+  InitEnvironment(&env_);
+
+  return wabt::ReadFile(spec_json_filename, &json_data_);
+}
+
+void SpecJSONParser::PrintParseError(const char* format, ...) {
+  WABT_SNPRINTF_ALLOCA(buffer, length, format);
+  fprintf(stderr, "%s:%d:%d: %s\n", loc_.filename, loc_.line, loc_.first_column,
+          buffer);
+}
+
+void SpecJSONParser::PrintCommandError(const char* format, ...) {
+  WABT_SNPRINTF_ALLOCA(buffer, length, format);
+  printf(PRIstringview ":%u: %s\n",
+         WABT_PRINTF_STRING_VIEW_ARG(source_filename_), command_line_number_,
+         buffer);
+}
+
+void SpecJSONParser::PutbackChar() {
+  assert(has_prev_loc_);
+  json_offset_--;
+  loc_ = prev_loc_;
+  has_prev_loc_ = false;
+}
+
+int SpecJSONParser::ReadChar() {
+  if (json_offset_ >= json_data_.size())
+    return -1;
+  prev_loc_ = loc_;
+  char c = json_data_[json_offset_++];
+  if (c == '\n') {
+    loc_.line++;
+    loc_.first_column = 1;
+  } else {
+    loc_.first_column++;
+  }
+  has_prev_loc_ = true;
+  return c;
+}
+
+void SpecJSONParser::SkipWhitespace() {
+  while (1) {
+    switch (ReadChar()) {
+      case -1:
+        return;
+
+      case ' ':
+      case '\t':
+      case '\n':
+      case '\r':
+        break;
+
+      default:
+        PutbackChar();
+        return;
+    }
+  }
+}
+
+bool SpecJSONParser::Match(const char* s) {
+  SkipWhitespace();
+  Location start_loc = loc_;
+  size_t start_offset = json_offset_;
+  while (*s && *s == ReadChar())
+    s++;
+
+  if (*s == 0) {
+    return true;
+  } else {
+    json_offset_ = start_offset;
+    loc_ = start_loc;
+    return false;
+  }
+}
+
+wabt::Result SpecJSONParser::Expect(const char* s) {
+  if (Match(s)) {
+    return wabt::Result::Ok;
+  } else {
+    PrintParseError("expected %s", s);
+    return wabt::Result::Error;
+  }
+}
+
+wabt::Result SpecJSONParser::ExpectKey(const char* key) {
+  size_t keylen = strlen(key);
+  size_t quoted_len = keylen + 2 + 1;
+  char* quoted = static_cast<char*>(alloca(quoted_len));
+  snprintf(quoted, quoted_len, "\"%s\"", key);
+  EXPECT(quoted);
+  EXPECT(":");
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseUint32(uint32_t* out_int) {
+  uint32_t result = 0;
+  SkipWhitespace();
+  while (1) {
+    int c = ReadChar();
+    if (c >= '0' && c <= '9') {
+      uint32_t last_result = result;
+      result = result * 10 + static_cast<uint32_t>(c - '0');
+      if (result < last_result) {
+        PrintParseError("uint32 overflow");
+        return wabt::Result::Error;
+      }
+    } else {
+      PutbackChar();
+      break;
+    }
+  }
+  *out_int = result;
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseString(std::string* out_string) {
+  out_string->clear();
+
+  SkipWhitespace();
+  if (ReadChar() != '"') {
+    PrintParseError("expected string");
+    return wabt::Result::Error;
+  }
+
+  while (1) {
+    int c = ReadChar();
+    if (c == '"') {
+      break;
+    } else if (c == '\\') {
+      /* The only escape supported is \uxxxx. */
+      c = ReadChar();
+      if (c != 'u') {
+        PrintParseError("expected escape: \\uxxxx");
+        return wabt::Result::Error;
+      }
+      uint16_t code = 0;
+      for (int i = 0; i < 4; ++i) {
+        c = ReadChar();
+        int cval;
+        if (c >= '0' && c <= '9') {
+          cval = c - '0';
+        } else if (c >= 'a' && c <= 'f') {
+          cval = c - 'a' + 10;
+        } else if (c >= 'A' && c <= 'F') {
+          cval = c - 'A' + 10;
+        } else {
+          PrintParseError("expected hex char");
+          return wabt::Result::Error;
+        }
+        code = (code << 4) + cval;
+      }
+
+      if (code < 256) {
+        *out_string += code;
+      } else {
+        PrintParseError("only escape codes < 256 allowed, got %u\n", code);
+      }
+    } else {
+      *out_string += c;
+    }
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseKeyStringValue(const char* key,
+                                                 std::string* out_string) {
+  out_string->clear();
+  EXPECT_KEY(key);
+  return ParseString(out_string);
+}
+
+wabt::Result SpecJSONParser::ParseOptNameStringValue(std::string* out_string) {
+  out_string->clear();
+  if (Match("\"name\"")) {
+    EXPECT(":");
+    CHECK_RESULT(ParseString(out_string));
+    EXPECT(",");
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseLine() {
+  EXPECT_KEY("line");
+  CHECK_RESULT(ParseUint32(&command_line_number_));
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseTypeObject(Type* out_type) {
+  std::string type_str;
+  EXPECT("{");
+  PARSE_KEY_STRING_VALUE("type", &type_str);
+  EXPECT("}");
+
+  if (type_str == "i32") {
+    *out_type = Type::I32;
+    return wabt::Result::Ok;
+  } else if (type_str == "f32") {
+    *out_type = Type::F32;
+    return wabt::Result::Ok;
+  } else if (type_str == "i64") {
+    *out_type = Type::I64;
+    return wabt::Result::Ok;
+  } else if (type_str == "f64") {
+    *out_type = Type::F64;
+    return wabt::Result::Ok;
+  } else {
+    PrintParseError("unknown type: \"" PRIstringview "\"",
+                    WABT_PRINTF_STRING_VIEW_ARG(type_str));
+    return wabt::Result::Error;
+  }
+}
+
+wabt::Result SpecJSONParser::ParseTypeVector(TypeVector* out_types) {
+  out_types->clear();
+  EXPECT("[");
+  bool first = true;
+  while (!Match("]")) {
+    if (!first)
+      EXPECT(",");
+    Type type;
+    CHECK_RESULT(ParseTypeObject(&type));
+    first = false;
+    out_types->push_back(type);
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseConst(TypedValue* out_value) {
+  std::string type_str;
+  std::string value_str;
+  EXPECT("{");
+  PARSE_KEY_STRING_VALUE("type", &type_str);
+  EXPECT(",");
+  PARSE_KEY_STRING_VALUE("value", &value_str);
+  EXPECT("}");
+
+  const char* value_start = value_str.data();
+  const char* value_end = value_str.data() + value_str.size();
+
+  if (type_str == "i32") {
+    uint32_t value;
+    CHECK_RESULT(
+        ParseInt32(value_start, value_end, &value, ParseIntType::UnsignedOnly));
+    out_value->type = Type::I32;
+    out_value->value.i32 = value;
+    return wabt::Result::Ok;
+  } else if (type_str == "f32") {
+    uint32_t value_bits;
+    CHECK_RESULT(ParseInt32(value_start, value_end, &value_bits,
+                            ParseIntType::UnsignedOnly));
+    out_value->type = Type::F32;
+    out_value->value.f32_bits = value_bits;
+    return wabt::Result::Ok;
+  } else if (type_str == "i64") {
+    uint64_t value;
+    CHECK_RESULT(
+        ParseInt64(value_start, value_end, &value, ParseIntType::UnsignedOnly));
+    out_value->type = Type::I64;
+    out_value->value.i64 = value;
+    return wabt::Result::Ok;
+  } else if (type_str == "f64") {
+    uint64_t value_bits;
+    CHECK_RESULT(ParseInt64(value_start, value_end, &value_bits,
+                            ParseIntType::UnsignedOnly));
+    out_value->type = Type::F64;
+    out_value->value.f64_bits = value_bits;
+    return wabt::Result::Ok;
+  } else {
+    PrintParseError("unknown type: \"" PRIstringview "\"",
+                    WABT_PRINTF_STRING_VIEW_ARG(type_str));
+    return wabt::Result::Error;
+  }
+}
+
+wabt::Result SpecJSONParser::ParseConstVector(
+    std::vector<TypedValue>* out_values) {
+  out_values->clear();
+  EXPECT("[");
+  bool first = true;
+  while (!Match("]")) {
+    if (!first)
+      EXPECT(",");
+    TypedValue value;
+    CHECK_RESULT(ParseConst(&value));
+    out_values->push_back(value);
+    first = false;
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseAction(::Action* out_action) {
+  EXPECT_KEY("action");
+  EXPECT("{");
+  EXPECT_KEY("type");
+  if (Match("\"invoke\"")) {
+    out_action->type = ::ActionType::Invoke;
+  } else {
+    EXPECT("\"get\"");
+    out_action->type = ::ActionType::Get;
+  }
+  EXPECT(",");
+  if (Match("\"module\"")) {
+    EXPECT(":");
+    CHECK_RESULT(ParseString(&out_action->module_name));
+    EXPECT(",");
+  }
+  PARSE_KEY_STRING_VALUE("field", &out_action->field_name);
+  if (out_action->type == ::ActionType::Invoke) {
+    EXPECT(",");
+    EXPECT_KEY("args");
+    CHECK_RESULT(ParseConstVector(&out_action->args));
+  }
+  EXPECT("}");
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseModuleType(ModuleType* out_type) {
+  std::string module_type_str;
+
+  PARSE_KEY_STRING_VALUE("module_type", &module_type_str);
+  if (module_type_str == "text") {
+    *out_type = ModuleType::Text;
+    return wabt::Result::Ok;
+  } else if (module_type_str == "binary") {
+    *out_type = ModuleType::Binary;
+    return wabt::Result::Ok;
+  } else {
+    PrintParseError("unknown module type: \"" PRIstringview "\"",
+                    WABT_PRINTF_STRING_VIEW_ARG(module_type_str));
+    return wabt::Result::Error;
+  }
+}
+
+std::string SpecJSONParser::CreateModulePath(string_view filename) {
+  const char* spec_json_filename = loc_.filename;
+  string_view dirname = GetDirname(spec_json_filename);
+  std::string path;
+
+  if (dirname.size() == 0) {
+    path = filename.to_string();
+  } else {
+    path = dirname.to_string();
+    path += '/';
+    path += filename.to_string();
+  }
+
+  ConvertBackslashToSlash(&path);
+  return path;
+}
+
+wabt::Result SpecJSONParser::OnModuleCommand(string_view filename,
+                                             string_view name) {
+  std::string path = CreateModulePath(filename);
+  Environment::MarkPoint mark = env_.Mark();
+  ErrorHandlerFile error_handler(Location::Type::Binary);
+  wabt::Result result =
+      ReadModule(path.c_str(), &env_, &error_handler, &last_module_);
+
+  if (Failed(result)) {
+    env_.ResetToMarkPoint(mark);
+    PrintCommandError("error reading module: \"%s\"", path.c_str());
+    return wabt::Result::Error;
+  }
+
+  interpreter::Result iresult = RunStartFunction(&thread_, last_module_);
+  if (iresult != interpreter::Result::Ok) {
+    env_.ResetToMarkPoint(mark);
+    PrintInterpreterResult("error running start function", iresult);
+    return wabt::Result::Error;
+  }
+
+  if (!name.empty()) {
+    last_module_->name = name.to_string();
+    env_.EmplaceModuleBinding(name.to_string(),
+                             Binding(env_.GetModuleCount() - 1));
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::RunAction(::Action* action,
+                                       interpreter::Result* out_iresult,
+                                       std::vector<TypedValue>* out_results,
+                                       RunVerbosity verbose) {
+  out_results->clear();
+
+  interpreter::Module* module;
+  if (!action->module_name.empty()) {
+    module = env_.FindModule(action->module_name);
+  } else {
+    module = env_.GetLastModule();
+  }
+  assert(module);
+
+  switch (action->type) {
+    case ::ActionType::Invoke:
+      *out_iresult = RunExportByName(&thread_, module, action->field_name,
+                                     action->args, out_results, verbose);
+      if (verbose == RunVerbosity::Verbose) {
+        PrintCall(string_view(), action->field_name, action->args, *out_results,
+                  *out_iresult);
+      }
+      return wabt::Result::Ok;
+
+    case ::ActionType::Get: {
+      *out_iresult = GetGlobalExportByName(&thread_, module, action->field_name,
+                                           out_results);
+      return wabt::Result::Ok;
+    }
+
+    default:
+      PrintCommandError("invalid action type %d",
+                        static_cast<int>(action->type));
+      return wabt::Result::Error;
+  }
+}
+
+wabt::Result SpecJSONParser::OnActionCommand(::Action* action) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
+
+  total_++;
+  wabt::Result result =
+      RunAction(action, &iresult, &results, RunVerbosity::Verbose);
+  if (Succeeded(result)) {
+    if (iresult == interpreter::Result::Ok) {
+      passed_++;
+    } else {
+      PrintCommandError("unexpected trap: %s",
+                        s_trap_strings[static_cast<size_t>(iresult)]);
+      result = wabt::Result::Error;
+    }
+  }
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::ReadInvalidTextModule(
+    const char* module_filename,
+    Environment* env,
+    ErrorHandler* error_handler) {
+  std::unique_ptr<WastLexer> lexer =
+      WastLexer::CreateFileLexer(module_filename);
+  std::unique_ptr<Script> script;
+  wabt::Result result = ParseWastScript(lexer.get(), &script, error_handler);
+  if (Succeeded(result)) {
+    wabt::Module* module = script->GetFirstModule();
+    result = ResolveNamesModule(lexer.get(), module, error_handler);
+    if (Succeeded(result)) {
+      // Don't do a full validation, just validate the function signatures.
+      result = ValidateFuncSignatures(lexer.get(), module, error_handler);
+    }
+  }
+  return result;
+}
+
+wabt::Result SpecJSONParser::ReadInvalidModule(const char* module_filename,
+                                               Environment* env,
+                                               ModuleType module_type,
+                                               const char* desc) {
+  std::string header =
+      StringPrintf(PRIstringview ":%d: %s passed",
+                   WABT_PRINTF_STRING_VIEW_ARG(source_filename_),
+                   command_line_number_, desc);
+
+  switch (module_type) {
+    case ModuleType::Text: {
+      ErrorHandlerFile error_handler(Location::Type::Text, stdout, header,
+                                     ErrorHandlerFile::PrintHeader::Once);
+      return ReadInvalidTextModule(module_filename, env, &error_handler);
+    }
+
+    case ModuleType::Binary: {
+      DefinedModule* module;
+      ErrorHandlerFile error_handler(Location::Type::Binary, stdout, header,
+                                     ErrorHandlerFile::PrintHeader::Once);
+      return ReadModule(module_filename, env, &error_handler, &module);
+    }
+  }
+
+  WABT_UNREACHABLE;
+}
+
+wabt::Result SpecJSONParser::OnAssertMalformedCommand(string_view filename,
+                                                      string_view text,
+                                                      ModuleType module_type) {
+  Environment env;
+  InitEnvironment(&env);
+
+  total_++;
+  std::string path = CreateModulePath(filename);
+  wabt::Result result =
+      ReadInvalidModule(path.c_str(), &env, module_type, "assert_malformed");
+  if (Failed(result)) {
+    passed_++;
+    result = wabt::Result::Ok;
+  } else {
+    PrintCommandError("expected module to be malformed: \"%s\"", path.c_str());
+    result = wabt::Result::Error;
+  }
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::OnRegisterCommand(string_view name,
+                                               string_view as) {
+  Index module_index;
+  if (!name.empty()) {
+    module_index = env_.FindModuleIndex(name);
+  } else {
+    module_index = env_.GetLastModuleIndex();
+  }
+
+  if (module_index == kInvalidIndex) {
+    PrintCommandError("unknown module in register");
+    return wabt::Result::Error;
+  }
+
+  env_.EmplaceRegisteredModuleBinding(as.to_string(), Binding(module_index));
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::OnAssertUnlinkableCommand(string_view filename,
+                                                       string_view text,
+                                                       ModuleType module_type) {
+  total_++;
+  std::string path = CreateModulePath(filename);
+  Environment::MarkPoint mark = env_.Mark();
+  wabt::Result result =
+      ReadInvalidModule(path.c_str(), &env_, module_type, "assert_unlinkable");
+  env_.ResetToMarkPoint(mark);
+
+  if (Failed(result)) {
+    passed_++;
+    result = wabt::Result::Ok;
+  } else {
+    PrintCommandError("expected module to be unlinkable: \"%s\"", path.c_str());
+    result = wabt::Result::Error;
+  }
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::OnAssertInvalidCommand(string_view filename,
+                                                    string_view text,
+                                                    ModuleType module_type) {
+  Environment env;
+  InitEnvironment(&env);
+
+  total_++;
+  std::string path = CreateModulePath(filename);
+  wabt::Result result =
+      ReadInvalidModule(path.c_str(), &env, module_type, "assert_invalid");
+  if (Failed(result)) {
+    passed_++;
+    result = wabt::Result::Ok;
+  } else {
+    PrintCommandError("expected module to be invalid: \"%s\"", path.c_str());
+    result = wabt::Result::Error;
+  }
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::OnAssertUninstantiableCommand(
+    string_view filename,
+    string_view text,
+    ModuleType module_type) {
+  ErrorHandlerFile error_handler(Location::Type::Binary);
+  total_++;
+  std::string path = CreateModulePath(filename);
+  DefinedModule* module;
+  Environment::MarkPoint mark = env_.Mark();
+  wabt::Result result =
+      ReadModule(path.c_str(), &env_, &error_handler, &module);
+
+  if (Succeeded(result)) {
+    interpreter::Result iresult = RunStartFunction(&thread_, module);
+    if (iresult == interpreter::Result::Ok) {
+      PrintCommandError("expected error running start function: \"%s\"",
+                        path.c_str());
+      result = wabt::Result::Error;
+    } else {
+      passed_++;
+      result = wabt::Result::Ok;
+    }
+  } else {
+    PrintCommandError("error reading module: \"%s\"", path.c_str());
+    result = wabt::Result::Error;
+  }
+
+  env_.ResetToMarkPoint(mark);
+  return result;
+}
+
+static bool TypedValuesAreEqual(const TypedValue* tv1, const TypedValue* tv2) {
+  if (tv1->type != tv2->type)
+    return false;
+
+  switch (tv1->type) {
+    case Type::I32:
+      return tv1->value.i32 == tv2->value.i32;
+    case Type::F32:
+      return tv1->value.f32_bits == tv2->value.f32_bits;
+    case Type::I64:
+      return tv1->value.i64 == tv2->value.i64;
+    case Type::F64:
+      return tv1->value.f64_bits == tv2->value.f64_bits;
+    default:
+      WABT_UNREACHABLE;
+  }
+}
+
+wabt::Result SpecJSONParser::OnAssertReturnCommand(
+    ::Action* action,
+    const std::vector<TypedValue>& expected) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
+
+  total_++;
+  wabt::Result result =
+      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
+
+  if (Succeeded(result)) {
+    if (iresult == interpreter::Result::Ok) {
+      if (results.size() == expected.size()) {
+        for (size_t i = 0; i < results.size(); ++i) {
+          const TypedValue* expected_tv = &expected[i];
+          const TypedValue* actual_tv = &results[i];
+          if (!TypedValuesAreEqual(expected_tv, actual_tv)) {
+            char expected_str[MAX_TYPED_VALUE_CHARS];
+            char actual_str[MAX_TYPED_VALUE_CHARS];
+            SPrintTypedValue(expected_str, sizeof(expected_str), expected_tv);
+            SPrintTypedValue(actual_str, sizeof(actual_str), actual_tv);
+            PrintCommandError("mismatch in result %" PRIzd
+                              " of assert_return: expected %s, got %s",
+                              i, expected_str, actual_str);
+            result = wabt::Result::Error;
+          }
+        }
+      } else {
+        PrintCommandError(
+            "result length mismatch in assert_return: expected %" PRIzd
+            ", got %" PRIzd,
+            expected.size(), results.size());
+        result = wabt::Result::Error;
+      }
+    } else {
+      PrintCommandError("unexpected trap: %s",
+                        s_trap_strings[static_cast<size_t>(iresult)]);
+      result = wabt::Result::Error;
+    }
+  }
+
+  if (Succeeded(result))
+    passed_++;
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::OnAssertReturnNanCommand(::Action* action,
+                                                      bool canonical) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
+
+  total_++;
+  wabt::Result result =
+      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
+  if (Succeeded(result)) {
+    if (iresult == interpreter::Result::Ok) {
+      if (results.size() != 1) {
+        PrintCommandError("expected one result, got %" PRIzd, results.size());
+        result = wabt::Result::Error;
+      }
+
+      const TypedValue& actual = results[0];
+      switch (actual.type) {
+        case Type::F32: {
+          bool is_nan = canonical ? IsCanonicalNan(actual.value.f32_bits)
+                                  : IsArithmeticNan(actual.value.f32_bits);
+          if (!is_nan) {
+            char actual_str[MAX_TYPED_VALUE_CHARS];
+            SPrintTypedValue(actual_str, sizeof(actual_str), &actual);
+            PrintCommandError("expected result to be nan, got %s", actual_str);
+            result = wabt::Result::Error;
+          }
+          break;
+        }
+
+        case Type::F64: {
+          bool is_nan = canonical ? IsCanonicalNan(actual.value.f64_bits)
+                                  : IsArithmeticNan(actual.value.f64_bits);
+          if (!is_nan) {
+            char actual_str[MAX_TYPED_VALUE_CHARS];
+            SPrintTypedValue(actual_str, sizeof(actual_str), &actual);
+            PrintCommandError("expected result to be nan, got %s", actual_str);
+            result = wabt::Result::Error;
+          }
+          break;
+        }
+
+        default:
+          PrintCommandError("expected result type to be f32 or f64, got %s",
+                            GetTypeName(actual.type));
+          result = wabt::Result::Error;
+          break;
+      }
+    } else {
+      PrintCommandError("unexpected trap: %s",
+                        s_trap_strings[static_cast<int>(iresult)]);
+      result = wabt::Result::Error;
+    }
+  }
+
+  if (Succeeded(result))
+    passed_++;
+
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::OnAssertTrapCommand(::Action* action,
+                                                 string_view text) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
+
+  total_++;
+  wabt::Result result =
+      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
+  if (Succeeded(result)) {
+    if (iresult != interpreter::Result::Ok) {
+      passed_++;
+    } else {
+      PrintCommandError("expected trap: \"" PRIstringview "\"",
+                        WABT_PRINTF_STRING_VIEW_ARG(text));
+      result = wabt::Result::Error;
+    }
+  }
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::OnAssertExhaustionCommand(::Action* action) {
+  std::vector<TypedValue> results;
+  interpreter::Result iresult;
+
+  total_++;
+  wabt::Result result =
+      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
+  if (Succeeded(result)) {
+    if (iresult == interpreter::Result::TrapCallStackExhausted ||
+        iresult == interpreter::Result::TrapValueStackExhausted) {
+      passed_++;
+    } else {
+      PrintCommandError("expected call stack exhaustion");
+      result = wabt::Result::Error;
+    }
+  }
+
+  return result;
+}
+
+wabt::Result SpecJSONParser::ParseCommand() {
+  EXPECT("{");
+  EXPECT_KEY("type");
+  if (Match("\"module\"")) {
+    std::string name;
+    std::string filename;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseOptNameStringValue(&name));
+    PARSE_KEY_STRING_VALUE("filename", &filename);
+    OnModuleCommand(filename, name);
+  } else if (Match("\"action\"")) {
+    ::Action action;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseAction(&action));
+    OnActionCommand(&action);
+  } else if (Match("\"register\"")) {
+    std::string as;
+    std::string name;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseOptNameStringValue(&name));
+    PARSE_KEY_STRING_VALUE("as", &as);
+    OnRegisterCommand(name, as);
+  } else if (Match("\"assert_malformed\"")) {
+    std::string filename;
+    std::string text;
+    ModuleType module_type;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("filename", &filename);
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("text", &text);
+    EXPECT(",");
+    CHECK_RESULT(ParseModuleType(&module_type));
+    OnAssertMalformedCommand(filename, text, module_type);
+  } else if (Match("\"assert_invalid\"")) {
+    std::string filename;
+    std::string text;
+    ModuleType module_type;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("filename", &filename);
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("text", &text);
+    EXPECT(",");
+    CHECK_RESULT(ParseModuleType(&module_type));
+    OnAssertInvalidCommand(filename, text, module_type);
+  } else if (Match("\"assert_unlinkable\"")) {
+    std::string filename;
+    std::string text;
+    ModuleType module_type;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("filename", &filename);
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("text", &text);
+    EXPECT(",");
+    CHECK_RESULT(ParseModuleType(&module_type));
+    OnAssertUnlinkableCommand(filename, text, module_type);
+  } else if (Match("\"assert_uninstantiable\"")) {
+    std::string filename;
+    std::string text;
+    ModuleType module_type;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("filename", &filename);
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("text", &text);
+    EXPECT(",");
+    CHECK_RESULT(ParseModuleType(&module_type));
+    OnAssertUninstantiableCommand(filename, text, module_type);
+  } else if (Match("\"assert_return\"")) {
+    ::Action action;
+    std::vector<TypedValue> expected;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseAction(&action));
+    EXPECT(",");
+    EXPECT_KEY("expected");
+    CHECK_RESULT(ParseConstVector(&expected));
+    OnAssertReturnCommand(&action, expected);
+  } else if (Match("\"assert_return_canonical_nan\"")) {
+    ::Action action;
+    TypeVector expected;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseAction(&action));
+    EXPECT(",");
+    /* Not needed for wabt-interp, but useful for other parsers. */
+    EXPECT_KEY("expected");
+    CHECK_RESULT(ParseTypeVector(&expected));
+    OnAssertReturnNanCommand(&action, true);
+  } else if (Match("\"assert_return_arithmetic_nan\"")) {
+    ::Action action;
+    TypeVector expected;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseAction(&action));
+    EXPECT(",");
+    /* Not needed for wabt-interp, but useful for other parsers. */
+    EXPECT_KEY("expected");
+    CHECK_RESULT(ParseTypeVector(&expected));
+    OnAssertReturnNanCommand(&action, false);
+  } else if (Match("\"assert_trap\"")) {
+    ::Action action;
+    std::string text;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseAction(&action));
+    EXPECT(",");
+    PARSE_KEY_STRING_VALUE("text", &text);
+    OnAssertTrapCommand(&action, text);
+  } else if (Match("\"assert_exhaustion\"")) {
+    ::Action action;
+    std::string text;
+
+    EXPECT(",");
+    CHECK_RESULT(ParseLine());
+    EXPECT(",");
+    CHECK_RESULT(ParseAction(&action));
+    OnAssertExhaustionCommand(&action);
+  } else {
+    PrintCommandError("unknown command type");
+    return wabt::Result::Error;
+  }
+  EXPECT("}");
+  return wabt::Result::Ok;
+}
+
+wabt::Result SpecJSONParser::ParseCommands() {
+  EXPECT("{");
+  PARSE_KEY_STRING_VALUE("source_filename", &source_filename_);
+  EXPECT(",");
+  EXPECT_KEY("commands");
+  EXPECT("[");
+  bool first = true;
+  while (!Match("]")) {
+    if (!first)
+      EXPECT(",");
+    CHECK_RESULT(ParseCommand());
+    first = false;
+  }
+  EXPECT("}");
+  return wabt::Result::Ok;
+}
+
+static wabt::Result ReadAndRunSpecJSON(const char* spec_json_filename) {
+  SpecJSONParser parser;
+  CHECK_RESULT(parser.ReadFile(spec_json_filename));
+  wabt::Result result = parser.ParseCommands();
+  printf("%d/%d tests passed.\n", parser.passed(), parser.total());
+  return result;
+}
+
+int ProgramMain(int argc, char** argv) {
+  InitStdio();
+  ParseOptions(argc, argv);
+
+  s_stdout_stream = FileStream::CreateStdout();
+
+  wabt::Result result;
+  result = ReadAndRunSpecJSON(s_infile);
+  return result != wabt::Result::Ok;
+}
+
+int main(int argc, char** argv) {
+  WABT_TRY
+  return ProgramMain(argc, argv);
+  WABT_CATCH_BAD_ALLOC_AND_EXIT
+}

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -48,8 +48,8 @@ static int s_verbose;
 static const char* s_infile;
 static Thread::Options s_thread_options;
 static bool s_trace;
-static bool s_spec;
 static bool s_run_all_exports;
+static bool s_host_print;
 static Features s_features;
 
 static std::unique_ptr<FileStream> s_log_stream;
@@ -73,9 +73,6 @@ examples:
 
   # parse test.wasm, run the exported functions and trace the output
   $ wasm-interp test.wasm --run-all-exports --trace
-
-  # parse test.json and run the spec tests
-  $ wasm-interp test.json --spec
 
   # parse test.wasm and run all its exported functions, setting the
   # value stack size to 100 elements
@@ -104,42 +101,21 @@ static void ParseOptions(int argc, char** argv) {
                      s_thread_options.call_stack_size = atoi(argument.c_str());
                    });
   parser.AddOption('t', "trace", "Trace execution", []() { s_trace = true; });
-  parser.AddOption("spec", "Run spec tests (input file should be .json)",
-                   []() { s_spec = true; });
   parser.AddOption(
       "run-all-exports",
       "Run all the exported functions, in order. Useful for testing",
       []() { s_run_all_exports = true; });
+  parser.AddOption("host-print",
+                   "Include an importable function named \"host.print\" for "
+                   "printing to stdout",
+                   []() { s_host_print = true; });
 
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) { s_infile = argument; });
   parser.Parse(argc, argv);
-
-  if (s_spec && s_run_all_exports)
-    WABT_FATAL("--spec and --run-all-exports are incompatible.\n");
 }
 
-enum class ModuleType {
-  Text,
-  Binary,
-};
-
-static string_view GetDirname(string_view path) {
-  // Strip everything after and including the last slash (or backslash), e.g.:
-  //
-  // s = "foo/bar/baz", => "foo/bar"
-  // s = "/usr/local/include/stdio.h", => "/usr/local/include"
-  // s = "foo.bar", => ""
-  // s = "some\windows\directory", => "some\windows"
-  size_t last_slash = path.find_last_of('/');
-  size_t last_backslash = path.find_last_of('\\');
-  if (last_slash == string_view::npos)
-    last_slash = 0;
-  if (last_backslash == string_view::npos)
-    last_backslash = 0;
-
-  return path.substr(0, std::max(last_slash, last_backslash));
-}
+// TODO(binji): Share these helper functions w/ spectest-interp as well.
 
 /* Not sure, but 100 chars is probably safe */
 #define MAX_TYPED_VALUE_CHARS 100
@@ -250,37 +226,6 @@ static interpreter::Result RunExport(Thread* thread,
   return RunFunction(thread, export_->index, args, out_results);
 }
 
-static interpreter::Result RunExportByName(Thread* thread,
-                                           interpreter::Module* module,
-                                           string_view name,
-                                           const std::vector<TypedValue>& args,
-                                           std::vector<TypedValue>* out_results,
-                                           RunVerbosity verbose) {
-  interpreter::Export* export_ = module->GetExport(name);
-  if (!export_)
-    return interpreter::Result::UnknownExport;
-  if (export_->kind != ExternalKind::Func)
-    return interpreter::Result::ExportKindMismatch;
-  return RunExport(thread, export_, args, out_results);
-}
-
-static interpreter::Result GetGlobalExportByName(
-    Thread* thread,
-    interpreter::Module* module,
-    string_view name,
-    std::vector<TypedValue>* out_results) {
-  interpreter::Export* export_ = module->GetExport(name);
-  if (!export_)
-    return interpreter::Result::UnknownExport;
-  if (export_->kind != ExternalKind::Global)
-    return interpreter::Result::ExportKindMismatch;
-
-  interpreter::Global* global = thread->env()->GetGlobal(export_->index);
-  out_results->clear();
-  out_results->push_back(global->typed_value);
-  return interpreter::Result::Ok;
-}
-
 static void RunAllExports(interpreter::Module* module,
                           Thread* thread,
                           RunVerbosity verbose) {
@@ -320,40 +265,19 @@ static wabt::Result ReadModule(const char* module_filename,
   return result;
 }
 
-static interpreter::Result DefaultHostCallback(
-    const HostFunc* func,
-    const interpreter::FuncSignature* sig,
-    Index num_args,
-    TypedValue* args,
-    Index num_results,
-    TypedValue* out_results,
-    void* user_data) {
-  memset(out_results, 0, sizeof(TypedValue) * num_results);
-  for (Index i = 0; i < num_results; ++i)
-    out_results[i].type = sig->result_types[i];
-
-  std::vector<TypedValue> vec_args(args, args + num_args);
-  std::vector<TypedValue> vec_results(out_results, out_results + num_results);
-
-  printf("called host ");
-  PrintCall(func->module_name, func->field_name, vec_args, vec_results,
-            interpreter::Result::Ok);
-  return interpreter::Result::Ok;
-}
-
 #define PRIimport "\"" PRIstringview "." PRIstringview "\""
 #define PRINTF_IMPORT_ARG(x)                    \
   WABT_PRINTF_STRING_VIEW_ARG((x).module_name) \
   , WABT_PRINTF_STRING_VIEW_ARG((x).field_name)
 
-class SpectestHostImportDelegate : public HostImportDelegate {
+class WasmInterpHostImportDelegate : public HostImportDelegate {
  public:
   wabt::Result ImportFunc(interpreter::FuncImport* import,
                           interpreter::Func* func,
                           interpreter::FuncSignature* func_sig,
                           const ErrorCallback& callback) override {
     if (import->field_name == "print") {
-      cast<HostFunc>(func)->callback = DefaultHostCallback;
+      cast<HostFunc>(func)->callback = PrintCallback;
       return wabt::Result::Ok;
     } else {
       PrintError(callback, "unknown host function import " PRIimport,
@@ -365,74 +289,43 @@ class SpectestHostImportDelegate : public HostImportDelegate {
   wabt::Result ImportTable(interpreter::TableImport* import,
                            interpreter::Table* table,
                            const ErrorCallback& callback) override {
-    if (import->field_name == "table") {
-      table->limits.has_max = true;
-      table->limits.initial = 10;
-      table->limits.max = 20;
-      return wabt::Result::Ok;
-    } else {
-      PrintError(callback, "unknown host table import " PRIimport,
-                 PRINTF_IMPORT_ARG(*import));
-      return wabt::Result::Error;
-    }
+    return wabt::Result::Error;
   }
 
   wabt::Result ImportMemory(interpreter::MemoryImport* import,
                             interpreter::Memory* memory,
                             const ErrorCallback& callback) override {
-    if (import->field_name == "memory") {
-      memory->page_limits.has_max = true;
-      memory->page_limits.initial = 1;
-      memory->page_limits.max = 2;
-      memory->data.resize(memory->page_limits.initial * WABT_MAX_PAGES);
-      return wabt::Result::Ok;
-    } else {
-      PrintError(callback, "unknown host memory import " PRIimport,
-                 PRINTF_IMPORT_ARG(*import));
-      return wabt::Result::Error;
-    }
+    return wabt::Result::Error;
   }
 
   wabt::Result ImportGlobal(interpreter::GlobalImport* import,
                             interpreter::Global* global,
                             const ErrorCallback& callback) override {
-    if (import->field_name == "global") {
-      switch (global->typed_value.type) {
-        case Type::I32:
-          global->typed_value.value.i32 = 666;
-          break;
-
-        case Type::F32: {
-          float value = 666.6f;
-          memcpy(&global->typed_value.value.f32_bits, &value, sizeof(value));
-          break;
-        }
-
-        case Type::I64:
-          global->typed_value.value.i64 = 666;
-          break;
-
-        case Type::F64: {
-          double value = 666.6;
-          memcpy(&global->typed_value.value.f64_bits, &value, sizeof(value));
-          break;
-        }
-
-        default:
-          PrintError(callback, "bad type for host global import " PRIimport,
-                     PRINTF_IMPORT_ARG(*import));
-          return wabt::Result::Error;
-      }
-
-      return wabt::Result::Ok;
-    } else {
-      PrintError(callback, "unknown host global import " PRIimport,
-                 PRINTF_IMPORT_ARG(*import));
-      return wabt::Result::Error;
-    }
+    return wabt::Result::Error;
   }
 
  private:
+  static interpreter::Result PrintCallback(
+      const HostFunc* func,
+      const interpreter::FuncSignature* sig,
+      Index num_args,
+      TypedValue* args,
+      Index num_results,
+      TypedValue* out_results,
+      void* user_data) {
+    memset(out_results, 0, sizeof(TypedValue) * num_results);
+    for (Index i = 0; i < num_results; ++i)
+      out_results[i].type = sig->result_types[i];
+
+    std::vector<TypedValue> vec_args(args, args + num_args);
+    std::vector<TypedValue> vec_results(out_results, out_results + num_results);
+
+    printf("called host ");
+    PrintCall(func->module_name, func->field_name, vec_args, vec_results,
+              interpreter::Result::Ok);
+    return interpreter::Result::Ok;
+  }
+
   void PrintError(const ErrorCallback& callback, const char* format, ...) {
     WABT_SNPRINTF_ALLOCA(buffer, length, format);
     callback(buffer);
@@ -440,8 +333,10 @@ class SpectestHostImportDelegate : public HostImportDelegate {
 };
 
 static void InitEnvironment(Environment* env) {
-  HostModule* host_module = env->AppendHostModule("spectest");
-  host_module->import_delegate.reset(new SpectestHostImportDelegate());
+  if (s_host_print) {
+    HostModule* host_module = env->AppendHostModule("host");
+    host_module->import_delegate.reset(new WasmInterpHostImportDelegate());
+  }
 }
 
 static wabt::Result ReadAndRunModule(const char* module_filename) {
@@ -465,1064 +360,13 @@ static wabt::Result ReadAndRunModule(const char* module_filename) {
   return result;
 }
 
-enum class ActionType {
-  Invoke,
-  Get,
-};
-
-struct Action {
-  ::ActionType type = ::ActionType::Invoke;
-  std::string module_name;
-  std::string field_name;
-  std::vector<TypedValue> args;
-};
-
-// An extremely simple JSON parser that only knows how to parse the expected
-// format from wat2wasm.
-class SpecJSONParser {
- public:
-  SpecJSONParser() : thread_(&env_, s_thread_options) {}
-
-  wabt::Result ReadFile(const char* spec_json_filename);
-  wabt::Result ParseCommands();
-
-  int passed() const { return passed_; }
-  int total() const { return total_; }
-
- private:
-  void WABT_PRINTF_FORMAT(2, 3) PrintParseError(const char* format, ...);
-  void WABT_PRINTF_FORMAT(2, 3) PrintCommandError(const char* format, ...);
-
-  void PutbackChar();
-  int ReadChar();
-  void SkipWhitespace();
-  bool Match(const char* s);
-  wabt::Result Expect(const char* s);
-  wabt::Result ExpectKey(const char* key);
-  wabt::Result ParseUint32(uint32_t* out_int);
-  wabt::Result ParseString(std::string* out_string);
-  wabt::Result ParseKeyStringValue(const char* key, std::string* out_string);
-  wabt::Result ParseOptNameStringValue(std::string* out_string);
-  wabt::Result ParseLine();
-  wabt::Result ParseTypeObject(Type* out_type);
-  wabt::Result ParseTypeVector(TypeVector* out_types);
-  wabt::Result ParseConst(TypedValue* out_value);
-  wabt::Result ParseConstVector(std::vector<TypedValue>* out_values);
-  wabt::Result ParseAction(::Action* out_action);
-  wabt::Result ParseModuleType(ModuleType* out_type);
-
-  std::string CreateModulePath(string_view filename);
-
-  wabt::Result OnModuleCommand(string_view filename, string_view name);
-  wabt::Result RunAction(::Action* action,
-                         interpreter::Result* out_iresult,
-                         std::vector<TypedValue>* out_results,
-                         RunVerbosity verbose);
-  wabt::Result OnActionCommand(::Action* action);
-  wabt::Result ReadInvalidTextModule(const char* module_filename,
-                                     Environment* env,
-                                     ErrorHandler* error_handler);
-  wabt::Result ReadInvalidModule(const char* module_filename,
-                                 Environment* env,
-                                 ModuleType module_type,
-                                 const char* desc);
-  wabt::Result OnAssertMalformedCommand(string_view filename,
-                                        string_view text,
-                                        ModuleType module_type);
-  wabt::Result OnRegisterCommand(string_view name, string_view as);
-  wabt::Result OnAssertUnlinkableCommand(string_view filename,
-                                         string_view text,
-                                         ModuleType module_type);
-  wabt::Result OnAssertInvalidCommand(string_view filename,
-                                      string_view text,
-                                      ModuleType module_type);
-  wabt::Result OnAssertUninstantiableCommand(string_view filename,
-                                             string_view text,
-                                             ModuleType module_type);
-  wabt::Result OnAssertReturnCommand(::Action* action,
-                                     const std::vector<TypedValue>& expected);
-  wabt::Result OnAssertReturnNanCommand(::Action* action, bool canonical);
-  wabt::Result OnAssertTrapCommand(::Action* action, string_view text);
-  wabt::Result OnAssertExhaustionCommand(::Action* action);
-  wabt::Result ParseCommand();
-
-  Environment env_;
-  Thread thread_;
-  DefinedModule* last_module_ = nullptr;
-
-  // Parsing info.
-  std::vector<uint8_t> json_data_;
-  std::string source_filename_;
-  size_t json_offset_ = 0;
-  Location loc_;
-  Location prev_loc_;
-  bool has_prev_loc_ = false;
-  uint32_t command_line_number_ = 0;
-
-  // Test info.
-  int passed_ = 0;
-  int total_ = 0;
-};
-
-#define EXPECT(x) CHECK_RESULT(Expect(x))
-#define EXPECT_KEY(x) CHECK_RESULT(ExpectKey(x))
-#define PARSE_KEY_STRING_VALUE(key, value) \
-  CHECK_RESULT(ParseKeyStringValue(key, value))
-
-wabt::Result SpecJSONParser::ReadFile(const char* spec_json_filename) {
-  loc_.filename = spec_json_filename;
-  loc_.line = 1;
-  loc_.first_column = 1;
-  InitEnvironment(&env_);
-
-  return wabt::ReadFile(spec_json_filename, &json_data_);
-}
-
-void SpecJSONParser::PrintParseError(const char* format, ...) {
-  WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  fprintf(stderr, "%s:%d:%d: %s\n", loc_.filename, loc_.line, loc_.first_column,
-          buffer);
-}
-
-void SpecJSONParser::PrintCommandError(const char* format, ...) {
-  WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  printf(PRIstringview ":%u: %s\n",
-         WABT_PRINTF_STRING_VIEW_ARG(source_filename_), command_line_number_,
-         buffer);
-}
-
-void SpecJSONParser::PutbackChar() {
-  assert(has_prev_loc_);
-  json_offset_--;
-  loc_ = prev_loc_;
-  has_prev_loc_ = false;
-}
-
-int SpecJSONParser::ReadChar() {
-  if (json_offset_ >= json_data_.size())
-    return -1;
-  prev_loc_ = loc_;
-  char c = json_data_[json_offset_++];
-  if (c == '\n') {
-    loc_.line++;
-    loc_.first_column = 1;
-  } else {
-    loc_.first_column++;
-  }
-  has_prev_loc_ = true;
-  return c;
-}
-
-void SpecJSONParser::SkipWhitespace() {
-  while (1) {
-    switch (ReadChar()) {
-      case -1:
-        return;
-
-      case ' ':
-      case '\t':
-      case '\n':
-      case '\r':
-        break;
-
-      default:
-        PutbackChar();
-        return;
-    }
-  }
-}
-
-bool SpecJSONParser::Match(const char* s) {
-  SkipWhitespace();
-  Location start_loc = loc_;
-  size_t start_offset = json_offset_;
-  while (*s && *s == ReadChar())
-    s++;
-
-  if (*s == 0) {
-    return true;
-  } else {
-    json_offset_ = start_offset;
-    loc_ = start_loc;
-    return false;
-  }
-}
-
-wabt::Result SpecJSONParser::Expect(const char* s) {
-  if (Match(s)) {
-    return wabt::Result::Ok;
-  } else {
-    PrintParseError("expected %s", s);
-    return wabt::Result::Error;
-  }
-}
-
-wabt::Result SpecJSONParser::ExpectKey(const char* key) {
-  size_t keylen = strlen(key);
-  size_t quoted_len = keylen + 2 + 1;
-  char* quoted = static_cast<char*>(alloca(quoted_len));
-  snprintf(quoted, quoted_len, "\"%s\"", key);
-  EXPECT(quoted);
-  EXPECT(":");
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseUint32(uint32_t* out_int) {
-  uint32_t result = 0;
-  SkipWhitespace();
-  while (1) {
-    int c = ReadChar();
-    if (c >= '0' && c <= '9') {
-      uint32_t last_result = result;
-      result = result * 10 + static_cast<uint32_t>(c - '0');
-      if (result < last_result) {
-        PrintParseError("uint32 overflow");
-        return wabt::Result::Error;
-      }
-    } else {
-      PutbackChar();
-      break;
-    }
-  }
-  *out_int = result;
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseString(std::string* out_string) {
-  out_string->clear();
-
-  SkipWhitespace();
-  if (ReadChar() != '"') {
-    PrintParseError("expected string");
-    return wabt::Result::Error;
-  }
-
-  while (1) {
-    int c = ReadChar();
-    if (c == '"') {
-      break;
-    } else if (c == '\\') {
-      /* The only escape supported is \uxxxx. */
-      c = ReadChar();
-      if (c != 'u') {
-        PrintParseError("expected escape: \\uxxxx");
-        return wabt::Result::Error;
-      }
-      uint16_t code = 0;
-      for (int i = 0; i < 4; ++i) {
-        c = ReadChar();
-        int cval;
-        if (c >= '0' && c <= '9') {
-          cval = c - '0';
-        } else if (c >= 'a' && c <= 'f') {
-          cval = c - 'a' + 10;
-        } else if (c >= 'A' && c <= 'F') {
-          cval = c - 'A' + 10;
-        } else {
-          PrintParseError("expected hex char");
-          return wabt::Result::Error;
-        }
-        code = (code << 4) + cval;
-      }
-
-      if (code < 256) {
-        *out_string += code;
-      } else {
-        PrintParseError("only escape codes < 256 allowed, got %u\n", code);
-      }
-    } else {
-      *out_string += c;
-    }
-  }
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseKeyStringValue(const char* key,
-                                                 std::string* out_string) {
-  out_string->clear();
-  EXPECT_KEY(key);
-  return ParseString(out_string);
-}
-
-wabt::Result SpecJSONParser::ParseOptNameStringValue(std::string* out_string) {
-  out_string->clear();
-  if (Match("\"name\"")) {
-    EXPECT(":");
-    CHECK_RESULT(ParseString(out_string));
-    EXPECT(",");
-  }
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseLine() {
-  EXPECT_KEY("line");
-  CHECK_RESULT(ParseUint32(&command_line_number_));
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseTypeObject(Type* out_type) {
-  std::string type_str;
-  EXPECT("{");
-  PARSE_KEY_STRING_VALUE("type", &type_str);
-  EXPECT("}");
-
-  if (type_str == "i32") {
-    *out_type = Type::I32;
-    return wabt::Result::Ok;
-  } else if (type_str == "f32") {
-    *out_type = Type::F32;
-    return wabt::Result::Ok;
-  } else if (type_str == "i64") {
-    *out_type = Type::I64;
-    return wabt::Result::Ok;
-  } else if (type_str == "f64") {
-    *out_type = Type::F64;
-    return wabt::Result::Ok;
-  } else {
-    PrintParseError("unknown type: \"" PRIstringview "\"",
-                    WABT_PRINTF_STRING_VIEW_ARG(type_str));
-    return wabt::Result::Error;
-  }
-}
-
-wabt::Result SpecJSONParser::ParseTypeVector(TypeVector* out_types) {
-  out_types->clear();
-  EXPECT("[");
-  bool first = true;
-  while (!Match("]")) {
-    if (!first)
-      EXPECT(",");
-    Type type;
-    CHECK_RESULT(ParseTypeObject(&type));
-    first = false;
-    out_types->push_back(type);
-  }
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseConst(TypedValue* out_value) {
-  std::string type_str;
-  std::string value_str;
-  EXPECT("{");
-  PARSE_KEY_STRING_VALUE("type", &type_str);
-  EXPECT(",");
-  PARSE_KEY_STRING_VALUE("value", &value_str);
-  EXPECT("}");
-
-  const char* value_start = value_str.data();
-  const char* value_end = value_str.data() + value_str.size();
-
-  if (type_str == "i32") {
-    uint32_t value;
-    CHECK_RESULT(
-        ParseInt32(value_start, value_end, &value, ParseIntType::UnsignedOnly));
-    out_value->type = Type::I32;
-    out_value->value.i32 = value;
-    return wabt::Result::Ok;
-  } else if (type_str == "f32") {
-    uint32_t value_bits;
-    CHECK_RESULT(ParseInt32(value_start, value_end, &value_bits,
-                            ParseIntType::UnsignedOnly));
-    out_value->type = Type::F32;
-    out_value->value.f32_bits = value_bits;
-    return wabt::Result::Ok;
-  } else if (type_str == "i64") {
-    uint64_t value;
-    CHECK_RESULT(
-        ParseInt64(value_start, value_end, &value, ParseIntType::UnsignedOnly));
-    out_value->type = Type::I64;
-    out_value->value.i64 = value;
-    return wabt::Result::Ok;
-  } else if (type_str == "f64") {
-    uint64_t value_bits;
-    CHECK_RESULT(ParseInt64(value_start, value_end, &value_bits,
-                            ParseIntType::UnsignedOnly));
-    out_value->type = Type::F64;
-    out_value->value.f64_bits = value_bits;
-    return wabt::Result::Ok;
-  } else {
-    PrintParseError("unknown type: \"" PRIstringview "\"",
-                    WABT_PRINTF_STRING_VIEW_ARG(type_str));
-    return wabt::Result::Error;
-  }
-}
-
-wabt::Result SpecJSONParser::ParseConstVector(
-    std::vector<TypedValue>* out_values) {
-  out_values->clear();
-  EXPECT("[");
-  bool first = true;
-  while (!Match("]")) {
-    if (!first)
-      EXPECT(",");
-    TypedValue value;
-    CHECK_RESULT(ParseConst(&value));
-    out_values->push_back(value);
-    first = false;
-  }
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseAction(::Action* out_action) {
-  EXPECT_KEY("action");
-  EXPECT("{");
-  EXPECT_KEY("type");
-  if (Match("\"invoke\"")) {
-    out_action->type = ::ActionType::Invoke;
-  } else {
-    EXPECT("\"get\"");
-    out_action->type = ::ActionType::Get;
-  }
-  EXPECT(",");
-  if (Match("\"module\"")) {
-    EXPECT(":");
-    CHECK_RESULT(ParseString(&out_action->module_name));
-    EXPECT(",");
-  }
-  PARSE_KEY_STRING_VALUE("field", &out_action->field_name);
-  if (out_action->type == ::ActionType::Invoke) {
-    EXPECT(",");
-    EXPECT_KEY("args");
-    CHECK_RESULT(ParseConstVector(&out_action->args));
-  }
-  EXPECT("}");
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseModuleType(ModuleType* out_type) {
-  std::string module_type_str;
-
-  PARSE_KEY_STRING_VALUE("module_type", &module_type_str);
-  if (module_type_str == "text") {
-    *out_type = ModuleType::Text;
-    return wabt::Result::Ok;
-  } else if (module_type_str == "binary") {
-    *out_type = ModuleType::Binary;
-    return wabt::Result::Ok;
-  } else {
-    PrintParseError("unknown module type: \"" PRIstringview "\"",
-                    WABT_PRINTF_STRING_VIEW_ARG(module_type_str));
-    return wabt::Result::Error;
-  }
-}
-
-std::string SpecJSONParser::CreateModulePath(string_view filename) {
-  const char* spec_json_filename = loc_.filename;
-  string_view dirname = GetDirname(spec_json_filename);
-  std::string path;
-
-  if (dirname.size() == 0) {
-    path = filename.to_string();
-  } else {
-    path = dirname.to_string();
-    path += '/';
-    path += filename.to_string();
-  }
-
-  ConvertBackslashToSlash(&path);
-  return path;
-}
-
-wabt::Result SpecJSONParser::OnModuleCommand(string_view filename,
-                                             string_view name) {
-  std::string path = CreateModulePath(filename);
-  Environment::MarkPoint mark = env_.Mark();
-  ErrorHandlerFile error_handler(Location::Type::Binary);
-  wabt::Result result =
-      ReadModule(path.c_str(), &env_, &error_handler, &last_module_);
-
-  if (Failed(result)) {
-    env_.ResetToMarkPoint(mark);
-    PrintCommandError("error reading module: \"%s\"", path.c_str());
-    return wabt::Result::Error;
-  }
-
-  interpreter::Result iresult = RunStartFunction(&thread_, last_module_);
-  if (iresult != interpreter::Result::Ok) {
-    env_.ResetToMarkPoint(mark);
-    PrintInterpreterResult("error running start function", iresult);
-    return wabt::Result::Error;
-  }
-
-  if (!name.empty()) {
-    last_module_->name = name.to_string();
-    env_.EmplaceModuleBinding(name.to_string(),
-                             Binding(env_.GetModuleCount() - 1));
-  }
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::RunAction(::Action* action,
-                                       interpreter::Result* out_iresult,
-                                       std::vector<TypedValue>* out_results,
-                                       RunVerbosity verbose) {
-  out_results->clear();
-
-  interpreter::Module* module;
-  if (!action->module_name.empty()) {
-    module = env_.FindModule(action->module_name);
-  } else {
-    module = env_.GetLastModule();
-  }
-  assert(module);
-
-  switch (action->type) {
-    case ::ActionType::Invoke:
-      *out_iresult = RunExportByName(&thread_, module, action->field_name,
-                                     action->args, out_results, verbose);
-      if (verbose == RunVerbosity::Verbose) {
-        PrintCall(string_view(), action->field_name, action->args, *out_results,
-                  *out_iresult);
-      }
-      return wabt::Result::Ok;
-
-    case ::ActionType::Get: {
-      *out_iresult = GetGlobalExportByName(&thread_, module, action->field_name,
-                                           out_results);
-      return wabt::Result::Ok;
-    }
-
-    default:
-      PrintCommandError("invalid action type %d",
-                        static_cast<int>(action->type));
-      return wabt::Result::Error;
-  }
-}
-
-wabt::Result SpecJSONParser::OnActionCommand(::Action* action) {
-  std::vector<TypedValue> results;
-  interpreter::Result iresult;
-
-  total_++;
-  wabt::Result result =
-      RunAction(action, &iresult, &results, RunVerbosity::Verbose);
-  if (Succeeded(result)) {
-    if (iresult == interpreter::Result::Ok) {
-      passed_++;
-    } else {
-      PrintCommandError("unexpected trap: %s",
-                        s_trap_strings[static_cast<size_t>(iresult)]);
-      result = wabt::Result::Error;
-    }
-  }
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::ReadInvalidTextModule(
-    const char* module_filename,
-    Environment* env,
-    ErrorHandler* error_handler) {
-  std::unique_ptr<WastLexer> lexer =
-      WastLexer::CreateFileLexer(module_filename);
-  std::unique_ptr<Script> script;
-  wabt::Result result = ParseWastScript(lexer.get(), &script, error_handler);
-  if (Succeeded(result)) {
-    wabt::Module* module = script->GetFirstModule();
-    result = ResolveNamesModule(lexer.get(), module, error_handler);
-    if (Succeeded(result)) {
-      // Don't do a full validation, just validate the function signatures.
-      result = ValidateFuncSignatures(lexer.get(), module, error_handler);
-    }
-  }
-  return result;
-}
-
-wabt::Result SpecJSONParser::ReadInvalidModule(const char* module_filename,
-                                               Environment* env,
-                                               ModuleType module_type,
-                                               const char* desc) {
-  std::string header =
-      StringPrintf(PRIstringview ":%d: %s passed",
-                   WABT_PRINTF_STRING_VIEW_ARG(source_filename_),
-                   command_line_number_, desc);
-
-  switch (module_type) {
-    case ModuleType::Text: {
-      ErrorHandlerFile error_handler(Location::Type::Text, stdout, header,
-                                     ErrorHandlerFile::PrintHeader::Once);
-      return ReadInvalidTextModule(module_filename, env, &error_handler);
-    }
-
-    case ModuleType::Binary: {
-      DefinedModule* module;
-      ErrorHandlerFile error_handler(Location::Type::Binary, stdout, header,
-                                     ErrorHandlerFile::PrintHeader::Once);
-      return ReadModule(module_filename, env, &error_handler, &module);
-    }
-  }
-
-  WABT_UNREACHABLE;
-}
-
-wabt::Result SpecJSONParser::OnAssertMalformedCommand(string_view filename,
-                                                      string_view text,
-                                                      ModuleType module_type) {
-  Environment env;
-  InitEnvironment(&env);
-
-  total_++;
-  std::string path = CreateModulePath(filename);
-  wabt::Result result =
-      ReadInvalidModule(path.c_str(), &env, module_type, "assert_malformed");
-  if (Failed(result)) {
-    passed_++;
-    result = wabt::Result::Ok;
-  } else {
-    PrintCommandError("expected module to be malformed: \"%s\"", path.c_str());
-    result = wabt::Result::Error;
-  }
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::OnRegisterCommand(string_view name,
-                                               string_view as) {
-  Index module_index;
-  if (!name.empty()) {
-    module_index = env_.FindModuleIndex(name);
-  } else {
-    module_index = env_.GetLastModuleIndex();
-  }
-
-  if (module_index == kInvalidIndex) {
-    PrintCommandError("unknown module in register");
-    return wabt::Result::Error;
-  }
-
-  env_.EmplaceRegisteredModuleBinding(as.to_string(), Binding(module_index));
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::OnAssertUnlinkableCommand(string_view filename,
-                                                       string_view text,
-                                                       ModuleType module_type) {
-  total_++;
-  std::string path = CreateModulePath(filename);
-  Environment::MarkPoint mark = env_.Mark();
-  wabt::Result result =
-      ReadInvalidModule(path.c_str(), &env_, module_type, "assert_unlinkable");
-  env_.ResetToMarkPoint(mark);
-
-  if (Failed(result)) {
-    passed_++;
-    result = wabt::Result::Ok;
-  } else {
-    PrintCommandError("expected module to be unlinkable: \"%s\"", path.c_str());
-    result = wabt::Result::Error;
-  }
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::OnAssertInvalidCommand(string_view filename,
-                                                    string_view text,
-                                                    ModuleType module_type) {
-  Environment env;
-  InitEnvironment(&env);
-
-  total_++;
-  std::string path = CreateModulePath(filename);
-  wabt::Result result =
-      ReadInvalidModule(path.c_str(), &env, module_type, "assert_invalid");
-  if (Failed(result)) {
-    passed_++;
-    result = wabt::Result::Ok;
-  } else {
-    PrintCommandError("expected module to be invalid: \"%s\"", path.c_str());
-    result = wabt::Result::Error;
-  }
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::OnAssertUninstantiableCommand(
-    string_view filename,
-    string_view text,
-    ModuleType module_type) {
-  ErrorHandlerFile error_handler(Location::Type::Binary);
-  total_++;
-  std::string path = CreateModulePath(filename);
-  DefinedModule* module;
-  Environment::MarkPoint mark = env_.Mark();
-  wabt::Result result =
-      ReadModule(path.c_str(), &env_, &error_handler, &module);
-
-  if (Succeeded(result)) {
-    interpreter::Result iresult = RunStartFunction(&thread_, module);
-    if (iresult == interpreter::Result::Ok) {
-      PrintCommandError("expected error running start function: \"%s\"",
-                        path.c_str());
-      result = wabt::Result::Error;
-    } else {
-      passed_++;
-      result = wabt::Result::Ok;
-    }
-  } else {
-    PrintCommandError("error reading module: \"%s\"", path.c_str());
-    result = wabt::Result::Error;
-  }
-
-  env_.ResetToMarkPoint(mark);
-  return result;
-}
-
-static bool TypedValuesAreEqual(const TypedValue* tv1, const TypedValue* tv2) {
-  if (tv1->type != tv2->type)
-    return false;
-
-  switch (tv1->type) {
-    case Type::I32:
-      return tv1->value.i32 == tv2->value.i32;
-    case Type::F32:
-      return tv1->value.f32_bits == tv2->value.f32_bits;
-    case Type::I64:
-      return tv1->value.i64 == tv2->value.i64;
-    case Type::F64:
-      return tv1->value.f64_bits == tv2->value.f64_bits;
-    default:
-      WABT_UNREACHABLE;
-  }
-}
-
-wabt::Result SpecJSONParser::OnAssertReturnCommand(
-    ::Action* action,
-    const std::vector<TypedValue>& expected) {
-  std::vector<TypedValue> results;
-  interpreter::Result iresult;
-
-  total_++;
-  wabt::Result result =
-      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
-
-  if (Succeeded(result)) {
-    if (iresult == interpreter::Result::Ok) {
-      if (results.size() == expected.size()) {
-        for (size_t i = 0; i < results.size(); ++i) {
-          const TypedValue* expected_tv = &expected[i];
-          const TypedValue* actual_tv = &results[i];
-          if (!TypedValuesAreEqual(expected_tv, actual_tv)) {
-            char expected_str[MAX_TYPED_VALUE_CHARS];
-            char actual_str[MAX_TYPED_VALUE_CHARS];
-            SPrintTypedValue(expected_str, sizeof(expected_str), expected_tv);
-            SPrintTypedValue(actual_str, sizeof(actual_str), actual_tv);
-            PrintCommandError("mismatch in result %" PRIzd
-                              " of assert_return: expected %s, got %s",
-                              i, expected_str, actual_str);
-            result = wabt::Result::Error;
-          }
-        }
-      } else {
-        PrintCommandError(
-            "result length mismatch in assert_return: expected %" PRIzd
-            ", got %" PRIzd,
-            expected.size(), results.size());
-        result = wabt::Result::Error;
-      }
-    } else {
-      PrintCommandError("unexpected trap: %s",
-                        s_trap_strings[static_cast<size_t>(iresult)]);
-      result = wabt::Result::Error;
-    }
-  }
-
-  if (Succeeded(result))
-    passed_++;
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::OnAssertReturnNanCommand(::Action* action,
-                                                      bool canonical) {
-  std::vector<TypedValue> results;
-  interpreter::Result iresult;
-
-  total_++;
-  wabt::Result result =
-      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
-  if (Succeeded(result)) {
-    if (iresult == interpreter::Result::Ok) {
-      if (results.size() != 1) {
-        PrintCommandError("expected one result, got %" PRIzd, results.size());
-        result = wabt::Result::Error;
-      }
-
-      const TypedValue& actual = results[0];
-      switch (actual.type) {
-        case Type::F32: {
-          bool is_nan = canonical ? IsCanonicalNan(actual.value.f32_bits)
-                                  : IsArithmeticNan(actual.value.f32_bits);
-          if (!is_nan) {
-            char actual_str[MAX_TYPED_VALUE_CHARS];
-            SPrintTypedValue(actual_str, sizeof(actual_str), &actual);
-            PrintCommandError("expected result to be nan, got %s", actual_str);
-            result = wabt::Result::Error;
-          }
-          break;
-        }
-
-        case Type::F64: {
-          bool is_nan = canonical ? IsCanonicalNan(actual.value.f64_bits)
-                                  : IsArithmeticNan(actual.value.f64_bits);
-          if (!is_nan) {
-            char actual_str[MAX_TYPED_VALUE_CHARS];
-            SPrintTypedValue(actual_str, sizeof(actual_str), &actual);
-            PrintCommandError("expected result to be nan, got %s", actual_str);
-            result = wabt::Result::Error;
-          }
-          break;
-        }
-
-        default:
-          PrintCommandError("expected result type to be f32 or f64, got %s",
-                            GetTypeName(actual.type));
-          result = wabt::Result::Error;
-          break;
-      }
-    } else {
-      PrintCommandError("unexpected trap: %s",
-                        s_trap_strings[static_cast<int>(iresult)]);
-      result = wabt::Result::Error;
-    }
-  }
-
-  if (Succeeded(result))
-    passed_++;
-
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::OnAssertTrapCommand(::Action* action,
-                                                 string_view text) {
-  std::vector<TypedValue> results;
-  interpreter::Result iresult;
-
-  total_++;
-  wabt::Result result =
-      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
-  if (Succeeded(result)) {
-    if (iresult != interpreter::Result::Ok) {
-      passed_++;
-    } else {
-      PrintCommandError("expected trap: \"" PRIstringview "\"",
-                        WABT_PRINTF_STRING_VIEW_ARG(text));
-      result = wabt::Result::Error;
-    }
-  }
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::OnAssertExhaustionCommand(::Action* action) {
-  std::vector<TypedValue> results;
-  interpreter::Result iresult;
-
-  total_++;
-  wabt::Result result =
-      RunAction(action, &iresult, &results, RunVerbosity::Quiet);
-  if (Succeeded(result)) {
-    if (iresult == interpreter::Result::TrapCallStackExhausted ||
-        iresult == interpreter::Result::TrapValueStackExhausted) {
-      passed_++;
-    } else {
-      PrintCommandError("expected call stack exhaustion");
-      result = wabt::Result::Error;
-    }
-  }
-
-  return result;
-}
-
-wabt::Result SpecJSONParser::ParseCommand() {
-  EXPECT("{");
-  EXPECT_KEY("type");
-  if (Match("\"module\"")) {
-    std::string name;
-    std::string filename;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseOptNameStringValue(&name));
-    PARSE_KEY_STRING_VALUE("filename", &filename);
-    OnModuleCommand(filename, name);
-  } else if (Match("\"action\"")) {
-    ::Action action;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseAction(&action));
-    OnActionCommand(&action);
-  } else if (Match("\"register\"")) {
-    std::string as;
-    std::string name;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseOptNameStringValue(&name));
-    PARSE_KEY_STRING_VALUE("as", &as);
-    OnRegisterCommand(name, as);
-  } else if (Match("\"assert_malformed\"")) {
-    std::string filename;
-    std::string text;
-    ModuleType module_type;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("filename", &filename);
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("text", &text);
-    EXPECT(",");
-    CHECK_RESULT(ParseModuleType(&module_type));
-    OnAssertMalformedCommand(filename, text, module_type);
-  } else if (Match("\"assert_invalid\"")) {
-    std::string filename;
-    std::string text;
-    ModuleType module_type;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("filename", &filename);
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("text", &text);
-    EXPECT(",");
-    CHECK_RESULT(ParseModuleType(&module_type));
-    OnAssertInvalidCommand(filename, text, module_type);
-  } else if (Match("\"assert_unlinkable\"")) {
-    std::string filename;
-    std::string text;
-    ModuleType module_type;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("filename", &filename);
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("text", &text);
-    EXPECT(",");
-    CHECK_RESULT(ParseModuleType(&module_type));
-    OnAssertUnlinkableCommand(filename, text, module_type);
-  } else if (Match("\"assert_uninstantiable\"")) {
-    std::string filename;
-    std::string text;
-    ModuleType module_type;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("filename", &filename);
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("text", &text);
-    EXPECT(",");
-    CHECK_RESULT(ParseModuleType(&module_type));
-    OnAssertUninstantiableCommand(filename, text, module_type);
-  } else if (Match("\"assert_return\"")) {
-    ::Action action;
-    std::vector<TypedValue> expected;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseAction(&action));
-    EXPECT(",");
-    EXPECT_KEY("expected");
-    CHECK_RESULT(ParseConstVector(&expected));
-    OnAssertReturnCommand(&action, expected);
-  } else if (Match("\"assert_return_canonical_nan\"")) {
-    ::Action action;
-    TypeVector expected;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseAction(&action));
-    EXPECT(",");
-    /* Not needed for wabt-interp, but useful for other parsers. */
-    EXPECT_KEY("expected");
-    CHECK_RESULT(ParseTypeVector(&expected));
-    OnAssertReturnNanCommand(&action, true);
-  } else if (Match("\"assert_return_arithmetic_nan\"")) {
-    ::Action action;
-    TypeVector expected;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseAction(&action));
-    EXPECT(",");
-    /* Not needed for wabt-interp, but useful for other parsers. */
-    EXPECT_KEY("expected");
-    CHECK_RESULT(ParseTypeVector(&expected));
-    OnAssertReturnNanCommand(&action, false);
-  } else if (Match("\"assert_trap\"")) {
-    ::Action action;
-    std::string text;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseAction(&action));
-    EXPECT(",");
-    PARSE_KEY_STRING_VALUE("text", &text);
-    OnAssertTrapCommand(&action, text);
-  } else if (Match("\"assert_exhaustion\"")) {
-    ::Action action;
-    std::string text;
-
-    EXPECT(",");
-    CHECK_RESULT(ParseLine());
-    EXPECT(",");
-    CHECK_RESULT(ParseAction(&action));
-    OnAssertExhaustionCommand(&action);
-  } else {
-    PrintCommandError("unknown command type");
-    return wabt::Result::Error;
-  }
-  EXPECT("}");
-  return wabt::Result::Ok;
-}
-
-wabt::Result SpecJSONParser::ParseCommands() {
-  EXPECT("{");
-  PARSE_KEY_STRING_VALUE("source_filename", &source_filename_);
-  EXPECT(",");
-  EXPECT_KEY("commands");
-  EXPECT("[");
-  bool first = true;
-  while (!Match("]")) {
-    if (!first)
-      EXPECT(",");
-    CHECK_RESULT(ParseCommand());
-    first = false;
-  }
-  EXPECT("}");
-  return wabt::Result::Ok;
-}
-
-static wabt::Result ReadAndRunSpecJSON(const char* spec_json_filename) {
-  SpecJSONParser parser;
-  CHECK_RESULT(parser.ReadFile(spec_json_filename));
-  wabt::Result result = parser.ParseCommands();
-  printf("%d/%d tests passed.\n", parser.passed(), parser.total());
-  return result;
-}
-
 int ProgramMain(int argc, char** argv) {
   InitStdio();
   ParseOptions(argc, argv);
 
   s_stdout_stream = FileStream::CreateStdout();
 
-  wabt::Result result;
-  if (s_spec) {
-    result = ReadAndRunSpecJSON(s_infile);
-  } else {
-    result = ReadAndRunModule(s_infile);
-  }
+  wabt::Result result = ReadAndRunModule(s_infile);
   return result != wabt::Result::Ok;
 }
 

--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -25,7 +25,7 @@ SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
 REPO_ROOT_DIR = os.path.dirname(SCRIPT_DIR)
 EXECUTABLES = [
     'wat2wasm', 'wast2json', 'wasm2wat', 'wasm-objdump', 'wasm-interp',
-    'wasm-opcodecnt', 'wat-desugar', 'wasm-link'
+    'wasm-opcodecnt', 'wat-desugar', 'wasm-link', 'spectest-interp',
 ]
 
 
@@ -86,6 +86,10 @@ def GetWasmlinkExecutable(override=None):
 
 def GetWasmInterpExecutable(override=None):
   return FindExecutable('wasm-interp', override)
+
+
+def GetSpectestInterpExecutable(override=None):
+  return FindExecutable('spectest-interp', override)
 
 
 def GetWasmOpcodeCntExecutable(override=None):

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -1,0 +1,21 @@
+;;; EXE: %(spectest-interp)s
+;;; FLAGS: --help
+(;; STDOUT ;;;
+usage: spectest-interp [options] filename
+
+  read a Spectest JSON file, and run its tests in the interpreter.
+
+examples:
+  # parse test.json and run the spec tests
+  $ spectest-interp test.json
+
+options:
+  -v, --verbose                               Use multiple times for more info
+  -h, --help                                  Print this help message
+      --enable-exceptions                     Experimental exception handling
+      --enable-saturating-float-to-int        Saturating float-to-int operators
+      --enable-threads                        Threading support
+  -V, --value-stack-size=SIZE                 Size in elements of the value stack
+  -C, --call-stack-size=SIZE                  Size in elements of the call stack
+  -t, --trace                                 Trace execution
+;;; STDOUT ;;)

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -16,9 +16,6 @@ examples:
   # parse test.wasm, run the exported functions and trace the output
   $ wasm-interp test.wasm --run-all-exports --trace
 
-  # parse test.json and run the spec tests
-  $ wasm-interp test.json --spec
-
   # parse test.wasm and run all its exported functions, setting the
   # value stack size to 100 elements
   $ wasm-interp test.wasm -V 100 --run-all-exports
@@ -32,6 +29,6 @@ options:
   -V, --value-stack-size=SIZE                 Size in elements of the value stack
   -C, --call-stack-size=SIZE                  Size in elements of the call stack
   -t, --trace                                 Trace execution
-      --spec                                  Run spec tests (input file should be .json)
       --run-all-exports                       Run all the exported functions, in order. Useful for testing
+      --host-print                            Include an importable function named "host.print" for printing to stdout
 ;;; STDOUT ;;)

--- a/test/interp/callimport-zero-args.txt
+++ b/test/interp/callimport-zero-args.txt
@@ -1,12 +1,13 @@
 ;;; TOOL: run-interp
+;;; FLAGS: --host-print
 (module
-  (import "spectest" "print" (func $imported (result i32)))
+  (import "host" "print" (func $imported (result i32)))
 
   (func (export "f") (result i32)
     i32.const 13
     call $imported
     i32.add))
 (;; STDOUT ;;;
-called host spectest.print() => i32:0
+called host host.print() => i32:0
 f() => i32:13
 ;;; STDOUT ;;)

--- a/test/interp/import.txt
+++ b/test/interp/import.txt
@@ -1,7 +1,8 @@
 ;;; TOOL: run-interp
+;;; FLAGS: --host-print
 (module
-  (import "spectest" "print" (func $print_i32 (param i32)))
-  (import "spectest" "print" (func $print_i32_i32 (param i32 i32)))
+  (import "host" "print" (func $print_i32 (param i32)))
+  (import "host" "print" (func $print_i32_i32 (param i32 i32)))
   (func (export "test") (result i32)
     i32.const 100
     call $print_i32
@@ -12,7 +13,7 @@
     return)
 )
 (;; STDOUT ;;;
-called host spectest.print(i32:100) =>
-called host spectest.print(i32:200, i32:300) =>
+called host host.print(i32:100) =>
+called host host.print(i32:200, i32:300) =>
 test() => i32:1
 ;;; STDOUT ;;)

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -1,8 +1,8 @@
 ;;; TOOL: run-interp
-;;; FLAGS: -v --enable-threads --enable-saturating-float-to-int
+;;; FLAGS: -v --host-print --enable-threads --enable-saturating-float-to-int
 
 (module
-  (import "spectest" "print" (func $print (param i32)))
+  (import "host" "print" (func $print (param i32)))
 
   (type $empty (func))
   (func $empty)
@@ -301,4135 +301,4135 @@
 0000013: 00                                        ; section size (guess)
 0000014: 01                                        ; num imports
 ; import header 0
-0000015: 08                                        ; string length
-0000016: 7370 6563 7465 7374                      spectest  ; import module name
-000001e: 05                                        ; string length
-000001f: 7072 696e 74                             print  ; import field name
-0000024: 00                                        ; import kind
-0000025: 01                                        ; import signature index
-0000013: 12                                        ; FIXUP section size
+0000015: 04                                        ; string length
+0000016: 686f 7374                                host  ; import module name
+000001a: 05                                        ; string length
+000001b: 7072 696e 74                             print  ; import field name
+0000020: 00                                        ; import kind
+0000021: 01                                        ; import signature index
+0000013: 0e                                        ; FIXUP section size
 ; section "Function" (3)
-0000026: 03                                        ; section code
-0000027: 00                                        ; section size (guess)
-0000028: f701                                      ; num functions
-000002a: 00                                        ; function 0 signature index
-000002b: 00                                        ; function 1 signature index
-000002c: 00                                        ; function 2 signature index
-000002d: 00                                        ; function 3 signature index
-000002e: 00                                        ; function 4 signature index
-000002f: 00                                        ; function 5 signature index
-0000030: 00                                        ; function 6 signature index
-0000031: 00                                        ; function 7 signature index
-0000032: 00                                        ; function 8 signature index
-0000033: 00                                        ; function 9 signature index
-0000034: 00                                        ; function 10 signature index
-0000035: 00                                        ; function 11 signature index
-0000036: 00                                        ; function 12 signature index
-0000037: 00                                        ; function 13 signature index
-0000038: 00                                        ; function 14 signature index
-0000039: 00                                        ; function 15 signature index
-000003a: 00                                        ; function 16 signature index
-000003b: 00                                        ; function 17 signature index
-000003c: 00                                        ; function 18 signature index
-000003d: 00                                        ; function 19 signature index
-000003e: 00                                        ; function 20 signature index
-000003f: 00                                        ; function 21 signature index
-0000040: 00                                        ; function 22 signature index
-0000041: 00                                        ; function 23 signature index
-0000042: 00                                        ; function 24 signature index
-0000043: 00                                        ; function 25 signature index
-0000044: 00                                        ; function 26 signature index
-0000045: 00                                        ; function 27 signature index
-0000046: 00                                        ; function 28 signature index
-0000047: 00                                        ; function 29 signature index
-0000048: 00                                        ; function 30 signature index
-0000049: 00                                        ; function 31 signature index
-000004a: 00                                        ; function 32 signature index
-000004b: 00                                        ; function 33 signature index
-000004c: 00                                        ; function 34 signature index
-000004d: 00                                        ; function 35 signature index
-000004e: 00                                        ; function 36 signature index
-000004f: 00                                        ; function 37 signature index
-0000050: 00                                        ; function 38 signature index
-0000051: 00                                        ; function 39 signature index
-0000052: 00                                        ; function 40 signature index
-0000053: 00                                        ; function 41 signature index
-0000054: 00                                        ; function 42 signature index
-0000055: 00                                        ; function 43 signature index
-0000056: 00                                        ; function 44 signature index
-0000057: 00                                        ; function 45 signature index
-0000058: 00                                        ; function 46 signature index
-0000059: 00                                        ; function 47 signature index
-000005a: 00                                        ; function 48 signature index
-000005b: 00                                        ; function 49 signature index
-000005c: 00                                        ; function 50 signature index
-000005d: 00                                        ; function 51 signature index
-000005e: 00                                        ; function 52 signature index
-000005f: 00                                        ; function 53 signature index
-0000060: 00                                        ; function 54 signature index
-0000061: 00                                        ; function 55 signature index
-0000062: 00                                        ; function 56 signature index
-0000063: 00                                        ; function 57 signature index
-0000064: 00                                        ; function 58 signature index
-0000065: 00                                        ; function 59 signature index
-0000066: 00                                        ; function 60 signature index
-0000067: 00                                        ; function 61 signature index
-0000068: 00                                        ; function 62 signature index
-0000069: 00                                        ; function 63 signature index
-000006a: 00                                        ; function 64 signature index
-000006b: 00                                        ; function 65 signature index
-000006c: 00                                        ; function 66 signature index
-000006d: 00                                        ; function 67 signature index
-000006e: 00                                        ; function 68 signature index
-000006f: 00                                        ; function 69 signature index
-0000070: 00                                        ; function 70 signature index
-0000071: 00                                        ; function 71 signature index
-0000072: 00                                        ; function 72 signature index
-0000073: 00                                        ; function 73 signature index
-0000074: 00                                        ; function 74 signature index
-0000075: 00                                        ; function 75 signature index
-0000076: 00                                        ; function 76 signature index
-0000077: 00                                        ; function 77 signature index
-0000078: 00                                        ; function 78 signature index
-0000079: 00                                        ; function 79 signature index
-000007a: 00                                        ; function 80 signature index
-000007b: 00                                        ; function 81 signature index
-000007c: 00                                        ; function 82 signature index
-000007d: 00                                        ; function 83 signature index
-000007e: 00                                        ; function 84 signature index
-000007f: 00                                        ; function 85 signature index
-0000080: 00                                        ; function 86 signature index
-0000081: 00                                        ; function 87 signature index
-0000082: 00                                        ; function 88 signature index
-0000083: 00                                        ; function 89 signature index
-0000084: 00                                        ; function 90 signature index
-0000085: 00                                        ; function 91 signature index
-0000086: 00                                        ; function 92 signature index
-0000087: 00                                        ; function 93 signature index
-0000088: 00                                        ; function 94 signature index
-0000089: 00                                        ; function 95 signature index
-000008a: 00                                        ; function 96 signature index
-000008b: 00                                        ; function 97 signature index
-000008c: 00                                        ; function 98 signature index
-000008d: 00                                        ; function 99 signature index
-000008e: 00                                        ; function 100 signature index
-000008f: 00                                        ; function 101 signature index
-0000090: 00                                        ; function 102 signature index
-0000091: 00                                        ; function 103 signature index
-0000092: 00                                        ; function 104 signature index
-0000093: 00                                        ; function 105 signature index
-0000094: 00                                        ; function 106 signature index
-0000095: 00                                        ; function 107 signature index
-0000096: 00                                        ; function 108 signature index
-0000097: 00                                        ; function 109 signature index
-0000098: 00                                        ; function 110 signature index
-0000099: 00                                        ; function 111 signature index
-000009a: 00                                        ; function 112 signature index
-000009b: 00                                        ; function 113 signature index
-000009c: 00                                        ; function 114 signature index
-000009d: 00                                        ; function 115 signature index
-000009e: 00                                        ; function 116 signature index
-000009f: 00                                        ; function 117 signature index
-00000a0: 00                                        ; function 118 signature index
-00000a1: 00                                        ; function 119 signature index
-00000a2: 00                                        ; function 120 signature index
-00000a3: 00                                        ; function 121 signature index
-00000a4: 00                                        ; function 122 signature index
-00000a5: 00                                        ; function 123 signature index
-00000a6: 00                                        ; function 124 signature index
-00000a7: 00                                        ; function 125 signature index
-00000a8: 00                                        ; function 126 signature index
-00000a9: 00                                        ; function 127 signature index
-00000aa: 00                                        ; function 128 signature index
-00000ab: 00                                        ; function 129 signature index
-00000ac: 00                                        ; function 130 signature index
-00000ad: 00                                        ; function 131 signature index
-00000ae: 00                                        ; function 132 signature index
-00000af: 00                                        ; function 133 signature index
-00000b0: 00                                        ; function 134 signature index
-00000b1: 00                                        ; function 135 signature index
-00000b2: 00                                        ; function 136 signature index
-00000b3: 00                                        ; function 137 signature index
-00000b4: 00                                        ; function 138 signature index
-00000b5: 00                                        ; function 139 signature index
-00000b6: 00                                        ; function 140 signature index
-00000b7: 00                                        ; function 141 signature index
-00000b8: 00                                        ; function 142 signature index
-00000b9: 00                                        ; function 143 signature index
-00000ba: 00                                        ; function 144 signature index
-00000bb: 00                                        ; function 145 signature index
-00000bc: 00                                        ; function 146 signature index
-00000bd: 00                                        ; function 147 signature index
-00000be: 00                                        ; function 148 signature index
-00000bf: 00                                        ; function 149 signature index
-00000c0: 00                                        ; function 150 signature index
-00000c1: 00                                        ; function 151 signature index
-00000c2: 00                                        ; function 152 signature index
-00000c3: 00                                        ; function 153 signature index
-00000c4: 00                                        ; function 154 signature index
-00000c5: 00                                        ; function 155 signature index
-00000c6: 00                                        ; function 156 signature index
-00000c7: 00                                        ; function 157 signature index
-00000c8: 00                                        ; function 158 signature index
-00000c9: 00                                        ; function 159 signature index
-00000ca: 00                                        ; function 160 signature index
-00000cb: 00                                        ; function 161 signature index
-00000cc: 00                                        ; function 162 signature index
-00000cd: 00                                        ; function 163 signature index
-00000ce: 00                                        ; function 164 signature index
-00000cf: 00                                        ; function 165 signature index
-00000d0: 00                                        ; function 166 signature index
-00000d1: 00                                        ; function 167 signature index
-00000d2: 00                                        ; function 168 signature index
-00000d3: 00                                        ; function 169 signature index
-00000d4: 00                                        ; function 170 signature index
-00000d5: 00                                        ; function 171 signature index
-00000d6: 00                                        ; function 172 signature index
-00000d7: 00                                        ; function 173 signature index
-00000d8: 00                                        ; function 174 signature index
-00000d9: 00                                        ; function 175 signature index
-00000da: 00                                        ; function 176 signature index
-00000db: 00                                        ; function 177 signature index
-00000dc: 00                                        ; function 178 signature index
-00000dd: 00                                        ; function 179 signature index
-00000de: 00                                        ; function 180 signature index
-00000df: 00                                        ; function 181 signature index
-00000e0: 00                                        ; function 182 signature index
-00000e1: 00                                        ; function 183 signature index
-00000e2: 00                                        ; function 184 signature index
-00000e3: 00                                        ; function 185 signature index
-00000e4: 00                                        ; function 186 signature index
-00000e5: 00                                        ; function 187 signature index
-00000e6: 00                                        ; function 188 signature index
-00000e7: 00                                        ; function 189 signature index
-00000e8: 00                                        ; function 190 signature index
-00000e9: 00                                        ; function 191 signature index
-00000ea: 00                                        ; function 192 signature index
-00000eb: 00                                        ; function 193 signature index
-00000ec: 00                                        ; function 194 signature index
-00000ed: 00                                        ; function 195 signature index
-00000ee: 00                                        ; function 196 signature index
-00000ef: 00                                        ; function 197 signature index
-00000f0: 00                                        ; function 198 signature index
-00000f1: 00                                        ; function 199 signature index
-00000f2: 00                                        ; function 200 signature index
-00000f3: 00                                        ; function 201 signature index
-00000f4: 00                                        ; function 202 signature index
-00000f5: 00                                        ; function 203 signature index
-00000f6: 00                                        ; function 204 signature index
-00000f7: 00                                        ; function 205 signature index
-00000f8: 00                                        ; function 206 signature index
-00000f9: 00                                        ; function 207 signature index
-00000fa: 00                                        ; function 208 signature index
-00000fb: 00                                        ; function 209 signature index
-00000fc: 00                                        ; function 210 signature index
-00000fd: 00                                        ; function 211 signature index
-00000fe: 00                                        ; function 212 signature index
-00000ff: 00                                        ; function 213 signature index
-0000100: 00                                        ; function 214 signature index
-0000101: 00                                        ; function 215 signature index
-0000102: 00                                        ; function 216 signature index
-0000103: 00                                        ; function 217 signature index
-0000104: 00                                        ; function 218 signature index
-0000105: 00                                        ; function 219 signature index
-0000106: 00                                        ; function 220 signature index
-0000107: 00                                        ; function 221 signature index
-0000108: 00                                        ; function 222 signature index
-0000109: 00                                        ; function 223 signature index
-000010a: 00                                        ; function 224 signature index
-000010b: 00                                        ; function 225 signature index
-000010c: 00                                        ; function 226 signature index
-000010d: 00                                        ; function 227 signature index
-000010e: 00                                        ; function 228 signature index
-000010f: 00                                        ; function 229 signature index
-0000110: 00                                        ; function 230 signature index
-0000111: 00                                        ; function 231 signature index
-0000112: 00                                        ; function 232 signature index
-0000113: 00                                        ; function 233 signature index
-0000114: 00                                        ; function 234 signature index
-0000115: 00                                        ; function 235 signature index
-0000116: 00                                        ; function 236 signature index
-0000117: 00                                        ; function 237 signature index
-0000118: 00                                        ; function 238 signature index
-0000119: 00                                        ; function 239 signature index
-000011a: 00                                        ; function 240 signature index
-000011b: 00                                        ; function 241 signature index
-000011c: 00                                        ; function 242 signature index
-000011d: 00                                        ; function 243 signature index
-000011e: 00                                        ; function 244 signature index
-000011f: 00                                        ; function 245 signature index
-0000120: 00                                        ; function 246 signature index
-; move data: [28, 121) -> [29, 122)
-0000027: f901                                      ; FIXUP section size
+0000022: 03                                        ; section code
+0000023: 00                                        ; section size (guess)
+0000024: f701                                      ; num functions
+0000026: 00                                        ; function 0 signature index
+0000027: 00                                        ; function 1 signature index
+0000028: 00                                        ; function 2 signature index
+0000029: 00                                        ; function 3 signature index
+000002a: 00                                        ; function 4 signature index
+000002b: 00                                        ; function 5 signature index
+000002c: 00                                        ; function 6 signature index
+000002d: 00                                        ; function 7 signature index
+000002e: 00                                        ; function 8 signature index
+000002f: 00                                        ; function 9 signature index
+0000030: 00                                        ; function 10 signature index
+0000031: 00                                        ; function 11 signature index
+0000032: 00                                        ; function 12 signature index
+0000033: 00                                        ; function 13 signature index
+0000034: 00                                        ; function 14 signature index
+0000035: 00                                        ; function 15 signature index
+0000036: 00                                        ; function 16 signature index
+0000037: 00                                        ; function 17 signature index
+0000038: 00                                        ; function 18 signature index
+0000039: 00                                        ; function 19 signature index
+000003a: 00                                        ; function 20 signature index
+000003b: 00                                        ; function 21 signature index
+000003c: 00                                        ; function 22 signature index
+000003d: 00                                        ; function 23 signature index
+000003e: 00                                        ; function 24 signature index
+000003f: 00                                        ; function 25 signature index
+0000040: 00                                        ; function 26 signature index
+0000041: 00                                        ; function 27 signature index
+0000042: 00                                        ; function 28 signature index
+0000043: 00                                        ; function 29 signature index
+0000044: 00                                        ; function 30 signature index
+0000045: 00                                        ; function 31 signature index
+0000046: 00                                        ; function 32 signature index
+0000047: 00                                        ; function 33 signature index
+0000048: 00                                        ; function 34 signature index
+0000049: 00                                        ; function 35 signature index
+000004a: 00                                        ; function 36 signature index
+000004b: 00                                        ; function 37 signature index
+000004c: 00                                        ; function 38 signature index
+000004d: 00                                        ; function 39 signature index
+000004e: 00                                        ; function 40 signature index
+000004f: 00                                        ; function 41 signature index
+0000050: 00                                        ; function 42 signature index
+0000051: 00                                        ; function 43 signature index
+0000052: 00                                        ; function 44 signature index
+0000053: 00                                        ; function 45 signature index
+0000054: 00                                        ; function 46 signature index
+0000055: 00                                        ; function 47 signature index
+0000056: 00                                        ; function 48 signature index
+0000057: 00                                        ; function 49 signature index
+0000058: 00                                        ; function 50 signature index
+0000059: 00                                        ; function 51 signature index
+000005a: 00                                        ; function 52 signature index
+000005b: 00                                        ; function 53 signature index
+000005c: 00                                        ; function 54 signature index
+000005d: 00                                        ; function 55 signature index
+000005e: 00                                        ; function 56 signature index
+000005f: 00                                        ; function 57 signature index
+0000060: 00                                        ; function 58 signature index
+0000061: 00                                        ; function 59 signature index
+0000062: 00                                        ; function 60 signature index
+0000063: 00                                        ; function 61 signature index
+0000064: 00                                        ; function 62 signature index
+0000065: 00                                        ; function 63 signature index
+0000066: 00                                        ; function 64 signature index
+0000067: 00                                        ; function 65 signature index
+0000068: 00                                        ; function 66 signature index
+0000069: 00                                        ; function 67 signature index
+000006a: 00                                        ; function 68 signature index
+000006b: 00                                        ; function 69 signature index
+000006c: 00                                        ; function 70 signature index
+000006d: 00                                        ; function 71 signature index
+000006e: 00                                        ; function 72 signature index
+000006f: 00                                        ; function 73 signature index
+0000070: 00                                        ; function 74 signature index
+0000071: 00                                        ; function 75 signature index
+0000072: 00                                        ; function 76 signature index
+0000073: 00                                        ; function 77 signature index
+0000074: 00                                        ; function 78 signature index
+0000075: 00                                        ; function 79 signature index
+0000076: 00                                        ; function 80 signature index
+0000077: 00                                        ; function 81 signature index
+0000078: 00                                        ; function 82 signature index
+0000079: 00                                        ; function 83 signature index
+000007a: 00                                        ; function 84 signature index
+000007b: 00                                        ; function 85 signature index
+000007c: 00                                        ; function 86 signature index
+000007d: 00                                        ; function 87 signature index
+000007e: 00                                        ; function 88 signature index
+000007f: 00                                        ; function 89 signature index
+0000080: 00                                        ; function 90 signature index
+0000081: 00                                        ; function 91 signature index
+0000082: 00                                        ; function 92 signature index
+0000083: 00                                        ; function 93 signature index
+0000084: 00                                        ; function 94 signature index
+0000085: 00                                        ; function 95 signature index
+0000086: 00                                        ; function 96 signature index
+0000087: 00                                        ; function 97 signature index
+0000088: 00                                        ; function 98 signature index
+0000089: 00                                        ; function 99 signature index
+000008a: 00                                        ; function 100 signature index
+000008b: 00                                        ; function 101 signature index
+000008c: 00                                        ; function 102 signature index
+000008d: 00                                        ; function 103 signature index
+000008e: 00                                        ; function 104 signature index
+000008f: 00                                        ; function 105 signature index
+0000090: 00                                        ; function 106 signature index
+0000091: 00                                        ; function 107 signature index
+0000092: 00                                        ; function 108 signature index
+0000093: 00                                        ; function 109 signature index
+0000094: 00                                        ; function 110 signature index
+0000095: 00                                        ; function 111 signature index
+0000096: 00                                        ; function 112 signature index
+0000097: 00                                        ; function 113 signature index
+0000098: 00                                        ; function 114 signature index
+0000099: 00                                        ; function 115 signature index
+000009a: 00                                        ; function 116 signature index
+000009b: 00                                        ; function 117 signature index
+000009c: 00                                        ; function 118 signature index
+000009d: 00                                        ; function 119 signature index
+000009e: 00                                        ; function 120 signature index
+000009f: 00                                        ; function 121 signature index
+00000a0: 00                                        ; function 122 signature index
+00000a1: 00                                        ; function 123 signature index
+00000a2: 00                                        ; function 124 signature index
+00000a3: 00                                        ; function 125 signature index
+00000a4: 00                                        ; function 126 signature index
+00000a5: 00                                        ; function 127 signature index
+00000a6: 00                                        ; function 128 signature index
+00000a7: 00                                        ; function 129 signature index
+00000a8: 00                                        ; function 130 signature index
+00000a9: 00                                        ; function 131 signature index
+00000aa: 00                                        ; function 132 signature index
+00000ab: 00                                        ; function 133 signature index
+00000ac: 00                                        ; function 134 signature index
+00000ad: 00                                        ; function 135 signature index
+00000ae: 00                                        ; function 136 signature index
+00000af: 00                                        ; function 137 signature index
+00000b0: 00                                        ; function 138 signature index
+00000b1: 00                                        ; function 139 signature index
+00000b2: 00                                        ; function 140 signature index
+00000b3: 00                                        ; function 141 signature index
+00000b4: 00                                        ; function 142 signature index
+00000b5: 00                                        ; function 143 signature index
+00000b6: 00                                        ; function 144 signature index
+00000b7: 00                                        ; function 145 signature index
+00000b8: 00                                        ; function 146 signature index
+00000b9: 00                                        ; function 147 signature index
+00000ba: 00                                        ; function 148 signature index
+00000bb: 00                                        ; function 149 signature index
+00000bc: 00                                        ; function 150 signature index
+00000bd: 00                                        ; function 151 signature index
+00000be: 00                                        ; function 152 signature index
+00000bf: 00                                        ; function 153 signature index
+00000c0: 00                                        ; function 154 signature index
+00000c1: 00                                        ; function 155 signature index
+00000c2: 00                                        ; function 156 signature index
+00000c3: 00                                        ; function 157 signature index
+00000c4: 00                                        ; function 158 signature index
+00000c5: 00                                        ; function 159 signature index
+00000c6: 00                                        ; function 160 signature index
+00000c7: 00                                        ; function 161 signature index
+00000c8: 00                                        ; function 162 signature index
+00000c9: 00                                        ; function 163 signature index
+00000ca: 00                                        ; function 164 signature index
+00000cb: 00                                        ; function 165 signature index
+00000cc: 00                                        ; function 166 signature index
+00000cd: 00                                        ; function 167 signature index
+00000ce: 00                                        ; function 168 signature index
+00000cf: 00                                        ; function 169 signature index
+00000d0: 00                                        ; function 170 signature index
+00000d1: 00                                        ; function 171 signature index
+00000d2: 00                                        ; function 172 signature index
+00000d3: 00                                        ; function 173 signature index
+00000d4: 00                                        ; function 174 signature index
+00000d5: 00                                        ; function 175 signature index
+00000d6: 00                                        ; function 176 signature index
+00000d7: 00                                        ; function 177 signature index
+00000d8: 00                                        ; function 178 signature index
+00000d9: 00                                        ; function 179 signature index
+00000da: 00                                        ; function 180 signature index
+00000db: 00                                        ; function 181 signature index
+00000dc: 00                                        ; function 182 signature index
+00000dd: 00                                        ; function 183 signature index
+00000de: 00                                        ; function 184 signature index
+00000df: 00                                        ; function 185 signature index
+00000e0: 00                                        ; function 186 signature index
+00000e1: 00                                        ; function 187 signature index
+00000e2: 00                                        ; function 188 signature index
+00000e3: 00                                        ; function 189 signature index
+00000e4: 00                                        ; function 190 signature index
+00000e5: 00                                        ; function 191 signature index
+00000e6: 00                                        ; function 192 signature index
+00000e7: 00                                        ; function 193 signature index
+00000e8: 00                                        ; function 194 signature index
+00000e9: 00                                        ; function 195 signature index
+00000ea: 00                                        ; function 196 signature index
+00000eb: 00                                        ; function 197 signature index
+00000ec: 00                                        ; function 198 signature index
+00000ed: 00                                        ; function 199 signature index
+00000ee: 00                                        ; function 200 signature index
+00000ef: 00                                        ; function 201 signature index
+00000f0: 00                                        ; function 202 signature index
+00000f1: 00                                        ; function 203 signature index
+00000f2: 00                                        ; function 204 signature index
+00000f3: 00                                        ; function 205 signature index
+00000f4: 00                                        ; function 206 signature index
+00000f5: 00                                        ; function 207 signature index
+00000f6: 00                                        ; function 208 signature index
+00000f7: 00                                        ; function 209 signature index
+00000f8: 00                                        ; function 210 signature index
+00000f9: 00                                        ; function 211 signature index
+00000fa: 00                                        ; function 212 signature index
+00000fb: 00                                        ; function 213 signature index
+00000fc: 00                                        ; function 214 signature index
+00000fd: 00                                        ; function 215 signature index
+00000fe: 00                                        ; function 216 signature index
+00000ff: 00                                        ; function 217 signature index
+0000100: 00                                        ; function 218 signature index
+0000101: 00                                        ; function 219 signature index
+0000102: 00                                        ; function 220 signature index
+0000103: 00                                        ; function 221 signature index
+0000104: 00                                        ; function 222 signature index
+0000105: 00                                        ; function 223 signature index
+0000106: 00                                        ; function 224 signature index
+0000107: 00                                        ; function 225 signature index
+0000108: 00                                        ; function 226 signature index
+0000109: 00                                        ; function 227 signature index
+000010a: 00                                        ; function 228 signature index
+000010b: 00                                        ; function 229 signature index
+000010c: 00                                        ; function 230 signature index
+000010d: 00                                        ; function 231 signature index
+000010e: 00                                        ; function 232 signature index
+000010f: 00                                        ; function 233 signature index
+0000110: 00                                        ; function 234 signature index
+0000111: 00                                        ; function 235 signature index
+0000112: 00                                        ; function 236 signature index
+0000113: 00                                        ; function 237 signature index
+0000114: 00                                        ; function 238 signature index
+0000115: 00                                        ; function 239 signature index
+0000116: 00                                        ; function 240 signature index
+0000117: 00                                        ; function 241 signature index
+0000118: 00                                        ; function 242 signature index
+0000119: 00                                        ; function 243 signature index
+000011a: 00                                        ; function 244 signature index
+000011b: 00                                        ; function 245 signature index
+000011c: 00                                        ; function 246 signature index
+; move data: [24, 11d) -> [25, 11e)
+0000023: f901                                      ; FIXUP section size
 ; section "Table" (4)
-0000122: 04                                        ; section code
-0000123: 00                                        ; section size (guess)
-0000124: 01                                        ; num tables
+000011e: 04                                        ; section code
+000011f: 00                                        ; section size (guess)
+0000120: 01                                        ; num tables
 ; table 0
-0000125: 70                                        ; anyfunc
-0000126: 01                                        ; limits: flags
-0000127: 02                                        ; limits: initial
-0000128: 02                                        ; limits: max
-0000123: 05                                        ; FIXUP section size
+0000121: 70                                        ; anyfunc
+0000122: 01                                        ; limits: flags
+0000123: 02                                        ; limits: initial
+0000124: 02                                        ; limits: max
+000011f: 05                                        ; FIXUP section size
 ; section "Memory" (5)
-0000129: 05                                        ; section code
-000012a: 00                                        ; section size (guess)
-000012b: 01                                        ; num memories
+0000125: 05                                        ; section code
+0000126: 00                                        ; section size (guess)
+0000127: 01                                        ; num memories
 ; memory 0
-000012c: 03                                        ; limits: flags
-000012d: 01                                        ; limits: initial
-000012e: 01                                        ; limits: max
-000012a: 04                                        ; FIXUP section size
+0000128: 03                                        ; limits: flags
+0000129: 01                                        ; limits: initial
+000012a: 01                                        ; limits: max
+0000126: 04                                        ; FIXUP section size
 ; section "Global" (6)
-000012f: 06                                        ; section code
-0000130: 00                                        ; section size (guess)
-0000131: 01                                        ; num globals
-0000132: 7f                                        ; i32
-0000133: 01                                        ; global mutability
-0000134: 41                                        ; i32.const
-0000135: 00                                        ; i32 literal
-0000136: 0b                                        ; end
-0000130: 06                                        ; FIXUP section size
+000012b: 06                                        ; section code
+000012c: 00                                        ; section size (guess)
+000012d: 01                                        ; num globals
+000012e: 7f                                        ; i32
+000012f: 01                                        ; global mutability
+0000130: 41                                        ; i32.const
+0000131: 00                                        ; i32 literal
+0000132: 0b                                        ; end
+000012c: 06                                        ; FIXUP section size
 ; section "Export" (7)
-0000137: 07                                        ; section code
-0000138: 00                                        ; section size (guess)
-0000139: f601                                      ; num exports
-000013b: 0b                                        ; string length
-000013c: 756e 7265 6163 6861 626c 65              unreachable  ; export name
-0000147: 00                                        ; export kind
-0000148: 02                                        ; export func index
-0000149: 02                                        ; string length
-000014a: 6272                                     br  ; export name
-000014c: 00                                        ; export kind
-000014d: 03                                        ; export func index
-000014e: 08                                        ; string length
-000014f: 6272 5f74 6162 6c65                      br_table  ; export name
-0000157: 00                                        ; export kind
-0000158: 04                                        ; export func index
-0000159: 06                                        ; string length
-000015a: 7265 7475 726e                           return  ; export name
-0000160: 00                                        ; export kind
-0000161: 05                                        ; export func index
-0000162: 04                                        ; string length
-0000163: 6361 6c6c                                call  ; export name
-0000167: 00                                        ; export kind
-0000168: 06                                        ; export func index
-0000169: 0d                                        ; string length
-000016a: 6361 6c6c 5f69 6e64 6972 6563 74         call_indirect  ; export name
-0000177: 00                                        ; export kind
-0000178: 07                                        ; export func index
-0000179: 04                                        ; string length
-000017a: 6472 6f70                                drop  ; export name
-000017e: 00                                        ; export kind
-000017f: 08                                        ; export func index
-0000180: 06                                        ; string length
-0000181: 7365 6c65 6374                           select  ; export name
-0000187: 00                                        ; export kind
-0000188: 09                                        ; export func index
-0000189: 09                                        ; string length
-000018a: 6765 745f 6c6f 6361 6c                   get_local  ; export name
-0000193: 00                                        ; export kind
-0000194: 0a                                        ; export func index
-0000195: 09                                        ; string length
-0000196: 7365 745f 6c6f 6361 6c                   set_local  ; export name
-000019f: 00                                        ; export kind
-00001a0: 0b                                        ; export func index
-00001a1: 09                                        ; string length
-00001a2: 7465 655f 6c6f 6361 6c                   tee_local  ; export name
-00001ab: 00                                        ; export kind
-00001ac: 0c                                        ; export func index
-00001ad: 0a                                        ; string length
-00001ae: 6765 745f 676c 6f62 616c                 get_global  ; export name
-00001b8: 00                                        ; export kind
-00001b9: 0d                                        ; export func index
-00001ba: 0a                                        ; string length
-00001bb: 7365 745f 676c 6f62 616c                 set_global  ; export name
-00001c5: 00                                        ; export kind
-00001c6: 0e                                        ; export func index
-00001c7: 08                                        ; string length
-00001c8: 6933 322e 6c6f 6164                      i32.load  ; export name
-00001d0: 00                                        ; export kind
-00001d1: 0f                                        ; export func index
-00001d2: 08                                        ; string length
-00001d3: 6936 342e 6c6f 6164                      i64.load  ; export name
-00001db: 00                                        ; export kind
-00001dc: 10                                        ; export func index
-00001dd: 08                                        ; string length
-00001de: 6633 322e 6c6f 6164                      f32.load  ; export name
-00001e6: 00                                        ; export kind
-00001e7: 11                                        ; export func index
-00001e8: 08                                        ; string length
-00001e9: 6636 342e 6c6f 6164                      f64.load  ; export name
-00001f1: 00                                        ; export kind
-00001f2: 12                                        ; export func index
-00001f3: 0b                                        ; string length
-00001f4: 6933 322e 6c6f 6164 385f 73              i32.load8_s  ; export name
-00001ff: 00                                        ; export kind
-0000200: 13                                        ; export func index
-0000201: 0b                                        ; string length
-0000202: 6933 322e 6c6f 6164 385f 75              i32.load8_u  ; export name
-000020d: 00                                        ; export kind
-000020e: 14                                        ; export func index
-000020f: 0c                                        ; string length
-0000210: 6933 322e 6c6f 6164 3136 5f73            i32.load16_s  ; export name
-000021c: 00                                        ; export kind
-000021d: 15                                        ; export func index
-000021e: 0c                                        ; string length
-000021f: 6933 322e 6c6f 6164 3136 5f75            i32.load16_u  ; export name
-000022b: 00                                        ; export kind
-000022c: 16                                        ; export func index
-000022d: 0b                                        ; string length
-000022e: 6936 342e 6c6f 6164 385f 73              i64.load8_s  ; export name
-0000239: 00                                        ; export kind
-000023a: 17                                        ; export func index
-000023b: 0b                                        ; string length
-000023c: 6936 342e 6c6f 6164 385f 75              i64.load8_u  ; export name
-0000247: 00                                        ; export kind
-0000248: 18                                        ; export func index
-0000249: 0c                                        ; string length
-000024a: 6936 342e 6c6f 6164 3136 5f73            i64.load16_s  ; export name
-0000256: 00                                        ; export kind
-0000257: 19                                        ; export func index
-0000258: 0c                                        ; string length
-0000259: 6936 342e 6c6f 6164 3136 5f75            i64.load16_u  ; export name
-0000265: 00                                        ; export kind
-0000266: 1a                                        ; export func index
-0000267: 0c                                        ; string length
-0000268: 6936 342e 6c6f 6164 3332 5f73            i64.load32_s  ; export name
-0000274: 00                                        ; export kind
-0000275: 1b                                        ; export func index
-0000276: 0c                                        ; string length
-0000277: 6936 342e 6c6f 6164 3332 5f75            i64.load32_u  ; export name
-0000283: 00                                        ; export kind
-0000284: 1c                                        ; export func index
-0000285: 09                                        ; string length
-0000286: 6933 322e 7374 6f72 65                   i32.store  ; export name
-000028f: 00                                        ; export kind
-0000290: 1d                                        ; export func index
-0000291: 09                                        ; string length
-0000292: 6936 342e 7374 6f72 65                   i64.store  ; export name
-000029b: 00                                        ; export kind
-000029c: 1e                                        ; export func index
-000029d: 09                                        ; string length
-000029e: 6633 322e 7374 6f72 65                   f32.store  ; export name
-00002a7: 00                                        ; export kind
-00002a8: 1f                                        ; export func index
-00002a9: 09                                        ; string length
-00002aa: 6636 342e 7374 6f72 65                   f64.store  ; export name
-00002b3: 00                                        ; export kind
-00002b4: 20                                        ; export func index
-00002b5: 0a                                        ; string length
-00002b6: 6933 322e 7374 6f72 6538                 i32.store8  ; export name
-00002c0: 00                                        ; export kind
-00002c1: 21                                        ; export func index
-00002c2: 0b                                        ; string length
-00002c3: 6933 322e 7374 6f72 6531 36              i32.store16  ; export name
-00002ce: 00                                        ; export kind
-00002cf: 22                                        ; export func index
-00002d0: 0a                                        ; string length
-00002d1: 6936 342e 7374 6f72 6538                 i64.store8  ; export name
-00002db: 00                                        ; export kind
-00002dc: 23                                        ; export func index
-00002dd: 0b                                        ; string length
-00002de: 6936 342e 7374 6f72 6531 36              i64.store16  ; export name
-00002e9: 00                                        ; export kind
-00002ea: 24                                        ; export func index
-00002eb: 0b                                        ; string length
-00002ec: 6936 342e 7374 6f72 6533 32              i64.store32  ; export name
-00002f7: 00                                        ; export kind
-00002f8: 25                                        ; export func index
-00002f9: 0e                                        ; string length
-00002fa: 6375 7272 656e 745f 6d65 6d6f 7279       current_memory  ; export name
-0000308: 00                                        ; export kind
-0000309: 26                                        ; export func index
-000030a: 0b                                        ; string length
-000030b: 6772 6f77 5f6d 656d 6f72 79              grow_memory  ; export name
-0000316: 00                                        ; export kind
-0000317: 27                                        ; export func index
-0000318: 09                                        ; string length
-0000319: 6933 322e 636f 6e73 74                   i32.const  ; export name
-0000322: 00                                        ; export kind
-0000323: 28                                        ; export func index
-0000324: 09                                        ; string length
-0000325: 6936 342e 636f 6e73 74                   i64.const  ; export name
-000032e: 00                                        ; export kind
-000032f: 29                                        ; export func index
-0000330: 09                                        ; string length
-0000331: 6633 322e 636f 6e73 74                   f32.const  ; export name
-000033a: 00                                        ; export kind
-000033b: 2a                                        ; export func index
-000033c: 09                                        ; string length
-000033d: 6636 342e 636f 6e73 74                   f64.const  ; export name
-0000346: 00                                        ; export kind
-0000347: 2b                                        ; export func index
-0000348: 07                                        ; string length
-0000349: 6933 322e 6571 7a                        i32.eqz  ; export name
-0000350: 00                                        ; export kind
-0000351: 2c                                        ; export func index
-0000352: 06                                        ; string length
-0000353: 6933 322e 6571                           i32.eq  ; export name
-0000359: 00                                        ; export kind
-000035a: 2d                                        ; export func index
-000035b: 06                                        ; string length
-000035c: 6933 322e 6e65                           i32.ne  ; export name
-0000362: 00                                        ; export kind
-0000363: 2e                                        ; export func index
-0000364: 08                                        ; string length
-0000365: 6933 322e 6c74 5f73                      i32.lt_s  ; export name
-000036d: 00                                        ; export kind
-000036e: 2f                                        ; export func index
-000036f: 08                                        ; string length
-0000370: 6933 322e 6c74 5f75                      i32.lt_u  ; export name
-0000378: 00                                        ; export kind
-0000379: 30                                        ; export func index
-000037a: 08                                        ; string length
-000037b: 6933 322e 6774 5f73                      i32.gt_s  ; export name
-0000383: 00                                        ; export kind
-0000384: 31                                        ; export func index
-0000385: 08                                        ; string length
-0000386: 6933 322e 6774 5f75                      i32.gt_u  ; export name
-000038e: 00                                        ; export kind
-000038f: 32                                        ; export func index
-0000390: 08                                        ; string length
-0000391: 6933 322e 6c65 5f73                      i32.le_s  ; export name
-0000399: 00                                        ; export kind
-000039a: 33                                        ; export func index
-000039b: 08                                        ; string length
-000039c: 6933 322e 6c65 5f75                      i32.le_u  ; export name
-00003a4: 00                                        ; export kind
-00003a5: 34                                        ; export func index
-00003a6: 08                                        ; string length
-00003a7: 6933 322e 6765 5f73                      i32.ge_s  ; export name
-00003af: 00                                        ; export kind
-00003b0: 35                                        ; export func index
-00003b1: 08                                        ; string length
-00003b2: 6933 322e 6765 5f75                      i32.ge_u  ; export name
-00003ba: 00                                        ; export kind
-00003bb: 36                                        ; export func index
-00003bc: 07                                        ; string length
-00003bd: 6936 342e 6571 7a                        i64.eqz  ; export name
-00003c4: 00                                        ; export kind
-00003c5: 37                                        ; export func index
-00003c6: 06                                        ; string length
-00003c7: 6936 342e 6571                           i64.eq  ; export name
-00003cd: 00                                        ; export kind
-00003ce: 38                                        ; export func index
-00003cf: 06                                        ; string length
-00003d0: 6936 342e 6e65                           i64.ne  ; export name
-00003d6: 00                                        ; export kind
-00003d7: 39                                        ; export func index
-00003d8: 08                                        ; string length
-00003d9: 6936 342e 6c74 5f73                      i64.lt_s  ; export name
-00003e1: 00                                        ; export kind
-00003e2: 3a                                        ; export func index
-00003e3: 08                                        ; string length
-00003e4: 6936 342e 6c74 5f75                      i64.lt_u  ; export name
-00003ec: 00                                        ; export kind
-00003ed: 3b                                        ; export func index
-00003ee: 08                                        ; string length
-00003ef: 6936 342e 6774 5f73                      i64.gt_s  ; export name
-00003f7: 00                                        ; export kind
-00003f8: 3c                                        ; export func index
-00003f9: 08                                        ; string length
-00003fa: 6936 342e 6774 5f75                      i64.gt_u  ; export name
-0000402: 00                                        ; export kind
-0000403: 3d                                        ; export func index
-0000404: 08                                        ; string length
-0000405: 6936 342e 6c65 5f73                      i64.le_s  ; export name
-000040d: 00                                        ; export kind
-000040e: 3e                                        ; export func index
-000040f: 08                                        ; string length
-0000410: 6936 342e 6c65 5f75                      i64.le_u  ; export name
-0000418: 00                                        ; export kind
-0000419: 3f                                        ; export func index
-000041a: 08                                        ; string length
-000041b: 6936 342e 6765 5f73                      i64.ge_s  ; export name
-0000423: 00                                        ; export kind
-0000424: 40                                        ; export func index
-0000425: 08                                        ; string length
-0000426: 6936 342e 6765 5f75                      i64.ge_u  ; export name
-000042e: 00                                        ; export kind
-000042f: 41                                        ; export func index
-0000430: 06                                        ; string length
-0000431: 6633 322e 6571                           f32.eq  ; export name
-0000437: 00                                        ; export kind
-0000438: 42                                        ; export func index
-0000439: 06                                        ; string length
-000043a: 6633 322e 6e65                           f32.ne  ; export name
-0000440: 00                                        ; export kind
-0000441: 43                                        ; export func index
-0000442: 06                                        ; string length
-0000443: 6633 322e 6c74                           f32.lt  ; export name
-0000449: 00                                        ; export kind
-000044a: 44                                        ; export func index
-000044b: 06                                        ; string length
-000044c: 6633 322e 6774                           f32.gt  ; export name
-0000452: 00                                        ; export kind
-0000453: 45                                        ; export func index
-0000454: 06                                        ; string length
-0000455: 6633 322e 6c65                           f32.le  ; export name
-000045b: 00                                        ; export kind
-000045c: 46                                        ; export func index
-000045d: 06                                        ; string length
-000045e: 6633 322e 6765                           f32.ge  ; export name
-0000464: 00                                        ; export kind
-0000465: 47                                        ; export func index
-0000466: 06                                        ; string length
-0000467: 6636 342e 6571                           f64.eq  ; export name
-000046d: 00                                        ; export kind
-000046e: 48                                        ; export func index
-000046f: 06                                        ; string length
-0000470: 6636 342e 6e65                           f64.ne  ; export name
-0000476: 00                                        ; export kind
-0000477: 49                                        ; export func index
-0000478: 06                                        ; string length
-0000479: 6636 342e 6c74                           f64.lt  ; export name
-000047f: 00                                        ; export kind
-0000480: 4a                                        ; export func index
-0000481: 06                                        ; string length
-0000482: 6636 342e 6774                           f64.gt  ; export name
-0000488: 00                                        ; export kind
-0000489: 4b                                        ; export func index
-000048a: 06                                        ; string length
-000048b: 6636 342e 6c65                           f64.le  ; export name
-0000491: 00                                        ; export kind
-0000492: 4c                                        ; export func index
-0000493: 06                                        ; string length
-0000494: 6636 342e 6765                           f64.ge  ; export name
-000049a: 00                                        ; export kind
-000049b: 4d                                        ; export func index
-000049c: 07                                        ; string length
-000049d: 6933 322e 636c 7a                        i32.clz  ; export name
-00004a4: 00                                        ; export kind
-00004a5: 4e                                        ; export func index
-00004a6: 07                                        ; string length
-00004a7: 6933 322e 6374 7a                        i32.ctz  ; export name
-00004ae: 00                                        ; export kind
-00004af: 4f                                        ; export func index
-00004b0: 0a                                        ; string length
-00004b1: 6933 322e 706f 7063 6e74                 i32.popcnt  ; export name
-00004bb: 00                                        ; export kind
-00004bc: 50                                        ; export func index
-00004bd: 07                                        ; string length
-00004be: 6933 322e 6164 64                        i32.add  ; export name
-00004c5: 00                                        ; export kind
-00004c6: 51                                        ; export func index
-00004c7: 07                                        ; string length
-00004c8: 6933 322e 7375 62                        i32.sub  ; export name
-00004cf: 00                                        ; export kind
-00004d0: 52                                        ; export func index
-00004d1: 07                                        ; string length
-00004d2: 6933 322e 6d75 6c                        i32.mul  ; export name
-00004d9: 00                                        ; export kind
-00004da: 53                                        ; export func index
-00004db: 09                                        ; string length
-00004dc: 6933 322e 6469 765f 73                   i32.div_s  ; export name
-00004e5: 00                                        ; export kind
-00004e6: 54                                        ; export func index
-00004e7: 09                                        ; string length
-00004e8: 6933 322e 6469 765f 75                   i32.div_u  ; export name
-00004f1: 00                                        ; export kind
-00004f2: 55                                        ; export func index
-00004f3: 09                                        ; string length
-00004f4: 6933 322e 7265 6d5f 73                   i32.rem_s  ; export name
-00004fd: 00                                        ; export kind
-00004fe: 56                                        ; export func index
-00004ff: 09                                        ; string length
-0000500: 6933 322e 7265 6d5f 75                   i32.rem_u  ; export name
-0000509: 00                                        ; export kind
-000050a: 57                                        ; export func index
-000050b: 07                                        ; string length
-000050c: 6933 322e 616e 64                        i32.and  ; export name
-0000513: 00                                        ; export kind
-0000514: 58                                        ; export func index
-0000515: 06                                        ; string length
-0000516: 6933 322e 6f72                           i32.or  ; export name
-000051c: 00                                        ; export kind
-000051d: 59                                        ; export func index
-000051e: 07                                        ; string length
-000051f: 6933 322e 786f 72                        i32.xor  ; export name
-0000526: 00                                        ; export kind
-0000527: 5a                                        ; export func index
-0000528: 07                                        ; string length
-0000529: 6933 322e 7368 6c                        i32.shl  ; export name
-0000530: 00                                        ; export kind
-0000531: 5b                                        ; export func index
-0000532: 09                                        ; string length
-0000533: 6933 322e 7368 725f 73                   i32.shr_s  ; export name
-000053c: 00                                        ; export kind
-000053d: 5c                                        ; export func index
-000053e: 09                                        ; string length
-000053f: 6933 322e 7368 725f 75                   i32.shr_u  ; export name
-0000548: 00                                        ; export kind
-0000549: 5d                                        ; export func index
-000054a: 08                                        ; string length
-000054b: 6933 322e 726f 746c                      i32.rotl  ; export name
-0000553: 00                                        ; export kind
-0000554: 5e                                        ; export func index
-0000555: 08                                        ; string length
-0000556: 6933 322e 726f 7472                      i32.rotr  ; export name
-000055e: 00                                        ; export kind
-000055f: 5f                                        ; export func index
-0000560: 07                                        ; string length
-0000561: 6936 342e 636c 7a                        i64.clz  ; export name
-0000568: 00                                        ; export kind
-0000569: 60                                        ; export func index
-000056a: 07                                        ; string length
-000056b: 6936 342e 6374 7a                        i64.ctz  ; export name
-0000572: 00                                        ; export kind
-0000573: 61                                        ; export func index
-0000574: 0a                                        ; string length
-0000575: 6936 342e 706f 7063 6e74                 i64.popcnt  ; export name
-000057f: 00                                        ; export kind
-0000580: 62                                        ; export func index
-0000581: 07                                        ; string length
-0000582: 6936 342e 6164 64                        i64.add  ; export name
-0000589: 00                                        ; export kind
-000058a: 63                                        ; export func index
-000058b: 07                                        ; string length
-000058c: 6936 342e 7375 62                        i64.sub  ; export name
-0000593: 00                                        ; export kind
-0000594: 64                                        ; export func index
-0000595: 07                                        ; string length
-0000596: 6936 342e 6d75 6c                        i64.mul  ; export name
-000059d: 00                                        ; export kind
-000059e: 65                                        ; export func index
-000059f: 09                                        ; string length
-00005a0: 6936 342e 6469 765f 73                   i64.div_s  ; export name
-00005a9: 00                                        ; export kind
-00005aa: 66                                        ; export func index
-00005ab: 09                                        ; string length
-00005ac: 6936 342e 6469 765f 75                   i64.div_u  ; export name
-00005b5: 00                                        ; export kind
-00005b6: 67                                        ; export func index
-00005b7: 09                                        ; string length
-00005b8: 6936 342e 7265 6d5f 73                   i64.rem_s  ; export name
-00005c1: 00                                        ; export kind
-00005c2: 68                                        ; export func index
-00005c3: 09                                        ; string length
-00005c4: 6936 342e 7265 6d5f 75                   i64.rem_u  ; export name
-00005cd: 00                                        ; export kind
-00005ce: 69                                        ; export func index
-00005cf: 07                                        ; string length
-00005d0: 6936 342e 616e 64                        i64.and  ; export name
-00005d7: 00                                        ; export kind
-00005d8: 6a                                        ; export func index
-00005d9: 06                                        ; string length
-00005da: 6936 342e 6f72                           i64.or  ; export name
-00005e0: 00                                        ; export kind
-00005e1: 6b                                        ; export func index
-00005e2: 07                                        ; string length
-00005e3: 6936 342e 786f 72                        i64.xor  ; export name
-00005ea: 00                                        ; export kind
-00005eb: 6c                                        ; export func index
-00005ec: 07                                        ; string length
-00005ed: 6936 342e 7368 6c                        i64.shl  ; export name
-00005f4: 00                                        ; export kind
-00005f5: 6d                                        ; export func index
-00005f6: 09                                        ; string length
-00005f7: 6936 342e 7368 725f 73                   i64.shr_s  ; export name
-0000600: 00                                        ; export kind
-0000601: 6e                                        ; export func index
-0000602: 09                                        ; string length
-0000603: 6936 342e 7368 725f 75                   i64.shr_u  ; export name
-000060c: 00                                        ; export kind
-000060d: 6f                                        ; export func index
-000060e: 08                                        ; string length
-000060f: 6936 342e 726f 746c                      i64.rotl  ; export name
-0000617: 00                                        ; export kind
-0000618: 70                                        ; export func index
-0000619: 08                                        ; string length
-000061a: 6936 342e 726f 7472                      i64.rotr  ; export name
-0000622: 00                                        ; export kind
-0000623: 71                                        ; export func index
-0000624: 07                                        ; string length
-0000625: 6633 322e 6162 73                        f32.abs  ; export name
-000062c: 00                                        ; export kind
-000062d: 72                                        ; export func index
-000062e: 07                                        ; string length
-000062f: 6633 322e 6e65 67                        f32.neg  ; export name
-0000636: 00                                        ; export kind
-0000637: 73                                        ; export func index
-0000638: 08                                        ; string length
-0000639: 6633 322e 6365 696c                      f32.ceil  ; export name
-0000641: 00                                        ; export kind
-0000642: 74                                        ; export func index
-0000643: 09                                        ; string length
-0000644: 6633 322e 666c 6f6f 72                   f32.floor  ; export name
-000064d: 00                                        ; export kind
-000064e: 75                                        ; export func index
-000064f: 09                                        ; string length
-0000650: 6633 322e 7472 756e 63                   f32.trunc  ; export name
-0000659: 00                                        ; export kind
-000065a: 76                                        ; export func index
-000065b: 0b                                        ; string length
-000065c: 6633 322e 6e65 6172 6573 74              f32.nearest  ; export name
-0000667: 00                                        ; export kind
-0000668: 77                                        ; export func index
-0000669: 08                                        ; string length
-000066a: 6633 322e 7371 7274                      f32.sqrt  ; export name
-0000672: 00                                        ; export kind
-0000673: 78                                        ; export func index
-0000674: 07                                        ; string length
-0000675: 6633 322e 6164 64                        f32.add  ; export name
-000067c: 00                                        ; export kind
-000067d: 79                                        ; export func index
-000067e: 07                                        ; string length
-000067f: 6633 322e 7375 62                        f32.sub  ; export name
-0000686: 00                                        ; export kind
-0000687: 7a                                        ; export func index
-0000688: 07                                        ; string length
-0000689: 6633 322e 6d75 6c                        f32.mul  ; export name
-0000690: 00                                        ; export kind
-0000691: 7b                                        ; export func index
-0000692: 07                                        ; string length
-0000693: 6633 322e 6469 76                        f32.div  ; export name
-000069a: 00                                        ; export kind
-000069b: 7c                                        ; export func index
-000069c: 07                                        ; string length
-000069d: 6633 322e 6d69 6e                        f32.min  ; export name
-00006a4: 00                                        ; export kind
-00006a5: 7d                                        ; export func index
-00006a6: 07                                        ; string length
-00006a7: 6633 322e 6d61 78                        f32.max  ; export name
-00006ae: 00                                        ; export kind
-00006af: 7e                                        ; export func index
-00006b0: 0c                                        ; string length
-00006b1: 6633 322e 636f 7079 7369 676e            f32.copysign  ; export name
-00006bd: 00                                        ; export kind
-00006be: 7f                                        ; export func index
-00006bf: 07                                        ; string length
-00006c0: 6636 342e 6162 73                        f64.abs  ; export name
-00006c7: 00                                        ; export kind
-00006c8: 8001                                      ; export func index
-00006ca: 07                                        ; string length
-00006cb: 6636 342e 6e65 67                        f64.neg  ; export name
-00006d2: 00                                        ; export kind
-00006d3: 8101                                      ; export func index
-00006d5: 08                                        ; string length
-00006d6: 6636 342e 6365 696c                      f64.ceil  ; export name
-00006de: 00                                        ; export kind
-00006df: 8201                                      ; export func index
-00006e1: 09                                        ; string length
-00006e2: 6636 342e 666c 6f6f 72                   f64.floor  ; export name
-00006eb: 00                                        ; export kind
-00006ec: 8301                                      ; export func index
-00006ee: 09                                        ; string length
-00006ef: 6636 342e 7472 756e 63                   f64.trunc  ; export name
-00006f8: 00                                        ; export kind
-00006f9: 8401                                      ; export func index
-00006fb: 0b                                        ; string length
-00006fc: 6636 342e 6e65 6172 6573 74              f64.nearest  ; export name
-0000707: 00                                        ; export kind
-0000708: 8501                                      ; export func index
-000070a: 08                                        ; string length
-000070b: 6636 342e 7371 7274                      f64.sqrt  ; export name
-0000713: 00                                        ; export kind
-0000714: 8601                                      ; export func index
-0000716: 07                                        ; string length
-0000717: 6636 342e 6164 64                        f64.add  ; export name
-000071e: 00                                        ; export kind
-000071f: 8701                                      ; export func index
-0000721: 07                                        ; string length
-0000722: 6636 342e 7375 62                        f64.sub  ; export name
-0000729: 00                                        ; export kind
-000072a: 8801                                      ; export func index
-000072c: 07                                        ; string length
-000072d: 6636 342e 6d75 6c                        f64.mul  ; export name
-0000734: 00                                        ; export kind
-0000735: 8901                                      ; export func index
-0000737: 07                                        ; string length
-0000738: 6636 342e 6469 76                        f64.div  ; export name
-000073f: 00                                        ; export kind
-0000740: 8a01                                      ; export func index
-0000742: 07                                        ; string length
-0000743: 6636 342e 6d69 6e                        f64.min  ; export name
-000074a: 00                                        ; export kind
-000074b: 8b01                                      ; export func index
-000074d: 07                                        ; string length
-000074e: 6636 342e 6d61 78                        f64.max  ; export name
-0000755: 00                                        ; export kind
-0000756: 8c01                                      ; export func index
-0000758: 0c                                        ; string length
-0000759: 6636 342e 636f 7079 7369 676e            f64.copysign  ; export name
-0000765: 00                                        ; export kind
-0000766: 8d01                                      ; export func index
-0000768: 0c                                        ; string length
-0000769: 6933 322e 7772 6170 2f69 3634            i32.wrap/i64  ; export name
-0000775: 00                                        ; export kind
-0000776: 8e01                                      ; export func index
-0000778: 0f                                        ; string length
-0000779: 6933 322e 7472 756e 635f 732f 6633 32    i32.trunc_s/f32  ; export name
-0000788: 00                                        ; export kind
-0000789: 8f01                                      ; export func index
-000078b: 0f                                        ; string length
-000078c: 6933 322e 7472 756e 635f 752f 6633 32    i32.trunc_u/f32  ; export name
-000079b: 00                                        ; export kind
-000079c: 9001                                      ; export func index
-000079e: 0f                                        ; string length
-000079f: 6933 322e 7472 756e 635f 732f 6636 34    i32.trunc_s/f64  ; export name
-00007ae: 00                                        ; export kind
-00007af: 9101                                      ; export func index
-00007b1: 0f                                        ; string length
-00007b2: 6933 322e 7472 756e 635f 752f 6636 34    i32.trunc_u/f64  ; export name
-00007c1: 00                                        ; export kind
-00007c2: 9201                                      ; export func index
-00007c4: 10                                        ; string length
-00007c5: 6936 342e 6578 7465 6e64 5f73 2f69 3332  i64.extend_s/i32  ; export name
-00007d5: 00                                        ; export kind
-00007d6: 9301                                      ; export func index
-00007d8: 10                                        ; string length
-00007d9: 6936 342e 6578 7465 6e64 5f75 2f69 3332  i64.extend_u/i32  ; export name
-00007e9: 00                                        ; export kind
-00007ea: 9401                                      ; export func index
-00007ec: 0f                                        ; string length
-00007ed: 6936 342e 7472 756e 635f 732f 6633 32    i64.trunc_s/f32  ; export name
-00007fc: 00                                        ; export kind
-00007fd: 9501                                      ; export func index
-00007ff: 0f                                        ; string length
-0000800: 6936 342e 7472 756e 635f 752f 6633 32    i64.trunc_u/f32  ; export name
-000080f: 00                                        ; export kind
-0000810: 9601                                      ; export func index
-0000812: 0f                                        ; string length
-0000813: 6936 342e 7472 756e 635f 732f 6636 34    i64.trunc_s/f64  ; export name
-0000822: 00                                        ; export kind
-0000823: 9701                                      ; export func index
-0000825: 0f                                        ; string length
-0000826: 6936 342e 7472 756e 635f 752f 6636 34    i64.trunc_u/f64  ; export name
-0000835: 00                                        ; export kind
-0000836: 9801                                      ; export func index
-0000838: 11                                        ; string length
-0000839: 6633 322e 636f 6e76 6572 745f 732f 6933  f32.convert_s/i3
-0000849: 32                                       2  ; export name
-000084a: 00                                        ; export kind
-000084b: 9901                                      ; export func index
-000084d: 11                                        ; string length
-000084e: 6633 322e 636f 6e76 6572 745f 752f 6933  f32.convert_u/i3
-000085e: 32                                       2  ; export name
-000085f: 00                                        ; export kind
-0000860: 9a01                                      ; export func index
-0000862: 11                                        ; string length
-0000863: 6633 322e 636f 6e76 6572 745f 732f 6936  f32.convert_s/i6
-0000873: 34                                       4  ; export name
-0000874: 00                                        ; export kind
-0000875: 9b01                                      ; export func index
-0000877: 11                                        ; string length
-0000878: 6633 322e 636f 6e76 6572 745f 752f 6936  f32.convert_u/i6
-0000888: 34                                       4  ; export name
-0000889: 00                                        ; export kind
-000088a: 9c01                                      ; export func index
-000088c: 0e                                        ; string length
-000088d: 6633 322e 6465 6d6f 7465 2f66 3634       f32.demote/f64  ; export name
-000089b: 00                                        ; export kind
-000089c: 9d01                                      ; export func index
-000089e: 11                                        ; string length
-000089f: 6636 342e 636f 6e76 6572 745f 732f 6933  f64.convert_s/i3
-00008af: 32                                       2  ; export name
-00008b0: 00                                        ; export kind
-00008b1: 9e01                                      ; export func index
-00008b3: 11                                        ; string length
-00008b4: 6636 342e 636f 6e76 6572 745f 752f 6933  f64.convert_u/i3
-00008c4: 32                                       2  ; export name
-00008c5: 00                                        ; export kind
-00008c6: 9f01                                      ; export func index
-00008c8: 11                                        ; string length
-00008c9: 6636 342e 636f 6e76 6572 745f 732f 6936  f64.convert_s/i6
-00008d9: 34                                       4  ; export name
-00008da: 00                                        ; export kind
-00008db: a001                                      ; export func index
-00008dd: 11                                        ; string length
-00008de: 6636 342e 636f 6e76 6572 745f 752f 6936  f64.convert_u/i6
-00008ee: 34                                       4  ; export name
-00008ef: 00                                        ; export kind
-00008f0: a101                                      ; export func index
-00008f2: 0f                                        ; string length
-00008f3: 6636 342e 7072 6f6d 6f74 652f 6633 32    f64.promote/f32  ; export name
-0000902: 00                                        ; export kind
-0000903: a201                                      ; export func index
-0000905: 13                                        ; string length
-0000906: 6933 322e 7265 696e 7465 7270 7265 742f  i32.reinterpret/
-0000916: 6633 32                                  f32  ; export name
-0000919: 00                                        ; export kind
-000091a: a301                                      ; export func index
-000091c: 13                                        ; string length
-000091d: 6633 322e 7265 696e 7465 7270 7265 742f  f32.reinterpret/
-000092d: 6933 32                                  i32  ; export name
-0000930: 00                                        ; export kind
-0000931: a401                                      ; export func index
-0000933: 13                                        ; string length
-0000934: 6936 342e 7265 696e 7465 7270 7265 742f  i64.reinterpret/
-0000944: 6636 34                                  f64  ; export name
-0000947: 00                                        ; export kind
-0000948: a501                                      ; export func index
-000094a: 13                                        ; string length
-000094b: 6636 342e 7265 696e 7465 7270 7265 742f  f64.reinterpret/
-000095b: 6936 34                                  i64  ; export name
-000095e: 00                                        ; export kind
-000095f: a601                                      ; export func index
-0000961: 0d                                        ; string length
-0000962: 6933 322e 6578 7465 6e64 385f 73         i32.extend8_s  ; export name
-000096f: 00                                        ; export kind
-0000970: a701                                      ; export func index
-0000972: 0e                                        ; string length
-0000973: 6933 322e 6578 7465 6e64 3136 5f73       i32.extend16_s  ; export name
-0000981: 00                                        ; export kind
-0000982: a801                                      ; export func index
-0000984: 0d                                        ; string length
-0000985: 6936 342e 6578 7465 6e64 385f 73         i64.extend8_s  ; export name
-0000992: 00                                        ; export kind
-0000993: a901                                      ; export func index
-0000995: 0e                                        ; string length
-0000996: 6936 342e 6578 7465 6e64 3136 5f73       i64.extend16_s  ; export name
-00009a4: 00                                        ; export kind
-00009a5: aa01                                      ; export func index
-00009a7: 0e                                        ; string length
-00009a8: 6936 342e 6578 7465 6e64 3332 5f73       i64.extend32_s  ; export name
-00009b6: 00                                        ; export kind
-00009b7: ab01                                      ; export func index
-00009b9: 06                                        ; string length
-00009ba: 616c 6c6f 6361                           alloca  ; export name
-00009c0: 00                                        ; export kind
-00009c1: ac01                                      ; export func index
-00009c3: 09                                        ; string length
-00009c4: 6272 5f75 6e6c 6573 73                   br_unless  ; export name
-00009cd: 00                                        ; export kind
-00009ce: ad01                                      ; export func index
-00009d0: 09                                        ; string length
-00009d1: 6361 6c6c 5f68 6f73 74                   call_host  ; export name
-00009da: 00                                        ; export kind
-00009db: ae01                                      ; export func index
-00009dd: 04                                        ; string length
-00009de: 6461 7461                                data  ; export name
-00009e2: 00                                        ; export kind
-00009e3: af01                                      ; export func index
-00009e5: 09                                        ; string length
-00009e6: 6472 6f70 5f6b 6565 70                   drop_keep  ; export name
-00009ef: 00                                        ; export kind
-00009f0: b001                                      ; export func index
-00009f2: 13                                        ; string length
-00009f3: 6933 322e 7472 756e 635f 733a 7361 742f  i32.trunc_s:sat/
-0000a03: 6633 32                                  f32  ; export name
-0000a06: 00                                        ; export kind
-0000a07: b101                                      ; export func index
-0000a09: 13                                        ; string length
-0000a0a: 6933 322e 7472 756e 635f 753a 7361 742f  i32.trunc_u:sat/
-0000a1a: 6633 32                                  f32  ; export name
-0000a1d: 00                                        ; export kind
-0000a1e: b201                                      ; export func index
-0000a20: 13                                        ; string length
-0000a21: 6933 322e 7472 756e 635f 733a 7361 742f  i32.trunc_s:sat/
-0000a31: 6636 34                                  f64  ; export name
-0000a34: 00                                        ; export kind
-0000a35: b301                                      ; export func index
-0000a37: 13                                        ; string length
-0000a38: 6933 322e 7472 756e 635f 753a 7361 742f  i32.trunc_u:sat/
-0000a48: 6636 34                                  f64  ; export name
-0000a4b: 00                                        ; export kind
-0000a4c: b401                                      ; export func index
-0000a4e: 13                                        ; string length
-0000a4f: 6936 342e 7472 756e 635f 733a 7361 742f  i64.trunc_s:sat/
-0000a5f: 6633 32                                  f32  ; export name
-0000a62: 00                                        ; export kind
-0000a63: b501                                      ; export func index
-0000a65: 13                                        ; string length
-0000a66: 6936 342e 7472 756e 635f 753a 7361 742f  i64.trunc_u:sat/
-0000a76: 6633 32                                  f32  ; export name
-0000a79: 00                                        ; export kind
-0000a7a: b601                                      ; export func index
-0000a7c: 13                                        ; string length
-0000a7d: 6936 342e 7472 756e 635f 733a 7361 742f  i64.trunc_s:sat/
-0000a8d: 6636 34                                  f64  ; export name
-0000a90: 00                                        ; export kind
-0000a91: b701                                      ; export func index
-0000a93: 13                                        ; string length
-0000a94: 6936 342e 7472 756e 635f 753a 7361 742f  i64.trunc_u:sat/
-0000aa4: 6636 34                                  f64  ; export name
-0000aa7: 00                                        ; export kind
-0000aa8: b801                                      ; export func index
-0000aaa: 0f                                        ; string length
-0000aab: 6933 322e 6174 6f6d 6963 2e6c 6f61 64    i32.atomic.load  ; export name
-0000aba: 00                                        ; export kind
-0000abb: b901                                      ; export func index
-0000abd: 0f                                        ; string length
-0000abe: 6936 342e 6174 6f6d 6963 2e6c 6f61 64    i64.atomic.load  ; export name
-0000acd: 00                                        ; export kind
-0000ace: ba01                                      ; export func index
-0000ad0: 12                                        ; string length
-0000ad1: 6933 322e 6174 6f6d 6963 2e6c 6f61 6438  i32.atomic.load8
-0000ae1: 5f75                                     _u  ; export name
-0000ae3: 00                                        ; export kind
-0000ae4: bb01                                      ; export func index
-0000ae6: 13                                        ; string length
-0000ae7: 6933 322e 6174 6f6d 6963 2e6c 6f61 6431  i32.atomic.load1
-0000af7: 365f 75                                  6_u  ; export name
-0000afa: 00                                        ; export kind
-0000afb: bc01                                      ; export func index
-0000afd: 12                                        ; string length
-0000afe: 6936 342e 6174 6f6d 6963 2e6c 6f61 6438  i64.atomic.load8
-0000b0e: 5f75                                     _u  ; export name
-0000b10: 00                                        ; export kind
-0000b11: bd01                                      ; export func index
-0000b13: 13                                        ; string length
-0000b14: 6936 342e 6174 6f6d 6963 2e6c 6f61 6431  i64.atomic.load1
-0000b24: 365f 75                                  6_u  ; export name
-0000b27: 00                                        ; export kind
-0000b28: be01                                      ; export func index
-0000b2a: 13                                        ; string length
-0000b2b: 6936 342e 6174 6f6d 6963 2e6c 6f61 6433  i64.atomic.load3
-0000b3b: 325f 75                                  2_u  ; export name
-0000b3e: 00                                        ; export kind
-0000b3f: bf01                                      ; export func index
-0000b41: 10                                        ; string length
-0000b42: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store  ; export name
-0000b52: 00                                        ; export kind
-0000b53: c001                                      ; export func index
-0000b55: 10                                        ; string length
-0000b56: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store  ; export name
-0000b66: 00                                        ; export kind
-0000b67: c101                                      ; export func index
-0000b69: 11                                        ; string length
-0000b6a: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
-0000b7a: 38                                       8  ; export name
-0000b7b: 00                                        ; export kind
-0000b7c: c201                                      ; export func index
-0000b7e: 12                                        ; string length
-0000b7f: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
-0000b8f: 3136                                     16  ; export name
-0000b91: 00                                        ; export kind
-0000b92: c301                                      ; export func index
-0000b94: 11                                        ; string length
-0000b95: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
-0000ba5: 38                                       8  ; export name
-0000ba6: 00                                        ; export kind
-0000ba7: c401                                      ; export func index
-0000ba9: 12                                        ; string length
-0000baa: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
-0000bba: 3136                                     16  ; export name
-0000bbc: 00                                        ; export kind
-0000bbd: c501                                      ; export func index
-0000bbf: 12                                        ; string length
-0000bc0: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
-0000bd0: 3332                                     32  ; export name
-0000bd2: 00                                        ; export kind
-0000bd3: c601                                      ; export func index
-0000bd5: 12                                        ; string length
-0000bd6: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
-0000be6: 6464                                     dd  ; export name
-0000be8: 00                                        ; export kind
-0000be9: c701                                      ; export func index
-0000beb: 12                                        ; string length
-0000bec: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
-0000bfc: 6464                                     dd  ; export name
-0000bfe: 00                                        ; export kind
-0000bff: c801                                      ; export func index
-0000c01: 15                                        ; string length
-0000c02: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000c12: 752e 6164 64                             u.add  ; export name
-0000c17: 00                                        ; export kind
-0000c18: c901                                      ; export func index
-0000c1a: 16                                        ; string length
-0000c1b: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000c2b: 5f75 2e61 6464                           _u.add  ; export name
-0000c31: 00                                        ; export kind
-0000c32: ca01                                      ; export func index
-0000c34: 15                                        ; string length
-0000c35: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000c45: 752e 6164 64                             u.add  ; export name
-0000c4a: 00                                        ; export kind
-0000c4b: cb01                                      ; export func index
-0000c4d: 16                                        ; string length
-0000c4e: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000c5e: 5f75 2e61 6464                           _u.add  ; export name
-0000c64: 00                                        ; export kind
-0000c65: cc01                                      ; export func index
-0000c67: 16                                        ; string length
-0000c68: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000c78: 5f75 2e61 6464                           _u.add  ; export name
-0000c7e: 00                                        ; export kind
-0000c7f: cd01                                      ; export func index
-0000c81: 12                                        ; string length
-0000c82: 6933 322e 6174 6f6d 6963 2e72 6d77 2e73  i32.atomic.rmw.s
-0000c92: 7562                                     ub  ; export name
-0000c94: 00                                        ; export kind
-0000c95: ce01                                      ; export func index
-0000c97: 12                                        ; string length
-0000c98: 6936 342e 6174 6f6d 6963 2e72 6d77 2e73  i64.atomic.rmw.s
-0000ca8: 7562                                     ub  ; export name
-0000caa: 00                                        ; export kind
-0000cab: cf01                                      ; export func index
-0000cad: 15                                        ; string length
-0000cae: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000cbe: 752e 7375 62                             u.sub  ; export name
-0000cc3: 00                                        ; export kind
-0000cc4: d001                                      ; export func index
-0000cc6: 16                                        ; string length
-0000cc7: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000cd7: 5f75 2e73 7562                           _u.sub  ; export name
-0000cdd: 00                                        ; export kind
-0000cde: d101                                      ; export func index
-0000ce0: 15                                        ; string length
-0000ce1: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000cf1: 752e 7375 62                             u.sub  ; export name
-0000cf6: 00                                        ; export kind
-0000cf7: d201                                      ; export func index
-0000cf9: 16                                        ; string length
-0000cfa: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000d0a: 5f75 2e73 7562                           _u.sub  ; export name
-0000d10: 00                                        ; export kind
-0000d11: d301                                      ; export func index
-0000d13: 16                                        ; string length
-0000d14: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000d24: 5f75 2e73 7562                           _u.sub  ; export name
-0000d2a: 00                                        ; export kind
-0000d2b: d401                                      ; export func index
-0000d2d: 12                                        ; string length
-0000d2e: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
-0000d3e: 6e64                                     nd  ; export name
-0000d40: 00                                        ; export kind
-0000d41: d501                                      ; export func index
-0000d43: 12                                        ; string length
-0000d44: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
-0000d54: 6e64                                     nd  ; export name
-0000d56: 00                                        ; export kind
-0000d57: d601                                      ; export func index
-0000d59: 15                                        ; string length
-0000d5a: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000d6a: 752e 616e 64                             u.and  ; export name
-0000d6f: 00                                        ; export kind
-0000d70: d701                                      ; export func index
-0000d72: 16                                        ; string length
-0000d73: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000d83: 5f75 2e61 6e64                           _u.and  ; export name
-0000d89: 00                                        ; export kind
-0000d8a: d801                                      ; export func index
-0000d8c: 15                                        ; string length
-0000d8d: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000d9d: 752e 616e 64                             u.and  ; export name
-0000da2: 00                                        ; export kind
-0000da3: d901                                      ; export func index
-0000da5: 16                                        ; string length
-0000da6: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000db6: 5f75 2e61 6e64                           _u.and  ; export name
-0000dbc: 00                                        ; export kind
-0000dbd: da01                                      ; export func index
-0000dbf: 16                                        ; string length
-0000dc0: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000dd0: 5f75 2e61 6e64                           _u.and  ; export name
-0000dd6: 00                                        ; export kind
-0000dd7: db01                                      ; export func index
-0000dd9: 11                                        ; string length
-0000dda: 6933 322e 6174 6f6d 6963 2e72 6d77 2e6f  i32.atomic.rmw.o
-0000dea: 72                                       r  ; export name
-0000deb: 00                                        ; export kind
-0000dec: dc01                                      ; export func index
-0000dee: 11                                        ; string length
-0000def: 6936 342e 6174 6f6d 6963 2e72 6d77 2e6f  i64.atomic.rmw.o
-0000dff: 72                                       r  ; export name
-0000e00: 00                                        ; export kind
-0000e01: dd01                                      ; export func index
-0000e03: 14                                        ; string length
-0000e04: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000e14: 752e 6f72                                u.or  ; export name
-0000e18: 00                                        ; export kind
-0000e19: de01                                      ; export func index
-0000e1b: 15                                        ; string length
-0000e1c: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000e2c: 5f75 2e6f 72                             _u.or  ; export name
-0000e31: 00                                        ; export kind
-0000e32: df01                                      ; export func index
-0000e34: 14                                        ; string length
-0000e35: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000e45: 752e 6f72                                u.or  ; export name
-0000e49: 00                                        ; export kind
-0000e4a: e001                                      ; export func index
-0000e4c: 15                                        ; string length
-0000e4d: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000e5d: 5f75 2e6f 72                             _u.or  ; export name
-0000e62: 00                                        ; export kind
-0000e63: e101                                      ; export func index
-0000e65: 15                                        ; string length
-0000e66: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000e76: 5f75 2e6f 72                             _u.or  ; export name
-0000e7b: 00                                        ; export kind
-0000e7c: e201                                      ; export func index
-0000e7e: 12                                        ; string length
-0000e7f: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
-0000e8f: 6f72                                     or  ; export name
-0000e91: 00                                        ; export kind
-0000e92: e301                                      ; export func index
-0000e94: 12                                        ; string length
-0000e95: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
-0000ea5: 6f72                                     or  ; export name
-0000ea7: 00                                        ; export kind
-0000ea8: e401                                      ; export func index
-0000eaa: 15                                        ; string length
-0000eab: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000ebb: 752e 786f 72                             u.xor  ; export name
-0000ec0: 00                                        ; export kind
-0000ec1: e501                                      ; export func index
-0000ec3: 16                                        ; string length
-0000ec4: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000ed4: 5f75 2e78 6f72                           _u.xor  ; export name
-0000eda: 00                                        ; export kind
-0000edb: e601                                      ; export func index
-0000edd: 15                                        ; string length
-0000ede: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000eee: 752e 786f 72                             u.xor  ; export name
-0000ef3: 00                                        ; export kind
-0000ef4: e701                                      ; export func index
-0000ef6: 16                                        ; string length
-0000ef7: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000f07: 5f75 2e78 6f72                           _u.xor  ; export name
-0000f0d: 00                                        ; export kind
-0000f0e: e801                                      ; export func index
-0000f10: 16                                        ; string length
-0000f11: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000f21: 5f75 2e78 6f72                           _u.xor  ; export name
-0000f27: 00                                        ; export kind
-0000f28: e901                                      ; export func index
-0000f2a: 13                                        ; string length
-0000f2b: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
-0000f3b: 6368 67                                  chg  ; export name
-0000f3e: 00                                        ; export kind
-0000f3f: ea01                                      ; export func index
-0000f41: 13                                        ; string length
-0000f42: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
-0000f52: 6368 67                                  chg  ; export name
-0000f55: 00                                        ; export kind
-0000f56: eb01                                      ; export func index
-0000f58: 16                                        ; string length
-0000f59: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000f69: 752e 7863 6867                           u.xchg  ; export name
-0000f6f: 00                                        ; export kind
-0000f70: ec01                                      ; export func index
-0000f72: 17                                        ; string length
-0000f73: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000f83: 5f75 2e78 6368 67                        _u.xchg  ; export name
-0000f8a: 00                                        ; export kind
-0000f8b: ed01                                      ; export func index
-0000f8d: 16                                        ; string length
-0000f8e: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000f9e: 752e 7863 6867                           u.xchg  ; export name
-0000fa4: 00                                        ; export kind
-0000fa5: ee01                                      ; export func index
-0000fa7: 17                                        ; string length
-0000fa8: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000fb8: 5f75 2e78 6368 67                        _u.xchg  ; export name
-0000fbf: 00                                        ; export kind
-0000fc0: ef01                                      ; export func index
-0000fc2: 17                                        ; string length
-0000fc3: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000fd3: 5f75 2e78 6368 67                        _u.xchg  ; export name
-0000fda: 00                                        ; export kind
-0000fdb: f001                                      ; export func index
-0000fdd: 16                                        ; string length
-0000fde: 6933 322e 6174 6f6d 6963 2e72 6d77 2e63  i32.atomic.rmw.c
-0000fee: 6d70 7863 6867                           mpxchg  ; export name
-0000ff4: 00                                        ; export kind
-0000ff5: f101                                      ; export func index
-0000ff7: 16                                        ; string length
-0000ff8: 6936 342e 6174 6f6d 6963 2e72 6d77 2e63  i64.atomic.rmw.c
-0001008: 6d70 7863 6867                           mpxchg  ; export name
-000100e: 00                                        ; export kind
-000100f: f201                                      ; export func index
-0001011: 19                                        ; string length
-0001012: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0001022: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
-000102b: 00                                        ; export kind
-000102c: f301                                      ; export func index
-000102e: 1a                                        ; string length
-000102f: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-000103f: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
-0001049: 00                                        ; export kind
-000104a: f401                                      ; export func index
-000104c: 19                                        ; string length
-000104d: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-000105d: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
-0001066: 00                                        ; export kind
-0001067: f501                                      ; export func index
-0001069: 1a                                        ; string length
-000106a: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-000107a: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
-0001084: 00                                        ; export kind
-0001085: f601                                      ; export func index
-0001087: 1a                                        ; string length
-0001088: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0001098: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
-00010a2: 00                                        ; export kind
-00010a3: f701                                      ; export func index
-; move data: [139, 10a5) -> [13a, 10a6)
-0000138: ec1e                                      ; FIXUP section size
+0000133: 07                                        ; section code
+0000134: 00                                        ; section size (guess)
+0000135: f601                                      ; num exports
+0000137: 0b                                        ; string length
+0000138: 756e 7265 6163 6861 626c 65              unreachable  ; export name
+0000143: 00                                        ; export kind
+0000144: 02                                        ; export func index
+0000145: 02                                        ; string length
+0000146: 6272                                     br  ; export name
+0000148: 00                                        ; export kind
+0000149: 03                                        ; export func index
+000014a: 08                                        ; string length
+000014b: 6272 5f74 6162 6c65                      br_table  ; export name
+0000153: 00                                        ; export kind
+0000154: 04                                        ; export func index
+0000155: 06                                        ; string length
+0000156: 7265 7475 726e                           return  ; export name
+000015c: 00                                        ; export kind
+000015d: 05                                        ; export func index
+000015e: 04                                        ; string length
+000015f: 6361 6c6c                                call  ; export name
+0000163: 00                                        ; export kind
+0000164: 06                                        ; export func index
+0000165: 0d                                        ; string length
+0000166: 6361 6c6c 5f69 6e64 6972 6563 74         call_indirect  ; export name
+0000173: 00                                        ; export kind
+0000174: 07                                        ; export func index
+0000175: 04                                        ; string length
+0000176: 6472 6f70                                drop  ; export name
+000017a: 00                                        ; export kind
+000017b: 08                                        ; export func index
+000017c: 06                                        ; string length
+000017d: 7365 6c65 6374                           select  ; export name
+0000183: 00                                        ; export kind
+0000184: 09                                        ; export func index
+0000185: 09                                        ; string length
+0000186: 6765 745f 6c6f 6361 6c                   get_local  ; export name
+000018f: 00                                        ; export kind
+0000190: 0a                                        ; export func index
+0000191: 09                                        ; string length
+0000192: 7365 745f 6c6f 6361 6c                   set_local  ; export name
+000019b: 00                                        ; export kind
+000019c: 0b                                        ; export func index
+000019d: 09                                        ; string length
+000019e: 7465 655f 6c6f 6361 6c                   tee_local  ; export name
+00001a7: 00                                        ; export kind
+00001a8: 0c                                        ; export func index
+00001a9: 0a                                        ; string length
+00001aa: 6765 745f 676c 6f62 616c                 get_global  ; export name
+00001b4: 00                                        ; export kind
+00001b5: 0d                                        ; export func index
+00001b6: 0a                                        ; string length
+00001b7: 7365 745f 676c 6f62 616c                 set_global  ; export name
+00001c1: 00                                        ; export kind
+00001c2: 0e                                        ; export func index
+00001c3: 08                                        ; string length
+00001c4: 6933 322e 6c6f 6164                      i32.load  ; export name
+00001cc: 00                                        ; export kind
+00001cd: 0f                                        ; export func index
+00001ce: 08                                        ; string length
+00001cf: 6936 342e 6c6f 6164                      i64.load  ; export name
+00001d7: 00                                        ; export kind
+00001d8: 10                                        ; export func index
+00001d9: 08                                        ; string length
+00001da: 6633 322e 6c6f 6164                      f32.load  ; export name
+00001e2: 00                                        ; export kind
+00001e3: 11                                        ; export func index
+00001e4: 08                                        ; string length
+00001e5: 6636 342e 6c6f 6164                      f64.load  ; export name
+00001ed: 00                                        ; export kind
+00001ee: 12                                        ; export func index
+00001ef: 0b                                        ; string length
+00001f0: 6933 322e 6c6f 6164 385f 73              i32.load8_s  ; export name
+00001fb: 00                                        ; export kind
+00001fc: 13                                        ; export func index
+00001fd: 0b                                        ; string length
+00001fe: 6933 322e 6c6f 6164 385f 75              i32.load8_u  ; export name
+0000209: 00                                        ; export kind
+000020a: 14                                        ; export func index
+000020b: 0c                                        ; string length
+000020c: 6933 322e 6c6f 6164 3136 5f73            i32.load16_s  ; export name
+0000218: 00                                        ; export kind
+0000219: 15                                        ; export func index
+000021a: 0c                                        ; string length
+000021b: 6933 322e 6c6f 6164 3136 5f75            i32.load16_u  ; export name
+0000227: 00                                        ; export kind
+0000228: 16                                        ; export func index
+0000229: 0b                                        ; string length
+000022a: 6936 342e 6c6f 6164 385f 73              i64.load8_s  ; export name
+0000235: 00                                        ; export kind
+0000236: 17                                        ; export func index
+0000237: 0b                                        ; string length
+0000238: 6936 342e 6c6f 6164 385f 75              i64.load8_u  ; export name
+0000243: 00                                        ; export kind
+0000244: 18                                        ; export func index
+0000245: 0c                                        ; string length
+0000246: 6936 342e 6c6f 6164 3136 5f73            i64.load16_s  ; export name
+0000252: 00                                        ; export kind
+0000253: 19                                        ; export func index
+0000254: 0c                                        ; string length
+0000255: 6936 342e 6c6f 6164 3136 5f75            i64.load16_u  ; export name
+0000261: 00                                        ; export kind
+0000262: 1a                                        ; export func index
+0000263: 0c                                        ; string length
+0000264: 6936 342e 6c6f 6164 3332 5f73            i64.load32_s  ; export name
+0000270: 00                                        ; export kind
+0000271: 1b                                        ; export func index
+0000272: 0c                                        ; string length
+0000273: 6936 342e 6c6f 6164 3332 5f75            i64.load32_u  ; export name
+000027f: 00                                        ; export kind
+0000280: 1c                                        ; export func index
+0000281: 09                                        ; string length
+0000282: 6933 322e 7374 6f72 65                   i32.store  ; export name
+000028b: 00                                        ; export kind
+000028c: 1d                                        ; export func index
+000028d: 09                                        ; string length
+000028e: 6936 342e 7374 6f72 65                   i64.store  ; export name
+0000297: 00                                        ; export kind
+0000298: 1e                                        ; export func index
+0000299: 09                                        ; string length
+000029a: 6633 322e 7374 6f72 65                   f32.store  ; export name
+00002a3: 00                                        ; export kind
+00002a4: 1f                                        ; export func index
+00002a5: 09                                        ; string length
+00002a6: 6636 342e 7374 6f72 65                   f64.store  ; export name
+00002af: 00                                        ; export kind
+00002b0: 20                                        ; export func index
+00002b1: 0a                                        ; string length
+00002b2: 6933 322e 7374 6f72 6538                 i32.store8  ; export name
+00002bc: 00                                        ; export kind
+00002bd: 21                                        ; export func index
+00002be: 0b                                        ; string length
+00002bf: 6933 322e 7374 6f72 6531 36              i32.store16  ; export name
+00002ca: 00                                        ; export kind
+00002cb: 22                                        ; export func index
+00002cc: 0a                                        ; string length
+00002cd: 6936 342e 7374 6f72 6538                 i64.store8  ; export name
+00002d7: 00                                        ; export kind
+00002d8: 23                                        ; export func index
+00002d9: 0b                                        ; string length
+00002da: 6936 342e 7374 6f72 6531 36              i64.store16  ; export name
+00002e5: 00                                        ; export kind
+00002e6: 24                                        ; export func index
+00002e7: 0b                                        ; string length
+00002e8: 6936 342e 7374 6f72 6533 32              i64.store32  ; export name
+00002f3: 00                                        ; export kind
+00002f4: 25                                        ; export func index
+00002f5: 0e                                        ; string length
+00002f6: 6375 7272 656e 745f 6d65 6d6f 7279       current_memory  ; export name
+0000304: 00                                        ; export kind
+0000305: 26                                        ; export func index
+0000306: 0b                                        ; string length
+0000307: 6772 6f77 5f6d 656d 6f72 79              grow_memory  ; export name
+0000312: 00                                        ; export kind
+0000313: 27                                        ; export func index
+0000314: 09                                        ; string length
+0000315: 6933 322e 636f 6e73 74                   i32.const  ; export name
+000031e: 00                                        ; export kind
+000031f: 28                                        ; export func index
+0000320: 09                                        ; string length
+0000321: 6936 342e 636f 6e73 74                   i64.const  ; export name
+000032a: 00                                        ; export kind
+000032b: 29                                        ; export func index
+000032c: 09                                        ; string length
+000032d: 6633 322e 636f 6e73 74                   f32.const  ; export name
+0000336: 00                                        ; export kind
+0000337: 2a                                        ; export func index
+0000338: 09                                        ; string length
+0000339: 6636 342e 636f 6e73 74                   f64.const  ; export name
+0000342: 00                                        ; export kind
+0000343: 2b                                        ; export func index
+0000344: 07                                        ; string length
+0000345: 6933 322e 6571 7a                        i32.eqz  ; export name
+000034c: 00                                        ; export kind
+000034d: 2c                                        ; export func index
+000034e: 06                                        ; string length
+000034f: 6933 322e 6571                           i32.eq  ; export name
+0000355: 00                                        ; export kind
+0000356: 2d                                        ; export func index
+0000357: 06                                        ; string length
+0000358: 6933 322e 6e65                           i32.ne  ; export name
+000035e: 00                                        ; export kind
+000035f: 2e                                        ; export func index
+0000360: 08                                        ; string length
+0000361: 6933 322e 6c74 5f73                      i32.lt_s  ; export name
+0000369: 00                                        ; export kind
+000036a: 2f                                        ; export func index
+000036b: 08                                        ; string length
+000036c: 6933 322e 6c74 5f75                      i32.lt_u  ; export name
+0000374: 00                                        ; export kind
+0000375: 30                                        ; export func index
+0000376: 08                                        ; string length
+0000377: 6933 322e 6774 5f73                      i32.gt_s  ; export name
+000037f: 00                                        ; export kind
+0000380: 31                                        ; export func index
+0000381: 08                                        ; string length
+0000382: 6933 322e 6774 5f75                      i32.gt_u  ; export name
+000038a: 00                                        ; export kind
+000038b: 32                                        ; export func index
+000038c: 08                                        ; string length
+000038d: 6933 322e 6c65 5f73                      i32.le_s  ; export name
+0000395: 00                                        ; export kind
+0000396: 33                                        ; export func index
+0000397: 08                                        ; string length
+0000398: 6933 322e 6c65 5f75                      i32.le_u  ; export name
+00003a0: 00                                        ; export kind
+00003a1: 34                                        ; export func index
+00003a2: 08                                        ; string length
+00003a3: 6933 322e 6765 5f73                      i32.ge_s  ; export name
+00003ab: 00                                        ; export kind
+00003ac: 35                                        ; export func index
+00003ad: 08                                        ; string length
+00003ae: 6933 322e 6765 5f75                      i32.ge_u  ; export name
+00003b6: 00                                        ; export kind
+00003b7: 36                                        ; export func index
+00003b8: 07                                        ; string length
+00003b9: 6936 342e 6571 7a                        i64.eqz  ; export name
+00003c0: 00                                        ; export kind
+00003c1: 37                                        ; export func index
+00003c2: 06                                        ; string length
+00003c3: 6936 342e 6571                           i64.eq  ; export name
+00003c9: 00                                        ; export kind
+00003ca: 38                                        ; export func index
+00003cb: 06                                        ; string length
+00003cc: 6936 342e 6e65                           i64.ne  ; export name
+00003d2: 00                                        ; export kind
+00003d3: 39                                        ; export func index
+00003d4: 08                                        ; string length
+00003d5: 6936 342e 6c74 5f73                      i64.lt_s  ; export name
+00003dd: 00                                        ; export kind
+00003de: 3a                                        ; export func index
+00003df: 08                                        ; string length
+00003e0: 6936 342e 6c74 5f75                      i64.lt_u  ; export name
+00003e8: 00                                        ; export kind
+00003e9: 3b                                        ; export func index
+00003ea: 08                                        ; string length
+00003eb: 6936 342e 6774 5f73                      i64.gt_s  ; export name
+00003f3: 00                                        ; export kind
+00003f4: 3c                                        ; export func index
+00003f5: 08                                        ; string length
+00003f6: 6936 342e 6774 5f75                      i64.gt_u  ; export name
+00003fe: 00                                        ; export kind
+00003ff: 3d                                        ; export func index
+0000400: 08                                        ; string length
+0000401: 6936 342e 6c65 5f73                      i64.le_s  ; export name
+0000409: 00                                        ; export kind
+000040a: 3e                                        ; export func index
+000040b: 08                                        ; string length
+000040c: 6936 342e 6c65 5f75                      i64.le_u  ; export name
+0000414: 00                                        ; export kind
+0000415: 3f                                        ; export func index
+0000416: 08                                        ; string length
+0000417: 6936 342e 6765 5f73                      i64.ge_s  ; export name
+000041f: 00                                        ; export kind
+0000420: 40                                        ; export func index
+0000421: 08                                        ; string length
+0000422: 6936 342e 6765 5f75                      i64.ge_u  ; export name
+000042a: 00                                        ; export kind
+000042b: 41                                        ; export func index
+000042c: 06                                        ; string length
+000042d: 6633 322e 6571                           f32.eq  ; export name
+0000433: 00                                        ; export kind
+0000434: 42                                        ; export func index
+0000435: 06                                        ; string length
+0000436: 6633 322e 6e65                           f32.ne  ; export name
+000043c: 00                                        ; export kind
+000043d: 43                                        ; export func index
+000043e: 06                                        ; string length
+000043f: 6633 322e 6c74                           f32.lt  ; export name
+0000445: 00                                        ; export kind
+0000446: 44                                        ; export func index
+0000447: 06                                        ; string length
+0000448: 6633 322e 6774                           f32.gt  ; export name
+000044e: 00                                        ; export kind
+000044f: 45                                        ; export func index
+0000450: 06                                        ; string length
+0000451: 6633 322e 6c65                           f32.le  ; export name
+0000457: 00                                        ; export kind
+0000458: 46                                        ; export func index
+0000459: 06                                        ; string length
+000045a: 6633 322e 6765                           f32.ge  ; export name
+0000460: 00                                        ; export kind
+0000461: 47                                        ; export func index
+0000462: 06                                        ; string length
+0000463: 6636 342e 6571                           f64.eq  ; export name
+0000469: 00                                        ; export kind
+000046a: 48                                        ; export func index
+000046b: 06                                        ; string length
+000046c: 6636 342e 6e65                           f64.ne  ; export name
+0000472: 00                                        ; export kind
+0000473: 49                                        ; export func index
+0000474: 06                                        ; string length
+0000475: 6636 342e 6c74                           f64.lt  ; export name
+000047b: 00                                        ; export kind
+000047c: 4a                                        ; export func index
+000047d: 06                                        ; string length
+000047e: 6636 342e 6774                           f64.gt  ; export name
+0000484: 00                                        ; export kind
+0000485: 4b                                        ; export func index
+0000486: 06                                        ; string length
+0000487: 6636 342e 6c65                           f64.le  ; export name
+000048d: 00                                        ; export kind
+000048e: 4c                                        ; export func index
+000048f: 06                                        ; string length
+0000490: 6636 342e 6765                           f64.ge  ; export name
+0000496: 00                                        ; export kind
+0000497: 4d                                        ; export func index
+0000498: 07                                        ; string length
+0000499: 6933 322e 636c 7a                        i32.clz  ; export name
+00004a0: 00                                        ; export kind
+00004a1: 4e                                        ; export func index
+00004a2: 07                                        ; string length
+00004a3: 6933 322e 6374 7a                        i32.ctz  ; export name
+00004aa: 00                                        ; export kind
+00004ab: 4f                                        ; export func index
+00004ac: 0a                                        ; string length
+00004ad: 6933 322e 706f 7063 6e74                 i32.popcnt  ; export name
+00004b7: 00                                        ; export kind
+00004b8: 50                                        ; export func index
+00004b9: 07                                        ; string length
+00004ba: 6933 322e 6164 64                        i32.add  ; export name
+00004c1: 00                                        ; export kind
+00004c2: 51                                        ; export func index
+00004c3: 07                                        ; string length
+00004c4: 6933 322e 7375 62                        i32.sub  ; export name
+00004cb: 00                                        ; export kind
+00004cc: 52                                        ; export func index
+00004cd: 07                                        ; string length
+00004ce: 6933 322e 6d75 6c                        i32.mul  ; export name
+00004d5: 00                                        ; export kind
+00004d6: 53                                        ; export func index
+00004d7: 09                                        ; string length
+00004d8: 6933 322e 6469 765f 73                   i32.div_s  ; export name
+00004e1: 00                                        ; export kind
+00004e2: 54                                        ; export func index
+00004e3: 09                                        ; string length
+00004e4: 6933 322e 6469 765f 75                   i32.div_u  ; export name
+00004ed: 00                                        ; export kind
+00004ee: 55                                        ; export func index
+00004ef: 09                                        ; string length
+00004f0: 6933 322e 7265 6d5f 73                   i32.rem_s  ; export name
+00004f9: 00                                        ; export kind
+00004fa: 56                                        ; export func index
+00004fb: 09                                        ; string length
+00004fc: 6933 322e 7265 6d5f 75                   i32.rem_u  ; export name
+0000505: 00                                        ; export kind
+0000506: 57                                        ; export func index
+0000507: 07                                        ; string length
+0000508: 6933 322e 616e 64                        i32.and  ; export name
+000050f: 00                                        ; export kind
+0000510: 58                                        ; export func index
+0000511: 06                                        ; string length
+0000512: 6933 322e 6f72                           i32.or  ; export name
+0000518: 00                                        ; export kind
+0000519: 59                                        ; export func index
+000051a: 07                                        ; string length
+000051b: 6933 322e 786f 72                        i32.xor  ; export name
+0000522: 00                                        ; export kind
+0000523: 5a                                        ; export func index
+0000524: 07                                        ; string length
+0000525: 6933 322e 7368 6c                        i32.shl  ; export name
+000052c: 00                                        ; export kind
+000052d: 5b                                        ; export func index
+000052e: 09                                        ; string length
+000052f: 6933 322e 7368 725f 73                   i32.shr_s  ; export name
+0000538: 00                                        ; export kind
+0000539: 5c                                        ; export func index
+000053a: 09                                        ; string length
+000053b: 6933 322e 7368 725f 75                   i32.shr_u  ; export name
+0000544: 00                                        ; export kind
+0000545: 5d                                        ; export func index
+0000546: 08                                        ; string length
+0000547: 6933 322e 726f 746c                      i32.rotl  ; export name
+000054f: 00                                        ; export kind
+0000550: 5e                                        ; export func index
+0000551: 08                                        ; string length
+0000552: 6933 322e 726f 7472                      i32.rotr  ; export name
+000055a: 00                                        ; export kind
+000055b: 5f                                        ; export func index
+000055c: 07                                        ; string length
+000055d: 6936 342e 636c 7a                        i64.clz  ; export name
+0000564: 00                                        ; export kind
+0000565: 60                                        ; export func index
+0000566: 07                                        ; string length
+0000567: 6936 342e 6374 7a                        i64.ctz  ; export name
+000056e: 00                                        ; export kind
+000056f: 61                                        ; export func index
+0000570: 0a                                        ; string length
+0000571: 6936 342e 706f 7063 6e74                 i64.popcnt  ; export name
+000057b: 00                                        ; export kind
+000057c: 62                                        ; export func index
+000057d: 07                                        ; string length
+000057e: 6936 342e 6164 64                        i64.add  ; export name
+0000585: 00                                        ; export kind
+0000586: 63                                        ; export func index
+0000587: 07                                        ; string length
+0000588: 6936 342e 7375 62                        i64.sub  ; export name
+000058f: 00                                        ; export kind
+0000590: 64                                        ; export func index
+0000591: 07                                        ; string length
+0000592: 6936 342e 6d75 6c                        i64.mul  ; export name
+0000599: 00                                        ; export kind
+000059a: 65                                        ; export func index
+000059b: 09                                        ; string length
+000059c: 6936 342e 6469 765f 73                   i64.div_s  ; export name
+00005a5: 00                                        ; export kind
+00005a6: 66                                        ; export func index
+00005a7: 09                                        ; string length
+00005a8: 6936 342e 6469 765f 75                   i64.div_u  ; export name
+00005b1: 00                                        ; export kind
+00005b2: 67                                        ; export func index
+00005b3: 09                                        ; string length
+00005b4: 6936 342e 7265 6d5f 73                   i64.rem_s  ; export name
+00005bd: 00                                        ; export kind
+00005be: 68                                        ; export func index
+00005bf: 09                                        ; string length
+00005c0: 6936 342e 7265 6d5f 75                   i64.rem_u  ; export name
+00005c9: 00                                        ; export kind
+00005ca: 69                                        ; export func index
+00005cb: 07                                        ; string length
+00005cc: 6936 342e 616e 64                        i64.and  ; export name
+00005d3: 00                                        ; export kind
+00005d4: 6a                                        ; export func index
+00005d5: 06                                        ; string length
+00005d6: 6936 342e 6f72                           i64.or  ; export name
+00005dc: 00                                        ; export kind
+00005dd: 6b                                        ; export func index
+00005de: 07                                        ; string length
+00005df: 6936 342e 786f 72                        i64.xor  ; export name
+00005e6: 00                                        ; export kind
+00005e7: 6c                                        ; export func index
+00005e8: 07                                        ; string length
+00005e9: 6936 342e 7368 6c                        i64.shl  ; export name
+00005f0: 00                                        ; export kind
+00005f1: 6d                                        ; export func index
+00005f2: 09                                        ; string length
+00005f3: 6936 342e 7368 725f 73                   i64.shr_s  ; export name
+00005fc: 00                                        ; export kind
+00005fd: 6e                                        ; export func index
+00005fe: 09                                        ; string length
+00005ff: 6936 342e 7368 725f 75                   i64.shr_u  ; export name
+0000608: 00                                        ; export kind
+0000609: 6f                                        ; export func index
+000060a: 08                                        ; string length
+000060b: 6936 342e 726f 746c                      i64.rotl  ; export name
+0000613: 00                                        ; export kind
+0000614: 70                                        ; export func index
+0000615: 08                                        ; string length
+0000616: 6936 342e 726f 7472                      i64.rotr  ; export name
+000061e: 00                                        ; export kind
+000061f: 71                                        ; export func index
+0000620: 07                                        ; string length
+0000621: 6633 322e 6162 73                        f32.abs  ; export name
+0000628: 00                                        ; export kind
+0000629: 72                                        ; export func index
+000062a: 07                                        ; string length
+000062b: 6633 322e 6e65 67                        f32.neg  ; export name
+0000632: 00                                        ; export kind
+0000633: 73                                        ; export func index
+0000634: 08                                        ; string length
+0000635: 6633 322e 6365 696c                      f32.ceil  ; export name
+000063d: 00                                        ; export kind
+000063e: 74                                        ; export func index
+000063f: 09                                        ; string length
+0000640: 6633 322e 666c 6f6f 72                   f32.floor  ; export name
+0000649: 00                                        ; export kind
+000064a: 75                                        ; export func index
+000064b: 09                                        ; string length
+000064c: 6633 322e 7472 756e 63                   f32.trunc  ; export name
+0000655: 00                                        ; export kind
+0000656: 76                                        ; export func index
+0000657: 0b                                        ; string length
+0000658: 6633 322e 6e65 6172 6573 74              f32.nearest  ; export name
+0000663: 00                                        ; export kind
+0000664: 77                                        ; export func index
+0000665: 08                                        ; string length
+0000666: 6633 322e 7371 7274                      f32.sqrt  ; export name
+000066e: 00                                        ; export kind
+000066f: 78                                        ; export func index
+0000670: 07                                        ; string length
+0000671: 6633 322e 6164 64                        f32.add  ; export name
+0000678: 00                                        ; export kind
+0000679: 79                                        ; export func index
+000067a: 07                                        ; string length
+000067b: 6633 322e 7375 62                        f32.sub  ; export name
+0000682: 00                                        ; export kind
+0000683: 7a                                        ; export func index
+0000684: 07                                        ; string length
+0000685: 6633 322e 6d75 6c                        f32.mul  ; export name
+000068c: 00                                        ; export kind
+000068d: 7b                                        ; export func index
+000068e: 07                                        ; string length
+000068f: 6633 322e 6469 76                        f32.div  ; export name
+0000696: 00                                        ; export kind
+0000697: 7c                                        ; export func index
+0000698: 07                                        ; string length
+0000699: 6633 322e 6d69 6e                        f32.min  ; export name
+00006a0: 00                                        ; export kind
+00006a1: 7d                                        ; export func index
+00006a2: 07                                        ; string length
+00006a3: 6633 322e 6d61 78                        f32.max  ; export name
+00006aa: 00                                        ; export kind
+00006ab: 7e                                        ; export func index
+00006ac: 0c                                        ; string length
+00006ad: 6633 322e 636f 7079 7369 676e            f32.copysign  ; export name
+00006b9: 00                                        ; export kind
+00006ba: 7f                                        ; export func index
+00006bb: 07                                        ; string length
+00006bc: 6636 342e 6162 73                        f64.abs  ; export name
+00006c3: 00                                        ; export kind
+00006c4: 8001                                      ; export func index
+00006c6: 07                                        ; string length
+00006c7: 6636 342e 6e65 67                        f64.neg  ; export name
+00006ce: 00                                        ; export kind
+00006cf: 8101                                      ; export func index
+00006d1: 08                                        ; string length
+00006d2: 6636 342e 6365 696c                      f64.ceil  ; export name
+00006da: 00                                        ; export kind
+00006db: 8201                                      ; export func index
+00006dd: 09                                        ; string length
+00006de: 6636 342e 666c 6f6f 72                   f64.floor  ; export name
+00006e7: 00                                        ; export kind
+00006e8: 8301                                      ; export func index
+00006ea: 09                                        ; string length
+00006eb: 6636 342e 7472 756e 63                   f64.trunc  ; export name
+00006f4: 00                                        ; export kind
+00006f5: 8401                                      ; export func index
+00006f7: 0b                                        ; string length
+00006f8: 6636 342e 6e65 6172 6573 74              f64.nearest  ; export name
+0000703: 00                                        ; export kind
+0000704: 8501                                      ; export func index
+0000706: 08                                        ; string length
+0000707: 6636 342e 7371 7274                      f64.sqrt  ; export name
+000070f: 00                                        ; export kind
+0000710: 8601                                      ; export func index
+0000712: 07                                        ; string length
+0000713: 6636 342e 6164 64                        f64.add  ; export name
+000071a: 00                                        ; export kind
+000071b: 8701                                      ; export func index
+000071d: 07                                        ; string length
+000071e: 6636 342e 7375 62                        f64.sub  ; export name
+0000725: 00                                        ; export kind
+0000726: 8801                                      ; export func index
+0000728: 07                                        ; string length
+0000729: 6636 342e 6d75 6c                        f64.mul  ; export name
+0000730: 00                                        ; export kind
+0000731: 8901                                      ; export func index
+0000733: 07                                        ; string length
+0000734: 6636 342e 6469 76                        f64.div  ; export name
+000073b: 00                                        ; export kind
+000073c: 8a01                                      ; export func index
+000073e: 07                                        ; string length
+000073f: 6636 342e 6d69 6e                        f64.min  ; export name
+0000746: 00                                        ; export kind
+0000747: 8b01                                      ; export func index
+0000749: 07                                        ; string length
+000074a: 6636 342e 6d61 78                        f64.max  ; export name
+0000751: 00                                        ; export kind
+0000752: 8c01                                      ; export func index
+0000754: 0c                                        ; string length
+0000755: 6636 342e 636f 7079 7369 676e            f64.copysign  ; export name
+0000761: 00                                        ; export kind
+0000762: 8d01                                      ; export func index
+0000764: 0c                                        ; string length
+0000765: 6933 322e 7772 6170 2f69 3634            i32.wrap/i64  ; export name
+0000771: 00                                        ; export kind
+0000772: 8e01                                      ; export func index
+0000774: 0f                                        ; string length
+0000775: 6933 322e 7472 756e 635f 732f 6633 32    i32.trunc_s/f32  ; export name
+0000784: 00                                        ; export kind
+0000785: 8f01                                      ; export func index
+0000787: 0f                                        ; string length
+0000788: 6933 322e 7472 756e 635f 752f 6633 32    i32.trunc_u/f32  ; export name
+0000797: 00                                        ; export kind
+0000798: 9001                                      ; export func index
+000079a: 0f                                        ; string length
+000079b: 6933 322e 7472 756e 635f 732f 6636 34    i32.trunc_s/f64  ; export name
+00007aa: 00                                        ; export kind
+00007ab: 9101                                      ; export func index
+00007ad: 0f                                        ; string length
+00007ae: 6933 322e 7472 756e 635f 752f 6636 34    i32.trunc_u/f64  ; export name
+00007bd: 00                                        ; export kind
+00007be: 9201                                      ; export func index
+00007c0: 10                                        ; string length
+00007c1: 6936 342e 6578 7465 6e64 5f73 2f69 3332  i64.extend_s/i32  ; export name
+00007d1: 00                                        ; export kind
+00007d2: 9301                                      ; export func index
+00007d4: 10                                        ; string length
+00007d5: 6936 342e 6578 7465 6e64 5f75 2f69 3332  i64.extend_u/i32  ; export name
+00007e5: 00                                        ; export kind
+00007e6: 9401                                      ; export func index
+00007e8: 0f                                        ; string length
+00007e9: 6936 342e 7472 756e 635f 732f 6633 32    i64.trunc_s/f32  ; export name
+00007f8: 00                                        ; export kind
+00007f9: 9501                                      ; export func index
+00007fb: 0f                                        ; string length
+00007fc: 6936 342e 7472 756e 635f 752f 6633 32    i64.trunc_u/f32  ; export name
+000080b: 00                                        ; export kind
+000080c: 9601                                      ; export func index
+000080e: 0f                                        ; string length
+000080f: 6936 342e 7472 756e 635f 732f 6636 34    i64.trunc_s/f64  ; export name
+000081e: 00                                        ; export kind
+000081f: 9701                                      ; export func index
+0000821: 0f                                        ; string length
+0000822: 6936 342e 7472 756e 635f 752f 6636 34    i64.trunc_u/f64  ; export name
+0000831: 00                                        ; export kind
+0000832: 9801                                      ; export func index
+0000834: 11                                        ; string length
+0000835: 6633 322e 636f 6e76 6572 745f 732f 6933  f32.convert_s/i3
+0000845: 32                                       2  ; export name
+0000846: 00                                        ; export kind
+0000847: 9901                                      ; export func index
+0000849: 11                                        ; string length
+000084a: 6633 322e 636f 6e76 6572 745f 752f 6933  f32.convert_u/i3
+000085a: 32                                       2  ; export name
+000085b: 00                                        ; export kind
+000085c: 9a01                                      ; export func index
+000085e: 11                                        ; string length
+000085f: 6633 322e 636f 6e76 6572 745f 732f 6936  f32.convert_s/i6
+000086f: 34                                       4  ; export name
+0000870: 00                                        ; export kind
+0000871: 9b01                                      ; export func index
+0000873: 11                                        ; string length
+0000874: 6633 322e 636f 6e76 6572 745f 752f 6936  f32.convert_u/i6
+0000884: 34                                       4  ; export name
+0000885: 00                                        ; export kind
+0000886: 9c01                                      ; export func index
+0000888: 0e                                        ; string length
+0000889: 6633 322e 6465 6d6f 7465 2f66 3634       f32.demote/f64  ; export name
+0000897: 00                                        ; export kind
+0000898: 9d01                                      ; export func index
+000089a: 11                                        ; string length
+000089b: 6636 342e 636f 6e76 6572 745f 732f 6933  f64.convert_s/i3
+00008ab: 32                                       2  ; export name
+00008ac: 00                                        ; export kind
+00008ad: 9e01                                      ; export func index
+00008af: 11                                        ; string length
+00008b0: 6636 342e 636f 6e76 6572 745f 752f 6933  f64.convert_u/i3
+00008c0: 32                                       2  ; export name
+00008c1: 00                                        ; export kind
+00008c2: 9f01                                      ; export func index
+00008c4: 11                                        ; string length
+00008c5: 6636 342e 636f 6e76 6572 745f 732f 6936  f64.convert_s/i6
+00008d5: 34                                       4  ; export name
+00008d6: 00                                        ; export kind
+00008d7: a001                                      ; export func index
+00008d9: 11                                        ; string length
+00008da: 6636 342e 636f 6e76 6572 745f 752f 6936  f64.convert_u/i6
+00008ea: 34                                       4  ; export name
+00008eb: 00                                        ; export kind
+00008ec: a101                                      ; export func index
+00008ee: 0f                                        ; string length
+00008ef: 6636 342e 7072 6f6d 6f74 652f 6633 32    f64.promote/f32  ; export name
+00008fe: 00                                        ; export kind
+00008ff: a201                                      ; export func index
+0000901: 13                                        ; string length
+0000902: 6933 322e 7265 696e 7465 7270 7265 742f  i32.reinterpret/
+0000912: 6633 32                                  f32  ; export name
+0000915: 00                                        ; export kind
+0000916: a301                                      ; export func index
+0000918: 13                                        ; string length
+0000919: 6633 322e 7265 696e 7465 7270 7265 742f  f32.reinterpret/
+0000929: 6933 32                                  i32  ; export name
+000092c: 00                                        ; export kind
+000092d: a401                                      ; export func index
+000092f: 13                                        ; string length
+0000930: 6936 342e 7265 696e 7465 7270 7265 742f  i64.reinterpret/
+0000940: 6636 34                                  f64  ; export name
+0000943: 00                                        ; export kind
+0000944: a501                                      ; export func index
+0000946: 13                                        ; string length
+0000947: 6636 342e 7265 696e 7465 7270 7265 742f  f64.reinterpret/
+0000957: 6936 34                                  i64  ; export name
+000095a: 00                                        ; export kind
+000095b: a601                                      ; export func index
+000095d: 0d                                        ; string length
+000095e: 6933 322e 6578 7465 6e64 385f 73         i32.extend8_s  ; export name
+000096b: 00                                        ; export kind
+000096c: a701                                      ; export func index
+000096e: 0e                                        ; string length
+000096f: 6933 322e 6578 7465 6e64 3136 5f73       i32.extend16_s  ; export name
+000097d: 00                                        ; export kind
+000097e: a801                                      ; export func index
+0000980: 0d                                        ; string length
+0000981: 6936 342e 6578 7465 6e64 385f 73         i64.extend8_s  ; export name
+000098e: 00                                        ; export kind
+000098f: a901                                      ; export func index
+0000991: 0e                                        ; string length
+0000992: 6936 342e 6578 7465 6e64 3136 5f73       i64.extend16_s  ; export name
+00009a0: 00                                        ; export kind
+00009a1: aa01                                      ; export func index
+00009a3: 0e                                        ; string length
+00009a4: 6936 342e 6578 7465 6e64 3332 5f73       i64.extend32_s  ; export name
+00009b2: 00                                        ; export kind
+00009b3: ab01                                      ; export func index
+00009b5: 06                                        ; string length
+00009b6: 616c 6c6f 6361                           alloca  ; export name
+00009bc: 00                                        ; export kind
+00009bd: ac01                                      ; export func index
+00009bf: 09                                        ; string length
+00009c0: 6272 5f75 6e6c 6573 73                   br_unless  ; export name
+00009c9: 00                                        ; export kind
+00009ca: ad01                                      ; export func index
+00009cc: 09                                        ; string length
+00009cd: 6361 6c6c 5f68 6f73 74                   call_host  ; export name
+00009d6: 00                                        ; export kind
+00009d7: ae01                                      ; export func index
+00009d9: 04                                        ; string length
+00009da: 6461 7461                                data  ; export name
+00009de: 00                                        ; export kind
+00009df: af01                                      ; export func index
+00009e1: 09                                        ; string length
+00009e2: 6472 6f70 5f6b 6565 70                   drop_keep  ; export name
+00009eb: 00                                        ; export kind
+00009ec: b001                                      ; export func index
+00009ee: 13                                        ; string length
+00009ef: 6933 322e 7472 756e 635f 733a 7361 742f  i32.trunc_s:sat/
+00009ff: 6633 32                                  f32  ; export name
+0000a02: 00                                        ; export kind
+0000a03: b101                                      ; export func index
+0000a05: 13                                        ; string length
+0000a06: 6933 322e 7472 756e 635f 753a 7361 742f  i32.trunc_u:sat/
+0000a16: 6633 32                                  f32  ; export name
+0000a19: 00                                        ; export kind
+0000a1a: b201                                      ; export func index
+0000a1c: 13                                        ; string length
+0000a1d: 6933 322e 7472 756e 635f 733a 7361 742f  i32.trunc_s:sat/
+0000a2d: 6636 34                                  f64  ; export name
+0000a30: 00                                        ; export kind
+0000a31: b301                                      ; export func index
+0000a33: 13                                        ; string length
+0000a34: 6933 322e 7472 756e 635f 753a 7361 742f  i32.trunc_u:sat/
+0000a44: 6636 34                                  f64  ; export name
+0000a47: 00                                        ; export kind
+0000a48: b401                                      ; export func index
+0000a4a: 13                                        ; string length
+0000a4b: 6936 342e 7472 756e 635f 733a 7361 742f  i64.trunc_s:sat/
+0000a5b: 6633 32                                  f32  ; export name
+0000a5e: 00                                        ; export kind
+0000a5f: b501                                      ; export func index
+0000a61: 13                                        ; string length
+0000a62: 6936 342e 7472 756e 635f 753a 7361 742f  i64.trunc_u:sat/
+0000a72: 6633 32                                  f32  ; export name
+0000a75: 00                                        ; export kind
+0000a76: b601                                      ; export func index
+0000a78: 13                                        ; string length
+0000a79: 6936 342e 7472 756e 635f 733a 7361 742f  i64.trunc_s:sat/
+0000a89: 6636 34                                  f64  ; export name
+0000a8c: 00                                        ; export kind
+0000a8d: b701                                      ; export func index
+0000a8f: 13                                        ; string length
+0000a90: 6936 342e 7472 756e 635f 753a 7361 742f  i64.trunc_u:sat/
+0000aa0: 6636 34                                  f64  ; export name
+0000aa3: 00                                        ; export kind
+0000aa4: b801                                      ; export func index
+0000aa6: 0f                                        ; string length
+0000aa7: 6933 322e 6174 6f6d 6963 2e6c 6f61 64    i32.atomic.load  ; export name
+0000ab6: 00                                        ; export kind
+0000ab7: b901                                      ; export func index
+0000ab9: 0f                                        ; string length
+0000aba: 6936 342e 6174 6f6d 6963 2e6c 6f61 64    i64.atomic.load  ; export name
+0000ac9: 00                                        ; export kind
+0000aca: ba01                                      ; export func index
+0000acc: 12                                        ; string length
+0000acd: 6933 322e 6174 6f6d 6963 2e6c 6f61 6438  i32.atomic.load8
+0000add: 5f75                                     _u  ; export name
+0000adf: 00                                        ; export kind
+0000ae0: bb01                                      ; export func index
+0000ae2: 13                                        ; string length
+0000ae3: 6933 322e 6174 6f6d 6963 2e6c 6f61 6431  i32.atomic.load1
+0000af3: 365f 75                                  6_u  ; export name
+0000af6: 00                                        ; export kind
+0000af7: bc01                                      ; export func index
+0000af9: 12                                        ; string length
+0000afa: 6936 342e 6174 6f6d 6963 2e6c 6f61 6438  i64.atomic.load8
+0000b0a: 5f75                                     _u  ; export name
+0000b0c: 00                                        ; export kind
+0000b0d: bd01                                      ; export func index
+0000b0f: 13                                        ; string length
+0000b10: 6936 342e 6174 6f6d 6963 2e6c 6f61 6431  i64.atomic.load1
+0000b20: 365f 75                                  6_u  ; export name
+0000b23: 00                                        ; export kind
+0000b24: be01                                      ; export func index
+0000b26: 13                                        ; string length
+0000b27: 6936 342e 6174 6f6d 6963 2e6c 6f61 6433  i64.atomic.load3
+0000b37: 325f 75                                  2_u  ; export name
+0000b3a: 00                                        ; export kind
+0000b3b: bf01                                      ; export func index
+0000b3d: 10                                        ; string length
+0000b3e: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store  ; export name
+0000b4e: 00                                        ; export kind
+0000b4f: c001                                      ; export func index
+0000b51: 10                                        ; string length
+0000b52: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store  ; export name
+0000b62: 00                                        ; export kind
+0000b63: c101                                      ; export func index
+0000b65: 11                                        ; string length
+0000b66: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
+0000b76: 38                                       8  ; export name
+0000b77: 00                                        ; export kind
+0000b78: c201                                      ; export func index
+0000b7a: 12                                        ; string length
+0000b7b: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
+0000b8b: 3136                                     16  ; export name
+0000b8d: 00                                        ; export kind
+0000b8e: c301                                      ; export func index
+0000b90: 11                                        ; string length
+0000b91: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
+0000ba1: 38                                       8  ; export name
+0000ba2: 00                                        ; export kind
+0000ba3: c401                                      ; export func index
+0000ba5: 12                                        ; string length
+0000ba6: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
+0000bb6: 3136                                     16  ; export name
+0000bb8: 00                                        ; export kind
+0000bb9: c501                                      ; export func index
+0000bbb: 12                                        ; string length
+0000bbc: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
+0000bcc: 3332                                     32  ; export name
+0000bce: 00                                        ; export kind
+0000bcf: c601                                      ; export func index
+0000bd1: 12                                        ; string length
+0000bd2: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
+0000be2: 6464                                     dd  ; export name
+0000be4: 00                                        ; export kind
+0000be5: c701                                      ; export func index
+0000be7: 12                                        ; string length
+0000be8: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
+0000bf8: 6464                                     dd  ; export name
+0000bfa: 00                                        ; export kind
+0000bfb: c801                                      ; export func index
+0000bfd: 15                                        ; string length
+0000bfe: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000c0e: 752e 6164 64                             u.add  ; export name
+0000c13: 00                                        ; export kind
+0000c14: c901                                      ; export func index
+0000c16: 16                                        ; string length
+0000c17: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000c27: 5f75 2e61 6464                           _u.add  ; export name
+0000c2d: 00                                        ; export kind
+0000c2e: ca01                                      ; export func index
+0000c30: 15                                        ; string length
+0000c31: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000c41: 752e 6164 64                             u.add  ; export name
+0000c46: 00                                        ; export kind
+0000c47: cb01                                      ; export func index
+0000c49: 16                                        ; string length
+0000c4a: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000c5a: 5f75 2e61 6464                           _u.add  ; export name
+0000c60: 00                                        ; export kind
+0000c61: cc01                                      ; export func index
+0000c63: 16                                        ; string length
+0000c64: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000c74: 5f75 2e61 6464                           _u.add  ; export name
+0000c7a: 00                                        ; export kind
+0000c7b: cd01                                      ; export func index
+0000c7d: 12                                        ; string length
+0000c7e: 6933 322e 6174 6f6d 6963 2e72 6d77 2e73  i32.atomic.rmw.s
+0000c8e: 7562                                     ub  ; export name
+0000c90: 00                                        ; export kind
+0000c91: ce01                                      ; export func index
+0000c93: 12                                        ; string length
+0000c94: 6936 342e 6174 6f6d 6963 2e72 6d77 2e73  i64.atomic.rmw.s
+0000ca4: 7562                                     ub  ; export name
+0000ca6: 00                                        ; export kind
+0000ca7: cf01                                      ; export func index
+0000ca9: 15                                        ; string length
+0000caa: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000cba: 752e 7375 62                             u.sub  ; export name
+0000cbf: 00                                        ; export kind
+0000cc0: d001                                      ; export func index
+0000cc2: 16                                        ; string length
+0000cc3: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000cd3: 5f75 2e73 7562                           _u.sub  ; export name
+0000cd9: 00                                        ; export kind
+0000cda: d101                                      ; export func index
+0000cdc: 15                                        ; string length
+0000cdd: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000ced: 752e 7375 62                             u.sub  ; export name
+0000cf2: 00                                        ; export kind
+0000cf3: d201                                      ; export func index
+0000cf5: 16                                        ; string length
+0000cf6: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000d06: 5f75 2e73 7562                           _u.sub  ; export name
+0000d0c: 00                                        ; export kind
+0000d0d: d301                                      ; export func index
+0000d0f: 16                                        ; string length
+0000d10: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000d20: 5f75 2e73 7562                           _u.sub  ; export name
+0000d26: 00                                        ; export kind
+0000d27: d401                                      ; export func index
+0000d29: 12                                        ; string length
+0000d2a: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
+0000d3a: 6e64                                     nd  ; export name
+0000d3c: 00                                        ; export kind
+0000d3d: d501                                      ; export func index
+0000d3f: 12                                        ; string length
+0000d40: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
+0000d50: 6e64                                     nd  ; export name
+0000d52: 00                                        ; export kind
+0000d53: d601                                      ; export func index
+0000d55: 15                                        ; string length
+0000d56: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000d66: 752e 616e 64                             u.and  ; export name
+0000d6b: 00                                        ; export kind
+0000d6c: d701                                      ; export func index
+0000d6e: 16                                        ; string length
+0000d6f: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000d7f: 5f75 2e61 6e64                           _u.and  ; export name
+0000d85: 00                                        ; export kind
+0000d86: d801                                      ; export func index
+0000d88: 15                                        ; string length
+0000d89: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000d99: 752e 616e 64                             u.and  ; export name
+0000d9e: 00                                        ; export kind
+0000d9f: d901                                      ; export func index
+0000da1: 16                                        ; string length
+0000da2: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000db2: 5f75 2e61 6e64                           _u.and  ; export name
+0000db8: 00                                        ; export kind
+0000db9: da01                                      ; export func index
+0000dbb: 16                                        ; string length
+0000dbc: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000dcc: 5f75 2e61 6e64                           _u.and  ; export name
+0000dd2: 00                                        ; export kind
+0000dd3: db01                                      ; export func index
+0000dd5: 11                                        ; string length
+0000dd6: 6933 322e 6174 6f6d 6963 2e72 6d77 2e6f  i32.atomic.rmw.o
+0000de6: 72                                       r  ; export name
+0000de7: 00                                        ; export kind
+0000de8: dc01                                      ; export func index
+0000dea: 11                                        ; string length
+0000deb: 6936 342e 6174 6f6d 6963 2e72 6d77 2e6f  i64.atomic.rmw.o
+0000dfb: 72                                       r  ; export name
+0000dfc: 00                                        ; export kind
+0000dfd: dd01                                      ; export func index
+0000dff: 14                                        ; string length
+0000e00: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000e10: 752e 6f72                                u.or  ; export name
+0000e14: 00                                        ; export kind
+0000e15: de01                                      ; export func index
+0000e17: 15                                        ; string length
+0000e18: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000e28: 5f75 2e6f 72                             _u.or  ; export name
+0000e2d: 00                                        ; export kind
+0000e2e: df01                                      ; export func index
+0000e30: 14                                        ; string length
+0000e31: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000e41: 752e 6f72                                u.or  ; export name
+0000e45: 00                                        ; export kind
+0000e46: e001                                      ; export func index
+0000e48: 15                                        ; string length
+0000e49: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000e59: 5f75 2e6f 72                             _u.or  ; export name
+0000e5e: 00                                        ; export kind
+0000e5f: e101                                      ; export func index
+0000e61: 15                                        ; string length
+0000e62: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000e72: 5f75 2e6f 72                             _u.or  ; export name
+0000e77: 00                                        ; export kind
+0000e78: e201                                      ; export func index
+0000e7a: 12                                        ; string length
+0000e7b: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
+0000e8b: 6f72                                     or  ; export name
+0000e8d: 00                                        ; export kind
+0000e8e: e301                                      ; export func index
+0000e90: 12                                        ; string length
+0000e91: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
+0000ea1: 6f72                                     or  ; export name
+0000ea3: 00                                        ; export kind
+0000ea4: e401                                      ; export func index
+0000ea6: 15                                        ; string length
+0000ea7: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000eb7: 752e 786f 72                             u.xor  ; export name
+0000ebc: 00                                        ; export kind
+0000ebd: e501                                      ; export func index
+0000ebf: 16                                        ; string length
+0000ec0: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000ed0: 5f75 2e78 6f72                           _u.xor  ; export name
+0000ed6: 00                                        ; export kind
+0000ed7: e601                                      ; export func index
+0000ed9: 15                                        ; string length
+0000eda: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000eea: 752e 786f 72                             u.xor  ; export name
+0000eef: 00                                        ; export kind
+0000ef0: e701                                      ; export func index
+0000ef2: 16                                        ; string length
+0000ef3: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000f03: 5f75 2e78 6f72                           _u.xor  ; export name
+0000f09: 00                                        ; export kind
+0000f0a: e801                                      ; export func index
+0000f0c: 16                                        ; string length
+0000f0d: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000f1d: 5f75 2e78 6f72                           _u.xor  ; export name
+0000f23: 00                                        ; export kind
+0000f24: e901                                      ; export func index
+0000f26: 13                                        ; string length
+0000f27: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
+0000f37: 6368 67                                  chg  ; export name
+0000f3a: 00                                        ; export kind
+0000f3b: ea01                                      ; export func index
+0000f3d: 13                                        ; string length
+0000f3e: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
+0000f4e: 6368 67                                  chg  ; export name
+0000f51: 00                                        ; export kind
+0000f52: eb01                                      ; export func index
+0000f54: 16                                        ; string length
+0000f55: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000f65: 752e 7863 6867                           u.xchg  ; export name
+0000f6b: 00                                        ; export kind
+0000f6c: ec01                                      ; export func index
+0000f6e: 17                                        ; string length
+0000f6f: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000f7f: 5f75 2e78 6368 67                        _u.xchg  ; export name
+0000f86: 00                                        ; export kind
+0000f87: ed01                                      ; export func index
+0000f89: 16                                        ; string length
+0000f8a: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000f9a: 752e 7863 6867                           u.xchg  ; export name
+0000fa0: 00                                        ; export kind
+0000fa1: ee01                                      ; export func index
+0000fa3: 17                                        ; string length
+0000fa4: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000fb4: 5f75 2e78 6368 67                        _u.xchg  ; export name
+0000fbb: 00                                        ; export kind
+0000fbc: ef01                                      ; export func index
+0000fbe: 17                                        ; string length
+0000fbf: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000fcf: 5f75 2e78 6368 67                        _u.xchg  ; export name
+0000fd6: 00                                        ; export kind
+0000fd7: f001                                      ; export func index
+0000fd9: 16                                        ; string length
+0000fda: 6933 322e 6174 6f6d 6963 2e72 6d77 2e63  i32.atomic.rmw.c
+0000fea: 6d70 7863 6867                           mpxchg  ; export name
+0000ff0: 00                                        ; export kind
+0000ff1: f101                                      ; export func index
+0000ff3: 16                                        ; string length
+0000ff4: 6936 342e 6174 6f6d 6963 2e72 6d77 2e63  i64.atomic.rmw.c
+0001004: 6d70 7863 6867                           mpxchg  ; export name
+000100a: 00                                        ; export kind
+000100b: f201                                      ; export func index
+000100d: 19                                        ; string length
+000100e: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+000101e: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
+0001027: 00                                        ; export kind
+0001028: f301                                      ; export func index
+000102a: 1a                                        ; string length
+000102b: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+000103b: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
+0001045: 00                                        ; export kind
+0001046: f401                                      ; export func index
+0001048: 19                                        ; string length
+0001049: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0001059: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
+0001062: 00                                        ; export kind
+0001063: f501                                      ; export func index
+0001065: 1a                                        ; string length
+0001066: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0001076: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
+0001080: 00                                        ; export kind
+0001081: f601                                      ; export func index
+0001083: 1a                                        ; string length
+0001084: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0001094: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
+000109e: 00                                        ; export kind
+000109f: f701                                      ; export func index
+; move data: [135, 10a1) -> [136, 10a2)
+0000134: ec1e                                      ; FIXUP section size
 ; section "Elem" (9)
-00010a6: 09                                        ; section code
-00010a7: 00                                        ; section size (guess)
-00010a8: 01                                        ; num elem segments
+00010a2: 09                                        ; section code
+00010a3: 00                                        ; section size (guess)
+00010a4: 01                                        ; num elem segments
 ; elem segment header 0
-00010a9: 00                                        ; table index
-00010aa: 41                                        ; i32.const
-00010ab: 00                                        ; i32 literal
-00010ac: 0b                                        ; end
-00010ad: 02                                        ; num function indices
-00010ae: 01                                        ; function index
-00010af: 01                                        ; function index
-00010a7: 08                                        ; FIXUP section size
+00010a5: 00                                        ; table index
+00010a6: 41                                        ; i32.const
+00010a7: 00                                        ; i32 literal
+00010a8: 0b                                        ; end
+00010a9: 02                                        ; num function indices
+00010aa: 01                                        ; function index
+00010ab: 01                                        ; function index
+00010a3: 08                                        ; FIXUP section size
 ; section "Code" (10)
-00010b0: 0a                                        ; section code
-00010b1: 00                                        ; section size (guess)
-00010b2: f701                                      ; num functions
+00010ac: 0a                                        ; section code
+00010ad: 00                                        ; section size (guess)
+00010ae: f701                                      ; num functions
 ; function body 0
-00010b4: 00                                        ; func body size (guess)
-00010b5: 00                                        ; local decl count
-00010b6: 0b                                        ; end
-00010b4: 02                                        ; FIXUP func body size
+00010b0: 00                                        ; func body size (guess)
+00010b1: 00                                        ; local decl count
+00010b2: 0b                                        ; end
+00010b0: 02                                        ; FIXUP func body size
 ; function body 1
+00010b3: 00                                        ; func body size (guess)
+00010b4: 00                                        ; local decl count
+00010b5: 00                                        ; unreachable
+00010b6: 0b                                        ; end
+00010b3: 03                                        ; FIXUP func body size
+; function body 2
 00010b7: 00                                        ; func body size (guess)
 00010b8: 00                                        ; local decl count
-00010b9: 00                                        ; unreachable
-00010ba: 0b                                        ; end
-00010b7: 03                                        ; FIXUP func body size
-; function body 2
-00010bb: 00                                        ; func body size (guess)
-00010bc: 00                                        ; local decl count
-00010bd: 0c                                        ; br
-00010be: 00                                        ; break depth
-00010bf: 0b                                        ; end
-00010bb: 04                                        ; FIXUP func body size
+00010b9: 0c                                        ; br
+00010ba: 00                                        ; break depth
+00010bb: 0b                                        ; end
+00010b7: 04                                        ; FIXUP func body size
 ; function body 3
-00010c0: 00                                        ; func body size (guess)
-00010c1: 00                                        ; local decl count
-00010c2: 41                                        ; i32.const
-00010c3: 01                                        ; i32 literal
-00010c4: 0e                                        ; br_table
-00010c5: 00                                        ; num targets
-00010c6: 00                                        ; break depth for default
-00010c7: 0b                                        ; end
-00010c0: 07                                        ; FIXUP func body size
+00010bc: 00                                        ; func body size (guess)
+00010bd: 00                                        ; local decl count
+00010be: 41                                        ; i32.const
+00010bf: 01                                        ; i32 literal
+00010c0: 0e                                        ; br_table
+00010c1: 00                                        ; num targets
+00010c2: 00                                        ; break depth for default
+00010c3: 0b                                        ; end
+00010bc: 07                                        ; FIXUP func body size
 ; function body 4
+00010c4: 00                                        ; func body size (guess)
+00010c5: 00                                        ; local decl count
+00010c6: 0f                                        ; return
+00010c7: 0b                                        ; end
+00010c4: 03                                        ; FIXUP func body size
+; function body 5
 00010c8: 00                                        ; func body size (guess)
 00010c9: 00                                        ; local decl count
-00010ca: 0f                                        ; return
-00010cb: 0b                                        ; end
-00010c8: 03                                        ; FIXUP func body size
-; function body 5
-00010cc: 00                                        ; func body size (guess)
-00010cd: 00                                        ; local decl count
-00010ce: 10                                        ; call
-00010cf: 01                                        ; function index
-00010d0: 0b                                        ; end
-00010cc: 04                                        ; FIXUP func body size
+00010ca: 10                                        ; call
+00010cb: 01                                        ; function index
+00010cc: 0b                                        ; end
+00010c8: 04                                        ; FIXUP func body size
 ; function body 6
-00010d1: 00                                        ; func body size (guess)
-00010d2: 00                                        ; local decl count
-00010d3: 41                                        ; i32.const
-00010d4: 01                                        ; i32 literal
-00010d5: 11                                        ; call_indirect
-00010d6: 00                                        ; signature index
-00010d7: 00                                        ; call_indirect reserved
-00010d8: 0b                                        ; end
-00010d1: 07                                        ; FIXUP func body size
+00010cd: 00                                        ; func body size (guess)
+00010ce: 00                                        ; local decl count
+00010cf: 41                                        ; i32.const
+00010d0: 01                                        ; i32 literal
+00010d1: 11                                        ; call_indirect
+00010d2: 00                                        ; signature index
+00010d3: 00                                        ; call_indirect reserved
+00010d4: 0b                                        ; end
+00010cd: 07                                        ; FIXUP func body size
 ; function body 7
-00010d9: 00                                        ; func body size (guess)
-00010da: 00                                        ; local decl count
-00010db: 41                                        ; i32.const
-00010dc: 01                                        ; i32 literal
-00010dd: 1a                                        ; drop
-00010de: 0b                                        ; end
-00010d9: 05                                        ; FIXUP func body size
+00010d5: 00                                        ; func body size (guess)
+00010d6: 00                                        ; local decl count
+00010d7: 41                                        ; i32.const
+00010d8: 01                                        ; i32 literal
+00010d9: 1a                                        ; drop
+00010da: 0b                                        ; end
+00010d5: 05                                        ; FIXUP func body size
 ; function body 8
-00010df: 00                                        ; func body size (guess)
-00010e0: 00                                        ; local decl count
+00010db: 00                                        ; func body size (guess)
+00010dc: 00                                        ; local decl count
+00010dd: 41                                        ; i32.const
+00010de: 01                                        ; i32 literal
+00010df: 41                                        ; i32.const
+00010e0: 02                                        ; i32 literal
 00010e1: 41                                        ; i32.const
-00010e2: 01                                        ; i32 literal
-00010e3: 41                                        ; i32.const
-00010e4: 02                                        ; i32 literal
-00010e5: 41                                        ; i32.const
-00010e6: 03                                        ; i32 literal
-00010e7: 1b                                        ; select
-00010e8: 1a                                        ; drop
-00010e9: 0b                                        ; end
-00010df: 0a                                        ; FIXUP func body size
+00010e2: 03                                        ; i32 literal
+00010e3: 1b                                        ; select
+00010e4: 1a                                        ; drop
+00010e5: 0b                                        ; end
+00010db: 0a                                        ; FIXUP func body size
 ; function body 9
-00010ea: 00                                        ; func body size (guess)
-00010eb: 01                                        ; local decl count
-00010ec: 01                                        ; local type count
-00010ed: 7f                                        ; i32
-00010ee: 20                                        ; get_local
-00010ef: 00                                        ; local index
-00010f0: 1a                                        ; drop
-00010f1: 0b                                        ; end
-00010ea: 07                                        ; FIXUP func body size
+00010e6: 00                                        ; func body size (guess)
+00010e7: 01                                        ; local decl count
+00010e8: 01                                        ; local type count
+00010e9: 7f                                        ; i32
+00010ea: 20                                        ; get_local
+00010eb: 00                                        ; local index
+00010ec: 1a                                        ; drop
+00010ed: 0b                                        ; end
+00010e6: 07                                        ; FIXUP func body size
 ; function body 10
-00010f2: 00                                        ; func body size (guess)
-00010f3: 01                                        ; local decl count
-00010f4: 01                                        ; local type count
-00010f5: 7f                                        ; i32
-00010f6: 41                                        ; i32.const
-00010f7: 01                                        ; i32 literal
-00010f8: 21                                        ; set_local
-00010f9: 00                                        ; local index
-00010fa: 0b                                        ; end
-00010f2: 08                                        ; FIXUP func body size
+00010ee: 00                                        ; func body size (guess)
+00010ef: 01                                        ; local decl count
+00010f0: 01                                        ; local type count
+00010f1: 7f                                        ; i32
+00010f2: 41                                        ; i32.const
+00010f3: 01                                        ; i32 literal
+00010f4: 21                                        ; set_local
+00010f5: 00                                        ; local index
+00010f6: 0b                                        ; end
+00010ee: 08                                        ; FIXUP func body size
 ; function body 11
-00010fb: 00                                        ; func body size (guess)
-00010fc: 01                                        ; local decl count
-00010fd: 01                                        ; local type count
-00010fe: 7f                                        ; i32
-00010ff: 41                                        ; i32.const
-0001100: 01                                        ; i32 literal
-0001101: 22                                        ; tee_local
-0001102: 00                                        ; local index
-0001103: 1a                                        ; drop
-0001104: 0b                                        ; end
-00010fb: 09                                        ; FIXUP func body size
+00010f7: 00                                        ; func body size (guess)
+00010f8: 01                                        ; local decl count
+00010f9: 01                                        ; local type count
+00010fa: 7f                                        ; i32
+00010fb: 41                                        ; i32.const
+00010fc: 01                                        ; i32 literal
+00010fd: 22                                        ; tee_local
+00010fe: 00                                        ; local index
+00010ff: 1a                                        ; drop
+0001100: 0b                                        ; end
+00010f7: 09                                        ; FIXUP func body size
 ; function body 12
-0001105: 00                                        ; func body size (guess)
-0001106: 00                                        ; local decl count
-0001107: 23                                        ; get_global
-0001108: 00                                        ; global index
-0001109: 1a                                        ; drop
-000110a: 0b                                        ; end
-0001105: 05                                        ; FIXUP func body size
+0001101: 00                                        ; func body size (guess)
+0001102: 00                                        ; local decl count
+0001103: 23                                        ; get_global
+0001104: 00                                        ; global index
+0001105: 1a                                        ; drop
+0001106: 0b                                        ; end
+0001101: 05                                        ; FIXUP func body size
 ; function body 13
-000110b: 00                                        ; func body size (guess)
-000110c: 00                                        ; local decl count
-000110d: 41                                        ; i32.const
-000110e: 01                                        ; i32 literal
-000110f: 24                                        ; set_global
-0001110: 00                                        ; global index
-0001111: 0b                                        ; end
-000110b: 06                                        ; FIXUP func body size
+0001107: 00                                        ; func body size (guess)
+0001108: 00                                        ; local decl count
+0001109: 41                                        ; i32.const
+000110a: 01                                        ; i32 literal
+000110b: 24                                        ; set_global
+000110c: 00                                        ; global index
+000110d: 0b                                        ; end
+0001107: 06                                        ; FIXUP func body size
 ; function body 14
-0001112: 00                                        ; func body size (guess)
-0001113: 00                                        ; local decl count
-0001114: 41                                        ; i32.const
-0001115: 01                                        ; i32 literal
-0001116: 28                                        ; i32.load
-0001117: 02                                        ; alignment
-0001118: 02                                        ; load offset
-0001119: 1a                                        ; drop
-000111a: 0b                                        ; end
-0001112: 08                                        ; FIXUP func body size
+000110e: 00                                        ; func body size (guess)
+000110f: 00                                        ; local decl count
+0001110: 41                                        ; i32.const
+0001111: 01                                        ; i32 literal
+0001112: 28                                        ; i32.load
+0001113: 02                                        ; alignment
+0001114: 02                                        ; load offset
+0001115: 1a                                        ; drop
+0001116: 0b                                        ; end
+000110e: 08                                        ; FIXUP func body size
 ; function body 15
-000111b: 00                                        ; func body size (guess)
-000111c: 00                                        ; local decl count
-000111d: 41                                        ; i32.const
-000111e: 01                                        ; i32 literal
-000111f: 29                                        ; i64.load
-0001120: 03                                        ; alignment
-0001121: 02                                        ; load offset
-0001122: 1a                                        ; drop
-0001123: 0b                                        ; end
-000111b: 08                                        ; FIXUP func body size
+0001117: 00                                        ; func body size (guess)
+0001118: 00                                        ; local decl count
+0001119: 41                                        ; i32.const
+000111a: 01                                        ; i32 literal
+000111b: 29                                        ; i64.load
+000111c: 03                                        ; alignment
+000111d: 02                                        ; load offset
+000111e: 1a                                        ; drop
+000111f: 0b                                        ; end
+0001117: 08                                        ; FIXUP func body size
 ; function body 16
-0001124: 00                                        ; func body size (guess)
-0001125: 00                                        ; local decl count
-0001126: 41                                        ; i32.const
-0001127: 01                                        ; i32 literal
-0001128: 2a                                        ; f32.load
-0001129: 02                                        ; alignment
-000112a: 02                                        ; load offset
-000112b: 1a                                        ; drop
-000112c: 0b                                        ; end
-0001124: 08                                        ; FIXUP func body size
+0001120: 00                                        ; func body size (guess)
+0001121: 00                                        ; local decl count
+0001122: 41                                        ; i32.const
+0001123: 01                                        ; i32 literal
+0001124: 2a                                        ; f32.load
+0001125: 02                                        ; alignment
+0001126: 02                                        ; load offset
+0001127: 1a                                        ; drop
+0001128: 0b                                        ; end
+0001120: 08                                        ; FIXUP func body size
 ; function body 17
-000112d: 00                                        ; func body size (guess)
-000112e: 00                                        ; local decl count
-000112f: 41                                        ; i32.const
-0001130: 01                                        ; i32 literal
-0001131: 2b                                        ; f64.load
-0001132: 03                                        ; alignment
-0001133: 02                                        ; load offset
-0001134: 1a                                        ; drop
-0001135: 0b                                        ; end
-000112d: 08                                        ; FIXUP func body size
+0001129: 00                                        ; func body size (guess)
+000112a: 00                                        ; local decl count
+000112b: 41                                        ; i32.const
+000112c: 01                                        ; i32 literal
+000112d: 2b                                        ; f64.load
+000112e: 03                                        ; alignment
+000112f: 02                                        ; load offset
+0001130: 1a                                        ; drop
+0001131: 0b                                        ; end
+0001129: 08                                        ; FIXUP func body size
 ; function body 18
-0001136: 00                                        ; func body size (guess)
-0001137: 00                                        ; local decl count
-0001138: 41                                        ; i32.const
-0001139: 01                                        ; i32 literal
-000113a: 2c                                        ; i32.load8_s
-000113b: 00                                        ; alignment
-000113c: 02                                        ; load offset
-000113d: 1a                                        ; drop
-000113e: 0b                                        ; end
-0001136: 08                                        ; FIXUP func body size
+0001132: 00                                        ; func body size (guess)
+0001133: 00                                        ; local decl count
+0001134: 41                                        ; i32.const
+0001135: 01                                        ; i32 literal
+0001136: 2c                                        ; i32.load8_s
+0001137: 00                                        ; alignment
+0001138: 02                                        ; load offset
+0001139: 1a                                        ; drop
+000113a: 0b                                        ; end
+0001132: 08                                        ; FIXUP func body size
 ; function body 19
-000113f: 00                                        ; func body size (guess)
-0001140: 00                                        ; local decl count
-0001141: 41                                        ; i32.const
-0001142: 01                                        ; i32 literal
-0001143: 2d                                        ; i32.load8_u
-0001144: 00                                        ; alignment
-0001145: 02                                        ; load offset
-0001146: 1a                                        ; drop
-0001147: 0b                                        ; end
-000113f: 08                                        ; FIXUP func body size
+000113b: 00                                        ; func body size (guess)
+000113c: 00                                        ; local decl count
+000113d: 41                                        ; i32.const
+000113e: 01                                        ; i32 literal
+000113f: 2d                                        ; i32.load8_u
+0001140: 00                                        ; alignment
+0001141: 02                                        ; load offset
+0001142: 1a                                        ; drop
+0001143: 0b                                        ; end
+000113b: 08                                        ; FIXUP func body size
 ; function body 20
-0001148: 00                                        ; func body size (guess)
-0001149: 00                                        ; local decl count
-000114a: 41                                        ; i32.const
-000114b: 01                                        ; i32 literal
-000114c: 2e                                        ; i32.load16_s
-000114d: 01                                        ; alignment
-000114e: 02                                        ; load offset
-000114f: 1a                                        ; drop
-0001150: 0b                                        ; end
-0001148: 08                                        ; FIXUP func body size
+0001144: 00                                        ; func body size (guess)
+0001145: 00                                        ; local decl count
+0001146: 41                                        ; i32.const
+0001147: 01                                        ; i32 literal
+0001148: 2e                                        ; i32.load16_s
+0001149: 01                                        ; alignment
+000114a: 02                                        ; load offset
+000114b: 1a                                        ; drop
+000114c: 0b                                        ; end
+0001144: 08                                        ; FIXUP func body size
 ; function body 21
-0001151: 00                                        ; func body size (guess)
-0001152: 00                                        ; local decl count
-0001153: 41                                        ; i32.const
-0001154: 01                                        ; i32 literal
-0001155: 2f                                        ; i32.load16_u
-0001156: 01                                        ; alignment
-0001157: 02                                        ; load offset
-0001158: 1a                                        ; drop
-0001159: 0b                                        ; end
-0001151: 08                                        ; FIXUP func body size
+000114d: 00                                        ; func body size (guess)
+000114e: 00                                        ; local decl count
+000114f: 41                                        ; i32.const
+0001150: 01                                        ; i32 literal
+0001151: 2f                                        ; i32.load16_u
+0001152: 01                                        ; alignment
+0001153: 02                                        ; load offset
+0001154: 1a                                        ; drop
+0001155: 0b                                        ; end
+000114d: 08                                        ; FIXUP func body size
 ; function body 22
-000115a: 00                                        ; func body size (guess)
-000115b: 00                                        ; local decl count
-000115c: 41                                        ; i32.const
-000115d: 01                                        ; i32 literal
-000115e: 30                                        ; i64.load8_s
-000115f: 00                                        ; alignment
-0001160: 02                                        ; load offset
-0001161: 1a                                        ; drop
-0001162: 0b                                        ; end
-000115a: 08                                        ; FIXUP func body size
+0001156: 00                                        ; func body size (guess)
+0001157: 00                                        ; local decl count
+0001158: 41                                        ; i32.const
+0001159: 01                                        ; i32 literal
+000115a: 30                                        ; i64.load8_s
+000115b: 00                                        ; alignment
+000115c: 02                                        ; load offset
+000115d: 1a                                        ; drop
+000115e: 0b                                        ; end
+0001156: 08                                        ; FIXUP func body size
 ; function body 23
-0001163: 00                                        ; func body size (guess)
-0001164: 00                                        ; local decl count
-0001165: 41                                        ; i32.const
-0001166: 01                                        ; i32 literal
-0001167: 31                                        ; i64.load8_u
-0001168: 00                                        ; alignment
-0001169: 02                                        ; load offset
-000116a: 1a                                        ; drop
-000116b: 0b                                        ; end
-0001163: 08                                        ; FIXUP func body size
+000115f: 00                                        ; func body size (guess)
+0001160: 00                                        ; local decl count
+0001161: 41                                        ; i32.const
+0001162: 01                                        ; i32 literal
+0001163: 31                                        ; i64.load8_u
+0001164: 00                                        ; alignment
+0001165: 02                                        ; load offset
+0001166: 1a                                        ; drop
+0001167: 0b                                        ; end
+000115f: 08                                        ; FIXUP func body size
 ; function body 24
-000116c: 00                                        ; func body size (guess)
-000116d: 00                                        ; local decl count
-000116e: 41                                        ; i32.const
-000116f: 01                                        ; i32 literal
-0001170: 32                                        ; i64.load16_s
-0001171: 01                                        ; alignment
-0001172: 02                                        ; load offset
-0001173: 1a                                        ; drop
-0001174: 0b                                        ; end
-000116c: 08                                        ; FIXUP func body size
+0001168: 00                                        ; func body size (guess)
+0001169: 00                                        ; local decl count
+000116a: 41                                        ; i32.const
+000116b: 01                                        ; i32 literal
+000116c: 32                                        ; i64.load16_s
+000116d: 01                                        ; alignment
+000116e: 02                                        ; load offset
+000116f: 1a                                        ; drop
+0001170: 0b                                        ; end
+0001168: 08                                        ; FIXUP func body size
 ; function body 25
-0001175: 00                                        ; func body size (guess)
-0001176: 00                                        ; local decl count
-0001177: 41                                        ; i32.const
-0001178: 01                                        ; i32 literal
-0001179: 33                                        ; i64.load16_u
-000117a: 01                                        ; alignment
-000117b: 02                                        ; load offset
-000117c: 1a                                        ; drop
-000117d: 0b                                        ; end
-0001175: 08                                        ; FIXUP func body size
+0001171: 00                                        ; func body size (guess)
+0001172: 00                                        ; local decl count
+0001173: 41                                        ; i32.const
+0001174: 01                                        ; i32 literal
+0001175: 33                                        ; i64.load16_u
+0001176: 01                                        ; alignment
+0001177: 02                                        ; load offset
+0001178: 1a                                        ; drop
+0001179: 0b                                        ; end
+0001171: 08                                        ; FIXUP func body size
 ; function body 26
-000117e: 00                                        ; func body size (guess)
-000117f: 00                                        ; local decl count
-0001180: 41                                        ; i32.const
-0001181: 01                                        ; i32 literal
-0001182: 34                                        ; i64.load32_s
-0001183: 02                                        ; alignment
-0001184: 02                                        ; load offset
-0001185: 1a                                        ; drop
-0001186: 0b                                        ; end
-000117e: 08                                        ; FIXUP func body size
+000117a: 00                                        ; func body size (guess)
+000117b: 00                                        ; local decl count
+000117c: 41                                        ; i32.const
+000117d: 01                                        ; i32 literal
+000117e: 34                                        ; i64.load32_s
+000117f: 02                                        ; alignment
+0001180: 02                                        ; load offset
+0001181: 1a                                        ; drop
+0001182: 0b                                        ; end
+000117a: 08                                        ; FIXUP func body size
 ; function body 27
-0001187: 00                                        ; func body size (guess)
-0001188: 00                                        ; local decl count
-0001189: 41                                        ; i32.const
-000118a: 01                                        ; i32 literal
-000118b: 35                                        ; i64.load32_u
-000118c: 02                                        ; alignment
-000118d: 02                                        ; load offset
-000118e: 1a                                        ; drop
-000118f: 0b                                        ; end
-0001187: 08                                        ; FIXUP func body size
+0001183: 00                                        ; func body size (guess)
+0001184: 00                                        ; local decl count
+0001185: 41                                        ; i32.const
+0001186: 01                                        ; i32 literal
+0001187: 35                                        ; i64.load32_u
+0001188: 02                                        ; alignment
+0001189: 02                                        ; load offset
+000118a: 1a                                        ; drop
+000118b: 0b                                        ; end
+0001183: 08                                        ; FIXUP func body size
 ; function body 28
-0001190: 00                                        ; func body size (guess)
-0001191: 00                                        ; local decl count
-0001192: 41                                        ; i32.const
-0001193: 01                                        ; i32 literal
-0001194: 41                                        ; i32.const
-0001195: 02                                        ; i32 literal
-0001196: 36                                        ; i32.store
-0001197: 02                                        ; alignment
-0001198: 02                                        ; store offset
-0001199: 0b                                        ; end
-0001190: 09                                        ; FIXUP func body size
+000118c: 00                                        ; func body size (guess)
+000118d: 00                                        ; local decl count
+000118e: 41                                        ; i32.const
+000118f: 01                                        ; i32 literal
+0001190: 41                                        ; i32.const
+0001191: 02                                        ; i32 literal
+0001192: 36                                        ; i32.store
+0001193: 02                                        ; alignment
+0001194: 02                                        ; store offset
+0001195: 0b                                        ; end
+000118c: 09                                        ; FIXUP func body size
 ; function body 29
-000119a: 00                                        ; func body size (guess)
-000119b: 00                                        ; local decl count
-000119c: 41                                        ; i32.const
-000119d: 01                                        ; i32 literal
-000119e: 42                                        ; i64.const
-000119f: 02                                        ; i64 literal
-00011a0: 37                                        ; i64.store
-00011a1: 03                                        ; alignment
-00011a2: 02                                        ; store offset
-00011a3: 0b                                        ; end
-000119a: 09                                        ; FIXUP func body size
+0001196: 00                                        ; func body size (guess)
+0001197: 00                                        ; local decl count
+0001198: 41                                        ; i32.const
+0001199: 01                                        ; i32 literal
+000119a: 42                                        ; i64.const
+000119b: 02                                        ; i64 literal
+000119c: 37                                        ; i64.store
+000119d: 03                                        ; alignment
+000119e: 02                                        ; store offset
+000119f: 0b                                        ; end
+0001196: 09                                        ; FIXUP func body size
 ; function body 30
-00011a4: 00                                        ; func body size (guess)
-00011a5: 00                                        ; local decl count
-00011a6: 41                                        ; i32.const
-00011a7: 01                                        ; i32 literal
-00011a8: 43                                        ; f32.const
-00011a9: 0000 0040                                 ; f32 literal
-00011ad: 38                                        ; f32.store
-00011ae: 02                                        ; alignment
-00011af: 02                                        ; store offset
-00011b0: 0b                                        ; end
-00011a4: 0c                                        ; FIXUP func body size
+00011a0: 00                                        ; func body size (guess)
+00011a1: 00                                        ; local decl count
+00011a2: 41                                        ; i32.const
+00011a3: 01                                        ; i32 literal
+00011a4: 43                                        ; f32.const
+00011a5: 0000 0040                                 ; f32 literal
+00011a9: 38                                        ; f32.store
+00011aa: 02                                        ; alignment
+00011ab: 02                                        ; store offset
+00011ac: 0b                                        ; end
+00011a0: 0c                                        ; FIXUP func body size
 ; function body 31
-00011b1: 00                                        ; func body size (guess)
-00011b2: 00                                        ; local decl count
-00011b3: 41                                        ; i32.const
-00011b4: 01                                        ; i32 literal
-00011b5: 44                                        ; f64.const
-00011b6: 0000 0000 0000 0040                       ; f64 literal
-00011be: 39                                        ; f64.store
-00011bf: 03                                        ; alignment
-00011c0: 02                                        ; store offset
-00011c1: 0b                                        ; end
-00011b1: 10                                        ; FIXUP func body size
+00011ad: 00                                        ; func body size (guess)
+00011ae: 00                                        ; local decl count
+00011af: 41                                        ; i32.const
+00011b0: 01                                        ; i32 literal
+00011b1: 44                                        ; f64.const
+00011b2: 0000 0000 0000 0040                       ; f64 literal
+00011ba: 39                                        ; f64.store
+00011bb: 03                                        ; alignment
+00011bc: 02                                        ; store offset
+00011bd: 0b                                        ; end
+00011ad: 10                                        ; FIXUP func body size
 ; function body 32
-00011c2: 00                                        ; func body size (guess)
-00011c3: 00                                        ; local decl count
-00011c4: 41                                        ; i32.const
-00011c5: 01                                        ; i32 literal
-00011c6: 41                                        ; i32.const
-00011c7: 02                                        ; i32 literal
-00011c8: 3a                                        ; i32.store8
-00011c9: 00                                        ; alignment
-00011ca: 02                                        ; store offset
-00011cb: 0b                                        ; end
-00011c2: 09                                        ; FIXUP func body size
+00011be: 00                                        ; func body size (guess)
+00011bf: 00                                        ; local decl count
+00011c0: 41                                        ; i32.const
+00011c1: 01                                        ; i32 literal
+00011c2: 41                                        ; i32.const
+00011c3: 02                                        ; i32 literal
+00011c4: 3a                                        ; i32.store8
+00011c5: 00                                        ; alignment
+00011c6: 02                                        ; store offset
+00011c7: 0b                                        ; end
+00011be: 09                                        ; FIXUP func body size
 ; function body 33
-00011cc: 00                                        ; func body size (guess)
-00011cd: 00                                        ; local decl count
-00011ce: 41                                        ; i32.const
-00011cf: 01                                        ; i32 literal
-00011d0: 41                                        ; i32.const
-00011d1: 02                                        ; i32 literal
-00011d2: 3b                                        ; i32.store16
-00011d3: 01                                        ; alignment
-00011d4: 02                                        ; store offset
-00011d5: 0b                                        ; end
-00011cc: 09                                        ; FIXUP func body size
+00011c8: 00                                        ; func body size (guess)
+00011c9: 00                                        ; local decl count
+00011ca: 41                                        ; i32.const
+00011cb: 01                                        ; i32 literal
+00011cc: 41                                        ; i32.const
+00011cd: 02                                        ; i32 literal
+00011ce: 3b                                        ; i32.store16
+00011cf: 01                                        ; alignment
+00011d0: 02                                        ; store offset
+00011d1: 0b                                        ; end
+00011c8: 09                                        ; FIXUP func body size
 ; function body 34
-00011d6: 00                                        ; func body size (guess)
-00011d7: 00                                        ; local decl count
-00011d8: 41                                        ; i32.const
-00011d9: 01                                        ; i32 literal
-00011da: 42                                        ; i64.const
-00011db: 02                                        ; i64 literal
-00011dc: 3c                                        ; i64.store8
-00011dd: 00                                        ; alignment
-00011de: 02                                        ; store offset
-00011df: 0b                                        ; end
-00011d6: 09                                        ; FIXUP func body size
+00011d2: 00                                        ; func body size (guess)
+00011d3: 00                                        ; local decl count
+00011d4: 41                                        ; i32.const
+00011d5: 01                                        ; i32 literal
+00011d6: 42                                        ; i64.const
+00011d7: 02                                        ; i64 literal
+00011d8: 3c                                        ; i64.store8
+00011d9: 00                                        ; alignment
+00011da: 02                                        ; store offset
+00011db: 0b                                        ; end
+00011d2: 09                                        ; FIXUP func body size
 ; function body 35
-00011e0: 00                                        ; func body size (guess)
-00011e1: 00                                        ; local decl count
-00011e2: 41                                        ; i32.const
-00011e3: 01                                        ; i32 literal
-00011e4: 42                                        ; i64.const
-00011e5: 02                                        ; i64 literal
-00011e6: 3d                                        ; i64.store16
-00011e7: 01                                        ; alignment
-00011e8: 02                                        ; store offset
-00011e9: 0b                                        ; end
-00011e0: 09                                        ; FIXUP func body size
+00011dc: 00                                        ; func body size (guess)
+00011dd: 00                                        ; local decl count
+00011de: 41                                        ; i32.const
+00011df: 01                                        ; i32 literal
+00011e0: 42                                        ; i64.const
+00011e1: 02                                        ; i64 literal
+00011e2: 3d                                        ; i64.store16
+00011e3: 01                                        ; alignment
+00011e4: 02                                        ; store offset
+00011e5: 0b                                        ; end
+00011dc: 09                                        ; FIXUP func body size
 ; function body 36
-00011ea: 00                                        ; func body size (guess)
-00011eb: 00                                        ; local decl count
-00011ec: 41                                        ; i32.const
-00011ed: 01                                        ; i32 literal
-00011ee: 42                                        ; i64.const
-00011ef: 02                                        ; i64 literal
-00011f0: 3e                                        ; i64.store32
-00011f1: 02                                        ; alignment
-00011f2: 02                                        ; store offset
-00011f3: 0b                                        ; end
-00011ea: 09                                        ; FIXUP func body size
+00011e6: 00                                        ; func body size (guess)
+00011e7: 00                                        ; local decl count
+00011e8: 41                                        ; i32.const
+00011e9: 01                                        ; i32 literal
+00011ea: 42                                        ; i64.const
+00011eb: 02                                        ; i64 literal
+00011ec: 3e                                        ; i64.store32
+00011ed: 02                                        ; alignment
+00011ee: 02                                        ; store offset
+00011ef: 0b                                        ; end
+00011e6: 09                                        ; FIXUP func body size
 ; function body 37
-00011f4: 00                                        ; func body size (guess)
-00011f5: 00                                        ; local decl count
-00011f6: 3f                                        ; current_memory
-00011f7: 00                                        ; current_memory reserved
-00011f8: 1a                                        ; drop
-00011f9: 0b                                        ; end
-00011f4: 05                                        ; FIXUP func body size
+00011f0: 00                                        ; func body size (guess)
+00011f1: 00                                        ; local decl count
+00011f2: 3f                                        ; current_memory
+00011f3: 00                                        ; current_memory reserved
+00011f4: 1a                                        ; drop
+00011f5: 0b                                        ; end
+00011f0: 05                                        ; FIXUP func body size
 ; function body 38
-00011fa: 00                                        ; func body size (guess)
-00011fb: 00                                        ; local decl count
-00011fc: 41                                        ; i32.const
-00011fd: 01                                        ; i32 literal
-00011fe: 40                                        ; grow_memory
-00011ff: 00                                        ; grow_memory reserved
-0001200: 1a                                        ; drop
-0001201: 0b                                        ; end
-00011fa: 07                                        ; FIXUP func body size
+00011f6: 00                                        ; func body size (guess)
+00011f7: 00                                        ; local decl count
+00011f8: 41                                        ; i32.const
+00011f9: 01                                        ; i32 literal
+00011fa: 40                                        ; grow_memory
+00011fb: 00                                        ; grow_memory reserved
+00011fc: 1a                                        ; drop
+00011fd: 0b                                        ; end
+00011f6: 07                                        ; FIXUP func body size
 ; function body 39
-0001202: 00                                        ; func body size (guess)
-0001203: 00                                        ; local decl count
-0001204: 41                                        ; i32.const
-0001205: 01                                        ; i32 literal
-0001206: 1a                                        ; drop
-0001207: 0b                                        ; end
-0001202: 05                                        ; FIXUP func body size
+00011fe: 00                                        ; func body size (guess)
+00011ff: 00                                        ; local decl count
+0001200: 41                                        ; i32.const
+0001201: 01                                        ; i32 literal
+0001202: 1a                                        ; drop
+0001203: 0b                                        ; end
+00011fe: 05                                        ; FIXUP func body size
 ; function body 40
-0001208: 00                                        ; func body size (guess)
-0001209: 00                                        ; local decl count
-000120a: 42                                        ; i64.const
-000120b: 01                                        ; i64 literal
-000120c: 1a                                        ; drop
-000120d: 0b                                        ; end
-0001208: 05                                        ; FIXUP func body size
+0001204: 00                                        ; func body size (guess)
+0001205: 00                                        ; local decl count
+0001206: 42                                        ; i64.const
+0001207: 01                                        ; i64 literal
+0001208: 1a                                        ; drop
+0001209: 0b                                        ; end
+0001204: 05                                        ; FIXUP func body size
 ; function body 41
-000120e: 00                                        ; func body size (guess)
-000120f: 00                                        ; local decl count
-0001210: 43                                        ; f32.const
-0001211: 0000 803f                                 ; f32 literal
-0001215: 1a                                        ; drop
-0001216: 0b                                        ; end
-000120e: 08                                        ; FIXUP func body size
+000120a: 00                                        ; func body size (guess)
+000120b: 00                                        ; local decl count
+000120c: 43                                        ; f32.const
+000120d: 0000 803f                                 ; f32 literal
+0001211: 1a                                        ; drop
+0001212: 0b                                        ; end
+000120a: 08                                        ; FIXUP func body size
 ; function body 42
-0001217: 00                                        ; func body size (guess)
-0001218: 00                                        ; local decl count
-0001219: 44                                        ; f64.const
-000121a: 0000 0000 0000 f03f                       ; f64 literal
-0001222: 1a                                        ; drop
-0001223: 0b                                        ; end
-0001217: 0c                                        ; FIXUP func body size
+0001213: 00                                        ; func body size (guess)
+0001214: 00                                        ; local decl count
+0001215: 44                                        ; f64.const
+0001216: 0000 0000 0000 f03f                       ; f64 literal
+000121e: 1a                                        ; drop
+000121f: 0b                                        ; end
+0001213: 0c                                        ; FIXUP func body size
 ; function body 43
-0001224: 00                                        ; func body size (guess)
-0001225: 00                                        ; local decl count
-0001226: 41                                        ; i32.const
-0001227: 01                                        ; i32 literal
-0001228: 45                                        ; i32.eqz
-0001229: 1a                                        ; drop
-000122a: 0b                                        ; end
-0001224: 06                                        ; FIXUP func body size
+0001220: 00                                        ; func body size (guess)
+0001221: 00                                        ; local decl count
+0001222: 41                                        ; i32.const
+0001223: 01                                        ; i32 literal
+0001224: 45                                        ; i32.eqz
+0001225: 1a                                        ; drop
+0001226: 0b                                        ; end
+0001220: 06                                        ; FIXUP func body size
 ; function body 44
-000122b: 00                                        ; func body size (guess)
-000122c: 00                                        ; local decl count
-000122d: 41                                        ; i32.const
-000122e: 01                                        ; i32 literal
-000122f: 41                                        ; i32.const
-0001230: 02                                        ; i32 literal
-0001231: 46                                        ; i32.eq
-0001232: 1a                                        ; drop
-0001233: 0b                                        ; end
-000122b: 08                                        ; FIXUP func body size
+0001227: 00                                        ; func body size (guess)
+0001228: 00                                        ; local decl count
+0001229: 41                                        ; i32.const
+000122a: 01                                        ; i32 literal
+000122b: 41                                        ; i32.const
+000122c: 02                                        ; i32 literal
+000122d: 46                                        ; i32.eq
+000122e: 1a                                        ; drop
+000122f: 0b                                        ; end
+0001227: 08                                        ; FIXUP func body size
 ; function body 45
-0001234: 00                                        ; func body size (guess)
-0001235: 00                                        ; local decl count
-0001236: 41                                        ; i32.const
-0001237: 01                                        ; i32 literal
-0001238: 41                                        ; i32.const
-0001239: 02                                        ; i32 literal
-000123a: 47                                        ; i32.ne
-000123b: 1a                                        ; drop
-000123c: 0b                                        ; end
-0001234: 08                                        ; FIXUP func body size
+0001230: 00                                        ; func body size (guess)
+0001231: 00                                        ; local decl count
+0001232: 41                                        ; i32.const
+0001233: 01                                        ; i32 literal
+0001234: 41                                        ; i32.const
+0001235: 02                                        ; i32 literal
+0001236: 47                                        ; i32.ne
+0001237: 1a                                        ; drop
+0001238: 0b                                        ; end
+0001230: 08                                        ; FIXUP func body size
 ; function body 46
-000123d: 00                                        ; func body size (guess)
-000123e: 00                                        ; local decl count
-000123f: 41                                        ; i32.const
-0001240: 01                                        ; i32 literal
-0001241: 41                                        ; i32.const
-0001242: 02                                        ; i32 literal
-0001243: 48                                        ; i32.lt_s
-0001244: 1a                                        ; drop
-0001245: 0b                                        ; end
-000123d: 08                                        ; FIXUP func body size
+0001239: 00                                        ; func body size (guess)
+000123a: 00                                        ; local decl count
+000123b: 41                                        ; i32.const
+000123c: 01                                        ; i32 literal
+000123d: 41                                        ; i32.const
+000123e: 02                                        ; i32 literal
+000123f: 48                                        ; i32.lt_s
+0001240: 1a                                        ; drop
+0001241: 0b                                        ; end
+0001239: 08                                        ; FIXUP func body size
 ; function body 47
-0001246: 00                                        ; func body size (guess)
-0001247: 00                                        ; local decl count
-0001248: 41                                        ; i32.const
-0001249: 01                                        ; i32 literal
-000124a: 41                                        ; i32.const
-000124b: 02                                        ; i32 literal
-000124c: 49                                        ; i32.lt_u
-000124d: 1a                                        ; drop
-000124e: 0b                                        ; end
-0001246: 08                                        ; FIXUP func body size
+0001242: 00                                        ; func body size (guess)
+0001243: 00                                        ; local decl count
+0001244: 41                                        ; i32.const
+0001245: 01                                        ; i32 literal
+0001246: 41                                        ; i32.const
+0001247: 02                                        ; i32 literal
+0001248: 49                                        ; i32.lt_u
+0001249: 1a                                        ; drop
+000124a: 0b                                        ; end
+0001242: 08                                        ; FIXUP func body size
 ; function body 48
-000124f: 00                                        ; func body size (guess)
-0001250: 00                                        ; local decl count
-0001251: 41                                        ; i32.const
-0001252: 01                                        ; i32 literal
-0001253: 41                                        ; i32.const
-0001254: 02                                        ; i32 literal
-0001255: 4a                                        ; i32.gt_s
-0001256: 1a                                        ; drop
-0001257: 0b                                        ; end
-000124f: 08                                        ; FIXUP func body size
+000124b: 00                                        ; func body size (guess)
+000124c: 00                                        ; local decl count
+000124d: 41                                        ; i32.const
+000124e: 01                                        ; i32 literal
+000124f: 41                                        ; i32.const
+0001250: 02                                        ; i32 literal
+0001251: 4a                                        ; i32.gt_s
+0001252: 1a                                        ; drop
+0001253: 0b                                        ; end
+000124b: 08                                        ; FIXUP func body size
 ; function body 49
-0001258: 00                                        ; func body size (guess)
-0001259: 00                                        ; local decl count
-000125a: 41                                        ; i32.const
-000125b: 01                                        ; i32 literal
-000125c: 41                                        ; i32.const
-000125d: 02                                        ; i32 literal
-000125e: 4b                                        ; i32.gt_u
-000125f: 1a                                        ; drop
-0001260: 0b                                        ; end
-0001258: 08                                        ; FIXUP func body size
+0001254: 00                                        ; func body size (guess)
+0001255: 00                                        ; local decl count
+0001256: 41                                        ; i32.const
+0001257: 01                                        ; i32 literal
+0001258: 41                                        ; i32.const
+0001259: 02                                        ; i32 literal
+000125a: 4b                                        ; i32.gt_u
+000125b: 1a                                        ; drop
+000125c: 0b                                        ; end
+0001254: 08                                        ; FIXUP func body size
 ; function body 50
-0001261: 00                                        ; func body size (guess)
-0001262: 00                                        ; local decl count
-0001263: 41                                        ; i32.const
-0001264: 01                                        ; i32 literal
-0001265: 41                                        ; i32.const
-0001266: 02                                        ; i32 literal
-0001267: 4c                                        ; i32.le_s
-0001268: 1a                                        ; drop
-0001269: 0b                                        ; end
-0001261: 08                                        ; FIXUP func body size
+000125d: 00                                        ; func body size (guess)
+000125e: 00                                        ; local decl count
+000125f: 41                                        ; i32.const
+0001260: 01                                        ; i32 literal
+0001261: 41                                        ; i32.const
+0001262: 02                                        ; i32 literal
+0001263: 4c                                        ; i32.le_s
+0001264: 1a                                        ; drop
+0001265: 0b                                        ; end
+000125d: 08                                        ; FIXUP func body size
 ; function body 51
-000126a: 00                                        ; func body size (guess)
-000126b: 00                                        ; local decl count
-000126c: 41                                        ; i32.const
-000126d: 01                                        ; i32 literal
-000126e: 41                                        ; i32.const
-000126f: 02                                        ; i32 literal
-0001270: 4d                                        ; i32.le_u
-0001271: 1a                                        ; drop
-0001272: 0b                                        ; end
-000126a: 08                                        ; FIXUP func body size
+0001266: 00                                        ; func body size (guess)
+0001267: 00                                        ; local decl count
+0001268: 41                                        ; i32.const
+0001269: 01                                        ; i32 literal
+000126a: 41                                        ; i32.const
+000126b: 02                                        ; i32 literal
+000126c: 4d                                        ; i32.le_u
+000126d: 1a                                        ; drop
+000126e: 0b                                        ; end
+0001266: 08                                        ; FIXUP func body size
 ; function body 52
-0001273: 00                                        ; func body size (guess)
-0001274: 00                                        ; local decl count
-0001275: 41                                        ; i32.const
-0001276: 01                                        ; i32 literal
-0001277: 41                                        ; i32.const
-0001278: 02                                        ; i32 literal
-0001279: 4e                                        ; i32.ge_s
-000127a: 1a                                        ; drop
-000127b: 0b                                        ; end
-0001273: 08                                        ; FIXUP func body size
+000126f: 00                                        ; func body size (guess)
+0001270: 00                                        ; local decl count
+0001271: 41                                        ; i32.const
+0001272: 01                                        ; i32 literal
+0001273: 41                                        ; i32.const
+0001274: 02                                        ; i32 literal
+0001275: 4e                                        ; i32.ge_s
+0001276: 1a                                        ; drop
+0001277: 0b                                        ; end
+000126f: 08                                        ; FIXUP func body size
 ; function body 53
-000127c: 00                                        ; func body size (guess)
-000127d: 00                                        ; local decl count
-000127e: 41                                        ; i32.const
-000127f: 01                                        ; i32 literal
-0001280: 41                                        ; i32.const
-0001281: 02                                        ; i32 literal
-0001282: 4f                                        ; i32.ge_u
-0001283: 1a                                        ; drop
-0001284: 0b                                        ; end
-000127c: 08                                        ; FIXUP func body size
+0001278: 00                                        ; func body size (guess)
+0001279: 00                                        ; local decl count
+000127a: 41                                        ; i32.const
+000127b: 01                                        ; i32 literal
+000127c: 41                                        ; i32.const
+000127d: 02                                        ; i32 literal
+000127e: 4f                                        ; i32.ge_u
+000127f: 1a                                        ; drop
+0001280: 0b                                        ; end
+0001278: 08                                        ; FIXUP func body size
 ; function body 54
-0001285: 00                                        ; func body size (guess)
-0001286: 00                                        ; local decl count
-0001287: 42                                        ; i64.const
-0001288: 01                                        ; i64 literal
-0001289: 50                                        ; i64.eqz
-000128a: 1a                                        ; drop
-000128b: 0b                                        ; end
-0001285: 06                                        ; FIXUP func body size
+0001281: 00                                        ; func body size (guess)
+0001282: 00                                        ; local decl count
+0001283: 42                                        ; i64.const
+0001284: 01                                        ; i64 literal
+0001285: 50                                        ; i64.eqz
+0001286: 1a                                        ; drop
+0001287: 0b                                        ; end
+0001281: 06                                        ; FIXUP func body size
 ; function body 55
-000128c: 00                                        ; func body size (guess)
-000128d: 00                                        ; local decl count
-000128e: 42                                        ; i64.const
-000128f: 01                                        ; i64 literal
-0001290: 42                                        ; i64.const
-0001291: 02                                        ; i64 literal
-0001292: 51                                        ; i64.eq
-0001293: 1a                                        ; drop
-0001294: 0b                                        ; end
-000128c: 08                                        ; FIXUP func body size
+0001288: 00                                        ; func body size (guess)
+0001289: 00                                        ; local decl count
+000128a: 42                                        ; i64.const
+000128b: 01                                        ; i64 literal
+000128c: 42                                        ; i64.const
+000128d: 02                                        ; i64 literal
+000128e: 51                                        ; i64.eq
+000128f: 1a                                        ; drop
+0001290: 0b                                        ; end
+0001288: 08                                        ; FIXUP func body size
 ; function body 56
-0001295: 00                                        ; func body size (guess)
-0001296: 00                                        ; local decl count
-0001297: 42                                        ; i64.const
-0001298: 01                                        ; i64 literal
-0001299: 42                                        ; i64.const
-000129a: 02                                        ; i64 literal
-000129b: 52                                        ; i64.ne
-000129c: 1a                                        ; drop
-000129d: 0b                                        ; end
-0001295: 08                                        ; FIXUP func body size
+0001291: 00                                        ; func body size (guess)
+0001292: 00                                        ; local decl count
+0001293: 42                                        ; i64.const
+0001294: 01                                        ; i64 literal
+0001295: 42                                        ; i64.const
+0001296: 02                                        ; i64 literal
+0001297: 52                                        ; i64.ne
+0001298: 1a                                        ; drop
+0001299: 0b                                        ; end
+0001291: 08                                        ; FIXUP func body size
 ; function body 57
-000129e: 00                                        ; func body size (guess)
-000129f: 00                                        ; local decl count
-00012a0: 42                                        ; i64.const
-00012a1: 01                                        ; i64 literal
-00012a2: 42                                        ; i64.const
-00012a3: 02                                        ; i64 literal
-00012a4: 53                                        ; i64.lt_s
-00012a5: 1a                                        ; drop
-00012a6: 0b                                        ; end
-000129e: 08                                        ; FIXUP func body size
+000129a: 00                                        ; func body size (guess)
+000129b: 00                                        ; local decl count
+000129c: 42                                        ; i64.const
+000129d: 01                                        ; i64 literal
+000129e: 42                                        ; i64.const
+000129f: 02                                        ; i64 literal
+00012a0: 53                                        ; i64.lt_s
+00012a1: 1a                                        ; drop
+00012a2: 0b                                        ; end
+000129a: 08                                        ; FIXUP func body size
 ; function body 58
-00012a7: 00                                        ; func body size (guess)
-00012a8: 00                                        ; local decl count
-00012a9: 42                                        ; i64.const
-00012aa: 01                                        ; i64 literal
-00012ab: 42                                        ; i64.const
-00012ac: 02                                        ; i64 literal
-00012ad: 54                                        ; i64.lt_u
-00012ae: 1a                                        ; drop
-00012af: 0b                                        ; end
-00012a7: 08                                        ; FIXUP func body size
+00012a3: 00                                        ; func body size (guess)
+00012a4: 00                                        ; local decl count
+00012a5: 42                                        ; i64.const
+00012a6: 01                                        ; i64 literal
+00012a7: 42                                        ; i64.const
+00012a8: 02                                        ; i64 literal
+00012a9: 54                                        ; i64.lt_u
+00012aa: 1a                                        ; drop
+00012ab: 0b                                        ; end
+00012a3: 08                                        ; FIXUP func body size
 ; function body 59
-00012b0: 00                                        ; func body size (guess)
-00012b1: 00                                        ; local decl count
-00012b2: 42                                        ; i64.const
-00012b3: 01                                        ; i64 literal
-00012b4: 42                                        ; i64.const
-00012b5: 02                                        ; i64 literal
-00012b6: 55                                        ; i64.gt_s
-00012b7: 1a                                        ; drop
-00012b8: 0b                                        ; end
-00012b0: 08                                        ; FIXUP func body size
+00012ac: 00                                        ; func body size (guess)
+00012ad: 00                                        ; local decl count
+00012ae: 42                                        ; i64.const
+00012af: 01                                        ; i64 literal
+00012b0: 42                                        ; i64.const
+00012b1: 02                                        ; i64 literal
+00012b2: 55                                        ; i64.gt_s
+00012b3: 1a                                        ; drop
+00012b4: 0b                                        ; end
+00012ac: 08                                        ; FIXUP func body size
 ; function body 60
-00012b9: 00                                        ; func body size (guess)
-00012ba: 00                                        ; local decl count
-00012bb: 42                                        ; i64.const
-00012bc: 01                                        ; i64 literal
-00012bd: 42                                        ; i64.const
-00012be: 02                                        ; i64 literal
-00012bf: 56                                        ; i64.gt_u
-00012c0: 1a                                        ; drop
-00012c1: 0b                                        ; end
-00012b9: 08                                        ; FIXUP func body size
+00012b5: 00                                        ; func body size (guess)
+00012b6: 00                                        ; local decl count
+00012b7: 42                                        ; i64.const
+00012b8: 01                                        ; i64 literal
+00012b9: 42                                        ; i64.const
+00012ba: 02                                        ; i64 literal
+00012bb: 56                                        ; i64.gt_u
+00012bc: 1a                                        ; drop
+00012bd: 0b                                        ; end
+00012b5: 08                                        ; FIXUP func body size
 ; function body 61
-00012c2: 00                                        ; func body size (guess)
-00012c3: 00                                        ; local decl count
-00012c4: 42                                        ; i64.const
-00012c5: 01                                        ; i64 literal
-00012c6: 42                                        ; i64.const
-00012c7: 02                                        ; i64 literal
-00012c8: 57                                        ; i64.le_s
-00012c9: 1a                                        ; drop
-00012ca: 0b                                        ; end
-00012c2: 08                                        ; FIXUP func body size
+00012be: 00                                        ; func body size (guess)
+00012bf: 00                                        ; local decl count
+00012c0: 42                                        ; i64.const
+00012c1: 01                                        ; i64 literal
+00012c2: 42                                        ; i64.const
+00012c3: 02                                        ; i64 literal
+00012c4: 57                                        ; i64.le_s
+00012c5: 1a                                        ; drop
+00012c6: 0b                                        ; end
+00012be: 08                                        ; FIXUP func body size
 ; function body 62
-00012cb: 00                                        ; func body size (guess)
-00012cc: 00                                        ; local decl count
-00012cd: 42                                        ; i64.const
-00012ce: 01                                        ; i64 literal
-00012cf: 42                                        ; i64.const
-00012d0: 02                                        ; i64 literal
-00012d1: 58                                        ; i64.le_u
-00012d2: 1a                                        ; drop
-00012d3: 0b                                        ; end
-00012cb: 08                                        ; FIXUP func body size
+00012c7: 00                                        ; func body size (guess)
+00012c8: 00                                        ; local decl count
+00012c9: 42                                        ; i64.const
+00012ca: 01                                        ; i64 literal
+00012cb: 42                                        ; i64.const
+00012cc: 02                                        ; i64 literal
+00012cd: 58                                        ; i64.le_u
+00012ce: 1a                                        ; drop
+00012cf: 0b                                        ; end
+00012c7: 08                                        ; FIXUP func body size
 ; function body 63
-00012d4: 00                                        ; func body size (guess)
-00012d5: 00                                        ; local decl count
-00012d6: 42                                        ; i64.const
-00012d7: 01                                        ; i64 literal
-00012d8: 42                                        ; i64.const
-00012d9: 02                                        ; i64 literal
-00012da: 59                                        ; i64.ge_s
-00012db: 1a                                        ; drop
-00012dc: 0b                                        ; end
-00012d4: 08                                        ; FIXUP func body size
+00012d0: 00                                        ; func body size (guess)
+00012d1: 00                                        ; local decl count
+00012d2: 42                                        ; i64.const
+00012d3: 01                                        ; i64 literal
+00012d4: 42                                        ; i64.const
+00012d5: 02                                        ; i64 literal
+00012d6: 59                                        ; i64.ge_s
+00012d7: 1a                                        ; drop
+00012d8: 0b                                        ; end
+00012d0: 08                                        ; FIXUP func body size
 ; function body 64
-00012dd: 00                                        ; func body size (guess)
-00012de: 00                                        ; local decl count
-00012df: 42                                        ; i64.const
-00012e0: 01                                        ; i64 literal
-00012e1: 42                                        ; i64.const
-00012e2: 02                                        ; i64 literal
-00012e3: 5a                                        ; i64.ge_u
-00012e4: 1a                                        ; drop
-00012e5: 0b                                        ; end
-00012dd: 08                                        ; FIXUP func body size
+00012d9: 00                                        ; func body size (guess)
+00012da: 00                                        ; local decl count
+00012db: 42                                        ; i64.const
+00012dc: 01                                        ; i64 literal
+00012dd: 42                                        ; i64.const
+00012de: 02                                        ; i64 literal
+00012df: 5a                                        ; i64.ge_u
+00012e0: 1a                                        ; drop
+00012e1: 0b                                        ; end
+00012d9: 08                                        ; FIXUP func body size
 ; function body 65
-00012e6: 00                                        ; func body size (guess)
-00012e7: 00                                        ; local decl count
-00012e8: 43                                        ; f32.const
-00012e9: 0000 803f                                 ; f32 literal
-00012ed: 43                                        ; f32.const
-00012ee: 0000 0040                                 ; f32 literal
-00012f2: 5b                                        ; f32.eq
-00012f3: 1a                                        ; drop
-00012f4: 0b                                        ; end
-00012e6: 0e                                        ; FIXUP func body size
+00012e2: 00                                        ; func body size (guess)
+00012e3: 00                                        ; local decl count
+00012e4: 43                                        ; f32.const
+00012e5: 0000 803f                                 ; f32 literal
+00012e9: 43                                        ; f32.const
+00012ea: 0000 0040                                 ; f32 literal
+00012ee: 5b                                        ; f32.eq
+00012ef: 1a                                        ; drop
+00012f0: 0b                                        ; end
+00012e2: 0e                                        ; FIXUP func body size
 ; function body 66
-00012f5: 00                                        ; func body size (guess)
-00012f6: 00                                        ; local decl count
-00012f7: 43                                        ; f32.const
-00012f8: 0000 803f                                 ; f32 literal
-00012fc: 43                                        ; f32.const
-00012fd: 0000 0040                                 ; f32 literal
-0001301: 5c                                        ; f32.ne
-0001302: 1a                                        ; drop
-0001303: 0b                                        ; end
-00012f5: 0e                                        ; FIXUP func body size
+00012f1: 00                                        ; func body size (guess)
+00012f2: 00                                        ; local decl count
+00012f3: 43                                        ; f32.const
+00012f4: 0000 803f                                 ; f32 literal
+00012f8: 43                                        ; f32.const
+00012f9: 0000 0040                                 ; f32 literal
+00012fd: 5c                                        ; f32.ne
+00012fe: 1a                                        ; drop
+00012ff: 0b                                        ; end
+00012f1: 0e                                        ; FIXUP func body size
 ; function body 67
-0001304: 00                                        ; func body size (guess)
-0001305: 00                                        ; local decl count
-0001306: 43                                        ; f32.const
-0001307: 0000 803f                                 ; f32 literal
-000130b: 43                                        ; f32.const
-000130c: 0000 0040                                 ; f32 literal
-0001310: 5d                                        ; f32.lt
-0001311: 1a                                        ; drop
-0001312: 0b                                        ; end
-0001304: 0e                                        ; FIXUP func body size
+0001300: 00                                        ; func body size (guess)
+0001301: 00                                        ; local decl count
+0001302: 43                                        ; f32.const
+0001303: 0000 803f                                 ; f32 literal
+0001307: 43                                        ; f32.const
+0001308: 0000 0040                                 ; f32 literal
+000130c: 5d                                        ; f32.lt
+000130d: 1a                                        ; drop
+000130e: 0b                                        ; end
+0001300: 0e                                        ; FIXUP func body size
 ; function body 68
-0001313: 00                                        ; func body size (guess)
-0001314: 00                                        ; local decl count
-0001315: 43                                        ; f32.const
-0001316: 0000 803f                                 ; f32 literal
-000131a: 43                                        ; f32.const
-000131b: 0000 0040                                 ; f32 literal
-000131f: 5e                                        ; f32.gt
-0001320: 1a                                        ; drop
-0001321: 0b                                        ; end
-0001313: 0e                                        ; FIXUP func body size
+000130f: 00                                        ; func body size (guess)
+0001310: 00                                        ; local decl count
+0001311: 43                                        ; f32.const
+0001312: 0000 803f                                 ; f32 literal
+0001316: 43                                        ; f32.const
+0001317: 0000 0040                                 ; f32 literal
+000131b: 5e                                        ; f32.gt
+000131c: 1a                                        ; drop
+000131d: 0b                                        ; end
+000130f: 0e                                        ; FIXUP func body size
 ; function body 69
-0001322: 00                                        ; func body size (guess)
-0001323: 00                                        ; local decl count
-0001324: 43                                        ; f32.const
-0001325: 0000 803f                                 ; f32 literal
-0001329: 43                                        ; f32.const
-000132a: 0000 0040                                 ; f32 literal
-000132e: 5f                                        ; f32.le
-000132f: 1a                                        ; drop
-0001330: 0b                                        ; end
-0001322: 0e                                        ; FIXUP func body size
+000131e: 00                                        ; func body size (guess)
+000131f: 00                                        ; local decl count
+0001320: 43                                        ; f32.const
+0001321: 0000 803f                                 ; f32 literal
+0001325: 43                                        ; f32.const
+0001326: 0000 0040                                 ; f32 literal
+000132a: 5f                                        ; f32.le
+000132b: 1a                                        ; drop
+000132c: 0b                                        ; end
+000131e: 0e                                        ; FIXUP func body size
 ; function body 70
-0001331: 00                                        ; func body size (guess)
-0001332: 00                                        ; local decl count
-0001333: 43                                        ; f32.const
-0001334: 0000 803f                                 ; f32 literal
-0001338: 43                                        ; f32.const
-0001339: 0000 0040                                 ; f32 literal
-000133d: 60                                        ; f32.ge
-000133e: 1a                                        ; drop
-000133f: 0b                                        ; end
-0001331: 0e                                        ; FIXUP func body size
+000132d: 00                                        ; func body size (guess)
+000132e: 00                                        ; local decl count
+000132f: 43                                        ; f32.const
+0001330: 0000 803f                                 ; f32 literal
+0001334: 43                                        ; f32.const
+0001335: 0000 0040                                 ; f32 literal
+0001339: 60                                        ; f32.ge
+000133a: 1a                                        ; drop
+000133b: 0b                                        ; end
+000132d: 0e                                        ; FIXUP func body size
 ; function body 71
-0001340: 00                                        ; func body size (guess)
-0001341: 00                                        ; local decl count
-0001342: 44                                        ; f64.const
-0001343: 0000 0000 0000 f03f                       ; f64 literal
-000134b: 44                                        ; f64.const
-000134c: 0000 0000 0000 0040                       ; f64 literal
-0001354: 61                                        ; f64.eq
-0001355: 1a                                        ; drop
-0001356: 0b                                        ; end
-0001340: 16                                        ; FIXUP func body size
+000133c: 00                                        ; func body size (guess)
+000133d: 00                                        ; local decl count
+000133e: 44                                        ; f64.const
+000133f: 0000 0000 0000 f03f                       ; f64 literal
+0001347: 44                                        ; f64.const
+0001348: 0000 0000 0000 0040                       ; f64 literal
+0001350: 61                                        ; f64.eq
+0001351: 1a                                        ; drop
+0001352: 0b                                        ; end
+000133c: 16                                        ; FIXUP func body size
 ; function body 72
-0001357: 00                                        ; func body size (guess)
-0001358: 00                                        ; local decl count
-0001359: 44                                        ; f64.const
-000135a: 0000 0000 0000 f03f                       ; f64 literal
-0001362: 44                                        ; f64.const
-0001363: 0000 0000 0000 0040                       ; f64 literal
-000136b: 62                                        ; f64.ne
-000136c: 1a                                        ; drop
-000136d: 0b                                        ; end
-0001357: 16                                        ; FIXUP func body size
+0001353: 00                                        ; func body size (guess)
+0001354: 00                                        ; local decl count
+0001355: 44                                        ; f64.const
+0001356: 0000 0000 0000 f03f                       ; f64 literal
+000135e: 44                                        ; f64.const
+000135f: 0000 0000 0000 0040                       ; f64 literal
+0001367: 62                                        ; f64.ne
+0001368: 1a                                        ; drop
+0001369: 0b                                        ; end
+0001353: 16                                        ; FIXUP func body size
 ; function body 73
-000136e: 00                                        ; func body size (guess)
-000136f: 00                                        ; local decl count
-0001370: 44                                        ; f64.const
-0001371: 0000 0000 0000 f03f                       ; f64 literal
-0001379: 44                                        ; f64.const
-000137a: 0000 0000 0000 0040                       ; f64 literal
-0001382: 63                                        ; f64.lt
-0001383: 1a                                        ; drop
-0001384: 0b                                        ; end
-000136e: 16                                        ; FIXUP func body size
+000136a: 00                                        ; func body size (guess)
+000136b: 00                                        ; local decl count
+000136c: 44                                        ; f64.const
+000136d: 0000 0000 0000 f03f                       ; f64 literal
+0001375: 44                                        ; f64.const
+0001376: 0000 0000 0000 0040                       ; f64 literal
+000137e: 63                                        ; f64.lt
+000137f: 1a                                        ; drop
+0001380: 0b                                        ; end
+000136a: 16                                        ; FIXUP func body size
 ; function body 74
-0001385: 00                                        ; func body size (guess)
-0001386: 00                                        ; local decl count
-0001387: 44                                        ; f64.const
-0001388: 0000 0000 0000 f03f                       ; f64 literal
-0001390: 44                                        ; f64.const
-0001391: 0000 0000 0000 0040                       ; f64 literal
-0001399: 64                                        ; f64.gt
-000139a: 1a                                        ; drop
-000139b: 0b                                        ; end
-0001385: 16                                        ; FIXUP func body size
+0001381: 00                                        ; func body size (guess)
+0001382: 00                                        ; local decl count
+0001383: 44                                        ; f64.const
+0001384: 0000 0000 0000 f03f                       ; f64 literal
+000138c: 44                                        ; f64.const
+000138d: 0000 0000 0000 0040                       ; f64 literal
+0001395: 64                                        ; f64.gt
+0001396: 1a                                        ; drop
+0001397: 0b                                        ; end
+0001381: 16                                        ; FIXUP func body size
 ; function body 75
-000139c: 00                                        ; func body size (guess)
-000139d: 00                                        ; local decl count
-000139e: 44                                        ; f64.const
-000139f: 0000 0000 0000 f03f                       ; f64 literal
-00013a7: 44                                        ; f64.const
-00013a8: 0000 0000 0000 0040                       ; f64 literal
-00013b0: 65                                        ; f64.le
-00013b1: 1a                                        ; drop
-00013b2: 0b                                        ; end
-000139c: 16                                        ; FIXUP func body size
+0001398: 00                                        ; func body size (guess)
+0001399: 00                                        ; local decl count
+000139a: 44                                        ; f64.const
+000139b: 0000 0000 0000 f03f                       ; f64 literal
+00013a3: 44                                        ; f64.const
+00013a4: 0000 0000 0000 0040                       ; f64 literal
+00013ac: 65                                        ; f64.le
+00013ad: 1a                                        ; drop
+00013ae: 0b                                        ; end
+0001398: 16                                        ; FIXUP func body size
 ; function body 76
-00013b3: 00                                        ; func body size (guess)
-00013b4: 00                                        ; local decl count
-00013b5: 44                                        ; f64.const
-00013b6: 0000 0000 0000 f03f                       ; f64 literal
-00013be: 44                                        ; f64.const
-00013bf: 0000 0000 0000 0040                       ; f64 literal
-00013c7: 66                                        ; f64.ge
-00013c8: 1a                                        ; drop
-00013c9: 0b                                        ; end
-00013b3: 16                                        ; FIXUP func body size
+00013af: 00                                        ; func body size (guess)
+00013b0: 00                                        ; local decl count
+00013b1: 44                                        ; f64.const
+00013b2: 0000 0000 0000 f03f                       ; f64 literal
+00013ba: 44                                        ; f64.const
+00013bb: 0000 0000 0000 0040                       ; f64 literal
+00013c3: 66                                        ; f64.ge
+00013c4: 1a                                        ; drop
+00013c5: 0b                                        ; end
+00013af: 16                                        ; FIXUP func body size
 ; function body 77
-00013ca: 00                                        ; func body size (guess)
-00013cb: 00                                        ; local decl count
-00013cc: 41                                        ; i32.const
-00013cd: 01                                        ; i32 literal
-00013ce: 67                                        ; i32.clz
-00013cf: 1a                                        ; drop
-00013d0: 0b                                        ; end
-00013ca: 06                                        ; FIXUP func body size
+00013c6: 00                                        ; func body size (guess)
+00013c7: 00                                        ; local decl count
+00013c8: 41                                        ; i32.const
+00013c9: 01                                        ; i32 literal
+00013ca: 67                                        ; i32.clz
+00013cb: 1a                                        ; drop
+00013cc: 0b                                        ; end
+00013c6: 06                                        ; FIXUP func body size
 ; function body 78
-00013d1: 00                                        ; func body size (guess)
-00013d2: 00                                        ; local decl count
-00013d3: 41                                        ; i32.const
-00013d4: 01                                        ; i32 literal
-00013d5: 68                                        ; i32.ctz
-00013d6: 1a                                        ; drop
-00013d7: 0b                                        ; end
-00013d1: 06                                        ; FIXUP func body size
+00013cd: 00                                        ; func body size (guess)
+00013ce: 00                                        ; local decl count
+00013cf: 41                                        ; i32.const
+00013d0: 01                                        ; i32 literal
+00013d1: 68                                        ; i32.ctz
+00013d2: 1a                                        ; drop
+00013d3: 0b                                        ; end
+00013cd: 06                                        ; FIXUP func body size
 ; function body 79
-00013d8: 00                                        ; func body size (guess)
-00013d9: 00                                        ; local decl count
-00013da: 41                                        ; i32.const
-00013db: 01                                        ; i32 literal
-00013dc: 69                                        ; i32.popcnt
-00013dd: 1a                                        ; drop
-00013de: 0b                                        ; end
-00013d8: 06                                        ; FIXUP func body size
+00013d4: 00                                        ; func body size (guess)
+00013d5: 00                                        ; local decl count
+00013d6: 41                                        ; i32.const
+00013d7: 01                                        ; i32 literal
+00013d8: 69                                        ; i32.popcnt
+00013d9: 1a                                        ; drop
+00013da: 0b                                        ; end
+00013d4: 06                                        ; FIXUP func body size
 ; function body 80
-00013df: 00                                        ; func body size (guess)
-00013e0: 00                                        ; local decl count
-00013e1: 41                                        ; i32.const
-00013e2: 01                                        ; i32 literal
-00013e3: 41                                        ; i32.const
-00013e4: 02                                        ; i32 literal
-00013e5: 6a                                        ; i32.add
-00013e6: 1a                                        ; drop
-00013e7: 0b                                        ; end
-00013df: 08                                        ; FIXUP func body size
+00013db: 00                                        ; func body size (guess)
+00013dc: 00                                        ; local decl count
+00013dd: 41                                        ; i32.const
+00013de: 01                                        ; i32 literal
+00013df: 41                                        ; i32.const
+00013e0: 02                                        ; i32 literal
+00013e1: 6a                                        ; i32.add
+00013e2: 1a                                        ; drop
+00013e3: 0b                                        ; end
+00013db: 08                                        ; FIXUP func body size
 ; function body 81
-00013e8: 00                                        ; func body size (guess)
-00013e9: 00                                        ; local decl count
-00013ea: 41                                        ; i32.const
-00013eb: 01                                        ; i32 literal
-00013ec: 41                                        ; i32.const
-00013ed: 02                                        ; i32 literal
-00013ee: 6b                                        ; i32.sub
-00013ef: 1a                                        ; drop
-00013f0: 0b                                        ; end
-00013e8: 08                                        ; FIXUP func body size
+00013e4: 00                                        ; func body size (guess)
+00013e5: 00                                        ; local decl count
+00013e6: 41                                        ; i32.const
+00013e7: 01                                        ; i32 literal
+00013e8: 41                                        ; i32.const
+00013e9: 02                                        ; i32 literal
+00013ea: 6b                                        ; i32.sub
+00013eb: 1a                                        ; drop
+00013ec: 0b                                        ; end
+00013e4: 08                                        ; FIXUP func body size
 ; function body 82
-00013f1: 00                                        ; func body size (guess)
-00013f2: 00                                        ; local decl count
-00013f3: 41                                        ; i32.const
-00013f4: 01                                        ; i32 literal
-00013f5: 41                                        ; i32.const
-00013f6: 02                                        ; i32 literal
-00013f7: 6c                                        ; i32.mul
-00013f8: 1a                                        ; drop
-00013f9: 0b                                        ; end
-00013f1: 08                                        ; FIXUP func body size
+00013ed: 00                                        ; func body size (guess)
+00013ee: 00                                        ; local decl count
+00013ef: 41                                        ; i32.const
+00013f0: 01                                        ; i32 literal
+00013f1: 41                                        ; i32.const
+00013f2: 02                                        ; i32 literal
+00013f3: 6c                                        ; i32.mul
+00013f4: 1a                                        ; drop
+00013f5: 0b                                        ; end
+00013ed: 08                                        ; FIXUP func body size
 ; function body 83
-00013fa: 00                                        ; func body size (guess)
-00013fb: 00                                        ; local decl count
-00013fc: 41                                        ; i32.const
-00013fd: 01                                        ; i32 literal
-00013fe: 41                                        ; i32.const
-00013ff: 02                                        ; i32 literal
-0001400: 6d                                        ; i32.div_s
-0001401: 1a                                        ; drop
-0001402: 0b                                        ; end
-00013fa: 08                                        ; FIXUP func body size
+00013f6: 00                                        ; func body size (guess)
+00013f7: 00                                        ; local decl count
+00013f8: 41                                        ; i32.const
+00013f9: 01                                        ; i32 literal
+00013fa: 41                                        ; i32.const
+00013fb: 02                                        ; i32 literal
+00013fc: 6d                                        ; i32.div_s
+00013fd: 1a                                        ; drop
+00013fe: 0b                                        ; end
+00013f6: 08                                        ; FIXUP func body size
 ; function body 84
-0001403: 00                                        ; func body size (guess)
-0001404: 00                                        ; local decl count
-0001405: 41                                        ; i32.const
-0001406: 01                                        ; i32 literal
-0001407: 41                                        ; i32.const
-0001408: 02                                        ; i32 literal
-0001409: 6e                                        ; i32.div_u
-000140a: 1a                                        ; drop
-000140b: 0b                                        ; end
-0001403: 08                                        ; FIXUP func body size
+00013ff: 00                                        ; func body size (guess)
+0001400: 00                                        ; local decl count
+0001401: 41                                        ; i32.const
+0001402: 01                                        ; i32 literal
+0001403: 41                                        ; i32.const
+0001404: 02                                        ; i32 literal
+0001405: 6e                                        ; i32.div_u
+0001406: 1a                                        ; drop
+0001407: 0b                                        ; end
+00013ff: 08                                        ; FIXUP func body size
 ; function body 85
-000140c: 00                                        ; func body size (guess)
-000140d: 00                                        ; local decl count
-000140e: 41                                        ; i32.const
-000140f: 01                                        ; i32 literal
-0001410: 41                                        ; i32.const
-0001411: 02                                        ; i32 literal
-0001412: 6f                                        ; i32.rem_s
-0001413: 1a                                        ; drop
-0001414: 0b                                        ; end
-000140c: 08                                        ; FIXUP func body size
+0001408: 00                                        ; func body size (guess)
+0001409: 00                                        ; local decl count
+000140a: 41                                        ; i32.const
+000140b: 01                                        ; i32 literal
+000140c: 41                                        ; i32.const
+000140d: 02                                        ; i32 literal
+000140e: 6f                                        ; i32.rem_s
+000140f: 1a                                        ; drop
+0001410: 0b                                        ; end
+0001408: 08                                        ; FIXUP func body size
 ; function body 86
-0001415: 00                                        ; func body size (guess)
-0001416: 00                                        ; local decl count
-0001417: 41                                        ; i32.const
-0001418: 01                                        ; i32 literal
-0001419: 41                                        ; i32.const
-000141a: 02                                        ; i32 literal
-000141b: 70                                        ; i32.rem_u
-000141c: 1a                                        ; drop
-000141d: 0b                                        ; end
-0001415: 08                                        ; FIXUP func body size
+0001411: 00                                        ; func body size (guess)
+0001412: 00                                        ; local decl count
+0001413: 41                                        ; i32.const
+0001414: 01                                        ; i32 literal
+0001415: 41                                        ; i32.const
+0001416: 02                                        ; i32 literal
+0001417: 70                                        ; i32.rem_u
+0001418: 1a                                        ; drop
+0001419: 0b                                        ; end
+0001411: 08                                        ; FIXUP func body size
 ; function body 87
-000141e: 00                                        ; func body size (guess)
-000141f: 00                                        ; local decl count
-0001420: 41                                        ; i32.const
-0001421: 01                                        ; i32 literal
-0001422: 41                                        ; i32.const
-0001423: 02                                        ; i32 literal
-0001424: 71                                        ; i32.and
-0001425: 1a                                        ; drop
-0001426: 0b                                        ; end
-000141e: 08                                        ; FIXUP func body size
+000141a: 00                                        ; func body size (guess)
+000141b: 00                                        ; local decl count
+000141c: 41                                        ; i32.const
+000141d: 01                                        ; i32 literal
+000141e: 41                                        ; i32.const
+000141f: 02                                        ; i32 literal
+0001420: 71                                        ; i32.and
+0001421: 1a                                        ; drop
+0001422: 0b                                        ; end
+000141a: 08                                        ; FIXUP func body size
 ; function body 88
-0001427: 00                                        ; func body size (guess)
-0001428: 00                                        ; local decl count
-0001429: 41                                        ; i32.const
-000142a: 01                                        ; i32 literal
-000142b: 41                                        ; i32.const
-000142c: 02                                        ; i32 literal
-000142d: 72                                        ; i32.or
-000142e: 1a                                        ; drop
-000142f: 0b                                        ; end
-0001427: 08                                        ; FIXUP func body size
+0001423: 00                                        ; func body size (guess)
+0001424: 00                                        ; local decl count
+0001425: 41                                        ; i32.const
+0001426: 01                                        ; i32 literal
+0001427: 41                                        ; i32.const
+0001428: 02                                        ; i32 literal
+0001429: 72                                        ; i32.or
+000142a: 1a                                        ; drop
+000142b: 0b                                        ; end
+0001423: 08                                        ; FIXUP func body size
 ; function body 89
-0001430: 00                                        ; func body size (guess)
-0001431: 00                                        ; local decl count
-0001432: 41                                        ; i32.const
-0001433: 01                                        ; i32 literal
-0001434: 41                                        ; i32.const
-0001435: 02                                        ; i32 literal
-0001436: 73                                        ; i32.xor
-0001437: 1a                                        ; drop
-0001438: 0b                                        ; end
-0001430: 08                                        ; FIXUP func body size
+000142c: 00                                        ; func body size (guess)
+000142d: 00                                        ; local decl count
+000142e: 41                                        ; i32.const
+000142f: 01                                        ; i32 literal
+0001430: 41                                        ; i32.const
+0001431: 02                                        ; i32 literal
+0001432: 73                                        ; i32.xor
+0001433: 1a                                        ; drop
+0001434: 0b                                        ; end
+000142c: 08                                        ; FIXUP func body size
 ; function body 90
-0001439: 00                                        ; func body size (guess)
-000143a: 00                                        ; local decl count
-000143b: 41                                        ; i32.const
-000143c: 01                                        ; i32 literal
-000143d: 41                                        ; i32.const
-000143e: 02                                        ; i32 literal
-000143f: 74                                        ; i32.shl
-0001440: 1a                                        ; drop
-0001441: 0b                                        ; end
-0001439: 08                                        ; FIXUP func body size
+0001435: 00                                        ; func body size (guess)
+0001436: 00                                        ; local decl count
+0001437: 41                                        ; i32.const
+0001438: 01                                        ; i32 literal
+0001439: 41                                        ; i32.const
+000143a: 02                                        ; i32 literal
+000143b: 74                                        ; i32.shl
+000143c: 1a                                        ; drop
+000143d: 0b                                        ; end
+0001435: 08                                        ; FIXUP func body size
 ; function body 91
-0001442: 00                                        ; func body size (guess)
-0001443: 00                                        ; local decl count
-0001444: 41                                        ; i32.const
-0001445: 01                                        ; i32 literal
-0001446: 41                                        ; i32.const
-0001447: 02                                        ; i32 literal
-0001448: 75                                        ; i32.shr_s
-0001449: 1a                                        ; drop
-000144a: 0b                                        ; end
-0001442: 08                                        ; FIXUP func body size
+000143e: 00                                        ; func body size (guess)
+000143f: 00                                        ; local decl count
+0001440: 41                                        ; i32.const
+0001441: 01                                        ; i32 literal
+0001442: 41                                        ; i32.const
+0001443: 02                                        ; i32 literal
+0001444: 75                                        ; i32.shr_s
+0001445: 1a                                        ; drop
+0001446: 0b                                        ; end
+000143e: 08                                        ; FIXUP func body size
 ; function body 92
-000144b: 00                                        ; func body size (guess)
-000144c: 00                                        ; local decl count
-000144d: 41                                        ; i32.const
-000144e: 01                                        ; i32 literal
-000144f: 41                                        ; i32.const
-0001450: 02                                        ; i32 literal
-0001451: 76                                        ; i32.shr_u
-0001452: 1a                                        ; drop
-0001453: 0b                                        ; end
-000144b: 08                                        ; FIXUP func body size
+0001447: 00                                        ; func body size (guess)
+0001448: 00                                        ; local decl count
+0001449: 41                                        ; i32.const
+000144a: 01                                        ; i32 literal
+000144b: 41                                        ; i32.const
+000144c: 02                                        ; i32 literal
+000144d: 76                                        ; i32.shr_u
+000144e: 1a                                        ; drop
+000144f: 0b                                        ; end
+0001447: 08                                        ; FIXUP func body size
 ; function body 93
-0001454: 00                                        ; func body size (guess)
-0001455: 00                                        ; local decl count
-0001456: 41                                        ; i32.const
-0001457: 01                                        ; i32 literal
-0001458: 41                                        ; i32.const
-0001459: 02                                        ; i32 literal
-000145a: 77                                        ; i32.rotl
-000145b: 1a                                        ; drop
-000145c: 0b                                        ; end
-0001454: 08                                        ; FIXUP func body size
+0001450: 00                                        ; func body size (guess)
+0001451: 00                                        ; local decl count
+0001452: 41                                        ; i32.const
+0001453: 01                                        ; i32 literal
+0001454: 41                                        ; i32.const
+0001455: 02                                        ; i32 literal
+0001456: 77                                        ; i32.rotl
+0001457: 1a                                        ; drop
+0001458: 0b                                        ; end
+0001450: 08                                        ; FIXUP func body size
 ; function body 94
-000145d: 00                                        ; func body size (guess)
-000145e: 00                                        ; local decl count
-000145f: 41                                        ; i32.const
-0001460: 01                                        ; i32 literal
-0001461: 41                                        ; i32.const
-0001462: 02                                        ; i32 literal
-0001463: 78                                        ; i32.rotr
-0001464: 1a                                        ; drop
-0001465: 0b                                        ; end
-000145d: 08                                        ; FIXUP func body size
+0001459: 00                                        ; func body size (guess)
+000145a: 00                                        ; local decl count
+000145b: 41                                        ; i32.const
+000145c: 01                                        ; i32 literal
+000145d: 41                                        ; i32.const
+000145e: 02                                        ; i32 literal
+000145f: 78                                        ; i32.rotr
+0001460: 1a                                        ; drop
+0001461: 0b                                        ; end
+0001459: 08                                        ; FIXUP func body size
 ; function body 95
-0001466: 00                                        ; func body size (guess)
-0001467: 00                                        ; local decl count
-0001468: 42                                        ; i64.const
-0001469: 01                                        ; i64 literal
-000146a: 79                                        ; i64.clz
-000146b: 1a                                        ; drop
-000146c: 0b                                        ; end
-0001466: 06                                        ; FIXUP func body size
+0001462: 00                                        ; func body size (guess)
+0001463: 00                                        ; local decl count
+0001464: 42                                        ; i64.const
+0001465: 01                                        ; i64 literal
+0001466: 79                                        ; i64.clz
+0001467: 1a                                        ; drop
+0001468: 0b                                        ; end
+0001462: 06                                        ; FIXUP func body size
 ; function body 96
-000146d: 00                                        ; func body size (guess)
-000146e: 00                                        ; local decl count
-000146f: 42                                        ; i64.const
-0001470: 01                                        ; i64 literal
-0001471: 7a                                        ; i64.ctz
-0001472: 1a                                        ; drop
-0001473: 0b                                        ; end
-000146d: 06                                        ; FIXUP func body size
+0001469: 00                                        ; func body size (guess)
+000146a: 00                                        ; local decl count
+000146b: 42                                        ; i64.const
+000146c: 01                                        ; i64 literal
+000146d: 7a                                        ; i64.ctz
+000146e: 1a                                        ; drop
+000146f: 0b                                        ; end
+0001469: 06                                        ; FIXUP func body size
 ; function body 97
-0001474: 00                                        ; func body size (guess)
-0001475: 00                                        ; local decl count
-0001476: 42                                        ; i64.const
-0001477: 01                                        ; i64 literal
-0001478: 7b                                        ; i64.popcnt
-0001479: 1a                                        ; drop
-000147a: 0b                                        ; end
-0001474: 06                                        ; FIXUP func body size
+0001470: 00                                        ; func body size (guess)
+0001471: 00                                        ; local decl count
+0001472: 42                                        ; i64.const
+0001473: 01                                        ; i64 literal
+0001474: 7b                                        ; i64.popcnt
+0001475: 1a                                        ; drop
+0001476: 0b                                        ; end
+0001470: 06                                        ; FIXUP func body size
 ; function body 98
-000147b: 00                                        ; func body size (guess)
-000147c: 00                                        ; local decl count
-000147d: 42                                        ; i64.const
-000147e: 01                                        ; i64 literal
-000147f: 42                                        ; i64.const
-0001480: 02                                        ; i64 literal
-0001481: 7c                                        ; i64.add
-0001482: 1a                                        ; drop
-0001483: 0b                                        ; end
-000147b: 08                                        ; FIXUP func body size
+0001477: 00                                        ; func body size (guess)
+0001478: 00                                        ; local decl count
+0001479: 42                                        ; i64.const
+000147a: 01                                        ; i64 literal
+000147b: 42                                        ; i64.const
+000147c: 02                                        ; i64 literal
+000147d: 7c                                        ; i64.add
+000147e: 1a                                        ; drop
+000147f: 0b                                        ; end
+0001477: 08                                        ; FIXUP func body size
 ; function body 99
-0001484: 00                                        ; func body size (guess)
-0001485: 00                                        ; local decl count
-0001486: 42                                        ; i64.const
-0001487: 01                                        ; i64 literal
-0001488: 42                                        ; i64.const
-0001489: 02                                        ; i64 literal
-000148a: 7d                                        ; i64.sub
-000148b: 1a                                        ; drop
-000148c: 0b                                        ; end
-0001484: 08                                        ; FIXUP func body size
+0001480: 00                                        ; func body size (guess)
+0001481: 00                                        ; local decl count
+0001482: 42                                        ; i64.const
+0001483: 01                                        ; i64 literal
+0001484: 42                                        ; i64.const
+0001485: 02                                        ; i64 literal
+0001486: 7d                                        ; i64.sub
+0001487: 1a                                        ; drop
+0001488: 0b                                        ; end
+0001480: 08                                        ; FIXUP func body size
 ; function body 100
-000148d: 00                                        ; func body size (guess)
-000148e: 00                                        ; local decl count
-000148f: 42                                        ; i64.const
-0001490: 01                                        ; i64 literal
-0001491: 42                                        ; i64.const
-0001492: 02                                        ; i64 literal
-0001493: 7e                                        ; i64.mul
-0001494: 1a                                        ; drop
-0001495: 0b                                        ; end
-000148d: 08                                        ; FIXUP func body size
+0001489: 00                                        ; func body size (guess)
+000148a: 00                                        ; local decl count
+000148b: 42                                        ; i64.const
+000148c: 01                                        ; i64 literal
+000148d: 42                                        ; i64.const
+000148e: 02                                        ; i64 literal
+000148f: 7e                                        ; i64.mul
+0001490: 1a                                        ; drop
+0001491: 0b                                        ; end
+0001489: 08                                        ; FIXUP func body size
 ; function body 101
-0001496: 00                                        ; func body size (guess)
-0001497: 00                                        ; local decl count
-0001498: 42                                        ; i64.const
-0001499: 01                                        ; i64 literal
-000149a: 42                                        ; i64.const
-000149b: 02                                        ; i64 literal
-000149c: 7f                                        ; i64.div_s
-000149d: 1a                                        ; drop
-000149e: 0b                                        ; end
-0001496: 08                                        ; FIXUP func body size
+0001492: 00                                        ; func body size (guess)
+0001493: 00                                        ; local decl count
+0001494: 42                                        ; i64.const
+0001495: 01                                        ; i64 literal
+0001496: 42                                        ; i64.const
+0001497: 02                                        ; i64 literal
+0001498: 7f                                        ; i64.div_s
+0001499: 1a                                        ; drop
+000149a: 0b                                        ; end
+0001492: 08                                        ; FIXUP func body size
 ; function body 102
-000149f: 00                                        ; func body size (guess)
-00014a0: 00                                        ; local decl count
-00014a1: 42                                        ; i64.const
-00014a2: 01                                        ; i64 literal
-00014a3: 42                                        ; i64.const
-00014a4: 02                                        ; i64 literal
-00014a5: 80                                        ; i64.div_u
-00014a6: 1a                                        ; drop
-00014a7: 0b                                        ; end
-000149f: 08                                        ; FIXUP func body size
+000149b: 00                                        ; func body size (guess)
+000149c: 00                                        ; local decl count
+000149d: 42                                        ; i64.const
+000149e: 01                                        ; i64 literal
+000149f: 42                                        ; i64.const
+00014a0: 02                                        ; i64 literal
+00014a1: 80                                        ; i64.div_u
+00014a2: 1a                                        ; drop
+00014a3: 0b                                        ; end
+000149b: 08                                        ; FIXUP func body size
 ; function body 103
-00014a8: 00                                        ; func body size (guess)
-00014a9: 00                                        ; local decl count
-00014aa: 42                                        ; i64.const
-00014ab: 01                                        ; i64 literal
-00014ac: 42                                        ; i64.const
-00014ad: 02                                        ; i64 literal
-00014ae: 81                                        ; i64.rem_s
-00014af: 1a                                        ; drop
-00014b0: 0b                                        ; end
-00014a8: 08                                        ; FIXUP func body size
+00014a4: 00                                        ; func body size (guess)
+00014a5: 00                                        ; local decl count
+00014a6: 42                                        ; i64.const
+00014a7: 01                                        ; i64 literal
+00014a8: 42                                        ; i64.const
+00014a9: 02                                        ; i64 literal
+00014aa: 81                                        ; i64.rem_s
+00014ab: 1a                                        ; drop
+00014ac: 0b                                        ; end
+00014a4: 08                                        ; FIXUP func body size
 ; function body 104
-00014b1: 00                                        ; func body size (guess)
-00014b2: 00                                        ; local decl count
-00014b3: 42                                        ; i64.const
-00014b4: 01                                        ; i64 literal
-00014b5: 42                                        ; i64.const
-00014b6: 02                                        ; i64 literal
-00014b7: 82                                        ; i64.rem_u
-00014b8: 1a                                        ; drop
-00014b9: 0b                                        ; end
-00014b1: 08                                        ; FIXUP func body size
+00014ad: 00                                        ; func body size (guess)
+00014ae: 00                                        ; local decl count
+00014af: 42                                        ; i64.const
+00014b0: 01                                        ; i64 literal
+00014b1: 42                                        ; i64.const
+00014b2: 02                                        ; i64 literal
+00014b3: 82                                        ; i64.rem_u
+00014b4: 1a                                        ; drop
+00014b5: 0b                                        ; end
+00014ad: 08                                        ; FIXUP func body size
 ; function body 105
-00014ba: 00                                        ; func body size (guess)
-00014bb: 00                                        ; local decl count
-00014bc: 42                                        ; i64.const
-00014bd: 01                                        ; i64 literal
-00014be: 42                                        ; i64.const
-00014bf: 02                                        ; i64 literal
-00014c0: 83                                        ; i64.and
-00014c1: 1a                                        ; drop
-00014c2: 0b                                        ; end
-00014ba: 08                                        ; FIXUP func body size
+00014b6: 00                                        ; func body size (guess)
+00014b7: 00                                        ; local decl count
+00014b8: 42                                        ; i64.const
+00014b9: 01                                        ; i64 literal
+00014ba: 42                                        ; i64.const
+00014bb: 02                                        ; i64 literal
+00014bc: 83                                        ; i64.and
+00014bd: 1a                                        ; drop
+00014be: 0b                                        ; end
+00014b6: 08                                        ; FIXUP func body size
 ; function body 106
-00014c3: 00                                        ; func body size (guess)
-00014c4: 00                                        ; local decl count
-00014c5: 42                                        ; i64.const
-00014c6: 01                                        ; i64 literal
-00014c7: 42                                        ; i64.const
-00014c8: 02                                        ; i64 literal
-00014c9: 84                                        ; i64.or
-00014ca: 1a                                        ; drop
-00014cb: 0b                                        ; end
-00014c3: 08                                        ; FIXUP func body size
+00014bf: 00                                        ; func body size (guess)
+00014c0: 00                                        ; local decl count
+00014c1: 42                                        ; i64.const
+00014c2: 01                                        ; i64 literal
+00014c3: 42                                        ; i64.const
+00014c4: 02                                        ; i64 literal
+00014c5: 84                                        ; i64.or
+00014c6: 1a                                        ; drop
+00014c7: 0b                                        ; end
+00014bf: 08                                        ; FIXUP func body size
 ; function body 107
-00014cc: 00                                        ; func body size (guess)
-00014cd: 00                                        ; local decl count
-00014ce: 42                                        ; i64.const
-00014cf: 01                                        ; i64 literal
-00014d0: 42                                        ; i64.const
-00014d1: 02                                        ; i64 literal
-00014d2: 85                                        ; i64.xor
-00014d3: 1a                                        ; drop
-00014d4: 0b                                        ; end
-00014cc: 08                                        ; FIXUP func body size
+00014c8: 00                                        ; func body size (guess)
+00014c9: 00                                        ; local decl count
+00014ca: 42                                        ; i64.const
+00014cb: 01                                        ; i64 literal
+00014cc: 42                                        ; i64.const
+00014cd: 02                                        ; i64 literal
+00014ce: 85                                        ; i64.xor
+00014cf: 1a                                        ; drop
+00014d0: 0b                                        ; end
+00014c8: 08                                        ; FIXUP func body size
 ; function body 108
-00014d5: 00                                        ; func body size (guess)
-00014d6: 00                                        ; local decl count
-00014d7: 42                                        ; i64.const
-00014d8: 01                                        ; i64 literal
-00014d9: 42                                        ; i64.const
-00014da: 02                                        ; i64 literal
-00014db: 86                                        ; i64.shl
-00014dc: 1a                                        ; drop
-00014dd: 0b                                        ; end
-00014d5: 08                                        ; FIXUP func body size
+00014d1: 00                                        ; func body size (guess)
+00014d2: 00                                        ; local decl count
+00014d3: 42                                        ; i64.const
+00014d4: 01                                        ; i64 literal
+00014d5: 42                                        ; i64.const
+00014d6: 02                                        ; i64 literal
+00014d7: 86                                        ; i64.shl
+00014d8: 1a                                        ; drop
+00014d9: 0b                                        ; end
+00014d1: 08                                        ; FIXUP func body size
 ; function body 109
-00014de: 00                                        ; func body size (guess)
-00014df: 00                                        ; local decl count
-00014e0: 42                                        ; i64.const
-00014e1: 01                                        ; i64 literal
-00014e2: 42                                        ; i64.const
-00014e3: 02                                        ; i64 literal
-00014e4: 87                                        ; i64.shr_s
-00014e5: 1a                                        ; drop
-00014e6: 0b                                        ; end
-00014de: 08                                        ; FIXUP func body size
+00014da: 00                                        ; func body size (guess)
+00014db: 00                                        ; local decl count
+00014dc: 42                                        ; i64.const
+00014dd: 01                                        ; i64 literal
+00014de: 42                                        ; i64.const
+00014df: 02                                        ; i64 literal
+00014e0: 87                                        ; i64.shr_s
+00014e1: 1a                                        ; drop
+00014e2: 0b                                        ; end
+00014da: 08                                        ; FIXUP func body size
 ; function body 110
-00014e7: 00                                        ; func body size (guess)
-00014e8: 00                                        ; local decl count
-00014e9: 42                                        ; i64.const
-00014ea: 01                                        ; i64 literal
-00014eb: 42                                        ; i64.const
-00014ec: 02                                        ; i64 literal
-00014ed: 88                                        ; i64.shr_u
-00014ee: 1a                                        ; drop
-00014ef: 0b                                        ; end
-00014e7: 08                                        ; FIXUP func body size
+00014e3: 00                                        ; func body size (guess)
+00014e4: 00                                        ; local decl count
+00014e5: 42                                        ; i64.const
+00014e6: 01                                        ; i64 literal
+00014e7: 42                                        ; i64.const
+00014e8: 02                                        ; i64 literal
+00014e9: 88                                        ; i64.shr_u
+00014ea: 1a                                        ; drop
+00014eb: 0b                                        ; end
+00014e3: 08                                        ; FIXUP func body size
 ; function body 111
-00014f0: 00                                        ; func body size (guess)
-00014f1: 00                                        ; local decl count
-00014f2: 42                                        ; i64.const
-00014f3: 01                                        ; i64 literal
-00014f4: 42                                        ; i64.const
-00014f5: 02                                        ; i64 literal
-00014f6: 89                                        ; i64.rotl
-00014f7: 1a                                        ; drop
-00014f8: 0b                                        ; end
-00014f0: 08                                        ; FIXUP func body size
+00014ec: 00                                        ; func body size (guess)
+00014ed: 00                                        ; local decl count
+00014ee: 42                                        ; i64.const
+00014ef: 01                                        ; i64 literal
+00014f0: 42                                        ; i64.const
+00014f1: 02                                        ; i64 literal
+00014f2: 89                                        ; i64.rotl
+00014f3: 1a                                        ; drop
+00014f4: 0b                                        ; end
+00014ec: 08                                        ; FIXUP func body size
 ; function body 112
-00014f9: 00                                        ; func body size (guess)
-00014fa: 00                                        ; local decl count
-00014fb: 42                                        ; i64.const
-00014fc: 01                                        ; i64 literal
-00014fd: 42                                        ; i64.const
-00014fe: 02                                        ; i64 literal
-00014ff: 8a                                        ; i64.rotr
-0001500: 1a                                        ; drop
-0001501: 0b                                        ; end
-00014f9: 08                                        ; FIXUP func body size
+00014f5: 00                                        ; func body size (guess)
+00014f6: 00                                        ; local decl count
+00014f7: 42                                        ; i64.const
+00014f8: 01                                        ; i64 literal
+00014f9: 42                                        ; i64.const
+00014fa: 02                                        ; i64 literal
+00014fb: 8a                                        ; i64.rotr
+00014fc: 1a                                        ; drop
+00014fd: 0b                                        ; end
+00014f5: 08                                        ; FIXUP func body size
 ; function body 113
-0001502: 00                                        ; func body size (guess)
-0001503: 00                                        ; local decl count
-0001504: 43                                        ; f32.const
-0001505: 0000 803f                                 ; f32 literal
-0001509: 8b                                        ; f32.abs
-000150a: 1a                                        ; drop
-000150b: 0b                                        ; end
-0001502: 09                                        ; FIXUP func body size
+00014fe: 00                                        ; func body size (guess)
+00014ff: 00                                        ; local decl count
+0001500: 43                                        ; f32.const
+0001501: 0000 803f                                 ; f32 literal
+0001505: 8b                                        ; f32.abs
+0001506: 1a                                        ; drop
+0001507: 0b                                        ; end
+00014fe: 09                                        ; FIXUP func body size
 ; function body 114
-000150c: 00                                        ; func body size (guess)
-000150d: 00                                        ; local decl count
-000150e: 43                                        ; f32.const
-000150f: 0000 803f                                 ; f32 literal
-0001513: 8c                                        ; f32.neg
-0001514: 1a                                        ; drop
-0001515: 0b                                        ; end
-000150c: 09                                        ; FIXUP func body size
+0001508: 00                                        ; func body size (guess)
+0001509: 00                                        ; local decl count
+000150a: 43                                        ; f32.const
+000150b: 0000 803f                                 ; f32 literal
+000150f: 8c                                        ; f32.neg
+0001510: 1a                                        ; drop
+0001511: 0b                                        ; end
+0001508: 09                                        ; FIXUP func body size
 ; function body 115
-0001516: 00                                        ; func body size (guess)
-0001517: 00                                        ; local decl count
-0001518: 43                                        ; f32.const
-0001519: 0000 803f                                 ; f32 literal
-000151d: 8d                                        ; f32.ceil
-000151e: 1a                                        ; drop
-000151f: 0b                                        ; end
-0001516: 09                                        ; FIXUP func body size
+0001512: 00                                        ; func body size (guess)
+0001513: 00                                        ; local decl count
+0001514: 43                                        ; f32.const
+0001515: 0000 803f                                 ; f32 literal
+0001519: 8d                                        ; f32.ceil
+000151a: 1a                                        ; drop
+000151b: 0b                                        ; end
+0001512: 09                                        ; FIXUP func body size
 ; function body 116
-0001520: 00                                        ; func body size (guess)
-0001521: 00                                        ; local decl count
-0001522: 43                                        ; f32.const
-0001523: 0000 803f                                 ; f32 literal
-0001527: 8e                                        ; f32.floor
-0001528: 1a                                        ; drop
-0001529: 0b                                        ; end
-0001520: 09                                        ; FIXUP func body size
+000151c: 00                                        ; func body size (guess)
+000151d: 00                                        ; local decl count
+000151e: 43                                        ; f32.const
+000151f: 0000 803f                                 ; f32 literal
+0001523: 8e                                        ; f32.floor
+0001524: 1a                                        ; drop
+0001525: 0b                                        ; end
+000151c: 09                                        ; FIXUP func body size
 ; function body 117
-000152a: 00                                        ; func body size (guess)
-000152b: 00                                        ; local decl count
-000152c: 43                                        ; f32.const
-000152d: 0000 803f                                 ; f32 literal
-0001531: 8f                                        ; f32.trunc
-0001532: 1a                                        ; drop
-0001533: 0b                                        ; end
-000152a: 09                                        ; FIXUP func body size
+0001526: 00                                        ; func body size (guess)
+0001527: 00                                        ; local decl count
+0001528: 43                                        ; f32.const
+0001529: 0000 803f                                 ; f32 literal
+000152d: 8f                                        ; f32.trunc
+000152e: 1a                                        ; drop
+000152f: 0b                                        ; end
+0001526: 09                                        ; FIXUP func body size
 ; function body 118
-0001534: 00                                        ; func body size (guess)
-0001535: 00                                        ; local decl count
-0001536: 43                                        ; f32.const
-0001537: 0000 803f                                 ; f32 literal
-000153b: 90                                        ; f32.nearest
-000153c: 1a                                        ; drop
-000153d: 0b                                        ; end
-0001534: 09                                        ; FIXUP func body size
+0001530: 00                                        ; func body size (guess)
+0001531: 00                                        ; local decl count
+0001532: 43                                        ; f32.const
+0001533: 0000 803f                                 ; f32 literal
+0001537: 90                                        ; f32.nearest
+0001538: 1a                                        ; drop
+0001539: 0b                                        ; end
+0001530: 09                                        ; FIXUP func body size
 ; function body 119
-000153e: 00                                        ; func body size (guess)
-000153f: 00                                        ; local decl count
-0001540: 43                                        ; f32.const
-0001541: 0000 803f                                 ; f32 literal
-0001545: 91                                        ; f32.sqrt
-0001546: 1a                                        ; drop
-0001547: 0b                                        ; end
-000153e: 09                                        ; FIXUP func body size
+000153a: 00                                        ; func body size (guess)
+000153b: 00                                        ; local decl count
+000153c: 43                                        ; f32.const
+000153d: 0000 803f                                 ; f32 literal
+0001541: 91                                        ; f32.sqrt
+0001542: 1a                                        ; drop
+0001543: 0b                                        ; end
+000153a: 09                                        ; FIXUP func body size
 ; function body 120
-0001548: 00                                        ; func body size (guess)
-0001549: 00                                        ; local decl count
-000154a: 43                                        ; f32.const
-000154b: 0000 803f                                 ; f32 literal
-000154f: 43                                        ; f32.const
-0001550: 0000 0040                                 ; f32 literal
-0001554: 92                                        ; f32.add
-0001555: 1a                                        ; drop
-0001556: 0b                                        ; end
-0001548: 0e                                        ; FIXUP func body size
+0001544: 00                                        ; func body size (guess)
+0001545: 00                                        ; local decl count
+0001546: 43                                        ; f32.const
+0001547: 0000 803f                                 ; f32 literal
+000154b: 43                                        ; f32.const
+000154c: 0000 0040                                 ; f32 literal
+0001550: 92                                        ; f32.add
+0001551: 1a                                        ; drop
+0001552: 0b                                        ; end
+0001544: 0e                                        ; FIXUP func body size
 ; function body 121
-0001557: 00                                        ; func body size (guess)
-0001558: 00                                        ; local decl count
-0001559: 43                                        ; f32.const
-000155a: 0000 803f                                 ; f32 literal
-000155e: 43                                        ; f32.const
-000155f: 0000 0040                                 ; f32 literal
-0001563: 93                                        ; f32.sub
-0001564: 1a                                        ; drop
-0001565: 0b                                        ; end
-0001557: 0e                                        ; FIXUP func body size
+0001553: 00                                        ; func body size (guess)
+0001554: 00                                        ; local decl count
+0001555: 43                                        ; f32.const
+0001556: 0000 803f                                 ; f32 literal
+000155a: 43                                        ; f32.const
+000155b: 0000 0040                                 ; f32 literal
+000155f: 93                                        ; f32.sub
+0001560: 1a                                        ; drop
+0001561: 0b                                        ; end
+0001553: 0e                                        ; FIXUP func body size
 ; function body 122
-0001566: 00                                        ; func body size (guess)
-0001567: 00                                        ; local decl count
-0001568: 43                                        ; f32.const
-0001569: 0000 803f                                 ; f32 literal
-000156d: 43                                        ; f32.const
-000156e: 0000 0040                                 ; f32 literal
-0001572: 94                                        ; f32.mul
-0001573: 1a                                        ; drop
-0001574: 0b                                        ; end
-0001566: 0e                                        ; FIXUP func body size
+0001562: 00                                        ; func body size (guess)
+0001563: 00                                        ; local decl count
+0001564: 43                                        ; f32.const
+0001565: 0000 803f                                 ; f32 literal
+0001569: 43                                        ; f32.const
+000156a: 0000 0040                                 ; f32 literal
+000156e: 94                                        ; f32.mul
+000156f: 1a                                        ; drop
+0001570: 0b                                        ; end
+0001562: 0e                                        ; FIXUP func body size
 ; function body 123
-0001575: 00                                        ; func body size (guess)
-0001576: 00                                        ; local decl count
-0001577: 43                                        ; f32.const
-0001578: 0000 803f                                 ; f32 literal
-000157c: 43                                        ; f32.const
-000157d: 0000 0040                                 ; f32 literal
-0001581: 95                                        ; f32.div
-0001582: 1a                                        ; drop
-0001583: 0b                                        ; end
-0001575: 0e                                        ; FIXUP func body size
+0001571: 00                                        ; func body size (guess)
+0001572: 00                                        ; local decl count
+0001573: 43                                        ; f32.const
+0001574: 0000 803f                                 ; f32 literal
+0001578: 43                                        ; f32.const
+0001579: 0000 0040                                 ; f32 literal
+000157d: 95                                        ; f32.div
+000157e: 1a                                        ; drop
+000157f: 0b                                        ; end
+0001571: 0e                                        ; FIXUP func body size
 ; function body 124
-0001584: 00                                        ; func body size (guess)
-0001585: 00                                        ; local decl count
-0001586: 43                                        ; f32.const
-0001587: 0000 803f                                 ; f32 literal
-000158b: 43                                        ; f32.const
-000158c: 0000 0040                                 ; f32 literal
-0001590: 96                                        ; f32.min
-0001591: 1a                                        ; drop
-0001592: 0b                                        ; end
-0001584: 0e                                        ; FIXUP func body size
+0001580: 00                                        ; func body size (guess)
+0001581: 00                                        ; local decl count
+0001582: 43                                        ; f32.const
+0001583: 0000 803f                                 ; f32 literal
+0001587: 43                                        ; f32.const
+0001588: 0000 0040                                 ; f32 literal
+000158c: 96                                        ; f32.min
+000158d: 1a                                        ; drop
+000158e: 0b                                        ; end
+0001580: 0e                                        ; FIXUP func body size
 ; function body 125
-0001593: 00                                        ; func body size (guess)
-0001594: 00                                        ; local decl count
-0001595: 43                                        ; f32.const
-0001596: 0000 803f                                 ; f32 literal
-000159a: 43                                        ; f32.const
-000159b: 0000 0040                                 ; f32 literal
-000159f: 97                                        ; f32.max
-00015a0: 1a                                        ; drop
-00015a1: 0b                                        ; end
-0001593: 0e                                        ; FIXUP func body size
+000158f: 00                                        ; func body size (guess)
+0001590: 00                                        ; local decl count
+0001591: 43                                        ; f32.const
+0001592: 0000 803f                                 ; f32 literal
+0001596: 43                                        ; f32.const
+0001597: 0000 0040                                 ; f32 literal
+000159b: 97                                        ; f32.max
+000159c: 1a                                        ; drop
+000159d: 0b                                        ; end
+000158f: 0e                                        ; FIXUP func body size
 ; function body 126
-00015a2: 00                                        ; func body size (guess)
-00015a3: 00                                        ; local decl count
-00015a4: 43                                        ; f32.const
-00015a5: 0000 803f                                 ; f32 literal
-00015a9: 43                                        ; f32.const
-00015aa: 0000 0040                                 ; f32 literal
-00015ae: 98                                        ; f32.copysign
-00015af: 1a                                        ; drop
-00015b0: 0b                                        ; end
-00015a2: 0e                                        ; FIXUP func body size
+000159e: 00                                        ; func body size (guess)
+000159f: 00                                        ; local decl count
+00015a0: 43                                        ; f32.const
+00015a1: 0000 803f                                 ; f32 literal
+00015a5: 43                                        ; f32.const
+00015a6: 0000 0040                                 ; f32 literal
+00015aa: 98                                        ; f32.copysign
+00015ab: 1a                                        ; drop
+00015ac: 0b                                        ; end
+000159e: 0e                                        ; FIXUP func body size
 ; function body 127
-00015b1: 00                                        ; func body size (guess)
-00015b2: 00                                        ; local decl count
-00015b3: 44                                        ; f64.const
-00015b4: 0000 0000 0000 f03f                       ; f64 literal
-00015bc: 99                                        ; f64.abs
-00015bd: 1a                                        ; drop
-00015be: 0b                                        ; end
-00015b1: 0d                                        ; FIXUP func body size
+00015ad: 00                                        ; func body size (guess)
+00015ae: 00                                        ; local decl count
+00015af: 44                                        ; f64.const
+00015b0: 0000 0000 0000 f03f                       ; f64 literal
+00015b8: 99                                        ; f64.abs
+00015b9: 1a                                        ; drop
+00015ba: 0b                                        ; end
+00015ad: 0d                                        ; FIXUP func body size
 ; function body 128
-00015bf: 00                                        ; func body size (guess)
-00015c0: 00                                        ; local decl count
-00015c1: 44                                        ; f64.const
-00015c2: 0000 0000 0000 f03f                       ; f64 literal
-00015ca: 9a                                        ; f64.neg
-00015cb: 1a                                        ; drop
-00015cc: 0b                                        ; end
-00015bf: 0d                                        ; FIXUP func body size
+00015bb: 00                                        ; func body size (guess)
+00015bc: 00                                        ; local decl count
+00015bd: 44                                        ; f64.const
+00015be: 0000 0000 0000 f03f                       ; f64 literal
+00015c6: 9a                                        ; f64.neg
+00015c7: 1a                                        ; drop
+00015c8: 0b                                        ; end
+00015bb: 0d                                        ; FIXUP func body size
 ; function body 129
-00015cd: 00                                        ; func body size (guess)
-00015ce: 00                                        ; local decl count
-00015cf: 44                                        ; f64.const
-00015d0: 0000 0000 0000 f03f                       ; f64 literal
-00015d8: 9b                                        ; f64.ceil
-00015d9: 1a                                        ; drop
-00015da: 0b                                        ; end
-00015cd: 0d                                        ; FIXUP func body size
+00015c9: 00                                        ; func body size (guess)
+00015ca: 00                                        ; local decl count
+00015cb: 44                                        ; f64.const
+00015cc: 0000 0000 0000 f03f                       ; f64 literal
+00015d4: 9b                                        ; f64.ceil
+00015d5: 1a                                        ; drop
+00015d6: 0b                                        ; end
+00015c9: 0d                                        ; FIXUP func body size
 ; function body 130
-00015db: 00                                        ; func body size (guess)
-00015dc: 00                                        ; local decl count
-00015dd: 44                                        ; f64.const
-00015de: 0000 0000 0000 f03f                       ; f64 literal
-00015e6: 9c                                        ; f64.floor
-00015e7: 1a                                        ; drop
-00015e8: 0b                                        ; end
-00015db: 0d                                        ; FIXUP func body size
+00015d7: 00                                        ; func body size (guess)
+00015d8: 00                                        ; local decl count
+00015d9: 44                                        ; f64.const
+00015da: 0000 0000 0000 f03f                       ; f64 literal
+00015e2: 9c                                        ; f64.floor
+00015e3: 1a                                        ; drop
+00015e4: 0b                                        ; end
+00015d7: 0d                                        ; FIXUP func body size
 ; function body 131
-00015e9: 00                                        ; func body size (guess)
-00015ea: 00                                        ; local decl count
-00015eb: 44                                        ; f64.const
-00015ec: 0000 0000 0000 f03f                       ; f64 literal
-00015f4: 9d                                        ; f64.trunc
-00015f5: 1a                                        ; drop
-00015f6: 0b                                        ; end
-00015e9: 0d                                        ; FIXUP func body size
+00015e5: 00                                        ; func body size (guess)
+00015e6: 00                                        ; local decl count
+00015e7: 44                                        ; f64.const
+00015e8: 0000 0000 0000 f03f                       ; f64 literal
+00015f0: 9d                                        ; f64.trunc
+00015f1: 1a                                        ; drop
+00015f2: 0b                                        ; end
+00015e5: 0d                                        ; FIXUP func body size
 ; function body 132
-00015f7: 00                                        ; func body size (guess)
-00015f8: 00                                        ; local decl count
-00015f9: 44                                        ; f64.const
-00015fa: 0000 0000 0000 f03f                       ; f64 literal
-0001602: 9e                                        ; f64.nearest
-0001603: 1a                                        ; drop
-0001604: 0b                                        ; end
-00015f7: 0d                                        ; FIXUP func body size
+00015f3: 00                                        ; func body size (guess)
+00015f4: 00                                        ; local decl count
+00015f5: 44                                        ; f64.const
+00015f6: 0000 0000 0000 f03f                       ; f64 literal
+00015fe: 9e                                        ; f64.nearest
+00015ff: 1a                                        ; drop
+0001600: 0b                                        ; end
+00015f3: 0d                                        ; FIXUP func body size
 ; function body 133
-0001605: 00                                        ; func body size (guess)
-0001606: 00                                        ; local decl count
-0001607: 44                                        ; f64.const
-0001608: 0000 0000 0000 f03f                       ; f64 literal
-0001610: 9f                                        ; f64.sqrt
-0001611: 1a                                        ; drop
-0001612: 0b                                        ; end
-0001605: 0d                                        ; FIXUP func body size
+0001601: 00                                        ; func body size (guess)
+0001602: 00                                        ; local decl count
+0001603: 44                                        ; f64.const
+0001604: 0000 0000 0000 f03f                       ; f64 literal
+000160c: 9f                                        ; f64.sqrt
+000160d: 1a                                        ; drop
+000160e: 0b                                        ; end
+0001601: 0d                                        ; FIXUP func body size
 ; function body 134
-0001613: 00                                        ; func body size (guess)
-0001614: 00                                        ; local decl count
-0001615: 44                                        ; f64.const
-0001616: 0000 0000 0000 f03f                       ; f64 literal
-000161e: 44                                        ; f64.const
-000161f: 0000 0000 0000 0040                       ; f64 literal
-0001627: a0                                        ; f64.add
-0001628: 1a                                        ; drop
-0001629: 0b                                        ; end
-0001613: 16                                        ; FIXUP func body size
+000160f: 00                                        ; func body size (guess)
+0001610: 00                                        ; local decl count
+0001611: 44                                        ; f64.const
+0001612: 0000 0000 0000 f03f                       ; f64 literal
+000161a: 44                                        ; f64.const
+000161b: 0000 0000 0000 0040                       ; f64 literal
+0001623: a0                                        ; f64.add
+0001624: 1a                                        ; drop
+0001625: 0b                                        ; end
+000160f: 16                                        ; FIXUP func body size
 ; function body 135
-000162a: 00                                        ; func body size (guess)
-000162b: 00                                        ; local decl count
-000162c: 44                                        ; f64.const
-000162d: 0000 0000 0000 f03f                       ; f64 literal
-0001635: 44                                        ; f64.const
-0001636: 0000 0000 0000 0040                       ; f64 literal
-000163e: a1                                        ; f64.sub
-000163f: 1a                                        ; drop
-0001640: 0b                                        ; end
-000162a: 16                                        ; FIXUP func body size
+0001626: 00                                        ; func body size (guess)
+0001627: 00                                        ; local decl count
+0001628: 44                                        ; f64.const
+0001629: 0000 0000 0000 f03f                       ; f64 literal
+0001631: 44                                        ; f64.const
+0001632: 0000 0000 0000 0040                       ; f64 literal
+000163a: a1                                        ; f64.sub
+000163b: 1a                                        ; drop
+000163c: 0b                                        ; end
+0001626: 16                                        ; FIXUP func body size
 ; function body 136
-0001641: 00                                        ; func body size (guess)
-0001642: 00                                        ; local decl count
-0001643: 44                                        ; f64.const
-0001644: 0000 0000 0000 f03f                       ; f64 literal
-000164c: 44                                        ; f64.const
-000164d: 0000 0000 0000 0040                       ; f64 literal
-0001655: a2                                        ; f64.mul
-0001656: 1a                                        ; drop
-0001657: 0b                                        ; end
-0001641: 16                                        ; FIXUP func body size
+000163d: 00                                        ; func body size (guess)
+000163e: 00                                        ; local decl count
+000163f: 44                                        ; f64.const
+0001640: 0000 0000 0000 f03f                       ; f64 literal
+0001648: 44                                        ; f64.const
+0001649: 0000 0000 0000 0040                       ; f64 literal
+0001651: a2                                        ; f64.mul
+0001652: 1a                                        ; drop
+0001653: 0b                                        ; end
+000163d: 16                                        ; FIXUP func body size
 ; function body 137
-0001658: 00                                        ; func body size (guess)
-0001659: 00                                        ; local decl count
-000165a: 44                                        ; f64.const
-000165b: 0000 0000 0000 f03f                       ; f64 literal
-0001663: 44                                        ; f64.const
-0001664: 0000 0000 0000 0040                       ; f64 literal
-000166c: a3                                        ; f64.div
-000166d: 1a                                        ; drop
-000166e: 0b                                        ; end
-0001658: 16                                        ; FIXUP func body size
+0001654: 00                                        ; func body size (guess)
+0001655: 00                                        ; local decl count
+0001656: 44                                        ; f64.const
+0001657: 0000 0000 0000 f03f                       ; f64 literal
+000165f: 44                                        ; f64.const
+0001660: 0000 0000 0000 0040                       ; f64 literal
+0001668: a3                                        ; f64.div
+0001669: 1a                                        ; drop
+000166a: 0b                                        ; end
+0001654: 16                                        ; FIXUP func body size
 ; function body 138
-000166f: 00                                        ; func body size (guess)
-0001670: 00                                        ; local decl count
-0001671: 44                                        ; f64.const
-0001672: 0000 0000 0000 f03f                       ; f64 literal
-000167a: 44                                        ; f64.const
-000167b: 0000 0000 0000 0040                       ; f64 literal
-0001683: a4                                        ; f64.min
-0001684: 1a                                        ; drop
-0001685: 0b                                        ; end
-000166f: 16                                        ; FIXUP func body size
+000166b: 00                                        ; func body size (guess)
+000166c: 00                                        ; local decl count
+000166d: 44                                        ; f64.const
+000166e: 0000 0000 0000 f03f                       ; f64 literal
+0001676: 44                                        ; f64.const
+0001677: 0000 0000 0000 0040                       ; f64 literal
+000167f: a4                                        ; f64.min
+0001680: 1a                                        ; drop
+0001681: 0b                                        ; end
+000166b: 16                                        ; FIXUP func body size
 ; function body 139
-0001686: 00                                        ; func body size (guess)
-0001687: 00                                        ; local decl count
-0001688: 44                                        ; f64.const
-0001689: 0000 0000 0000 f03f                       ; f64 literal
-0001691: 44                                        ; f64.const
-0001692: 0000 0000 0000 0040                       ; f64 literal
-000169a: a5                                        ; f64.max
-000169b: 1a                                        ; drop
-000169c: 0b                                        ; end
-0001686: 16                                        ; FIXUP func body size
+0001682: 00                                        ; func body size (guess)
+0001683: 00                                        ; local decl count
+0001684: 44                                        ; f64.const
+0001685: 0000 0000 0000 f03f                       ; f64 literal
+000168d: 44                                        ; f64.const
+000168e: 0000 0000 0000 0040                       ; f64 literal
+0001696: a5                                        ; f64.max
+0001697: 1a                                        ; drop
+0001698: 0b                                        ; end
+0001682: 16                                        ; FIXUP func body size
 ; function body 140
-000169d: 00                                        ; func body size (guess)
-000169e: 00                                        ; local decl count
-000169f: 44                                        ; f64.const
-00016a0: 0000 0000 0000 f03f                       ; f64 literal
-00016a8: 44                                        ; f64.const
-00016a9: 0000 0000 0000 0040                       ; f64 literal
-00016b1: a6                                        ; f64.copysign
-00016b2: 1a                                        ; drop
-00016b3: 0b                                        ; end
-000169d: 16                                        ; FIXUP func body size
+0001699: 00                                        ; func body size (guess)
+000169a: 00                                        ; local decl count
+000169b: 44                                        ; f64.const
+000169c: 0000 0000 0000 f03f                       ; f64 literal
+00016a4: 44                                        ; f64.const
+00016a5: 0000 0000 0000 0040                       ; f64 literal
+00016ad: a6                                        ; f64.copysign
+00016ae: 1a                                        ; drop
+00016af: 0b                                        ; end
+0001699: 16                                        ; FIXUP func body size
 ; function body 141
-00016b4: 00                                        ; func body size (guess)
-00016b5: 00                                        ; local decl count
-00016b6: 42                                        ; i64.const
-00016b7: 01                                        ; i64 literal
-00016b8: a7                                        ; i32.wrap/i64
-00016b9: 1a                                        ; drop
-00016ba: 0b                                        ; end
-00016b4: 06                                        ; FIXUP func body size
+00016b0: 00                                        ; func body size (guess)
+00016b1: 00                                        ; local decl count
+00016b2: 42                                        ; i64.const
+00016b3: 01                                        ; i64 literal
+00016b4: a7                                        ; i32.wrap/i64
+00016b5: 1a                                        ; drop
+00016b6: 0b                                        ; end
+00016b0: 06                                        ; FIXUP func body size
 ; function body 142
-00016bb: 00                                        ; func body size (guess)
-00016bc: 00                                        ; local decl count
-00016bd: 43                                        ; f32.const
-00016be: 0000 803f                                 ; f32 literal
-00016c2: a8                                        ; i32.trunc_s/f32
-00016c3: 1a                                        ; drop
-00016c4: 0b                                        ; end
-00016bb: 09                                        ; FIXUP func body size
+00016b7: 00                                        ; func body size (guess)
+00016b8: 00                                        ; local decl count
+00016b9: 43                                        ; f32.const
+00016ba: 0000 803f                                 ; f32 literal
+00016be: a8                                        ; i32.trunc_s/f32
+00016bf: 1a                                        ; drop
+00016c0: 0b                                        ; end
+00016b7: 09                                        ; FIXUP func body size
 ; function body 143
-00016c5: 00                                        ; func body size (guess)
-00016c6: 00                                        ; local decl count
-00016c7: 43                                        ; f32.const
-00016c8: 0000 803f                                 ; f32 literal
-00016cc: a9                                        ; i32.trunc_u/f32
-00016cd: 1a                                        ; drop
-00016ce: 0b                                        ; end
-00016c5: 09                                        ; FIXUP func body size
+00016c1: 00                                        ; func body size (guess)
+00016c2: 00                                        ; local decl count
+00016c3: 43                                        ; f32.const
+00016c4: 0000 803f                                 ; f32 literal
+00016c8: a9                                        ; i32.trunc_u/f32
+00016c9: 1a                                        ; drop
+00016ca: 0b                                        ; end
+00016c1: 09                                        ; FIXUP func body size
 ; function body 144
-00016cf: 00                                        ; func body size (guess)
-00016d0: 00                                        ; local decl count
-00016d1: 44                                        ; f64.const
-00016d2: 0000 0000 0000 f03f                       ; f64 literal
-00016da: aa                                        ; i32.trunc_s/f64
-00016db: 1a                                        ; drop
-00016dc: 0b                                        ; end
-00016cf: 0d                                        ; FIXUP func body size
+00016cb: 00                                        ; func body size (guess)
+00016cc: 00                                        ; local decl count
+00016cd: 44                                        ; f64.const
+00016ce: 0000 0000 0000 f03f                       ; f64 literal
+00016d6: aa                                        ; i32.trunc_s/f64
+00016d7: 1a                                        ; drop
+00016d8: 0b                                        ; end
+00016cb: 0d                                        ; FIXUP func body size
 ; function body 145
-00016dd: 00                                        ; func body size (guess)
-00016de: 00                                        ; local decl count
-00016df: 44                                        ; f64.const
-00016e0: 0000 0000 0000 f03f                       ; f64 literal
-00016e8: ab                                        ; i32.trunc_u/f64
-00016e9: 1a                                        ; drop
-00016ea: 0b                                        ; end
-00016dd: 0d                                        ; FIXUP func body size
+00016d9: 00                                        ; func body size (guess)
+00016da: 00                                        ; local decl count
+00016db: 44                                        ; f64.const
+00016dc: 0000 0000 0000 f03f                       ; f64 literal
+00016e4: ab                                        ; i32.trunc_u/f64
+00016e5: 1a                                        ; drop
+00016e6: 0b                                        ; end
+00016d9: 0d                                        ; FIXUP func body size
 ; function body 146
-00016eb: 00                                        ; func body size (guess)
-00016ec: 00                                        ; local decl count
-00016ed: 41                                        ; i32.const
-00016ee: 01                                        ; i32 literal
-00016ef: ac                                        ; i64.extend_s/i32
-00016f0: 1a                                        ; drop
-00016f1: 0b                                        ; end
-00016eb: 06                                        ; FIXUP func body size
+00016e7: 00                                        ; func body size (guess)
+00016e8: 00                                        ; local decl count
+00016e9: 41                                        ; i32.const
+00016ea: 01                                        ; i32 literal
+00016eb: ac                                        ; i64.extend_s/i32
+00016ec: 1a                                        ; drop
+00016ed: 0b                                        ; end
+00016e7: 06                                        ; FIXUP func body size
 ; function body 147
-00016f2: 00                                        ; func body size (guess)
-00016f3: 00                                        ; local decl count
-00016f4: 41                                        ; i32.const
-00016f5: 01                                        ; i32 literal
-00016f6: ad                                        ; i64.extend_u/i32
-00016f7: 1a                                        ; drop
-00016f8: 0b                                        ; end
-00016f2: 06                                        ; FIXUP func body size
+00016ee: 00                                        ; func body size (guess)
+00016ef: 00                                        ; local decl count
+00016f0: 41                                        ; i32.const
+00016f1: 01                                        ; i32 literal
+00016f2: ad                                        ; i64.extend_u/i32
+00016f3: 1a                                        ; drop
+00016f4: 0b                                        ; end
+00016ee: 06                                        ; FIXUP func body size
 ; function body 148
-00016f9: 00                                        ; func body size (guess)
-00016fa: 00                                        ; local decl count
-00016fb: 43                                        ; f32.const
-00016fc: 0000 803f                                 ; f32 literal
-0001700: ae                                        ; i64.trunc_s/f32
-0001701: 1a                                        ; drop
-0001702: 0b                                        ; end
-00016f9: 09                                        ; FIXUP func body size
+00016f5: 00                                        ; func body size (guess)
+00016f6: 00                                        ; local decl count
+00016f7: 43                                        ; f32.const
+00016f8: 0000 803f                                 ; f32 literal
+00016fc: ae                                        ; i64.trunc_s/f32
+00016fd: 1a                                        ; drop
+00016fe: 0b                                        ; end
+00016f5: 09                                        ; FIXUP func body size
 ; function body 149
-0001703: 00                                        ; func body size (guess)
-0001704: 00                                        ; local decl count
-0001705: 43                                        ; f32.const
-0001706: 0000 803f                                 ; f32 literal
-000170a: af                                        ; i64.trunc_u/f32
-000170b: 1a                                        ; drop
-000170c: 0b                                        ; end
-0001703: 09                                        ; FIXUP func body size
+00016ff: 00                                        ; func body size (guess)
+0001700: 00                                        ; local decl count
+0001701: 43                                        ; f32.const
+0001702: 0000 803f                                 ; f32 literal
+0001706: af                                        ; i64.trunc_u/f32
+0001707: 1a                                        ; drop
+0001708: 0b                                        ; end
+00016ff: 09                                        ; FIXUP func body size
 ; function body 150
-000170d: 00                                        ; func body size (guess)
-000170e: 00                                        ; local decl count
-000170f: 44                                        ; f64.const
-0001710: 0000 0000 0000 f03f                       ; f64 literal
-0001718: b0                                        ; i64.trunc_s/f64
-0001719: 1a                                        ; drop
-000171a: 0b                                        ; end
-000170d: 0d                                        ; FIXUP func body size
+0001709: 00                                        ; func body size (guess)
+000170a: 00                                        ; local decl count
+000170b: 44                                        ; f64.const
+000170c: 0000 0000 0000 f03f                       ; f64 literal
+0001714: b0                                        ; i64.trunc_s/f64
+0001715: 1a                                        ; drop
+0001716: 0b                                        ; end
+0001709: 0d                                        ; FIXUP func body size
 ; function body 151
-000171b: 00                                        ; func body size (guess)
-000171c: 00                                        ; local decl count
-000171d: 44                                        ; f64.const
-000171e: 0000 0000 0000 f03f                       ; f64 literal
-0001726: b1                                        ; i64.trunc_u/f64
-0001727: 1a                                        ; drop
-0001728: 0b                                        ; end
-000171b: 0d                                        ; FIXUP func body size
+0001717: 00                                        ; func body size (guess)
+0001718: 00                                        ; local decl count
+0001719: 44                                        ; f64.const
+000171a: 0000 0000 0000 f03f                       ; f64 literal
+0001722: b1                                        ; i64.trunc_u/f64
+0001723: 1a                                        ; drop
+0001724: 0b                                        ; end
+0001717: 0d                                        ; FIXUP func body size
 ; function body 152
-0001729: 00                                        ; func body size (guess)
-000172a: 00                                        ; local decl count
-000172b: 41                                        ; i32.const
-000172c: 01                                        ; i32 literal
-000172d: b2                                        ; f32.convert_s/i32
-000172e: 1a                                        ; drop
-000172f: 0b                                        ; end
-0001729: 06                                        ; FIXUP func body size
+0001725: 00                                        ; func body size (guess)
+0001726: 00                                        ; local decl count
+0001727: 41                                        ; i32.const
+0001728: 01                                        ; i32 literal
+0001729: b2                                        ; f32.convert_s/i32
+000172a: 1a                                        ; drop
+000172b: 0b                                        ; end
+0001725: 06                                        ; FIXUP func body size
 ; function body 153
-0001730: 00                                        ; func body size (guess)
-0001731: 00                                        ; local decl count
-0001732: 41                                        ; i32.const
-0001733: 01                                        ; i32 literal
-0001734: b3                                        ; f32.convert_u/i32
-0001735: 1a                                        ; drop
-0001736: 0b                                        ; end
-0001730: 06                                        ; FIXUP func body size
+000172c: 00                                        ; func body size (guess)
+000172d: 00                                        ; local decl count
+000172e: 41                                        ; i32.const
+000172f: 01                                        ; i32 literal
+0001730: b3                                        ; f32.convert_u/i32
+0001731: 1a                                        ; drop
+0001732: 0b                                        ; end
+000172c: 06                                        ; FIXUP func body size
 ; function body 154
-0001737: 00                                        ; func body size (guess)
-0001738: 00                                        ; local decl count
-0001739: 42                                        ; i64.const
-000173a: 01                                        ; i64 literal
-000173b: b4                                        ; f32.convert_s/i64
-000173c: 1a                                        ; drop
-000173d: 0b                                        ; end
-0001737: 06                                        ; FIXUP func body size
+0001733: 00                                        ; func body size (guess)
+0001734: 00                                        ; local decl count
+0001735: 42                                        ; i64.const
+0001736: 01                                        ; i64 literal
+0001737: b4                                        ; f32.convert_s/i64
+0001738: 1a                                        ; drop
+0001739: 0b                                        ; end
+0001733: 06                                        ; FIXUP func body size
 ; function body 155
-000173e: 00                                        ; func body size (guess)
-000173f: 00                                        ; local decl count
-0001740: 42                                        ; i64.const
-0001741: 01                                        ; i64 literal
-0001742: b5                                        ; f32.convert_u/i64
-0001743: 1a                                        ; drop
-0001744: 0b                                        ; end
-000173e: 06                                        ; FIXUP func body size
+000173a: 00                                        ; func body size (guess)
+000173b: 00                                        ; local decl count
+000173c: 42                                        ; i64.const
+000173d: 01                                        ; i64 literal
+000173e: b5                                        ; f32.convert_u/i64
+000173f: 1a                                        ; drop
+0001740: 0b                                        ; end
+000173a: 06                                        ; FIXUP func body size
 ; function body 156
-0001745: 00                                        ; func body size (guess)
-0001746: 00                                        ; local decl count
-0001747: 44                                        ; f64.const
-0001748: 0000 0000 0000 f03f                       ; f64 literal
-0001750: b6                                        ; f32.demote/f64
-0001751: 1a                                        ; drop
-0001752: 0b                                        ; end
-0001745: 0d                                        ; FIXUP func body size
+0001741: 00                                        ; func body size (guess)
+0001742: 00                                        ; local decl count
+0001743: 44                                        ; f64.const
+0001744: 0000 0000 0000 f03f                       ; f64 literal
+000174c: b6                                        ; f32.demote/f64
+000174d: 1a                                        ; drop
+000174e: 0b                                        ; end
+0001741: 0d                                        ; FIXUP func body size
 ; function body 157
-0001753: 00                                        ; func body size (guess)
-0001754: 00                                        ; local decl count
-0001755: 41                                        ; i32.const
-0001756: 01                                        ; i32 literal
-0001757: b7                                        ; f64.convert_s/i32
-0001758: 1a                                        ; drop
-0001759: 0b                                        ; end
-0001753: 06                                        ; FIXUP func body size
+000174f: 00                                        ; func body size (guess)
+0001750: 00                                        ; local decl count
+0001751: 41                                        ; i32.const
+0001752: 01                                        ; i32 literal
+0001753: b7                                        ; f64.convert_s/i32
+0001754: 1a                                        ; drop
+0001755: 0b                                        ; end
+000174f: 06                                        ; FIXUP func body size
 ; function body 158
-000175a: 00                                        ; func body size (guess)
-000175b: 00                                        ; local decl count
-000175c: 41                                        ; i32.const
-000175d: 01                                        ; i32 literal
-000175e: b8                                        ; f64.convert_u/i32
-000175f: 1a                                        ; drop
-0001760: 0b                                        ; end
-000175a: 06                                        ; FIXUP func body size
+0001756: 00                                        ; func body size (guess)
+0001757: 00                                        ; local decl count
+0001758: 41                                        ; i32.const
+0001759: 01                                        ; i32 literal
+000175a: b8                                        ; f64.convert_u/i32
+000175b: 1a                                        ; drop
+000175c: 0b                                        ; end
+0001756: 06                                        ; FIXUP func body size
 ; function body 159
-0001761: 00                                        ; func body size (guess)
-0001762: 00                                        ; local decl count
-0001763: 42                                        ; i64.const
-0001764: 01                                        ; i64 literal
-0001765: b9                                        ; f64.convert_s/i64
-0001766: 1a                                        ; drop
-0001767: 0b                                        ; end
-0001761: 06                                        ; FIXUP func body size
+000175d: 00                                        ; func body size (guess)
+000175e: 00                                        ; local decl count
+000175f: 42                                        ; i64.const
+0001760: 01                                        ; i64 literal
+0001761: b9                                        ; f64.convert_s/i64
+0001762: 1a                                        ; drop
+0001763: 0b                                        ; end
+000175d: 06                                        ; FIXUP func body size
 ; function body 160
-0001768: 00                                        ; func body size (guess)
-0001769: 00                                        ; local decl count
-000176a: 42                                        ; i64.const
-000176b: 01                                        ; i64 literal
-000176c: ba                                        ; f64.convert_u/i64
-000176d: 1a                                        ; drop
-000176e: 0b                                        ; end
-0001768: 06                                        ; FIXUP func body size
+0001764: 00                                        ; func body size (guess)
+0001765: 00                                        ; local decl count
+0001766: 42                                        ; i64.const
+0001767: 01                                        ; i64 literal
+0001768: ba                                        ; f64.convert_u/i64
+0001769: 1a                                        ; drop
+000176a: 0b                                        ; end
+0001764: 06                                        ; FIXUP func body size
 ; function body 161
-000176f: 00                                        ; func body size (guess)
-0001770: 00                                        ; local decl count
-0001771: 43                                        ; f32.const
-0001772: 0000 803f                                 ; f32 literal
-0001776: bb                                        ; f64.promote/f32
-0001777: 1a                                        ; drop
-0001778: 0b                                        ; end
-000176f: 09                                        ; FIXUP func body size
+000176b: 00                                        ; func body size (guess)
+000176c: 00                                        ; local decl count
+000176d: 43                                        ; f32.const
+000176e: 0000 803f                                 ; f32 literal
+0001772: bb                                        ; f64.promote/f32
+0001773: 1a                                        ; drop
+0001774: 0b                                        ; end
+000176b: 09                                        ; FIXUP func body size
 ; function body 162
-0001779: 00                                        ; func body size (guess)
-000177a: 00                                        ; local decl count
-000177b: 41                                        ; i32.const
-000177c: 01                                        ; i32 literal
-000177d: be                                        ; f32.reinterpret/i32
-000177e: 1a                                        ; drop
-000177f: 0b                                        ; end
-0001779: 06                                        ; FIXUP func body size
+0001775: 00                                        ; func body size (guess)
+0001776: 00                                        ; local decl count
+0001777: 41                                        ; i32.const
+0001778: 01                                        ; i32 literal
+0001779: be                                        ; f32.reinterpret/i32
+000177a: 1a                                        ; drop
+000177b: 0b                                        ; end
+0001775: 06                                        ; FIXUP func body size
 ; function body 163
-0001780: 00                                        ; func body size (guess)
-0001781: 00                                        ; local decl count
-0001782: 43                                        ; f32.const
-0001783: 0000 803f                                 ; f32 literal
-0001787: bc                                        ; i32.reinterpret/f32
-0001788: 1a                                        ; drop
-0001789: 0b                                        ; end
-0001780: 09                                        ; FIXUP func body size
+000177c: 00                                        ; func body size (guess)
+000177d: 00                                        ; local decl count
+000177e: 43                                        ; f32.const
+000177f: 0000 803f                                 ; f32 literal
+0001783: bc                                        ; i32.reinterpret/f32
+0001784: 1a                                        ; drop
+0001785: 0b                                        ; end
+000177c: 09                                        ; FIXUP func body size
 ; function body 164
-000178a: 00                                        ; func body size (guess)
-000178b: 00                                        ; local decl count
-000178c: 42                                        ; i64.const
-000178d: 01                                        ; i64 literal
-000178e: bf                                        ; f64.reinterpret/i64
-000178f: 1a                                        ; drop
-0001790: 0b                                        ; end
-000178a: 06                                        ; FIXUP func body size
+0001786: 00                                        ; func body size (guess)
+0001787: 00                                        ; local decl count
+0001788: 42                                        ; i64.const
+0001789: 01                                        ; i64 literal
+000178a: bf                                        ; f64.reinterpret/i64
+000178b: 1a                                        ; drop
+000178c: 0b                                        ; end
+0001786: 06                                        ; FIXUP func body size
 ; function body 165
-0001791: 00                                        ; func body size (guess)
-0001792: 00                                        ; local decl count
-0001793: 44                                        ; f64.const
-0001794: 0000 0000 0000 f03f                       ; f64 literal
-000179c: bd                                        ; i64.reinterpret/f64
-000179d: 1a                                        ; drop
-000179e: 0b                                        ; end
-0001791: 0d                                        ; FIXUP func body size
+000178d: 00                                        ; func body size (guess)
+000178e: 00                                        ; local decl count
+000178f: 44                                        ; f64.const
+0001790: 0000 0000 0000 f03f                       ; f64 literal
+0001798: bd                                        ; i64.reinterpret/f64
+0001799: 1a                                        ; drop
+000179a: 0b                                        ; end
+000178d: 0d                                        ; FIXUP func body size
 ; function body 166
-000179f: 00                                        ; func body size (guess)
-00017a0: 00                                        ; local decl count
-00017a1: 41                                        ; i32.const
-00017a2: 01                                        ; i32 literal
-00017a3: c0                                        ; i32.extend8_s
-00017a4: 1a                                        ; drop
-00017a5: 0b                                        ; end
-000179f: 06                                        ; FIXUP func body size
+000179b: 00                                        ; func body size (guess)
+000179c: 00                                        ; local decl count
+000179d: 41                                        ; i32.const
+000179e: 01                                        ; i32 literal
+000179f: c0                                        ; i32.extend8_s
+00017a0: 1a                                        ; drop
+00017a1: 0b                                        ; end
+000179b: 06                                        ; FIXUP func body size
 ; function body 167
-00017a6: 00                                        ; func body size (guess)
-00017a7: 00                                        ; local decl count
-00017a8: 41                                        ; i32.const
-00017a9: 01                                        ; i32 literal
-00017aa: c1                                        ; i32.extend16_s
-00017ab: 1a                                        ; drop
-00017ac: 0b                                        ; end
-00017a6: 06                                        ; FIXUP func body size
+00017a2: 00                                        ; func body size (guess)
+00017a3: 00                                        ; local decl count
+00017a4: 41                                        ; i32.const
+00017a5: 01                                        ; i32 literal
+00017a6: c1                                        ; i32.extend16_s
+00017a7: 1a                                        ; drop
+00017a8: 0b                                        ; end
+00017a2: 06                                        ; FIXUP func body size
 ; function body 168
-00017ad: 00                                        ; func body size (guess)
-00017ae: 00                                        ; local decl count
-00017af: 42                                        ; i64.const
-00017b0: 01                                        ; i64 literal
-00017b1: c2                                        ; i64.extend8_s
-00017b2: 1a                                        ; drop
-00017b3: 0b                                        ; end
-00017ad: 06                                        ; FIXUP func body size
+00017a9: 00                                        ; func body size (guess)
+00017aa: 00                                        ; local decl count
+00017ab: 42                                        ; i64.const
+00017ac: 01                                        ; i64 literal
+00017ad: c2                                        ; i64.extend8_s
+00017ae: 1a                                        ; drop
+00017af: 0b                                        ; end
+00017a9: 06                                        ; FIXUP func body size
 ; function body 169
-00017b4: 00                                        ; func body size (guess)
-00017b5: 00                                        ; local decl count
-00017b6: 42                                        ; i64.const
-00017b7: 01                                        ; i64 literal
-00017b8: c3                                        ; i64.extend16_s
-00017b9: 1a                                        ; drop
-00017ba: 0b                                        ; end
-00017b4: 06                                        ; FIXUP func body size
+00017b0: 00                                        ; func body size (guess)
+00017b1: 00                                        ; local decl count
+00017b2: 42                                        ; i64.const
+00017b3: 01                                        ; i64 literal
+00017b4: c3                                        ; i64.extend16_s
+00017b5: 1a                                        ; drop
+00017b6: 0b                                        ; end
+00017b0: 06                                        ; FIXUP func body size
 ; function body 170
-00017bb: 00                                        ; func body size (guess)
-00017bc: 00                                        ; local decl count
-00017bd: 42                                        ; i64.const
-00017be: 01                                        ; i64 literal
-00017bf: c4                                        ; i64.extend32_s
-00017c0: 1a                                        ; drop
-00017c1: 0b                                        ; end
-00017bb: 06                                        ; FIXUP func body size
+00017b7: 00                                        ; func body size (guess)
+00017b8: 00                                        ; local decl count
+00017b9: 42                                        ; i64.const
+00017ba: 01                                        ; i64 literal
+00017bb: c4                                        ; i64.extend32_s
+00017bc: 1a                                        ; drop
+00017bd: 0b                                        ; end
+00017b7: 06                                        ; FIXUP func body size
 ; function body 171
-00017c2: 00                                        ; func body size (guess)
-00017c3: 01                                        ; local decl count
-00017c4: 01                                        ; local type count
-00017c5: 7f                                        ; i32
-00017c6: 0b                                        ; end
-00017c2: 04                                        ; FIXUP func body size
+00017be: 00                                        ; func body size (guess)
+00017bf: 01                                        ; local decl count
+00017c0: 01                                        ; local type count
+00017c1: 7f                                        ; i32
+00017c2: 0b                                        ; end
+00017be: 04                                        ; FIXUP func body size
 ; function body 172
-00017c7: 00                                        ; func body size (guess)
-00017c8: 00                                        ; local decl count
-00017c9: 41                                        ; i32.const
-00017ca: 01                                        ; i32 literal
-00017cb: 0d                                        ; br_if
-00017cc: 00                                        ; break depth
-00017cd: 0b                                        ; end
-00017c7: 06                                        ; FIXUP func body size
+00017c3: 00                                        ; func body size (guess)
+00017c4: 00                                        ; local decl count
+00017c5: 41                                        ; i32.const
+00017c6: 01                                        ; i32 literal
+00017c7: 0d                                        ; br_if
+00017c8: 00                                        ; break depth
+00017c9: 0b                                        ; end
+00017c3: 06                                        ; FIXUP func body size
 ; function body 173
-00017ce: 00                                        ; func body size (guess)
-00017cf: 00                                        ; local decl count
-00017d0: 41                                        ; i32.const
-00017d1: 01                                        ; i32 literal
-00017d2: 10                                        ; call
-00017d3: 00                                        ; function index
-00017d4: 0b                                        ; end
-00017ce: 06                                        ; FIXUP func body size
+00017ca: 00                                        ; func body size (guess)
+00017cb: 00                                        ; local decl count
+00017cc: 41                                        ; i32.const
+00017cd: 01                                        ; i32 literal
+00017ce: 10                                        ; call
+00017cf: 00                                        ; function index
+00017d0: 0b                                        ; end
+00017ca: 06                                        ; FIXUP func body size
 ; function body 174
-00017d5: 00                                        ; func body size (guess)
-00017d6: 00                                        ; local decl count
-00017d7: 41                                        ; i32.const
-00017d8: 01                                        ; i32 literal
-00017d9: 0e                                        ; br_table
-00017da: 00                                        ; num targets
-00017db: 00                                        ; break depth for default
-00017dc: 0b                                        ; end
-00017d5: 07                                        ; FIXUP func body size
+00017d1: 00                                        ; func body size (guess)
+00017d2: 00                                        ; local decl count
+00017d3: 41                                        ; i32.const
+00017d4: 01                                        ; i32 literal
+00017d5: 0e                                        ; br_table
+00017d6: 00                                        ; num targets
+00017d7: 00                                        ; break depth for default
+00017d8: 0b                                        ; end
+00017d1: 07                                        ; FIXUP func body size
 ; function body 175
-00017dd: 00                                        ; func body size (guess)
-00017de: 00                                        ; local decl count
-00017df: 02                                        ; block
-00017e0: 7f                                        ; i32
-00017e1: 41                                        ; i32.const
-00017e2: 01                                        ; i32 literal
-00017e3: 41                                        ; i32.const
-00017e4: 02                                        ; i32 literal
-00017e5: 0c                                        ; br
-00017e6: 00                                        ; break depth
-00017e7: 0b                                        ; end
-00017e8: 1a                                        ; drop
-00017e9: 0b                                        ; end
-00017dd: 0c                                        ; FIXUP func body size
+00017d9: 00                                        ; func body size (guess)
+00017da: 00                                        ; local decl count
+00017db: 02                                        ; block
+00017dc: 7f                                        ; i32
+00017dd: 41                                        ; i32.const
+00017de: 01                                        ; i32 literal
+00017df: 41                                        ; i32.const
+00017e0: 02                                        ; i32 literal
+00017e1: 0c                                        ; br
+00017e2: 00                                        ; break depth
+00017e3: 0b                                        ; end
+00017e4: 1a                                        ; drop
+00017e5: 0b                                        ; end
+00017d9: 0c                                        ; FIXUP func body size
 ; function body 176
-00017ea: 00                                        ; func body size (guess)
-00017eb: 00                                        ; local decl count
-00017ec: 43                                        ; f32.const
-00017ed: 0000 803f                                 ; f32 literal
-00017f1: fc                                        ; prefix
-00017f2: 00                                        ; i32.trunc_s:sat/f32
-00017f3: 1a                                        ; drop
-00017f4: 0b                                        ; end
-00017ea: 0a                                        ; FIXUP func body size
+00017e6: 00                                        ; func body size (guess)
+00017e7: 00                                        ; local decl count
+00017e8: 43                                        ; f32.const
+00017e9: 0000 803f                                 ; f32 literal
+00017ed: fc                                        ; prefix
+00017ee: 00                                        ; i32.trunc_s:sat/f32
+00017ef: 1a                                        ; drop
+00017f0: 0b                                        ; end
+00017e6: 0a                                        ; FIXUP func body size
 ; function body 177
-00017f5: 00                                        ; func body size (guess)
-00017f6: 00                                        ; local decl count
-00017f7: 43                                        ; f32.const
-00017f8: 0000 803f                                 ; f32 literal
-00017fc: fc                                        ; prefix
-00017fd: 01                                        ; i32.trunc_u:sat/f32
-00017fe: 1a                                        ; drop
-00017ff: 0b                                        ; end
-00017f5: 0a                                        ; FIXUP func body size
+00017f1: 00                                        ; func body size (guess)
+00017f2: 00                                        ; local decl count
+00017f3: 43                                        ; f32.const
+00017f4: 0000 803f                                 ; f32 literal
+00017f8: fc                                        ; prefix
+00017f9: 01                                        ; i32.trunc_u:sat/f32
+00017fa: 1a                                        ; drop
+00017fb: 0b                                        ; end
+00017f1: 0a                                        ; FIXUP func body size
 ; function body 178
-0001800: 00                                        ; func body size (guess)
-0001801: 00                                        ; local decl count
-0001802: 44                                        ; f64.const
-0001803: 0000 0000 0000 f03f                       ; f64 literal
-000180b: fc                                        ; prefix
-000180c: 02                                        ; i32.trunc_s:sat/f64
-000180d: 1a                                        ; drop
-000180e: 0b                                        ; end
-0001800: 0e                                        ; FIXUP func body size
+00017fc: 00                                        ; func body size (guess)
+00017fd: 00                                        ; local decl count
+00017fe: 44                                        ; f64.const
+00017ff: 0000 0000 0000 f03f                       ; f64 literal
+0001807: fc                                        ; prefix
+0001808: 02                                        ; i32.trunc_s:sat/f64
+0001809: 1a                                        ; drop
+000180a: 0b                                        ; end
+00017fc: 0e                                        ; FIXUP func body size
 ; function body 179
-000180f: 00                                        ; func body size (guess)
-0001810: 00                                        ; local decl count
-0001811: 44                                        ; f64.const
-0001812: 0000 0000 0000 f03f                       ; f64 literal
-000181a: fc                                        ; prefix
-000181b: 03                                        ; i32.trunc_u:sat/f64
-000181c: 1a                                        ; drop
-000181d: 0b                                        ; end
-000180f: 0e                                        ; FIXUP func body size
+000180b: 00                                        ; func body size (guess)
+000180c: 00                                        ; local decl count
+000180d: 44                                        ; f64.const
+000180e: 0000 0000 0000 f03f                       ; f64 literal
+0001816: fc                                        ; prefix
+0001817: 03                                        ; i32.trunc_u:sat/f64
+0001818: 1a                                        ; drop
+0001819: 0b                                        ; end
+000180b: 0e                                        ; FIXUP func body size
 ; function body 180
-000181e: 00                                        ; func body size (guess)
-000181f: 00                                        ; local decl count
-0001820: 43                                        ; f32.const
-0001821: 0000 803f                                 ; f32 literal
-0001825: fc                                        ; prefix
-0001826: 04                                        ; i64.trunc_s:sat/f32
-0001827: 1a                                        ; drop
-0001828: 0b                                        ; end
-000181e: 0a                                        ; FIXUP func body size
+000181a: 00                                        ; func body size (guess)
+000181b: 00                                        ; local decl count
+000181c: 43                                        ; f32.const
+000181d: 0000 803f                                 ; f32 literal
+0001821: fc                                        ; prefix
+0001822: 04                                        ; i64.trunc_s:sat/f32
+0001823: 1a                                        ; drop
+0001824: 0b                                        ; end
+000181a: 0a                                        ; FIXUP func body size
 ; function body 181
-0001829: 00                                        ; func body size (guess)
-000182a: 00                                        ; local decl count
-000182b: 43                                        ; f32.const
-000182c: 0000 803f                                 ; f32 literal
-0001830: fc                                        ; prefix
-0001831: 05                                        ; i64.trunc_u:sat/f32
-0001832: 1a                                        ; drop
-0001833: 0b                                        ; end
-0001829: 0a                                        ; FIXUP func body size
+0001825: 00                                        ; func body size (guess)
+0001826: 00                                        ; local decl count
+0001827: 43                                        ; f32.const
+0001828: 0000 803f                                 ; f32 literal
+000182c: fc                                        ; prefix
+000182d: 05                                        ; i64.trunc_u:sat/f32
+000182e: 1a                                        ; drop
+000182f: 0b                                        ; end
+0001825: 0a                                        ; FIXUP func body size
 ; function body 182
-0001834: 00                                        ; func body size (guess)
-0001835: 00                                        ; local decl count
-0001836: 44                                        ; f64.const
-0001837: 0000 0000 0000 f03f                       ; f64 literal
-000183f: fc                                        ; prefix
-0001840: 06                                        ; i64.trunc_s:sat/f64
-0001841: 1a                                        ; drop
-0001842: 0b                                        ; end
-0001834: 0e                                        ; FIXUP func body size
+0001830: 00                                        ; func body size (guess)
+0001831: 00                                        ; local decl count
+0001832: 44                                        ; f64.const
+0001833: 0000 0000 0000 f03f                       ; f64 literal
+000183b: fc                                        ; prefix
+000183c: 06                                        ; i64.trunc_s:sat/f64
+000183d: 1a                                        ; drop
+000183e: 0b                                        ; end
+0001830: 0e                                        ; FIXUP func body size
 ; function body 183
-0001843: 00                                        ; func body size (guess)
-0001844: 00                                        ; local decl count
-0001845: 44                                        ; f64.const
-0001846: 0000 0000 0000 f03f                       ; f64 literal
-000184e: fc                                        ; prefix
-000184f: 07                                        ; i64.trunc_u:sat/f64
-0001850: 1a                                        ; drop
-0001851: 0b                                        ; end
-0001843: 0e                                        ; FIXUP func body size
+000183f: 00                                        ; func body size (guess)
+0001840: 00                                        ; local decl count
+0001841: 44                                        ; f64.const
+0001842: 0000 0000 0000 f03f                       ; f64 literal
+000184a: fc                                        ; prefix
+000184b: 07                                        ; i64.trunc_u:sat/f64
+000184c: 1a                                        ; drop
+000184d: 0b                                        ; end
+000183f: 0e                                        ; FIXUP func body size
 ; function body 184
-0001852: 00                                        ; func body size (guess)
-0001853: 00                                        ; local decl count
-0001854: 41                                        ; i32.const
-0001855: 01                                        ; i32 literal
-0001856: fe                                        ; prefix
-0001857: 10                                        ; i32.atomic.load
-0001858: 02                                        ; alignment
-0001859: 03                                        ; memory offset
-000185a: 1a                                        ; drop
-000185b: 0b                                        ; end
-0001852: 09                                        ; FIXUP func body size
+000184e: 00                                        ; func body size (guess)
+000184f: 00                                        ; local decl count
+0001850: 41                                        ; i32.const
+0001851: 01                                        ; i32 literal
+0001852: fe                                        ; prefix
+0001853: 10                                        ; i32.atomic.load
+0001854: 02                                        ; alignment
+0001855: 03                                        ; memory offset
+0001856: 1a                                        ; drop
+0001857: 0b                                        ; end
+000184e: 09                                        ; FIXUP func body size
 ; function body 185
-000185c: 00                                        ; func body size (guess)
-000185d: 00                                        ; local decl count
-000185e: 41                                        ; i32.const
-000185f: 01                                        ; i32 literal
-0001860: fe                                        ; prefix
-0001861: 11                                        ; i64.atomic.load
-0001862: 03                                        ; alignment
-0001863: 07                                        ; memory offset
-0001864: 1a                                        ; drop
-0001865: 0b                                        ; end
-000185c: 09                                        ; FIXUP func body size
+0001858: 00                                        ; func body size (guess)
+0001859: 00                                        ; local decl count
+000185a: 41                                        ; i32.const
+000185b: 01                                        ; i32 literal
+000185c: fe                                        ; prefix
+000185d: 11                                        ; i64.atomic.load
+000185e: 03                                        ; alignment
+000185f: 07                                        ; memory offset
+0001860: 1a                                        ; drop
+0001861: 0b                                        ; end
+0001858: 09                                        ; FIXUP func body size
 ; function body 186
-0001866: 00                                        ; func body size (guess)
-0001867: 00                                        ; local decl count
-0001868: 41                                        ; i32.const
-0001869: 01                                        ; i32 literal
-000186a: fe                                        ; prefix
-000186b: 12                                        ; i32.atomic.load8_u
-000186c: 00                                        ; alignment
-000186d: 03                                        ; memory offset
-000186e: 1a                                        ; drop
-000186f: 0b                                        ; end
-0001866: 09                                        ; FIXUP func body size
+0001862: 00                                        ; func body size (guess)
+0001863: 00                                        ; local decl count
+0001864: 41                                        ; i32.const
+0001865: 01                                        ; i32 literal
+0001866: fe                                        ; prefix
+0001867: 12                                        ; i32.atomic.load8_u
+0001868: 00                                        ; alignment
+0001869: 03                                        ; memory offset
+000186a: 1a                                        ; drop
+000186b: 0b                                        ; end
+0001862: 09                                        ; FIXUP func body size
 ; function body 187
-0001870: 00                                        ; func body size (guess)
-0001871: 00                                        ; local decl count
-0001872: 41                                        ; i32.const
-0001873: 01                                        ; i32 literal
-0001874: fe                                        ; prefix
-0001875: 13                                        ; i32.atomic.load16_u
-0001876: 01                                        ; alignment
-0001877: 03                                        ; memory offset
-0001878: 1a                                        ; drop
-0001879: 0b                                        ; end
-0001870: 09                                        ; FIXUP func body size
+000186c: 00                                        ; func body size (guess)
+000186d: 00                                        ; local decl count
+000186e: 41                                        ; i32.const
+000186f: 01                                        ; i32 literal
+0001870: fe                                        ; prefix
+0001871: 13                                        ; i32.atomic.load16_u
+0001872: 01                                        ; alignment
+0001873: 03                                        ; memory offset
+0001874: 1a                                        ; drop
+0001875: 0b                                        ; end
+000186c: 09                                        ; FIXUP func body size
 ; function body 188
-000187a: 00                                        ; func body size (guess)
-000187b: 00                                        ; local decl count
-000187c: 41                                        ; i32.const
-000187d: 01                                        ; i32 literal
-000187e: fe                                        ; prefix
-000187f: 14                                        ; i64.atomic.load8_u
-0001880: 00                                        ; alignment
-0001881: 03                                        ; memory offset
-0001882: 1a                                        ; drop
-0001883: 0b                                        ; end
-000187a: 09                                        ; FIXUP func body size
+0001876: 00                                        ; func body size (guess)
+0001877: 00                                        ; local decl count
+0001878: 41                                        ; i32.const
+0001879: 01                                        ; i32 literal
+000187a: fe                                        ; prefix
+000187b: 14                                        ; i64.atomic.load8_u
+000187c: 00                                        ; alignment
+000187d: 03                                        ; memory offset
+000187e: 1a                                        ; drop
+000187f: 0b                                        ; end
+0001876: 09                                        ; FIXUP func body size
 ; function body 189
-0001884: 00                                        ; func body size (guess)
-0001885: 00                                        ; local decl count
-0001886: 41                                        ; i32.const
-0001887: 01                                        ; i32 literal
-0001888: fe                                        ; prefix
-0001889: 15                                        ; i64.atomic.load16_u
-000188a: 01                                        ; alignment
-000188b: 03                                        ; memory offset
-000188c: 1a                                        ; drop
-000188d: 0b                                        ; end
-0001884: 09                                        ; FIXUP func body size
+0001880: 00                                        ; func body size (guess)
+0001881: 00                                        ; local decl count
+0001882: 41                                        ; i32.const
+0001883: 01                                        ; i32 literal
+0001884: fe                                        ; prefix
+0001885: 15                                        ; i64.atomic.load16_u
+0001886: 01                                        ; alignment
+0001887: 03                                        ; memory offset
+0001888: 1a                                        ; drop
+0001889: 0b                                        ; end
+0001880: 09                                        ; FIXUP func body size
 ; function body 190
-000188e: 00                                        ; func body size (guess)
-000188f: 00                                        ; local decl count
-0001890: 41                                        ; i32.const
-0001891: 01                                        ; i32 literal
-0001892: fe                                        ; prefix
-0001893: 16                                        ; i64.atomic.load32_u
-0001894: 02                                        ; alignment
-0001895: 03                                        ; memory offset
-0001896: 1a                                        ; drop
-0001897: 0b                                        ; end
-000188e: 09                                        ; FIXUP func body size
+000188a: 00                                        ; func body size (guess)
+000188b: 00                                        ; local decl count
+000188c: 41                                        ; i32.const
+000188d: 01                                        ; i32 literal
+000188e: fe                                        ; prefix
+000188f: 16                                        ; i64.atomic.load32_u
+0001890: 02                                        ; alignment
+0001891: 03                                        ; memory offset
+0001892: 1a                                        ; drop
+0001893: 0b                                        ; end
+000188a: 09                                        ; FIXUP func body size
 ; function body 191
-0001898: 00                                        ; func body size (guess)
-0001899: 00                                        ; local decl count
-000189a: 41                                        ; i32.const
-000189b: 01                                        ; i32 literal
-000189c: 41                                        ; i32.const
-000189d: 02                                        ; i32 literal
-000189e: fe                                        ; prefix
-000189f: 17                                        ; i32.atomic.store
-00018a0: 02                                        ; alignment
-00018a1: 03                                        ; memory offset
-00018a2: 0b                                        ; end
-0001898: 0a                                        ; FIXUP func body size
+0001894: 00                                        ; func body size (guess)
+0001895: 00                                        ; local decl count
+0001896: 41                                        ; i32.const
+0001897: 01                                        ; i32 literal
+0001898: 41                                        ; i32.const
+0001899: 02                                        ; i32 literal
+000189a: fe                                        ; prefix
+000189b: 17                                        ; i32.atomic.store
+000189c: 02                                        ; alignment
+000189d: 03                                        ; memory offset
+000189e: 0b                                        ; end
+0001894: 0a                                        ; FIXUP func body size
 ; function body 192
-00018a3: 00                                        ; func body size (guess)
-00018a4: 00                                        ; local decl count
-00018a5: 41                                        ; i32.const
-00018a6: 01                                        ; i32 literal
-00018a7: 42                                        ; i64.const
-00018a8: 02                                        ; i64 literal
-00018a9: fe                                        ; prefix
-00018aa: 18                                        ; i64.atomic.store
-00018ab: 03                                        ; alignment
-00018ac: 07                                        ; memory offset
-00018ad: 0b                                        ; end
-00018a3: 0a                                        ; FIXUP func body size
+000189f: 00                                        ; func body size (guess)
+00018a0: 00                                        ; local decl count
+00018a1: 41                                        ; i32.const
+00018a2: 01                                        ; i32 literal
+00018a3: 42                                        ; i64.const
+00018a4: 02                                        ; i64 literal
+00018a5: fe                                        ; prefix
+00018a6: 18                                        ; i64.atomic.store
+00018a7: 03                                        ; alignment
+00018a8: 07                                        ; memory offset
+00018a9: 0b                                        ; end
+000189f: 0a                                        ; FIXUP func body size
 ; function body 193
-00018ae: 00                                        ; func body size (guess)
-00018af: 00                                        ; local decl count
-00018b0: 41                                        ; i32.const
-00018b1: 01                                        ; i32 literal
-00018b2: 41                                        ; i32.const
-00018b3: 02                                        ; i32 literal
-00018b4: fe                                        ; prefix
-00018b5: 19                                        ; i32.atomic.store8
-00018b6: 00                                        ; alignment
-00018b7: 03                                        ; memory offset
-00018b8: 0b                                        ; end
-00018ae: 0a                                        ; FIXUP func body size
+00018aa: 00                                        ; func body size (guess)
+00018ab: 00                                        ; local decl count
+00018ac: 41                                        ; i32.const
+00018ad: 01                                        ; i32 literal
+00018ae: 41                                        ; i32.const
+00018af: 02                                        ; i32 literal
+00018b0: fe                                        ; prefix
+00018b1: 19                                        ; i32.atomic.store8
+00018b2: 00                                        ; alignment
+00018b3: 03                                        ; memory offset
+00018b4: 0b                                        ; end
+00018aa: 0a                                        ; FIXUP func body size
 ; function body 194
-00018b9: 00                                        ; func body size (guess)
-00018ba: 00                                        ; local decl count
-00018bb: 41                                        ; i32.const
-00018bc: 01                                        ; i32 literal
-00018bd: 41                                        ; i32.const
-00018be: 02                                        ; i32 literal
-00018bf: fe                                        ; prefix
-00018c0: 1a                                        ; i32.atomic.store16
-00018c1: 01                                        ; alignment
-00018c2: 03                                        ; memory offset
-00018c3: 0b                                        ; end
-00018b9: 0a                                        ; FIXUP func body size
+00018b5: 00                                        ; func body size (guess)
+00018b6: 00                                        ; local decl count
+00018b7: 41                                        ; i32.const
+00018b8: 01                                        ; i32 literal
+00018b9: 41                                        ; i32.const
+00018ba: 02                                        ; i32 literal
+00018bb: fe                                        ; prefix
+00018bc: 1a                                        ; i32.atomic.store16
+00018bd: 01                                        ; alignment
+00018be: 03                                        ; memory offset
+00018bf: 0b                                        ; end
+00018b5: 0a                                        ; FIXUP func body size
 ; function body 195
-00018c4: 00                                        ; func body size (guess)
-00018c5: 00                                        ; local decl count
-00018c6: 41                                        ; i32.const
-00018c7: 01                                        ; i32 literal
-00018c8: 42                                        ; i64.const
-00018c9: 02                                        ; i64 literal
-00018ca: fe                                        ; prefix
-00018cb: 1b                                        ; i64.atomic.store8
-00018cc: 00                                        ; alignment
-00018cd: 03                                        ; memory offset
-00018ce: 0b                                        ; end
-00018c4: 0a                                        ; FIXUP func body size
+00018c0: 00                                        ; func body size (guess)
+00018c1: 00                                        ; local decl count
+00018c2: 41                                        ; i32.const
+00018c3: 01                                        ; i32 literal
+00018c4: 42                                        ; i64.const
+00018c5: 02                                        ; i64 literal
+00018c6: fe                                        ; prefix
+00018c7: 1b                                        ; i64.atomic.store8
+00018c8: 00                                        ; alignment
+00018c9: 03                                        ; memory offset
+00018ca: 0b                                        ; end
+00018c0: 0a                                        ; FIXUP func body size
 ; function body 196
-00018cf: 00                                        ; func body size (guess)
-00018d0: 00                                        ; local decl count
-00018d1: 41                                        ; i32.const
-00018d2: 01                                        ; i32 literal
-00018d3: 42                                        ; i64.const
-00018d4: 02                                        ; i64 literal
-00018d5: fe                                        ; prefix
-00018d6: 1c                                        ; i64.atomic.store16
-00018d7: 01                                        ; alignment
-00018d8: 03                                        ; memory offset
-00018d9: 0b                                        ; end
-00018cf: 0a                                        ; FIXUP func body size
+00018cb: 00                                        ; func body size (guess)
+00018cc: 00                                        ; local decl count
+00018cd: 41                                        ; i32.const
+00018ce: 01                                        ; i32 literal
+00018cf: 42                                        ; i64.const
+00018d0: 02                                        ; i64 literal
+00018d1: fe                                        ; prefix
+00018d2: 1c                                        ; i64.atomic.store16
+00018d3: 01                                        ; alignment
+00018d4: 03                                        ; memory offset
+00018d5: 0b                                        ; end
+00018cb: 0a                                        ; FIXUP func body size
 ; function body 197
-00018da: 00                                        ; func body size (guess)
-00018db: 00                                        ; local decl count
-00018dc: 41                                        ; i32.const
-00018dd: 01                                        ; i32 literal
-00018de: 42                                        ; i64.const
-00018df: 02                                        ; i64 literal
-00018e0: fe                                        ; prefix
-00018e1: 1d                                        ; i64.atomic.store32
-00018e2: 02                                        ; alignment
-00018e3: 03                                        ; memory offset
-00018e4: 0b                                        ; end
-00018da: 0a                                        ; FIXUP func body size
+00018d6: 00                                        ; func body size (guess)
+00018d7: 00                                        ; local decl count
+00018d8: 41                                        ; i32.const
+00018d9: 01                                        ; i32 literal
+00018da: 42                                        ; i64.const
+00018db: 02                                        ; i64 literal
+00018dc: fe                                        ; prefix
+00018dd: 1d                                        ; i64.atomic.store32
+00018de: 02                                        ; alignment
+00018df: 03                                        ; memory offset
+00018e0: 0b                                        ; end
+00018d6: 0a                                        ; FIXUP func body size
 ; function body 198
-00018e5: 00                                        ; func body size (guess)
-00018e6: 00                                        ; local decl count
-00018e7: 41                                        ; i32.const
-00018e8: 01                                        ; i32 literal
-00018e9: 41                                        ; i32.const
-00018ea: 02                                        ; i32 literal
-00018eb: fe                                        ; prefix
-00018ec: 1e                                        ; i32.atomic.rmw.add
-00018ed: 02                                        ; alignment
-00018ee: 03                                        ; memory offset
-00018ef: 1a                                        ; drop
-00018f0: 0b                                        ; end
-00018e5: 0b                                        ; FIXUP func body size
+00018e1: 00                                        ; func body size (guess)
+00018e2: 00                                        ; local decl count
+00018e3: 41                                        ; i32.const
+00018e4: 01                                        ; i32 literal
+00018e5: 41                                        ; i32.const
+00018e6: 02                                        ; i32 literal
+00018e7: fe                                        ; prefix
+00018e8: 1e                                        ; i32.atomic.rmw.add
+00018e9: 02                                        ; alignment
+00018ea: 03                                        ; memory offset
+00018eb: 1a                                        ; drop
+00018ec: 0b                                        ; end
+00018e1: 0b                                        ; FIXUP func body size
 ; function body 199
-00018f1: 00                                        ; func body size (guess)
-00018f2: 00                                        ; local decl count
-00018f3: 41                                        ; i32.const
-00018f4: 01                                        ; i32 literal
-00018f5: 42                                        ; i64.const
-00018f6: 02                                        ; i64 literal
-00018f7: fe                                        ; prefix
-00018f8: 1f                                        ; i64.atomic.rmw.add
-00018f9: 03                                        ; alignment
-00018fa: 07                                        ; memory offset
-00018fb: 1a                                        ; drop
-00018fc: 0b                                        ; end
-00018f1: 0b                                        ; FIXUP func body size
+00018ed: 00                                        ; func body size (guess)
+00018ee: 00                                        ; local decl count
+00018ef: 41                                        ; i32.const
+00018f0: 01                                        ; i32 literal
+00018f1: 42                                        ; i64.const
+00018f2: 02                                        ; i64 literal
+00018f3: fe                                        ; prefix
+00018f4: 1f                                        ; i64.atomic.rmw.add
+00018f5: 03                                        ; alignment
+00018f6: 07                                        ; memory offset
+00018f7: 1a                                        ; drop
+00018f8: 0b                                        ; end
+00018ed: 0b                                        ; FIXUP func body size
 ; function body 200
-00018fd: 00                                        ; func body size (guess)
-00018fe: 00                                        ; local decl count
-00018ff: 41                                        ; i32.const
-0001900: 01                                        ; i32 literal
-0001901: 41                                        ; i32.const
-0001902: 02                                        ; i32 literal
-0001903: fe                                        ; prefix
-0001904: 20                                        ; i32.atomic.rmw8_u.add
-0001905: 00                                        ; alignment
-0001906: 03                                        ; memory offset
-0001907: 1a                                        ; drop
-0001908: 0b                                        ; end
-00018fd: 0b                                        ; FIXUP func body size
+00018f9: 00                                        ; func body size (guess)
+00018fa: 00                                        ; local decl count
+00018fb: 41                                        ; i32.const
+00018fc: 01                                        ; i32 literal
+00018fd: 41                                        ; i32.const
+00018fe: 02                                        ; i32 literal
+00018ff: fe                                        ; prefix
+0001900: 20                                        ; i32.atomic.rmw8_u.add
+0001901: 00                                        ; alignment
+0001902: 03                                        ; memory offset
+0001903: 1a                                        ; drop
+0001904: 0b                                        ; end
+00018f9: 0b                                        ; FIXUP func body size
 ; function body 201
-0001909: 00                                        ; func body size (guess)
-000190a: 00                                        ; local decl count
-000190b: 41                                        ; i32.const
-000190c: 01                                        ; i32 literal
-000190d: 41                                        ; i32.const
-000190e: 02                                        ; i32 literal
-000190f: fe                                        ; prefix
-0001910: 21                                        ; i32.atomic.rmw16_u.add
-0001911: 01                                        ; alignment
-0001912: 03                                        ; memory offset
-0001913: 1a                                        ; drop
-0001914: 0b                                        ; end
-0001909: 0b                                        ; FIXUP func body size
+0001905: 00                                        ; func body size (guess)
+0001906: 00                                        ; local decl count
+0001907: 41                                        ; i32.const
+0001908: 01                                        ; i32 literal
+0001909: 41                                        ; i32.const
+000190a: 02                                        ; i32 literal
+000190b: fe                                        ; prefix
+000190c: 21                                        ; i32.atomic.rmw16_u.add
+000190d: 01                                        ; alignment
+000190e: 03                                        ; memory offset
+000190f: 1a                                        ; drop
+0001910: 0b                                        ; end
+0001905: 0b                                        ; FIXUP func body size
 ; function body 202
-0001915: 00                                        ; func body size (guess)
-0001916: 00                                        ; local decl count
-0001917: 41                                        ; i32.const
-0001918: 01                                        ; i32 literal
-0001919: 42                                        ; i64.const
-000191a: 02                                        ; i64 literal
-000191b: fe                                        ; prefix
-000191c: 22                                        ; i64.atomic.rmw8_u.add
-000191d: 00                                        ; alignment
-000191e: 03                                        ; memory offset
-000191f: 1a                                        ; drop
-0001920: 0b                                        ; end
-0001915: 0b                                        ; FIXUP func body size
+0001911: 00                                        ; func body size (guess)
+0001912: 00                                        ; local decl count
+0001913: 41                                        ; i32.const
+0001914: 01                                        ; i32 literal
+0001915: 42                                        ; i64.const
+0001916: 02                                        ; i64 literal
+0001917: fe                                        ; prefix
+0001918: 22                                        ; i64.atomic.rmw8_u.add
+0001919: 00                                        ; alignment
+000191a: 03                                        ; memory offset
+000191b: 1a                                        ; drop
+000191c: 0b                                        ; end
+0001911: 0b                                        ; FIXUP func body size
 ; function body 203
-0001921: 00                                        ; func body size (guess)
-0001922: 00                                        ; local decl count
-0001923: 41                                        ; i32.const
-0001924: 01                                        ; i32 literal
-0001925: 42                                        ; i64.const
-0001926: 02                                        ; i64 literal
-0001927: fe                                        ; prefix
-0001928: 23                                        ; i64.atomic.rmw16_u.add
-0001929: 01                                        ; alignment
-000192a: 03                                        ; memory offset
-000192b: 1a                                        ; drop
-000192c: 0b                                        ; end
-0001921: 0b                                        ; FIXUP func body size
+000191d: 00                                        ; func body size (guess)
+000191e: 00                                        ; local decl count
+000191f: 41                                        ; i32.const
+0001920: 01                                        ; i32 literal
+0001921: 42                                        ; i64.const
+0001922: 02                                        ; i64 literal
+0001923: fe                                        ; prefix
+0001924: 23                                        ; i64.atomic.rmw16_u.add
+0001925: 01                                        ; alignment
+0001926: 03                                        ; memory offset
+0001927: 1a                                        ; drop
+0001928: 0b                                        ; end
+000191d: 0b                                        ; FIXUP func body size
 ; function body 204
-000192d: 00                                        ; func body size (guess)
-000192e: 00                                        ; local decl count
-000192f: 41                                        ; i32.const
-0001930: 01                                        ; i32 literal
-0001931: 42                                        ; i64.const
-0001932: 02                                        ; i64 literal
-0001933: fe                                        ; prefix
-0001934: 24                                        ; i64.atomic.rmw32_u.add
-0001935: 02                                        ; alignment
-0001936: 03                                        ; memory offset
-0001937: 1a                                        ; drop
-0001938: 0b                                        ; end
-000192d: 0b                                        ; FIXUP func body size
+0001929: 00                                        ; func body size (guess)
+000192a: 00                                        ; local decl count
+000192b: 41                                        ; i32.const
+000192c: 01                                        ; i32 literal
+000192d: 42                                        ; i64.const
+000192e: 02                                        ; i64 literal
+000192f: fe                                        ; prefix
+0001930: 24                                        ; i64.atomic.rmw32_u.add
+0001931: 02                                        ; alignment
+0001932: 03                                        ; memory offset
+0001933: 1a                                        ; drop
+0001934: 0b                                        ; end
+0001929: 0b                                        ; FIXUP func body size
 ; function body 205
-0001939: 00                                        ; func body size (guess)
-000193a: 00                                        ; local decl count
-000193b: 41                                        ; i32.const
-000193c: 01                                        ; i32 literal
-000193d: 41                                        ; i32.const
-000193e: 02                                        ; i32 literal
-000193f: fe                                        ; prefix
-0001940: 25                                        ; i32.atomic.rmw.sub
-0001941: 02                                        ; alignment
-0001942: 03                                        ; memory offset
-0001943: 1a                                        ; drop
-0001944: 0b                                        ; end
-0001939: 0b                                        ; FIXUP func body size
+0001935: 00                                        ; func body size (guess)
+0001936: 00                                        ; local decl count
+0001937: 41                                        ; i32.const
+0001938: 01                                        ; i32 literal
+0001939: 41                                        ; i32.const
+000193a: 02                                        ; i32 literal
+000193b: fe                                        ; prefix
+000193c: 25                                        ; i32.atomic.rmw.sub
+000193d: 02                                        ; alignment
+000193e: 03                                        ; memory offset
+000193f: 1a                                        ; drop
+0001940: 0b                                        ; end
+0001935: 0b                                        ; FIXUP func body size
 ; function body 206
-0001945: 00                                        ; func body size (guess)
-0001946: 00                                        ; local decl count
-0001947: 41                                        ; i32.const
-0001948: 01                                        ; i32 literal
-0001949: 42                                        ; i64.const
-000194a: 02                                        ; i64 literal
-000194b: fe                                        ; prefix
-000194c: 26                                        ; i64.atomic.rmw.sub
-000194d: 03                                        ; alignment
-000194e: 07                                        ; memory offset
-000194f: 1a                                        ; drop
-0001950: 0b                                        ; end
-0001945: 0b                                        ; FIXUP func body size
+0001941: 00                                        ; func body size (guess)
+0001942: 00                                        ; local decl count
+0001943: 41                                        ; i32.const
+0001944: 01                                        ; i32 literal
+0001945: 42                                        ; i64.const
+0001946: 02                                        ; i64 literal
+0001947: fe                                        ; prefix
+0001948: 26                                        ; i64.atomic.rmw.sub
+0001949: 03                                        ; alignment
+000194a: 07                                        ; memory offset
+000194b: 1a                                        ; drop
+000194c: 0b                                        ; end
+0001941: 0b                                        ; FIXUP func body size
 ; function body 207
-0001951: 00                                        ; func body size (guess)
-0001952: 00                                        ; local decl count
-0001953: 41                                        ; i32.const
-0001954: 01                                        ; i32 literal
-0001955: 41                                        ; i32.const
-0001956: 02                                        ; i32 literal
-0001957: fe                                        ; prefix
-0001958: 27                                        ; i32.atomic.rmw8_u.sub
-0001959: 00                                        ; alignment
-000195a: 03                                        ; memory offset
-000195b: 1a                                        ; drop
-000195c: 0b                                        ; end
-0001951: 0b                                        ; FIXUP func body size
+000194d: 00                                        ; func body size (guess)
+000194e: 00                                        ; local decl count
+000194f: 41                                        ; i32.const
+0001950: 01                                        ; i32 literal
+0001951: 41                                        ; i32.const
+0001952: 02                                        ; i32 literal
+0001953: fe                                        ; prefix
+0001954: 27                                        ; i32.atomic.rmw8_u.sub
+0001955: 00                                        ; alignment
+0001956: 03                                        ; memory offset
+0001957: 1a                                        ; drop
+0001958: 0b                                        ; end
+000194d: 0b                                        ; FIXUP func body size
 ; function body 208
-000195d: 00                                        ; func body size (guess)
-000195e: 00                                        ; local decl count
-000195f: 41                                        ; i32.const
-0001960: 01                                        ; i32 literal
-0001961: 41                                        ; i32.const
-0001962: 02                                        ; i32 literal
-0001963: fe                                        ; prefix
-0001964: 28                                        ; i32.atomic.rmw16_u.sub
-0001965: 01                                        ; alignment
-0001966: 03                                        ; memory offset
-0001967: 1a                                        ; drop
-0001968: 0b                                        ; end
-000195d: 0b                                        ; FIXUP func body size
+0001959: 00                                        ; func body size (guess)
+000195a: 00                                        ; local decl count
+000195b: 41                                        ; i32.const
+000195c: 01                                        ; i32 literal
+000195d: 41                                        ; i32.const
+000195e: 02                                        ; i32 literal
+000195f: fe                                        ; prefix
+0001960: 28                                        ; i32.atomic.rmw16_u.sub
+0001961: 01                                        ; alignment
+0001962: 03                                        ; memory offset
+0001963: 1a                                        ; drop
+0001964: 0b                                        ; end
+0001959: 0b                                        ; FIXUP func body size
 ; function body 209
-0001969: 00                                        ; func body size (guess)
-000196a: 00                                        ; local decl count
-000196b: 41                                        ; i32.const
-000196c: 01                                        ; i32 literal
-000196d: 42                                        ; i64.const
-000196e: 02                                        ; i64 literal
-000196f: fe                                        ; prefix
-0001970: 29                                        ; i64.atomic.rmw8_u.sub
-0001971: 00                                        ; alignment
-0001972: 03                                        ; memory offset
-0001973: 1a                                        ; drop
-0001974: 0b                                        ; end
-0001969: 0b                                        ; FIXUP func body size
+0001965: 00                                        ; func body size (guess)
+0001966: 00                                        ; local decl count
+0001967: 41                                        ; i32.const
+0001968: 01                                        ; i32 literal
+0001969: 42                                        ; i64.const
+000196a: 02                                        ; i64 literal
+000196b: fe                                        ; prefix
+000196c: 29                                        ; i64.atomic.rmw8_u.sub
+000196d: 00                                        ; alignment
+000196e: 03                                        ; memory offset
+000196f: 1a                                        ; drop
+0001970: 0b                                        ; end
+0001965: 0b                                        ; FIXUP func body size
 ; function body 210
-0001975: 00                                        ; func body size (guess)
-0001976: 00                                        ; local decl count
-0001977: 41                                        ; i32.const
-0001978: 01                                        ; i32 literal
-0001979: 42                                        ; i64.const
-000197a: 02                                        ; i64 literal
-000197b: fe                                        ; prefix
-000197c: 2a                                        ; i64.atomic.rmw16_u.sub
-000197d: 01                                        ; alignment
-000197e: 03                                        ; memory offset
-000197f: 1a                                        ; drop
-0001980: 0b                                        ; end
-0001975: 0b                                        ; FIXUP func body size
+0001971: 00                                        ; func body size (guess)
+0001972: 00                                        ; local decl count
+0001973: 41                                        ; i32.const
+0001974: 01                                        ; i32 literal
+0001975: 42                                        ; i64.const
+0001976: 02                                        ; i64 literal
+0001977: fe                                        ; prefix
+0001978: 2a                                        ; i64.atomic.rmw16_u.sub
+0001979: 01                                        ; alignment
+000197a: 03                                        ; memory offset
+000197b: 1a                                        ; drop
+000197c: 0b                                        ; end
+0001971: 0b                                        ; FIXUP func body size
 ; function body 211
-0001981: 00                                        ; func body size (guess)
-0001982: 00                                        ; local decl count
-0001983: 41                                        ; i32.const
-0001984: 01                                        ; i32 literal
-0001985: 42                                        ; i64.const
-0001986: 02                                        ; i64 literal
-0001987: fe                                        ; prefix
-0001988: 2b                                        ; i64.atomic.rmw32_u.sub
-0001989: 02                                        ; alignment
-000198a: 03                                        ; memory offset
-000198b: 1a                                        ; drop
-000198c: 0b                                        ; end
-0001981: 0b                                        ; FIXUP func body size
+000197d: 00                                        ; func body size (guess)
+000197e: 00                                        ; local decl count
+000197f: 41                                        ; i32.const
+0001980: 01                                        ; i32 literal
+0001981: 42                                        ; i64.const
+0001982: 02                                        ; i64 literal
+0001983: fe                                        ; prefix
+0001984: 2b                                        ; i64.atomic.rmw32_u.sub
+0001985: 02                                        ; alignment
+0001986: 03                                        ; memory offset
+0001987: 1a                                        ; drop
+0001988: 0b                                        ; end
+000197d: 0b                                        ; FIXUP func body size
 ; function body 212
-000198d: 00                                        ; func body size (guess)
-000198e: 00                                        ; local decl count
-000198f: 41                                        ; i32.const
-0001990: 01                                        ; i32 literal
-0001991: 41                                        ; i32.const
-0001992: 02                                        ; i32 literal
-0001993: fe                                        ; prefix
-0001994: 2c                                        ; i32.atomic.rmw.and
-0001995: 02                                        ; alignment
-0001996: 03                                        ; memory offset
-0001997: 1a                                        ; drop
-0001998: 0b                                        ; end
-000198d: 0b                                        ; FIXUP func body size
+0001989: 00                                        ; func body size (guess)
+000198a: 00                                        ; local decl count
+000198b: 41                                        ; i32.const
+000198c: 01                                        ; i32 literal
+000198d: 41                                        ; i32.const
+000198e: 02                                        ; i32 literal
+000198f: fe                                        ; prefix
+0001990: 2c                                        ; i32.atomic.rmw.and
+0001991: 02                                        ; alignment
+0001992: 03                                        ; memory offset
+0001993: 1a                                        ; drop
+0001994: 0b                                        ; end
+0001989: 0b                                        ; FIXUP func body size
 ; function body 213
-0001999: 00                                        ; func body size (guess)
-000199a: 00                                        ; local decl count
-000199b: 41                                        ; i32.const
-000199c: 01                                        ; i32 literal
-000199d: 42                                        ; i64.const
-000199e: 02                                        ; i64 literal
-000199f: fe                                        ; prefix
-00019a0: 2d                                        ; i64.atomic.rmw.and
-00019a1: 03                                        ; alignment
-00019a2: 07                                        ; memory offset
-00019a3: 1a                                        ; drop
-00019a4: 0b                                        ; end
-0001999: 0b                                        ; FIXUP func body size
+0001995: 00                                        ; func body size (guess)
+0001996: 00                                        ; local decl count
+0001997: 41                                        ; i32.const
+0001998: 01                                        ; i32 literal
+0001999: 42                                        ; i64.const
+000199a: 02                                        ; i64 literal
+000199b: fe                                        ; prefix
+000199c: 2d                                        ; i64.atomic.rmw.and
+000199d: 03                                        ; alignment
+000199e: 07                                        ; memory offset
+000199f: 1a                                        ; drop
+00019a0: 0b                                        ; end
+0001995: 0b                                        ; FIXUP func body size
 ; function body 214
-00019a5: 00                                        ; func body size (guess)
-00019a6: 00                                        ; local decl count
-00019a7: 41                                        ; i32.const
-00019a8: 01                                        ; i32 literal
-00019a9: 41                                        ; i32.const
-00019aa: 02                                        ; i32 literal
-00019ab: fe                                        ; prefix
-00019ac: 2e                                        ; i32.atomic.rmw8_u.and
-00019ad: 00                                        ; alignment
-00019ae: 03                                        ; memory offset
-00019af: 1a                                        ; drop
-00019b0: 0b                                        ; end
-00019a5: 0b                                        ; FIXUP func body size
+00019a1: 00                                        ; func body size (guess)
+00019a2: 00                                        ; local decl count
+00019a3: 41                                        ; i32.const
+00019a4: 01                                        ; i32 literal
+00019a5: 41                                        ; i32.const
+00019a6: 02                                        ; i32 literal
+00019a7: fe                                        ; prefix
+00019a8: 2e                                        ; i32.atomic.rmw8_u.and
+00019a9: 00                                        ; alignment
+00019aa: 03                                        ; memory offset
+00019ab: 1a                                        ; drop
+00019ac: 0b                                        ; end
+00019a1: 0b                                        ; FIXUP func body size
 ; function body 215
-00019b1: 00                                        ; func body size (guess)
-00019b2: 00                                        ; local decl count
-00019b3: 41                                        ; i32.const
-00019b4: 01                                        ; i32 literal
-00019b5: 41                                        ; i32.const
-00019b6: 02                                        ; i32 literal
-00019b7: fe                                        ; prefix
-00019b8: 2f                                        ; i32.atomic.rmw16_u.and
-00019b9: 01                                        ; alignment
-00019ba: 03                                        ; memory offset
-00019bb: 1a                                        ; drop
-00019bc: 0b                                        ; end
-00019b1: 0b                                        ; FIXUP func body size
+00019ad: 00                                        ; func body size (guess)
+00019ae: 00                                        ; local decl count
+00019af: 41                                        ; i32.const
+00019b0: 01                                        ; i32 literal
+00019b1: 41                                        ; i32.const
+00019b2: 02                                        ; i32 literal
+00019b3: fe                                        ; prefix
+00019b4: 2f                                        ; i32.atomic.rmw16_u.and
+00019b5: 01                                        ; alignment
+00019b6: 03                                        ; memory offset
+00019b7: 1a                                        ; drop
+00019b8: 0b                                        ; end
+00019ad: 0b                                        ; FIXUP func body size
 ; function body 216
-00019bd: 00                                        ; func body size (guess)
-00019be: 00                                        ; local decl count
-00019bf: 41                                        ; i32.const
-00019c0: 01                                        ; i32 literal
-00019c1: 42                                        ; i64.const
-00019c2: 02                                        ; i64 literal
-00019c3: fe                                        ; prefix
-00019c4: 30                                        ; i64.atomic.rmw8_u.and
-00019c5: 00                                        ; alignment
-00019c6: 03                                        ; memory offset
-00019c7: 1a                                        ; drop
-00019c8: 0b                                        ; end
-00019bd: 0b                                        ; FIXUP func body size
+00019b9: 00                                        ; func body size (guess)
+00019ba: 00                                        ; local decl count
+00019bb: 41                                        ; i32.const
+00019bc: 01                                        ; i32 literal
+00019bd: 42                                        ; i64.const
+00019be: 02                                        ; i64 literal
+00019bf: fe                                        ; prefix
+00019c0: 30                                        ; i64.atomic.rmw8_u.and
+00019c1: 00                                        ; alignment
+00019c2: 03                                        ; memory offset
+00019c3: 1a                                        ; drop
+00019c4: 0b                                        ; end
+00019b9: 0b                                        ; FIXUP func body size
 ; function body 217
-00019c9: 00                                        ; func body size (guess)
-00019ca: 00                                        ; local decl count
-00019cb: 41                                        ; i32.const
-00019cc: 01                                        ; i32 literal
-00019cd: 42                                        ; i64.const
-00019ce: 02                                        ; i64 literal
-00019cf: fe                                        ; prefix
-00019d0: 31                                        ; i64.atomic.rmw16_u.and
-00019d1: 01                                        ; alignment
-00019d2: 03                                        ; memory offset
-00019d3: 1a                                        ; drop
-00019d4: 0b                                        ; end
-00019c9: 0b                                        ; FIXUP func body size
+00019c5: 00                                        ; func body size (guess)
+00019c6: 00                                        ; local decl count
+00019c7: 41                                        ; i32.const
+00019c8: 01                                        ; i32 literal
+00019c9: 42                                        ; i64.const
+00019ca: 02                                        ; i64 literal
+00019cb: fe                                        ; prefix
+00019cc: 31                                        ; i64.atomic.rmw16_u.and
+00019cd: 01                                        ; alignment
+00019ce: 03                                        ; memory offset
+00019cf: 1a                                        ; drop
+00019d0: 0b                                        ; end
+00019c5: 0b                                        ; FIXUP func body size
 ; function body 218
-00019d5: 00                                        ; func body size (guess)
-00019d6: 00                                        ; local decl count
-00019d7: 41                                        ; i32.const
-00019d8: 01                                        ; i32 literal
-00019d9: 42                                        ; i64.const
-00019da: 02                                        ; i64 literal
-00019db: fe                                        ; prefix
-00019dc: 32                                        ; i64.atomic.rmw32_u.and
-00019dd: 02                                        ; alignment
-00019de: 03                                        ; memory offset
-00019df: 1a                                        ; drop
-00019e0: 0b                                        ; end
-00019d5: 0b                                        ; FIXUP func body size
+00019d1: 00                                        ; func body size (guess)
+00019d2: 00                                        ; local decl count
+00019d3: 41                                        ; i32.const
+00019d4: 01                                        ; i32 literal
+00019d5: 42                                        ; i64.const
+00019d6: 02                                        ; i64 literal
+00019d7: fe                                        ; prefix
+00019d8: 32                                        ; i64.atomic.rmw32_u.and
+00019d9: 02                                        ; alignment
+00019da: 03                                        ; memory offset
+00019db: 1a                                        ; drop
+00019dc: 0b                                        ; end
+00019d1: 0b                                        ; FIXUP func body size
 ; function body 219
-00019e1: 00                                        ; func body size (guess)
-00019e2: 00                                        ; local decl count
-00019e3: 41                                        ; i32.const
-00019e4: 01                                        ; i32 literal
-00019e5: 41                                        ; i32.const
-00019e6: 02                                        ; i32 literal
-00019e7: fe                                        ; prefix
-00019e8: 33                                        ; i32.atomic.rmw.or
-00019e9: 02                                        ; alignment
-00019ea: 03                                        ; memory offset
-00019eb: 1a                                        ; drop
-00019ec: 0b                                        ; end
-00019e1: 0b                                        ; FIXUP func body size
+00019dd: 00                                        ; func body size (guess)
+00019de: 00                                        ; local decl count
+00019df: 41                                        ; i32.const
+00019e0: 01                                        ; i32 literal
+00019e1: 41                                        ; i32.const
+00019e2: 02                                        ; i32 literal
+00019e3: fe                                        ; prefix
+00019e4: 33                                        ; i32.atomic.rmw.or
+00019e5: 02                                        ; alignment
+00019e6: 03                                        ; memory offset
+00019e7: 1a                                        ; drop
+00019e8: 0b                                        ; end
+00019dd: 0b                                        ; FIXUP func body size
 ; function body 220
-00019ed: 00                                        ; func body size (guess)
-00019ee: 00                                        ; local decl count
-00019ef: 41                                        ; i32.const
-00019f0: 01                                        ; i32 literal
-00019f1: 42                                        ; i64.const
-00019f2: 02                                        ; i64 literal
-00019f3: fe                                        ; prefix
-00019f4: 34                                        ; i64.atomic.rmw.or
-00019f5: 03                                        ; alignment
-00019f6: 07                                        ; memory offset
-00019f7: 1a                                        ; drop
-00019f8: 0b                                        ; end
-00019ed: 0b                                        ; FIXUP func body size
+00019e9: 00                                        ; func body size (guess)
+00019ea: 00                                        ; local decl count
+00019eb: 41                                        ; i32.const
+00019ec: 01                                        ; i32 literal
+00019ed: 42                                        ; i64.const
+00019ee: 02                                        ; i64 literal
+00019ef: fe                                        ; prefix
+00019f0: 34                                        ; i64.atomic.rmw.or
+00019f1: 03                                        ; alignment
+00019f2: 07                                        ; memory offset
+00019f3: 1a                                        ; drop
+00019f4: 0b                                        ; end
+00019e9: 0b                                        ; FIXUP func body size
 ; function body 221
-00019f9: 00                                        ; func body size (guess)
-00019fa: 00                                        ; local decl count
-00019fb: 41                                        ; i32.const
-00019fc: 01                                        ; i32 literal
-00019fd: 41                                        ; i32.const
-00019fe: 02                                        ; i32 literal
-00019ff: fe                                        ; prefix
-0001a00: 35                                        ; i32.atomic.rmw8_u.or
-0001a01: 00                                        ; alignment
-0001a02: 03                                        ; memory offset
-0001a03: 1a                                        ; drop
-0001a04: 0b                                        ; end
-00019f9: 0b                                        ; FIXUP func body size
+00019f5: 00                                        ; func body size (guess)
+00019f6: 00                                        ; local decl count
+00019f7: 41                                        ; i32.const
+00019f8: 01                                        ; i32 literal
+00019f9: 41                                        ; i32.const
+00019fa: 02                                        ; i32 literal
+00019fb: fe                                        ; prefix
+00019fc: 35                                        ; i32.atomic.rmw8_u.or
+00019fd: 00                                        ; alignment
+00019fe: 03                                        ; memory offset
+00019ff: 1a                                        ; drop
+0001a00: 0b                                        ; end
+00019f5: 0b                                        ; FIXUP func body size
 ; function body 222
-0001a05: 00                                        ; func body size (guess)
-0001a06: 00                                        ; local decl count
-0001a07: 41                                        ; i32.const
-0001a08: 01                                        ; i32 literal
-0001a09: 41                                        ; i32.const
-0001a0a: 02                                        ; i32 literal
-0001a0b: fe                                        ; prefix
-0001a0c: 36                                        ; i32.atomic.rmw16_u.or
-0001a0d: 01                                        ; alignment
-0001a0e: 03                                        ; memory offset
-0001a0f: 1a                                        ; drop
-0001a10: 0b                                        ; end
-0001a05: 0b                                        ; FIXUP func body size
+0001a01: 00                                        ; func body size (guess)
+0001a02: 00                                        ; local decl count
+0001a03: 41                                        ; i32.const
+0001a04: 01                                        ; i32 literal
+0001a05: 41                                        ; i32.const
+0001a06: 02                                        ; i32 literal
+0001a07: fe                                        ; prefix
+0001a08: 36                                        ; i32.atomic.rmw16_u.or
+0001a09: 01                                        ; alignment
+0001a0a: 03                                        ; memory offset
+0001a0b: 1a                                        ; drop
+0001a0c: 0b                                        ; end
+0001a01: 0b                                        ; FIXUP func body size
 ; function body 223
-0001a11: 00                                        ; func body size (guess)
-0001a12: 00                                        ; local decl count
-0001a13: 41                                        ; i32.const
-0001a14: 01                                        ; i32 literal
-0001a15: 42                                        ; i64.const
-0001a16: 02                                        ; i64 literal
-0001a17: fe                                        ; prefix
-0001a18: 37                                        ; i64.atomic.rmw8_u.or
-0001a19: 00                                        ; alignment
-0001a1a: 03                                        ; memory offset
-0001a1b: 1a                                        ; drop
-0001a1c: 0b                                        ; end
-0001a11: 0b                                        ; FIXUP func body size
+0001a0d: 00                                        ; func body size (guess)
+0001a0e: 00                                        ; local decl count
+0001a0f: 41                                        ; i32.const
+0001a10: 01                                        ; i32 literal
+0001a11: 42                                        ; i64.const
+0001a12: 02                                        ; i64 literal
+0001a13: fe                                        ; prefix
+0001a14: 37                                        ; i64.atomic.rmw8_u.or
+0001a15: 00                                        ; alignment
+0001a16: 03                                        ; memory offset
+0001a17: 1a                                        ; drop
+0001a18: 0b                                        ; end
+0001a0d: 0b                                        ; FIXUP func body size
 ; function body 224
-0001a1d: 00                                        ; func body size (guess)
-0001a1e: 00                                        ; local decl count
-0001a1f: 41                                        ; i32.const
-0001a20: 01                                        ; i32 literal
-0001a21: 42                                        ; i64.const
-0001a22: 02                                        ; i64 literal
-0001a23: fe                                        ; prefix
-0001a24: 38                                        ; i64.atomic.rmw16_u.or
-0001a25: 01                                        ; alignment
-0001a26: 03                                        ; memory offset
-0001a27: 1a                                        ; drop
-0001a28: 0b                                        ; end
-0001a1d: 0b                                        ; FIXUP func body size
+0001a19: 00                                        ; func body size (guess)
+0001a1a: 00                                        ; local decl count
+0001a1b: 41                                        ; i32.const
+0001a1c: 01                                        ; i32 literal
+0001a1d: 42                                        ; i64.const
+0001a1e: 02                                        ; i64 literal
+0001a1f: fe                                        ; prefix
+0001a20: 38                                        ; i64.atomic.rmw16_u.or
+0001a21: 01                                        ; alignment
+0001a22: 03                                        ; memory offset
+0001a23: 1a                                        ; drop
+0001a24: 0b                                        ; end
+0001a19: 0b                                        ; FIXUP func body size
 ; function body 225
-0001a29: 00                                        ; func body size (guess)
-0001a2a: 00                                        ; local decl count
-0001a2b: 41                                        ; i32.const
-0001a2c: 01                                        ; i32 literal
-0001a2d: 42                                        ; i64.const
-0001a2e: 02                                        ; i64 literal
-0001a2f: fe                                        ; prefix
-0001a30: 39                                        ; i64.atomic.rmw32_u.or
-0001a31: 02                                        ; alignment
-0001a32: 03                                        ; memory offset
-0001a33: 1a                                        ; drop
-0001a34: 0b                                        ; end
-0001a29: 0b                                        ; FIXUP func body size
+0001a25: 00                                        ; func body size (guess)
+0001a26: 00                                        ; local decl count
+0001a27: 41                                        ; i32.const
+0001a28: 01                                        ; i32 literal
+0001a29: 42                                        ; i64.const
+0001a2a: 02                                        ; i64 literal
+0001a2b: fe                                        ; prefix
+0001a2c: 39                                        ; i64.atomic.rmw32_u.or
+0001a2d: 02                                        ; alignment
+0001a2e: 03                                        ; memory offset
+0001a2f: 1a                                        ; drop
+0001a30: 0b                                        ; end
+0001a25: 0b                                        ; FIXUP func body size
 ; function body 226
-0001a35: 00                                        ; func body size (guess)
-0001a36: 00                                        ; local decl count
-0001a37: 41                                        ; i32.const
-0001a38: 01                                        ; i32 literal
-0001a39: 41                                        ; i32.const
-0001a3a: 02                                        ; i32 literal
-0001a3b: fe                                        ; prefix
-0001a3c: 3a                                        ; i32.atomic.rmw.xor
-0001a3d: 02                                        ; alignment
-0001a3e: 03                                        ; memory offset
-0001a3f: 1a                                        ; drop
-0001a40: 0b                                        ; end
-0001a35: 0b                                        ; FIXUP func body size
+0001a31: 00                                        ; func body size (guess)
+0001a32: 00                                        ; local decl count
+0001a33: 41                                        ; i32.const
+0001a34: 01                                        ; i32 literal
+0001a35: 41                                        ; i32.const
+0001a36: 02                                        ; i32 literal
+0001a37: fe                                        ; prefix
+0001a38: 3a                                        ; i32.atomic.rmw.xor
+0001a39: 02                                        ; alignment
+0001a3a: 03                                        ; memory offset
+0001a3b: 1a                                        ; drop
+0001a3c: 0b                                        ; end
+0001a31: 0b                                        ; FIXUP func body size
 ; function body 227
-0001a41: 00                                        ; func body size (guess)
-0001a42: 00                                        ; local decl count
-0001a43: 41                                        ; i32.const
-0001a44: 01                                        ; i32 literal
-0001a45: 42                                        ; i64.const
-0001a46: 02                                        ; i64 literal
-0001a47: fe                                        ; prefix
-0001a48: 3b                                        ; i64.atomic.rmw.xor
-0001a49: 03                                        ; alignment
-0001a4a: 07                                        ; memory offset
-0001a4b: 1a                                        ; drop
-0001a4c: 0b                                        ; end
-0001a41: 0b                                        ; FIXUP func body size
+0001a3d: 00                                        ; func body size (guess)
+0001a3e: 00                                        ; local decl count
+0001a3f: 41                                        ; i32.const
+0001a40: 01                                        ; i32 literal
+0001a41: 42                                        ; i64.const
+0001a42: 02                                        ; i64 literal
+0001a43: fe                                        ; prefix
+0001a44: 3b                                        ; i64.atomic.rmw.xor
+0001a45: 03                                        ; alignment
+0001a46: 07                                        ; memory offset
+0001a47: 1a                                        ; drop
+0001a48: 0b                                        ; end
+0001a3d: 0b                                        ; FIXUP func body size
 ; function body 228
-0001a4d: 00                                        ; func body size (guess)
-0001a4e: 00                                        ; local decl count
-0001a4f: 41                                        ; i32.const
-0001a50: 01                                        ; i32 literal
-0001a51: 41                                        ; i32.const
-0001a52: 02                                        ; i32 literal
-0001a53: fe                                        ; prefix
-0001a54: 3c                                        ; i32.atomic.rmw8_u.xor
-0001a55: 00                                        ; alignment
-0001a56: 03                                        ; memory offset
-0001a57: 1a                                        ; drop
-0001a58: 0b                                        ; end
-0001a4d: 0b                                        ; FIXUP func body size
+0001a49: 00                                        ; func body size (guess)
+0001a4a: 00                                        ; local decl count
+0001a4b: 41                                        ; i32.const
+0001a4c: 01                                        ; i32 literal
+0001a4d: 41                                        ; i32.const
+0001a4e: 02                                        ; i32 literal
+0001a4f: fe                                        ; prefix
+0001a50: 3c                                        ; i32.atomic.rmw8_u.xor
+0001a51: 00                                        ; alignment
+0001a52: 03                                        ; memory offset
+0001a53: 1a                                        ; drop
+0001a54: 0b                                        ; end
+0001a49: 0b                                        ; FIXUP func body size
 ; function body 229
-0001a59: 00                                        ; func body size (guess)
-0001a5a: 00                                        ; local decl count
-0001a5b: 41                                        ; i32.const
-0001a5c: 01                                        ; i32 literal
-0001a5d: 41                                        ; i32.const
-0001a5e: 02                                        ; i32 literal
-0001a5f: fe                                        ; prefix
-0001a60: 3d                                        ; i32.atomic.rmw16_u.xor
-0001a61: 01                                        ; alignment
-0001a62: 03                                        ; memory offset
-0001a63: 1a                                        ; drop
-0001a64: 0b                                        ; end
-0001a59: 0b                                        ; FIXUP func body size
+0001a55: 00                                        ; func body size (guess)
+0001a56: 00                                        ; local decl count
+0001a57: 41                                        ; i32.const
+0001a58: 01                                        ; i32 literal
+0001a59: 41                                        ; i32.const
+0001a5a: 02                                        ; i32 literal
+0001a5b: fe                                        ; prefix
+0001a5c: 3d                                        ; i32.atomic.rmw16_u.xor
+0001a5d: 01                                        ; alignment
+0001a5e: 03                                        ; memory offset
+0001a5f: 1a                                        ; drop
+0001a60: 0b                                        ; end
+0001a55: 0b                                        ; FIXUP func body size
 ; function body 230
-0001a65: 00                                        ; func body size (guess)
-0001a66: 00                                        ; local decl count
-0001a67: 41                                        ; i32.const
-0001a68: 01                                        ; i32 literal
-0001a69: 42                                        ; i64.const
-0001a6a: 02                                        ; i64 literal
-0001a6b: fe                                        ; prefix
-0001a6c: 3e                                        ; i64.atomic.rmw8_u.xor
-0001a6d: 00                                        ; alignment
-0001a6e: 03                                        ; memory offset
-0001a6f: 1a                                        ; drop
-0001a70: 0b                                        ; end
-0001a65: 0b                                        ; FIXUP func body size
+0001a61: 00                                        ; func body size (guess)
+0001a62: 00                                        ; local decl count
+0001a63: 41                                        ; i32.const
+0001a64: 01                                        ; i32 literal
+0001a65: 42                                        ; i64.const
+0001a66: 02                                        ; i64 literal
+0001a67: fe                                        ; prefix
+0001a68: 3e                                        ; i64.atomic.rmw8_u.xor
+0001a69: 00                                        ; alignment
+0001a6a: 03                                        ; memory offset
+0001a6b: 1a                                        ; drop
+0001a6c: 0b                                        ; end
+0001a61: 0b                                        ; FIXUP func body size
 ; function body 231
-0001a71: 00                                        ; func body size (guess)
-0001a72: 00                                        ; local decl count
-0001a73: 41                                        ; i32.const
-0001a74: 01                                        ; i32 literal
-0001a75: 42                                        ; i64.const
-0001a76: 02                                        ; i64 literal
-0001a77: fe                                        ; prefix
-0001a78: 3f                                        ; i64.atomic.rmw16_u.xor
-0001a79: 01                                        ; alignment
-0001a7a: 03                                        ; memory offset
-0001a7b: 1a                                        ; drop
-0001a7c: 0b                                        ; end
-0001a71: 0b                                        ; FIXUP func body size
+0001a6d: 00                                        ; func body size (guess)
+0001a6e: 00                                        ; local decl count
+0001a6f: 41                                        ; i32.const
+0001a70: 01                                        ; i32 literal
+0001a71: 42                                        ; i64.const
+0001a72: 02                                        ; i64 literal
+0001a73: fe                                        ; prefix
+0001a74: 3f                                        ; i64.atomic.rmw16_u.xor
+0001a75: 01                                        ; alignment
+0001a76: 03                                        ; memory offset
+0001a77: 1a                                        ; drop
+0001a78: 0b                                        ; end
+0001a6d: 0b                                        ; FIXUP func body size
 ; function body 232
-0001a7d: 00                                        ; func body size (guess)
-0001a7e: 00                                        ; local decl count
-0001a7f: 41                                        ; i32.const
-0001a80: 01                                        ; i32 literal
-0001a81: 42                                        ; i64.const
-0001a82: 02                                        ; i64 literal
-0001a83: fe                                        ; prefix
-0001a84: 40                                        ; i64.atomic.rmw32_u.xor
-0001a85: 02                                        ; alignment
-0001a86: 03                                        ; memory offset
-0001a87: 1a                                        ; drop
-0001a88: 0b                                        ; end
-0001a7d: 0b                                        ; FIXUP func body size
+0001a79: 00                                        ; func body size (guess)
+0001a7a: 00                                        ; local decl count
+0001a7b: 41                                        ; i32.const
+0001a7c: 01                                        ; i32 literal
+0001a7d: 42                                        ; i64.const
+0001a7e: 02                                        ; i64 literal
+0001a7f: fe                                        ; prefix
+0001a80: 40                                        ; i64.atomic.rmw32_u.xor
+0001a81: 02                                        ; alignment
+0001a82: 03                                        ; memory offset
+0001a83: 1a                                        ; drop
+0001a84: 0b                                        ; end
+0001a79: 0b                                        ; FIXUP func body size
 ; function body 233
-0001a89: 00                                        ; func body size (guess)
-0001a8a: 00                                        ; local decl count
-0001a8b: 41                                        ; i32.const
-0001a8c: 01                                        ; i32 literal
-0001a8d: 41                                        ; i32.const
-0001a8e: 02                                        ; i32 literal
-0001a8f: fe                                        ; prefix
-0001a90: 41                                        ; i32.atomic.rmw.xchg
-0001a91: 02                                        ; alignment
-0001a92: 03                                        ; memory offset
-0001a93: 1a                                        ; drop
-0001a94: 0b                                        ; end
-0001a89: 0b                                        ; FIXUP func body size
+0001a85: 00                                        ; func body size (guess)
+0001a86: 00                                        ; local decl count
+0001a87: 41                                        ; i32.const
+0001a88: 01                                        ; i32 literal
+0001a89: 41                                        ; i32.const
+0001a8a: 02                                        ; i32 literal
+0001a8b: fe                                        ; prefix
+0001a8c: 41                                        ; i32.atomic.rmw.xchg
+0001a8d: 02                                        ; alignment
+0001a8e: 03                                        ; memory offset
+0001a8f: 1a                                        ; drop
+0001a90: 0b                                        ; end
+0001a85: 0b                                        ; FIXUP func body size
 ; function body 234
-0001a95: 00                                        ; func body size (guess)
-0001a96: 00                                        ; local decl count
-0001a97: 41                                        ; i32.const
-0001a98: 01                                        ; i32 literal
-0001a99: 42                                        ; i64.const
-0001a9a: 02                                        ; i64 literal
-0001a9b: fe                                        ; prefix
-0001a9c: 42                                        ; i64.atomic.rmw.xchg
-0001a9d: 03                                        ; alignment
-0001a9e: 07                                        ; memory offset
-0001a9f: 1a                                        ; drop
-0001aa0: 0b                                        ; end
-0001a95: 0b                                        ; FIXUP func body size
+0001a91: 00                                        ; func body size (guess)
+0001a92: 00                                        ; local decl count
+0001a93: 41                                        ; i32.const
+0001a94: 01                                        ; i32 literal
+0001a95: 42                                        ; i64.const
+0001a96: 02                                        ; i64 literal
+0001a97: fe                                        ; prefix
+0001a98: 42                                        ; i64.atomic.rmw.xchg
+0001a99: 03                                        ; alignment
+0001a9a: 07                                        ; memory offset
+0001a9b: 1a                                        ; drop
+0001a9c: 0b                                        ; end
+0001a91: 0b                                        ; FIXUP func body size
 ; function body 235
-0001aa1: 00                                        ; func body size (guess)
-0001aa2: 00                                        ; local decl count
-0001aa3: 41                                        ; i32.const
-0001aa4: 01                                        ; i32 literal
-0001aa5: 41                                        ; i32.const
-0001aa6: 02                                        ; i32 literal
-0001aa7: fe                                        ; prefix
-0001aa8: 43                                        ; i32.atomic.rmw8_u.xchg
-0001aa9: 00                                        ; alignment
-0001aaa: 03                                        ; memory offset
-0001aab: 1a                                        ; drop
-0001aac: 0b                                        ; end
-0001aa1: 0b                                        ; FIXUP func body size
+0001a9d: 00                                        ; func body size (guess)
+0001a9e: 00                                        ; local decl count
+0001a9f: 41                                        ; i32.const
+0001aa0: 01                                        ; i32 literal
+0001aa1: 41                                        ; i32.const
+0001aa2: 02                                        ; i32 literal
+0001aa3: fe                                        ; prefix
+0001aa4: 43                                        ; i32.atomic.rmw8_u.xchg
+0001aa5: 00                                        ; alignment
+0001aa6: 03                                        ; memory offset
+0001aa7: 1a                                        ; drop
+0001aa8: 0b                                        ; end
+0001a9d: 0b                                        ; FIXUP func body size
 ; function body 236
-0001aad: 00                                        ; func body size (guess)
-0001aae: 00                                        ; local decl count
-0001aaf: 41                                        ; i32.const
-0001ab0: 01                                        ; i32 literal
-0001ab1: 41                                        ; i32.const
-0001ab2: 02                                        ; i32 literal
-0001ab3: fe                                        ; prefix
-0001ab4: 44                                        ; i32.atomic.rmw16_u.xchg
-0001ab5: 01                                        ; alignment
-0001ab6: 03                                        ; memory offset
-0001ab7: 1a                                        ; drop
-0001ab8: 0b                                        ; end
-0001aad: 0b                                        ; FIXUP func body size
+0001aa9: 00                                        ; func body size (guess)
+0001aaa: 00                                        ; local decl count
+0001aab: 41                                        ; i32.const
+0001aac: 01                                        ; i32 literal
+0001aad: 41                                        ; i32.const
+0001aae: 02                                        ; i32 literal
+0001aaf: fe                                        ; prefix
+0001ab0: 44                                        ; i32.atomic.rmw16_u.xchg
+0001ab1: 01                                        ; alignment
+0001ab2: 03                                        ; memory offset
+0001ab3: 1a                                        ; drop
+0001ab4: 0b                                        ; end
+0001aa9: 0b                                        ; FIXUP func body size
 ; function body 237
-0001ab9: 00                                        ; func body size (guess)
-0001aba: 00                                        ; local decl count
-0001abb: 41                                        ; i32.const
-0001abc: 01                                        ; i32 literal
-0001abd: 42                                        ; i64.const
-0001abe: 02                                        ; i64 literal
-0001abf: fe                                        ; prefix
-0001ac0: 45                                        ; i64.atomic.rmw8_u.xchg
-0001ac1: 00                                        ; alignment
-0001ac2: 03                                        ; memory offset
-0001ac3: 1a                                        ; drop
-0001ac4: 0b                                        ; end
-0001ab9: 0b                                        ; FIXUP func body size
+0001ab5: 00                                        ; func body size (guess)
+0001ab6: 00                                        ; local decl count
+0001ab7: 41                                        ; i32.const
+0001ab8: 01                                        ; i32 literal
+0001ab9: 42                                        ; i64.const
+0001aba: 02                                        ; i64 literal
+0001abb: fe                                        ; prefix
+0001abc: 45                                        ; i64.atomic.rmw8_u.xchg
+0001abd: 00                                        ; alignment
+0001abe: 03                                        ; memory offset
+0001abf: 1a                                        ; drop
+0001ac0: 0b                                        ; end
+0001ab5: 0b                                        ; FIXUP func body size
 ; function body 238
-0001ac5: 00                                        ; func body size (guess)
-0001ac6: 00                                        ; local decl count
-0001ac7: 41                                        ; i32.const
-0001ac8: 01                                        ; i32 literal
-0001ac9: 42                                        ; i64.const
-0001aca: 02                                        ; i64 literal
-0001acb: fe                                        ; prefix
-0001acc: 46                                        ; i64.atomic.rmw16_u.xchg
-0001acd: 01                                        ; alignment
-0001ace: 03                                        ; memory offset
-0001acf: 1a                                        ; drop
-0001ad0: 0b                                        ; end
-0001ac5: 0b                                        ; FIXUP func body size
+0001ac1: 00                                        ; func body size (guess)
+0001ac2: 00                                        ; local decl count
+0001ac3: 41                                        ; i32.const
+0001ac4: 01                                        ; i32 literal
+0001ac5: 42                                        ; i64.const
+0001ac6: 02                                        ; i64 literal
+0001ac7: fe                                        ; prefix
+0001ac8: 46                                        ; i64.atomic.rmw16_u.xchg
+0001ac9: 01                                        ; alignment
+0001aca: 03                                        ; memory offset
+0001acb: 1a                                        ; drop
+0001acc: 0b                                        ; end
+0001ac1: 0b                                        ; FIXUP func body size
 ; function body 239
-0001ad1: 00                                        ; func body size (guess)
-0001ad2: 00                                        ; local decl count
-0001ad3: 41                                        ; i32.const
-0001ad4: 01                                        ; i32 literal
-0001ad5: 42                                        ; i64.const
-0001ad6: 02                                        ; i64 literal
-0001ad7: fe                                        ; prefix
-0001ad8: 47                                        ; i64.atomic.rmw32_u.xchg
-0001ad9: 02                                        ; alignment
-0001ada: 03                                        ; memory offset
-0001adb: 1a                                        ; drop
-0001adc: 0b                                        ; end
-0001ad1: 0b                                        ; FIXUP func body size
+0001acd: 00                                        ; func body size (guess)
+0001ace: 00                                        ; local decl count
+0001acf: 41                                        ; i32.const
+0001ad0: 01                                        ; i32 literal
+0001ad1: 42                                        ; i64.const
+0001ad2: 02                                        ; i64 literal
+0001ad3: fe                                        ; prefix
+0001ad4: 47                                        ; i64.atomic.rmw32_u.xchg
+0001ad5: 02                                        ; alignment
+0001ad6: 03                                        ; memory offset
+0001ad7: 1a                                        ; drop
+0001ad8: 0b                                        ; end
+0001acd: 0b                                        ; FIXUP func body size
 ; function body 240
-0001add: 00                                        ; func body size (guess)
-0001ade: 00                                        ; local decl count
+0001ad9: 00                                        ; func body size (guess)
+0001ada: 00                                        ; local decl count
+0001adb: 41                                        ; i32.const
+0001adc: 01                                        ; i32 literal
+0001add: 41                                        ; i32.const
+0001ade: 02                                        ; i32 literal
 0001adf: 41                                        ; i32.const
-0001ae0: 01                                        ; i32 literal
-0001ae1: 41                                        ; i32.const
-0001ae2: 02                                        ; i32 literal
-0001ae3: 41                                        ; i32.const
-0001ae4: 03                                        ; i32 literal
-0001ae5: fe                                        ; prefix
-0001ae6: 48                                        ; i32.atomic.rmw.cmpxchg
-0001ae7: 02                                        ; alignment
-0001ae8: 03                                        ; memory offset
-0001ae9: 1a                                        ; drop
-0001aea: 0b                                        ; end
-0001add: 0d                                        ; FIXUP func body size
+0001ae0: 03                                        ; i32 literal
+0001ae1: fe                                        ; prefix
+0001ae2: 48                                        ; i32.atomic.rmw.cmpxchg
+0001ae3: 02                                        ; alignment
+0001ae4: 03                                        ; memory offset
+0001ae5: 1a                                        ; drop
+0001ae6: 0b                                        ; end
+0001ad9: 0d                                        ; FIXUP func body size
 ; function body 241
-0001aeb: 00                                        ; func body size (guess)
-0001aec: 00                                        ; local decl count
-0001aed: 41                                        ; i32.const
-0001aee: 01                                        ; i32 literal
-0001aef: 42                                        ; i64.const
-0001af0: 02                                        ; i64 literal
-0001af1: 42                                        ; i64.const
-0001af2: 03                                        ; i64 literal
-0001af3: fe                                        ; prefix
-0001af4: 49                                        ; i64.atomic.rmw.cmpxchg
-0001af5: 03                                        ; alignment
-0001af6: 07                                        ; memory offset
-0001af7: 1a                                        ; drop
-0001af8: 0b                                        ; end
-0001aeb: 0d                                        ; FIXUP func body size
+0001ae7: 00                                        ; func body size (guess)
+0001ae8: 00                                        ; local decl count
+0001ae9: 41                                        ; i32.const
+0001aea: 01                                        ; i32 literal
+0001aeb: 42                                        ; i64.const
+0001aec: 02                                        ; i64 literal
+0001aed: 42                                        ; i64.const
+0001aee: 03                                        ; i64 literal
+0001aef: fe                                        ; prefix
+0001af0: 49                                        ; i64.atomic.rmw.cmpxchg
+0001af1: 03                                        ; alignment
+0001af2: 07                                        ; memory offset
+0001af3: 1a                                        ; drop
+0001af4: 0b                                        ; end
+0001ae7: 0d                                        ; FIXUP func body size
 ; function body 242
-0001af9: 00                                        ; func body size (guess)
-0001afa: 00                                        ; local decl count
+0001af5: 00                                        ; func body size (guess)
+0001af6: 00                                        ; local decl count
+0001af7: 41                                        ; i32.const
+0001af8: 01                                        ; i32 literal
+0001af9: 41                                        ; i32.const
+0001afa: 02                                        ; i32 literal
 0001afb: 41                                        ; i32.const
-0001afc: 01                                        ; i32 literal
-0001afd: 41                                        ; i32.const
-0001afe: 02                                        ; i32 literal
-0001aff: 41                                        ; i32.const
-0001b00: 03                                        ; i32 literal
-0001b01: fe                                        ; prefix
-0001b02: 4a                                        ; i32.atomic.rmw8_u.cmpxchg
-0001b03: 00                                        ; alignment
-0001b04: 03                                        ; memory offset
-0001b05: 1a                                        ; drop
-0001b06: 0b                                        ; end
-0001af9: 0d                                        ; FIXUP func body size
+0001afc: 03                                        ; i32 literal
+0001afd: fe                                        ; prefix
+0001afe: 4a                                        ; i32.atomic.rmw8_u.cmpxchg
+0001aff: 00                                        ; alignment
+0001b00: 03                                        ; memory offset
+0001b01: 1a                                        ; drop
+0001b02: 0b                                        ; end
+0001af5: 0d                                        ; FIXUP func body size
 ; function body 243
-0001b07: 00                                        ; func body size (guess)
-0001b08: 00                                        ; local decl count
+0001b03: 00                                        ; func body size (guess)
+0001b04: 00                                        ; local decl count
+0001b05: 41                                        ; i32.const
+0001b06: 01                                        ; i32 literal
+0001b07: 41                                        ; i32.const
+0001b08: 02                                        ; i32 literal
 0001b09: 41                                        ; i32.const
-0001b0a: 01                                        ; i32 literal
-0001b0b: 41                                        ; i32.const
-0001b0c: 02                                        ; i32 literal
-0001b0d: 41                                        ; i32.const
-0001b0e: 03                                        ; i32 literal
-0001b0f: fe                                        ; prefix
-0001b10: 4b                                        ; i32.atomic.rmw16_u.cmpxchg
-0001b11: 01                                        ; alignment
-0001b12: 03                                        ; memory offset
-0001b13: 1a                                        ; drop
-0001b14: 0b                                        ; end
-0001b07: 0d                                        ; FIXUP func body size
+0001b0a: 03                                        ; i32 literal
+0001b0b: fe                                        ; prefix
+0001b0c: 4b                                        ; i32.atomic.rmw16_u.cmpxchg
+0001b0d: 01                                        ; alignment
+0001b0e: 03                                        ; memory offset
+0001b0f: 1a                                        ; drop
+0001b10: 0b                                        ; end
+0001b03: 0d                                        ; FIXUP func body size
 ; function body 244
-0001b15: 00                                        ; func body size (guess)
-0001b16: 00                                        ; local decl count
-0001b17: 41                                        ; i32.const
-0001b18: 01                                        ; i32 literal
-0001b19: 42                                        ; i64.const
-0001b1a: 02                                        ; i64 literal
-0001b1b: 42                                        ; i64.const
-0001b1c: 03                                        ; i64 literal
-0001b1d: fe                                        ; prefix
-0001b1e: 4c                                        ; i64.atomic.rmw8_u.cmpxchg
-0001b1f: 00                                        ; alignment
-0001b20: 03                                        ; memory offset
-0001b21: 1a                                        ; drop
-0001b22: 0b                                        ; end
-0001b15: 0d                                        ; FIXUP func body size
+0001b11: 00                                        ; func body size (guess)
+0001b12: 00                                        ; local decl count
+0001b13: 41                                        ; i32.const
+0001b14: 01                                        ; i32 literal
+0001b15: 42                                        ; i64.const
+0001b16: 02                                        ; i64 literal
+0001b17: 42                                        ; i64.const
+0001b18: 03                                        ; i64 literal
+0001b19: fe                                        ; prefix
+0001b1a: 4c                                        ; i64.atomic.rmw8_u.cmpxchg
+0001b1b: 00                                        ; alignment
+0001b1c: 03                                        ; memory offset
+0001b1d: 1a                                        ; drop
+0001b1e: 0b                                        ; end
+0001b11: 0d                                        ; FIXUP func body size
 ; function body 245
-0001b23: 00                                        ; func body size (guess)
-0001b24: 00                                        ; local decl count
-0001b25: 41                                        ; i32.const
-0001b26: 01                                        ; i32 literal
-0001b27: 42                                        ; i64.const
-0001b28: 02                                        ; i64 literal
-0001b29: 42                                        ; i64.const
-0001b2a: 03                                        ; i64 literal
-0001b2b: fe                                        ; prefix
-0001b2c: 4d                                        ; i64.atomic.rmw16_u.cmpxchg
-0001b2d: 01                                        ; alignment
-0001b2e: 03                                        ; memory offset
-0001b2f: 1a                                        ; drop
-0001b30: 0b                                        ; end
-0001b23: 0d                                        ; FIXUP func body size
+0001b1f: 00                                        ; func body size (guess)
+0001b20: 00                                        ; local decl count
+0001b21: 41                                        ; i32.const
+0001b22: 01                                        ; i32 literal
+0001b23: 42                                        ; i64.const
+0001b24: 02                                        ; i64 literal
+0001b25: 42                                        ; i64.const
+0001b26: 03                                        ; i64 literal
+0001b27: fe                                        ; prefix
+0001b28: 4d                                        ; i64.atomic.rmw16_u.cmpxchg
+0001b29: 01                                        ; alignment
+0001b2a: 03                                        ; memory offset
+0001b2b: 1a                                        ; drop
+0001b2c: 0b                                        ; end
+0001b1f: 0d                                        ; FIXUP func body size
 ; function body 246
-0001b31: 00                                        ; func body size (guess)
-0001b32: 00                                        ; local decl count
-0001b33: 41                                        ; i32.const
-0001b34: 01                                        ; i32 literal
-0001b35: 42                                        ; i64.const
-0001b36: 02                                        ; i64 literal
-0001b37: 42                                        ; i64.const
-0001b38: 03                                        ; i64 literal
-0001b39: fe                                        ; prefix
-0001b3a: 4e                                        ; i64.atomic.rmw32_u.cmpxchg
-0001b3b: 02                                        ; alignment
-0001b3c: 03                                        ; memory offset
-0001b3d: 1a                                        ; drop
-0001b3e: 0b                                        ; end
-0001b31: 0d                                        ; FIXUP func body size
-; move data: [10b2, 1b3f) -> [10b3, 1b40)
-00010b1: 8d15                                      ; FIXUP section size
+0001b2d: 00                                        ; func body size (guess)
+0001b2e: 00                                        ; local decl count
+0001b2f: 41                                        ; i32.const
+0001b30: 01                                        ; i32 literal
+0001b31: 42                                        ; i64.const
+0001b32: 02                                        ; i64 literal
+0001b33: 42                                        ; i64.const
+0001b34: 03                                        ; i64 literal
+0001b35: fe                                        ; prefix
+0001b36: 4e                                        ; i64.atomic.rmw32_u.cmpxchg
+0001b37: 02                                        ; alignment
+0001b38: 03                                        ; memory offset
+0001b39: 1a                                        ; drop
+0001b3a: 0b                                        ; end
+0001b2d: 0d                                        ; FIXUP func body size
+; move data: [10ae, 1b3b) -> [10af, 1b3c)
+00010ad: 8d15                                      ; FIXUP section size
 BeginModule(version: 1)
   BeginTypeSection(8)
     OnTypeCount(2)
     OnType(index: 0, params: [], results: [])
     OnType(index: 1, params: [i32], results: [])
   EndTypeSection
-  BeginImportSection(18)
+  BeginImportSection(14)
     OnImportCount(1)
-    OnImport(index: 0, module: "spectest", field: "print")
+    OnImport(index: 0, module: "host", field: "print")
     OnImportFunc(import_index: 0, func_index: 0, sig_index: 1)
   EndImportSection
   BeginFunctionSection(249)
@@ -7836,7 +7836,7 @@ i64.extend16_s() =>
 i64.extend32_s() =>
 alloca() =>
 br_unless() =>
-called host spectest.print(i32:1) =>
+called host host.print(i32:1) =>
 call_host() =>
 data() =>
 drop_keep() =>

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -1,8 +1,8 @@
 ;;; TOOL: run-interp
-;;; FLAGS: --trace --enable-threads --enable-saturating-float-to-int
+;;; FLAGS: --trace --host-print --enable-threads --enable-saturating-float-to-int
 
 (module
-  (import "spectest" "print" (func $print (param i32)))
+  (import "host" "print" (func $print (param i32)))
 
   (type $empty (func))
   (func $empty)
@@ -1377,7 +1377,7 @@ br_unless() =>
 >>> running export "call_host":
 #0. 2466: V:0  | i32.const $1
 #0. 2471: V:1  | call_host $0
-called host spectest.print(i32:1) =>
+called host host.print(i32:1) =>
 #0. 2476: V:0  | return
 call_host() =>
 >>> running export "drop_keep":

--- a/test/run-wasm-link.py
+++ b/test/run-wasm-link.py
@@ -73,13 +73,14 @@ def main(args):
       find_exe.GetWasmdumpExecutable(options.bindir),
       error_cmdline=options.error_cmdline)
 
-  wasm_interp = utils.Executable(find_exe.GetWasmInterpExecutable(
-      options.bindir), error_cmdline=options.error_cmdline)
+  spectest_interp = utils.Executable(
+      find_exe.GetSpectestInterpExecutable(options.bindir),
+      error_cmdline=options.error_cmdline)
 
   wast2json.verbose = options.print_cmd
   wasm_link.verbose = options.print_cmd
   wasm_objdump.verbose = options.print_cmd
-  wasm_interp.verbose = options.print_cmd
+  spectest_interp.verbose = options.print_cmd
 
   filename = options.file
 
@@ -123,7 +124,7 @@ def main(args):
       with open(out_file, 'wb') as json_file:
         json.dump(spec, json_file, indent=4)
 
-      wasm_interp.RunWithArgs('--spec', out_file)
+      spectest_interp.RunWithArgs(out_file)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* `wasm-interp` tool now only runs `.wasm` file, not spec tests
* `wasm-interp` has a new flag `--host-print` for importing a print
  function named "host.print"
* `spectest-interp` tool runs only `.json` files