### PR TITLE
Update testsuite; call_indirect has new syntax

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -272,7 +272,8 @@ Result NameApplier::OnCallExpr(CallExpr* expr) {
 }
 
 Result NameApplier::OnCallIndirectExpr(CallIndirectExpr* expr) {
-  CHECK_RESULT(UseNameForFuncTypeVar(&expr->var));
+  if (expr->decl.has_func_type)
+    CHECK_RESULT(UseNameForFuncTypeVar(&expr->decl.type_var));
   return Result::Ok;
 }
 

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -595,8 +595,11 @@ Result BinaryReaderIR::OnCallExpr(Index func_index) {
 
 Result BinaryReaderIR::OnCallIndirectExpr(Index sig_index) {
   assert(sig_index < module_->func_types.size());
-  return AppendExpr(
-      MakeUnique<CallIndirectExpr>(Var(sig_index, GetLocation())));
+  auto expr = MakeUnique<CallIndirectExpr>(GetLocation());
+  expr->decl.has_func_type = true;
+  expr->decl.type_var = Var(sig_index, GetLocation());
+  expr->decl.sig = module_->func_types[sig_index]->sig;
+  return AppendExpr(std::move(expr));
 }
 
 Result BinaryReaderIR::OnCompareExpr(Opcode opcode) {

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -398,7 +398,8 @@ void BinaryWriter::WriteExpr(const Module* module,
       break;
     }
     case ExprType::CallIndirect: {
-      Index index = module->GetFuncTypeIndex(cast<CallIndirectExpr>(expr)->var);
+      Index index =
+          module->GetFuncTypeIndex(cast<CallIndirectExpr>(expr)->decl);
       WriteOpcode(stream_, Opcode::CallIndirect);
       WriteU32Leb128WithReloc(index, "signature index",
                               RelocType::TypeIndexLEB);

--- a/src/ir.h
+++ b/src/ir.h
@@ -113,6 +113,42 @@ struct Const {
 };
 typedef std::vector<Const> ConstVector;
 
+struct FuncSignature {
+  TypeVector param_types;
+  TypeVector result_types;
+
+  Index GetNumParams() const { return param_types.size(); }
+  Index GetNumResults() const { return result_types.size(); }
+  Type GetParamType(Index index) const { return param_types[index]; }
+  Type GetResultType(Index index) const { return result_types[index]; }
+
+  bool operator==(const FuncSignature&) const;
+};
+
+struct FuncType {
+  FuncType() = default;
+  explicit FuncType(string_view name) : name(name.to_string()) {}
+
+  Index GetNumParams() const { return sig.GetNumParams(); }
+  Index GetNumResults() const { return sig.GetNumResults(); }
+  Type GetParamType(Index index) const { return sig.GetParamType(index); }
+  Type GetResultType(Index index) const { return sig.GetResultType(index); }
+
+  std::string name;
+  FuncSignature sig;
+};
+
+struct FuncDeclaration {
+  Index GetNumParams() const { return sig.GetNumParams(); }
+  Index GetNumResults() const { return sig.GetNumResults(); }
+  Type GetParamType(Index index) const { return sig.GetParamType(index); }
+  Type GetResultType(Index index) const { return sig.GetResultType(index); }
+
+  bool has_func_type = false;
+  Var type_var;
+  FuncSignature sig;
+};
+
 enum class ExprType {
   AtomicLoad,
   AtomicStore,
@@ -246,7 +282,6 @@ class VarExpr : public ExprMixin<TypeEnum> {
 typedef VarExpr<ExprType::Br> BrExpr;
 typedef VarExpr<ExprType::BrIf> BrIfExpr;
 typedef VarExpr<ExprType::Call> CallExpr;
-typedef VarExpr<ExprType::CallIndirect> CallIndirectExpr;
 typedef VarExpr<ExprType::GetGlobal> GetGlobalExpr;
 typedef VarExpr<ExprType::GetLocal> GetLocalExpr;
 typedef VarExpr<ExprType::Rethrow> RethrowExpr;
@@ -254,6 +289,14 @@ typedef VarExpr<ExprType::SetGlobal> SetGlobalExpr;
 typedef VarExpr<ExprType::SetLocal> SetLocalExpr;
 typedef VarExpr<ExprType::TeeLocal> TeeLocalExpr;
 typedef VarExpr<ExprType::Throw> ThrowExpr;
+
+class CallIndirectExpr : public ExprMixin<ExprType::CallIndirect> {
+ public:
+  explicit CallIndirectExpr(const Location& loc = Location())
+      : ExprMixin<ExprType::CallIndirect>(loc) {}
+
+  FuncDeclaration decl;
+};
 
 template <ExprType TypeEnum>
 class BlockExprBase : public ExprMixin<TypeEnum> {
@@ -335,42 +378,6 @@ struct Exception {
 
   std::string name;
   TypeVector sig;
-};
-
-struct FuncSignature {
-  TypeVector param_types;
-  TypeVector result_types;
-
-  Index GetNumParams() const { return param_types.size(); }
-  Index GetNumResults() const { return result_types.size(); }
-  Type GetParamType(Index index) const { return param_types[index]; }
-  Type GetResultType(Index index) const { return result_types[index]; }
-
-  bool operator==(const FuncSignature&) const;
-};
-
-struct FuncType {
-  FuncType() = default;
-  explicit FuncType(string_view name) : name(name.to_string()) {}
-
-  Index GetNumParams() const { return sig.GetNumParams(); }
-  Index GetNumResults() const { return sig.GetNumResults(); }
-  Type GetParamType(Index index) const { return sig.GetParamType(index); }
-  Type GetResultType(Index index) const { return sig.GetResultType(index); }
-
-  std::string name;
-  FuncSignature sig;
-};
-
-struct FuncDeclaration {
-  Index GetNumParams() const { return sig.GetNumParams(); }
-  Index GetNumResults() const { return sig.GetNumResults(); }
-  Type GetParamType(Index index) const { return sig.GetParamType(index); }
-  Type GetResultType(Index index) const { return sig.GetResultType(index); }
-
-  bool has_func_type = false;
-  Var type_var;
-  FuncSignature sig;
 };
 
 struct Func {

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -245,7 +245,8 @@ Result NameResolver::OnCallExpr(CallExpr* expr) {
 }
 
 Result NameResolver::OnCallIndirectExpr(CallIndirectExpr* expr) {
-  ResolveFuncTypeVar(&expr->var);
+  if (expr->decl.has_func_type)
+    ResolveFuncTypeVar(&expr->decl.type_var);
   return Result::Ok;
 }
 

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -149,7 +149,9 @@ class WastParser {
   Result ParseInlineImport(Import*);
   Result ParseTypeUseOpt(FuncDeclaration*);
   Result ParseFuncSignature(FuncSignature*, BindingHash* param_bindings);
+  Result ParseUnboundFuncSignature(FuncSignature*);
   Result ParseBoundValueTypeList(TokenType, TypeVector*, BindingHash*);
+  Result ParseUnboundValueTypeList(TokenType, TypeVector*);
   Result ParseResultList(TypeVector*);
   Result ParseInstrList(ExprList*);
   Result ParseTerminatingInstrList(ExprList*);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -524,7 +524,10 @@ void WatWriter::WriteExpr(const Expr* expr) {
 
     case ExprType::CallIndirect:
       WritePutsSpace(Opcode::CallIndirect_Opcode.GetName());
-      WriteVar(cast<CallIndirectExpr>(expr)->var, NextChar::Newline);
+      WriteOpenSpace("type");
+      WriteVar(cast<CallIndirectExpr>(expr)->decl.type_var,
+               NextChar::Space);
+      WriteCloseNewline();
       break;
 
     case ExprType::Compare:
@@ -758,9 +761,9 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
     }
 
     case ExprType::CallIndirect: {
-      const Var& var = cast<CallIndirectExpr>(expr)->var;
-      PushExpr(expr, GetFuncSigParamCount(var) + 1,
-               GetFuncSigResultCount(var));
+      const auto* ci_expr = cast<CallIndirectExpr>(expr);
+      PushExpr(expr, ci_expr->decl.GetNumParams() + 1,
+               ci_expr->decl.GetNumResults());
       break;
     }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -160,8 +160,6 @@ class WatWriter {
   Index GetLabelArity(const Var& var);
   Index GetFuncParamCount(const Var& var);
   Index GetFuncResultCount(const Var& var);
-  Index GetFuncSigParamCount(const Var& var);
-  Index GetFuncSigResultCount(const Var& var);
   void PushExpr(const Expr* expr, Index operand_count, Index result_count);
   void FlushExprTree(const ExprTree& expr_tree);
   void FlushExprTreeVector(const std::vector<ExprTree>&);
@@ -708,16 +706,6 @@ Index WatWriter::GetFuncParamCount(const Var& var) {
 Index WatWriter::GetFuncResultCount(const Var& var) {
   const Func* func = module_->GetFunc(var);
   return func ? func->GetNumResults() : 0;
-}
-
-Index WatWriter::GetFuncSigParamCount(const Var& var) {
-  const FuncType* func_type = module_->GetFuncType(var);
-  return func_type ? func_type->GetNumParams() : 0;
-}
-
-Index WatWriter::GetFuncSigResultCount(const Var& var) {
-  const FuncType* func_type = module_->GetFuncType(var);
-  return func_type ? func_type->GetNumResults() : 0;
 }
 
 void WatWriter::WriteFoldedExpr(const Expr* expr) {

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -5,7 +5,7 @@
   (func $f (type $t)
     i32.const 0
     i32.const 0
-    call_indirect $t )
+    call_indirect (type $t))
   (table anyfunc (elem $f)))
 (;; STDOUT ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -9,7 +9,7 @@
   (func $f1 (param i32 i32)
     get_local 0
     get_local 1
-    call_indirect $t
+    call_indirect (type $t)
     drop)
   (func $f2 (param i32)
     get_local 0

--- a/test/interp/callindirect.txt
+++ b/test/interp/callindirect.txt
@@ -8,7 +8,7 @@
 
   (func $nullary (param i32) (result i32)
     get_local 0
-    call_indirect $v_i)
+    call_indirect (type $v_i))
 
   (type $ii_i (func (param i32 i32) (result i32)))
   (func $add (type $ii_i)
@@ -24,7 +24,7 @@
     get_local 0
     get_local 1
     get_local 2
-    call_indirect $ii_i)
+    call_indirect (type $ii_i))
 
   (table anyfunc (elem $zero $one $add $sub))
 

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -27,7 +27,7 @@
   (; 0x0e ;) (func (export "br_table") i32.const 1 br_table 0)
   (; 0x0f ;) (func (export "return") return)
   (; 0x10 ;) (func (export "call") call $empty)
-  (; 0x11 ;) (func (export "call_indirect") i32.const 1 call_indirect $empty)
+  (; 0x11 ;) (func (export "call_indirect") i32.const 1 call_indirect (type $empty))
   (; 0x1a ;) (func (export "drop") i32.const 1 drop)
   (; 0x1b ;) (func (export "select") i32.const 1 i32.const 2 i32.const 3 select drop)
   (; 0x20 ;) (func (export "get_local") (local i32) get_local 0 drop)

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -27,7 +27,7 @@
   (; 0x0e ;) (func (export "br_table") i32.const 1 br_table 0)
   (; 0x0f ;) (func (export "return") return)
   (; 0x10 ;) (func (export "call") call $empty)
-  (; 0x11 ;) (func (export "call_indirect") i32.const 1 call_indirect $empty)
+  (; 0x11 ;) (func (export "call_indirect") i32.const 1 call_indirect (type $empty))
   (; 0x1a ;) (func (export "drop") i32.const 1 drop)
   (; 0x1b ;) (func (export "select") i32.const 1 i32.const 2 i32.const 3 select drop)
   (; 0x20 ;) (func (export "get_local") (local i32) get_local 0 drop)

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -11,7 +11,7 @@
   (table anyfunc (elem $func3 $func2 $func2))
   (func $func4
     i64.const 7
-    call_indirect $t1
+    call_indirect (type $t1)
   )
 )
 (;; STDOUT ;;;

--- a/test/parse/expr/callindirect-named.txt
+++ b/test/parse/expr/callindirect-named.txt
@@ -4,4 +4,4 @@
   (func $g
     i32.const 0
     i32.const 0
-    call_indirect $t))
+    call_indirect (type $t)))

--- a/test/parse/expr/callindirect.txt
+++ b/test/parse/expr/callindirect.txt
@@ -4,4 +4,4 @@
   (func
     i32.const 0
     i32.const 0
-    call_indirect 0))
+    call_indirect (type 0)))

--- a/test/roundtrip/fold-call.txt
+++ b/test/roundtrip/fold-call.txt
@@ -31,7 +31,7 @@
   (func $fold-call-indirect (result i32)
     i32.const 1
     i32.const 2
-    call_indirect $i_i)
+    call_indirect (type $i_i))
 )
 
 (;; STDOUT ;;;
@@ -61,7 +61,7 @@
         (i32.const 3)
         (f32.const 0x1p+2 (;=4;)))))
   (func (;5;) (type 3) (result i32)
-    (call_indirect 0
+    (call_indirect (type 0)
       (i32.const 1)
       (i32.const 2)))
   (table (;0;) 2 2 anyfunc)

--- a/test/roundtrip/generate-func-type-names.txt
+++ b/test/roundtrip/generate-func-type-names.txt
@@ -8,7 +8,7 @@
   (func (type 0))
   (func (type 1)
     i32.const 0
-    call_indirect 0
+    call_indirect (type 0)
     i32.const 1))
 (;; STDOUT ;;;
 (module
@@ -18,7 +18,7 @@
   (func $f1 (type $t0))
   (func $f2 (type $t1) (result i32)
     i32.const 0
-    call_indirect $t0
+    call_indirect (type $t0)
     i32.const 1)
   (table $T0 1 1 anyfunc)
   (elem (i32.const 0) $foo.bar))

--- a/test/roundtrip/generate-some-names.txt
+++ b/test/roundtrip/generate-some-names.txt
@@ -19,7 +19,7 @@
     drop
     i32.const 0
     i32.const 1
-    call_indirect 0
+    call_indirect (type 0)
     drop
     get_local 1
     drop
@@ -45,7 +45,7 @@
     drop
     i32.const 0
     i32.const 1
-    call_indirect $t0
+    call_indirect (type $t0)
     drop
     get_local $param1
     drop

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -1,51 +1,116 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call_indirect.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/call_indirect.wast:237: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:273: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.1.wast:1:122: error: unexpected token "param", expected an expr.
+  ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
+                                        ^^^^^
+  out/third_party/testsuite/call_indirect/call_indirect.1.wast:1:166: error: unexpected token ), expected EOF.
+  ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:285: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.2.wast:1:109: error: unexpected token "type", expected an expr.
+  ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
+                                        ^^^^
+  out/third_party/testsuite/call_indirect/call_indirect.2.wast:1:166: error: unexpected token ), expected EOF.
+  ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:297: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.3.wast:1:122: error: unexpected token "type", expected an expr.
+  ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
+                                        ^^^^
+  out/third_party/testsuite/call_indirect/call_indirect.3.wast:1:166: error: unexpected token ), expected EOF.
+  ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:309: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.4.wast:1:110: error: unexpected token "type", expected an expr.
+  ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
+                                        ^^^^
+  out/third_party/testsuite/call_indirect/call_indirect.4.wast:1:166: error: unexpected token ), expected EOF.
+  ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:321: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.5.wast:1:110: error: unexpected token "param", expected an expr.
+  ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
+                                        ^^^^^
+  out/third_party/testsuite/call_indirect/call_indirect.5.wast:1:166: error: unexpected token ), expected EOF.
+  ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:333: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.6.wast:1:67: error: unexpected token "param", expected an expr.
+  ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
+                                          ^^^^^
+  out/third_party/testsuite/call_indirect/call_indirect.6.wast:1:106: error: unexpected token ), expected EOF.
+  ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:343: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.7.wast:1:46: error: unexpected token $x, expected ).
+  ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
+                                             ^^
+  out/third_party/testsuite/call_indirect/call_indirect.7.wast:1:82: error: unexpected token ), expected EOF.
+  ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
+                                                                                 ^
+out/third_party/testsuite/call_indirect.wast:350: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.8.wast:1:57: error: expected 0 results, got 1
+  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
+                                    ^^^^^^^^^^^^^
+out/third_party/testsuite/call_indirect.wast:360: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.9.wast:1:82: error: expected 1 arguments, got 0
+  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
+                                    ^^^^^^^^^^^^^
+out/third_party/testsuite/call_indirect.wast:370: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.10.wast:1:69: error: expected 1 results, got 0
+  ...i32)))(table 0 anyfunc)(func  (call_indirect (type $sig) (param i32) (i32....
+                                    ^^^^^^^^^^^^^
+out/third_party/testsuite/call_indirect.wast:380: assert_malformed passed:
+  out/third_party/testsuite/call_indirect/call_indirect.11.wast:1:86: error: expected 2 arguments, got 1
+  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
+                                    ^^^^^^^^^^^^^
+out/third_party/testsuite/call_indirect.wast:395: assert_invalid passed:
   error: found call_indirect operator, but no table
   000001c: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:245: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:403: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
-out/third_party/testsuite/call_indirect.wast:253: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:411: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
-out/third_party/testsuite/call_indirect.wast:262: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:420: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:270: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:428: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:278: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:436: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
-out/third_party/testsuite/call_indirect.wast:286: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:444: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
-out/third_party/testsuite/call_indirect.wast:297: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:455: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:305: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:463: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:314: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:472: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:324: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:482: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:334: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:492: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:344: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:502: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:358: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:516: assert_invalid passed:
   0000021: error: invalid call_indirect signature index
-out/third_party/testsuite/call_indirect.wast:365: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:523: assert_invalid passed:
   0000025: error: invalid call_indirect signature index
-out/third_party/testsuite/call_indirect.wast:376: assert_invalid passed:
+out/third_party/testsuite/call_indirect.wast:534: assert_invalid passed:
   error: invalid func_index: 0 (max 0)
   0000018: error: OnElemSegmentFunctionIndex callback failed
-64/64 tests passed.
+75/75 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -107,155 +107,155 @@ out/third_party/testsuite/imports.wast:252: assert_unlinkable passed:
 out/third_party/testsuite/imports.wast:256: assert_unlinkable passed:
   error: unknown host global import "spectest.memory"
   000001e: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:298: assert_invalid passed:
-  error: unknown import module ""
-  0000011: error: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:302: assert_invalid passed:
   error: unknown import module ""
   0000011: error: OnImportTable callback failed
 out/third_party/testsuite/imports.wast:306: assert_invalid passed:
+  error: unknown import module ""
+  0000011: error: OnImportTable callback failed
+out/third_party/testsuite/imports.wast:310: assert_invalid passed:
   000000b: error: table count (2) must be 0 or 1
-out/third_party/testsuite/imports.wast:323: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:327: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001c: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:327: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:331: assert_unlinkable passed:
   error: unknown host table import "spectest.unknown"
   0000020: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:332: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:336: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
   0000021: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:336: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:340: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (20)
   0000022: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:340: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:344: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
   000001e: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:344: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:348: assert_unlinkable passed:
   error: max size (20) larger than declared (15)
   000001f: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:349: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:353: assert_unlinkable passed:
   error: expected import "test.func" to have kind table, not func
   0000019: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:353: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:357: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind table, not global
   000001f: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:357: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:361: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind table, not memory
   0000021: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:361: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:365: assert_unlinkable passed:
   error: unknown host table import "spectest.print"
   000001e: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:393: assert_invalid passed:
-  error: unknown import module ""
-  0000010: error: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:397: assert_invalid passed:
   error: unknown import module ""
   0000010: error: OnImportMemory callback failed
 out/third_party/testsuite/imports.wast:401: assert_invalid passed:
+  error: unknown import module ""
+  0000010: error: OnImportMemory callback failed
+out/third_party/testsuite/imports.wast:405: assert_invalid passed:
   000000b: error: memory count must be 0 or 1
-out/third_party/testsuite/imports.wast:416: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:420: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001b: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:420: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:424: assert_unlinkable passed:
   error: unknown host memory import "spectest.unknown"
   000001f: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:425: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:429: assert_unlinkable passed:
   error: actual size (2) smaller than declared (3)
   0000020: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:429: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:433: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (3)
   0000021: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:433: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:437: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:437: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:441: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
   000001f: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:442: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:446: assert_unlinkable passed:
   error: expected import "test.func-i32" to have kind memory, not func
   000001c: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:446: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:450: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind memory, not global
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:450: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:454: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind memory, not table
   0000020: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:454: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:458: assert_unlinkable passed:
   error: unknown host memory import "spectest.print"
   000001d: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:458: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:462: assert_unlinkable passed:
   error: unknown host memory import "spectest.global"
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:462: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:466: assert_unlinkable passed:
   error: unknown host memory import "spectest.table"
   000001d: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:467: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:471: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:471: assert_unlinkable passed:
+out/third_party/testsuite/imports.wast:475: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
   000001f: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:489: assert_malformed passed:
+out/third_party/testsuite/imports.wast:493: assert_malformed passed:
   out/third_party/testsuite/imports/imports.99.wast:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (func))
           ^^^^^^
-out/third_party/testsuite/imports.wast:493: assert_malformed passed:
+out/third_party/testsuite/imports.wast:497: assert_malformed passed:
   out/third_party/testsuite/imports/imports.100.wast:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (global i64))
           ^^^^^^
-out/third_party/testsuite/imports.wast:497: assert_malformed passed:
+out/third_party/testsuite/imports.wast:501: assert_malformed passed:
   out/third_party/testsuite/imports/imports.101.wast:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (table 0 anyfunc))
           ^^^^^^
-out/third_party/testsuite/imports.wast:501: assert_malformed passed:
+out/third_party/testsuite/imports.wast:505: assert_malformed passed:
   out/third_party/testsuite/imports/imports.102.wast:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (memory 0))
           ^^^^^^
-out/third_party/testsuite/imports.wast:506: assert_malformed passed:
+out/third_party/testsuite/imports.wast:510: assert_malformed passed:
   out/third_party/testsuite/imports/imports.103.wast:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (func))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:510: assert_malformed passed:
+out/third_party/testsuite/imports.wast:514: assert_malformed passed:
   out/third_party/testsuite/imports/imports.104.wast:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (global f32))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:514: assert_malformed passed:
+out/third_party/testsuite/imports.wast:518: assert_malformed passed:
   out/third_party/testsuite/imports/imports.105.wast:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (table 0 anyfunc))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:518: assert_malformed passed:
+out/third_party/testsuite/imports.wast:522: assert_malformed passed:
   out/third_party/testsuite/imports/imports.106.wast:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (memory 0))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:523: assert_malformed passed:
+out/third_party/testsuite/imports.wast:527: assert_malformed passed:
   out/third_party/testsuite/imports/imports.107.wast:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (func))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:527: assert_malformed passed:
+out/third_party/testsuite/imports.wast:531: assert_malformed passed:
   out/third_party/testsuite/imports/imports.108.wast:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (global i32))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:531: assert_malformed passed:
+out/third_party/testsuite/imports.wast:535: assert_malformed passed:
   out/third_party/testsuite/imports/imports.109.wast:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (table 0 anyfunc))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:535: assert_malformed passed:
+out/third_party/testsuite/imports.wast:539: assert_malformed passed:
   out/third_party/testsuite/imports/imports.110.wast:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (memory 0))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:540: assert_malformed passed:
+out/third_party/testsuite/imports.wast:544: assert_malformed passed:
   out/third_party/testsuite/imports/imports.111.wast:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (func))
               ^^^^^^
-out/third_party/testsuite/imports.wast:544: assert_malformed passed:
+out/third_party/testsuite/imports.wast:548: assert_malformed passed:
   out/third_party/testsuite/imports/imports.112.wast:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (global i32))
               ^^^^^^
-out/third_party/testsuite/imports.wast:548: assert_malformed passed:
+out/third_party/testsuite/imports.wast:552: assert_malformed passed:
   out/third_party/testsuite/imports/imports.113.wast:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (table 1 3 anyfunc))
               ^^^^^^
-out/third_party/testsuite/imports.wast:552: assert_malformed passed:
+out/third_party/testsuite/imports.wast:556: assert_malformed passed:
   out/third_party/testsuite/imports/imports.114.wast:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (memory 1 2))
               ^^^^^^

--- a/test/spec/return.txt
+++ b/test/spec/return.txt
@@ -1,13 +1,13 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/return.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/return.wast:276: assert_invalid passed:
+out/third_party/testsuite/return.wast:284: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got []
   0000019: error: OnReturnExpr callback failed
-out/third_party/testsuite/return.wast:280: assert_invalid passed:
+out/third_party/testsuite/return.wast:288: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got []
   000001a: error: OnReturnExpr callback failed
-out/third_party/testsuite/return.wast:284: assert_invalid passed:
+out/third_party/testsuite/return.wast:292: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got [i64]
   000001b: error: OnReturnExpr callback failed
 60/60 tests passed.

--- a/test/typecheck/bad-call-result-mismatch.txt
+++ b/test/typecheck/bad-call-result-mismatch.txt
@@ -18,7 +18,7 @@
     end
     if
       i32.const 0
-      call_indirect $indirect
+      call_indirect (type $indirect)
     else
       nop
     end))
@@ -39,6 +39,6 @@ out/test/typecheck/bad-call-result-mismatch.txt:19:5: error: type mismatch in if
     if
     ^^
 out/test/typecheck/bad-call-result-mismatch.txt:21:7: error: type mismatch in if true branch, expected [] but got [i64]
-      call_indirect $indirect
+      call_indirect (type $indirect)
       ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callindirect-func-type-mismatch.txt
+++ b/test/typecheck/bad-callindirect-func-type-mismatch.txt
@@ -4,9 +4,9 @@
   (type $t (func))
   (func 
     f32.const 0
-    call_indirect $t))
+    call_indirect (type $t)))
 (;; STDERR ;;;
 out/test/typecheck/bad-callindirect-func-type-mismatch.txt:7:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
-    call_indirect $t))
+    call_indirect (type $t)))
     ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callindirect-type-mismatch.txt
+++ b/test/typecheck/bad-callindirect-type-mismatch.txt
@@ -6,10 +6,10 @@
   (func
     f32.const 0
     i32.const 0
-    call_indirect $t
+    call_indirect (type $t)
     drop))
 (;; STDERR ;;;
 out/test/typecheck/bad-callindirect-type-mismatch.txt:9:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
-    call_indirect $t
+    call_indirect (type $t)
     ^^^^^^^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
The `call_indirect` instruction now allows the type to be specified
inline or via the common "type use" syntax (or both):

```
call_indirect (type $t1) ...
call_indirect (param i32 f32) (result f64) ...
call_indirect (type $t2) (param i32) ...
```

This means that `CallIndirectExpr` changes from storing a `Var` (the
referenced func type) to a `FuncDeclaration`, which can store both a
type use and a function signature. Most of the changes here are fallout
from that change.

The other major change is that function signature resolution and error
checking now needs to iterate over a functions expr list looking for
`call_indirect` instructions. I'm not sure if this is a significant
overhead in parsing/validation yet, but there are plenty of ways to
optimize it if it ends up in profiles.