### PR TITLE
Better type-checking errors

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -96,17 +96,10 @@ Result TypeChecker::PeekType(Index depth, Type* out_type) {
   return Result::Ok;
 }
 
-Result TypeChecker::TopType(Type* out_type) {
-  return PeekType(0, out_type);
-}
-
-Result TypeChecker::PopType(Type* out_type) {
-  Label* label;
-  CHECK_RESULT(TopLabel(&label));
-  Result result = TopType(out_type);
-  if (type_stack_.size() > label->type_stack_limit)
-    type_stack_.pop_back();
-  return result;
+Result TypeChecker::PeekAndCheckType(Index depth, Type expected) {
+  Type actual;
+  Result result = PeekType(depth, &actual);
+  return result | CheckType(actual, expected);
 }
 
 Result TypeChecker::DropTypes(size_t drop_count) {
@@ -133,52 +126,33 @@ void TypeChecker::PushTypes(const TypeVector& types) {
     PushType(type);
 }
 
-Result TypeChecker::CheckTypeStackLimit(size_t expected, const char* desc) {
-  Label* label;
-  CHECK_RESULT(TopLabel(&label));
-  size_t avail = type_stack_.size() - label->type_stack_limit;
-  if (!label->unreachable && expected > avail) {
-    PrintError("type stack size too small at %s. got %" PRIzd
-               ", expected at least %" PRIzd,
-               desc, avail, expected);
-    return Result::Error;
-  }
-  return Result::Ok;
-}
-
 Result TypeChecker::CheckTypeStackEnd(const char* desc) {
   Label* label;
   CHECK_RESULT(TopLabel(&label));
-  if (type_stack_.size() != label->type_stack_limit) {
-    PrintError("type stack at end of %s is %" PRIzd ", expected %" PRIzd, desc,
-               type_stack_.size(), label->type_stack_limit);
-    return Result::Error;
-  }
-  return Result::Ok;
+  Result result = (type_stack_.size() == label->type_stack_limit)
+                      ? Result::Ok
+                      : Result::Error;
+  PrintStackIfFailed(result, desc);
+  return result;
 }
 
-Result TypeChecker::CheckType(Type actual, Type expected, const char* desc) {
-  if (expected != actual && expected != Type::Any && actual != Type::Any) {
-    PrintError("type mismatch in %s, expected %s but got %s.", desc,
-               GetTypeName(expected), GetTypeName(actual));
-    return Result::Error;
-  }
-  return Result::Ok;
+Result TypeChecker::CheckType(Type actual, Type expected) {
+  return (expected == actual || expected == Type::Any || actual == Type::Any)
+             ? Result::Ok
+             : Result::Error;
 }
 
-Result TypeChecker::CheckSignature(const TypeVector& sig, const char* desc) {
-  Result result = CheckTypeStackLimit(sig.size(), desc);
-  for (size_t i = 0; i < sig.size(); ++i) {
-    Type actual = Type::Any;
-    result |= PeekType(sig.size() - i - 1, &actual);
-    result |= CheckType(actual, sig[i], desc);
-  }
+Result TypeChecker::CheckSignature(const TypeVector& sig) {
+  Result result = Result::Ok;
+  for (size_t i = 0; i < sig.size(); ++i)
+    result |= PeekAndCheckType(sig.size() - i - 1, sig[i]);
   return result;
 }
 
 Result TypeChecker::PopAndCheckSignature(const TypeVector& sig,
                                          const char* desc) {
-  Result result = CheckSignature(sig, desc);
+  Result result = CheckSignature(sig);
+  PrintStackIfFailed(result, desc, sig);
   result |= DropTypes(sig.size());
   return result;
 }
@@ -186,12 +160,8 @@ Result TypeChecker::PopAndCheckSignature(const TypeVector& sig,
 Result TypeChecker::PopAndCheckCall(const TypeVector& param_types,
                                     const TypeVector& result_types,
                                     const char* desc) {
-  Result result = CheckTypeStackLimit(param_types.size(), desc);
-  for (size_t i = 0; i < param_types.size(); ++i) {
-    Type actual = Type::Any;
-    result |= PeekType(param_types.size() - i - 1, &actual);
-    result |= CheckType(actual, param_types[i], desc);
-  }
+  Result result = CheckSignature(param_types);
+  PrintStackIfFailed(result, desc, param_types);
   result |= DropTypes(param_types.size());
   PushTypes(result_types);
   return result;
@@ -199,10 +169,9 @@ Result TypeChecker::PopAndCheckCall(const TypeVector& param_types,
 
 Result TypeChecker::PopAndCheck1Type(Type expected, const char* desc) {
   Result result = Result::Ok;
-  Type actual = Type::Any;
-  result |= CheckTypeStackLimit(1, desc);
-  result |= PopType(&actual);
-  result |= CheckType(actual, expected, desc);
+  result |= PeekAndCheckType(0, expected);
+  PrintStackIfFailed(result, desc, expected);
+  result |= DropTypes(1);
   return result;
 }
 
@@ -210,13 +179,10 @@ Result TypeChecker::PopAndCheck2Types(Type expected1,
                                       Type expected2,
                                       const char* desc) {
   Result result = Result::Ok;
-  Type actual1 = Type::Any;
-  Type actual2 = Type::Any;
-  result |= CheckTypeStackLimit(2, desc);
-  result |= PopType(&actual2);
-  result |= PopType(&actual1);
-  result |= CheckType(actual1, expected1, desc);
-  result |= CheckType(actual2, expected2, desc);
+  result |= PeekAndCheckType(0, expected2);
+  result |= PeekAndCheckType(1, expected1);
+  PrintStackIfFailed(result, desc, expected1, expected2);
+  result |= DropTypes(2);
   return result;
 }
 
@@ -225,29 +191,11 @@ Result TypeChecker::PopAndCheck3Types(Type expected1,
                                       Type expected3,
                                       const char* desc) {
   Result result = Result::Ok;
-  Type actual1 = Type::Any;
-  Type actual2 = Type::Any;
-  Type actual3 = Type::Any;
-  result |= CheckTypeStackLimit(3, desc);
-  result |= PopType(&actual3);
-  result |= PopType(&actual2);
-  result |= PopType(&actual1);
-  result |= CheckType(actual1, expected1, desc);
-  result |= CheckType(actual2, expected2, desc);
-  result |= CheckType(actual3, expected3, desc);
-  return result;
-}
-
-Result TypeChecker::PopAndCheck2TypesAreEqual(Type* out_type,
-                                              const char* desc) {
-  Result result = Result::Ok;
-  Type right = Type::Any;
-  Type left = Type::Any;
-  result |= CheckTypeStackLimit(2, desc);
-  result |= PopType(&right);
-  result |= PopType(&left);
-  result |= CheckType(left, right, desc);
-  *out_type = right;
+  result |= PeekAndCheckType(0, expected3);
+  result |= PeekAndCheckType(1, expected2);
+  result |= PeekAndCheckType(2, expected1);
+  PrintStackIfFailed(result, desc, expected1, expected2, expected3);
+  result |= DropTypes(3);
   return result;
 }
 
@@ -270,6 +218,67 @@ Result TypeChecker::CheckOpcode3(Opcode opcode) {
                         opcode.GetParamType3(), opcode.GetName());
   PushType(opcode.GetResultType());
   return result;
+}
+
+static std::string TypesToString(const TypeVector& types,
+                                 const char* prefix = nullptr) {
+  std::string result = "[";
+  if (prefix)
+    result += prefix;
+
+  for (size_t i = 0; i < types.size(); ++i) {
+    result += GetTypeName(types[i]);
+    if (i < types.size() - 1)
+      result += ", ";
+  }
+  result += "]";
+  return result;
+}
+
+void TypeChecker::PrintStackIfFailed(Result result,
+                                     const char* desc,
+                                     const TypeVector& expected) {
+  if (Failed(result)) {
+    size_t limit = 0;
+    Label* label;
+    if (Succeeded(TopLabel(&label))) {
+      limit = label->type_stack_limit;
+    }
+
+    TypeVector actual;
+    size_t max_depth = type_stack_.size() - limit;
+
+    // In general we want to print as many values of the actual stack as were
+    // expected. However, if the stack was expected to be empty, we should
+    // print some amount of the actual stack.
+    size_t actual_size;
+    if (expected.size() == 0) {
+      // Don't print too many elements if the stack is really deep.
+      const size_t kMaxActualStackToPrint = 4;
+      actual_size = std::min(kMaxActualStackToPrint, max_depth);
+    } else {
+      actual_size = std::min(expected.size(), max_depth);
+    }
+
+    bool incomplete_actual_stack = actual_size != max_depth;
+
+    for (size_t i = 0; i < actual_size; ++i) {
+      Type type;
+      Result result = PeekType(actual_size - i - 1, &type);
+      assert(Succeeded(result));
+      actual.push_back(type);
+    }
+
+    std::string message = "type mismatch in ";
+    message += desc;
+    message += ", expected ";
+    message += TypesToString(expected);
+    message += " but got ";
+    message +=
+        TypesToString(actual, incomplete_actual_stack ? "... " : nullptr);
+
+    PrintError("%s", message.c_str());
+  }
 }
 
 Result TypeChecker::BeginFunction(const TypeVector* sig) {
@@ -309,7 +318,8 @@ Result TypeChecker::OnBr(Index depth) {
   Label* label;
   CHECK_RESULT(GetLabel(depth, &label));
   if (label->label_type != LabelType::Loop)
-    result |= CheckSignature(label->sig, "br");
+    result |= CheckSignature(label->sig);
+  PrintStackIfFailed(result, "loop", label->sig);
   CHECK_RESULT(SetUnreachable());
   return result;
 }
@@ -340,13 +350,16 @@ Result TypeChecker::OnBrTableTarget(Index depth) {
   } else {
     assert(label->sig.size() <= 1);
     label_sig = label->sig.size() == 0 ? Type::Void : label->sig[0];
+
+    result |= CheckSignature(label->sig);
+    PrintStackIfFailed(result, "br_table", label_sig);
   }
 
-  result |= CheckType(br_table_sig_, label_sig, "br_table");
+  // Make sure this label's signature is consistent with the previous labels'
+  // signatures.
+  result |= CheckType(br_table_sig_, label_sig);
   br_table_sig_ = label_sig;
 
-  if (label->label_type != LabelType::Loop)
-    result |= CheckSignature(label->sig, "br_table");
   return result;
 }
 
@@ -404,9 +417,8 @@ Result TypeChecker::OnCurrentMemory() {
 
 Result TypeChecker::OnDrop() {
   Result result = Result::Ok;
-  Type type = Type::Any;
-  result |= CheckTypeStackLimit(1, "drop");
-  result |= PopType(&type);
+  result |= DropTypes(1);
+  PrintStackIfFailed(result, "drop", Type::Any);
   return result;
 }
 
@@ -528,9 +540,12 @@ Result TypeChecker::OnReturn() {
 
 Result TypeChecker::OnSelect() {
   Result result = Result::Ok;
-  result |= PopAndCheck1Type(Type::I32, "select");
   Type type = Type::Any;
-  result |= PopAndCheck2TypesAreEqual(&type, "select");
+  result |= PeekAndCheckType(0, Type::I32);
+  result |= PeekType(1, &type);
+  result |= PeekAndCheckType(2, type);
+  PrintStackIfFailed(result, "select", Type::I32, type, type);
+  result |= DropTypes(3);
   PushType(type);
   return result;
 }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -97,7 +97,7 @@ Result TypeChecker::PeekType(Index depth, Type* out_type) {
 }
 
 Result TypeChecker::PeekAndCheckType(Index depth, Type expected) {
-  Type actual;
+  Type actual = Type::Any;
   Result result = PeekType(depth, &actual);
   return result | CheckType(actual, expected);
 }
@@ -265,6 +265,7 @@ void TypeChecker::PrintStackIfFailed(Result result,
     for (size_t i = 0; i < actual_size; ++i) {
       Type type;
       Result result = PeekType(actual_size - i - 1, &type);
+      WABT_USE(result);
       assert(Succeeded(result));
       actual.push_back(type);
     }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -319,7 +319,7 @@ Result TypeChecker::OnBr(Index depth) {
   CHECK_RESULT(GetLabel(depth, &label));
   if (label->label_type != LabelType::Loop)
     result |= CheckSignature(label->sig);
-  PrintStackIfFailed(result, "loop", label->sig);
+  PrintStackIfFailed(result, "br", label->sig);
   CHECK_RESULT(SetUnreachable());
   return result;
 }

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -104,15 +104,13 @@ class TypeChecker {
   Result PopLabel();
   Result CheckLabelType(Label* label, LabelType label_type);
   Result PeekType(Index depth, Type* out_type);
-  Result TopType(Type* out_type);
-  Result PopType(Type* out_type);
+  Result PeekAndCheckType(Index depth, Type expected);
   Result DropTypes(size_t drop_count);
   void PushType(Type type);
   void PushTypes(const TypeVector& types);
-  Result CheckTypeStackLimit(size_t expected, const char* desc);
   Result CheckTypeStackEnd(const char* desc);
-  Result CheckType(Type actual, Type expected, const char* desc);
-  Result CheckSignature(const TypeVector& sig, const char* desc);
+  Result CheckType(Type actual, Type expected);
+  Result CheckSignature(const TypeVector& sig);
   Result PopAndCheckSignature(const TypeVector& sig, const char* desc);
   Result PopAndCheckCall(const TypeVector& param_types,
                          const TypeVector& result_types,
@@ -123,11 +121,20 @@ class TypeChecker {
                            Type expected2,
                            Type expected3,
                            const char* desc);
-  Result PopAndCheck2TypesAreEqual(Type* out_type, const char* desc);
   Result CheckOpcode1(Opcode opcode);
   Result CheckOpcode2(Opcode opcode);
   Result CheckOpcode3(Opcode opcode);
   Result OnEnd(Label* label, const char* sig_desc, const char* end_desc);
+
+  template <typename... Args>
+  void PrintStackIfFailed(Result result, const char* desc, Args... args) {
+    // Minor optimzation, check result before constructing the vector to pass
+    // to the other overload of PrintStackIfFailed.
+    if (Failed(result))
+      PrintStackIfFailed(result, desc, {args...});
+  }
+
+  void PrintStackIfFailed(Result, const char* desc, const TypeVector&);
 
   ErrorCallback error_callback_;
   TypeVector type_stack_;

--- a/test/binary/bad-typecheck-missing-drop.txt
+++ b/test/binary/bad-typecheck-missing-drop.txt
@@ -15,6 +15,6 @@ section(CODE) {
 }
 (;; STDERR ;;;
 Error running "wasm2wat":
-out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type stack at end of function is 1, expected 0
+out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
 
 ;;; STDERR ;;)

--- a/test/binary/linking-section.txt
+++ b/test/binary/linking-section.txt
@@ -41,5 +41,4 @@ Custom:
   - segment info [count=2]
    - 0: data1 align=4 flags=0
    - 1: data2 align=8 flags=0
-
 ;;; STDOUT ;;)

--- a/test/exceptions/bad-throw.txt
+++ b/test/exceptions/bad-throw.txt
@@ -9,7 +9,7 @@
   )
 ) 
 (;; STDERR ;;;
-out/test/exceptions/bad-throw.txt:8:6: error: type mismatch in throw, expected i32 but got i64.
+out/test/exceptions/bad-throw.txt:8:6: error: type mismatch in throw, expected [i32] but got [i64]
     (throw $ex)
      ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-binary-one-expr.txt
+++ b/test/parse/expr/bad-binary-one-expr.txt
@@ -3,10 +3,10 @@
    i32.const 0 
    i32.add))
 (;; STDERR ;;;
-out/test/parse/expr/bad-binary-one-expr.txt:4:4: error: type stack size too small at i32.add. got 1, expected at least 2
+out/test/parse/expr/bad-binary-one-expr.txt:4:4: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
    i32.add))
    ^^^^^^^
-out/test/parse/expr/bad-binary-one-expr.txt:4:4: error: type stack at end of function is 1, expected 0
+out/test/parse/expr/bad-binary-one-expr.txt:4:4: error: type mismatch in function, expected [] but got [i32, i32]
    i32.add))
    ^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-compare-one-expr.txt
+++ b/test/parse/expr/bad-compare-one-expr.txt
@@ -3,10 +3,10 @@
           i32.const 0 
           i32.lt_s))
 (;; STDERR ;;;
-out/test/parse/expr/bad-compare-one-expr.txt:4:11: error: type stack size too small at i32.lt_s. got 1, expected at least 2
+out/test/parse/expr/bad-compare-one-expr.txt:4:11: error: type mismatch in i32.lt_s, expected [i32, i32] but got [i32]
           i32.lt_s))
           ^^^^^^^^
-out/test/parse/expr/bad-compare-one-expr.txt:4:11: error: type stack at end of function is 1, expected 0
+out/test/parse/expr/bad-compare-one-expr.txt:4:11: error: type mismatch in function, expected [] but got [i32, i32]
           i32.lt_s))
           ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setlocal-no-value.txt
+++ b/test/parse/expr/bad-setlocal-no-value.txt
@@ -3,7 +3,7 @@
   (local i32)
   set_local 0))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setlocal-no-value.txt:4:3: error: type stack size too small at set_local. got 0, expected at least 1
+out/test/parse/expr/bad-setlocal-no-value.txt:4:3: error: type mismatch in set_local, expected [i32] but got []
   set_local 0))
   ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-mismatch.txt
+++ b/test/parse/func/bad-sig-result-type-mismatch.txt
@@ -6,7 +6,7 @@
 out/test/parse/func/bad-sig-result-type-mismatch.txt:4:4: error: type mismatch for result 0 of function. got i64, expected f32
   (func (type $t) (param i32) (result i64)))
    ^^^^
-out/test/parse/func/bad-sig-result-type-mismatch.txt:4:4: error: type stack size too small at implicit return. got 0, expected at least 1
+out/test/parse/func/bad-sig-result-type-mismatch.txt:4:4: error: type mismatch in implicit return, expected [i64] but got []
   (func (type $t) (param i32) (result i64)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-not-void.txt
+++ b/test/parse/func/bad-sig-result-type-not-void.txt
@@ -6,7 +6,7 @@
 out/test/parse/func/bad-sig-result-type-not-void.txt:4:4: error: expected 0 results, got 1
   (func (type $t) (param i32) (result f32)))
    ^^^^
-out/test/parse/func/bad-sig-result-type-not-void.txt:4:4: error: type stack size too small at implicit return. got 0, expected at least 1
+out/test/parse/func/bad-sig-result-type-not-void.txt:4:4: error: type mismatch in implicit return, expected [f32] but got []
   (func (type $t) (param i32) (result f32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-10.txt
+++ b/test/regress/regress-10.txt
@@ -7,7 +7,7 @@
       tee_local 0
     end))
 (;; STDERR ;;;
-out/test/regress/regress-10.txt:7:7: error: type stack at end of block is 1, expected 0
+out/test/regress/regress-10.txt:7:7: error: type mismatch in block, expected [] but got [i32]
       tee_local 0
       ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-11.txt
+++ b/test/regress/regress-11.txt
@@ -9,7 +9,7 @@
       i32.const 1
     end))
 (;; STDERR ;;;
-out/test/regress/regress-11.txt:7:9: error: type stack at end of block is 1, expected 0
+out/test/regress/regress-11.txt:7:9: error: type mismatch in block, expected [] but got [i32]
         br_if 1
         ^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-5.txt
+++ b/test/regress/regress-5.txt
@@ -117,7 +117,7 @@
     (i64.const 0))  ;; deliberate type-check error
 )
 (;; STDERR ;;;
-out/test/regress/regress-5.txt:117:6: error: type mismatch in implicit return, expected i32 but got i64.
+out/test/regress/regress-5.txt:117:6: error: type mismatch in implicit return, expected [i32] but got [i64]
     (i64.const 0))  ;; deliberate type-check error
      ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -2,70 +2,70 @@
 ;;; STDIN_FILE: third_party/testsuite/block.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/block.wast:159: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:163: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:167: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:171: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:176: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:182: assert_invalid passed:
-  error: type stack size too small at block. got 0, expected at least 1
+  error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:188: assert_invalid passed:
-  error: type stack size too small at block. got 0, expected at least 1
+  error: type mismatch in block, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:194: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
+  error: type mismatch in block, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/block.wast:200: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:207: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:213: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:220: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:226: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:232: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:238: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:245: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:251: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:258: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:264: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:273: assert_invalid passed:
-  error: type stack size too small at i32.ctz. got 0, expected at least 1
+  error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/block.wast:279: assert_invalid passed:
-  error: type stack size too small at i64.ctz. got 0, expected at least 1
+  error: type mismatch in i64.ctz, expected [i64] but got []
   000001f: error: OnUnaryExpr callback failed
 out/third_party/testsuite/block.wast:285: assert_invalid passed:
-  error: type stack size too small at i64.ctz. got 0, expected at least 1
+  error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
 out/third_party/testsuite/block.wast:293: assert_malformed passed:
   out/third_party/testsuite/block/block.23.wast:1:17: error: unexpected label "$l"

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -29,34 +29,34 @@ out/third_party/testsuite/block.wast:200: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:207: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:213: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:220: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:226: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:232: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:238: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:245: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
 out/third_party/testsuite/block.wast:251: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:258: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:264: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/third_party/testsuite/block.wast:273: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/br.wast:411: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:418: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:424: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:430: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:437: assert_invalid passed:
   error: invalid depth: 1 (max 0)

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/br.wast:411: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:418: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:424: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:430: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/br.wast:437: assert_invalid passed:
   error: invalid depth: 1 (max 0)

--- a/test/spec/br_if.txt
+++ b/test/spec/br_if.txt
@@ -2,67 +2,67 @@
 ;;; STDIN_FILE: third_party/testsuite/br_if.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/br_if.wast:191: assert_invalid passed:
-  error: type stack size too small at i32.ctz. got 0, expected at least 1
+  error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:195: assert_invalid passed:
-  error: type stack size too small at i64.ctz. got 0, expected at least 1
+  error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:199: assert_invalid passed:
-  error: type stack size too small at f32.neg. got 0, expected at least 1
+  error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:203: assert_invalid passed:
-  error: type stack size too small at f64.neg. got 0, expected at least 1
+  error: type mismatch in f64.neg, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:208: assert_invalid passed:
-  error: type stack size too small at i32.ctz. got 0, expected at least 1
+  error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/br_if.wast:212: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got i64.
+  error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:216: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got f32.
+  error: type mismatch in br_if, expected [i32] but got [f32]
   0000020: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:220: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got i64.
+  error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:225: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:231: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:237: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/br_if.wast:243: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/br_if.wast:250: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:256: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:262: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got i64.
+  error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:270: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got i64.
+  error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:279: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   000001c: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:285: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got i64.
+  error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:291: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:297: assert_invalid passed:
-  error: type stack size too small at br_if. got 0, expected at least 1
+  error: type mismatch in br_if, expected [i32] but got []
   0000022: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:303: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got i64.
+  error: type mismatch in br_if, expected [i32] but got [... i64]
   0000020: error: OnBrIfExpr callback failed
 out/third_party/testsuite/br_if.wast:310: assert_invalid passed:
   error: invalid depth: 1 (max 0)

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -2,31 +2,30 @@
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/br_table.wast:1413: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/third_party/testsuite/br_table.wast:1420: assert_invalid passed:
-  error: type stack size too small at br_table. got 0, expected at least 1
+  error: type mismatch in br_table, expected [i32] but got []
   0000020: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1426: assert_invalid passed:
-  error: type mismatch in br_table, expected i32 but got i64.
+  error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1434: assert_invalid passed:
-  error: type mismatch in br_table, expected void but got f32.
   0000026: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1446: assert_invalid passed:
-  error: type stack size too small at br_table. got 0, expected at least 1
+  error: type mismatch in br_table, expected [i32] but got []
   000001f: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1452: assert_invalid passed:
-  error: type mismatch in br_table, expected i32 but got i64.
+  error: type mismatch in br_table, expected [i32] but got [i64]
   000001e: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1458: assert_invalid passed:
-  error: type stack size too small at br_table. got 0, expected at least 1
+  error: type mismatch in br_table, expected [i32] but got []
   0000021: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1464: assert_invalid passed:
-  error: type stack size too small at br_table. got 0, expected at least 1
+  error: type mismatch in br_table, expected [i32] but got []
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1470: assert_invalid passed:
-  error: type mismatch in br_table, expected i32 but got i64.
+  error: type mismatch in br_table, expected [i32] but got [... i64]
   0000022: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1479: assert_invalid passed:
   error: invalid depth: 2 (max 1)

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -2,36 +2,34 @@
 ;;; STDIN_FILE: third_party/testsuite/call.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/call.wast:160: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001b: error: OnConvertExpr callback failed
 out/third_party/testsuite/call.wast:167: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got i64.
+  error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001f: error: OnConvertExpr callback failed
 out/third_party/testsuite/call.wast:175: assert_invalid passed:
-  error: type stack size too small at call. got 0, expected at least 1
+  error: type mismatch in call, expected [i32] but got []
   000001e: error: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:182: assert_invalid passed:
-  error: type stack size too small at call. got 0, expected at least 2
+  error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:189: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/third_party/testsuite/call.wast:196: assert_invalid passed:
-  error: type stack at end of function is 2, expected 0
+  error: type mismatch in function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/call.wast:204: assert_invalid passed:
-  error: type stack size too small at call. got 1, expected at least 2
+  error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:211: assert_invalid passed:
-  error: type stack size too small at call. got 1, expected at least 2
+  error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:218: assert_invalid passed:
-  error: type mismatch in call, expected i32 but got f64.
-  error: type mismatch in call, expected f64 but got i32.
+  error: type mismatch in call, expected [i32, f64] but got [f64, i32]
   000002a: error: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:225: assert_invalid passed:
-  error: type mismatch in call, expected f64 but got i32.
-  error: type mismatch in call, expected i32 but got f64.
+  error: type mismatch in call, expected [f64, i32] but got [i32, f64]
   000002a: error: OnCallExpr callback failed
 out/third_party/testsuite/call.wast:236: assert_invalid passed:
   0000019: error: invalid call function index: 1

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -5,42 +5,40 @@ out/third_party/testsuite/call_indirect.wast:237: assert_invalid passed:
   error: found call_indirect operator, but no table
   000001c: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:245: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
 out/third_party/testsuite/call_indirect.wast:253: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got i64.
+  error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
 out/third_party/testsuite/call_indirect.wast:262: assert_invalid passed:
-  error: type stack size too small at call_indirect. got 0, expected at least 1
+  error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:270: assert_invalid passed:
-  error: type stack size too small at call_indirect. got 0, expected at least 2
+  error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:278: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/third_party/testsuite/call_indirect.wast:286: assert_invalid passed:
-  error: type stack at end of function is 2, expected 0
+  error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
 out/third_party/testsuite/call_indirect.wast:297: assert_invalid passed:
-  error: type stack size too small at call_indirect. got 0, expected at least 1
+  error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:305: assert_invalid passed:
-  error: type mismatch in call_indirect, expected i32 but got i64.
+  error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:314: assert_invalid passed:
-  error: type stack size too small at call_indirect. got 1, expected at least 2
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:324: assert_invalid passed:
-  error: type stack size too small at call_indirect. got 1, expected at least 2
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:334: assert_invalid passed:
-  error: type mismatch in call_indirect, expected i32 but got f64.
-  error: type mismatch in call_indirect, expected f64 but got i32.
+  error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:344: assert_invalid passed:
-  error: type mismatch in call_indirect, expected f64 but got i32.
-  error: type mismatch in call_indirect, expected i32 but got f64.
+  error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/call_indirect.wast:358: assert_invalid passed:
   0000021: error: invalid call_indirect signature index

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -47,92 +47,92 @@ out/third_party/testsuite/func.wast:450: assert_malformed passed:
   ...unc (param i32 i32) (result i32)))(func (type $sig) (param i32) (result i3...
                                         ^^^^
 out/third_party/testsuite/func.wast:461: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:465: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/func.wast:469: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/func.wast:477: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:481: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
 out/third_party/testsuite/func.wast:485: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/third_party/testsuite/func.wast:493: assert_invalid passed:
   000000e: error: result count must be 0 or 1
 out/third_party/testsuite/func.wast:497: assert_invalid passed:
   000000e: error: result count must be 0 or 1
 out/third_party/testsuite/func.wast:506: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000019: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:510: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   0000019: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:514: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   0000019: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:518: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   0000019: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:523: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:529: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:535: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got f32.
+  error: type mismatch in implicit return, expected [i32] but got [f32]
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/func.wast:542: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:548: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:554: assert_invalid passed:
-  error: type mismatch in return, expected i32 but got i64.
+  error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:561: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:567: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:573: assert_invalid passed:
-  error: type mismatch in return, expected i32 but got i64.
+  error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:579: assert_invalid passed:
-  error: type mismatch in return, expected i32 but got i64.
+  error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:586: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:592: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   000001f: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:598: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:604: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:610: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:617: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:623: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:629: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:639: assert_malformed passed:
   out/third_party/testsuite/func/func.44.wast:1:14: error: unexpected token "local", expected an instr.

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -111,28 +111,28 @@ out/third_party/testsuite/func.wast:579: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/third_party/testsuite/func.wast:586: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:592: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  error: type mismatch in br, expected [i32] but got [f32]
   000001f: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:598: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:604: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:610: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:617: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:623: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:629: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/func.wast:639: assert_malformed passed:
   out/third_party/testsuite/func/func.44.wast:1:14: error: unexpected token "local", expected an instr.

--- a/test/spec/get_local.txt
+++ b/test/spec/get_local.txt
@@ -2,22 +2,22 @@
 ;;; STDIN_FILE: third_party/testsuite/get_local.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/get_local.wast:91: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/third_party/testsuite/get_local.wast:95: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/get_local.wast:99: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/get_local.wast:107: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/get_local.wast:111: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
 out/third_party/testsuite/get_local.wast:115: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/third_party/testsuite/get_local.wast:123: assert_invalid passed:
   error: invalid local_index: 3 (max 2)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -2,107 +2,107 @@
 ;;; STDIN_FILE: third_party/testsuite/if.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/if.wast:183: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:187: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:191: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:195: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:200: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:204: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:208: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:212: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:217: assert_invalid passed:
-  error: type stack at end of if is 1, expected 0
+  error: type mismatch in if, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:223: assert_invalid passed:
-  error: type stack at end of if is 1, expected 0
+  error: type mismatch in if, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:229: assert_invalid passed:
-  error: type stack at end of if false branch is 1, expected 0
+  error: type mismatch in if false branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:235: assert_invalid passed:
-  error: type stack at end of if true branch is 1, expected 0
+  error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:242: assert_invalid passed:
-  error: type stack size too small at if true branch. got 0, expected at least 1
+  error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:248: assert_invalid passed:
   error: if without else cannot have type signature.
   000001f: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:254: assert_invalid passed:
   error: if without else cannot have type signature.
-  error: type stack size too small at if. got 0, expected at least 1
+  error: type mismatch in if, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:260: assert_invalid passed:
   error: if without else cannot have type signature.
   000001f: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:267: assert_invalid passed:
-  error: type stack size too small at if true branch. got 0, expected at least 1
+  error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:273: assert_invalid passed:
-  error: type stack size too small at if false branch. got 0, expected at least 1
+  error: type mismatch in if false branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:279: assert_invalid passed:
-  error: type stack size too small at if true branch. got 0, expected at least 1
+  error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:286: assert_invalid passed:
-  error: type mismatch in if true branch, expected i32 but got i64.
+  error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:292: assert_invalid passed:
-  error: type mismatch in if false branch, expected i32 but got i64.
+  error: type mismatch in if false branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
 out/third_party/testsuite/if.wast:298: assert_invalid passed:
-  error: type mismatch in if true branch, expected i32 but got i64.
+  error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:304: assert_invalid passed:
-  error: type mismatch in if true branch, expected i32 but got i64.
+  error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/third_party/testsuite/if.wast:311: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:321: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:331: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:342: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:348: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:354: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:363: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:372: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:381: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:391: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:400: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got i64.
+  error: type mismatch in loop, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:411: assert_malformed passed:
   out/third_party/testsuite/if/if.35.wast:1:14: error: unexpected label "$l"

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -81,28 +81,28 @@ out/third_party/testsuite/if.wast:331: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
 out/third_party/testsuite/if.wast:342: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:348: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:354: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:363: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:372: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:381: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:391: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:400: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [i64]
+  error: type mismatch in br, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
 out/third_party/testsuite/if.wast:411: assert_malformed passed:
   out/third_party/testsuite/if/if.35.wast:1:14: error: unexpected label "$l"

--- a/test/spec/labels.txt
+++ b/test/spec/labels.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/labels.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/labels.wast:303: assert_invalid passed:
-  error: type stack size too small at f32.neg. got 0, expected at least 1
+  error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/third_party/testsuite/labels.wast:307: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/third_party/testsuite/labels.wast:311: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 27/27 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -2,31 +2,31 @@
 ;;; STDIN_FILE: third_party/testsuite/loop.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/loop.wast:254: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:258: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:262: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:266: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:271: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:277: assert_invalid passed:
-  error: type stack size too small at loop. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:283: assert_invalid passed:
-  error: type stack size too small at loop. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:289: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/loop.wast:295: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/third_party/testsuite/loop.wast:303: assert_malformed passed:
   out/third_party/testsuite/loop/loop.10.wast:1:16: error: unexpected label "$l"

--- a/test/spec/nop.txt
+++ b/test/spec/nop.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/nop.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/nop.wast:250: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/nop.wast:254: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/nop.wast:258: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/nop.wast:262: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   000001a: error: EndFunctionBody callback failed
 54/54 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/return.txt
+++ b/test/spec/return.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/return.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/return.wast:276: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [f64] but got []
   0000019: error: OnReturnExpr callback failed
 out/third_party/testsuite/return.wast:280: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [f64] but got []
   000001a: error: OnReturnExpr callback failed
 out/third_party/testsuite/return.wast:284: assert_invalid passed:
-  error: type mismatch in return, expected f64 but got i64.
+  error: type mismatch in return, expected [f64] but got [i64]
   000001b: error: OnReturnExpr callback failed
 60/60 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/select.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/select.wast:65: assert_invalid passed:
-  error: type stack size too small at select. got 0, expected at least 2
+  error: type mismatch in select, expected [i32, any, any] but got [i32]
   000001c: error: OnSelectExpr callback failed
 29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/set_local.txt
+++ b/test/spec/set_local.txt
@@ -2,46 +2,46 @@
 ;;; STDIN_FILE: third_party/testsuite/set_local.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/set_local.wast:95: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001f: error: EndFunctionBody callback failed
 out/third_party/testsuite/set_local.wast:101: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   0000021: error: OnConvertExpr callback failed
 out/third_party/testsuite/set_local.wast:107: assert_invalid passed:
-  error: type stack size too small at f64.neg. got 0, expected at least 1
+  error: type mismatch in f64.neg, expected [f64] but got []
   0000020: error: OnUnaryExpr callback failed
 out/third_party/testsuite/set_local.wast:114: assert_invalid passed:
-  error: type stack size too small at set_local. got 0, expected at least 1
+  error: type mismatch in set_local, expected [i32] but got []
   000001c: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:118: assert_invalid passed:
-  error: type mismatch in set_local, expected i32 but got f32.
+  error: type mismatch in set_local, expected [i32] but got [f32]
   0000020: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:122: assert_invalid passed:
-  error: type mismatch in set_local, expected f32 but got f64.
+  error: type mismatch in set_local, expected [f32] but got [f64]
   0000024: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:126: assert_invalid passed:
-  error: type mismatch in set_local, expected i64 but got f64.
+  error: type mismatch in set_local, expected [i64] but got [f64]
   0000026: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:134: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/set_local.wast:138: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
 out/third_party/testsuite/set_local.wast:142: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/third_party/testsuite/set_local.wast:147: assert_invalid passed:
-  error: type stack size too small at set_local. got 0, expected at least 1
+  error: type mismatch in set_local, expected [i32] but got []
   000001b: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:151: assert_invalid passed:
-  error: type mismatch in set_local, expected i32 but got f32.
+  error: type mismatch in set_local, expected [i32] but got [f32]
   000001f: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:155: assert_invalid passed:
-  error: type mismatch in set_local, expected f32 but got f64.
+  error: type mismatch in set_local, expected [f32] but got [f64]
   0000023: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:159: assert_invalid passed:
-  error: type mismatch in set_local, expected i64 but got f64.
+  error: type mismatch in set_local, expected [i64] but got [f64]
   0000024: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:167: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
@@ -62,13 +62,13 @@ out/third_party/testsuite/set_local.wast:189: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
   0000021: error: OnGetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:194: assert_invalid passed:
-  error: type mismatch in set_local, expected i32 but got f32.
+  error: type mismatch in set_local, expected [i32] but got [f32]
   0000021: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:198: assert_invalid passed:
-  error: type mismatch in set_local, expected i32 but got f32.
+  error: type mismatch in set_local, expected [i32] but got [f32]
   0000022: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/set_local.wast:202: assert_invalid passed:
-  error: type mismatch in set_local, expected f64 but got i64.
+  error: type mismatch in set_local, expected [f64] but got [i64]
   0000020: error: OnSetLocalExpr callback failed
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/store_retval.txt
+++ b/test/spec/store_retval.txt
@@ -2,43 +2,43 @@
 ;;; STDIN_FILE: third_party/testsuite/store_retval.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/store_retval.wast:2: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:6: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:10: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   0000021: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:14: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   0000025: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:19: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:23: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:27: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f32] but got []
   0000029: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:31: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [f64] but got []
   000002d: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:36: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:40: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:44: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:48: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/third_party/testsuite/store_retval.wast:52: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 13/13 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/tee_local.txt
+++ b/test/spec/tee_local.txt
@@ -2,46 +2,46 @@
 ;;; STDIN_FILE: third_party/testsuite/tee_local.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/tee_local.wast:132: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/third_party/testsuite/tee_local.wast:136: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/third_party/testsuite/tee_local.wast:140: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   0000020: error: OnUnaryExpr callback failed
 out/third_party/testsuite/tee_local.wast:145: assert_invalid passed:
-  error: type stack size too small at tee_local. got 0, expected at least 1
+  error: type mismatch in tee_local, expected [i32] but got []
   000001c: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:149: assert_invalid passed:
-  error: type mismatch in tee_local, expected i32 but got f32.
+  error: type mismatch in tee_local, expected [i32] but got [f32]
   0000020: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:153: assert_invalid passed:
-  error: type mismatch in tee_local, expected f32 but got f64.
+  error: type mismatch in tee_local, expected [f32] but got [f64]
   0000024: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:157: assert_invalid passed:
-  error: type mismatch in tee_local, expected i64 but got f64.
+  error: type mismatch in tee_local, expected [i64] but got [f64]
   0000026: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:165: assert_invalid passed:
-  error: type mismatch in implicit return, expected i64 but got i32.
+  error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/tee_local.wast:169: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
 out/third_party/testsuite/tee_local.wast:173: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/third_party/testsuite/tee_local.wast:178: assert_invalid passed:
-  error: type stack size too small at tee_local. got 0, expected at least 1
+  error: type mismatch in tee_local, expected [i32] but got []
   000001b: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:182: assert_invalid passed:
-  error: type mismatch in tee_local, expected i32 but got f32.
+  error: type mismatch in tee_local, expected [i32] but got [f32]
   000001f: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:186: assert_invalid passed:
-  error: type mismatch in tee_local, expected f32 but got f64.
+  error: type mismatch in tee_local, expected [f32] but got [f64]
   0000023: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:190: assert_invalid passed:
-  error: type mismatch in tee_local, expected i64 but got f64.
+  error: type mismatch in tee_local, expected [i64] but got [f64]
   0000024: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:198: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
@@ -62,13 +62,13 @@ out/third_party/testsuite/tee_local.wast:220: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
   0000021: error: OnGetLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:225: assert_invalid passed:
-  error: type mismatch in tee_local, expected i32 but got f32.
+  error: type mismatch in tee_local, expected [i32] but got [f32]
   0000021: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:229: assert_invalid passed:
-  error: type mismatch in tee_local, expected i32 but got f32.
+  error: type mismatch in tee_local, expected [i32] but got [f32]
   0000022: error: OnTeeLocalExpr callback failed
 out/third_party/testsuite/tee_local.wast:233: assert_invalid passed:
-  error: type mismatch in tee_local, expected f64 but got i64.
+  error: type mismatch in tee_local, expected [f64] but got [i64]
   0000020: error: OnTeeLocalExpr callback failed
 34/34 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/typecheck.txt
+++ b/test/spec/typecheck.txt
@@ -2,660 +2,583 @@
 ;;; STDIN_FILE: third_party/testsuite/typecheck.wast
 (;; STDOUT ;;;
 out/third_party/testsuite/typecheck.wast:4: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:10: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:17: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:24: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:31: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   0000021: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:39: assert_invalid passed:
-  error: type stack size too small at i32.add. got 0, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:45: assert_invalid passed:
-  error: type stack size too small at i32.add. got 1, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:51: assert_invalid passed:
-  error: type stack size too small at i32.add. got 0, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:58: assert_invalid passed:
-  error: type stack size too small at i32.add. got 1, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:65: assert_invalid passed:
-  error: type stack size too small at i32.add. got 0, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:72: assert_invalid passed:
-  error: type stack size too small at i32.add. got 1, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:79: assert_invalid passed:
-  error: type stack size too small at drop. got 0, expected at least 1
+  error: type mismatch in drop, expected [any] but got []
   0000021: error: OnDropExpr callback failed
 out/third_party/testsuite/typecheck.wast:86: assert_invalid passed:
-  error: type stack size too small at i32.add. got 0, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   0000020: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:93: assert_invalid passed:
-  error: type stack size too small at i32.add. got 0, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:101: assert_invalid passed:
-  error: type stack size too small at i32.add. got 0, expected at least 2
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   0000021: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:110: assert_invalid passed:
-  error: type stack size too small at if. got 0, expected at least 1
+  error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:116: assert_invalid passed:
-  error: type stack size too small at if. got 0, expected at least 1
+  error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:123: assert_invalid passed:
-  error: type stack size too small at if. got 0, expected at least 1
+  error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:130: assert_invalid passed:
-  error: type stack size too small at if. got 0, expected at least 1
+  error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:137: assert_invalid passed:
-  error: type stack size too small at if. got 0, expected at least 1
+  error: type mismatch in if, expected [i32] but got []
   0000022: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:146: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:153: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:161: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:171: assert_invalid passed:
-  error: type stack size too small at br. got 0, expected at least 1
+  error: type mismatch in loop, expected [i32] but got []
   0000024: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:182: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:188: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:195: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:202: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   000001f: error: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:209: assert_invalid passed:
-  error: type stack size too small at return. got 0, expected at least 1
+  error: type mismatch in return, expected [i32] but got []
   0000022: error: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:219: assert_invalid passed:
-  error: type mismatch in if, expected i32 but got f32.
+  error: type mismatch in if, expected [i32] but got [f32]
   000001e: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:222: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got f32.
+  error: type mismatch in br_if, expected [i32] but got [f32]
   0000020: error: OnBrIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:226: assert_invalid passed:
-  error: type mismatch in br_table, expected i32 but got f32.
+  error: type mismatch in br_table, expected [i32] but got [f32]
   0000021: error: OnBrTableExpr callback failed
 out/third_party/testsuite/typecheck.wast:230: assert_invalid passed:
-  error: type mismatch in call, expected i32 but got f32.
+  error: type mismatch in call, expected [i32] but got [f32]
   0000026: error: OnCallExpr callback failed
 out/third_party/testsuite/typecheck.wast:232: assert_invalid passed:
-  error: type mismatch in call_indirect, expected i32 but got f32.
+  error: type mismatch in call_indirect, expected [i32] but got [... f32]
   000002f: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/typecheck.wast:242: assert_invalid passed:
-  error: type mismatch in call_indirect, expected i32 but got f32.
+  error: type mismatch in call_indirect, expected [i32] but got [f32]
   0000029: error: OnCallIndirectExpr callback failed
 out/third_party/testsuite/typecheck.wast:250: assert_invalid passed:
-  error: type mismatch in return, expected i32 but got f32.
+  error: type mismatch in return, expected [i32] but got [f32]
   000001e: error: OnReturnExpr callback failed
 out/third_party/testsuite/typecheck.wast:253: assert_invalid passed:
-  error: type mismatch in set_local, expected i32 but got f32.
+  error: type mismatch in set_local, expected [i32] but got [f32]
   0000020: error: OnSetLocalExpr callback failed
 out/third_party/testsuite/typecheck.wast:256: assert_invalid passed:
-  error: type mismatch in i32.load, expected i32 but got f32.
+  error: type mismatch in i32.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:257: assert_invalid passed:
-  error: type mismatch in i32.load8_s, expected i32 but got f32.
+  error: type mismatch in i32.load8_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:258: assert_invalid passed:
-  error: type mismatch in i32.load8_u, expected i32 but got f32.
+  error: type mismatch in i32.load8_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:259: assert_invalid passed:
-  error: type mismatch in i32.load16_s, expected i32 but got f32.
+  error: type mismatch in i32.load16_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:260: assert_invalid passed:
-  error: type mismatch in i32.load16_u, expected i32 but got f32.
+  error: type mismatch in i32.load16_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:261: assert_invalid passed:
-  error: type mismatch in i64.load, expected i32 but got f32.
+  error: type mismatch in i64.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:262: assert_invalid passed:
-  error: type mismatch in i64.load8_s, expected i32 but got f32.
+  error: type mismatch in i64.load8_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:263: assert_invalid passed:
-  error: type mismatch in i64.load8_u, expected i32 but got f32.
+  error: type mismatch in i64.load8_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:264: assert_invalid passed:
-  error: type mismatch in i64.load16_s, expected i32 but got f32.
+  error: type mismatch in i64.load16_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:265: assert_invalid passed:
-  error: type mismatch in i64.load16_u, expected i32 but got f32.
+  error: type mismatch in i64.load16_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:266: assert_invalid passed:
-  error: type mismatch in i64.load32_s, expected i32 but got f32.
+  error: type mismatch in i64.load32_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:267: assert_invalid passed:
-  error: type mismatch in i64.load32_u, expected i32 but got f32.
+  error: type mismatch in i64.load32_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:268: assert_invalid passed:
-  error: type mismatch in f32.load, expected i32 but got f32.
+  error: type mismatch in f32.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:269: assert_invalid passed:
-  error: type mismatch in f64.load, expected i32 but got f32.
+  error: type mismatch in f64.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
 out/third_party/testsuite/typecheck.wast:272: assert_invalid passed:
-  error: type mismatch in i32.store, expected i32 but got f32.
+  error: type mismatch in i32.store, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:273: assert_invalid passed:
-  error: type mismatch in i32.store8, expected i32 but got f32.
+  error: type mismatch in i32.store8, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:274: assert_invalid passed:
-  error: type mismatch in i32.store16, expected i32 but got f32.
+  error: type mismatch in i32.store16, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:275: assert_invalid passed:
-  error: type mismatch in i64.store, expected i32 but got f32.
-  error: type mismatch in i64.store, expected i64 but got i32.
+  error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:276: assert_invalid passed:
-  error: type mismatch in i64.store8, expected i32 but got f32.
+  error: type mismatch in i64.store8, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:277: assert_invalid passed:
-  error: type mismatch in i64.store16, expected i32 but got f32.
+  error: type mismatch in i64.store16, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:278: assert_invalid passed:
-  error: type mismatch in i64.store32, expected i32 but got f32.
+  error: type mismatch in i64.store32, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:279: assert_invalid passed:
-  error: type mismatch in f32.store, expected i32 but got f32.
+  error: type mismatch in f32.store, expected [i32, f32] but got [f32, f32]
   0000029: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:280: assert_invalid passed:
-  error: type mismatch in f64.store, expected i32 but got f32.
+  error: type mismatch in f64.store, expected [i32, f64] but got [f32, f64]
   000002d: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:283: assert_invalid passed:
-  error: type mismatch in i32.store, expected i32 but got f32.
+  error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:284: assert_invalid passed:
-  error: type mismatch in i32.store8, expected i32 but got f32.
+  error: type mismatch in i32.store8, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:285: assert_invalid passed:
-  error: type mismatch in i32.store16, expected i32 but got f32.
+  error: type mismatch in i32.store16, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:286: assert_invalid passed:
-  error: type mismatch in i64.store, expected i64 but got f32.
+  error: type mismatch in i64.store, expected [i32, i64] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:287: assert_invalid passed:
-  error: type mismatch in i64.store8, expected i64 but got f64.
+  error: type mismatch in i64.store8, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:288: assert_invalid passed:
-  error: type mismatch in i64.store16, expected i64 but got f64.
+  error: type mismatch in i64.store16, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:289: assert_invalid passed:
-  error: type mismatch in i64.store32, expected i64 but got f64.
+  error: type mismatch in i64.store32, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:290: assert_invalid passed:
-  error: type mismatch in f32.store, expected f32 but got i32.
+  error: type mismatch in f32.store, expected [i32, f32] but got [i32, i32]
   0000023: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:291: assert_invalid passed:
-  error: type mismatch in f64.store, expected f64 but got i64.
+  error: type mismatch in f64.store, expected [i32, f64] but got [i32, i64]
   0000023: error: OnStoreExpr callback failed
 out/third_party/testsuite/typecheck.wast:294: assert_invalid passed:
-  error: type mismatch in i32.add, expected i32 but got i64.
-  error: type mismatch in i32.add, expected i32 but got f32.
+  error: type mismatch in i32.add, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:295: assert_invalid passed:
-  error: type mismatch in i32.and, expected i32 but got i64.
-  error: type mismatch in i32.and, expected i32 but got f32.
+  error: type mismatch in i32.and, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:296: assert_invalid passed:
-  error: type mismatch in i32.div_s, expected i32 but got i64.
-  error: type mismatch in i32.div_s, expected i32 but got f32.
+  error: type mismatch in i32.div_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:297: assert_invalid passed:
-  error: type mismatch in i32.div_u, expected i32 but got i64.
-  error: type mismatch in i32.div_u, expected i32 but got f32.
+  error: type mismatch in i32.div_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:298: assert_invalid passed:
-  error: type mismatch in i32.mul, expected i32 but got i64.
-  error: type mismatch in i32.mul, expected i32 but got f32.
+  error: type mismatch in i32.mul, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:299: assert_invalid passed:
-  error: type mismatch in i32.or, expected i32 but got i64.
-  error: type mismatch in i32.or, expected i32 but got f32.
+  error: type mismatch in i32.or, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:300: assert_invalid passed:
-  error: type mismatch in i32.rem_s, expected i32 but got i64.
-  error: type mismatch in i32.rem_s, expected i32 but got f32.
+  error: type mismatch in i32.rem_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:301: assert_invalid passed:
-  error: type mismatch in i32.rem_u, expected i32 but got i64.
-  error: type mismatch in i32.rem_u, expected i32 but got f32.
+  error: type mismatch in i32.rem_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:302: assert_invalid passed:
-  error: type mismatch in i32.rotl, expected i32 but got i64.
-  error: type mismatch in i32.rotl, expected i32 but got f32.
+  error: type mismatch in i32.rotl, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:303: assert_invalid passed:
-  error: type mismatch in i32.rotr, expected i32 but got i64.
-  error: type mismatch in i32.rotr, expected i32 but got f32.
+  error: type mismatch in i32.rotr, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:304: assert_invalid passed:
-  error: type mismatch in i32.shl, expected i32 but got i64.
-  error: type mismatch in i32.shl, expected i32 but got f32.
+  error: type mismatch in i32.shl, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:305: assert_invalid passed:
-  error: type mismatch in i32.shr_s, expected i32 but got i64.
-  error: type mismatch in i32.shr_s, expected i32 but got f32.
+  error: type mismatch in i32.shr_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:306: assert_invalid passed:
-  error: type mismatch in i32.shr_u, expected i32 but got i64.
-  error: type mismatch in i32.shr_u, expected i32 but got f32.
+  error: type mismatch in i32.shr_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:307: assert_invalid passed:
-  error: type mismatch in i32.sub, expected i32 but got i64.
-  error: type mismatch in i32.sub, expected i32 but got f32.
+  error: type mismatch in i32.sub, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:308: assert_invalid passed:
-  error: type mismatch in i32.xor, expected i32 but got i64.
-  error: type mismatch in i32.xor, expected i32 but got f32.
+  error: type mismatch in i32.xor, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:309: assert_invalid passed:
-  error: type mismatch in i64.add, expected i64 but got i32.
-  error: type mismatch in i64.add, expected i64 but got f32.
+  error: type mismatch in i64.add, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:310: assert_invalid passed:
-  error: type mismatch in i64.and, expected i64 but got i32.
-  error: type mismatch in i64.and, expected i64 but got f32.
+  error: type mismatch in i64.and, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:311: assert_invalid passed:
-  error: type mismatch in i64.div_s, expected i64 but got i32.
-  error: type mismatch in i64.div_s, expected i64 but got f32.
+  error: type mismatch in i64.div_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:312: assert_invalid passed:
-  error: type mismatch in i64.div_u, expected i64 but got i32.
-  error: type mismatch in i64.div_u, expected i64 but got f32.
+  error: type mismatch in i64.div_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:313: assert_invalid passed:
-  error: type mismatch in i64.mul, expected i64 but got i32.
-  error: type mismatch in i64.mul, expected i64 but got f32.
+  error: type mismatch in i64.mul, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:314: assert_invalid passed:
-  error: type mismatch in i64.or, expected i64 but got i32.
-  error: type mismatch in i64.or, expected i64 but got f32.
+  error: type mismatch in i64.or, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:315: assert_invalid passed:
-  error: type mismatch in i64.rem_s, expected i64 but got i32.
-  error: type mismatch in i64.rem_s, expected i64 but got f32.
+  error: type mismatch in i64.rem_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:316: assert_invalid passed:
-  error: type mismatch in i64.rem_u, expected i64 but got i32.
-  error: type mismatch in i64.rem_u, expected i64 but got f32.
+  error: type mismatch in i64.rem_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:317: assert_invalid passed:
-  error: type mismatch in i64.rotl, expected i64 but got i32.
-  error: type mismatch in i64.rotl, expected i64 but got f32.
+  error: type mismatch in i64.rotl, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:318: assert_invalid passed:
-  error: type mismatch in i64.rotr, expected i64 but got i32.
-  error: type mismatch in i64.rotr, expected i64 but got f32.
+  error: type mismatch in i64.rotr, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:319: assert_invalid passed:
-  error: type mismatch in i64.shl, expected i64 but got i32.
-  error: type mismatch in i64.shl, expected i64 but got f32.
+  error: type mismatch in i64.shl, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:320: assert_invalid passed:
-  error: type mismatch in i64.shr_s, expected i64 but got i32.
-  error: type mismatch in i64.shr_s, expected i64 but got f32.
+  error: type mismatch in i64.shr_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:321: assert_invalid passed:
-  error: type mismatch in i64.shr_u, expected i64 but got i32.
-  error: type mismatch in i64.shr_u, expected i64 but got f32.
+  error: type mismatch in i64.shr_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:322: assert_invalid passed:
-  error: type mismatch in i64.sub, expected i64 but got i32.
-  error: type mismatch in i64.sub, expected i64 but got f32.
+  error: type mismatch in i64.sub, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:323: assert_invalid passed:
-  error: type mismatch in i64.xor, expected i64 but got i32.
-  error: type mismatch in i64.xor, expected i64 but got f32.
+  error: type mismatch in i64.xor, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:324: assert_invalid passed:
-  error: type mismatch in f32.add, expected f32 but got i64.
-  error: type mismatch in f32.add, expected f32 but got f64.
+  error: type mismatch in f32.add, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:325: assert_invalid passed:
-  error: type mismatch in f32.copysign, expected f32 but got i64.
-  error: type mismatch in f32.copysign, expected f32 but got f64.
+  error: type mismatch in f32.copysign, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:326: assert_invalid passed:
-  error: type mismatch in f32.div, expected f32 but got i64.
-  error: type mismatch in f32.div, expected f32 but got f64.
+  error: type mismatch in f32.div, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:327: assert_invalid passed:
-  error: type mismatch in f32.max, expected f32 but got i64.
-  error: type mismatch in f32.max, expected f32 but got f64.
+  error: type mismatch in f32.max, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:328: assert_invalid passed:
-  error: type mismatch in f32.min, expected f32 but got i64.
-  error: type mismatch in f32.min, expected f32 but got f64.
+  error: type mismatch in f32.min, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:329: assert_invalid passed:
-  error: type mismatch in f32.mul, expected f32 but got i64.
-  error: type mismatch in f32.mul, expected f32 but got f64.
+  error: type mismatch in f32.mul, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:330: assert_invalid passed:
-  error: type mismatch in f32.sub, expected f32 but got i64.
-  error: type mismatch in f32.sub, expected f32 but got f64.
+  error: type mismatch in f32.sub, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:331: assert_invalid passed:
-  error: type mismatch in f64.add, expected f64 but got i64.
-  error: type mismatch in f64.add, expected f64 but got f32.
+  error: type mismatch in f64.add, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:332: assert_invalid passed:
-  error: type mismatch in f64.copysign, expected f64 but got i64.
-  error: type mismatch in f64.copysign, expected f64 but got f32.
+  error: type mismatch in f64.copysign, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:333: assert_invalid passed:
-  error: type mismatch in f64.div, expected f64 but got i64.
-  error: type mismatch in f64.div, expected f64 but got f32.
+  error: type mismatch in f64.div, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:334: assert_invalid passed:
-  error: type mismatch in f64.max, expected f64 but got i64.
-  error: type mismatch in f64.max, expected f64 but got f32.
+  error: type mismatch in f64.max, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:335: assert_invalid passed:
-  error: type mismatch in f64.min, expected f64 but got i64.
-  error: type mismatch in f64.min, expected f64 but got f32.
+  error: type mismatch in f64.min, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:336: assert_invalid passed:
-  error: type mismatch in f64.mul, expected f64 but got i64.
-  error: type mismatch in f64.mul, expected f64 but got f32.
+  error: type mismatch in f64.mul, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:337: assert_invalid passed:
-  error: type mismatch in f64.sub, expected f64 but got i64.
-  error: type mismatch in f64.sub, expected f64 but got f32.
+  error: type mismatch in f64.sub, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:340: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got i64.
+  error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:341: assert_invalid passed:
-  error: type mismatch in i32.clz, expected i32 but got i64.
+  error: type mismatch in i32.clz, expected [i32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:342: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected i32 but got i64.
+  error: type mismatch in i32.ctz, expected [i32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:343: assert_invalid passed:
-  error: type mismatch in i32.popcnt, expected i32 but got i64.
+  error: type mismatch in i32.popcnt, expected [i32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:344: assert_invalid passed:
-  error: type mismatch in i64.eqz, expected i64 but got i32.
+  error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:345: assert_invalid passed:
-  error: type mismatch in i64.clz, expected i64 but got i32.
+  error: type mismatch in i64.clz, expected [i64] but got [i32]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:346: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected i64 but got i32.
+  error: type mismatch in i64.ctz, expected [i64] but got [i32]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:347: assert_invalid passed:
-  error: type mismatch in i64.popcnt, expected i64 but got i32.
+  error: type mismatch in i64.popcnt, expected [i64] but got [i32]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:348: assert_invalid passed:
-  error: type mismatch in f32.abs, expected f32 but got i64.
+  error: type mismatch in f32.abs, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:349: assert_invalid passed:
-  error: type mismatch in f32.ceil, expected f32 but got i64.
+  error: type mismatch in f32.ceil, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:350: assert_invalid passed:
-  error: type mismatch in f32.floor, expected f32 but got i64.
+  error: type mismatch in f32.floor, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:351: assert_invalid passed:
-  error: type mismatch in f32.nearest, expected f32 but got i64.
+  error: type mismatch in f32.nearest, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:352: assert_invalid passed:
-  error: type mismatch in f32.neg, expected f32 but got i64.
+  error: type mismatch in f32.neg, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:353: assert_invalid passed:
-  error: type mismatch in f32.sqrt, expected f32 but got i64.
+  error: type mismatch in f32.sqrt, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:354: assert_invalid passed:
-  error: type mismatch in f32.trunc, expected f32 but got i64.
+  error: type mismatch in f32.trunc, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:355: assert_invalid passed:
-  error: type mismatch in f64.abs, expected f64 but got i64.
+  error: type mismatch in f64.abs, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:356: assert_invalid passed:
-  error: type mismatch in f64.ceil, expected f64 but got i64.
+  error: type mismatch in f64.ceil, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:357: assert_invalid passed:
-  error: type mismatch in f64.floor, expected f64 but got i64.
+  error: type mismatch in f64.floor, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:358: assert_invalid passed:
-  error: type mismatch in f64.nearest, expected f64 but got i64.
+  error: type mismatch in f64.nearest, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:359: assert_invalid passed:
-  error: type mismatch in f64.neg, expected f64 but got i64.
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:360: assert_invalid passed:
-  error: type mismatch in f64.sqrt, expected f64 but got i64.
+  error: type mismatch in f64.sqrt, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:361: assert_invalid passed:
-  error: type mismatch in f64.trunc, expected f64 but got i64.
+  error: type mismatch in f64.trunc, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
 out/third_party/testsuite/typecheck.wast:364: assert_invalid passed:
-  error: type mismatch in i32.eq, expected i32 but got i64.
-  error: type mismatch in i32.eq, expected i32 but got f32.
+  error: type mismatch in i32.eq, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:365: assert_invalid passed:
-  error: type mismatch in i32.ge_s, expected i32 but got i64.
-  error: type mismatch in i32.ge_s, expected i32 but got f32.
+  error: type mismatch in i32.ge_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:366: assert_invalid passed:
-  error: type mismatch in i32.ge_u, expected i32 but got i64.
-  error: type mismatch in i32.ge_u, expected i32 but got f32.
+  error: type mismatch in i32.ge_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:367: assert_invalid passed:
-  error: type mismatch in i32.gt_s, expected i32 but got i64.
-  error: type mismatch in i32.gt_s, expected i32 but got f32.
+  error: type mismatch in i32.gt_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:368: assert_invalid passed:
-  error: type mismatch in i32.gt_u, expected i32 but got i64.
-  error: type mismatch in i32.gt_u, expected i32 but got f32.
+  error: type mismatch in i32.gt_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:369: assert_invalid passed:
-  error: type mismatch in i32.le_s, expected i32 but got i64.
-  error: type mismatch in i32.le_s, expected i32 but got f32.
+  error: type mismatch in i32.le_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:370: assert_invalid passed:
-  error: type mismatch in i32.le_u, expected i32 but got i64.
-  error: type mismatch in i32.le_u, expected i32 but got f32.
+  error: type mismatch in i32.le_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:371: assert_invalid passed:
-  error: type mismatch in i32.lt_s, expected i32 but got i64.
-  error: type mismatch in i32.lt_s, expected i32 but got f32.
+  error: type mismatch in i32.lt_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:372: assert_invalid passed:
-  error: type mismatch in i32.lt_u, expected i32 but got i64.
-  error: type mismatch in i32.lt_u, expected i32 but got f32.
+  error: type mismatch in i32.lt_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:373: assert_invalid passed:
-  error: type mismatch in i32.ne, expected i32 but got i64.
-  error: type mismatch in i32.ne, expected i32 but got f32.
+  error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:374: assert_invalid passed:
-  error: type mismatch in i64.eq, expected i64 but got i32.
-  error: type mismatch in i64.eq, expected i64 but got f32.
+  error: type mismatch in i64.eq, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:375: assert_invalid passed:
-  error: type mismatch in i64.ge_s, expected i64 but got i32.
-  error: type mismatch in i64.ge_s, expected i64 but got f32.
+  error: type mismatch in i64.ge_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:376: assert_invalid passed:
-  error: type mismatch in i64.ge_u, expected i64 but got i32.
-  error: type mismatch in i64.ge_u, expected i64 but got f32.
+  error: type mismatch in i64.ge_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:377: assert_invalid passed:
-  error: type mismatch in i64.gt_s, expected i64 but got i32.
-  error: type mismatch in i64.gt_s, expected i64 but got f32.
+  error: type mismatch in i64.gt_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:378: assert_invalid passed:
-  error: type mismatch in i64.gt_u, expected i64 but got i32.
-  error: type mismatch in i64.gt_u, expected i64 but got f32.
+  error: type mismatch in i64.gt_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:379: assert_invalid passed:
-  error: type mismatch in i64.le_s, expected i64 but got i32.
-  error: type mismatch in i64.le_s, expected i64 but got f32.
+  error: type mismatch in i64.le_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:380: assert_invalid passed:
-  error: type mismatch in i64.le_u, expected i64 but got i32.
-  error: type mismatch in i64.le_u, expected i64 but got f32.
+  error: type mismatch in i64.le_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:381: assert_invalid passed:
-  error: type mismatch in i64.lt_s, expected i64 but got i32.
-  error: type mismatch in i64.lt_s, expected i64 but got f32.
+  error: type mismatch in i64.lt_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:382: assert_invalid passed:
-  error: type mismatch in i64.lt_u, expected i64 but got i32.
-  error: type mismatch in i64.lt_u, expected i64 but got f32.
+  error: type mismatch in i64.lt_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:383: assert_invalid passed:
-  error: type mismatch in i64.ne, expected i64 but got i32.
-  error: type mismatch in i64.ne, expected i64 but got f32.
+  error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:384: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i64.
-  error: type mismatch in f32.eq, expected f32 but got f64.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:385: assert_invalid passed:
-  error: type mismatch in f32.ge, expected f32 but got i64.
-  error: type mismatch in f32.ge, expected f32 but got f64.
+  error: type mismatch in f32.ge, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:386: assert_invalid passed:
-  error: type mismatch in f32.gt, expected f32 but got i64.
-  error: type mismatch in f32.gt, expected f32 but got f64.
+  error: type mismatch in f32.gt, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:387: assert_invalid passed:
-  error: type mismatch in f32.le, expected f32 but got i64.
-  error: type mismatch in f32.le, expected f32 but got f64.
+  error: type mismatch in f32.le, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:388: assert_invalid passed:
-  error: type mismatch in f32.lt, expected f32 but got i64.
-  error: type mismatch in f32.lt, expected f32 but got f64.
+  error: type mismatch in f32.lt, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:389: assert_invalid passed:
-  error: type mismatch in f32.ne, expected f32 but got i64.
-  error: type mismatch in f32.ne, expected f32 but got f64.
+  error: type mismatch in f32.ne, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:390: assert_invalid passed:
-  error: type mismatch in f64.eq, expected f64 but got i64.
-  error: type mismatch in f64.eq, expected f64 but got f32.
+  error: type mismatch in f64.eq, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:391: assert_invalid passed:
-  error: type mismatch in f64.ge, expected f64 but got i64.
-  error: type mismatch in f64.ge, expected f64 but got f32.
+  error: type mismatch in f64.ge, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:392: assert_invalid passed:
-  error: type mismatch in f64.gt, expected f64 but got i64.
-  error: type mismatch in f64.gt, expected f64 but got f32.
+  error: type mismatch in f64.gt, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:393: assert_invalid passed:
-  error: type mismatch in f64.le, expected f64 but got i64.
-  error: type mismatch in f64.le, expected f64 but got f32.
+  error: type mismatch in f64.le, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:394: assert_invalid passed:
-  error: type mismatch in f64.lt, expected f64 but got i64.
-  error: type mismatch in f64.lt, expected f64 but got f32.
+  error: type mismatch in f64.lt, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:395: assert_invalid passed:
-  error: type mismatch in f64.ne, expected f64 but got i64.
-  error: type mismatch in f64.ne, expected f64 but got f32.
+  error: type mismatch in f64.ne, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
 out/third_party/testsuite/typecheck.wast:398: assert_invalid passed:
-  error: type mismatch in i32.wrap/i64, expected i64 but got f32.
+  error: type mismatch in i32.wrap/i64, expected [i64] but got [f32]
   000001d: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:399: assert_invalid passed:
-  error: type mismatch in i32.trunc_s/f32, expected f32 but got i64.
+  error: type mismatch in i32.trunc_s/f32, expected [f32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:400: assert_invalid passed:
-  error: type mismatch in i32.trunc_u/f32, expected f32 but got i64.
+  error: type mismatch in i32.trunc_u/f32, expected [f32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:401: assert_invalid passed:
-  error: type mismatch in i32.trunc_s/f64, expected f64 but got i64.
+  error: type mismatch in i32.trunc_s/f64, expected [f64] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:402: assert_invalid passed:
-  error: type mismatch in i32.trunc_u/f64, expected f64 but got i64.
+  error: type mismatch in i32.trunc_u/f64, expected [f64] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:403: assert_invalid passed:
-  error: type mismatch in i32.reinterpret/f32, expected f32 but got i64.
+  error: type mismatch in i32.reinterpret/f32, expected [f32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:404: assert_invalid passed:
-  error: type mismatch in i64.extend_s/i32, expected i32 but got f32.
+  error: type mismatch in i64.extend_s/i32, expected [i32] but got [f32]
   000001d: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:405: assert_invalid passed:
-  error: type mismatch in i64.extend_u/i32, expected i32 but got f32.
+  error: type mismatch in i64.extend_u/i32, expected [i32] but got [f32]
   000001d: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:406: assert_invalid passed:
-  error: type mismatch in i64.trunc_s/f32, expected f32 but got i32.
+  error: type mismatch in i64.trunc_s/f32, expected [f32] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:407: assert_invalid passed:
-  error: type mismatch in i64.trunc_u/f32, expected f32 but got i32.
+  error: type mismatch in i64.trunc_u/f32, expected [f32] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:408: assert_invalid passed:
-  error: type mismatch in i64.trunc_s/f64, expected f64 but got i32.
+  error: type mismatch in i64.trunc_s/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:409: assert_invalid passed:
-  error: type mismatch in i64.trunc_u/f64, expected f64 but got i32.
+  error: type mismatch in i64.trunc_u/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:410: assert_invalid passed:
-  error: type mismatch in i64.reinterpret/f64, expected f64 but got i32.
+  error: type mismatch in i64.reinterpret/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:411: assert_invalid passed:
-  error: type mismatch in f32.convert_s/i32, expected i32 but got i64.
+  error: type mismatch in f32.convert_s/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:412: assert_invalid passed:
-  error: type mismatch in f32.convert_u/i32, expected i32 but got i64.
+  error: type mismatch in f32.convert_u/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:413: assert_invalid passed:
-  error: type mismatch in f32.convert_s/i64, expected i64 but got i32.
+  error: type mismatch in f32.convert_s/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:414: assert_invalid passed:
-  error: type mismatch in f32.convert_u/i64, expected i64 but got i32.
+  error: type mismatch in f32.convert_u/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:415: assert_invalid passed:
-  error: type mismatch in f32.demote/f64, expected f64 but got i32.
+  error: type mismatch in f32.demote/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:416: assert_invalid passed:
-  error: type mismatch in f32.reinterpret/i32, expected i32 but got i64.
+  error: type mismatch in f32.reinterpret/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:417: assert_invalid passed:
-  error: type mismatch in f64.convert_s/i32, expected i32 but got i64.
+  error: type mismatch in f64.convert_s/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:418: assert_invalid passed:
-  error: type mismatch in f64.convert_u/i32, expected i32 but got i64.
+  error: type mismatch in f64.convert_u/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:419: assert_invalid passed:
-  error: type mismatch in f64.convert_s/i64, expected i64 but got i32.
+  error: type mismatch in f64.convert_s/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:420: assert_invalid passed:
-  error: type mismatch in f64.convert_u/i64, expected i64 but got i32.
+  error: type mismatch in f64.convert_u/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:421: assert_invalid passed:
-  error: type mismatch in f64.promote/f32, expected f32 but got i32.
+  error: type mismatch in f64.promote/f32, expected [f32] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:422: assert_invalid passed:
-  error: type mismatch in f64.reinterpret/i64, expected i64 but got i32.
+  error: type mismatch in f64.reinterpret/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
 out/third_party/testsuite/typecheck.wast:425: assert_invalid passed:
-  error: type mismatch in grow_memory, expected i32 but got f32.
+  error: type mismatch in grow_memory, expected [i32] but got [f32]
   0000023: error: OnGrowMemoryExpr callback failed
 193/193 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/typecheck.txt
+++ b/test/spec/typecheck.txt
@@ -62,16 +62,16 @@ out/third_party/testsuite/typecheck.wast:137: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000022: error: OnIfExpr callback failed
 out/third_party/testsuite/typecheck.wast:146: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001b: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:153: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:161: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:171: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  error: type mismatch in br, expected [i32] but got []
   0000024: error: OnBrExpr callback failed
 out/third_party/testsuite/typecheck.wast:182: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -241,7 +241,7 @@ out/third_party/testsuite/unreached-invalid.wast:470: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [f64]
   0000025: error: OnReturnExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:477: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f64]
+  error: type mismatch in br, expected [i32] but got [f64]
   0000029: error: OnBrExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:484: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [f32]

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -13,331 +13,323 @@ out/third_party/testsuite/unreached-invalid.wast:16: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   000001a: error: OnBrExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:21: assert_invalid passed:
-  error: type mismatch in i64.eqz, expected i64 but got i32.
+  error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:27: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:33: assert_invalid passed:
-  error: type mismatch in select, expected i32 but got i64.
+  error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
   0000023: error: OnSelectExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:42: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:46: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:50: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:56: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:60: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [any]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:64: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:71: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:77: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:83: assert_invalid passed:
-  error: type stack size too small at f32.eq. got 1, expected at least 2
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000020: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:89: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:95: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:101: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
+  error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:107: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:113: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:119: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:125: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got f32.
+  error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:132: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:138: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:144: assert_invalid passed:
-  error: type stack size too small at f32.eq. got 1, expected at least 2
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001d: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:150: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:156: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:162: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
+  error: type mismatch in block, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:168: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:174: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:180: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:186: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got f32.
+  error: type mismatch in implicit return, expected [i32] but got [f32]
   0000021: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:193: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:199: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:205: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:211: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:217: assert_invalid passed:
-  error: type stack size too small at f32.eq. got 1, expected at least 2
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001d: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:223: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:229: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:235: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
+  error: type mismatch in block, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:241: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:247: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000021: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:253: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:259: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got f32.
+  error: type mismatch in implicit return, expected [i32] but got [f32]
   000001f: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:265: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:271: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:277: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:284: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:290: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:296: assert_invalid passed:
-  error: type stack size too small at f32.eq. got 1, expected at least 2
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000020: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:302: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:308: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:314: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [i32] but got [... f32]
+  error: type mismatch in block, expected [] but got [i32]
   0000026: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:321: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:327: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:334: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:340: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got f32.
+  error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:348: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:354: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000022: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:360: assert_invalid passed:
-  error: type stack size too small at f32.eq. got 1, expected at least 2
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000021: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:366: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000024: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:372: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:378: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [i32] but got [... f32]
+  error: type mismatch in block, expected [] but got [i32]
   0000027: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:384: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:390: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:396: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:402: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got f32.
+  error: type mismatch in implicit return, expected [i32] but got [f32]
   0000023: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:409: assert_invalid passed:
-  error: type stack size too small at i32.eqz. got 0, expected at least 1
+  error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:415: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected i32 but got f32.
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:421: assert_invalid passed:
-  error: type stack size too small at f32.eq. got 1, expected at least 2
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001e: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:427: assert_invalid passed:
-  error: type mismatch in f32.eq, expected f32 but got i32.
+  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:433: assert_invalid passed:
-  error: type stack at end of if is 1, expected 0
+  error: type mismatch in if, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:439: assert_invalid passed:
   error: if without else cannot have type signature.
-  error: type mismatch in if, expected i32 but got f32.
+  error: type mismatch in if, expected [i32] but got [f32]
   0000022: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:445: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:451: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got f32.
+  error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:457: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:463: assert_invalid passed:
-  error: type mismatch in loop, expected i32 but got f32.
+  error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:470: assert_invalid passed:
-  error: type mismatch in return, expected i32 but got f64.
+  error: type mismatch in return, expected [i32] but got [f64]
   0000025: error: OnReturnExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:477: assert_invalid passed:
-  error: type mismatch in br, expected i32 but got f64.
+  error: type mismatch in loop, expected [i32] but got [f64]
   0000029: error: OnBrExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:484: assert_invalid passed:
-  error: type mismatch in br_if, expected i32 but got f32.
+  error: type mismatch in br_if, expected [i32] but got [f32]
   0000021: error: OnBrIfExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:490: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:498: assert_invalid passed:
-  error: type mismatch in block, expected f32 but got i32.
+  error: type mismatch in block, expected [f32] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:507: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:515: assert_invalid passed:
-  error: type mismatch in br_table, expected i32 but got f32.
+  error: type mismatch in br_table, expected [i32] but got [f32]
   0000022: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:521: assert_invalid passed:
-  error: type mismatch in br_table, expected i32 but got f32.
+  error: type mismatch in br_table, expected [i32] but got [f32]
   0000025: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:527: assert_invalid passed:
-  error: type mismatch in br_table, expected void but got f32.
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:539: assert_invalid passed:
-  error: type mismatch in br_table, expected f64 but got f32.
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:554: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:560: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:566: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:572: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:579: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:585: assert_invalid passed:
-  error: type stack size too small at block. got 0, expected at least 1
+  error: type mismatch in block, expected [i32] but got []
   0000022: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:591: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got i64.
+  error: type mismatch in block, expected [i32] but got [i64]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:598: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:604: assert_invalid passed:
-  error: type stack size too small at block. got 0, expected at least 1
+  error: type mismatch in block, expected [i32] but got []
   0000025: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:610: assert_invalid passed:
-  error: type mismatch in block, expected i32 but got i64.
+  error: type mismatch in block, expected [i32] but got [i64]
   0000027: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:618: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:625: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:631: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000022: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:637: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:643: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000025: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:651: assert_invalid passed:
-  error: type stack at end of loop is 1, expected 0
+  error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:657: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:663: assert_invalid passed:
-  error: type mismatch in implicit return, expected i32 but got i64.
+  error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:670: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   000001f: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:676: assert_invalid passed:
-  error: type stack size too small at implicit return. got 0, expected at least 1
+  error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:683: assert_invalid passed:
-  error: type stack at end of function is 1, expected 0
+  error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/third_party/testsuite/unreached-invalid.wast:690: assert_invalid passed:
-  error: type stack at end of block is 1, expected 0
+  error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 110/110 tests passed.
 ;;; STDOUT ;;)

--- a/test/typecheck/bad-atomic-type-mismatch.txt
+++ b/test/typecheck/bad-atomic-type-mismatch.txt
@@ -207,583 +207,583 @@
 
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-atomic-type-mismatch.txt:8:33: error: type mismatch in wake, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:8:33: error: type mismatch in wake, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 wake drop)
                                 ^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:9:45: error: type mismatch in i32.wait, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:9:45: error: type mismatch in i32.wait, expected [i32, i32, i64] but got [f32, i32, i64]
   (func f32.const 0 i32.const 0 i64.const 0 i32.wait drop)
                                             ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:10:45: error: type mismatch in i64.wait, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:10:45: error: type mismatch in i64.wait, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.wait drop)
                                             ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:11:21: error: type mismatch in i32.atomic.load, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:11:21: error: type mismatch in i32.atomic.load, expected [i32] but got [f32]
   (func f32.const 0 i32.atomic.load drop)
                     ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:12:21: error: type mismatch in i64.atomic.load, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:12:21: error: type mismatch in i64.atomic.load, expected [i32] but got [f32]
   (func f32.const 0 i64.atomic.load drop)
                     ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:13:21: error: type mismatch in i32.atomic.load8_u, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:13:21: error: type mismatch in i32.atomic.load8_u, expected [i32] but got [f32]
   (func f32.const 0 i32.atomic.load8_u drop)
                     ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:14:21: error: type mismatch in i32.atomic.load16_u, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:14:21: error: type mismatch in i32.atomic.load16_u, expected [i32] but got [f32]
   (func f32.const 0 i32.atomic.load16_u drop)
                     ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:15:21: error: type mismatch in i64.atomic.load8_u, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:15:21: error: type mismatch in i64.atomic.load8_u, expected [i32] but got [f32]
   (func f32.const 0 i64.atomic.load8_u drop)
                     ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:16:21: error: type mismatch in i64.atomic.load16_u, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:16:21: error: type mismatch in i64.atomic.load16_u, expected [i32] but got [f32]
   (func f32.const 0 i64.atomic.load16_u drop)
                     ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:17:21: error: type mismatch in i64.atomic.load32_u, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:17:21: error: type mismatch in i64.atomic.load32_u, expected [i32] but got [f32]
   (func f32.const 0 i64.atomic.load32_u drop)
                     ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:18:33: error: type mismatch in i32.atomic.store, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:18:33: error: type mismatch in i32.atomic.store, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.store)
                                 ^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:19:33: error: type mismatch in i64.atomic.store, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:19:33: error: type mismatch in i64.atomic.store, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.store)
                                 ^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:20:33: error: type mismatch in i32.atomic.store8, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:20:33: error: type mismatch in i32.atomic.store8, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.store8)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:21:33: error: type mismatch in i32.atomic.store16, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:21:33: error: type mismatch in i32.atomic.store16, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.store16)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:22:33: error: type mismatch in i64.atomic.store8, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:22:33: error: type mismatch in i64.atomic.store8, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.store8)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:23:33: error: type mismatch in i64.atomic.store16, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:23:33: error: type mismatch in i64.atomic.store16, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.store16)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:24:33: error: type mismatch in i64.atomic.store32, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:24:33: error: type mismatch in i64.atomic.store32, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.store32)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:25:33: error: type mismatch in i32.atomic.rmw.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:25:33: error: type mismatch in i32.atomic.rmw.add, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw.add drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:26:33: error: type mismatch in i64.atomic.rmw.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:26:33: error: type mismatch in i64.atomic.rmw.add, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw.add drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:27:33: error: type mismatch in i32.atomic.rmw8_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:27:33: error: type mismatch in i32.atomic.rmw8_u.add, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw8_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:28:33: error: type mismatch in i32.atomic.rmw16_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:28:33: error: type mismatch in i32.atomic.rmw16_u.add, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw16_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:29:33: error: type mismatch in i64.atomic.rmw8_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:29:33: error: type mismatch in i64.atomic.rmw8_u.add, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw8_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:30:33: error: type mismatch in i64.atomic.rmw16_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:30:33: error: type mismatch in i64.atomic.rmw16_u.add, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw16_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:31:33: error: type mismatch in i64.atomic.rmw32_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:31:33: error: type mismatch in i64.atomic.rmw32_u.add, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw32_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:32:33: error: type mismatch in i32.atomic.rmw.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:32:33: error: type mismatch in i32.atomic.rmw.sub, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw.sub drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:33:33: error: type mismatch in i64.atomic.rmw.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:33:33: error: type mismatch in i64.atomic.rmw.sub, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw.sub drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:34:33: error: type mismatch in i32.atomic.rmw8_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:34:33: error: type mismatch in i32.atomic.rmw8_u.sub, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw8_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:35:33: error: type mismatch in i32.atomic.rmw16_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:35:33: error: type mismatch in i32.atomic.rmw16_u.sub, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw16_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:36:33: error: type mismatch in i64.atomic.rmw8_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:36:33: error: type mismatch in i64.atomic.rmw8_u.sub, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw8_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:37:33: error: type mismatch in i64.atomic.rmw16_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:37:33: error: type mismatch in i64.atomic.rmw16_u.sub, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw16_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:38:33: error: type mismatch in i64.atomic.rmw32_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:38:33: error: type mismatch in i64.atomic.rmw32_u.sub, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw32_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:39:33: error: type mismatch in i32.atomic.rmw.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:39:33: error: type mismatch in i32.atomic.rmw.and, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw.and drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:40:33: error: type mismatch in i64.atomic.rmw.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:40:33: error: type mismatch in i64.atomic.rmw.and, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw.and drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:41:33: error: type mismatch in i32.atomic.rmw8_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:41:33: error: type mismatch in i32.atomic.rmw8_u.and, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw8_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:42:33: error: type mismatch in i32.atomic.rmw16_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:42:33: error: type mismatch in i32.atomic.rmw16_u.and, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw16_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:43:33: error: type mismatch in i64.atomic.rmw8_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:43:33: error: type mismatch in i64.atomic.rmw8_u.and, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw8_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:44:33: error: type mismatch in i64.atomic.rmw16_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:44:33: error: type mismatch in i64.atomic.rmw16_u.and, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw16_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:45:33: error: type mismatch in i64.atomic.rmw32_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:45:33: error: type mismatch in i64.atomic.rmw32_u.and, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw32_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:46:33: error: type mismatch in i32.atomic.rmw.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:46:33: error: type mismatch in i32.atomic.rmw.or, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw.or drop)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:47:33: error: type mismatch in i64.atomic.rmw.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:47:33: error: type mismatch in i64.atomic.rmw.or, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw.or drop)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:48:33: error: type mismatch in i32.atomic.rmw8_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:48:33: error: type mismatch in i32.atomic.rmw8_u.or, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw8_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:49:33: error: type mismatch in i32.atomic.rmw16_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:49:33: error: type mismatch in i32.atomic.rmw16_u.or, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw16_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:50:33: error: type mismatch in i64.atomic.rmw8_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:50:33: error: type mismatch in i64.atomic.rmw8_u.or, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw8_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:51:33: error: type mismatch in i64.atomic.rmw16_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:51:33: error: type mismatch in i64.atomic.rmw16_u.or, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw16_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:52:33: error: type mismatch in i64.atomic.rmw32_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:52:33: error: type mismatch in i64.atomic.rmw32_u.or, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw32_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:53:33: error: type mismatch in i32.atomic.rmw.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:53:33: error: type mismatch in i32.atomic.rmw.xor, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw.xor drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:54:33: error: type mismatch in i64.atomic.rmw.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:54:33: error: type mismatch in i64.atomic.rmw.xor, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw.xor drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:55:33: error: type mismatch in i32.atomic.rmw8_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:55:33: error: type mismatch in i32.atomic.rmw8_u.xor, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw8_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:56:33: error: type mismatch in i32.atomic.rmw16_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:56:33: error: type mismatch in i32.atomic.rmw16_u.xor, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw16_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:57:33: error: type mismatch in i64.atomic.rmw8_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:57:33: error: type mismatch in i64.atomic.rmw8_u.xor, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw8_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:58:33: error: type mismatch in i64.atomic.rmw16_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:58:33: error: type mismatch in i64.atomic.rmw16_u.xor, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw16_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:59:33: error: type mismatch in i64.atomic.rmw32_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:59:33: error: type mismatch in i64.atomic.rmw32_u.xor, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw32_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:60:33: error: type mismatch in i32.atomic.rmw.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:60:33: error: type mismatch in i32.atomic.rmw.xchg, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:61:33: error: type mismatch in i64.atomic.rmw.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:61:33: error: type mismatch in i64.atomic.rmw.xchg, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:62:33: error: type mismatch in i32.atomic.rmw8_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:62:33: error: type mismatch in i32.atomic.rmw8_u.xchg, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw8_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:63:33: error: type mismatch in i32.atomic.rmw16_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:63:33: error: type mismatch in i32.atomic.rmw16_u.xchg, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 i32.atomic.rmw16_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:64:33: error: type mismatch in i64.atomic.rmw8_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:64:33: error: type mismatch in i64.atomic.rmw8_u.xchg, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw8_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:65:33: error: type mismatch in i64.atomic.rmw16_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:65:33: error: type mismatch in i64.atomic.rmw16_u.xchg, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw16_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:66:33: error: type mismatch in i64.atomic.rmw32_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:66:33: error: type mismatch in i64.atomic.rmw32_u.xchg, expected [i32, i64] but got [f32, i64]
   (func f32.const 0 i64.const 0 i64.atomic.rmw32_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:67:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:67:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected [i32, i32, i32] but got [f32, i32, i32]
   (func f32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:68:45: error: type mismatch in i64.atomic.rmw.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:68:45: error: type mismatch in i64.atomic.rmw.cmpxchg, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:69:45: error: type mismatch in i32.atomic.rmw8_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:69:45: error: type mismatch in i32.atomic.rmw8_u.cmpxchg, expected [i32, i32, i32] but got [f32, i32, i32]
   (func f32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:70:45: error: type mismatch in i32.atomic.rmw16_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:70:45: error: type mismatch in i32.atomic.rmw16_u.cmpxchg, expected [i32, i32, i32] but got [f32, i32, i32]
   (func f32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:71:45: error: type mismatch in i64.atomic.rmw8_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:71:45: error: type mismatch in i64.atomic.rmw8_u.cmpxchg, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:72:45: error: type mismatch in i64.atomic.rmw16_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:72:45: error: type mismatch in i64.atomic.rmw16_u.cmpxchg, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:73:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:73:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:76:33: error: type mismatch in wake, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:76:33: error: type mismatch in wake, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 wake drop)
                                 ^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:77:45: error: type mismatch in i32.wait, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:77:45: error: type mismatch in i32.wait, expected [i32, i32, i64] but got [i32, f32, i64]
   (func i32.const 0 f32.const 0 i64.const 0 i32.wait drop)
                                             ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:78:45: error: type mismatch in i64.wait, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:78:45: error: type mismatch in i64.wait, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.wait drop)
                                             ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:79:33: error: type mismatch in i32.atomic.store, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:79:33: error: type mismatch in i32.atomic.store, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.store)
                                 ^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:80:33: error: type mismatch in i64.atomic.store, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:80:33: error: type mismatch in i64.atomic.store, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.store)
                                 ^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:81:33: error: type mismatch in i32.atomic.store8, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:81:33: error: type mismatch in i32.atomic.store8, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.store8)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:82:33: error: type mismatch in i32.atomic.store16, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:82:33: error: type mismatch in i32.atomic.store16, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.store16)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:83:33: error: type mismatch in i64.atomic.store8, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:83:33: error: type mismatch in i64.atomic.store8, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.store8)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:84:33: error: type mismatch in i64.atomic.store16, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:84:33: error: type mismatch in i64.atomic.store16, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.store16)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:85:33: error: type mismatch in i64.atomic.store32, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:85:33: error: type mismatch in i64.atomic.store32, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.store32)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:86:33: error: type mismatch in i32.atomic.rmw.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:86:33: error: type mismatch in i32.atomic.rmw.add, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw.add drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:87:33: error: type mismatch in i64.atomic.rmw.add, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:87:33: error: type mismatch in i64.atomic.rmw.add, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw.add drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:88:33: error: type mismatch in i32.atomic.rmw8_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:88:33: error: type mismatch in i32.atomic.rmw8_u.add, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw8_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:89:33: error: type mismatch in i32.atomic.rmw16_u.add, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:89:33: error: type mismatch in i32.atomic.rmw16_u.add, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw16_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:90:33: error: type mismatch in i64.atomic.rmw8_u.add, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:90:33: error: type mismatch in i64.atomic.rmw8_u.add, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw8_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:91:33: error: type mismatch in i64.atomic.rmw16_u.add, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:91:33: error: type mismatch in i64.atomic.rmw16_u.add, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw16_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:92:33: error: type mismatch in i64.atomic.rmw32_u.add, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:92:33: error: type mismatch in i64.atomic.rmw32_u.add, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw32_u.add drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:93:33: error: type mismatch in i32.atomic.rmw.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:93:33: error: type mismatch in i32.atomic.rmw.sub, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw.sub drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:94:33: error: type mismatch in i64.atomic.rmw.sub, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:94:33: error: type mismatch in i64.atomic.rmw.sub, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw.sub drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:95:33: error: type mismatch in i32.atomic.rmw8_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:95:33: error: type mismatch in i32.atomic.rmw8_u.sub, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw8_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:96:33: error: type mismatch in i32.atomic.rmw16_u.sub, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:96:33: error: type mismatch in i32.atomic.rmw16_u.sub, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw16_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:97:33: error: type mismatch in i64.atomic.rmw8_u.sub, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:97:33: error: type mismatch in i64.atomic.rmw8_u.sub, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw8_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:98:33: error: type mismatch in i64.atomic.rmw16_u.sub, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:98:33: error: type mismatch in i64.atomic.rmw16_u.sub, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw16_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:99:33: error: type mismatch in i64.atomic.rmw32_u.sub, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:99:33: error: type mismatch in i64.atomic.rmw32_u.sub, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw32_u.sub drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:100:33: error: type mismatch in i32.atomic.rmw.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:100:33: error: type mismatch in i32.atomic.rmw.and, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw.and drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:101:33: error: type mismatch in i64.atomic.rmw.and, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:101:33: error: type mismatch in i64.atomic.rmw.and, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw.and drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:102:33: error: type mismatch in i32.atomic.rmw8_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:102:33: error: type mismatch in i32.atomic.rmw8_u.and, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw8_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:103:33: error: type mismatch in i32.atomic.rmw16_u.and, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:103:33: error: type mismatch in i32.atomic.rmw16_u.and, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw16_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:104:33: error: type mismatch in i64.atomic.rmw8_u.and, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:104:33: error: type mismatch in i64.atomic.rmw8_u.and, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw8_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:105:33: error: type mismatch in i64.atomic.rmw16_u.and, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:105:33: error: type mismatch in i64.atomic.rmw16_u.and, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw16_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:106:33: error: type mismatch in i64.atomic.rmw32_u.and, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:106:33: error: type mismatch in i64.atomic.rmw32_u.and, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw32_u.and drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:107:33: error: type mismatch in i32.atomic.rmw.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:107:33: error: type mismatch in i32.atomic.rmw.or, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw.or drop)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:108:33: error: type mismatch in i64.atomic.rmw.or, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:108:33: error: type mismatch in i64.atomic.rmw.or, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw.or drop)
                                 ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:109:33: error: type mismatch in i32.atomic.rmw8_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:109:33: error: type mismatch in i32.atomic.rmw8_u.or, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw8_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:110:33: error: type mismatch in i32.atomic.rmw16_u.or, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:110:33: error: type mismatch in i32.atomic.rmw16_u.or, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw16_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:111:33: error: type mismatch in i64.atomic.rmw8_u.or, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:111:33: error: type mismatch in i64.atomic.rmw8_u.or, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw8_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:112:33: error: type mismatch in i64.atomic.rmw16_u.or, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:112:33: error: type mismatch in i64.atomic.rmw16_u.or, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw16_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:113:33: error: type mismatch in i64.atomic.rmw32_u.or, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:113:33: error: type mismatch in i64.atomic.rmw32_u.or, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw32_u.or drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:114:33: error: type mismatch in i32.atomic.rmw.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:114:33: error: type mismatch in i32.atomic.rmw.xor, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw.xor drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:115:33: error: type mismatch in i64.atomic.rmw.xor, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:115:33: error: type mismatch in i64.atomic.rmw.xor, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw.xor drop)
                                 ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:116:33: error: type mismatch in i32.atomic.rmw8_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:116:33: error: type mismatch in i32.atomic.rmw8_u.xor, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw8_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:117:33: error: type mismatch in i32.atomic.rmw16_u.xor, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:117:33: error: type mismatch in i32.atomic.rmw16_u.xor, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw16_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:118:33: error: type mismatch in i64.atomic.rmw8_u.xor, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:118:33: error: type mismatch in i64.atomic.rmw8_u.xor, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw8_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:119:33: error: type mismatch in i64.atomic.rmw16_u.xor, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:119:33: error: type mismatch in i64.atomic.rmw16_u.xor, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw16_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:120:33: error: type mismatch in i64.atomic.rmw32_u.xor, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:120:33: error: type mismatch in i64.atomic.rmw32_u.xor, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw32_u.xor drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:121:33: error: type mismatch in i32.atomic.rmw.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:121:33: error: type mismatch in i32.atomic.rmw.xchg, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:122:33: error: type mismatch in i64.atomic.rmw.xchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:122:33: error: type mismatch in i64.atomic.rmw.xchg, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:123:33: error: type mismatch in i32.atomic.rmw8_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:123:33: error: type mismatch in i32.atomic.rmw8_u.xchg, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw8_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:124:33: error: type mismatch in i32.atomic.rmw16_u.xchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:124:33: error: type mismatch in i32.atomic.rmw16_u.xchg, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.rmw16_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:125:33: error: type mismatch in i64.atomic.rmw8_u.xchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:125:33: error: type mismatch in i64.atomic.rmw8_u.xchg, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw8_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:126:33: error: type mismatch in i64.atomic.rmw16_u.xchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:126:33: error: type mismatch in i64.atomic.rmw16_u.xchg, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw16_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:127:33: error: type mismatch in i64.atomic.rmw32_u.xchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:127:33: error: type mismatch in i64.atomic.rmw32_u.xchg, expected [i32, i64] but got [i32, f64]
   (func i32.const 0 f64.const 0 i64.atomic.rmw32_u.xchg drop)
                                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:128:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:128:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected [i32, i32, i32] but got [i32, f32, i32]
   (func i32.const 0 f32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:129:45: error: type mismatch in i64.atomic.rmw.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:129:45: error: type mismatch in i64.atomic.rmw.cmpxchg, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:130:45: error: type mismatch in i32.atomic.rmw8_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:130:45: error: type mismatch in i32.atomic.rmw8_u.cmpxchg, expected [i32, i32, i32] but got [i32, f32, i32]
   (func i32.const 0 f32.const 0 i32.const 0 i32.atomic.rmw8_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:131:45: error: type mismatch in i32.atomic.rmw16_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:131:45: error: type mismatch in i32.atomic.rmw16_u.cmpxchg, expected [i32, i32, i32] but got [i32, f32, i32]
   (func i32.const 0 f32.const 0 i32.const 0 i32.atomic.rmw16_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:132:45: error: type mismatch in i64.atomic.rmw8_u.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:132:45: error: type mismatch in i64.atomic.rmw8_u.cmpxchg, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw8_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:133:45: error: type mismatch in i64.atomic.rmw16_u.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:133:45: error: type mismatch in i64.atomic.rmw16_u.cmpxchg, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw16_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:134:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:134:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:137:45: error: type mismatch in i32.wait, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:137:45: error: type mismatch in i32.wait, expected [i32, i32, i64] but got [i32, i32, f64]
   (func i32.const 0 i32.const 0 f64.const 0 i32.wait drop)
                                             ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:138:45: error: type mismatch in i64.wait, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:138:45: error: type mismatch in i64.wait, expected [i32, i64, i64] but got [i32, i64, f64]
   (func i32.const 0 i64.const 0 f64.const 0 i64.wait drop)
                                             ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:139:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:139:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected [i32, i32, i32] but got [i32, i32, f32]
   (func i32.const 0 i32.const 0 f32.const 0 i32.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:140:45: error: type mismatch in i64.atomic.rmw.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:140:45: error: type mismatch in i64.atomic.rmw.cmpxchg, expected [i32, i64, i64] but got [i32, i64, f64]
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:141:45: error: type mismatch in i32.atomic.rmw8_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:141:45: error: type mismatch in i32.atomic.rmw8_u.cmpxchg, expected [i32, i32, i32] but got [i32, i32, f32]
   (func i32.const 0 i32.const 0 f32.const 0 i32.atomic.rmw8_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:142:45: error: type mismatch in i32.atomic.rmw16_u.cmpxchg, expected i32 but got f32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:142:45: error: type mismatch in i32.atomic.rmw16_u.cmpxchg, expected [i32, i32, i32] but got [i32, i32, f32]
   (func i32.const 0 i32.const 0 f32.const 0 i32.atomic.rmw16_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:143:45: error: type mismatch in i64.atomic.rmw8_u.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:143:45: error: type mismatch in i64.atomic.rmw8_u.cmpxchg, expected [i32, i64, i64] but got [i32, i64, f64]
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw8_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:144:45: error: type mismatch in i64.atomic.rmw16_u.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:144:45: error: type mismatch in i64.atomic.rmw16_u.cmpxchg, expected [i32, i64, i64] but got [i32, i64, f64]
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw16_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:145:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected i64 but got f64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:145:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected [i32, i64, i64] but got [i32, i64, f64]
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:148:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:148:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 wake)
                                              ^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:149:58: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:149:58: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i64.const 0 i32.wait)
                                                          ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:150:58: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:150:58: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i64.const 0 i64.const 0 i64.wait)
                                                          ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:151:34: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:151:34: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.atomic.load)
                                  ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:152:34: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:152:34: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.atomic.load)
                                  ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:153:34: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:153:34: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.atomic.load8_u)
                                  ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:154:34: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:154:34: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.atomic.load16_u)
                                  ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:155:34: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:155:34: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.atomic.load8_u)
                                  ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:156:34: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:156:34: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.atomic.load16_u)
                                  ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:157:34: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:157:34: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.atomic.load32_u)
                                  ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:158:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:158:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw.add)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:159:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:159:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw.add)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:160:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:160:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw8_u.add)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:161:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:161:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw16_u.add)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:162:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:162:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw8_u.add)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:163:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:163:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw16_u.add)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:164:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:164:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw32_u.add)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:165:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:165:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw.sub)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:166:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:166:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw.sub)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:167:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:167:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw8_u.sub)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:168:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:168:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw16_u.sub)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:169:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:169:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw8_u.sub)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:170:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:170:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw16_u.sub)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:171:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:171:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw32_u.sub)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:172:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:172:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw.and)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:173:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:173:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw.and)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:174:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:174:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw8_u.and)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:175:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:175:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw16_u.and)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:176:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:176:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw8_u.and)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:177:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:177:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw16_u.and)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:178:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:178:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw32_u.and)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:179:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:179:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw.or)
                                              ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:180:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:180:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw.or)
                                              ^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:181:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:181:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw8_u.or)
                                              ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:182:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:182:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw16_u.or)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:183:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:183:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw8_u.or)
                                              ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:184:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:184:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw16_u.or)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:185:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:185:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw32_u.or)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:186:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:186:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw.xor)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:187:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:187:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw.xor)
                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:188:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:188:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw8_u.xor)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:189:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:189:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw16_u.xor)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:190:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:190:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw8_u.xor)
                                              ^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:191:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:191:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw16_u.xor)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:192:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:192:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw32_u.xor)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:193:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:193:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw.xchg)
                                              ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:194:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:194:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw.xchg)
                                              ^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:195:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:195:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw8_u.xchg)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:196:46: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:196:46: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.atomic.rmw16_u.xchg)
                                              ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:197:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:197:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw8_u.xchg)
                                              ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:198:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:198:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw16_u.xchg)
                                              ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:199:46: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:199:46: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.atomic.rmw32_u.xchg)
                                              ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:200:58: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:200:58: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg)
                                                          ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:201:58: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:201:58: error: type mismatch in implicit return, expected [f64] but got [i64]
   (func (result f64) i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg)
                                                          ^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:202:58: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:202:58: error: type mismatch in implicit return, expected [f32] but got [i32]
 ...c (result f32) i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8_u.cmpxchg)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:203:58: error: type mismatch in implicit return, expected f32 but got i32.
+out/test/typecheck/bad-atomic-type-mismatch.txt:203:58: error: type mismatch in implicit return, expected [f32] but got [i32]
 ... (result f32) i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16_u.cmpxchg)
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:204:58: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:204:58: error: type mismatch in implicit return, expected [f64] but got [i64]
 ...c (result f64) i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8_u.cmpxchg)
                                                       ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:205:58: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:205:58: error: type mismatch in implicit return, expected [f64] but got [i64]
 ... (result f64) i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16_u.cmpxchg)
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:206:58: error: type mismatch in implicit return, expected f64 but got i64.
+out/test/typecheck/bad-atomic-type-mismatch.txt:206:58: error: type mismatch in implicit return, expected [f64] but got [i64]
 ... (result f64) i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg)
                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-binary-type-mismatch-1.txt
+++ b/test/typecheck/bad-binary-type-mismatch-1.txt
@@ -6,7 +6,7 @@
     i32.add  
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-binary-type-mismatch-1.txt:6:5: error: type mismatch in i32.add, expected i32 but got f32.
+out/test/typecheck/bad-binary-type-mismatch-1.txt:6:5: error: type mismatch in i32.add, expected [i32, i32] but got [f32, i32]
     i32.add  
     ^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-binary-type-mismatch-2.txt
+++ b/test/typecheck/bad-binary-type-mismatch-2.txt
@@ -6,7 +6,7 @@
     i32.add 
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-binary-type-mismatch-2.txt:6:5: error: type mismatch in i32.add, expected i32 but got f32.
+out/test/typecheck/bad-binary-type-mismatch-2.txt:6:5: error: type mismatch in i32.add, expected [i32, i32] but got [i32, f32]
     i32.add 
     ^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-brtable-type-mismatch.txt
+++ b/test/typecheck/bad-brtable-type-mismatch.txt
@@ -11,7 +11,7 @@
     end
     i32.const 2))
 (;; STDERR ;;;
-out/test/typecheck/bad-brtable-type-mismatch.txt:7:9: error: type mismatch in br_table, expected i32 but got f32.
+out/test/typecheck/bad-brtable-type-mismatch.txt:7:9: error: type mismatch in br_table, expected [i32] but got [f32]
         br_table 0 1 
         ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-call-result-mismatch.txt
+++ b/test/typecheck/bad-call-result-mismatch.txt
@@ -23,22 +23,22 @@
       nop
     end))
 (;; STDERR ;;;
-out/test/typecheck/bad-call-result-mismatch.txt:9:5: error: type stack size too small at if. got 0, expected at least 1
+out/test/typecheck/bad-call-result-mismatch.txt:9:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:10:7: error: type stack at end of if true branch is 1, expected 0
+out/test/typecheck/bad-call-result-mismatch.txt:10:7: error: type mismatch in if true branch, expected [] but got [i64]
       call $direct
       ^^^^
-out/test/typecheck/bad-call-result-mismatch.txt:14:5: error: type stack size too small at if. got 0, expected at least 1
+out/test/typecheck/bad-call-result-mismatch.txt:14:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:15:7: error: type stack at end of if true branch is 1, expected 0
+out/test/typecheck/bad-call-result-mismatch.txt:15:7: error: type mismatch in if true branch, expected [] but got [f32]
       call $import
       ^^^^
-out/test/typecheck/bad-call-result-mismatch.txt:19:5: error: type stack size too small at if. got 0, expected at least 1
+out/test/typecheck/bad-call-result-mismatch.txt:19:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:21:7: error: type stack at end of if true branch is 1, expected 0
+out/test/typecheck/bad-call-result-mismatch.txt:21:7: error: type mismatch in if true branch, expected [] but got [i64]
       call_indirect $indirect
       ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-call-type-mismatch.txt
+++ b/test/typecheck/bad-call-type-mismatch.txt
@@ -5,7 +5,7 @@
     i64.const 0
     call 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-call-type-mismatch.txt:6:5: error: type mismatch in call, expected i32 but got i64.
+out/test/typecheck/bad-call-type-mismatch.txt:6:5: error: type mismatch in call, expected [i32, i64] but got [i64, i64]
     call 0))
     ^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callimport-type-mismatch.txt
+++ b/test/typecheck/bad-callimport-type-mismatch.txt
@@ -5,7 +5,7 @@
     f32.const 0
     call 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-callimport-type-mismatch.txt:6:5: error: type mismatch in call, expected i32 but got f32.
+out/test/typecheck/bad-callimport-type-mismatch.txt:6:5: error: type mismatch in call, expected [i32] but got [f32]
     call 0))
     ^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callindirect-func-type-mismatch.txt
+++ b/test/typecheck/bad-callindirect-func-type-mismatch.txt
@@ -6,7 +6,7 @@
     f32.const 0
     call_indirect $t))
 (;; STDERR ;;;
-out/test/typecheck/bad-callindirect-func-type-mismatch.txt:7:5: error: type mismatch in call_indirect, expected i32 but got f32.
+out/test/typecheck/bad-callindirect-func-type-mismatch.txt:7:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
     call_indirect $t))
     ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callindirect-type-mismatch.txt
+++ b/test/typecheck/bad-callindirect-type-mismatch.txt
@@ -9,7 +9,7 @@
     call_indirect $t
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-callindirect-type-mismatch.txt:9:5: error: type mismatch in call_indirect, expected i32 but got f32.
+out/test/typecheck/bad-callindirect-type-mismatch.txt:9:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
     call_indirect $t
     ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-cast-type-mismatch.txt
+++ b/test/typecheck/bad-cast-type-mismatch.txt
@@ -5,7 +5,7 @@
     f32.reinterpret/i32
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-cast-type-mismatch.txt:5:5: error: type mismatch in f32.reinterpret/i32, expected i32 but got f32.
+out/test/typecheck/bad-cast-type-mismatch.txt:5:5: error: type mismatch in f32.reinterpret/i32, expected [i32] but got [f32]
     f32.reinterpret/i32
     ^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-compare-type-mismatch-1.txt
+++ b/test/typecheck/bad-compare-type-mismatch-1.txt
@@ -6,7 +6,7 @@
     i32.eq
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-compare-type-mismatch-1.txt:6:5: error: type mismatch in i32.eq, expected i32 but got f32.
+out/test/typecheck/bad-compare-type-mismatch-1.txt:6:5: error: type mismatch in i32.eq, expected [i32, i32] but got [f32, i32]
     i32.eq
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-compare-type-mismatch-2.txt
+++ b/test/typecheck/bad-compare-type-mismatch-2.txt
@@ -6,7 +6,7 @@
     f32.lt
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-compare-type-mismatch-2.txt:6:5: error: type mismatch in f32.lt, expected f32 but got i32.
+out/test/typecheck/bad-compare-type-mismatch-2.txt:6:5: error: type mismatch in f32.lt, expected [f32, f32] but got [f32, i32]
     f32.lt
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-convert-type-mismatch.txt
+++ b/test/typecheck/bad-convert-type-mismatch.txt
@@ -5,7 +5,7 @@
     i32.trunc_s/f32 
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-convert-type-mismatch.txt:5:5: error: type mismatch in i32.trunc_s/f32, expected f32 but got i32.
+out/test/typecheck/bad-convert-type-mismatch.txt:5:5: error: type mismatch in i32.trunc_s/f32, expected [f32] but got [i32]
     i32.trunc_s/f32 
     ^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-expr-if.txt
+++ b/test/typecheck/bad-expr-if.txt
@@ -9,7 +9,10 @@
     end
     i32.add))
 (;; STDERR ;;;
-out/test/typecheck/bad-expr-if.txt:10:5: error: type stack size too small at i32.add. got 1, expected at least 2
+out/test/typecheck/bad-expr-if.txt:10:5: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+    i32.add))
+    ^^^^^^^
+out/test/typecheck/bad-expr-if.txt:10:5: error: type mismatch in function, expected [] but got [i32]
     i32.add))
     ^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-function-result-type-mismatch.txt
+++ b/test/typecheck/bad-function-result-type-mismatch.txt
@@ -3,7 +3,7 @@
   (func (result i32)
     f32.const 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-function-result-type-mismatch.txt:4:5: error: type mismatch in implicit return, expected i32 but got f32.
+out/test/typecheck/bad-function-result-type-mismatch.txt:4:5: error: type mismatch in implicit return, expected [i32] but got [f32]
     f32.const 0))
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-grow-memory-type-mismatch.txt
+++ b/test/typecheck/bad-grow-memory-type-mismatch.txt
@@ -6,7 +6,7 @@
     grow_memory
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-grow-memory-type-mismatch.txt:6:5: error: type mismatch in grow_memory, expected i32 but got f32.
+out/test/typecheck/bad-grow-memory-type-mismatch.txt:6:5: error: type mismatch in grow_memory, expected [i32] but got [f32]
     grow_memory
     ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-condition-type-mismatch.txt
+++ b/test/typecheck/bad-if-condition-type-mismatch.txt
@@ -10,7 +10,7 @@
     drop)
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-if-condition-type-mismatch.txt:5:5: error: type mismatch in if, expected i32 but got f32.
+out/test/typecheck/bad-if-condition-type-mismatch.txt:5:5: error: type mismatch in if, expected [i32] but got [f32]
     if (result i32)
     ^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-type-mismatch.txt
+++ b/test/typecheck/bad-if-type-mismatch.txt
@@ -9,7 +9,7 @@
     end
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-if-type-mismatch.txt:6:7: error: type mismatch in if true branch, expected i32 but got f32.
+out/test/typecheck/bad-if-type-mismatch.txt:6:7: error: type mismatch in if true branch, expected [i32] but got [f32]
       f32.const 0
       ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-value-void.txt
+++ b/test/typecheck/bad-if-value-void.txt
@@ -11,7 +11,7 @@
       drop
     end))
 (;; STDERR ;;;
-out/test/typecheck/bad-if-value-void.txt:7:9: error: type stack size too small at if true branch. got 0, expected at least 1
+out/test/typecheck/bad-if-value-void.txt:7:9: error: type mismatch in if true branch, expected [f32] but got []
         nop
         ^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-load-type-mismatch.txt
+++ b/test/typecheck/bad-load-type-mismatch.txt
@@ -6,7 +6,7 @@
     i32.load
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-load-type-mismatch.txt:6:5: error: type mismatch in i32.load, expected i32 but got f32.
+out/test/typecheck/bad-load-type-mismatch.txt:6:5: error: type mismatch in i32.load, expected [i32] but got [f32]
     i32.load
     ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-nested-br.txt
+++ b/test/typecheck/bad-nested-br.txt
@@ -18,7 +18,7 @@
     ;; return statement here, or a value returned from (br $outer).
   ))
 (;; STDERR ;;;
-out/test/typecheck/bad-nested-br.txt:15:7: error: type stack size too small at implicit return. got 0, expected at least 1
+out/test/typecheck/bad-nested-br.txt:15:7: error: type mismatch in implicit return, expected [i32] but got []
       return
       ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-return-type-mismatch.txt
+++ b/test/typecheck/bad-return-type-mismatch.txt
@@ -4,7 +4,7 @@
     f32.const 0
     return))
 (;; STDERR ;;;
-out/test/typecheck/bad-return-type-mismatch.txt:5:5: error: type mismatch in return, expected i32 but got f32.
+out/test/typecheck/bad-return-type-mismatch.txt:5:5: error: type mismatch in return, expected [i32] but got [f32]
     return))
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-cond.txt
+++ b/test/typecheck/bad-select-cond.txt
@@ -1,12 +1,12 @@
 ;;; ERROR: 1
 (module
   (func (result i32)
-    i32.const 0
-    i32.const 0
     f32.const 0
+    i32.const 0
+    i32.const 0
     select))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-cond.txt:7:5: error: type mismatch in select, expected i32 but got f32.
+out/test/typecheck/bad-select-cond.txt:7:5: error: type mismatch in select, expected [i32, i32, i32] but got [f32, i32, i32]
     select))
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value0.txt
+++ b/test/typecheck/bad-select-value0.txt
@@ -1,12 +1,13 @@
 ;;; ERROR: 1
 (module
-  (func (result f32)
+  (func
+    i32.const 0
     f64.const 0
     f32.const 0
-    i32.const 0
-    select))
+    select
+    drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-value0.txt:7:5: error: type mismatch in select, expected f32 but got f64.
-    select))
+out/test/typecheck/bad-select-value0.txt:7:5: error: type mismatch in select, expected [i32, f64, f64] but got [i32, f64, f32]
+    select
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value1.txt
+++ b/test/typecheck/bad-select-value1.txt
@@ -1,13 +1,13 @@
 ;;; ERROR: 1
 (module
   (func
+    i32.const 0
     i64.const 0
     f32.const 0
-    i32.const 0
     select
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-value1.txt:7:5: error: type mismatch in select, expected f32 but got i64.
+out/test/typecheck/bad-select-value1.txt:7:5: error: type mismatch in select, expected [i32, i64, i64] but got [i32, i64, f32]
     select
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-setlocal-type-mismatch.txt
+++ b/test/typecheck/bad-setlocal-type-mismatch.txt
@@ -4,7 +4,7 @@
     f32.const 0
     set_local 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-setlocal-type-mismatch.txt:5:5: error: type mismatch in set_local, expected i32 but got f32.
+out/test/typecheck/bad-setlocal-type-mismatch.txt:5:5: error: type mismatch in set_local, expected [i32] but got [f32]
     set_local 0))
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-store-index-type-mismatch.txt
+++ b/test/typecheck/bad-store-index-type-mismatch.txt
@@ -6,7 +6,7 @@
     f32.const 0
     i32.store))
 (;; STDERR ;;;
-out/test/typecheck/bad-store-index-type-mismatch.txt:7:5: error: type mismatch in i32.store, expected i32 but got f32.
+out/test/typecheck/bad-store-index-type-mismatch.txt:7:5: error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
     i32.store))
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-unary-type-mismatch.txt
+++ b/test/typecheck/bad-unary-type-mismatch.txt
@@ -5,7 +5,7 @@
     f32.neg
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-unary-type-mismatch.txt:5:5: error: type mismatch in f32.neg, expected f32 but got f64.
+out/test/typecheck/bad-unary-type-mismatch.txt:5:5: error: type mismatch in f32.neg, expected [f32] but got [f64]
     f32.neg
     ^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
Instead of printing errors on every failure, accumulate errors for each
operation. If any fails, then print a message. It changes errors such
as:

```
error: type mismatch in i64.store, expected i32 but got f32.
error: type mismatch in i64.store, expected i64 but got i32.
```

to:

```
error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
```