### PR TITLE
Fix error message w/ inconsistent br_table labels

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -358,7 +358,11 @@ Result TypeChecker::OnBrTableTarget(Index depth) {
 
   // Make sure this label's signature is consistent with the previous labels'
   // signatures.
-  result |= CheckType(br_table_sig_, label_sig);
+  if (Failed(CheckType(br_table_sig_, label_sig))) {
+    result |= Result::Error;
+    PrintError("br_table labels have inconsistent types: expected %s, got %s",
+               GetTypeName(br_table_sig_), GetTypeName(label_sig));
+  }
   br_table_sig_ = label_sig;
 
   return result;

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -11,6 +11,7 @@ out/third_party/testsuite/br_table.wast:1426: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1434: assert_invalid passed:
+  error: br_table labels have inconsistent types: expected f32, got void
   0000026: error: OnBrTableExpr callback failed
 out/third_party/testsuite/br_table.wast:1446: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -262,8 +262,10 @@ out/third_party/testsuite/unreached-invalid.wast:521: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
   0000025: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:527: assert_invalid passed:
+  error: br_table labels have inconsistent types: expected f32, got void
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:539: assert_invalid passed:
+  error: br_table labels have inconsistent types: expected f32, got f64
   0000023: error: OnBrTableExpr callback failed
 out/third_party/testsuite/unreached-invalid.wast:554: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]


### PR DESCRIPTION
When I refactored the type-checker to produce nicer error messages, I
forgot to handle this error:

```
(block
  (block (result f32)
    i32.const 0
    br_table 0 1 ...
```

The label signatures are inconsistent, which is invalid. The
type-checker was returning the proper result (error) but wasn't printing
an error message.

Fixes #670.