### PR TITLE
Rename interpreter -> interp everywhere

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,8 +227,8 @@ add_library(libwabt STATIC
   src/binary-reader-ir.cc
   src/binding-hash.cc
   src/wat-writer.cc
-  src/interpreter.cc
-  src/binary-reader-interpreter.cc
+  src/interp.cc
+  src/binary-reader-interp.cc
   src/apply-names.cc
   src/generate-names.cc
   src/resolve-names.cc

--- a/src/binary-reader-interp.cc
+++ b/src/binary-reader-interp.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include "src/binary-reader-interpreter.h"
+#include "src/binary-reader-interp.h"
 
 #include <cassert>
 #include <cinttypes>
@@ -25,13 +25,13 @@
 #include "src/binary-reader-nop.h"
 #include "src/cast.h"
 #include "src/error-handler.h"
-#include "src/interpreter.h"
+#include "src/interp.h"
 #include "src/stream.h"
 #include "src/type-checker.h"
 
 namespace wabt {
 
-using namespace interpreter;
+using namespace interp;
 
 namespace {
 
@@ -66,12 +66,12 @@ struct DataSegmentInfo {
   IstreamOffset size;
 };
 
-class BinaryReaderInterpreter : public BinaryReaderNop {
+class BinaryReaderInterp : public BinaryReaderNop {
  public:
-  BinaryReaderInterpreter(Environment* env,
-                          DefinedModule* module,
-                          std::unique_ptr<OutputBuffer> istream,
-                          ErrorHandler* error_handler);
+  BinaryReaderInterp(Environment* env,
+                     DefinedModule* module,
+                     std::unique_ptr<OutputBuffer> istream,
+                     ErrorHandler* error_handler);
 
   wabt::Result ReadBinary(DefinedModule* out_module);
 
@@ -306,11 +306,10 @@ class BinaryReaderInterpreter : public BinaryReaderNop {
   IstreamOffset table_offset_ = 0;
 };
 
-BinaryReaderInterpreter::BinaryReaderInterpreter(
-    Environment* env,
-    DefinedModule* module,
-    std::unique_ptr<OutputBuffer> istream,
-    ErrorHandler* error_handler)
+BinaryReaderInterp::BinaryReaderInterp(Environment* env,
+                                       DefinedModule* module,
+                                       std::unique_ptr<OutputBuffer> istream,
+                                       ErrorHandler* error_handler)
     : error_handler_(error_handler),
       env_(env),
       module_(module),
@@ -320,91 +319,88 @@ BinaryReaderInterpreter::BinaryReaderInterpreter(
       [this](const char* msg) { PrintError("%s", msg); });
 }
 
-std::unique_ptr<OutputBuffer> BinaryReaderInterpreter::ReleaseOutputBuffer() {
+std::unique_ptr<OutputBuffer> BinaryReaderInterp::ReleaseOutputBuffer() {
   return istream_.ReleaseOutputBuffer();
 }
 
-Label* BinaryReaderInterpreter::GetLabel(Index depth) {
+Label* BinaryReaderInterp::GetLabel(Index depth) {
   assert(depth < label_stack_.size());
   return &label_stack_[label_stack_.size() - depth - 1];
 }
 
-Label* BinaryReaderInterpreter::TopLabel() {
+Label* BinaryReaderInterp::TopLabel() {
   return GetLabel(0);
 }
 
-bool BinaryReaderInterpreter::HandleError(Offset offset, const char* message) {
+bool BinaryReaderInterp::HandleError(Offset offset, const char* message) {
   return error_handler_->OnError(offset, message);
 }
 
-void WABT_PRINTF_FORMAT(2, 3)
-    BinaryReaderInterpreter::PrintError(const char* format, ...) {
+void WABT_PRINTF_FORMAT(2, 3) BinaryReaderInterp::PrintError(const char* format,
+                                                             ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
   HandleError(kInvalidOffset, buffer);
 }
 
-Index BinaryReaderInterpreter::TranslateSigIndexToEnv(Index sig_index) {
+Index BinaryReaderInterp::TranslateSigIndexToEnv(Index sig_index) {
   assert(sig_index < sig_index_mapping_.size());
   return sig_index_mapping_[sig_index];
 }
 
-FuncSignature* BinaryReaderInterpreter::GetSignatureByModuleIndex(
-    Index sig_index) {
+FuncSignature* BinaryReaderInterp::GetSignatureByModuleIndex(Index sig_index) {
   return env_->GetFuncSignature(TranslateSigIndexToEnv(sig_index));
 }
 
-Index BinaryReaderInterpreter::TranslateFuncIndexToEnv(Index func_index) {
+Index BinaryReaderInterp::TranslateFuncIndexToEnv(Index func_index) {
   assert(func_index < func_index_mapping_.size());
   return func_index_mapping_[func_index];
 }
 
-Index BinaryReaderInterpreter::TranslateModuleFuncIndexToDefined(
-    Index func_index) {
+Index BinaryReaderInterp::TranslateModuleFuncIndexToDefined(Index func_index) {
   assert(func_index >= num_func_imports_);
   return func_index - num_func_imports_;
 }
 
-Func* BinaryReaderInterpreter::GetFuncByModuleIndex(Index func_index) {
+Func* BinaryReaderInterp::GetFuncByModuleIndex(Index func_index) {
   return env_->GetFunc(TranslateFuncIndexToEnv(func_index));
 }
 
-Index BinaryReaderInterpreter::TranslateGlobalIndexToEnv(Index global_index) {
+Index BinaryReaderInterp::TranslateGlobalIndexToEnv(Index global_index) {
   return global_index_mapping_[global_index];
 }
 
-Global* BinaryReaderInterpreter::GetGlobalByModuleIndex(Index global_index) {
+Global* BinaryReaderInterp::GetGlobalByModuleIndex(Index global_index) {
   return env_->GetGlobal(TranslateGlobalIndexToEnv(global_index));
 }
 
-Type BinaryReaderInterpreter::GetGlobalTypeByModuleIndex(Index global_index) {
+Type BinaryReaderInterp::GetGlobalTypeByModuleIndex(Index global_index) {
   return GetGlobalByModuleIndex(global_index)->typed_value.type;
 }
 
-Type BinaryReaderInterpreter::GetLocalTypeByIndex(Func* func,
-                                                  Index local_index) {
+Type BinaryReaderInterp::GetLocalTypeByIndex(Func* func, Index local_index) {
   assert(!func->is_host);
   return cast<DefinedFunc>(func)->param_and_local_types[local_index];
 }
 
-IstreamOffset BinaryReaderInterpreter::GetIstreamOffset() {
+IstreamOffset BinaryReaderInterp::GetIstreamOffset() {
   return istream_offset_;
 }
 
-wabt::Result BinaryReaderInterpreter::EmitDataAt(IstreamOffset offset,
-                                                 const void* data,
-                                                 IstreamOffset size) {
+wabt::Result BinaryReaderInterp::EmitDataAt(IstreamOffset offset,
+                                            const void* data,
+                                            IstreamOffset size) {
   istream_.WriteDataAt(offset, data, size);
   return istream_.result();
 }
 
-wabt::Result BinaryReaderInterpreter::EmitData(const void* data,
-                                               IstreamOffset size) {
+wabt::Result BinaryReaderInterp::EmitData(const void* data,
+                                          IstreamOffset size) {
   CHECK_RESULT(EmitDataAt(istream_offset_, data, size));
   istream_offset_ += size;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EmitOpcode(Opcode opcode) {
+wabt::Result BinaryReaderInterp::EmitOpcode(Opcode opcode) {
   if (opcode.HasPrefix()) {
     CHECK_RESULT(EmitI8(opcode.GetPrefix()));
   }
@@ -415,32 +411,31 @@ wabt::Result BinaryReaderInterpreter::EmitOpcode(Opcode opcode) {
   return EmitI8(code);
 }
 
-wabt::Result BinaryReaderInterpreter::EmitI8(uint8_t value) {
+wabt::Result BinaryReaderInterp::EmitI8(uint8_t value) {
   return EmitData(&value, sizeof(value));
 }
 
-wabt::Result BinaryReaderInterpreter::EmitI32(uint32_t value) {
+wabt::Result BinaryReaderInterp::EmitI32(uint32_t value) {
   return EmitData(&value, sizeof(value));
 }
 
-wabt::Result BinaryReaderInterpreter::EmitI64(uint64_t value) {
+wabt::Result BinaryReaderInterp::EmitI64(uint64_t value) {
   return EmitData(&value, sizeof(value));
 }
 
-wabt::Result BinaryReaderInterpreter::EmitI32At(IstreamOffset offset,
-                                                uint32_t value) {
+wabt::Result BinaryReaderInterp::EmitI32At(IstreamOffset offset,
+                                           uint32_t value) {
   return EmitDataAt(offset, &value, sizeof(value));
 }
 
-wabt::Result BinaryReaderInterpreter::EmitDropKeep(uint32_t drop,
-                                                   uint8_t keep) {
+wabt::Result BinaryReaderInterp::EmitDropKeep(uint32_t drop, uint8_t keep) {
   assert(drop != UINT32_MAX);
   assert(keep <= 1);
   if (drop > 0) {
     if (drop == 1 && keep == 0) {
       CHECK_RESULT(EmitOpcode(Opcode::Drop));
     } else {
-      CHECK_RESULT(EmitOpcode(Opcode::InterpreterDropKeep));
+      CHECK_RESULT(EmitOpcode(Opcode::InterpDropKeep));
       CHECK_RESULT(EmitI32(drop));
       CHECK_RESULT(EmitI8(keep));
     }
@@ -448,7 +443,7 @@ wabt::Result BinaryReaderInterpreter::EmitDropKeep(uint32_t drop,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::AppendFixup(
+wabt::Result BinaryReaderInterp::AppendFixup(
     IstreamOffsetVectorVector* fixups_vector,
     Index index) {
   if (index >= fixups_vector->size())
@@ -457,8 +452,8 @@ wabt::Result BinaryReaderInterpreter::AppendFixup(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EmitBrOffset(Index depth,
-                                                   IstreamOffset offset) {
+wabt::Result BinaryReaderInterp::EmitBrOffset(Index depth,
+                                              IstreamOffset offset) {
   if (offset == kInvalidIstreamOffset) {
     /* depth_fixups_ stores the depth counting up from zero, where zero is the
      * top-level function scope. */
@@ -469,10 +464,9 @@ wabt::Result BinaryReaderInterpreter::EmitBrOffset(Index depth,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::GetBrDropKeepCount(
-    Index depth,
-    Index* out_drop_count,
-    Index* out_keep_count) {
+wabt::Result BinaryReaderInterp::GetBrDropKeepCount(Index depth,
+                                                    Index* out_drop_count,
+                                                    Index* out_keep_count) {
   TypeChecker::Label* label;
   CHECK_RESULT(typechecker_.GetLabel(depth, &label));
   *out_keep_count =
@@ -487,25 +481,24 @@ wabt::Result BinaryReaderInterpreter::GetBrDropKeepCount(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::GetReturnDropKeepCount(
-    Index* out_drop_count,
-    Index* out_keep_count) {
+wabt::Result BinaryReaderInterp::GetReturnDropKeepCount(Index* out_drop_count,
+                                                        Index* out_keep_count) {
   CHECK_RESULT(GetBrDropKeepCount(label_stack_.size() - 1, out_drop_count,
                                   out_keep_count));
   *out_drop_count += current_func_->param_and_local_types.size();
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EmitBr(Index depth,
-                                             Index drop_count,
-                                             Index keep_count) {
+wabt::Result BinaryReaderInterp::EmitBr(Index depth,
+                                        Index drop_count,
+                                        Index keep_count) {
   CHECK_RESULT(EmitDropKeep(drop_count, keep_count));
   CHECK_RESULT(EmitOpcode(Opcode::Br));
   CHECK_RESULT(EmitBrOffset(depth, GetLabel(depth)->offset));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EmitBrTableOffset(Index depth) {
+wabt::Result BinaryReaderInterp::EmitBrTableOffset(Index depth) {
   Index drop_count, keep_count;
   CHECK_RESULT(GetBrDropKeepCount(depth, &drop_count, &keep_count));
   CHECK_RESULT(EmitBrOffset(depth, GetLabel(depth)->offset));
@@ -514,7 +507,7 @@ wabt::Result BinaryReaderInterpreter::EmitBrTableOffset(Index depth) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::FixupTopLabel() {
+wabt::Result BinaryReaderInterp::FixupTopLabel() {
   IstreamOffset offset = GetIstreamOffset();
   Index top = label_stack_.size() - 1;
   if (top >= depth_fixups_.size()) {
@@ -529,8 +522,8 @@ wabt::Result BinaryReaderInterpreter::FixupTopLabel() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EmitFuncOffset(DefinedFunc* func,
-                                                     Index func_index) {
+wabt::Result BinaryReaderInterp::EmitFuncOffset(DefinedFunc* func,
+                                                Index func_index) {
   if (func->offset == kInvalidIstreamOffset) {
     Index defined_index = TranslateModuleFuncIndexToDefined(func_index);
     CHECK_RESULT(AppendFixup(&func_fixups_, defined_index));
@@ -539,11 +532,11 @@ wabt::Result BinaryReaderInterpreter::EmitFuncOffset(DefinedFunc* func,
   return wabt::Result::Ok;
 }
 
-bool BinaryReaderInterpreter::OnError(const char* message) {
+bool BinaryReaderInterp::OnError(const char* message) {
   return HandleError(state->offset, message);
 }
 
-wabt::Result BinaryReaderInterpreter::OnTypeCount(Index count) {
+wabt::Result BinaryReaderInterp::OnTypeCount(Index count) {
   Index sig_count = env_->GetFuncSignatureCount();
   sig_index_mapping_.resize(count);
   for (Index i = 0; i < count; ++i)
@@ -551,18 +544,18 @@ wabt::Result BinaryReaderInterpreter::OnTypeCount(Index count) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnType(Index index,
-                                             Index param_count,
-                                             Type* param_types,
-                                             Index result_count,
-                                             Type* result_types) {
+wabt::Result BinaryReaderInterp::OnType(Index index,
+                                        Index param_count,
+                                        Type* param_types,
+                                        Index result_count,
+                                        Type* result_types) {
   assert(TranslateSigIndexToEnv(index) == env_->GetFuncSignatureCount());
   env_->EmplaceBackFuncSignature(param_count, param_types, result_count,
                                  result_types);
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckLocal(Index local_index) {
+wabt::Result BinaryReaderInterp::CheckLocal(Index local_index) {
   Index max_local_index = current_func_->param_and_local_types.size();
   if (local_index >= max_local_index) {
     PrintError("invalid local_index: %" PRIindex " (max %" PRIindex ")",
@@ -572,7 +565,7 @@ wabt::Result BinaryReaderInterpreter::CheckLocal(Index local_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckGlobal(Index global_index) {
+wabt::Result BinaryReaderInterp::CheckGlobal(Index global_index) {
   Index max_global_index = global_index_mapping_.size();
   if (global_index >= max_global_index) {
     PrintError("invalid global_index: %" PRIindex " (max %" PRIindex ")",
@@ -582,9 +575,8 @@ wabt::Result BinaryReaderInterpreter::CheckGlobal(Index global_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckImportKind(
-    Import* import,
-    ExternalKind actual_kind) {
+wabt::Result BinaryReaderInterp::CheckImportKind(Import* import,
+                                                 ExternalKind actual_kind) {
   if (import->kind != actual_kind) {
     PrintError("expected import \"" PRIstringview "." PRIstringview
                "\" to have kind %s, not %s",
@@ -596,7 +588,7 @@ wabt::Result BinaryReaderInterpreter::CheckImportKind(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckImportLimits(
+wabt::Result BinaryReaderInterp::CheckImportLimits(
     const Limits* declared_limits,
     const Limits* actual_limits) {
   if (actual_limits->initial < declared_limits->initial) {
@@ -620,10 +612,10 @@ wabt::Result BinaryReaderInterpreter::CheckImportLimits(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::AppendExport(Module* module,
-                                                   ExternalKind kind,
-                                                   Index item_index,
-                                                   string_view name) {
+wabt::Result BinaryReaderInterp::AppendExport(Module* module,
+                                              ExternalKind kind,
+                                              Index item_index,
+                                              string_view name) {
   if (module->export_bindings.FindIndex(name) != kInvalidIndex) {
     PrintError("duplicate export \"" PRIstringview "\"",
                WABT_PRINTF_STRING_VIEW_ARG(name));
@@ -638,9 +630,8 @@ wabt::Result BinaryReaderInterpreter::AppendExport(Module* module,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::FindRegisteredModule(
-    string_view module_name,
-    Module** out_module) {
+wabt::Result BinaryReaderInterp::FindRegisteredModule(string_view module_name,
+                                                      Module** out_module) {
   Module* module = env_->FindRegisteredModule(module_name);
   if (!module) {
     PrintError("unknown import module \"" PRIstringview "\"",
@@ -652,9 +643,9 @@ wabt::Result BinaryReaderInterpreter::FindRegisteredModule(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::GetModuleExport(Module* module,
-                                                      string_view field_name,
-                                                      Export** out_export) {
+wabt::Result BinaryReaderInterp::GetModuleExport(Module* module,
+                                                 string_view field_name,
+                                                 Export** out_export) {
   Export* export_ = module->GetExport(field_name);
   if (!export_) {
     PrintError("unknown module field \"" PRIstringview "\"",
@@ -666,16 +657,15 @@ wabt::Result BinaryReaderInterpreter::GetModuleExport(Module* module,
   return wabt::Result::Ok;
 }
 
-HostImportDelegate::ErrorCallback
-BinaryReaderInterpreter::MakePrintErrorCallback() {
+HostImportDelegate::ErrorCallback BinaryReaderInterp::MakePrintErrorCallback() {
   return [this](const char* msg) { PrintError("%s", msg); };
 }
 
-wabt::Result BinaryReaderInterpreter::OnImportFunc(Index import_index,
-                                                   string_view module_name,
-                                                   string_view field_name,
-                                                   Index func_index,
-                                                   Index sig_index) {
+wabt::Result BinaryReaderInterp::OnImportFunc(Index import_index,
+                                              string_view module_name,
+                                              string_view field_name,
+                                              Index func_index,
+                                              Index sig_index) {
   module_->func_imports.emplace_back(module_name, field_name);
   FuncImport* import = &module_->func_imports.back();
   import->sig_index = TranslateSigIndexToEnv(sig_index);
@@ -715,12 +705,12 @@ wabt::Result BinaryReaderInterpreter::OnImportFunc(Index import_index,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnImportTable(Index import_index,
-                                                    string_view module_name,
-                                                    string_view field_name,
-                                                    Index table_index,
-                                                    Type elem_type,
-                                                    const Limits* elem_limits) {
+wabt::Result BinaryReaderInterp::OnImportTable(Index import_index,
+                                               string_view module_name,
+                                               string_view field_name,
+                                               Index table_index,
+                                               Type elem_type,
+                                               const Limits* elem_limits) {
   if (module_->table_index != kInvalidIndex) {
     PrintError("only one table allowed");
     return wabt::Result::Error;
@@ -757,12 +747,11 @@ wabt::Result BinaryReaderInterpreter::OnImportTable(Index import_index,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnImportMemory(
-    Index import_index,
-    string_view module_name,
-    string_view field_name,
-    Index memory_index,
-    const Limits* page_limits) {
+wabt::Result BinaryReaderInterp::OnImportMemory(Index import_index,
+                                                string_view module_name,
+                                                string_view field_name,
+                                                Index memory_index,
+                                                const Limits* page_limits) {
   if (module_->memory_index != kInvalidIndex) {
     PrintError("only one memory allowed");
     return wabt::Result::Error;
@@ -799,12 +788,12 @@ wabt::Result BinaryReaderInterpreter::OnImportMemory(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnImportGlobal(Index import_index,
-                                                     string_view module_name,
-                                                     string_view field_name,
-                                                     Index global_index,
-                                                     Type type,
-                                                     bool mutable_) {
+wabt::Result BinaryReaderInterp::OnImportGlobal(Index import_index,
+                                                string_view module_name,
+                                                string_view field_name,
+                                                Index global_index,
+                                                Type type,
+                                                bool mutable_) {
   module_->global_imports.emplace_back(module_name, field_name);
   GlobalImport* import = &module_->global_imports.back();
 
@@ -836,21 +825,21 @@ wabt::Result BinaryReaderInterpreter::OnImportGlobal(Index import_index,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnFunctionCount(Index count) {
+wabt::Result BinaryReaderInterp::OnFunctionCount(Index count) {
   for (Index i = 0; i < count; ++i)
     func_index_mapping_.push_back(env_->GetFuncCount() + i);
   func_fixups_.resize(count);
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnFunction(Index index, Index sig_index) {
+wabt::Result BinaryReaderInterp::OnFunction(Index index, Index sig_index) {
   env_->EmplaceBackFunc(new DefinedFunc(TranslateSigIndexToEnv(sig_index)));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnTable(Index index,
-                                              Type elem_type,
-                                              const Limits* elem_limits) {
+wabt::Result BinaryReaderInterp::OnTable(Index index,
+                                         Type elem_type,
+                                         const Limits* elem_limits) {
   if (module_->table_index != kInvalidIndex) {
     PrintError("only one table allowed");
     return wabt::Result::Error;
@@ -860,8 +849,8 @@ wabt::Result BinaryReaderInterpreter::OnTable(Index index,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnMemory(Index index,
-                                               const Limits* page_limits) {
+wabt::Result BinaryReaderInterp::OnMemory(Index index,
+                                          const Limits* page_limits) {
   if (module_->memory_index != kInvalidIndex) {
     PrintError("only one memory allowed");
     return wabt::Result::Error;
@@ -871,22 +860,22 @@ wabt::Result BinaryReaderInterpreter::OnMemory(Index index,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnGlobalCount(Index count) {
+wabt::Result BinaryReaderInterp::OnGlobalCount(Index count) {
   for (Index i = 0; i < count; ++i)
     global_index_mapping_.push_back(env_->GetGlobalCount() + i);
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::BeginGlobal(Index index,
-                                                  Type type,
-                                                  bool mutable_) {
+wabt::Result BinaryReaderInterp::BeginGlobal(Index index,
+                                             Type type,
+                                             bool mutable_) {
   assert(TranslateGlobalIndexToEnv(index) == env_->GetGlobalCount());
   env_->EmplaceBackGlobal(TypedValue(type), mutable_);
   init_expr_value_.type = Type::Void;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EndGlobalInitExpr(Index index) {
+wabt::Result BinaryReaderInterp::EndGlobalInitExpr(Index index) {
   Global* global = GetGlobalByModuleIndex(index);
   if (init_expr_value_.type != global->typed_value.type) {
     PrintError("type mismatch in global, expected %s but got %s.",
@@ -898,25 +887,22 @@ wabt::Result BinaryReaderInterpreter::EndGlobalInitExpr(Index index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnInitExprF32ConstExpr(
-    Index index,
-    uint32_t value_bits) {
+wabt::Result BinaryReaderInterp::OnInitExprF32ConstExpr(Index index,
+                                                        uint32_t value_bits) {
   init_expr_value_.type = Type::F32;
   init_expr_value_.value.f32_bits = value_bits;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnInitExprF64ConstExpr(
-    Index index,
-    uint64_t value_bits) {
+wabt::Result BinaryReaderInterp::OnInitExprF64ConstExpr(Index index,
+                                                        uint64_t value_bits) {
   init_expr_value_.type = Type::F64;
   init_expr_value_.value.f64_bits = value_bits;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnInitExprGetGlobalExpr(
-    Index index,
-    Index global_index) {
+wabt::Result BinaryReaderInterp::OnInitExprGetGlobalExpr(Index index,
+                                                         Index global_index) {
   if (global_index >= num_global_imports_) {
     PrintError("initializer expression can only reference an imported global");
     return wabt::Result::Error;
@@ -930,24 +916,24 @@ wabt::Result BinaryReaderInterpreter::OnInitExprGetGlobalExpr(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnInitExprI32ConstExpr(Index index,
-                                                             uint32_t value) {
+wabt::Result BinaryReaderInterp::OnInitExprI32ConstExpr(Index index,
+                                                        uint32_t value) {
   init_expr_value_.type = Type::I32;
   init_expr_value_.value.i32 = value;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnInitExprI64ConstExpr(Index index,
-                                                             uint64_t value) {
+wabt::Result BinaryReaderInterp::OnInitExprI64ConstExpr(Index index,
+                                                        uint64_t value) {
   init_expr_value_.type = Type::I64;
   init_expr_value_.value.i64 = value;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnExport(Index index,
-                                               ExternalKind kind,
-                                               Index item_index,
-                                               string_view name) {
+wabt::Result BinaryReaderInterp::OnExport(Index index,
+                                          ExternalKind kind,
+                                          Index item_index,
+                                          string_view name) {
   switch (kind) {
     case ExternalKind::Func:
       item_index = TranslateFuncIndexToEnv(item_index);
@@ -973,13 +959,13 @@ wabt::Result BinaryReaderInterpreter::OnExport(Index index,
 
     case ExternalKind::Except:
       // TODO(karlschimpf) Define
-      WABT_FATAL("BinaryReaderInterpreter::OnExport(except) not implemented");
+      WABT_FATAL("BinaryReaderInterp::OnExport(except) not implemented");
       break;
   }
   return AppendExport(module_, kind, item_index, name);
 }
 
-wabt::Result BinaryReaderInterpreter::OnStartFunction(Index func_index) {
+wabt::Result BinaryReaderInterp::OnStartFunction(Index func_index) {
   Index start_func_index = TranslateFuncIndexToEnv(func_index);
   Func* start_func = env_->GetFunc(start_func_index);
   FuncSignature* sig = env_->GetFuncSignature(start_func->sig_index);
@@ -995,15 +981,14 @@ wabt::Result BinaryReaderInterpreter::OnStartFunction(Index func_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EndElemSegmentInitExpr(Index index) {
+wabt::Result BinaryReaderInterp::EndElemSegmentInitExpr(Index index) {
   assert(init_expr_value_.type == Type::I32);
   table_offset_ = init_expr_value_.value.i32;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnElemSegmentFunctionIndex(
-    Index index,
-    Index func_index) {
+wabt::Result BinaryReaderInterp::OnElemSegmentFunctionIndex(Index index,
+                                                            Index func_index) {
   assert(module_->table_index != kInvalidIndex);
   Table* table = env_->GetTable(module_->table_index);
   if (table_offset_ >= table->func_indexes.size()) {
@@ -1024,9 +1009,9 @@ wabt::Result BinaryReaderInterpreter::OnElemSegmentFunctionIndex(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnDataSegmentData(Index index,
-                                                        const void* src_data,
-                                                        Address size) {
+wabt::Result BinaryReaderInterp::OnDataSegmentData(Index index,
+                                                   const void* src_data,
+                                                   Address size) {
   assert(module_->memory_index != kInvalidIndex);
   Memory* memory = env_->GetMemory(module_->memory_index);
   assert(init_expr_value_.type == Type::I32);
@@ -1046,12 +1031,12 @@ wabt::Result BinaryReaderInterpreter::OnDataSegmentData(Index index,
   return wabt::Result::Ok;
 }
 
-void BinaryReaderInterpreter::PushLabel(IstreamOffset offset,
-                                        IstreamOffset fixup_offset) {
+void BinaryReaderInterp::PushLabel(IstreamOffset offset,
+                                   IstreamOffset fixup_offset) {
   label_stack_.emplace_back(offset, fixup_offset);
 }
 
-void BinaryReaderInterpreter::PopLabel() {
+void BinaryReaderInterp::PopLabel() {
   label_stack_.pop_back();
   /* reduce the depth_fixups_ stack as well, but it may be smaller than
    * label_stack_ so only do it conditionally. */
@@ -1061,7 +1046,7 @@ void BinaryReaderInterpreter::PopLabel() {
   }
 }
 
-wabt::Result BinaryReaderInterpreter::BeginFunctionBody(Index index) {
+wabt::Result BinaryReaderInterp::BeginFunctionBody(Index index) {
   auto* func = cast<DefinedFunc>(GetFuncByModuleIndex(index));
   FuncSignature* sig = env_->GetFuncSignature(func->sig_index);
 
@@ -1090,7 +1075,7 @@ wabt::Result BinaryReaderInterpreter::BeginFunctionBody(Index index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EndFunctionBody(Index index) {
+wabt::Result BinaryReaderInterp::EndFunctionBody(Index index) {
   FixupTopLabel();
   Index drop_count, keep_count;
   CHECK_RESULT(GetReturnDropKeepCount(&drop_count, &keep_count));
@@ -1102,14 +1087,14 @@ wabt::Result BinaryReaderInterpreter::EndFunctionBody(Index index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnLocalDeclCount(Index count) {
+wabt::Result BinaryReaderInterp::OnLocalDeclCount(Index count) {
   current_func_->local_decl_count = count;
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnLocalDecl(Index decl_index,
-                                                  Index count,
-                                                  Type type) {
+wabt::Result BinaryReaderInterp::OnLocalDecl(Index decl_index,
+                                             Index count,
+                                             Type type) {
   current_func_->local_count += count;
 
   for (Index i = 0; i < count; ++i)
@@ -1117,13 +1102,13 @@ wabt::Result BinaryReaderInterpreter::OnLocalDecl(Index decl_index,
 
   if (decl_index == current_func_->local_decl_count - 1) {
     /* last local declaration, allocate space for all locals. */
-    CHECK_RESULT(EmitOpcode(Opcode::InterpreterAlloca));
+    CHECK_RESULT(EmitOpcode(Opcode::InterpAlloca));
     CHECK_RESULT(EmitI32(current_func_->local_count));
   }
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckHasMemory(wabt::Opcode opcode) {
+wabt::Result BinaryReaderInterp::CheckHasMemory(wabt::Opcode opcode) {
   if (module_->memory_index == kInvalidIndex) {
     PrintError("%s requires an imported or defined memory.", opcode.GetName());
     return wabt::Result::Error;
@@ -1131,8 +1116,8 @@ wabt::Result BinaryReaderInterpreter::CheckHasMemory(wabt::Opcode opcode) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckAlign(uint32_t alignment_log2,
-                                                 Address natural_alignment) {
+wabt::Result BinaryReaderInterp::CheckAlign(uint32_t alignment_log2,
+                                            Address natural_alignment) {
   if (alignment_log2 >= 32 || (1U << alignment_log2) > natural_alignment) {
     PrintError("alignment must not be larger than natural alignment (%u)",
                natural_alignment);
@@ -1141,9 +1126,8 @@ wabt::Result BinaryReaderInterpreter::CheckAlign(uint32_t alignment_log2,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::CheckAtomicAlign(
-    uint32_t alignment_log2,
-    Address natural_alignment) {
+wabt::Result BinaryReaderInterp::CheckAtomicAlign(uint32_t alignment_log2,
+                                                  Address natural_alignment) {
   if (alignment_log2 >= 32 || (1U << alignment_log2) != natural_alignment) {
     PrintError("alignment must be equal to natural alignment (%u)",
                natural_alignment);
@@ -1152,15 +1136,15 @@ wabt::Result BinaryReaderInterpreter::CheckAtomicAlign(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnUnaryExpr(wabt::Opcode opcode) {
+wabt::Result BinaryReaderInterp::OnUnaryExpr(wabt::Opcode opcode) {
   CHECK_RESULT(typechecker_.OnUnary(opcode));
   CHECK_RESULT(EmitOpcode(opcode));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnAtomicLoadExpr(Opcode opcode,
-                                                       uint32_t alignment_log2,
-                                                       Address offset) {
+wabt::Result BinaryReaderInterp::OnAtomicLoadExpr(Opcode opcode,
+                                                  uint32_t alignment_log2,
+                                                  Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnAtomicLoad(opcode));
@@ -1170,9 +1154,9 @@ wabt::Result BinaryReaderInterpreter::OnAtomicLoadExpr(Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnAtomicStoreExpr(Opcode opcode,
-                                                        uint32_t alignment_log2,
-                                                        Address offset) {
+wabt::Result BinaryReaderInterp::OnAtomicStoreExpr(Opcode opcode,
+                                                   uint32_t alignment_log2,
+                                                   Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnAtomicStore(opcode));
@@ -1182,9 +1166,9 @@ wabt::Result BinaryReaderInterpreter::OnAtomicStoreExpr(Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnAtomicRmwExpr(Opcode opcode,
-                                                      uint32_t alignment_log2,
-                                                      Address offset) {
+wabt::Result BinaryReaderInterp::OnAtomicRmwExpr(Opcode opcode,
+                                                 uint32_t alignment_log2,
+                                                 Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnAtomicRmw(opcode));
@@ -1194,10 +1178,9 @@ wabt::Result BinaryReaderInterpreter::OnAtomicRmwExpr(Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnAtomicRmwCmpxchgExpr(
-    Opcode opcode,
-    uint32_t alignment_log2,
-    Address offset) {
+wabt::Result BinaryReaderInterp::OnAtomicRmwCmpxchgExpr(Opcode opcode,
+                                                        uint32_t alignment_log2,
+                                                        Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnAtomicRmwCmpxchg(opcode));
@@ -1207,40 +1190,37 @@ wabt::Result BinaryReaderInterpreter::OnAtomicRmwCmpxchgExpr(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnBinaryExpr(wabt::Opcode opcode) {
+wabt::Result BinaryReaderInterp::OnBinaryExpr(wabt::Opcode opcode) {
   CHECK_RESULT(typechecker_.OnBinary(opcode));
   CHECK_RESULT(EmitOpcode(opcode));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnBlockExpr(Index num_types,
-                                                  Type* sig_types) {
+wabt::Result BinaryReaderInterp::OnBlockExpr(Index num_types, Type* sig_types) {
   TypeVector sig(sig_types, sig_types + num_types);
   CHECK_RESULT(typechecker_.OnBlock(&sig));
   PushLabel(kInvalidIstreamOffset, kInvalidIstreamOffset);
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnLoopExpr(Index num_types,
-                                                 Type* sig_types) {
+wabt::Result BinaryReaderInterp::OnLoopExpr(Index num_types, Type* sig_types) {
   TypeVector sig(sig_types, sig_types + num_types);
   CHECK_RESULT(typechecker_.OnLoop(&sig));
   PushLabel(GetIstreamOffset(), kInvalidIstreamOffset);
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnIfExpr(Index num_types,
-                                               Type* sig_types) {
+wabt::Result BinaryReaderInterp::OnIfExpr(Index num_types, Type* sig_types) {
   TypeVector sig(sig_types, sig_types + num_types);
   CHECK_RESULT(typechecker_.OnIf(&sig));
-  CHECK_RESULT(EmitOpcode(Opcode::InterpreterBrUnless));
+  CHECK_RESULT(EmitOpcode(Opcode::InterpBrUnless));
   IstreamOffset fixup_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
   PushLabel(kInvalidIstreamOffset, fixup_offset);
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnElseExpr() {
+wabt::Result BinaryReaderInterp::OnElseExpr() {
   CHECK_RESULT(typechecker_.OnElse());
   Label* label = TopLabel();
   IstreamOffset fixup_cond_offset = label->fixup_offset;
@@ -1251,7 +1231,7 @@ wabt::Result BinaryReaderInterpreter::OnElseExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnEndExpr() {
+wabt::Result BinaryReaderInterp::OnEndExpr() {
   TypeChecker::Label* label;
   CHECK_RESULT(typechecker_.GetLabel(0, &label));
   LabelType label_type = label->label_type;
@@ -1264,7 +1244,7 @@ wabt::Result BinaryReaderInterpreter::OnEndExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnBrExpr(Index depth) {
+wabt::Result BinaryReaderInterp::OnBrExpr(Index depth) {
   Index drop_count, keep_count;
   CHECK_RESULT(GetBrDropKeepCount(depth, &drop_count, &keep_count));
   CHECK_RESULT(typechecker_.OnBr(depth));
@@ -1272,12 +1252,12 @@ wabt::Result BinaryReaderInterpreter::OnBrExpr(Index depth) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnBrIfExpr(Index depth) {
+wabt::Result BinaryReaderInterp::OnBrIfExpr(Index depth) {
   Index drop_count, keep_count;
   CHECK_RESULT(typechecker_.OnBrIf(depth));
   CHECK_RESULT(GetBrDropKeepCount(depth, &drop_count, &keep_count));
   /* flip the br_if so if <cond> is true it can drop values from the stack */
-  CHECK_RESULT(EmitOpcode(Opcode::InterpreterBrUnless));
+  CHECK_RESULT(EmitOpcode(Opcode::InterpBrUnless));
   IstreamOffset fixup_br_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
   CHECK_RESULT(EmitBr(depth, drop_count, keep_count));
@@ -1285,18 +1265,17 @@ wabt::Result BinaryReaderInterpreter::OnBrIfExpr(Index depth) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnBrTableExpr(
-    Index num_targets,
-    Index* target_depths,
-    Index default_target_depth) {
+wabt::Result BinaryReaderInterp::OnBrTableExpr(Index num_targets,
+                                               Index* target_depths,
+                                               Index default_target_depth) {
   CHECK_RESULT(typechecker_.BeginBrTable());
   CHECK_RESULT(EmitOpcode(Opcode::BrTable));
   CHECK_RESULT(EmitI32(num_targets));
   IstreamOffset fixup_table_offset = GetIstreamOffset();
   CHECK_RESULT(EmitI32(kInvalidIstreamOffset));
-  /* not necessary for the interpreter, but it makes it easier to disassemble.
+  /* not necessary for the interp, but it makes it easier to disassemble.
    * This opcode specifies how many bytes of data follow. */
-  CHECK_RESULT(EmitOpcode(Opcode::InterpreterData));
+  CHECK_RESULT(EmitOpcode(Opcode::InterpData));
   CHECK_RESULT(EmitI32((num_targets + 1) * WABT_TABLE_ENTRY_SIZE));
   CHECK_RESULT(EmitI32At(fixup_table_offset, GetIstreamOffset()));
 
@@ -1310,13 +1289,13 @@ wabt::Result BinaryReaderInterpreter::OnBrTableExpr(
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnCallExpr(Index func_index) {
+wabt::Result BinaryReaderInterp::OnCallExpr(Index func_index) {
   Func* func = GetFuncByModuleIndex(func_index);
   FuncSignature* sig = env_->GetFuncSignature(func->sig_index);
   CHECK_RESULT(typechecker_.OnCall(&sig->param_types, &sig->result_types));
 
   if (func->is_host) {
-    CHECK_RESULT(EmitOpcode(Opcode::InterpreterCallHost));
+    CHECK_RESULT(EmitOpcode(Opcode::InterpCallHost));
     CHECK_RESULT(EmitI32(TranslateFuncIndexToEnv(func_index)));
   } else {
     CHECK_RESULT(EmitOpcode(Opcode::Call));
@@ -1326,7 +1305,7 @@ wabt::Result BinaryReaderInterpreter::OnCallExpr(Index func_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnCallIndirectExpr(Index sig_index) {
+wabt::Result BinaryReaderInterp::OnCallIndirectExpr(Index sig_index) {
   if (module_->table_index == kInvalidIndex) {
     PrintError("found call_indirect operator, but no table");
     return wabt::Result::Error;
@@ -1341,49 +1320,49 @@ wabt::Result BinaryReaderInterpreter::OnCallIndirectExpr(Index sig_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnCompareExpr(wabt::Opcode opcode) {
+wabt::Result BinaryReaderInterp::OnCompareExpr(wabt::Opcode opcode) {
   return OnBinaryExpr(opcode);
 }
 
-wabt::Result BinaryReaderInterpreter::OnConvertExpr(wabt::Opcode opcode) {
+wabt::Result BinaryReaderInterp::OnConvertExpr(wabt::Opcode opcode) {
   return OnUnaryExpr(opcode);
 }
 
-wabt::Result BinaryReaderInterpreter::OnDropExpr() {
+wabt::Result BinaryReaderInterp::OnDropExpr() {
   CHECK_RESULT(typechecker_.OnDrop());
   CHECK_RESULT(EmitOpcode(Opcode::Drop));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnI32ConstExpr(uint32_t value) {
+wabt::Result BinaryReaderInterp::OnI32ConstExpr(uint32_t value) {
   CHECK_RESULT(typechecker_.OnConst(Type::I32));
   CHECK_RESULT(EmitOpcode(Opcode::I32Const));
   CHECK_RESULT(EmitI32(value));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnI64ConstExpr(uint64_t value) {
+wabt::Result BinaryReaderInterp::OnI64ConstExpr(uint64_t value) {
   CHECK_RESULT(typechecker_.OnConst(Type::I64));
   CHECK_RESULT(EmitOpcode(Opcode::I64Const));
   CHECK_RESULT(EmitI64(value));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnF32ConstExpr(uint32_t value_bits) {
+wabt::Result BinaryReaderInterp::OnF32ConstExpr(uint32_t value_bits) {
   CHECK_RESULT(typechecker_.OnConst(Type::F32));
   CHECK_RESULT(EmitOpcode(Opcode::F32Const));
   CHECK_RESULT(EmitI32(value_bits));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnF64ConstExpr(uint64_t value_bits) {
+wabt::Result BinaryReaderInterp::OnF64ConstExpr(uint64_t value_bits) {
   CHECK_RESULT(typechecker_.OnConst(Type::F64));
   CHECK_RESULT(EmitOpcode(Opcode::F64Const));
   CHECK_RESULT(EmitI64(value_bits));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnGetGlobalExpr(Index global_index) {
+wabt::Result BinaryReaderInterp::OnGetGlobalExpr(Index global_index) {
   CHECK_RESULT(CheckGlobal(global_index));
   Type type = GetGlobalTypeByModuleIndex(global_index);
   CHECK_RESULT(typechecker_.OnGetGlobal(type));
@@ -1392,7 +1371,7 @@ wabt::Result BinaryReaderInterpreter::OnGetGlobalExpr(Index global_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnSetGlobalExpr(Index global_index) {
+wabt::Result BinaryReaderInterp::OnSetGlobalExpr(Index global_index) {
   CHECK_RESULT(CheckGlobal(global_index));
   Global* global = GetGlobalByModuleIndex(global_index);
   if (!global->mutable_) {
@@ -1406,12 +1385,12 @@ wabt::Result BinaryReaderInterpreter::OnSetGlobalExpr(Index global_index) {
   return wabt::Result::Ok;
 }
 
-Index BinaryReaderInterpreter::TranslateLocalIndex(Index local_index) {
+Index BinaryReaderInterp::TranslateLocalIndex(Index local_index) {
   return typechecker_.type_stack_size() +
          current_func_->param_and_local_types.size() - local_index;
 }
 
-wabt::Result BinaryReaderInterpreter::OnGetLocalExpr(Index local_index) {
+wabt::Result BinaryReaderInterp::OnGetLocalExpr(Index local_index) {
   CHECK_RESULT(CheckLocal(local_index));
   Type type = GetLocalTypeByIndex(current_func_, local_index);
   // Get the translated index before calling typechecker_.OnGetLocal because it
@@ -1424,7 +1403,7 @@ wabt::Result BinaryReaderInterpreter::OnGetLocalExpr(Index local_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnSetLocalExpr(Index local_index) {
+wabt::Result BinaryReaderInterp::OnSetLocalExpr(Index local_index) {
   CHECK_RESULT(CheckLocal(local_index));
   Type type = GetLocalTypeByIndex(current_func_, local_index);
   CHECK_RESULT(typechecker_.OnSetLocal(type));
@@ -1433,7 +1412,7 @@ wabt::Result BinaryReaderInterpreter::OnSetLocalExpr(Index local_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnTeeLocalExpr(Index local_index) {
+wabt::Result BinaryReaderInterp::OnTeeLocalExpr(Index local_index) {
   CHECK_RESULT(CheckLocal(local_index));
   Type type = GetLocalTypeByIndex(current_func_, local_index);
   CHECK_RESULT(typechecker_.OnTeeLocal(type));
@@ -1442,7 +1421,7 @@ wabt::Result BinaryReaderInterpreter::OnTeeLocalExpr(Index local_index) {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnGrowMemoryExpr() {
+wabt::Result BinaryReaderInterp::OnGrowMemoryExpr() {
   CHECK_RESULT(CheckHasMemory(wabt::Opcode::GrowMemory));
   CHECK_RESULT(typechecker_.OnGrowMemory());
   CHECK_RESULT(EmitOpcode(Opcode::GrowMemory));
@@ -1450,9 +1429,9 @@ wabt::Result BinaryReaderInterpreter::OnGrowMemoryExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnLoadExpr(wabt::Opcode opcode,
-                                                 uint32_t alignment_log2,
-                                                 Address offset) {
+wabt::Result BinaryReaderInterp::OnLoadExpr(wabt::Opcode opcode,
+                                            uint32_t alignment_log2,
+                                            Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnLoad(opcode));
@@ -1462,9 +1441,9 @@ wabt::Result BinaryReaderInterpreter::OnLoadExpr(wabt::Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnStoreExpr(wabt::Opcode opcode,
-                                                  uint32_t alignment_log2,
-                                                  Address offset) {
+wabt::Result BinaryReaderInterp::OnStoreExpr(wabt::Opcode opcode,
+                                             uint32_t alignment_log2,
+                                             Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnStore(opcode));
@@ -1474,7 +1453,7 @@ wabt::Result BinaryReaderInterpreter::OnStoreExpr(wabt::Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnCurrentMemoryExpr() {
+wabt::Result BinaryReaderInterp::OnCurrentMemoryExpr() {
   CHECK_RESULT(CheckHasMemory(wabt::Opcode::CurrentMemory));
   CHECK_RESULT(typechecker_.OnCurrentMemory());
   CHECK_RESULT(EmitOpcode(Opcode::CurrentMemory));
@@ -1482,11 +1461,11 @@ wabt::Result BinaryReaderInterpreter::OnCurrentMemoryExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnNopExpr() {
+wabt::Result BinaryReaderInterp::OnNopExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnReturnExpr() {
+wabt::Result BinaryReaderInterp::OnReturnExpr() {
   Index drop_count, keep_count;
   CHECK_RESULT(GetReturnDropKeepCount(&drop_count, &keep_count));
   CHECK_RESULT(typechecker_.OnReturn());
@@ -1495,21 +1474,21 @@ wabt::Result BinaryReaderInterpreter::OnReturnExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnSelectExpr() {
+wabt::Result BinaryReaderInterp::OnSelectExpr() {
   CHECK_RESULT(typechecker_.OnSelect());
   CHECK_RESULT(EmitOpcode(Opcode::Select));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnUnreachableExpr() {
+wabt::Result BinaryReaderInterp::OnUnreachableExpr() {
   CHECK_RESULT(typechecker_.OnUnreachable());
   CHECK_RESULT(EmitOpcode(Opcode::Unreachable));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnWaitExpr(Opcode opcode,
-                                                 uint32_t alignment_log2,
-                                                 Address offset) {
+wabt::Result BinaryReaderInterp::OnWaitExpr(Opcode opcode,
+                                            uint32_t alignment_log2,
+                                            Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnWait(opcode));
@@ -1519,9 +1498,9 @@ wabt::Result BinaryReaderInterpreter::OnWaitExpr(Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::OnWakeExpr(Opcode opcode,
-                                                 uint32_t alignment_log2,
-                                                 Address offset) {
+wabt::Result BinaryReaderInterp::OnWakeExpr(Opcode opcode,
+                                            uint32_t alignment_log2,
+                                            Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
   CHECK_RESULT(typechecker_.OnWake(opcode));
@@ -1531,7 +1510,7 @@ wabt::Result BinaryReaderInterpreter::OnWakeExpr(Opcode opcode,
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterpreter::EndModule() {
+wabt::Result BinaryReaderInterp::EndModule() {
   for (ElemSegmentInfo& info : elem_segment_infos_) {
     *info.dst = info.func_index;
   }
@@ -1543,12 +1522,12 @@ wabt::Result BinaryReaderInterpreter::EndModule() {
 
 }  // end anonymous namespace
 
-wabt::Result ReadBinaryInterpreter(Environment* env,
-                                   const void* data,
-                                   size_t size,
-                                   const ReadBinaryOptions* options,
-                                   ErrorHandler* error_handler,
-                                   DefinedModule** out_module) {
+wabt::Result ReadBinaryInterp(Environment* env,
+                              const void* data,
+                              size_t size,
+                              const ReadBinaryOptions* options,
+                              ErrorHandler* error_handler,
+                              DefinedModule** out_module) {
   // Need to mark before taking ownership of env->istream.
   Environment::MarkPoint mark = env->Mark();
 
@@ -1556,8 +1535,7 @@ wabt::Result ReadBinaryInterpreter(Environment* env,
   IstreamOffset istream_offset = istream->size();
   DefinedModule* module = new DefinedModule();
 
-  BinaryReaderInterpreter reader(env, module, std::move(istream),
-                                 error_handler);
+  BinaryReaderInterp reader(env, module, std::move(istream), error_handler);
   env->EmplaceBackModule(module);
 
   wabt::Result result = ReadBinary(data, size, &reader, options);

--- a/src/binary-reader-interp.h
+++ b/src/binary-reader-interp.h
@@ -14,30 +14,30 @@
  * limitations under the License.
  */
 
-#ifndef WABT_BINARY_READER_INTERPRETER_H_
-#define WABT_BINARY_READER_INTERPRETER_H_
+#ifndef WABT_BINARY_READER_INTERP_H_
+#define WABT_BINARY_READER_INTERP_H_
 
 #include "src/common.h"
 
 namespace wabt {
 
-namespace interpreter {
+namespace interp {
 
 struct DefinedModule;
 class Environment;
 
-} // namespace interpreter
+}  // namespace interp
 
 class ErrorHandler;
 struct ReadBinaryOptions;
 
-Result ReadBinaryInterpreter(interpreter::Environment* env,
-                             const void* data,
-                             size_t size,
-                             const ReadBinaryOptions* options,
-                             ErrorHandler*,
-                             interpreter::DefinedModule** out_module);
+Result ReadBinaryInterp(interp::Environment* env,
+                        const void* data,
+                        size_t size,
+                        const ReadBinaryOptions* options,
+                        ErrorHandler*,
+                        interp::DefinedModule** out_module);
 
 }  // namespace wabt
 
-#endif /* WABT_BINARY_READER_INTERPRETER_H_ */
+#endif /* WABT_BINARY_READER_INTERP_H_ */

--- a/src/interp.h
+++ b/src/interp.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-#ifndef WABT_INTERPRETER_H_
-#define WABT_INTERPRETER_H_
+#ifndef WABT_INTERP_H_
+#define WABT_INTERP_H_
 
 #include <stdint.h>
 
@@ -30,9 +30,9 @@
 
 namespace wabt {
 
-namespace interpreter {
+namespace interp {
 
-#define FOREACH_INTERPRETER_RESULT(V)                                       \
+#define FOREACH_INTERP_RESULT(V)                                            \
   V(Ok, "ok")                                                               \
   /* returned from the top-most function */                                 \
   V(Returned, "returned")                                                   \
@@ -73,7 +73,7 @@ namespace interpreter {
 
 enum class Result {
 #define V(Name, str) Name,
-  FOREACH_INTERPRETER_RESULT(V)
+  FOREACH_INTERP_RESULT(V)
 #undef V
 };
 
@@ -598,7 +598,7 @@ void WriteCall(Stream* stream,
                const TypedValues& results,
                Result);
 
-}  // namespace interpreter
+}  // namespace interp
 }  // namespace wabt
 
-#endif /* WABT_INTERPRETER_H_ */
+#endif /* WABT_INTERP_H_ */

--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -180,11 +180,11 @@ bool Opcode::IsEnabled(const Features& features) const {
       return features.threads_enabled();
 
     // Interpreter opcodes are never "enabled".
-    case Opcode::InterpreterAlloca:
-    case Opcode::InterpreterBrUnless:
-    case Opcode::InterpreterCallHost:
-    case Opcode::InterpreterData:
-    case Opcode::InterpreterDropKeep:
+    case Opcode::InterpAlloca:
+    case Opcode::InterpBrUnless:
+    case Opcode::InterpCallHost:
+    case Opcode::InterpData:
+    case Opcode::InterpDropKeep:
       return false;
 
     default:

--- a/src/opcode.def
+++ b/src/opcode.def
@@ -219,11 +219,11 @@ WABT_OPCODE(I64, I64, ___, ___, 0, 0,     0xC3, I64Extend16S, "i64.extend16_s")
 WABT_OPCODE(I64, I64, ___, ___, 0, 0,     0xC4, I64Extend32S, "i64.extend32_s")
 
 /* Interpreter-only opcodes */
-WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe0, InterpreterAlloca, "alloca")
-WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe1, InterpreterBrUnless, "br_unless")
-WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe2, InterpreterCallHost, "call_host")
-WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe3, InterpreterData, "data")
-WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe4, InterpreterDropKeep, "drop_keep")
+WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe0, InterpAlloca, "alloca")
+WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe1, InterpBrUnless, "br_unless")
+WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe2, InterpCallHost, "call_host")
+WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe3, InterpData, "data")
+WABT_OPCODE(___, ___, ___, ___, 0, 0,     0xe4, InterpDropKeep, "drop_keep")
 
 WABT_OPCODE(I32, F32, ___, ___, 0, 0xfc,  0x00, I32TruncSSatF32, "i32.trunc_s:sat/f32")
 WABT_OPCODE(I32, F32, ___, ___, 0, 0xfc,  0x01, I32TruncUSatF32, "i32.trunc_u:sat/f32")

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -23,12 +23,12 @@
 #include <string>
 #include <vector>
 
-#include "src/binary-reader-interpreter.h"
+#include "src/binary-reader-interp.h"
 #include "src/binary-reader.h"
 #include "src/cast.h"
 #include "src/error-handler.h"
 #include "src/feature.h"
-#include "src/interpreter.h"
+#include "src/interp.h"
 #include "src/literal.h"
 #include "src/option-parser.h"
 #include "src/resolve-names.h"
@@ -38,7 +38,7 @@
 #include "src/wast-parser.h"
 
 using namespace wabt;
-using namespace wabt::interpreter;
+using namespace wabt::interp;
 
 static int s_verbose;
 static const char* s_infile;
@@ -56,7 +56,7 @@ enum class RunVerbosity {
 };
 
 static const char s_description[] =
-R"(  read a file in the wasm binary format, and run in it a stack-based
+    R"(  read a file in the wasm binary format, and run in it a stack-based
   interpreter.
 
 examples:
@@ -112,13 +112,13 @@ static void ParseOptions(int argc, char** argv) {
   parser.Parse(argc, argv);
 }
 
-static void RunAllExports(interpreter::Module* module,
+static void RunAllExports(interp::Module* module,
                           Thread* thread,
                           RunVerbosity verbose) {
   TypedValues args;
   TypedValues results;
-  for (const interpreter::Export& export_ : module->exports) {
-    interpreter::Result iresult = thread->RunExport(&export_, args, &results);
+  for (const interp::Export& export_ : module->exports) {
+    interp::Result iresult = thread->RunExport(&export_, args, &results);
     if (verbose == RunVerbosity::Verbose) {
       WriteCall(s_stdout_stream.get(), string_view(), export_.name, args,
                 results, iresult);
@@ -141,8 +141,8 @@ static wabt::Result ReadModule(const char* module_filename,
     const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
                               kStopOnFirstError);
-    result = ReadBinaryInterpreter(env, DataOrNull(file_data), file_data.size(),
-                                   &options, error_handler, out_module);
+    result = ReadBinaryInterp(env, DataOrNull(file_data), file_data.size(),
+                              &options, error_handler, out_module);
 
     if (Succeeded(result)) {
       if (s_verbose)
@@ -153,15 +153,15 @@ static wabt::Result ReadModule(const char* module_filename,
 }
 
 #define PRIimport "\"" PRIstringview "." PRIstringview "\""
-#define PRINTF_IMPORT_ARG(x)                    \
+#define PRINTF_IMPORT_ARG(x)                   \
   WABT_PRINTF_STRING_VIEW_ARG((x).module_name) \
   , WABT_PRINTF_STRING_VIEW_ARG((x).field_name)
 
 class WasmInterpHostImportDelegate : public HostImportDelegate {
  public:
-  wabt::Result ImportFunc(interpreter::FuncImport* import,
-                          interpreter::Func* func,
-                          interpreter::FuncSignature* func_sig,
+  wabt::Result ImportFunc(interp::FuncImport* import,
+                          interp::Func* func,
+                          interp::FuncSignature* func_sig,
                           const ErrorCallback& callback) override {
     if (import->field_name == "print") {
       cast<HostFunc>(func)->callback = PrintCallback;
@@ -173,33 +173,32 @@ class WasmInterpHostImportDelegate : public HostImportDelegate {
     }
   }
 
-  wabt::Result ImportTable(interpreter::TableImport* import,
-                           interpreter::Table* table,
+  wabt::Result ImportTable(interp::TableImport* import,
+                           interp::Table* table,
                            const ErrorCallback& callback) override {
     return wabt::Result::Error;
   }
 
-  wabt::Result ImportMemory(interpreter::MemoryImport* import,
-                            interpreter::Memory* memory,
+  wabt::Result ImportMemory(interp::MemoryImport* import,
+                            interp::Memory* memory,
                             const ErrorCallback& callback) override {
     return wabt::Result::Error;
   }
 
-  wabt::Result ImportGlobal(interpreter::GlobalImport* import,
-                            interpreter::Global* global,
+  wabt::Result ImportGlobal(interp::GlobalImport* import,
+                            interp::Global* global,
                             const ErrorCallback& callback) override {
     return wabt::Result::Error;
   }
 
  private:
-  static interpreter::Result PrintCallback(
-      const HostFunc* func,
-      const interpreter::FuncSignature* sig,
-      Index num_args,
-      TypedValue* args,
-      Index num_results,
-      TypedValue* out_results,
-      void* user_data) {
+  static interp::Result PrintCallback(const HostFunc* func,
+                                      const interp::FuncSignature* sig,
+                                      Index num_args,
+                                      TypedValue* args,
+                                      Index num_results,
+                                      TypedValue* out_results,
+                                      void* user_data) {
     memset(out_results, 0, sizeof(TypedValue) * num_results);
     for (Index i = 0; i < num_results; ++i)
       out_results[i].type = sig->result_types[i];
@@ -209,8 +208,8 @@ class WasmInterpHostImportDelegate : public HostImportDelegate {
 
     printf("called host ");
     WriteCall(s_stdout_stream.get(), func->module_name, func->field_name,
-              vec_args, vec_results, interpreter::Result::Ok);
-    return interpreter::Result::Ok;
+              vec_args, vec_results, interp::Result::Ok);
+    return interp::Result::Ok;
   }
 
   void PrintError(const ErrorCallback& callback, const char* format, ...) {
@@ -236,8 +235,8 @@ static wabt::Result ReadAndRunModule(const char* module_filename) {
   result = ReadModule(module_filename, &env, &error_handler, &module);
   if (Succeeded(result)) {
     Thread thread(&env, s_thread_options);
-    interpreter::Result iresult = thread.RunStartFunction(module);
-    if (iresult == interpreter::Result::Ok) {
+    interp::Result iresult = thread.RunStartFunction(module);
+    if (iresult == interp::Result::Ok) {
       if (s_run_all_exports)
         RunAllExports(module, &thread, RunVerbosity::Verbose);
     } else {


### PR DESCRIPTION
We already used `interp` in a few places, may as well be consistent.