### PR TITLE
Change shared memory text syntax

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -621,11 +621,6 @@ bool WastParser::ParseAlignOpt(uint32_t* out_align) {
 Result WastParser::ParseLimits(Limits* out_limits) {
   WABT_TRACE(ParseLimits);
 
-  if (PeekMatch(TokenType::Lpar)) {
-    Consume();
-    EXPECT(Shared);
-    out_limits->is_shared = true;
-  }
   CHECK_RESULT(ParseNat(&out_limits->initial));
   if (PeekMatch(TokenType::Nat)) {
     CHECK_RESULT(ParseNat(&out_limits->max));
@@ -633,8 +628,9 @@ Result WastParser::ParseLimits(Limits* out_limits) {
   } else {
     out_limits->has_max = false;
   }
-  if (out_limits->is_shared) {
-    EXPECT(Rpar);
+
+  if (Match(TokenType::Shared)) {
+    out_limits->is_shared = true;
   }
 
   return Result::Ok;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1056,15 +1056,11 @@ void WatWriter::WriteException(const Exception& except) {
 }
 
 void WatWriter::WriteLimits(const Limits& limits) {
-  if (limits.is_shared) {
-    WriteOpenSpace("shared");
-  }
   Writef("%" PRIu64, limits.initial);
   if (limits.has_max)
     Writef("%" PRIu64, limits.max);
-  if (limits.is_shared) {
-    WriteCloseSpace();
-  }
+  if (limits.is_shared)
+    Writef("shared");
 }
 
 void WatWriter::WriteTable(const Table& table) {

--- a/test/dump/atomic.txt
+++ b/test/dump/atomic.txt
@@ -2,7 +2,7 @@
 ;;; FLAGS: --enable-threads
 
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (func
     i32.const 0 i32.const 0 wake drop
     i32.const 0 i32.const 0 i64.const 0 i32.wait drop

--- a/test/interp/atomic-load.txt
+++ b/test/interp/atomic-load.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (data (i32.const 0) "\ff\ff\ff\ff")
   (data (i32.const 4) "\00\00\ce\41")
   (data (i32.const 8) "\00\00\00\00\00\ff\8f\40")

--- a/test/interp/atomic-rmw-add.txt
+++ b/test/interp/atomic-rmw-add.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-rmw-and.txt
+++ b/test/interp/atomic-rmw-and.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-rmw-cmpxchg.txt
+++ b/test/interp/atomic-rmw-cmpxchg.txt
@@ -1,7 +1,7 @@
 ;;; FLAGS: --enable-threads
 ;;; TOOL: run-interp
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-rmw-or.txt
+++ b/test/interp/atomic-rmw-or.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-rmw-sub.txt
+++ b/test/interp/atomic-rmw-sub.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-rmw-xchg.txt
+++ b/test/interp/atomic-rmw-xchg.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-rmw-xor.txt
+++ b/test/interp/atomic-rmw-xor.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; i32
 

--- a/test/interp/atomic-store.txt
+++ b/test/interp/atomic-store.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   (func (export "i32.atomic.store8") (result i32)
       i32.const 0 i32.const 0xfb i32.atomic.store8

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -6,7 +6,7 @@
 
   (type $empty (func))
   (func $empty)
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (table anyfunc (elem $empty $empty))
   (global $g (mut i32) (i32.const 0))
 

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -6,7 +6,7 @@
 
   (type $empty (func))
   (func $empty)
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (table anyfunc (elem $empty $empty))
   (global $g (mut i32) (i32.const 0))
 

--- a/test/parse/expr/atomic-align.txt
+++ b/test/parse/expr/atomic-align.txt
@@ -1,6 +1,6 @@
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (func
     i32.const 0 i32.const 0 wake align=4 drop
     i32.const 0 i32.const 0 i64.const 0 i32.wait align=4 drop

--- a/test/parse/expr/atomic.txt
+++ b/test/parse/expr/atomic.txt
@@ -1,6 +1,6 @@
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (func
     i32.const 0 i32.const 0 wake drop
     i32.const 0 i32.const 0 i64.const 0 i32.wait drop

--- a/test/parse/expr/bad-atomic-unnatural-align.txt
+++ b/test/parse/expr/bad-atomic-unnatural-align.txt
@@ -1,7 +1,7 @@
 ;;; ERROR: 1
 ;;; FLAGS: --enable-threads
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (func
     i32.const 0 i32.const 0 wake align=8 drop
     i32.const 0 i32.const 0 i64.const 0 i32.wait align=8 drop

--- a/test/parse/module/bad-import-table-shared.txt
+++ b/test/parse/module/bad-import-table-shared.txt
@@ -1,9 +1,9 @@
 ;;; ERROR: 1
 (module
-  (import "foo" "bar" (table (shared 0 3) anyfunc))
+  (import "foo" "bar" (table 0 3 shared anyfunc))
 )
 (;; STDERR ;;;
 out/test/parse/module/bad-import-table-shared.txt:3:4: error: tables may not be shared
-  (import "foo" "bar" (table (shared 0 3) anyfunc))
+  (import "foo" "bar" (table 0 3 shared anyfunc))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-shared-nomax.txt
+++ b/test/parse/module/bad-memory-shared-nomax.txt
@@ -1,8 +1,8 @@
 ;;; ERROR: 1
-(module (memory (shared 1)))
+(module (memory 1 shared))
 
 (;; STDERR ;;;
 out/test/parse/module/bad-memory-shared-nomax.txt:2:10: error: shared memories must have max sizes
-(module (memory (shared 1)))
+(module (memory 1 shared))
          ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/import-memory-shared.txt
+++ b/test/parse/module/import-memory-shared.txt
@@ -1,2 +1,2 @@
 (module
-  (import "foo" "2" (memory (shared 0 2))))
+  (import "foo" "2" (memory 0 2 shared)))

--- a/test/parse/module/memory-shared.txt
+++ b/test/parse/module/memory-shared.txt
@@ -1,1 +1,1 @@
-(module (memory (shared 1 1)))
+(module (memory 1 1 shared))

--- a/test/roundtrip/fold-atomic.txt
+++ b/test/roundtrip/fold-atomic.txt
@@ -2,7 +2,7 @@
 ;;; FLAGS: --stdout --fold-exprs --enable-threads
 
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
   (func
     i32.const 0 i32.const 0 wake drop
     i32.const 0 i32.const 0 i64.const 0 i32.wait drop
@@ -344,5 +344,5 @@
         (i32.const 0)
         (i64.const 0)
         (i64.const 0))))
-  (memory (;0;) (shared 1 1)))
+  (memory (;0;) 1 1 shared))
 ;;; STDOUT ;;)

--- a/test/typecheck/bad-atomic-type-mismatch.txt
+++ b/test/typecheck/bad-atomic-type-mismatch.txt
@@ -2,7 +2,7 @@
 ;;; FLAGS: --enable-threads
 
 (module
-  (memory (shared 1 1))
+  (memory 1 1 shared)
 
   ;; Mismatch address.
   (func f32.const 0 i32.const 0 wake drop)


### PR DESCRIPTION
This used to be `(shared <min> <max>)` and is now `<min> <max> shared`.

See https://github.com/WebAssembly/threads/pull/74.