### PR TITLE
Set the `loc` member in `Const`

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1446,7 +1446,7 @@ Result WastParser::ParseConst(Const* const_) {
   Opcode opcode = Consume().opcode();
   Literal literal;
 
-  Location loc = GetLocation();
+  const_->loc = GetLocation();
 
   switch (Peek()) {
     case TokenType::Nat:
@@ -1493,7 +1493,7 @@ Result WastParser::ParseConst(Const* const_) {
   }
 
   if (Failed(result)) {
-    Error(loc, "invalid literal \"%s\"", literal.text.c_str());
+    Error(const_->loc, "invalid literal \"%s\"", literal.text.c_str());
   }
 
   return Result::Ok;

--- a/test/regress/regress-17.txt
+++ b/test/regress/regress-17.txt
@@ -1,0 +1,13 @@
+;;; ERROR: 1
+;;; TOOL: run-interp-spec
+(module (func (export "foo") (param i64)))
+
+;; Make sure that the error below has the correct location.
+(invoke "foo" (i32.const 1))
+(;; STDERR ;;;
+Error running "wast2json":
+out/test/regress/regress-17.txt:6:26: error: type mismatch for argument 0 of invoke. got i32, expected i64
+(invoke "foo" (i32.const 1))
+                         ^
+
+;;; STDERR ;;)


### PR DESCRIPTION
After the switch to the recursive descent parser, this wasn't properly
being set. As a result, certain errors would not have a proper location.