### PR TITLE
Fix bad folding w/ imports and generating names

### DIFF
--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -85,13 +85,19 @@ class NameGenerator : public ExprVisitor::DelegateNop {
   Result VisitTable(Index table_index, Table* table);
   Result VisitMemory(Index memory_index, Memory* memory);
   Result VisitExcept(Index except_index, Exception* except);
-  Result VisitImport(Index import_index, Import* import);
-  Result VisitExport(Index export_index, Export* export_);
+  Result VisitImport(Import* import);
+  Result VisitExport(Export* export_);
 
   Module* module_ = nullptr;
   ExprVisitor visitor_;
   std::vector<std::string> index_to_name_;
   Index label_count_ = 0;
+
+  Index num_func_imports_ = 0;
+  Index num_table_imports_ = 0;
+  Index num_memory_imports_ = 0;
+  Index num_global_imports_ = 0;
+  Index num_exception_imports_ = 0;
 };
 
 NameGenerator::NameGenerator() : visitor_(this) {}
@@ -245,15 +251,17 @@ Result NameGenerator::VisitExcept(Index except_index, Exception* except) {
   return Result::Ok;
 }
 
-Result NameGenerator::VisitImport(Index import_index, Import* import) {
+Result NameGenerator::VisitImport(Import* import) {
   BindingHash* bindings = nullptr;
   std::string* name = nullptr;
+  Index index = kInvalidIndex;
 
   switch (import->kind()) {
     case ExternalKind::Func:
       if (auto* func_import = cast<FuncImport>(import)) {
         bindings = &module_->func_bindings;
         name = &func_import->func.name;
+        index = num_func_imports_++;
       }
       break;
 
@@ -261,6 +269,7 @@ Result NameGenerator::VisitImport(Index import_index, Import* import) {
       if (auto* table_import = cast<TableImport>(import)) {
         bindings = &module_->table_bindings;
         name = &table_import->table.name;
+        index = num_table_imports_++;
       }
       break;
 
@@ -268,6 +277,7 @@ Result NameGenerator::VisitImport(Index import_index, Import* import) {
       if (auto* memory_import = cast<MemoryImport>(import)) {
         bindings = &module_->memory_bindings;
         name = &memory_import->memory.name;
+        index = num_memory_imports_++;
       }
       break;
 
@@ -275,6 +285,7 @@ Result NameGenerator::VisitImport(Index import_index, Import* import) {
       if (auto* global_import = cast<GlobalImport>(import)) {
         bindings = &module_->global_bindings;
         name = &global_import->global.name;
+        index = num_global_imports_++;
       }
       break;
 
@@ -282,19 +293,21 @@ Result NameGenerator::VisitImport(Index import_index, Import* import) {
       if (auto* except_import = cast<ExceptionImport>(import)) {
         bindings = &module_->except_bindings;
         name = &except_import->except.name;
+        index = num_exception_imports_++;
       }
       break;
   }
 
   if (bindings && name) {
+    assert(index != kInvalidIndex);
     std::string new_name = '$' + import->module_name + '.' + import->field_name;
-    MaybeUseAndBindName(bindings, new_name.c_str(), import_index, name);
+    MaybeUseAndBindName(bindings, new_name.c_str(), index, name);
   }
 
   return Result::Ok;
 }
 
-Result NameGenerator::VisitExport(Index export_index, Export* export_) {
+Result NameGenerator::VisitExport(Export* export_) {
   BindingHash* bindings = nullptr;
   std::string* name = nullptr;
   Index index = kInvalidIndex;
@@ -354,9 +367,9 @@ Result NameGenerator::VisitModule(Module* module) {
   // Visit imports and exports first to give better names, derived from the
   // import/export name.
   for (Index i = 0; i < module->imports.size(); ++i)
-    CHECK_RESULT(VisitImport(i, module->imports[i]));
+    CHECK_RESULT(VisitImport(module->imports[i]));
   for (Index i = 0; i < module->exports.size(); ++i)
-    CHECK_RESULT(VisitExport(i, module->exports[i]));
+    CHECK_RESULT(VisitExport(module->exports[i]));
 
   for (Index i = 0; i < module->globals.size(); ++i)
     CHECK_RESULT(VisitGlobal(i, module->globals[i]));

--- a/test/regress/regress-18.txt
+++ b/test/regress/regress-18.txt
@@ -1,0 +1,31 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --fold-exprs --generate-names
+
+;; This was folding incorrectly since the import index was being used as the
+;; function index, so the folder didn't know how many parameters the function
+;; had.
+
+(module
+  (import "a" "b" (global i32))
+  (import "c" "d" (func $g (param i32 i32) (result i32)))
+  (func $f (param i32))
+  (func
+    (call $f
+      (call $g
+        (i32.const 1)
+        (i32.const 2)))))
+
+(;; STDOUT ;;;
+(module
+  (type $t0 (func (param i32 i32) (result i32)))
+  (type $t1 (func (param i32)))
+  (type $t2 (func))
+  (import "a" "b" (global $a.b i32))
+  (import "c" "d" (func $c.d (type $t0)))
+  (func $f1 (type $t1) (param $p0 i32))
+  (func $f2 (type $t2)
+    (call $f1
+      (call $c.d
+        (i32.const 1)
+        (i32.const 2)))))
+;;; STDOUT ;;)


### PR DESCRIPTION
The name generation pass was adding an entry to the function binding
hash, but using the import index instead of the function/global/etc.
index. As a result, subsequent lookups would return the wrong function.

In this case, it would cause the wat folding code to use a function with
the wrong number of parameters.