### PR TITLE
Rename {wake,wait} -> atomic.{wake,wait}

### DIFF
--- a/src/binary-reader-interp.cc
+++ b/src/binary-reader-interp.cc
@@ -148,6 +148,12 @@ class BinaryReaderInterp : public BinaryReaderNop {
   wabt::Result OnAtomicRmwCmpxchgExpr(Opcode opcode,
                                       uint32_t alignment_log2,
                                       Address offset) override;
+  wabt::Result OnAtomicWaitExpr(Opcode opcode,
+                                uint32_t alignment_log2,
+                                Address offset) override;
+  wabt::Result OnAtomicWakeExpr(Opcode opcode,
+                                uint32_t alignment_log2,
+                                Address offset) override;
   wabt::Result OnBinaryExpr(wabt::Opcode opcode) override;
   wabt::Result OnBlockExpr(Index num_types, Type* sig_types) override;
   wabt::Result OnBrExpr(Index depth) override;
@@ -186,12 +192,6 @@ class BinaryReaderInterp : public BinaryReaderNop {
   wabt::Result OnTeeLocalExpr(Index local_index) override;
   wabt::Result OnUnaryExpr(wabt::Opcode opcode) override;
   wabt::Result OnUnreachableExpr() override;
-  wabt::Result OnWaitExpr(Opcode opcode,
-                          uint32_t alignment_log2,
-                          Address offset) override;
-  wabt::Result OnWakeExpr(Opcode opcode,
-                          uint32_t alignment_log2,
-                          Address offset) override;
   wabt::Result EndFunctionBody(Index index) override;
 
   wabt::Result EndElemSegmentInitExpr(Index index) override;
@@ -1486,24 +1486,24 @@ wabt::Result BinaryReaderInterp::OnUnreachableExpr() {
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterp::OnWaitExpr(Opcode opcode,
-                                            uint32_t alignment_log2,
-                                            Address offset) {
+wabt::Result BinaryReaderInterp::OnAtomicWaitExpr(Opcode opcode,
+                                                  uint32_t alignment_log2,
+                                                  Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
-  CHECK_RESULT(typechecker_.OnWait(opcode));
+  CHECK_RESULT(typechecker_.OnAtomicWait(opcode));
   CHECK_RESULT(EmitOpcode(opcode));
   CHECK_RESULT(EmitI32(module_->memory_index));
   CHECK_RESULT(EmitI32(offset));
   return wabt::Result::Ok;
 }
 
-wabt::Result BinaryReaderInterp::OnWakeExpr(Opcode opcode,
-                                            uint32_t alignment_log2,
-                                            Address offset) {
+wabt::Result BinaryReaderInterp::OnAtomicWakeExpr(Opcode opcode,
+                                                  uint32_t alignment_log2,
+                                                  Address offset) {
   CHECK_RESULT(CheckHasMemory(opcode));
   CHECK_RESULT(CheckAtomicAlign(alignment_log2, opcode.GetMemorySize()));
-  CHECK_RESULT(typechecker_.OnWake(opcode));
+  CHECK_RESULT(typechecker_.OnAtomicWake(opcode));
   CHECK_RESULT(EmitOpcode(opcode));
   CHECK_RESULT(EmitI32(module_->memory_index));
   CHECK_RESULT(EmitI32(offset));

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -128,6 +128,12 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnAtomicRmwCmpxchgExpr(Opcode opcode,
                                 uint32_t alignment_log2,
                                 Address offset) override;
+  wabt::Result OnAtomicWaitExpr(Opcode opcode,
+                                uint32_t alignment_log2,
+                                Address offset) override;
+  wabt::Result OnAtomicWakeExpr(Opcode opcode,
+                                uint32_t alignment_log2,
+                                Address offset) override;
   Result OnBinaryExpr(Opcode opcode) override;
   Result OnBlockExpr(Index num_types, Type* sig_types) override;
   Result OnBrExpr(Index depth) override;
@@ -171,12 +177,6 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnTryExpr(Index num_types, Type* sig_types) override;
   Result OnUnaryExpr(Opcode opcode) override;
   Result OnUnreachableExpr() override;
-  wabt::Result OnWaitExpr(Opcode opcode,
-                          uint32_t alignment_log2,
-                          Address offset) override;
-  wabt::Result OnWakeExpr(Opcode opcode,
-                          uint32_t alignment_log2,
-                          Address offset) override;
   Result EndFunctionBody(Index index) override;
 
   Result OnElemSegmentCount(Index count) override;
@@ -555,6 +555,20 @@ Result BinaryReaderIR::OnAtomicRmwCmpxchgExpr(Opcode opcode,
       MakeUnique<AtomicRmwCmpxchgExpr>(opcode, 1 << alignment_log2, offset));
 }
 
+wabt::Result BinaryReaderIR::OnAtomicWaitExpr(Opcode opcode,
+                                              uint32_t alignment_log2,
+                                              Address offset) {
+  return AppendExpr(
+      MakeUnique<AtomicWaitExpr>(opcode, 1 << alignment_log2, offset));
+}
+
+wabt::Result BinaryReaderIR::OnAtomicWakeExpr(Opcode opcode,
+                                              uint32_t alignment_log2,
+                                              Address offset) {
+  return AppendExpr(
+      MakeUnique<AtomicWakeExpr>(opcode, 1 << alignment_log2, offset));
+}
+
 Result BinaryReaderIR::OnBinaryExpr(Opcode opcode) {
   return AppendExpr(MakeUnique<BinaryExpr>(opcode, GetLocation()));
 }
@@ -772,18 +786,6 @@ Result BinaryReaderIR::OnUnaryExpr(Opcode opcode) {
 
 Result BinaryReaderIR::OnUnreachableExpr() {
   return AppendExpr(MakeUnique<UnreachableExpr>());
-}
-
-wabt::Result BinaryReaderIR::OnWaitExpr(Opcode opcode,
-                                        uint32_t alignment_log2,
-                                        Address offset) {
-  return AppendExpr(MakeUnique<WaitExpr>(opcode, 1 << alignment_log2, offset));
-}
-
-wabt::Result BinaryReaderIR::OnWakeExpr(Opcode opcode,
-                                        uint32_t alignment_log2,
-                                        Address offset) {
-  return AppendExpr(MakeUnique<WakeExpr>(opcode, 1 << alignment_log2, offset));
 }
 
 Result BinaryReaderIR::EndFunctionBody(Index index) {

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -550,6 +550,8 @@ DEFINE_LOAD_STORE_OPCODE(OnAtomicLoadExpr);
 DEFINE_LOAD_STORE_OPCODE(OnAtomicRmwExpr);
 DEFINE_LOAD_STORE_OPCODE(OnAtomicRmwCmpxchgExpr);
 DEFINE_LOAD_STORE_OPCODE(OnAtomicStoreExpr);
+DEFINE_LOAD_STORE_OPCODE(OnAtomicWaitExpr);
+DEFINE_LOAD_STORE_OPCODE(OnAtomicWakeExpr);
 DEFINE_OPCODE(OnBinaryExpr)
 DEFINE_INDEX_DESC(OnCallExpr, "func_index")
 DEFINE_INDEX_DESC(OnCallIndirectExpr, "sig_index")
@@ -576,8 +578,6 @@ DEFINE_INDEX_DESC(OnTeeLocalExpr, "index")
 DEFINE_INDEX_DESC(OnThrowExpr, "except_index")
 DEFINE0(OnUnreachableExpr)
 DEFINE_OPCODE(OnUnaryExpr)
-DEFINE_LOAD_STORE_OPCODE(OnWaitExpr);
-DEFINE_LOAD_STORE_OPCODE(OnWakeExpr);
 DEFINE_END(EndCodeSection)
 
 DEFINE_BEGIN(BeginElemSection)

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -189,12 +189,12 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnTryExpr(Index num_types, Type* sig_types) override;
   Result OnUnaryExpr(Opcode opcode) override;
   Result OnUnreachableExpr() override;
-  Result OnWaitExpr(Opcode opcode,
-                    uint32_t alignment_log2,
-                    Address offset) override;
-  Result OnWakeExpr(Opcode opcode,
-                    uint32_t alignment_log2,
-                    Address offset) override;
+  Result OnAtomicWaitExpr(Opcode opcode,
+                          uint32_t alignment_log2,
+                          Address offset) override;
+  Result OnAtomicWakeExpr(Opcode opcode,
+                          uint32_t alignment_log2,
+                          Address offset) override;
   Result EndFunctionBody(Index index) override;
   Result EndCodeSection() override;
 

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -195,6 +195,12 @@ class BinaryReaderNop : public BinaryReaderDelegate {
                                 Address offset) override {
     return Result::Ok;
   }
+  Result OnAtomicWaitExpr(Opcode, uint32_t, Address) override {
+    return Result::Ok;
+  }
+  Result OnAtomicWakeExpr(Opcode, uint32_t, Address) override {
+    return Result::Ok;
+  }
   Result OnBinaryExpr(Opcode opcode) override { return Result::Ok; }
   Result OnBlockExpr(Index num_types, Type* sig_types) override {
     return Result::Ok;
@@ -253,8 +259,6 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   }
   Result OnUnaryExpr(Opcode opcode) override { return Result::Ok; }
   Result OnUnreachableExpr() override { return Result::Ok; }
-  Result OnWaitExpr(Opcode, uint32_t, Address) override { return Result::Ok; }
-  Result OnWakeExpr(Opcode, uint32_t, Address) override { return Result::Ok; }
   Result EndFunctionBody(Index index) override { return Result::Ok; }
   Result EndCodeSection() override { return Result::Ok; }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -959,25 +959,25 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         CALLBACK0(OnOpcodeBare);
         break;
 
-      case Opcode::Wake: {
+      case Opcode::AtomicWake: {
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
         CHECK_RESULT(ReadU32Leb128(&offset, "load offset"));
 
-        CALLBACK(OnWakeExpr, opcode, alignment_log2, offset);
+        CALLBACK(OnAtomicWakeExpr, opcode, alignment_log2, offset);
         CALLBACK(OnOpcodeUint32Uint32, alignment_log2, offset);
         break;
       }
 
-      case Opcode::I32Wait:
-      case Opcode::I64Wait: {
+      case Opcode::I32AtomicWait:
+      case Opcode::I64AtomicWait: {
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
         CHECK_RESULT(ReadU32Leb128(&offset, "load offset"));
 
-        CALLBACK(OnWaitExpr, opcode, alignment_log2, offset);
+        CALLBACK(OnAtomicWaitExpr, opcode, alignment_log2, offset);
         CALLBACK(OnOpcodeUint32Uint32, alignment_log2, offset);
         break;
       }

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -191,6 +191,12 @@ class BinaryReaderDelegate {
   virtual Result OnAtomicRmwCmpxchgExpr(Opcode opcode,
                                         uint32_t alignment_log2,
                                         Address offset) = 0;
+  virtual Result OnAtomicWaitExpr(Opcode opcode,
+                                  uint32_t alignment_log2,
+                                  Address offset) = 0;
+  virtual Result OnAtomicWakeExpr(Opcode opcode,
+                                  uint32_t alignment_log2,
+                                  Address offset) = 0;
   virtual Result OnBinaryExpr(Opcode opcode) = 0;
   virtual Result OnBlockExpr(Index num_types, Type* sig_types) = 0;
   virtual Result OnBrExpr(Index depth) = 0;
@@ -236,12 +242,6 @@ class BinaryReaderDelegate {
 
   virtual Result OnUnaryExpr(Opcode opcode) = 0;
   virtual Result OnUnreachableExpr() = 0;
-  virtual Result OnWaitExpr(Opcode opcode,
-                            uint32_t alignment_log2,
-                            Address offset) = 0;
-  virtual Result OnWakeExpr(Opcode opcode,
-                            uint32_t alignment_log2,
-                            Address offset) = 0;
   virtual Result EndFunctionBody(Index index) = 0;
   virtual Result EndCodeSection() = 0;
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -359,6 +359,12 @@ void BinaryWriter::WriteExpr(const Module* module,
     case ExprType::AtomicStore:
       WriteLoadStoreExpr<AtomicStoreExpr>(module, func, expr, "memory offset");
       break;
+    case ExprType::AtomicWait:
+      WriteLoadStoreExpr<AtomicWaitExpr>(module, func, expr, "memory offset");
+      break;
+    case ExprType::AtomicWake:
+      WriteLoadStoreExpr<AtomicWakeExpr>(module, func, expr, "memory offset");
+      break;
     case ExprType::Binary:
       WriteOpcode(stream_, cast<BinaryExpr>(expr)->opcode);
       break;
@@ -544,12 +550,6 @@ void BinaryWriter::WriteExpr(const Module* module,
       break;
     case ExprType::Unreachable:
       WriteOpcode(stream_, Opcode::Unreachable);
-      break;
-    case ExprType::Wait:
-      WriteLoadStoreExpr<WaitExpr>(module, func, expr, "memory offset");
-      break;
-    case ExprType::Wake:
-      WriteLoadStoreExpr<WakeExpr>(module, func, expr, "memory offset");
       break;
   }
 }

--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -42,6 +42,14 @@ Result ExprVisitor::VisitExpr(Expr* expr) {
           delegate_->OnAtomicRmwCmpxchgExpr(cast<AtomicRmwCmpxchgExpr>(expr)));
       break;
 
+    case ExprType::AtomicWait:
+      CHECK_RESULT(delegate_->OnAtomicWaitExpr(cast<AtomicWaitExpr>(expr)));
+      break;
+
+    case ExprType::AtomicWake:
+      CHECK_RESULT(delegate_->OnAtomicWakeExpr(cast<AtomicWakeExpr>(expr)));
+      break;
+
     case ExprType::Binary:
       CHECK_RESULT(delegate_->OnBinaryExpr(cast<BinaryExpr>(expr)));
       break;
@@ -183,14 +191,6 @@ Result ExprVisitor::VisitExpr(Expr* expr) {
 
     case ExprType::Unreachable:
       CHECK_RESULT(delegate_->OnUnreachableExpr(cast<UnreachableExpr>(expr)));
-      break;
-
-    case ExprType::Wait:
-      CHECK_RESULT(delegate_->OnWaitExpr(cast<WaitExpr>(expr)));
-      break;
-
-    case ExprType::Wake:
-      CHECK_RESULT(delegate_->OnWakeExpr(cast<WakeExpr>(expr)));
       break;
   }
 

--- a/src/expr-visitor.h
+++ b/src/expr-visitor.h
@@ -77,8 +77,8 @@ class ExprVisitor::Delegate {
   virtual Result OnCatchExpr(TryExpr*, Catch*) = 0;
   virtual Result OnThrowExpr(ThrowExpr*) = 0;
   virtual Result OnRethrowExpr(RethrowExpr*) = 0;
-  virtual Result OnWaitExpr(WaitExpr*) = 0;
-  virtual Result OnWakeExpr(WakeExpr*) = 0;
+  virtual Result OnAtomicWaitExpr(AtomicWaitExpr*) = 0;
+  virtual Result OnAtomicWakeExpr(AtomicWakeExpr*) = 0;
   virtual Result OnAtomicLoadExpr(AtomicLoadExpr*) = 0;
   virtual Result OnAtomicStoreExpr(AtomicStoreExpr*) = 0;
   virtual Result OnAtomicRmwExpr(AtomicRmwExpr*) = 0;
@@ -123,8 +123,8 @@ class ExprVisitor::DelegateNop : public ExprVisitor::Delegate {
   Result OnCatchExpr(TryExpr*, Catch*) override { return Result::Ok; }
   Result OnThrowExpr(ThrowExpr*) override { return Result::Ok; }
   Result OnRethrowExpr(RethrowExpr*) override { return Result::Ok; }
-  Result OnWaitExpr(WaitExpr*) override { return Result::Ok; }
-  Result OnWakeExpr(WakeExpr*) override { return Result::Ok; }
+  Result OnAtomicWaitExpr(AtomicWaitExpr*) override { return Result::Ok; }
+  Result OnAtomicWakeExpr(AtomicWakeExpr*) override { return Result::Ok; }
   Result OnAtomicLoadExpr(AtomicLoadExpr*) override { return Result::Ok; }
   Result OnAtomicStoreExpr(AtomicStoreExpr*) override { return Result::Ok; }
   Result OnAtomicRmwExpr(AtomicRmwExpr*) override { return Result::Ok; }

--- a/src/interp.cc
+++ b/src/interp.cc
@@ -2180,9 +2180,9 @@ Result Thread::Run(int num_instructions) {
       case Opcode::Nop:
         break;
 
-      case Opcode::I32Wait:
-      case Opcode::I64Wait:
-      case Opcode::Wake:
+      case Opcode::I32AtomicWait:
+      case Opcode::I64AtomicWait:
+      case Opcode::AtomicWake:
         // TODO(binji): Implement.
         TRAP(Unreachable);
         break;
@@ -2329,7 +2329,7 @@ void Thread::Trace(Stream* stream) {
       break;
     }
 
-    case Opcode::Wake:
+    case Opcode::AtomicWake:
     case Opcode::I32AtomicStore:
     case Opcode::I32AtomicStore8:
     case Opcode::I32AtomicStore16:
@@ -2409,7 +2409,7 @@ void Thread::Trace(Stream* stream) {
       break;
     }
 
-    case Opcode::I32Wait: {
+    case Opcode::I32AtomicWait: {
       Index memory_index = ReadU32(&pc);
       stream->Writef("%s $%" PRIindex ":%u+$%u, %u, %" PRIu64 "\n",
                      opcode.GetName(), memory_index, Pick(3).i32, ReadU32At(pc),
@@ -2417,7 +2417,7 @@ void Thread::Trace(Stream* stream) {
       break;
     }
 
-    case Opcode::I64Wait:
+    case Opcode::I64AtomicWait:
     case Opcode::I64AtomicRmwCmpxchg:
     case Opcode::I64AtomicRmw8UCmpxchg:
     case Opcode::I64AtomicRmw16UCmpxchg:
@@ -2782,7 +2782,7 @@ void Environment::Disassemble(Stream* stream,
         break;
       }
 
-      case Opcode::Wake:
+      case Opcode::AtomicWake:
       case Opcode::I32AtomicStore:
       case Opcode::I64AtomicStore:
       case Opcode::I32AtomicStore8:
@@ -2847,8 +2847,8 @@ void Environment::Disassemble(Stream* stream,
         break;
       }
 
-      case Opcode::I32Wait:
-      case Opcode::I64Wait:
+      case Opcode::I32AtomicWait:
+      case Opcode::I64AtomicWait:
       case Opcode::I32AtomicRmwCmpxchg:
       case Opcode::I64AtomicRmwCmpxchg:
       case Opcode::I32AtomicRmw8UCmpxchg:

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -24,6 +24,12 @@
 namespace {
 
 const char* ExprTypeName[] = {
+  "AtomicLoad",
+  "AtomicRmw",
+  "AtomicRmwCmpxchg",
+  "AtomicStore",
+  "AtomicWait",
+  "AtomicWake",
   "Binary",
   "Block",
   "Br",
@@ -54,8 +60,6 @@ const char* ExprTypeName[] = {
   "TryBlock",
   "Unary",
   "Unreachable",
-  "Wait",
-  "Wake"
 };
 
 }  // end of anonymous namespace

--- a/src/ir.h
+++ b/src/ir.h
@@ -151,9 +151,11 @@ struct FuncDeclaration {
 
 enum class ExprType {
   AtomicLoad,
-  AtomicStore,
   AtomicRmw,
   AtomicRmwCmpxchg,
+  AtomicStore,
+  AtomicWait,
+  AtomicWake,
   Binary,
   Block,
   Br,
@@ -184,11 +186,9 @@ enum class ExprType {
   TryBlock,
   Unary,
   Unreachable,
-  Wait,
-  Wake,
 
-  First = Binary,
-  Last = Wake
+  First = AtomicLoad,
+  Last = Unreachable
 };
 
 const char* GetExprTypeName(ExprType type);
@@ -369,8 +369,8 @@ typedef LoadStoreExpr<ExprType::AtomicLoad> AtomicLoadExpr;
 typedef LoadStoreExpr<ExprType::AtomicStore> AtomicStoreExpr;
 typedef LoadStoreExpr<ExprType::AtomicRmw> AtomicRmwExpr;
 typedef LoadStoreExpr<ExprType::AtomicRmwCmpxchg> AtomicRmwCmpxchgExpr;
-typedef LoadStoreExpr<ExprType::Wait> WaitExpr;
-typedef LoadStoreExpr<ExprType::Wake> WakeExpr;
+typedef LoadStoreExpr<ExprType::AtomicWait> AtomicWaitExpr;
+typedef LoadStoreExpr<ExprType::AtomicWake> AtomicWakeExpr;
 
 struct Exception {
   Exception() = default;

--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -111,9 +111,9 @@ bool Opcode::IsEnabled(const Features& features) const {
     case Opcode::I64Extend8S:
     case Opcode::I64Extend16S:
     case Opcode::I64Extend32S:
-    case Opcode::Wake:
-    case Opcode::I32Wait:
-    case Opcode::I64Wait:
+    case Opcode::AtomicWake:
+    case Opcode::I32AtomicWait:
+    case Opcode::I64AtomicWait:
     case Opcode::I32AtomicLoad:
     case Opcode::I64AtomicLoad:
     case Opcode::I32AtomicLoad8U:

--- a/src/opcode.def
+++ b/src/opcode.def
@@ -234,9 +234,9 @@ WABT_OPCODE(I64, F32, ___, ___, 0, 0xfc,  0x05, I64TruncUSatF32, "i64.trunc_u:sa
 WABT_OPCODE(I64, F64, ___, ___, 0, 0xfc,  0x06, I64TruncSSatF64, "i64.trunc_s:sat/f64")
 WABT_OPCODE(I64, F64, ___, ___, 0, 0xfc,  0x07, I64TruncUSatF64, "i64.trunc_u:sat/f64")
 
-WABT_OPCODE(I32, I32, I32, ___, 4, 0xfe,  0x00, Wake, "wake")
-WABT_OPCODE(I32, I32, I32, I64, 4, 0xfe,  0x01, I32Wait, "i32.wait")
-WABT_OPCODE(I32, I32, I64, I64, 8, 0xfe,  0x02, I64Wait, "i64.wait")
+WABT_OPCODE(I32, I32, I32, ___, 4, 0xfe,  0x00, AtomicWake, "atomic.wake")
+WABT_OPCODE(I32, I32, I32, I64, 4, 0xfe,  0x01, I32AtomicWait, "i32.atomic.wait")
+WABT_OPCODE(I32, I32, I64, I64, 8, 0xfe,  0x02, I64AtomicWait, "i64.atomic.wait")
 WABT_OPCODE(I32, I32, ___, ___, 4, 0xfe,  0x10, I32AtomicLoad, "i32.atomic.load")
 WABT_OPCODE(I64, I32, ___, ___, 8, 0xfe,  0x11, I64AtomicLoad, "i64.atomic.load")
 WABT_OPCODE(I32, I32, ___, ___, 1, 0xfe,  0x12, I32AtomicLoad8U, "i32.atomic.load8_u")

--- a/src/prebuilt/wast-lexer-gen.cc
+++ b/src/prebuilt/wast-lexer-gen.cc
@@ -743,8 +743,8 @@ YYCOND_i:
 		if (yybm[0+yych] & 4) {
 			goto yy81;
 		}
-		if (yych <= 'f') {
-			if (yych <= ',') {
+		if (yych <= 'e') {
+			if (yych <= '+') {
 				if (yych <= '#') {
 					if (yych <= 0x1F) {
 						if (yych <= 0x08) goto yy79;
@@ -760,78 +760,76 @@ YYCOND_i:
 						goto yy92;
 					} else {
 						if (yych <= ')') goto yy94;
-						if (yych == '+') goto yy96;
-						goto yy86;
+						if (yych <= '*') goto yy86;
+						goto yy96;
 					}
 				}
 			} else {
-				if (yych <= ';') {
-					if (yych <= '0') {
-						if (yych <= '-') goto yy96;
-						if (yych <= '/') goto yy86;
-						goto yy97;
+				if (yych <= ':') {
+					if (yych <= '/') {
+						if (yych == '-') goto yy96;
+						goto yy86;
 					} else {
+						if (yych <= '0') goto yy97;
 						if (yych <= '9') goto yy99;
-						if (yych <= ':') goto yy86;
-						goto yy101;
+						goto yy86;
 					}
 				} else {
-					if (yych <= 'b') {
+					if (yych <= 'a') {
+						if (yych <= ';') goto yy101;
 						if (yych <= '`') goto yy86;
-						if (yych <= 'a') goto yy102;
-						goto yy103;
+						goto yy102;
 					} else {
+						if (yych <= 'b') goto yy103;
 						if (yych <= 'c') goto yy104;
 						if (yych <= 'd') goto yy105;
-						if (yych <= 'e') goto yy106;
-						goto yy107;
+						goto yy106;
 					}
 				}
 			}
 		} else {
-			if (yych <= 't') {
-				if (yych <= 'm') {
-					if (yych <= 'i') {
+			if (yych <= 'r') {
+				if (yych <= 'l') {
+					if (yych <= 'h') {
+						if (yych <= 'f') goto yy107;
 						if (yych <= 'g') goto yy108;
-						if (yych <= 'h') goto yy86;
-						goto yy109;
+						goto yy86;
 					} else {
+						if (yych <= 'i') goto yy109;
 						if (yych <= 'k') goto yy86;
-						if (yych <= 'l') goto yy110;
-						goto yy111;
+						goto yy110;
 					}
 				} else {
-					if (yych <= 'p') {
+					if (yych <= 'o') {
+						if (yych <= 'm') goto yy111;
 						if (yych <= 'n') goto yy112;
-						if (yych <= 'o') goto yy113;
-						goto yy114;
+						goto yy113;
 					} else {
+						if (yych <= 'p') goto yy114;
 						if (yych <= 'q') goto yy115;
-						if (yych <= 'r') goto yy116;
-						if (yych <= 's') goto yy117;
-						goto yy118;
+						goto yy116;
 					}
 				}
 			} else {
 				if (yych <= 0xC1) {
-					if (yych <= 'w') {
-						if (yych <= 'u') goto yy119;
-						if (yych <= 'v') goto yy86;
-						goto yy120;
+					if (yych <= 'u') {
+						if (yych <= 's') goto yy117;
+						if (yych <= 't') goto yy118;
+						goto yy119;
 					} else {
 						if (yych <= '~') goto yy86;
-						if (yych >= 0x80) goto yy121;
+						if (yych >= 0x80) goto yy120;
 					}
 				} else {
 					if (yych <= 0xEF) {
-						if (yych <= 0xDF) goto yy123;
-						if (yych <= 0xE0) goto yy124;
-						goto yy125;
+						if (yych <= 0xDF) goto yy122;
+						if (yych <= 0xE0) goto yy123;
+						goto yy124;
 					} else {
-						if (yych <= 0xF0) goto yy126;
-						if (yych <= 0xF3) goto yy127;
-						if (yych <= 0xF4) goto yy128;
-						goto yy121;
+						if (yych <= 0xF0) goto yy125;
+						if (yych <= 0xF3) goto yy126;
+						if (yych <= 0xF4) goto yy127;
+						goto yy120;
 					}
 				}
 			}
@@ -841,7 +839,7 @@ yy79:
 yy80:
 #line 564 "src/wast-lexer.cc"
 		{ ERROR("unexpected char"); continue; }
-#line 845 "src/prebuilt/wast-lexer-gen.cc"
+#line 843 "src/prebuilt/wast-lexer-gen.cc"
 yy81:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -851,12 +849,12 @@ yy81:
 		}
 #line 562 "src/wast-lexer.cc"
 		{ continue; }
-#line 855 "src/prebuilt/wast-lexer-gen.cc"
+#line 853 "src/prebuilt/wast-lexer-gen.cc"
 yy84:
 		++cursor_;
 #line 561 "src/wast-lexer.cc"
 		{ NEWLINE; continue; }
-#line 860 "src/prebuilt/wast-lexer-gen.cc"
+#line 858 "src/prebuilt/wast-lexer-gen.cc"
 yy86:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
@@ -868,56 +866,56 @@ yy87:
 yy88:
 #line 563 "src/wast-lexer.cc"
 		{ RETURN_TEXT(Reserved); }
-#line 872 "src/prebuilt/wast-lexer-gen.cc"
+#line 870 "src/prebuilt/wast-lexer-gen.cc"
 yy89:
 		yyaccept = 0;
 		yych = *(marker_ = ++cursor_);
 		if (yych <= 0x1F) goto yy90;
-		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0x7F) goto yy129;
 		if (yych <= 0xC1) goto yy90;
-		if (yych <= 0xF4) goto yy130;
+		if (yych <= 0xF4) goto yy129;
 yy90:
 		BEGIN(YYCOND_BAD_TEXT);
 #line 239 "src/wast-lexer.cc"
 		{ continue; }
-#line 884 "src/prebuilt/wast-lexer-gen.cc"
+#line 882 "src/prebuilt/wast-lexer-gen.cc"
 yy91:
 		yych = *++cursor_;
 		if (yych <= '\'') {
-			if (yych == '!') goto yy142;
+			if (yych == '!') goto yy141;
 			if (yych <= '"') goto yy88;
-			goto yy142;
+			goto yy141;
 		} else {
 			if (yych <= ':') {
 				if (yych <= ')') goto yy88;
-				goto yy142;
+				goto yy141;
 			} else {
 				if (yych <= ';') goto yy88;
-				if (yych <= '~') goto yy142;
+				if (yych <= '~') goto yy141;
 				goto yy88;
 			}
 		}
 yy92:
 		++cursor_;
-		if ((yych = *cursor_) == ';') goto yy144;
+		if ((yych = *cursor_) == ';') goto yy143;
 #line 230 "src/wast-lexer.cc"
 		{ RETURN(Lpar); }
-#line 906 "src/prebuilt/wast-lexer-gen.cc"
+#line 904 "src/prebuilt/wast-lexer-gen.cc"
 yy94:
 		++cursor_;
 #line 231 "src/wast-lexer.cc"
 		{ RETURN(Rpar); }
-#line 911 "src/prebuilt/wast-lexer-gen.cc"
+#line 909 "src/prebuilt/wast-lexer-gen.cc"
 yy96:
 		yych = *++cursor_;
 		if (yych <= 'h') {
 			if (yych <= '/') goto yy87;
-			if (yych <= '0') goto yy146;
-			if (yych <= '9') goto yy148;
+			if (yych <= '0') goto yy145;
+			if (yych <= '9') goto yy147;
 			goto yy87;
 		} else {
-			if (yych <= 'i') goto yy150;
-			if (yych == 'n') goto yy151;
+			if (yych <= 'i') goto yy149;
+			if (yych == 'n') goto yy150;
 			goto yy87;
 		}
 yy97:
@@ -933,7 +931,7 @@ yy97:
 				if (yych <= '-') {
 					if (yych >= '*') goto yy86;
 				} else {
-					if (yych <= '.') goto yy152;
+					if (yych <= '.') goto yy151;
 					if (yych <= ':') goto yy86;
 				}
 			}
@@ -941,17 +939,17 @@ yy97:
 			if (yych <= 'd') {
 				if (yych <= 'E') {
 					if (yych <= 'D') goto yy86;
-					goto yy154;
+					goto yy153;
 				} else {
-					if (yych == '_') goto yy155;
+					if (yych == '_') goto yy154;
 					goto yy86;
 				}
 			} else {
 				if (yych <= 'w') {
-					if (yych <= 'e') goto yy154;
+					if (yych <= 'e') goto yy153;
 					goto yy86;
 				} else {
-					if (yych <= 'x') goto yy156;
+					if (yych <= 'x') goto yy155;
 					if (yych <= '~') goto yy86;
 				}
 			}
@@ -959,7 +957,7 @@ yy97:
 yy98:
 #line 232 "src/wast-lexer.cc"
 		{ RETURN_LITERAL(Nat, Int); }
-#line 963 "src/prebuilt/wast-lexer-gen.cc"
+#line 961 "src/prebuilt/wast-lexer-gen.cc"
 yy99:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
@@ -974,20 +972,20 @@ yy99:
 				goto yy86;
 			} else {
 				if (yych <= ')') goto yy98;
-				if (yych == '.') goto yy152;
+				if (yych == '.') goto yy151;
 				goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
 				if (yych <= ';') goto yy98;
-				if (yych == 'E') goto yy154;
+				if (yych == 'E') goto yy153;
 				goto yy86;
 			} else {
 				if (yych <= 'd') {
-					if (yych <= '_') goto yy155;
+					if (yych <= '_') goto yy154;
 					goto yy86;
 				} else {
-					if (yych <= 'e') goto yy154;
+					if (yych <= 'e') goto yy153;
 					if (yych <= '~') goto yy86;
 					goto yy98;
 				}
@@ -995,16 +993,18 @@ yy99:
 		}
 yy101:
 		yych = *++cursor_;
-		if (yych == ';') goto yy157;
+		if (yych == ';') goto yy156;
 		goto yy80;
 yy102:
 		yych = *++cursor_;
-		if (yych <= 'm') {
-			if (yych == 'l') goto yy159;
-			goto yy87;
+		if (yych <= 'n') {
+			if (yych == 'l') goto yy158;
+			if (yych <= 'm') goto yy87;
+			goto yy159;
 		} else {
-			if (yych <= 'n') goto yy160;
-			if (yych == 's') goto yy161;
+			if (yych <= 'r') goto yy87;
+			if (yych <= 's') goto yy160;
+			if (yych <= 't') goto yy161;
 			goto yy87;
 		}
 yy103:
@@ -1137,207 +1137,203 @@ yy119:
 		if (yych == 'n') goto yy203;
 		goto yy87;
 yy120:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy204;
-		goto yy87;
-yy121:
 		++cursor_;
-yy122:
+yy121:
 #line 565 "src/wast-lexer.cc"
 		{ MAYBE_MALFORMED_UTF8(""); }
-#line 1149 "src/prebuilt/wast-lexer-gen.cc"
-yy123:
+#line 1145 "src/prebuilt/wast-lexer-gen.cc"
+yy122:
 		yych = *++cursor_;
-		if (yych <= 0x7F) goto yy122;
+		if (yych <= 0x7F) goto yy121;
 		if (yych <= 0xBF) goto yy79;
-		goto yy122;
+		goto yy121;
+yy123:
+		yyaccept = 1;
+		yych = *(marker_ = ++cursor_);
+		if (yych <= 0x9F) goto yy121;
+		if (yych <= 0xBF) goto yy204;
+		goto yy121;
 yy124:
 		yyaccept = 1;
 		yych = *(marker_ = ++cursor_);
-		if (yych <= 0x9F) goto yy122;
-		if (yych <= 0xBF) goto yy205;
-		goto yy122;
+		if (yych <= 0x7F) goto yy121;
+		if (yych <= 0xBF) goto yy204;
+		goto yy121;
 yy125:
 		yyaccept = 1;
 		yych = *(marker_ = ++cursor_);
-		if (yych <= 0x7F) goto yy122;
+		if (yych <= 0x8F) goto yy121;
 		if (yych <= 0xBF) goto yy205;
-		goto yy122;
+		goto yy121;
 yy126:
 		yyaccept = 1;
 		yych = *(marker_ = ++cursor_);
-		if (yych <= 0x8F) goto yy122;
-		if (yych <= 0xBF) goto yy206;
-		goto yy122;
+		if (yych <= 0x7F) goto yy121;
+		if (yych <= 0xBF) goto yy205;
+		goto yy121;
 yy127:
 		yyaccept = 1;
 		yych = *(marker_ = ++cursor_);
-		if (yych <= 0x7F) goto yy122;
-		if (yych <= 0xBF) goto yy206;
-		goto yy122;
+		if (yych <= 0x7F) goto yy121;
+		if (yych <= 0x8F) goto yy205;
+		goto yy121;
 yy128:
-		yyaccept = 1;
-		yych = *(marker_ = ++cursor_);
-		if (yych <= 0x7F) goto yy122;
-		if (yych <= 0x8F) goto yy206;
-		goto yy122;
-yy129:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-yy130:
+yy129:
 		if (yybm[0+yych] & 32) {
-			goto yy129;
+			goto yy128;
 		}
 		if (yych <= 0xDF) {
 			if (yych <= '"') {
-				if (yych >= ' ') goto yy132;
+				if (yych >= ' ') goto yy131;
 			} else {
-				if (yych <= '\\') goto yy134;
-				if (yych >= 0xC2) goto yy135;
+				if (yych <= '\\') goto yy133;
+				if (yych >= 0xC2) goto yy134;
 			}
 		} else {
 			if (yych <= 0xF0) {
-				if (yych <= 0xE0) goto yy136;
-				if (yych <= 0xEF) goto yy137;
-				goto yy138;
+				if (yych <= 0xE0) goto yy135;
+				if (yych <= 0xEF) goto yy136;
+				goto yy137;
 			} else {
-				if (yych <= 0xF3) goto yy139;
-				if (yych <= 0xF4) goto yy140;
+				if (yych <= 0xF3) goto yy138;
+				if (yych <= 0xF4) goto yy139;
 			}
 		}
-yy131:
+yy130:
 		cursor_ = marker_;
 		if (yyaccept == 0) {
 			goto yy90;
 		} else {
-			goto yy122;
+			goto yy121;
 		}
-yy132:
+yy131:
 		++cursor_;
 #line 238 "src/wast-lexer.cc"
 		{ RETURN_TEXT(Text); }
-#line 1221 "src/prebuilt/wast-lexer-gen.cc"
-yy134:
+#line 1217 "src/prebuilt/wast-lexer-gen.cc"
+yy133:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= '[') {
 			if (yych <= '\'') {
-				if (yych == '"') goto yy129;
-				if (yych <= '&') goto yy131;
-				goto yy129;
+				if (yych == '"') goto yy128;
+				if (yych <= '&') goto yy130;
+				goto yy128;
 			} else {
 				if (yych <= '9') {
-					if (yych <= '/') goto yy131;
-					goto yy207;
+					if (yych <= '/') goto yy130;
+					goto yy206;
 				} else {
-					if (yych <= '@') goto yy131;
-					if (yych <= 'F') goto yy207;
-					goto yy131;
+					if (yych <= '@') goto yy130;
+					if (yych <= 'F') goto yy206;
+					goto yy130;
 				}
 			}
 		} else {
 			if (yych <= 'n') {
 				if (yych <= '`') {
-					if (yych <= '\\') goto yy129;
-					goto yy131;
+					if (yych <= '\\') goto yy128;
+					goto yy130;
 				} else {
-					if (yych <= 'f') goto yy207;
-					if (yych <= 'm') goto yy131;
-					goto yy129;
+					if (yych <= 'f') goto yy206;
+					if (yych <= 'm') goto yy130;
+					goto yy128;
 				}
 			} else {
 				if (yych <= 'r') {
-					if (yych <= 'q') goto yy131;
-					goto yy129;
+					if (yych <= 'q') goto yy130;
+					goto yy128;
 				} else {
-					if (yych == 't') goto yy129;
-					goto yy131;
+					if (yych == 't') goto yy128;
+					goto yy130;
 				}
 			}
 		}
+yy134:
+		++cursor_;
+		if (limit_ <= cursor_) FILL(1);
+		yych = *cursor_;
+		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0xBF) goto yy128;
+		goto yy130;
 yy135:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-		if (yych <= 0x7F) goto yy131;
-		if (yych <= 0xBF) goto yy129;
-		goto yy131;
+		if (yych <= 0x9F) goto yy130;
+		if (yych <= 0xBF) goto yy134;
+		goto yy130;
 yy136:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-		if (yych <= 0x9F) goto yy131;
-		if (yych <= 0xBF) goto yy135;
-		goto yy131;
+		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0xBF) goto yy134;
+		goto yy130;
 yy137:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-		if (yych <= 0x7F) goto yy131;
-		if (yych <= 0xBF) goto yy135;
-		goto yy131;
+		if (yych <= 0x8F) goto yy130;
+		if (yych <= 0xBF) goto yy136;
+		goto yy130;
 yy138:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-		if (yych <= 0x8F) goto yy131;
-		if (yych <= 0xBF) goto yy137;
-		goto yy131;
+		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0xBF) goto yy136;
+		goto yy130;
 yy139:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-		if (yych <= 0x7F) goto yy131;
-		if (yych <= 0xBF) goto yy137;
-		goto yy131;
+		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0x8F) goto yy136;
+		goto yy130;
 yy140:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
-		if (yych <= 0x7F) goto yy131;
-		if (yych <= 0x8F) goto yy137;
-		goto yy131;
 yy141:
-		++cursor_;
-		if (limit_ <= cursor_) FILL(1);
-		yych = *cursor_;
-yy142:
 		if (yybm[0+yych] & 64) {
-			goto yy141;
+			goto yy140;
 		}
-		if (yych <= ')') goto yy143;
+		if (yych <= ')') goto yy142;
 		if (yych <= ',') goto yy86;
-		if (yych <= ';') goto yy143;
+		if (yych <= ';') goto yy142;
 		if (yych <= '}') goto yy86;
-yy143:
+yy142:
 #line 547 "src/wast-lexer.cc"
 		{ RETURN_TEXT(Var); }
-#line 1318 "src/prebuilt/wast-lexer-gen.cc"
-yy144:
+#line 1314 "src/prebuilt/wast-lexer-gen.cc"
+yy143:
 		++cursor_;
 		BEGIN(YYCOND_BLOCK_COMMENT);
 #line 553 "src/wast-lexer.cc"
 		{ COMMENT_NESTING = 1; continue; }
-#line 1324 "src/prebuilt/wast-lexer-gen.cc"
-yy146:
+#line 1320 "src/prebuilt/wast-lexer-gen.cc"
+yy145:
 		++cursor_;
 		if ((yych = *cursor_) <= ':') {
 			if (yych <= ')') {
 				if (yych <= '!') {
 					if (yych >= '!') goto yy86;
 				} else {
-					if (yych <= '"') goto yy147;
+					if (yych <= '"') goto yy146;
 					if (yych <= '\'') goto yy86;
 				}
 			} else {
 				if (yych <= '.') {
 					if (yych <= '-') goto yy86;
-					goto yy152;
+					goto yy151;
 				} else {
 					if (yych <= '/') goto yy86;
-					if (yych <= '9') goto yy148;
+					if (yych <= '9') goto yy147;
 					goto yy86;
 				}
 			}
@@ -1346,108 +1342,108 @@ yy146:
 				if (yych <= 'D') {
 					if (yych >= '<') goto yy86;
 				} else {
-					if (yych <= 'E') goto yy154;
+					if (yych <= 'E') goto yy153;
 					if (yych <= '^') goto yy86;
-					goto yy208;
+					goto yy207;
 				}
 			} else {
 				if (yych <= 'w') {
-					if (yych == 'e') goto yy154;
+					if (yych == 'e') goto yy153;
 					goto yy86;
 				} else {
-					if (yych <= 'x') goto yy209;
+					if (yych <= 'x') goto yy208;
 					if (yych <= '~') goto yy86;
 				}
 			}
 		}
-yy147:
+yy146:
 #line 233 "src/wast-lexer.cc"
 		{ RETURN_LITERAL(Int, Int); }
-#line 1367 "src/prebuilt/wast-lexer-gen.cc"
-yy148:
+#line 1363 "src/prebuilt/wast-lexer-gen.cc"
+yy147:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
 		yych = *cursor_;
 		if (yych <= '9') {
 			if (yych <= '\'') {
 				if (yych == '!') goto yy86;
-				if (yych <= '"') goto yy147;
+				if (yych <= '"') goto yy146;
 				goto yy86;
 			} else {
 				if (yych <= '-') {
-					if (yych <= ')') goto yy147;
+					if (yych <= ')') goto yy146;
 					goto yy86;
 				} else {
-					if (yych <= '.') goto yy152;
+					if (yych <= '.') goto yy151;
 					if (yych <= '/') goto yy86;
-					goto yy148;
+					goto yy147;
 				}
 			}
 		} else {
 			if (yych <= '^') {
 				if (yych <= ';') {
 					if (yych <= ':') goto yy86;
-					goto yy147;
+					goto yy146;
 				} else {
-					if (yych == 'E') goto yy154;
+					if (yych == 'E') goto yy153;
 					goto yy86;
 				}
 			} else {
 				if (yych <= 'd') {
-					if (yych <= '_') goto yy208;
+					if (yych <= '_') goto yy207;
 					goto yy86;
 				} else {
-					if (yych <= 'e') goto yy154;
+					if (yych <= 'e') goto yy153;
 					if (yych <= '~') goto yy86;
-					goto yy147;
+					goto yy146;
 				}
 			}
 		}
-yy150:
+yy149:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy210;
+		if (yych == 'n') goto yy209;
 		goto yy87;
-yy151:
+yy150:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy189;
 		goto yy87;
-yy152:
+yy151:
 		++cursor_;
 		if ((yych = *cursor_) <= '9') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy153;
+				if (yych <= ')') goto yy152;
 				if (yych <= '/') goto yy86;
-				goto yy211;
+				goto yy210;
 			}
 		} else {
 			if (yych <= 'E') {
-				if (yych == ';') goto yy153;
+				if (yych == ';') goto yy152;
 				if (yych <= 'D') goto yy86;
-				goto yy154;
+				goto yy153;
 			} else {
-				if (yych == 'e') goto yy154;
+				if (yych == 'e') goto yy153;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy153:
+yy152:
 #line 234 "src/wast-lexer.cc"
 		{ RETURN_LITERAL(Float, Float); }
-#line 1439 "src/prebuilt/wast-lexer-gen.cc"
-yy154:
+#line 1435 "src/prebuilt/wast-lexer-gen.cc"
+yy153:
 		yych = *++cursor_;
 		if (yych <= ',') {
-			if (yych == '+') goto yy213;
+			if (yych == '+') goto yy212;
 			goto yy87;
 		} else {
-			if (yych <= '-') goto yy213;
+			if (yych <= '-') goto yy212;
 			if (yych <= '/') goto yy87;
-			if (yych <= '9') goto yy214;
+			if (yych <= '9') goto yy213;
 			goto yy87;
 		}
-yy155:
+yy154:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -1468,12 +1464,12 @@ yy155:
 				goto yy88;
 			}
 		}
-yy156:
+yy155:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yybm[0+yych] & 128) {
-			goto yy216;
+			goto yy215;
 		}
 		if (yych <= '\'') {
 			if (yych == '!') goto yy86;
@@ -1489,23 +1485,27 @@ yy156:
 				goto yy88;
 			}
 		}
-yy157:
+yy156:
 		++cursor_;
 		BEGIN(YYCOND_LINE_COMMENT);
 #line 550 "src/wast-lexer.cc"
 		{ continue; }
-#line 1498 "src/prebuilt/wast-lexer-gen.cc"
+#line 1494 "src/prebuilt/wast-lexer-gen.cc"
+yy158:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy217;
+		goto yy87;
 yy159:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy218;
+		if (yych == 'y') goto yy218;
 		goto yy87;
 yy160:
 		yych = *++cursor_;
-		if (yych == 'y') goto yy219;
+		if (yych == 's') goto yy219;
 		goto yy87;
 yy161:
 		yych = *++cursor_;
-		if (yych == 's') goto yy220;
+		if (yych == 'o') goto yy220;
 		goto yy87;
 yy162:
 		yych = *++cursor_;
@@ -1703,33 +1703,29 @@ yy203:
 		goto yy87;
 yy204:
 		yych = *++cursor_;
-		if (yych == 'k') goto yy280;
-		goto yy87;
+		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0xBF) goto yy79;
+		goto yy130;
 yy205:
 		yych = *++cursor_;
-		if (yych <= 0x7F) goto yy131;
-		if (yych <= 0xBF) goto yy79;
-		goto yy131;
+		if (yych <= 0x7F) goto yy130;
+		if (yych <= 0xBF) goto yy204;
+		goto yy130;
 yy206:
-		yych = *++cursor_;
-		if (yych <= 0x7F) goto yy131;
-		if (yych <= 0xBF) goto yy205;
-		goto yy131;
-yy207:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= '@') {
-			if (yych <= '/') goto yy131;
-			if (yych <= '9') goto yy129;
-			goto yy131;
+			if (yych <= '/') goto yy130;
+			if (yych <= '9') goto yy128;
+			goto yy130;
 		} else {
-			if (yych <= 'F') goto yy129;
-			if (yych <= '`') goto yy131;
-			if (yych <= 'f') goto yy129;
-			goto yy131;
+			if (yych <= 'F') goto yy128;
+			if (yych <= '`') goto yy130;
+			if (yych <= 'f') goto yy128;
+			goto yy130;
 		}
-yy208:
+yy207:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -1745,7 +1741,7 @@ yy208:
 		} else {
 			if (yych <= ':') {
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy148;
+				if (yych <= '9') goto yy147;
 				goto yy86;
 			} else {
 				if (yych <= ';') goto yy88;
@@ -1753,7 +1749,7 @@ yy208:
 				goto yy88;
 			}
 		}
-yy209:
+yy208:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -1765,56 +1761,56 @@ yy209:
 				if (yych <= '\'') goto yy86;
 				if (yych <= ')') goto yy88;
 				if (yych <= '/') goto yy86;
-				goto yy281;
+				goto yy280;
 			}
 		} else {
 			if (yych <= 'F') {
 				if (yych == ';') goto yy88;
 				if (yych <= '@') goto yy86;
-				goto yy281;
+				goto yy280;
 			} else {
 				if (yych <= '`') goto yy86;
-				if (yych <= 'f') goto yy281;
+				if (yych <= 'f') goto yy280;
 				if (yych <= '~') goto yy86;
 				goto yy88;
 			}
 		}
-yy210:
+yy209:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy249;
 		goto yy87;
-yy211:
+yy210:
 		++cursor_;
 		if ((limit_ - cursor_) < 2) FILL(2);
 		yych = *cursor_;
 		if (yych <= ':') {
 			if (yych <= '\'') {
 				if (yych == '!') goto yy86;
-				if (yych <= '"') goto yy153;
+				if (yych <= '"') goto yy152;
 				goto yy86;
 			} else {
-				if (yych <= ')') goto yy153;
+				if (yych <= ')') goto yy152;
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy211;
+				if (yych <= '9') goto yy210;
 				goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
-				if (yych <= ';') goto yy153;
-				if (yych == 'E') goto yy154;
+				if (yych <= ';') goto yy152;
+				if (yych == 'E') goto yy153;
 				goto yy86;
 			} else {
 				if (yych <= 'd') {
-					if (yych <= '_') goto yy283;
+					if (yych <= '_') goto yy282;
 					goto yy86;
 				} else {
-					if (yych <= 'e') goto yy154;
+					if (yych <= 'e') goto yy153;
 					if (yych <= '~') goto yy86;
-					goto yy153;
+					goto yy152;
 				}
 			}
 		}
-yy213:
+yy212:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -1837,36 +1833,36 @@ yy213:
 				goto yy88;
 			}
 		}
-yy214:
+yy213:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= '/') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
-				goto yy153;
+				goto yy152;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy153;
+				if (yych <= ')') goto yy152;
 				goto yy86;
 			}
 		} else {
 			if (yych <= ';') {
-				if (yych <= '9') goto yy214;
+				if (yych <= '9') goto yy213;
 				if (yych <= ':') goto yy86;
-				goto yy153;
+				goto yy152;
 			} else {
-				if (yych == '_') goto yy213;
+				if (yych == '_') goto yy212;
 				if (yych <= '~') goto yy86;
-				goto yy153;
+				goto yy152;
 			}
 		}
-yy216:
+yy215:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
 		yych = *cursor_;
 		if (yybm[0+yych] & 128) {
-			goto yy216;
+			goto yy215;
 		}
 		if (yych <= ':') {
 			if (yych <= '\'') {
@@ -1875,36 +1871,40 @@ yy216:
 				goto yy86;
 			} else {
 				if (yych <= ')') goto yy98;
-				if (yych == '.') goto yy284;
+				if (yych == '.') goto yy283;
 				goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
 				if (yych <= ';') goto yy98;
-				if (yych == 'P') goto yy286;
+				if (yych == 'P') goto yy285;
 				goto yy86;
 			} else {
 				if (yych <= 'o') {
-					if (yych <= '_') goto yy156;
+					if (yych <= '_') goto yy155;
 					goto yy86;
 				} else {
-					if (yych <= 'p') goto yy286;
+					if (yych <= 'p') goto yy285;
 					if (yych <= '~') goto yy86;
 					goto yy98;
 				}
 			}
 		}
+yy217:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy286;
+		goto yy87;
 yy218:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy287;
+		if (yych == 'f') goto yy287;
 		goto yy87;
 yy219:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy288;
+		if (yych == 'e') goto yy288;
 		goto yy87;
 yy220:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy289;
+		if (yych == 'm') goto yy289;
 		goto yy87;
 yy221:
 		yych = *++cursor_;
@@ -2228,57 +2228,53 @@ yy279:
 		if (yych == 'e') goto yy343;
 		goto yy87;
 yy280:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy344;
-		goto yy87;
-yy281:
 		++cursor_;
 		if ((limit_ - cursor_) < 3) FILL(3);
 		yych = *cursor_;
 		if (yych <= ';') {
 			if (yych <= ')') {
 				if (yych <= '!') {
-					if (yych <= ' ') goto yy147;
+					if (yych <= ' ') goto yy146;
 					goto yy86;
 				} else {
-					if (yych <= '"') goto yy147;
+					if (yych <= '"') goto yy146;
 					if (yych <= '\'') goto yy86;
-					goto yy147;
+					goto yy146;
 				}
 			} else {
 				if (yych <= '/') {
-					if (yych == '.') goto yy284;
+					if (yych == '.') goto yy283;
 					goto yy86;
 				} else {
-					if (yych <= '9') goto yy281;
+					if (yych <= '9') goto yy280;
 					if (yych <= ':') goto yy86;
-					goto yy147;
+					goto yy146;
 				}
 			}
 		} else {
 			if (yych <= '_') {
 				if (yych <= 'O') {
 					if (yych <= '@') goto yy86;
-					if (yych <= 'F') goto yy281;
+					if (yych <= 'F') goto yy280;
 					goto yy86;
 				} else {
-					if (yych <= 'P') goto yy286;
+					if (yych <= 'P') goto yy285;
 					if (yych <= '^') goto yy86;
-					goto yy209;
+					goto yy208;
 				}
 			} else {
 				if (yych <= 'o') {
 					if (yych <= '`') goto yy86;
-					if (yych <= 'f') goto yy281;
+					if (yych <= 'f') goto yy280;
 					goto yy86;
 				} else {
-					if (yych <= 'p') goto yy286;
+					if (yych <= 'p') goto yy285;
 					if (yych <= '~') goto yy86;
-					goto yy147;
+					goto yy146;
 				}
 			}
 		}
-yy283:
+yy282:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -2294,7 +2290,7 @@ yy283:
 		} else {
 			if (yych <= ':') {
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy211;
+				if (yych <= '9') goto yy210;
 				goto yy86;
 			} else {
 				if (yych <= ';') goto yy88;
@@ -2302,7 +2298,7 @@ yy283:
 				goto yy88;
 			}
 		}
-yy284:
+yy283:
 		++cursor_;
 		if ((yych = *cursor_) <= ';') {
 			if (yych <= '\'') {
@@ -2312,7 +2308,7 @@ yy284:
 				if (yych <= '/') {
 					if (yych >= '*') goto yy86;
 				} else {
-					if (yych <= '9') goto yy346;
+					if (yych <= '9') goto yy344;
 					if (yych <= ':') goto yy86;
 				}
 			}
@@ -2320,63 +2316,67 @@ yy284:
 			if (yych <= '`') {
 				if (yych <= 'F') {
 					if (yych <= '@') goto yy86;
-					goto yy346;
+					goto yy344;
 				} else {
-					if (yych == 'P') goto yy286;
+					if (yych == 'P') goto yy285;
 					goto yy86;
 				}
 			} else {
 				if (yych <= 'o') {
-					if (yych <= 'f') goto yy346;
+					if (yych <= 'f') goto yy344;
 					goto yy86;
 				} else {
-					if (yych <= 'p') goto yy286;
+					if (yych <= 'p') goto yy285;
 					if (yych <= '~') goto yy86;
 				}
 			}
 		}
-yy285:
+yy284:
 #line 235 "src/wast-lexer.cc"
 		{ RETURN_LITERAL(Float, Hexfloat); }
-#line 2342 "src/prebuilt/wast-lexer-gen.cc"
-yy286:
+#line 2338 "src/prebuilt/wast-lexer-gen.cc"
+yy285:
 		yych = *++cursor_;
 		if (yych <= ',') {
-			if (yych == '+') goto yy348;
+			if (yych == '+') goto yy346;
 			goto yy87;
 		} else {
-			if (yych <= '-') goto yy348;
+			if (yych <= '-') goto yy346;
 			if (yych <= '/') goto yy87;
-			if (yych <= '9') goto yy349;
+			if (yych <= '9') goto yy347;
 			goto yy87;
 		}
+yy286:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy349;
+		goto yy87;
 yy287:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy351;
+		if (yych == 'u') goto yy350;
 		goto yy87;
 yy288:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy352;
+		if (yych == 'r') goto yy351;
 		goto yy87;
 yy289:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy353;
+		if (yych == 'i') goto yy352;
 		goto yy87;
 yy290:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy354;
+		if (yych == 'r') goto yy353;
 		goto yy87;
 yy291:
 		yych = *++cursor_;
-		if (yych == 'k') goto yy355;
+		if (yych == 'k') goto yy354;
 		goto yy87;
 yy292:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy357;
+		if (yych == 'f') goto yy356;
 		goto yy87;
 yy293:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy359;
+		if (yych == 'a') goto yy358;
 		goto yy87;
 yy294:
 		++cursor_;
@@ -2391,7 +2391,7 @@ yy294:
 			if (yych <= '^') {
 				if (yych != ';') goto yy86;
 			} else {
-				if (yych <= '_') goto yy360;
+				if (yych <= '_') goto yy359;
 				if (yych <= '~') goto yy86;
 			}
 		}
@@ -2401,11 +2401,11 @@ yy295:
 #line 2402 "src/prebuilt/wast-lexer-gen.cc"
 yy296:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy361;
+		if (yych == 'h') goto yy360;
 		goto yy87;
 yy297:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy363;
+		if (yych == 'e') goto yy362;
 		goto yy87;
 yy298:
 		++cursor_;
@@ -2441,45 +2441,45 @@ yy304:
 #line 2442 "src/prebuilt/wast-lexer-gen.cc"
 yy306:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy364;
+		if (yych == 'p') goto yy363;
 		goto yy87;
 yy307:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy365;
+		if (yych == 'r') goto yy364;
 		goto yy87;
 yy308:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'a':	goto yy366;
-		case 'c':	goto yy367;
-		case 'd':	goto yy368;
-		case 'e':	goto yy369;
-		case 'f':	goto yy370;
-		case 'g':	goto yy371;
-		case 'l':	goto yy372;
-		case 'm':	goto yy373;
-		case 'n':	goto yy374;
-		case 'r':	goto yy375;
-		case 's':	goto yy376;
-		case 't':	goto yy377;
+		case 'a':	goto yy365;
+		case 'c':	goto yy366;
+		case 'd':	goto yy367;
+		case 'e':	goto yy368;
+		case 'f':	goto yy369;
+		case 'g':	goto yy370;
+		case 'l':	goto yy371;
+		case 'm':	goto yy372;
+		case 'n':	goto yy373;
+		case 'r':	goto yy374;
+		case 's':	goto yy375;
+		case 't':	goto yy376;
 		default:	goto yy87;
 		}
 yy309:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'a':	goto yy378;
-		case 'c':	goto yy379;
-		case 'd':	goto yy380;
-		case 'e':	goto yy381;
-		case 'f':	goto yy382;
-		case 'g':	goto yy383;
-		case 'l':	goto yy384;
-		case 'm':	goto yy385;
-		case 'n':	goto yy386;
-		case 'p':	goto yy387;
-		case 'r':	goto yy388;
-		case 's':	goto yy389;
-		case 't':	goto yy390;
+		case 'a':	goto yy377;
+		case 'c':	goto yy378;
+		case 'd':	goto yy379;
+		case 'e':	goto yy380;
+		case 'f':	goto yy381;
+		case 'g':	goto yy382;
+		case 'l':	goto yy383;
+		case 'm':	goto yy384;
+		case 'n':	goto yy385;
+		case 'p':	goto yy386;
+		case 'r':	goto yy387;
+		case 's':	goto yy388;
+		case 't':	goto yy389;
 		default:	goto yy87;
 		}
 yy310:
@@ -2492,68 +2492,67 @@ yy310:
 #line 2493 "src/prebuilt/wast-lexer-gen.cc"
 yy312:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy391;
-		if (yych == 'l') goto yy392;
+		if (yych == 'g') goto yy390;
+		if (yych == 'l') goto yy391;
 		goto yy87;
 yy313:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy393;
+		if (yych == 'a') goto yy392;
 		goto yy87;
 yy314:
 		yych = *++cursor_;
-		if (yych == '_') goto yy394;
+		if (yych == '_') goto yy393;
 		goto yy87;
 yy315:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'a':	goto yy395;
-		case 'c':	goto yy396;
-		case 'd':	goto yy397;
-		case 'e':	goto yy398;
-		case 'g':	goto yy399;
-		case 'l':	goto yy400;
-		case 'm':	goto yy401;
-		case 'n':	goto yy402;
-		case 'o':	goto yy403;
-		case 'p':	goto yy404;
-		case 'r':	goto yy405;
-		case 's':	goto yy406;
-		case 't':	goto yy407;
-		case 'w':	goto yy408;
-		case 'x':	goto yy409;
+		case 'a':	goto yy394;
+		case 'c':	goto yy395;
+		case 'd':	goto yy396;
+		case 'e':	goto yy397;
+		case 'g':	goto yy398;
+		case 'l':	goto yy399;
+		case 'm':	goto yy400;
+		case 'n':	goto yy401;
+		case 'o':	goto yy402;
+		case 'p':	goto yy403;
+		case 'r':	goto yy404;
+		case 's':	goto yy405;
+		case 't':	goto yy406;
+		case 'w':	goto yy407;
+		case 'x':	goto yy408;
 		default:	goto yy87;
 		}
 yy316:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'a':	goto yy410;
-		case 'c':	goto yy411;
-		case 'd':	goto yy412;
-		case 'e':	goto yy413;
-		case 'g':	goto yy414;
-		case 'l':	goto yy415;
-		case 'm':	goto yy416;
-		case 'n':	goto yy417;
-		case 'o':	goto yy418;
-		case 'p':	goto yy419;
-		case 'r':	goto yy420;
-		case 's':	goto yy421;
-		case 't':	goto yy422;
-		case 'w':	goto yy423;
-		case 'x':	goto yy424;
+		case 'a':	goto yy409;
+		case 'c':	goto yy410;
+		case 'd':	goto yy411;
+		case 'e':	goto yy412;
+		case 'g':	goto yy413;
+		case 'l':	goto yy414;
+		case 'm':	goto yy415;
+		case 'n':	goto yy416;
+		case 'o':	goto yy417;
+		case 'p':	goto yy418;
+		case 'r':	goto yy419;
+		case 's':	goto yy420;
+		case 't':	goto yy421;
+		case 'x':	goto yy422;
 		default:	goto yy87;
 		}
 yy317:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy425;
+		if (yych == 'r') goto yy423;
 		goto yy87;
 yy318:
 		yych = *++cursor_;
-		if (yych == 'k') goto yy426;
+		if (yych == 'k') goto yy424;
 		goto yy87;
 yy319:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy427;
+		if (yych == 'l') goto yy425;
 		goto yy87;
 yy320:
 		++cursor_;
@@ -2562,71 +2561,71 @@ yy320:
 		}
 #line 262 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Loop); }
-#line 2566 "src/prebuilt/wast-lexer-gen.cc"
+#line 2565 "src/prebuilt/wast-lexer-gen.cc"
 yy322:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy429;
+		if (yych == 'r') goto yy427;
 		goto yy87;
 yy323:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy430;
+		if (yych == 'l') goto yy428;
 		goto yy87;
 yy324:
 		yych = *++cursor_;
-		if (yych == '0') goto yy431;
+		if (yych == '0') goto yy429;
 		goto yy87;
 yy325:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy432;
+		if (yych == 'e') goto yy430;
 		goto yy87;
 yy326:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy433;
+		if (yych == 'm') goto yy431;
 		goto yy87;
 yy327:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy435;
+		if (yych == 'e') goto yy433;
 		goto yy87;
 yy328:
 		yych = *++cursor_;
-		if (yych == 's') goto yy437;
+		if (yych == 's') goto yy435;
 		goto yy87;
 yy329:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy438;
+		if (yych == 'l') goto yy436;
 		goto yy87;
 yy330:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy439;
+		if (yych == 'r') goto yy437;
 		goto yy87;
 yy331:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy440;
+		if (yych == 'r') goto yy438;
 		goto yy87;
 yy332:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy441;
+		if (yych == 'c') goto yy439;
 		goto yy87;
 yy333:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy442;
-		if (yych == 'l') goto yy443;
+		if (yych == 'g') goto yy440;
+		if (yych == 'l') goto yy441;
 		goto yy87;
 yy334:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy444;
+		if (yych == 'e') goto yy442;
 		goto yy87;
 yy335:
 		yych = *++cursor_;
-		if (yych == 't') goto yy445;
+		if (yych == 't') goto yy443;
 		goto yy87;
 yy336:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy447;
+		if (yych == 'e') goto yy445;
 		goto yy87;
 yy337:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy449;
+		if (yych == 'l') goto yy447;
 		goto yy87;
 yy338:
 		++cursor_;
@@ -2635,10 +2634,10 @@ yy338:
 		}
 #line 260 "src/wast-lexer.cc"
 		{ RETURN(Then); }
-#line 2639 "src/prebuilt/wast-lexer-gen.cc"
+#line 2638 "src/prebuilt/wast-lexer-gen.cc"
 yy340:
 		yych = *++cursor_;
-		if (yych == 'w') goto yy450;
+		if (yych == 'w') goto yy448;
 		goto yy87;
 yy341:
 		++cursor_;
@@ -2647,65 +2646,57 @@ yy341:
 		}
 #line 513 "src/wast-lexer.cc"
 		{ RETURN(Type); }
-#line 2651 "src/prebuilt/wast-lexer-gen.cc"
+#line 2650 "src/prebuilt/wast-lexer-gen.cc"
 yy343:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy452;
+		if (yych == 'a') goto yy450;
 		goto yy87;
 yy344:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 448 "src/wast-lexer.cc"
-		{ RETURN_OPCODE0(Wake); }
-#line 2663 "src/prebuilt/wast-lexer-gen.cc"
-yy346:
 		++cursor_;
 		if ((limit_ - cursor_) < 2) FILL(2);
 		yych = *cursor_;
 		if (yych <= '@') {
 			if (yych <= ')') {
 				if (yych <= '!') {
-					if (yych <= ' ') goto yy285;
+					if (yych <= ' ') goto yy284;
 					goto yy86;
 				} else {
-					if (yych <= '"') goto yy285;
+					if (yych <= '"') goto yy284;
 					if (yych <= '\'') goto yy86;
-					goto yy285;
+					goto yy284;
 				}
 			} else {
 				if (yych <= '9') {
 					if (yych <= '/') goto yy86;
-					goto yy346;
+					goto yy344;
 				} else {
-					if (yych == ';') goto yy285;
+					if (yych == ';') goto yy284;
 					goto yy86;
 				}
 			}
 		} else {
 			if (yych <= '_') {
 				if (yych <= 'O') {
-					if (yych <= 'F') goto yy346;
+					if (yych <= 'F') goto yy344;
 					goto yy86;
 				} else {
-					if (yych <= 'P') goto yy286;
+					if (yych <= 'P') goto yy285;
 					if (yych <= '^') goto yy86;
-					goto yy453;
+					goto yy451;
 				}
 			} else {
 				if (yych <= 'o') {
 					if (yych <= '`') goto yy86;
-					if (yych <= 'f') goto yy346;
+					if (yych <= 'f') goto yy344;
 					goto yy86;
 				} else {
-					if (yych <= 'p') goto yy286;
+					if (yych <= 'p') goto yy285;
 					if (yych <= '~') goto yy86;
-					goto yy285;
+					goto yy284;
 				}
 			}
 		}
-yy348:
+yy346:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -2728,550 +2719,549 @@ yy348:
 				goto yy88;
 			}
 		}
-yy349:
+yy347:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= '/') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
-				goto yy285;
+				goto yy284;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy285;
+				if (yych <= ')') goto yy284;
 				goto yy86;
 			}
 		} else {
 			if (yych <= ';') {
-				if (yych <= '9') goto yy349;
+				if (yych <= '9') goto yy347;
 				if (yych <= ':') goto yy86;
-				goto yy285;
+				goto yy284;
 			} else {
-				if (yych == '_') goto yy348;
+				if (yych == '_') goto yy346;
 				if (yych <= '~') goto yy86;
-				goto yy285;
+				goto yy284;
 			}
 		}
+yy349:
+		yych = *++cursor_;
+		if (yych == '=') goto yy452;
+		goto yy87;
+yy350:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy453;
+		goto yy87;
 yy351:
 		yych = *++cursor_;
-		if (yych == '=') goto yy454;
+		if (yych == 't') goto yy454;
 		goto yy87;
 yy352:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy455;
+		if (yych == 'c') goto yy455;
 		goto yy87;
 yy353:
 		yych = *++cursor_;
-		if (yych == 't') goto yy456;
+		if (yych == 'y') goto yy456;
 		goto yy87;
 yy354:
-		yych = *++cursor_;
-		if (yych == 'y') goto yy457;
-		goto yy87;
-yy355:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 258 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Block); }
-#line 2779 "src/prebuilt/wast-lexer-gen.cc"
-yy357:
+#line 2774 "src/prebuilt/wast-lexer-gen.cc"
+yy356:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 264 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(BrIf); }
-#line 2787 "src/prebuilt/wast-lexer-gen.cc"
+#line 2782 "src/prebuilt/wast-lexer-gen.cc"
+yy358:
+		yych = *++cursor_;
+		if (yych == 'b') goto yy458;
+		goto yy87;
 yy359:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy459;
+		if (yych == 'i') goto yy459;
 		goto yy87;
 yy360:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy460;
-		goto yy87;
-yy361:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
 			if (yych <= '!') {
 				if (yych >= '!') goto yy86;
 			} else {
-				if (yych <= '"') goto yy362;
+				if (yych <= '"') goto yy361;
 				if (yych <= '\'') goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
 				if (yych != ';') goto yy86;
 			} else {
-				if (yych <= '_') goto yy461;
+				if (yych <= '_') goto yy460;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy362:
+yy361:
 #line 543 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Catch); }
-#line 2816 "src/prebuilt/wast-lexer-gen.cc"
+#line 2811 "src/prebuilt/wast-lexer-gen.cc"
+yy362:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy461;
+		goto yy87;
 yy363:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy462;
+		if (yych == 't') goto yy462;
 		goto yy87;
 yy364:
 		yych = *++cursor_;
-		if (yych == 't') goto yy463;
+		if (yych == 't') goto yy464;
 		goto yy87;
 yy365:
 		yych = *++cursor_;
-		if (yych == 't') goto yy465;
+		if (yych == 'b') goto yy466;
+		if (yych == 'd') goto yy467;
 		goto yy87;
 yy366:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy467;
-		if (yych == 'd') goto yy468;
+		if (yych == 'e') goto yy468;
+		if (yych == 'o') goto yy469;
 		goto yy87;
 yy367:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy469;
-		if (yych == 'o') goto yy470;
+		if (yych == 'e') goto yy470;
+		if (yych == 'i') goto yy471;
 		goto yy87;
 yy368:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy471;
-		if (yych == 'i') goto yy472;
+		if (yych == 'q') goto yy472;
 		goto yy87;
 yy369:
 		yych = *++cursor_;
-		if (yych == 'q') goto yy473;
+		if (yych == 'l') goto yy474;
 		goto yy87;
 yy370:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy475;
+		if (yych == 'e') goto yy475;
+		if (yych == 't') goto yy477;
 		goto yy87;
 yy371:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy476;
-		if (yych == 't') goto yy478;
-		goto yy87;
-yy372:
-		yych = *++cursor_;
 		if (yych <= 'n') {
-			if (yych == 'e') goto yy480;
+			if (yych == 'e') goto yy479;
 			goto yy87;
 		} else {
-			if (yych <= 'o') goto yy482;
-			if (yych == 't') goto yy483;
+			if (yych <= 'o') goto yy481;
+			if (yych == 't') goto yy482;
+			goto yy87;
+		}
+yy372:
+		yych = *++cursor_;
+		if (yych <= 'h') {
+			if (yych == 'a') goto yy484;
+			goto yy87;
+		} else {
+			if (yych <= 'i') goto yy485;
+			if (yych == 'u') goto yy486;
 			goto yy87;
 		}
 yy373:
 		yych = *++cursor_;
-		if (yych <= 'h') {
-			if (yych == 'a') goto yy485;
-			goto yy87;
-		} else {
-			if (yych <= 'i') goto yy486;
-			if (yych == 'u') goto yy487;
-			goto yy87;
-		}
+		if (yych == 'e') goto yy487;
+		goto yy87;
 yy374:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy488;
+		if (yych == 'e') goto yy489;
 		goto yy87;
 yy375:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy490;
-		goto yy87;
-yy376:
-		yych = *++cursor_;
 		if (yych <= 's') {
-			if (yych == 'q') goto yy491;
+			if (yych == 'q') goto yy490;
 			goto yy87;
 		} else {
-			if (yych <= 't') goto yy492;
-			if (yych <= 'u') goto yy493;
+			if (yych <= 't') goto yy491;
+			if (yych <= 'u') goto yy492;
 			goto yy87;
 		}
+yy376:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy493;
+		goto yy87;
 yy377:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy494;
+		if (yych == 'b') goto yy494;
+		if (yych == 'd') goto yy495;
 		goto yy87;
 yy378:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy495;
-		if (yych == 'd') goto yy496;
+		if (yych == 'e') goto yy496;
+		if (yych == 'o') goto yy497;
 		goto yy87;
 yy379:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy497;
-		if (yych == 'o') goto yy498;
+		if (yych == 'i') goto yy498;
 		goto yy87;
 yy380:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy499;
+		if (yych == 'q') goto yy499;
 		goto yy87;
 yy381:
 		yych = *++cursor_;
-		if (yych == 'q') goto yy500;
+		if (yych == 'l') goto yy501;
 		goto yy87;
 yy382:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy502;
+		if (yych == 'e') goto yy502;
+		if (yych == 't') goto yy504;
 		goto yy87;
 yy383:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy503;
-		if (yych == 't') goto yy505;
-		goto yy87;
-yy384:
-		yych = *++cursor_;
 		if (yych <= 'n') {
-			if (yych == 'e') goto yy507;
+			if (yych == 'e') goto yy506;
 			goto yy87;
 		} else {
-			if (yych <= 'o') goto yy509;
-			if (yych == 't') goto yy510;
+			if (yych <= 'o') goto yy508;
+			if (yych == 't') goto yy509;
+			goto yy87;
+		}
+yy384:
+		yych = *++cursor_;
+		if (yych <= 'h') {
+			if (yych == 'a') goto yy511;
+			goto yy87;
+		} else {
+			if (yych <= 'i') goto yy512;
+			if (yych == 'u') goto yy513;
 			goto yy87;
 		}
 yy385:
 		yych = *++cursor_;
-		if (yych <= 'h') {
-			if (yych == 'a') goto yy512;
-			goto yy87;
-		} else {
-			if (yych <= 'i') goto yy513;
-			if (yych == 'u') goto yy514;
-			goto yy87;
-		}
+		if (yych == 'e') goto yy514;
+		goto yy87;
 yy386:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy515;
+		if (yych == 'r') goto yy516;
 		goto yy87;
 yy387:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy517;
+		if (yych == 'e') goto yy517;
 		goto yy87;
 yy388:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy518;
-		goto yy87;
-yy389:
-		yych = *++cursor_;
 		if (yych <= 's') {
-			if (yych == 'q') goto yy519;
+			if (yych == 'q') goto yy518;
 			goto yy87;
 		} else {
-			if (yych <= 't') goto yy520;
-			if (yych <= 'u') goto yy521;
+			if (yych <= 't') goto yy519;
+			if (yych <= 'u') goto yy520;
 			goto yy87;
 		}
+yy389:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy521;
+		goto yy87;
 yy390:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy522;
+		if (yych == 'l') goto yy522;
 		goto yy87;
 yy391:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy523;
+		if (yych == 'o') goto yy523;
 		goto yy87;
 yy392:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy524;
+		if (yych == 'l') goto yy524;
 		goto yy87;
 yy393:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy525;
+		if (yych == 'm') goto yy526;
 		goto yy87;
 yy394:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy527;
-		goto yy87;
-yy395:
-		yych = *++cursor_;
 		if (yych <= 'm') {
-			if (yych == 'd') goto yy528;
+			if (yych == 'd') goto yy527;
 			goto yy87;
 		} else {
-			if (yych <= 'n') goto yy529;
-			if (yych == 't') goto yy530;
+			if (yych <= 'n') goto yy528;
+			if (yych == 't') goto yy529;
+			goto yy87;
+		}
+yy395:
+		yych = *++cursor_;
+		if (yych <= 'n') {
+			if (yych == 'l') goto yy530;
+			goto yy87;
+		} else {
+			if (yych <= 'o') goto yy531;
+			if (yych == 't') goto yy532;
 			goto yy87;
 		}
 yy396:
 		yych = *++cursor_;
-		if (yych <= 'n') {
-			if (yych == 'l') goto yy531;
-			goto yy87;
-		} else {
-			if (yych <= 'o') goto yy532;
-			if (yych == 't') goto yy533;
-			goto yy87;
-		}
+		if (yych == 'i') goto yy533;
+		goto yy87;
 yy397:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy534;
+		if (yych == 'q') goto yy534;
+		if (yych == 'x') goto yy536;
 		goto yy87;
 yy398:
 		yych = *++cursor_;
-		if (yych == 'q') goto yy535;
-		if (yych == 'x') goto yy537;
+		if (yych == 'e') goto yy537;
+		if (yych == 't') goto yy538;
 		goto yy87;
 yy399:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy538;
-		if (yych == 't') goto yy539;
-		goto yy87;
-yy400:
-		yych = *++cursor_;
 		if (yych <= 'n') {
-			if (yych == 'e') goto yy540;
+			if (yych == 'e') goto yy539;
 			goto yy87;
 		} else {
-			if (yych <= 'o') goto yy541;
-			if (yych == 't') goto yy542;
+			if (yych <= 'o') goto yy540;
+			if (yych == 't') goto yy541;
 			goto yy87;
 		}
+yy400:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy542;
+		goto yy87;
 yy401:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy543;
+		if (yych == 'e') goto yy543;
 		goto yy87;
 yy402:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy544;
+		if (yych == 'r') goto yy545;
 		goto yy87;
 yy403:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy546;
+		if (yych == 'o') goto yy547;
 		goto yy87;
 yy404:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy548;
+		if (yych == 'e') goto yy548;
+		if (yych == 'o') goto yy549;
 		goto yy87;
 yy405:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy549;
-		if (yych == 'o') goto yy550;
-		goto yy87;
-yy406:
-		yych = *++cursor_;
 		if (yych <= 's') {
-			if (yych == 'h') goto yy551;
+			if (yych == 'h') goto yy550;
 			goto yy87;
 		} else {
-			if (yych <= 't') goto yy552;
-			if (yych <= 'u') goto yy553;
+			if (yych <= 't') goto yy551;
+			if (yych <= 'u') goto yy552;
 			goto yy87;
 		}
+yy406:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy553;
+		goto yy87;
 yy407:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy554;
 		goto yy87;
 yy408:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy555;
-		if (yych == 'r') goto yy556;
+		if (yych == 'o') goto yy555;
 		goto yy87;
 yy409:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy557;
-		goto yy87;
-yy410:
-		yych = *++cursor_;
 		if (yych <= 'm') {
-			if (yych == 'd') goto yy558;
+			if (yych == 'd') goto yy556;
 			goto yy87;
 		} else {
-			if (yych <= 'n') goto yy559;
-			if (yych == 't') goto yy560;
+			if (yych <= 'n') goto yy557;
+			if (yych == 't') goto yy558;
+			goto yy87;
+		}
+yy410:
+		yych = *++cursor_;
+		if (yych <= 'n') {
+			if (yych == 'l') goto yy559;
+			goto yy87;
+		} else {
+			if (yych <= 'o') goto yy560;
+			if (yych == 't') goto yy561;
 			goto yy87;
 		}
 yy411:
 		yych = *++cursor_;
-		if (yych <= 'n') {
-			if (yych == 'l') goto yy561;
-			goto yy87;
-		} else {
-			if (yych <= 'o') goto yy562;
-			if (yych == 't') goto yy563;
-			goto yy87;
-		}
+		if (yych == 'i') goto yy562;
+		goto yy87;
 yy412:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy564;
+		if (yych == 'q') goto yy563;
+		if (yych == 'x') goto yy565;
 		goto yy87;
 yy413:
 		yych = *++cursor_;
-		if (yych == 'q') goto yy565;
-		if (yych == 'x') goto yy567;
+		if (yych == 'e') goto yy566;
+		if (yych == 't') goto yy567;
 		goto yy87;
 yy414:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy568;
-		if (yych == 't') goto yy569;
-		goto yy87;
-yy415:
-		yych = *++cursor_;
 		if (yych <= 'n') {
-			if (yych == 'e') goto yy570;
+			if (yych == 'e') goto yy568;
 			goto yy87;
 		} else {
-			if (yych <= 'o') goto yy571;
-			if (yych == 't') goto yy572;
+			if (yych <= 'o') goto yy569;
+			if (yych == 't') goto yy570;
 			goto yy87;
 		}
+yy415:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy571;
+		goto yy87;
 yy416:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy573;
+		if (yych == 'e') goto yy572;
 		goto yy87;
 yy417:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy574;
+		if (yych == 'r') goto yy574;
 		goto yy87;
 yy418:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy576;
+		if (yych == 'o') goto yy576;
 		goto yy87;
 yy419:
 		yych = *++cursor_;
+		if (yych == 'e') goto yy577;
 		if (yych == 'o') goto yy578;
 		goto yy87;
 yy420:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy579;
-		if (yych == 'o') goto yy580;
-		goto yy87;
-yy421:
-		yych = *++cursor_;
 		if (yych <= 's') {
-			if (yych == 'h') goto yy581;
+			if (yych == 'h') goto yy579;
 			goto yy87;
 		} else {
-			if (yych <= 't') goto yy582;
-			if (yych <= 'u') goto yy583;
+			if (yych <= 't') goto yy580;
+			if (yych <= 'u') goto yy581;
 			goto yy87;
 		}
+yy421:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy582;
+		goto yy87;
 yy422:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy584;
+		if (yych == 'o') goto yy583;
 		goto yy87;
 yy423:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy585;
+		if (yych == 't') goto yy584;
 		goto yy87;
 yy424:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy586;
+		if (yych == 'e') goto yy586;
 		goto yy87;
 yy425:
-		yych = *++cursor_;
-		if (yych == 't') goto yy587;
-		goto yy87;
-yy426:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy589;
-		goto yy87;
-yy427:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 517 "src/wast-lexer.cc"
 		{ RETURN(Local); }
-#line 3178 "src/prebuilt/wast-lexer-gen.cc"
+#line 3168 "src/prebuilt/wast-lexer-gen.cc"
+yy427:
+		yych = *++cursor_;
+		if (yych == 'y') goto yy588;
+		goto yy87;
+yy428:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy590;
+		goto yy87;
 yy429:
 		yych = *++cursor_;
-		if (yych == 'y') goto yy591;
+		if (yych == 'x') goto yy592;
 		goto yy87;
 yy430:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy593;
+		if (yych == 't') goto yy593;
 		goto yy87;
 yy431:
-		yych = *++cursor_;
-		if (yych == 'x') goto yy595;
-		goto yy87;
-yy432:
-		yych = *++cursor_;
-		if (yych == 't') goto yy596;
-		goto yy87;
-yy433:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 515 "src/wast-lexer.cc"
 		{ RETURN(Param); }
-#line 3202 "src/prebuilt/wast-lexer-gen.cc"
-yy435:
+#line 3192 "src/prebuilt/wast-lexer-gen.cc"
+yy433:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 521 "src/wast-lexer.cc"
 		{ RETURN(Quote); }
-#line 3210 "src/prebuilt/wast-lexer-gen.cc"
+#line 3200 "src/prebuilt/wast-lexer-gen.cc"
+yy435:
+		yych = *++cursor_;
+		if (yych == 't') goto yy595;
+		goto yy87;
+yy436:
+		yych = *++cursor_;
+		if (yych == 't') goto yy596;
+		goto yy87;
 yy437:
 		yych = *++cursor_;
-		if (yych == 't') goto yy598;
+		if (yych == 'o') goto yy598;
 		goto yy87;
 yy438:
 		yych = *++cursor_;
-		if (yych == 't') goto yy599;
+		if (yych == 'n') goto yy599;
 		goto yy87;
 yy439:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy601;
+		if (yych == 't') goto yy601;
 		goto yy87;
 yy440:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy602;
+		if (yych == 'l') goto yy603;
 		goto yy87;
 yy441:
 		yych = *++cursor_;
-		if (yych == 't') goto yy604;
+		if (yych == 'o') goto yy604;
 		goto yy87;
 yy442:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy606;
+		if (yych == 'd') goto yy605;
 		goto yy87;
 yy443:
-		yych = *++cursor_;
-		if (yych == 'o') goto yy607;
-		goto yy87;
-yy444:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy608;
-		goto yy87;
-yy445:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 524 "src/wast-lexer.cc"
 		{ RETURN(Start); }
-#line 3250 "src/prebuilt/wast-lexer-gen.cc"
-yy447:
+#line 3240 "src/prebuilt/wast-lexer-gen.cc"
+yy445:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 522 "src/wast-lexer.cc"
 		{ RETURN(Table); }
-#line 3258 "src/prebuilt/wast-lexer-gen.cc"
-yy449:
+#line 3248 "src/prebuilt/wast-lexer-gen.cc"
+yy447:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy610;
+		if (yych == 'o') goto yy607;
 		goto yy87;
-yy450:
+yy448:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 545 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Throw); }
-#line 3270 "src/prebuilt/wast-lexer-gen.cc"
-yy452:
+#line 3260 "src/prebuilt/wast-lexer-gen.cc"
+yy450:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy611;
+		if (yych == 'c') goto yy608;
 		goto yy87;
-yy453:
+yy451:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -3283,160 +3273,164 @@ yy453:
 				if (yych <= '\'') goto yy86;
 				if (yych <= ')') goto yy88;
 				if (yych <= '/') goto yy86;
-				goto yy346;
+				goto yy344;
 			}
 		} else {
 			if (yych <= 'F') {
 				if (yych == ';') goto yy88;
 				if (yych <= '@') goto yy86;
-				goto yy346;
+				goto yy344;
 			} else {
 				if (yych <= '`') goto yy86;
-				if (yych <= 'f') goto yy346;
+				if (yych <= 'f') goto yy344;
 				if (yych <= '~') goto yy86;
 				goto yy88;
 			}
 		}
-yy454:
+yy452:
 		yych = *++cursor_;
 		if (yych <= '/') goto yy87;
-		if (yych <= '0') goto yy612;
-		if (yych <= '9') goto yy614;
+		if (yych <= '0') goto yy609;
+		if (yych <= '9') goto yy611;
+		goto yy87;
+yy453:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy613;
+		goto yy87;
+yy454:
+		yych = *++cursor_;
+		if (yych == '_') goto yy615;
 		goto yy87;
 yy455:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy616;
+		if (yych == '.') goto yy616;
 		goto yy87;
 yy456:
-		yych = *++cursor_;
-		if (yych == '_') goto yy618;
-		goto yy87;
-yy457:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 520 "src/wast-lexer.cc"
 		{ RETURN(Bin); }
-#line 3322 "src/prebuilt/wast-lexer-gen.cc"
+#line 3316 "src/prebuilt/wast-lexer-gen.cc"
+yy458:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy617;
+		goto yy87;
 yy459:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy619;
+		if (yych == 'n') goto yy618;
 		goto yy87;
 yy460:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy620;
+		if (yych == 'a') goto yy619;
 		goto yy87;
 yy461:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy621;
+		if (yych == 't') goto yy620;
 		goto yy87;
 yy462:
-		yych = *++cursor_;
-		if (yych == 't') goto yy622;
-		goto yy87;
-yy463:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 530 "src/wast-lexer.cc"
 		{ RETURN(Except); }
-#line 3346 "src/prebuilt/wast-lexer-gen.cc"
-yy465:
+#line 3340 "src/prebuilt/wast-lexer-gen.cc"
+yy464:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 529 "src/wast-lexer.cc"
 		{ RETURN(Export); }
-#line 3354 "src/prebuilt/wast-lexer-gen.cc"
+#line 3348 "src/prebuilt/wast-lexer-gen.cc"
+yy466:
+		yych = *++cursor_;
+		if (yych == 's') goto yy621;
+		goto yy87;
 yy467:
 		yych = *++cursor_;
-		if (yych == 's') goto yy623;
+		if (yych == 'd') goto yy623;
 		goto yy87;
 yy468:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy625;
+		if (yych == 'i') goto yy625;
 		goto yy87;
 yy469:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy627;
+		if (yych == 'n') goto yy626;
+		if (yych == 'p') goto yy627;
 		goto yy87;
 yy470:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy628;
-		if (yych == 'p') goto yy629;
+		if (yych == 'm') goto yy628;
 		goto yy87;
 yy471:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy630;
+		if (yych == 'v') goto yy629;
 		goto yy87;
 yy472:
-		yych = *++cursor_;
-		if (yych == 'v') goto yy631;
-		goto yy87;
-yy473:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 396 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F32Eq); }
-#line 3387 "src/prebuilt/wast-lexer-gen.cc"
-yy475:
+#line 3381 "src/prebuilt/wast-lexer-gen.cc"
+yy474:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy633;
+		if (yych == 'o') goto yy631;
 		goto yy87;
-yy476:
+yy475:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 406 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F32Ge); }
-#line 3399 "src/prebuilt/wast-lexer-gen.cc"
-yy478:
+#line 3393 "src/prebuilt/wast-lexer-gen.cc"
+yy477:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 404 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F32Gt); }
-#line 3407 "src/prebuilt/wast-lexer-gen.cc"
-yy480:
+#line 3401 "src/prebuilt/wast-lexer-gen.cc"
+yy479:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 402 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F32Le); }
-#line 3415 "src/prebuilt/wast-lexer-gen.cc"
-yy482:
+#line 3409 "src/prebuilt/wast-lexer-gen.cc"
+yy481:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy634;
+		if (yych == 'a') goto yy632;
 		goto yy87;
-yy483:
+yy482:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 400 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F32Lt); }
-#line 3427 "src/prebuilt/wast-lexer-gen.cc"
+#line 3421 "src/prebuilt/wast-lexer-gen.cc"
+yy484:
+		yych = *++cursor_;
+		if (yych == 'x') goto yy633;
+		goto yy87;
 yy485:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy635;
+		if (yych == 'n') goto yy635;
 		goto yy87;
 yy486:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy637;
+		if (yych == 'l') goto yy637;
 		goto yy87;
 yy487:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy639;
-		goto yy87;
-yy488:
 		++cursor_;
 		if ((yych = *cursor_) <= ':') {
 			if (yych <= '"') {
@@ -3447,120 +3441,120 @@ yy488:
 			}
 		} else {
 			if (yych <= 'a') {
-				if (yych <= ';') goto yy489;
+				if (yych <= ';') goto yy488;
 				if (yych <= '`') goto yy86;
-				goto yy641;
+				goto yy639;
 			} else {
-				if (yych == 'g') goto yy642;
+				if (yych == 'g') goto yy640;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy489:
+yy488:
 #line 398 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F32Ne); }
-#line 3462 "src/prebuilt/wast-lexer-gen.cc"
+#line 3456 "src/prebuilt/wast-lexer-gen.cc"
+yy489:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy642;
+		goto yy87;
 yy490:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy644;
+		if (yych == 'r') goto yy643;
 		goto yy87;
 yy491:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy645;
+		if (yych == 'o') goto yy644;
 		goto yy87;
 yy492:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy646;
+		if (yych == 'b') goto yy645;
 		goto yy87;
 yy493:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy647;
+		if (yych == 'u') goto yy647;
 		goto yy87;
 yy494:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy649;
+		if (yych == 's') goto yy648;
 		goto yy87;
 yy495:
 		yych = *++cursor_;
-		if (yych == 's') goto yy650;
+		if (yych == 'd') goto yy650;
 		goto yy87;
 yy496:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy652;
+		if (yych == 'i') goto yy652;
 		goto yy87;
 yy497:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy654;
+		if (yych == 'n') goto yy653;
+		if (yych == 'p') goto yy654;
 		goto yy87;
 yy498:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy655;
-		if (yych == 'p') goto yy656;
+		if (yych == 'v') goto yy655;
 		goto yy87;
 yy499:
-		yych = *++cursor_;
-		if (yych == 'v') goto yy657;
-		goto yy87;
-yy500:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 397 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F64Eq); }
-#line 3511 "src/prebuilt/wast-lexer-gen.cc"
-yy502:
+#line 3505 "src/prebuilt/wast-lexer-gen.cc"
+yy501:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy659;
+		if (yych == 'o') goto yy657;
 		goto yy87;
-yy503:
+yy502:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 407 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F64Ge); }
-#line 3523 "src/prebuilt/wast-lexer-gen.cc"
-yy505:
+#line 3517 "src/prebuilt/wast-lexer-gen.cc"
+yy504:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 405 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F64Gt); }
-#line 3531 "src/prebuilt/wast-lexer-gen.cc"
-yy507:
+#line 3525 "src/prebuilt/wast-lexer-gen.cc"
+yy506:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 403 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F64Le); }
-#line 3539 "src/prebuilt/wast-lexer-gen.cc"
-yy509:
+#line 3533 "src/prebuilt/wast-lexer-gen.cc"
+yy508:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy660;
+		if (yych == 'a') goto yy658;
 		goto yy87;
-yy510:
+yy509:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 401 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F64Lt); }
-#line 3551 "src/prebuilt/wast-lexer-gen.cc"
+#line 3545 "src/prebuilt/wast-lexer-gen.cc"
+yy511:
+		yych = *++cursor_;
+		if (yych == 'x') goto yy659;
+		goto yy87;
 yy512:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy661;
+		if (yych == 'n') goto yy661;
 		goto yy87;
 yy513:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy663;
+		if (yych == 'l') goto yy663;
 		goto yy87;
 yy514:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy665;
-		goto yy87;
-yy515:
 		++cursor_;
 		if ((yych = *cursor_) <= ':') {
 			if (yych <= '"') {
@@ -3571,61 +3565,65 @@ yy515:
 			}
 		} else {
 			if (yych <= 'a') {
-				if (yych <= ';') goto yy516;
+				if (yych <= ';') goto yy515;
 				if (yych <= '`') goto yy86;
-				goto yy667;
+				goto yy665;
 			} else {
-				if (yych == 'g') goto yy668;
+				if (yych == 'g') goto yy666;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy516:
+yy515:
 #line 399 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, F64Ne); }
-#line 3586 "src/prebuilt/wast-lexer-gen.cc"
+#line 3580 "src/prebuilt/wast-lexer-gen.cc"
+yy516:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy668;
+		goto yy87;
 yy517:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy670;
+		if (yych == 'i') goto yy669;
 		goto yy87;
 yy518:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy671;
+		if (yych == 'r') goto yy670;
 		goto yy87;
 yy519:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy672;
+		if (yych == 'o') goto yy671;
 		goto yy87;
 yy520:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy673;
+		if (yych == 'b') goto yy672;
 		goto yy87;
 yy521:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy674;
+		if (yych == 'u') goto yy674;
 		goto yy87;
 yy522:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy676;
+		if (yych == 'o') goto yy675;
 		goto yy87;
 yy523:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy677;
+		if (yych == 'c') goto yy676;
 		goto yy87;
 yy524:
-		yych = *++cursor_;
-		if (yych == 'c') goto yy678;
-		goto yy87;
-yy525:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 518 "src/wast-lexer.cc"
 		{ RETURN(Global); }
-#line 3626 "src/prebuilt/wast-lexer-gen.cc"
+#line 3620 "src/prebuilt/wast-lexer-gen.cc"
+yy526:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy677;
+		goto yy87;
 yy527:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy679;
+		if (yych == 'd') goto yy678;
 		goto yy87;
 yy528:
 		yych = *++cursor_;
@@ -3633,146 +3631,146 @@ yy528:
 		goto yy87;
 yy529:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy682;
+		if (yych == 'o') goto yy682;
 		goto yy87;
 yy530:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy684;
+		if (yych == 'z') goto yy683;
 		goto yy87;
 yy531:
 		yych = *++cursor_;
-		if (yych == 'z') goto yy685;
+		if (yych == 'n') goto yy685;
 		goto yy87;
 yy532:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy687;
+		if (yych == 'z') goto yy686;
 		goto yy87;
 yy533:
 		yych = *++cursor_;
-		if (yych == 'z') goto yy688;
+		if (yych == 'v') goto yy688;
 		goto yy87;
 yy534:
-		yych = *++cursor_;
-		if (yych == 'v') goto yy690;
-		goto yy87;
-yy535:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
 			if (yych <= '!') {
 				if (yych >= '!') goto yy86;
 			} else {
-				if (yych <= '"') goto yy536;
+				if (yych <= '"') goto yy535;
 				if (yych <= '\'') goto yy86;
 			}
 		} else {
 			if (yych <= 'y') {
 				if (yych != ';') goto yy86;
 			} else {
-				if (yych <= 'z') goto yy691;
+				if (yych <= 'z') goto yy689;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy536:
+yy535:
 #line 376 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32Eq); }
-#line 3679 "src/prebuilt/wast-lexer-gen.cc"
+#line 3673 "src/prebuilt/wast-lexer-gen.cc"
+yy536:
+		yych = *++cursor_;
+		if (yych == 't') goto yy691;
+		goto yy87;
 yy537:
 		yych = *++cursor_;
-		if (yych == 't') goto yy693;
+		if (yych == '_') goto yy692;
 		goto yy87;
 yy538:
 		yych = *++cursor_;
-		if (yych == '_') goto yy694;
+		if (yych == '_') goto yy693;
 		goto yy87;
 yy539:
 		yych = *++cursor_;
-		if (yych == '_') goto yy695;
+		if (yych == '_') goto yy694;
 		goto yy87;
 yy540:
 		yych = *++cursor_;
-		if (yych == '_') goto yy696;
+		if (yych == 'a') goto yy695;
 		goto yy87;
 yy541:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy697;
+		if (yych == '_') goto yy696;
 		goto yy87;
 yy542:
 		yych = *++cursor_;
-		if (yych == '_') goto yy698;
+		if (yych == 'l') goto yy697;
 		goto yy87;
 yy543:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy699;
-		goto yy87;
-yy544:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 378 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32Ne); }
-#line 3715 "src/prebuilt/wast-lexer-gen.cc"
-yy546:
+#line 3709 "src/prebuilt/wast-lexer-gen.cc"
+yy545:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 348 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Or); }
-#line 3723 "src/prebuilt/wast-lexer-gen.cc"
+#line 3717 "src/prebuilt/wast-lexer-gen.cc"
+yy547:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy699;
+		goto yy87;
 yy548:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy701;
+		if (yych == 'i') goto yy700;
+		if (yych == 'm') goto yy701;
 		goto yy87;
 yy549:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy702;
-		if (yych == 'm') goto yy703;
+		if (yych == 't') goto yy702;
 		goto yy87;
 yy550:
 		yych = *++cursor_;
-		if (yych == 't') goto yy704;
+		if (yych == 'l') goto yy703;
+		if (yych == 'r') goto yy705;
 		goto yy87;
 yy551:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy705;
-		if (yych == 'r') goto yy707;
+		if (yych == 'o') goto yy706;
 		goto yy87;
 yy552:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy708;
+		if (yych == 'b') goto yy707;
 		goto yy87;
 yy553:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy709;
+		if (yych == 'u') goto yy709;
 		goto yy87;
 yy554:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy711;
+		if (yych == 'a') goto yy710;
 		goto yy87;
 yy555:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy712;
+		if (yych == 'r') goto yy711;
 		goto yy87;
 yy556:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy713;
+		if (yych == 'd') goto yy713;
 		goto yy87;
 yy557:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy714;
+		if (yych == 'd') goto yy715;
 		goto yy87;
 yy558:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy716;
+		if (yych == 'o') goto yy717;
 		goto yy87;
 yy559:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy718;
+		if (yych == 'z') goto yy718;
 		goto yy87;
 yy560:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy720;
+		if (yych == 'n') goto yy720;
 		goto yy87;
 yy561:
 		yych = *++cursor_;
@@ -3780,152 +3778,140 @@ yy561:
 		goto yy87;
 yy562:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy723;
+		if (yych == 'v') goto yy723;
 		goto yy87;
 yy563:
-		yych = *++cursor_;
-		if (yych == 'z') goto yy724;
-		goto yy87;
-yy564:
-		yych = *++cursor_;
-		if (yych == 'v') goto yy726;
-		goto yy87;
-yy565:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
 			if (yych <= '!') {
 				if (yych >= '!') goto yy86;
 			} else {
-				if (yych <= '"') goto yy566;
+				if (yych <= '"') goto yy564;
 				if (yych <= '\'') goto yy86;
 			}
 		} else {
 			if (yych <= 'y') {
 				if (yych != ';') goto yy86;
 			} else {
-				if (yych <= 'z') goto yy727;
+				if (yych <= 'z') goto yy724;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy566:
+yy564:
 #line 377 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64Eq); }
-#line 3814 "src/prebuilt/wast-lexer-gen.cc"
+#line 3804 "src/prebuilt/wast-lexer-gen.cc"
+yy565:
+		yych = *++cursor_;
+		if (yych == 't') goto yy726;
+		goto yy87;
+yy566:
+		yych = *++cursor_;
+		if (yych == '_') goto yy727;
+		goto yy87;
 yy567:
 		yych = *++cursor_;
-		if (yych == 't') goto yy729;
+		if (yych == '_') goto yy728;
 		goto yy87;
 yy568:
 		yych = *++cursor_;
-		if (yych == '_') goto yy730;
+		if (yych == '_') goto yy729;
 		goto yy87;
 yy569:
 		yych = *++cursor_;
-		if (yych == '_') goto yy731;
+		if (yych == 'a') goto yy730;
 		goto yy87;
 yy570:
 		yych = *++cursor_;
-		if (yych == '_') goto yy732;
+		if (yych == '_') goto yy731;
 		goto yy87;
 yy571:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy733;
+		if (yych == 'l') goto yy732;
 		goto yy87;
 yy572:
-		yych = *++cursor_;
-		if (yych == '_') goto yy734;
-		goto yy87;
-yy573:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy735;
-		goto yy87;
-yy574:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 379 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64Ne); }
-#line 3850 "src/prebuilt/wast-lexer-gen.cc"
-yy576:
+#line 3840 "src/prebuilt/wast-lexer-gen.cc"
+yy574:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 349 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Or); }
-#line 3858 "src/prebuilt/wast-lexer-gen.cc"
+#line 3848 "src/prebuilt/wast-lexer-gen.cc"
+yy576:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy734;
+		goto yy87;
+yy577:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy735;
+		if (yych == 'm') goto yy736;
+		goto yy87;
 yy578:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy737;
+		if (yych == 't') goto yy737;
 		goto yy87;
 yy579:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy738;
-		if (yych == 'm') goto yy739;
+		if (yych == 'l') goto yy738;
+		if (yych == 'r') goto yy740;
 		goto yy87;
 yy580:
 		yych = *++cursor_;
-		if (yych == 't') goto yy740;
+		if (yych == 'o') goto yy741;
 		goto yy87;
 yy581:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy741;
-		if (yych == 'r') goto yy743;
+		if (yych == 'b') goto yy742;
 		goto yy87;
 yy582:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy744;
+		if (yych == 'u') goto yy744;
 		goto yy87;
 yy583:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy745;
+		if (yych == 'r') goto yy745;
 		goto yy87;
 yy584:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy747;
-		goto yy87;
-yy585:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy748;
-		goto yy87;
-yy586:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy749;
-		goto yy87;
-yy587:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 528 "src/wast-lexer.cc"
 		{ RETURN(Import); }
-#line 3904 "src/prebuilt/wast-lexer-gen.cc"
-yy589:
+#line 3890 "src/prebuilt/wast-lexer-gen.cc"
+yy586:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 532 "src/wast-lexer.cc"
 		{ RETURN(Invoke); }
-#line 3912 "src/prebuilt/wast-lexer-gen.cc"
-yy591:
+#line 3898 "src/prebuilt/wast-lexer-gen.cc"
+yy588:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 523 "src/wast-lexer.cc"
 		{ RETURN(Memory); }
-#line 3920 "src/prebuilt/wast-lexer-gen.cc"
-yy593:
+#line 3906 "src/prebuilt/wast-lexer-gen.cc"
+yy590:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 519 "src/wast-lexer.cc"
 		{ RETURN(Module); }
-#line 3928 "src/prebuilt/wast-lexer-gen.cc"
-yy595:
+#line 3914 "src/prebuilt/wast-lexer-gen.cc"
+yy592:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -3937,706 +3923,702 @@ yy595:
 				if (yych <= '\'') goto yy86;
 				if (yych <= ')') goto yy88;
 				if (yych <= '/') goto yy86;
-				goto yy751;
+				goto yy747;
 			}
 		} else {
 			if (yych <= 'F') {
 				if (yych == ';') goto yy88;
 				if (yych <= '@') goto yy86;
-				goto yy751;
+				goto yy747;
 			} else {
 				if (yych <= '`') goto yy86;
-				if (yych <= 'f') goto yy751;
+				if (yych <= 'f') goto yy747;
 				if (yych <= '~') goto yy86;
 				goto yy88;
 			}
 		}
-yy596:
+yy593:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
 			if (yych <= '!') {
 				if (yych >= '!') goto yy86;
 			} else {
-				if (yych <= '"') goto yy597;
+				if (yych <= '"') goto yy594;
 				if (yych <= '\'') goto yy86;
 			}
 		} else {
 			if (yych <= '<') {
 				if (yych != ';') goto yy86;
 			} else {
-				if (yych <= '=') goto yy753;
+				if (yych <= '=') goto yy749;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy597:
+yy594:
 #line 527 "src/wast-lexer.cc"
 		{ RETURN(Offset); }
-#line 3975 "src/prebuilt/wast-lexer-gen.cc"
-yy598:
+#line 3961 "src/prebuilt/wast-lexer-gen.cc"
+yy595:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy754;
+		if (yych == 'e') goto yy750;
 		goto yy87;
-yy599:
+yy596:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 516 "src/wast-lexer.cc"
 		{ RETURN(Result); }
-#line 3987 "src/prebuilt/wast-lexer-gen.cc"
-yy601:
+#line 3973 "src/prebuilt/wast-lexer-gen.cc"
+yy598:
 		yych = *++cursor_;
-		if (yych == 'w') goto yy755;
+		if (yych == 'w') goto yy751;
 		goto yy87;
-yy602:
+yy599:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 270 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Return); }
-#line 3999 "src/prebuilt/wast-lexer-gen.cc"
-yy604:
+#line 3985 "src/prebuilt/wast-lexer-gen.cc"
+yy601:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 441 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Select); }
-#line 4007 "src/prebuilt/wast-lexer-gen.cc"
-yy606:
+#line 3993 "src/prebuilt/wast-lexer-gen.cc"
+yy603:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy757;
+		if (yych == 'o') goto yy753;
 		goto yy87;
-yy607:
+yy604:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy758;
+		if (yych == 'c') goto yy754;
 		goto yy87;
-yy608:
+yy605:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 548 "src/wast-lexer.cc"
 		{ RETURN(Shared); }
-#line 4023 "src/prebuilt/wast-lexer-gen.cc"
-yy610:
+#line 4009 "src/prebuilt/wast-lexer-gen.cc"
+yy607:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy759;
+		if (yych == 'c') goto yy755;
 		goto yy87;
-yy611:
+yy608:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy760;
+		if (yych == 'h') goto yy756;
 		goto yy87;
-yy612:
+yy609:
 		++cursor_;
 		if ((yych = *cursor_) <= '9') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy613;
+				if (yych <= ')') goto yy610;
 				if (yych <= '/') goto yy86;
-				goto yy614;
+				goto yy611;
 			}
 		} else {
 			if (yych <= '_') {
-				if (yych == ';') goto yy613;
+				if (yych == ';') goto yy610;
 				if (yych <= '^') goto yy86;
-				goto yy761;
+				goto yy757;
 			} else {
-				if (yych == 'x') goto yy762;
+				if (yych == 'x') goto yy758;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy613:
+yy610:
 #line 300 "src/wast-lexer.cc"
 		{ RETURN_TEXT_AT(AlignEqNat, 6); }
-#line 4056 "src/prebuilt/wast-lexer-gen.cc"
-yy614:
+#line 4042 "src/prebuilt/wast-lexer-gen.cc"
+yy611:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= '/') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
-				goto yy613;
+				goto yy610;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy613;
+				if (yych <= ')') goto yy610;
 				goto yy86;
 			}
 		} else {
 			if (yych <= ';') {
-				if (yych <= '9') goto yy614;
+				if (yych <= '9') goto yy611;
 				if (yych <= ':') goto yy86;
-				goto yy613;
+				goto yy610;
 			} else {
-				if (yych == '_') goto yy761;
+				if (yych == '_') goto yy757;
 				if (yych <= '~') goto yy86;
-				goto yy613;
+				goto yy610;
 			}
 		}
-yy616:
+yy613:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 255 "src/wast-lexer.cc"
 		{ RETURN(Anyfunc); }
-#line 4088 "src/prebuilt/wast-lexer-gen.cc"
-yy618:
+#line 4074 "src/prebuilt/wast-lexer-gen.cc"
+yy615:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'e':	goto yy763;
-		case 'i':	goto yy764;
-		case 'm':	goto yy765;
-		case 'r':	goto yy766;
-		case 't':	goto yy767;
-		case 'u':	goto yy768;
+		case 'e':	goto yy759;
+		case 'i':	goto yy760;
+		case 'm':	goto yy761;
+		case 'r':	goto yy762;
+		case 't':	goto yy763;
+		case 'u':	goto yy764;
 		default:	goto yy87;
 		}
+yy616:
+		yych = *++cursor_;
+		if (yych == 'w') goto yy765;
+		goto yy87;
+yy617:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy766;
+		goto yy87;
+yy618:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy768;
+		goto yy87;
 yy619:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy769;
+		if (yych == 'l') goto yy769;
 		goto yy87;
 yy620:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy771;
+		if (yych == '_') goto yy770;
 		goto yy87;
 yy621:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy772;
-		goto yy87;
-yy622:
-		yych = *++cursor_;
-		if (yych == '_') goto yy773;
-		goto yy87;
-yy623:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 315 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Abs); }
-#line 4123 "src/prebuilt/wast-lexer-gen.cc"
-yy625:
+#line 4113 "src/prebuilt/wast-lexer-gen.cc"
+yy623:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 362 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Add); }
-#line 4131 "src/prebuilt/wast-lexer-gen.cc"
+#line 4121 "src/prebuilt/wast-lexer-gen.cc"
+yy625:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy771;
+		goto yy87;
+yy626:
+		yych = *++cursor_;
+		if (yych == 's') goto yy773;
+		if (yych == 'v') goto yy774;
+		goto yy87;
 yy627:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy774;
+		if (yych == 'y') goto yy775;
 		goto yy87;
 yy628:
 		yych = *++cursor_;
-		if (yych == 's') goto yy776;
-		if (yych == 'v') goto yy777;
+		if (yych == 'o') goto yy776;
 		goto yy87;
 yy629:
-		yych = *++cursor_;
-		if (yych == 'y') goto yy778;
-		goto yy87;
-yy630:
-		yych = *++cursor_;
-		if (yych == 'o') goto yy779;
-		goto yy87;
-yy631:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 368 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Div); }
-#line 4156 "src/prebuilt/wast-lexer-gen.cc"
+#line 4146 "src/prebuilt/wast-lexer-gen.cc"
+yy631:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy777;
+		goto yy87;
+yy632:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy778;
+		goto yy87;
 yy633:
-		yych = *++cursor_;
-		if (yych == 'o') goto yy780;
-		goto yy87;
-yy634:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy781;
-		goto yy87;
-yy635:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 372 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Max); }
-#line 4172 "src/prebuilt/wast-lexer-gen.cc"
-yy637:
+#line 4162 "src/prebuilt/wast-lexer-gen.cc"
+yy635:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 370 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Min); }
-#line 4180 "src/prebuilt/wast-lexer-gen.cc"
-yy639:
+#line 4170 "src/prebuilt/wast-lexer-gen.cc"
+yy637:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 366 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Mul); }
-#line 4188 "src/prebuilt/wast-lexer-gen.cc"
-yy641:
+#line 4178 "src/prebuilt/wast-lexer-gen.cc"
+yy639:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy783;
+		if (yych == 'r') goto yy780;
 		goto yy87;
-yy642:
+yy640:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 313 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Neg); }
-#line 4200 "src/prebuilt/wast-lexer-gen.cc"
+#line 4190 "src/prebuilt/wast-lexer-gen.cc"
+yy642:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy781;
+		goto yy87;
+yy643:
+		yych = *++cursor_;
+		if (yych == 't') goto yy782;
+		goto yy87;
 yy644:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy784;
+		if (yych == 'r') goto yy784;
 		goto yy87;
 yy645:
-		yych = *++cursor_;
-		if (yych == 't') goto yy785;
-		goto yy87;
-yy646:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy787;
-		goto yy87;
-yy647:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 364 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Sub); }
-#line 4220 "src/prebuilt/wast-lexer-gen.cc"
-yy649:
+#line 4210 "src/prebuilt/wast-lexer-gen.cc"
+yy647:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy788;
+		if (yych == 'n') goto yy785;
 		goto yy87;
-yy650:
+yy648:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 316 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Abs); }
-#line 4232 "src/prebuilt/wast-lexer-gen.cc"
-yy652:
+#line 4222 "src/prebuilt/wast-lexer-gen.cc"
+yy650:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 363 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Add); }
-#line 4240 "src/prebuilt/wast-lexer-gen.cc"
+#line 4230 "src/prebuilt/wast-lexer-gen.cc"
+yy652:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy786;
+		goto yy87;
+yy653:
+		yych = *++cursor_;
+		if (yych == 's') goto yy788;
+		if (yych == 'v') goto yy789;
+		goto yy87;
 yy654:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy789;
+		if (yych == 'y') goto yy790;
 		goto yy87;
 yy655:
-		yych = *++cursor_;
-		if (yych == 's') goto yy791;
-		if (yych == 'v') goto yy792;
-		goto yy87;
-yy656:
-		yych = *++cursor_;
-		if (yych == 'y') goto yy793;
-		goto yy87;
-yy657:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 369 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Div); }
-#line 4261 "src/prebuilt/wast-lexer-gen.cc"
+#line 4251 "src/prebuilt/wast-lexer-gen.cc"
+yy657:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy791;
+		goto yy87;
+yy658:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy792;
+		goto yy87;
 yy659:
-		yych = *++cursor_;
-		if (yych == 'o') goto yy794;
-		goto yy87;
-yy660:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy795;
-		goto yy87;
-yy661:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 373 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Max); }
-#line 4277 "src/prebuilt/wast-lexer-gen.cc"
-yy663:
+#line 4267 "src/prebuilt/wast-lexer-gen.cc"
+yy661:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 371 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Min); }
-#line 4285 "src/prebuilt/wast-lexer-gen.cc"
-yy665:
+#line 4275 "src/prebuilt/wast-lexer-gen.cc"
+yy663:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 367 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Mul); }
-#line 4293 "src/prebuilt/wast-lexer-gen.cc"
-yy667:
+#line 4283 "src/prebuilt/wast-lexer-gen.cc"
+yy665:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy797;
+		if (yych == 'r') goto yy794;
 		goto yy87;
-yy668:
+yy666:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 314 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Neg); }
-#line 4305 "src/prebuilt/wast-lexer-gen.cc"
+#line 4295 "src/prebuilt/wast-lexer-gen.cc"
+yy668:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy795;
+		goto yy87;
+yy669:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy796;
+		goto yy87;
 yy670:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy798;
+		if (yych == 't') goto yy797;
 		goto yy87;
 yy671:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy799;
+		if (yych == 'r') goto yy799;
 		goto yy87;
 yy672:
-		yych = *++cursor_;
-		if (yych == 't') goto yy800;
-		goto yy87;
-yy673:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy802;
-		goto yy87;
-yy674:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 365 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Sub); }
-#line 4329 "src/prebuilt/wast-lexer-gen.cc"
+#line 4319 "src/prebuilt/wast-lexer-gen.cc"
+yy674:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy800;
+		goto yy87;
+yy675:
+		yych = *++cursor_;
+		if (yych == 'b') goto yy801;
+		goto yy87;
 yy676:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy803;
+		if (yych == 'a') goto yy802;
 		goto yy87;
 yy677:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy804;
+		if (yych == 'm') goto yy803;
 		goto yy87;
 yy678:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy805;
-		goto yy87;
-yy679:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy806;
-		goto yy87;
-yy680:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 332 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Add); }
-#line 4353 "src/prebuilt/wast-lexer-gen.cc"
-yy682:
+#line 4343 "src/prebuilt/wast-lexer-gen.cc"
+yy680:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 346 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32And); }
-#line 4361 "src/prebuilt/wast-lexer-gen.cc"
-yy684:
+#line 4351 "src/prebuilt/wast-lexer-gen.cc"
+yy682:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy807;
+		if (yych == 'm') goto yy804;
 		goto yy87;
-yy685:
+yy683:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 307 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I32Clz); }
-#line 4373 "src/prebuilt/wast-lexer-gen.cc"
-yy687:
+#line 4363 "src/prebuilt/wast-lexer-gen.cc"
+yy685:
 		yych = *++cursor_;
-		if (yych == 's') goto yy808;
+		if (yych == 's') goto yy805;
 		goto yy87;
-yy688:
+yy686:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 309 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I32Ctz); }
-#line 4385 "src/prebuilt/wast-lexer-gen.cc"
-yy690:
+#line 4375 "src/prebuilt/wast-lexer-gen.cc"
+yy688:
 		yych = *++cursor_;
-		if (yych == '_') goto yy809;
+		if (yych == '_') goto yy806;
 		goto yy87;
-yy691:
+yy689:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 305 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32Eqz); }
-#line 4397 "src/prebuilt/wast-lexer-gen.cc"
+#line 4387 "src/prebuilt/wast-lexer-gen.cc"
+yy691:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy807;
+		goto yy87;
+yy692:
+		yych = *++cursor_;
+		if (yych == 's') goto yy808;
+		if (yych == 'u') goto yy810;
+		goto yy87;
 yy693:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy810;
+		if (yych == 's') goto yy812;
+		if (yych == 'u') goto yy814;
 		goto yy87;
 yy694:
 		yych = *++cursor_;
-		if (yych == 's') goto yy811;
-		if (yych == 'u') goto yy813;
+		if (yych == 's') goto yy816;
+		if (yych == 'u') goto yy818;
 		goto yy87;
 yy695:
 		yych = *++cursor_;
-		if (yych == 's') goto yy815;
-		if (yych == 'u') goto yy817;
+		if (yych == 'd') goto yy820;
 		goto yy87;
 yy696:
 		yych = *++cursor_;
-		if (yych == 's') goto yy819;
-		if (yych == 'u') goto yy821;
+		if (yych == 's') goto yy822;
+		if (yych == 'u') goto yy824;
 		goto yy87;
 yy697:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy823;
-		goto yy87;
-yy698:
-		yych = *++cursor_;
-		if (yych == 's') goto yy825;
-		if (yych == 'u') goto yy827;
-		goto yy87;
-yy699:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 336 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Mul); }
-#line 4433 "src/prebuilt/wast-lexer-gen.cc"
+#line 4423 "src/prebuilt/wast-lexer-gen.cc"
+yy699:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy826;
+		goto yy87;
+yy700:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy827;
+		goto yy87;
 yy701:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy829;
+		if (yych == '_') goto yy828;
 		goto yy87;
 yy702:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy830;
+		if (yych == 'l') goto yy829;
+		if (yych == 'r') goto yy831;
 		goto yy87;
 yy703:
-		yych = *++cursor_;
-		if (yych == '_') goto yy831;
-		goto yy87;
-yy704:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy832;
-		if (yych == 'r') goto yy834;
-		goto yy87;
-yy705:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 352 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Shl); }
-#line 4458 "src/prebuilt/wast-lexer-gen.cc"
+#line 4448 "src/prebuilt/wast-lexer-gen.cc"
+yy705:
+		yych = *++cursor_;
+		if (yych == '_') goto yy833;
+		goto yy87;
+yy706:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy834;
+		goto yy87;
 yy707:
-		yych = *++cursor_;
-		if (yych == '_') goto yy836;
-		goto yy87;
-yy708:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy837;
-		goto yy87;
-yy709:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 334 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Sub); }
-#line 4474 "src/prebuilt/wast-lexer-gen.cc"
+#line 4464 "src/prebuilt/wast-lexer-gen.cc"
+yy709:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy835;
+		goto yy87;
+yy710:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy836;
+		goto yy87;
 yy711:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy838;
-		goto yy87;
-yy712:
-		yych = *++cursor_;
-		if (yych == 't') goto yy839;
-		goto yy87;
-yy713:
-		yych = *++cursor_;
-		if (yych == 'p') goto yy841;
-		goto yy87;
-yy714:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 350 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Xor); }
-#line 4494 "src/prebuilt/wast-lexer-gen.cc"
-yy716:
+#line 4480 "src/prebuilt/wast-lexer-gen.cc"
+yy713:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 333 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Add); }
-#line 4502 "src/prebuilt/wast-lexer-gen.cc"
-yy718:
+#line 4488 "src/prebuilt/wast-lexer-gen.cc"
+yy715:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 347 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64And); }
-#line 4510 "src/prebuilt/wast-lexer-gen.cc"
-yy720:
+#line 4496 "src/prebuilt/wast-lexer-gen.cc"
+yy717:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy842;
+		if (yych == 'm') goto yy837;
 		goto yy87;
-yy721:
+yy718:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 308 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I64Clz); }
-#line 4522 "src/prebuilt/wast-lexer-gen.cc"
-yy723:
+#line 4508 "src/prebuilt/wast-lexer-gen.cc"
+yy720:
 		yych = *++cursor_;
-		if (yych == 's') goto yy843;
+		if (yych == 's') goto yy838;
 		goto yy87;
-yy724:
+yy721:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 310 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I64Ctz); }
-#line 4534 "src/prebuilt/wast-lexer-gen.cc"
-yy726:
+#line 4520 "src/prebuilt/wast-lexer-gen.cc"
+yy723:
 		yych = *++cursor_;
-		if (yych == '_') goto yy844;
+		if (yych == '_') goto yy839;
 		goto yy87;
-yy727:
+yy724:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 306 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64Eqz); }
-#line 4546 "src/prebuilt/wast-lexer-gen.cc"
+#line 4532 "src/prebuilt/wast-lexer-gen.cc"
+yy726:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy840;
+		goto yy87;
+yy727:
+		yych = *++cursor_;
+		if (yych == 's') goto yy841;
+		if (yych == 'u') goto yy843;
+		goto yy87;
+yy728:
+		yych = *++cursor_;
+		if (yych == 's') goto yy845;
+		if (yych == 'u') goto yy847;
+		goto yy87;
 yy729:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy845;
+		if (yych == 's') goto yy849;
+		if (yych == 'u') goto yy851;
 		goto yy87;
 yy730:
 		yych = *++cursor_;
-		if (yych == 's') goto yy846;
-		if (yych == 'u') goto yy848;
+		if (yych == 'd') goto yy853;
 		goto yy87;
 yy731:
 		yych = *++cursor_;
-		if (yych == 's') goto yy850;
-		if (yych == 'u') goto yy852;
+		if (yych == 's') goto yy855;
+		if (yych == 'u') goto yy857;
 		goto yy87;
 yy732:
-		yych = *++cursor_;
-		if (yych == 's') goto yy854;
-		if (yych == 'u') goto yy856;
-		goto yy87;
-yy733:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy858;
-		goto yy87;
-yy734:
-		yych = *++cursor_;
-		if (yych == 's') goto yy860;
-		if (yych == 'u') goto yy862;
-		goto yy87;
-yy735:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 337 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Mul); }
-#line 4582 "src/prebuilt/wast-lexer-gen.cc"
+#line 4568 "src/prebuilt/wast-lexer-gen.cc"
+yy734:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy859;
+		goto yy87;
+yy735:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy860;
+		goto yy87;
+yy736:
+		yych = *++cursor_;
+		if (yych == '_') goto yy861;
+		goto yy87;
 yy737:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy864;
+		if (yych == 'l') goto yy862;
+		if (yych == 'r') goto yy864;
 		goto yy87;
 yy738:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy865;
-		goto yy87;
-yy739:
-		yych = *++cursor_;
-		if (yych == '_') goto yy866;
-		goto yy87;
-yy740:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy867;
-		if (yych == 'r') goto yy869;
-		goto yy87;
-yy741:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 353 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Shl); }
-#line 4607 "src/prebuilt/wast-lexer-gen.cc"
-yy743:
+#line 4593 "src/prebuilt/wast-lexer-gen.cc"
+yy740:
 		yych = *++cursor_;
-		if (yych == '_') goto yy871;
+		if (yych == '_') goto yy866;
 		goto yy87;
-yy744:
+yy741:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy872;
+		if (yych == 'r') goto yy867;
 		goto yy87;
-yy745:
+yy742:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 335 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Sub); }
-#line 4623 "src/prebuilt/wast-lexer-gen.cc"
-yy747:
+#line 4609 "src/prebuilt/wast-lexer-gen.cc"
+yy744:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy873;
+		if (yych == 'n') goto yy868;
 		goto yy87;
-yy748:
-		yych = *++cursor_;
-		if (yych == 't') goto yy874;
-		goto yy87;
-yy749:
+yy745:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 351 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Xor); }
-#line 4639 "src/prebuilt/wast-lexer-gen.cc"
-yy751:
+#line 4621 "src/prebuilt/wast-lexer-gen.cc"
+yy747:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -4648,61 +4630,61 @@ yy751:
 			} else {
 				if (yych <= ')') goto yy259;
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy751;
+				if (yych <= '9') goto yy747;
 				goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
 				if (yych <= ';') goto yy259;
 				if (yych <= '@') goto yy86;
-				if (yych <= 'F') goto yy751;
+				if (yych <= 'F') goto yy747;
 				goto yy86;
 			} else {
 				if (yych <= '`') {
-					if (yych <= '_') goto yy595;
+					if (yych <= '_') goto yy592;
 					goto yy86;
 				} else {
-					if (yych <= 'f') goto yy751;
+					if (yych <= 'f') goto yy747;
 					if (yych <= '~') goto yy86;
 					goto yy259;
 				}
 			}
 		}
-yy753:
+yy749:
 		yych = *++cursor_;
 		if (yych <= '/') goto yy87;
-		if (yych <= '0') goto yy876;
-		if (yych <= '9') goto yy878;
+		if (yych <= '0') goto yy869;
+		if (yych <= '9') goto yy871;
 		goto yy87;
-yy754:
+yy750:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy880;
+		if (yych == 'r') goto yy873;
 		goto yy87;
-yy755:
+yy751:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 546 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Rethrow); }
-#line 4689 "src/prebuilt/wast-lexer-gen.cc"
+#line 4671 "src/prebuilt/wast-lexer-gen.cc"
+yy753:
+		yych = *++cursor_;
+		if (yych == 'b') goto yy875;
+		goto yy87;
+yy754:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy876;
+		goto yy87;
+yy755:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy877;
+		goto yy87;
+yy756:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy878;
+		goto yy87;
 yy757:
-		yych = *++cursor_;
-		if (yych == 'b') goto yy882;
-		goto yy87;
-yy758:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy883;
-		goto yy87;
-yy759:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy884;
-		goto yy87;
-yy760:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy885;
-		goto yy87;
-yy761:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -4718,7 +4700,7 @@ yy761:
 		} else {
 			if (yych <= ':') {
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy614;
+				if (yych <= '9') goto yy611;
 				goto yy86;
 			} else {
 				if (yych <= ';') goto yy88;
@@ -4726,7 +4708,7 @@ yy761:
 				goto yy88;
 			}
 		}
-yy762:
+yy758:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -4738,262 +4720,266 @@ yy762:
 				if (yych <= '\'') goto yy86;
 				if (yych <= ')') goto yy88;
 				if (yych <= '/') goto yy86;
-				goto yy886;
+				goto yy879;
 			}
 		} else {
 			if (yych <= 'F') {
 				if (yych == ';') goto yy88;
 				if (yych <= '@') goto yy86;
-				goto yy886;
+				goto yy879;
 			} else {
 				if (yych <= '`') goto yy86;
-				if (yych <= 'f') goto yy886;
+				if (yych <= 'f') goto yy879;
 				if (yych <= '~') goto yy86;
 				goto yy88;
 			}
 		}
+yy759:
+		yych = *++cursor_;
+		if (yych == 'x') goto yy881;
+		goto yy87;
+yy760:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy882;
+		goto yy87;
+yy761:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy883;
+		goto yy87;
+yy762:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy884;
+		goto yy87;
 yy763:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy888;
+		if (yych == 'r') goto yy885;
 		goto yy87;
 yy764:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy889;
+		if (yych == 'n') goto yy886;
 		goto yy87;
 yy765:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy890;
+		if (yych == 'a') goto yy887;
 		goto yy87;
 yy766:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy891;
-		goto yy87;
-yy767:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy892;
-		goto yy87;
-yy768:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy893;
-		goto yy87;
-yy769:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 265 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(BrTable); }
-#line 4787 "src/prebuilt/wast-lexer-gen.cc"
+#line 4773 "src/prebuilt/wast-lexer-gen.cc"
+yy768:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy888;
+		goto yy87;
+yy769:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy889;
+		goto yy87;
+yy770:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy891;
+		goto yy87;
 yy771:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy894;
-		goto yy87;
-yy772:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy895;
-		goto yy87;
-yy773:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy897;
-		goto yy87;
-yy774:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 319 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Ceil); }
-#line 4807 "src/prebuilt/wast-lexer-gen.cc"
+#line 4793 "src/prebuilt/wast-lexer-gen.cc"
+yy773:
+		yych = *++cursor_;
+		if (yych == 't') goto yy892;
+		goto yy87;
+yy774:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy894;
+		goto yy87;
+yy775:
+		yych = *++cursor_;
+		if (yych == 's') goto yy895;
+		goto yy87;
 yy776:
 		yych = *++cursor_;
-		if (yych == 't') goto yy898;
+		if (yych == 't') goto yy896;
 		goto yy87;
 yy777:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy900;
+		if (yych == 'r') goto yy897;
 		goto yy87;
 yy778:
-		yych = *++cursor_;
-		if (yych == 's') goto yy901;
-		goto yy87;
-yy779:
-		yych = *++cursor_;
-		if (yych == 't') goto yy902;
-		goto yy87;
-yy780:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy903;
-		goto yy87;
-yy781:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 278 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, F32Load); }
-#line 4835 "src/prebuilt/wast-lexer-gen.cc"
-yy783:
+#line 4821 "src/prebuilt/wast-lexer-gen.cc"
+yy780:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy905;
+		if (yych == 'e') goto yy899;
 		goto yy87;
-yy784:
+yy781:
 		yych = *++cursor_;
-		if (yych == 't') goto yy906;
+		if (yych == 't') goto yy900;
 		goto yy87;
-yy785:
+yy782:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 317 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Sqrt); }
-#line 4851 "src/prebuilt/wast-lexer-gen.cc"
-yy787:
+#line 4837 "src/prebuilt/wast-lexer-gen.cc"
+yy784:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy907;
+		if (yych == 'e') goto yy901;
 		goto yy87;
-yy788:
+yy785:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy909;
+		if (yych == 'c') goto yy903;
 		goto yy87;
-yy789:
+yy786:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 320 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Ceil); }
-#line 4867 "src/prebuilt/wast-lexer-gen.cc"
+#line 4853 "src/prebuilt/wast-lexer-gen.cc"
+yy788:
+		yych = *++cursor_;
+		if (yych == 't') goto yy905;
+		goto yy87;
+yy789:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy907;
+		goto yy87;
+yy790:
+		yych = *++cursor_;
+		if (yych == 's') goto yy908;
+		goto yy87;
 yy791:
 		yych = *++cursor_;
-		if (yych == 't') goto yy911;
+		if (yych == 'r') goto yy909;
 		goto yy87;
 yy792:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy913;
-		goto yy87;
-yy793:
-		yych = *++cursor_;
-		if (yych == 's') goto yy914;
-		goto yy87;
-yy794:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy915;
-		goto yy87;
-yy795:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 279 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, F64Load); }
-#line 4891 "src/prebuilt/wast-lexer-gen.cc"
+#line 4877 "src/prebuilt/wast-lexer-gen.cc"
+yy794:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy911;
+		goto yy87;
+yy795:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy912;
+		goto yy87;
+yy796:
+		yych = *++cursor_;
+		if (yych == 't') goto yy913;
+		goto yy87;
 yy797:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy917;
-		goto yy87;
-yy798:
-		yych = *++cursor_;
-		if (yych == 'o') goto yy918;
-		goto yy87;
-yy799:
-		yych = *++cursor_;
-		if (yych == 't') goto yy919;
-		goto yy87;
-yy800:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 318 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Sqrt); }
-#line 4911 "src/prebuilt/wast-lexer-gen.cc"
+#line 4897 "src/prebuilt/wast-lexer-gen.cc"
+yy799:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy914;
+		goto yy87;
+yy800:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy916;
+		goto yy87;
+yy801:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy918;
+		goto yy87;
 yy802:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy920;
+		if (yych == 'l') goto yy919;
 		goto yy87;
 yy803:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy922;
+		if (yych == 'o') goto yy921;
 		goto yy87;
 yy804:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy924;
+		if (yych == 'i') goto yy922;
 		goto yy87;
 yy805:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy925;
+		if (yych == 't') goto yy923;
 		goto yy87;
 yy806:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy927;
+		if (yych == 's') goto yy925;
+		if (yych == 'u') goto yy927;
 		goto yy87;
 yy807:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy928;
+		if (yych == 'n') goto yy929;
 		goto yy87;
 yy808:
-		yych = *++cursor_;
-		if (yych == 't') goto yy929;
-		goto yy87;
-yy809:
-		yych = *++cursor_;
-		if (yych == 's') goto yy931;
-		if (yych == 'u') goto yy933;
-		goto yy87;
-yy810:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy935;
-		goto yy87;
-yy811:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 392 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32GeS); }
-#line 4956 "src/prebuilt/wast-lexer-gen.cc"
-yy813:
+#line 4942 "src/prebuilt/wast-lexer-gen.cc"
+yy810:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 394 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32GeU); }
-#line 4964 "src/prebuilt/wast-lexer-gen.cc"
-yy815:
+#line 4950 "src/prebuilt/wast-lexer-gen.cc"
+yy812:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 388 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32GtS); }
-#line 4972 "src/prebuilt/wast-lexer-gen.cc"
-yy817:
+#line 4958 "src/prebuilt/wast-lexer-gen.cc"
+yy814:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 390 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32GtU); }
-#line 4980 "src/prebuilt/wast-lexer-gen.cc"
-yy819:
+#line 4966 "src/prebuilt/wast-lexer-gen.cc"
+yy816:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 384 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32LeS); }
-#line 4988 "src/prebuilt/wast-lexer-gen.cc"
-yy821:
+#line 4974 "src/prebuilt/wast-lexer-gen.cc"
+yy818:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 386 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32LeU); }
-#line 4996 "src/prebuilt/wast-lexer-gen.cc"
-yy823:
+#line 4982 "src/prebuilt/wast-lexer-gen.cc"
+yy820:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
 			if (yych <= '"') {
@@ -5004,590 +4990,578 @@ yy823:
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych <= '1') goto yy936;
+				if (yych <= '1') goto yy930;
 				if (yych <= '7') goto yy86;
-				goto yy937;
+				goto yy931;
 			} else {
-				if (yych == ';') goto yy824;
+				if (yych == ';') goto yy821;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy824:
+yy821:
 #line 276 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I32Load); }
-#line 5019 "src/prebuilt/wast-lexer-gen.cc"
-yy825:
+#line 5005 "src/prebuilt/wast-lexer-gen.cc"
+yy822:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 380 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32LtS); }
-#line 5027 "src/prebuilt/wast-lexer-gen.cc"
-yy827:
+#line 5013 "src/prebuilt/wast-lexer-gen.cc"
+yy824:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 382 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I32LtU); }
-#line 5035 "src/prebuilt/wast-lexer-gen.cc"
+#line 5021 "src/prebuilt/wast-lexer-gen.cc"
+yy826:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy932;
+		goto yy87;
+yy827:
+		yych = *++cursor_;
+		if (yych == 't') goto yy933;
+		goto yy87;
+yy828:
+		yych = *++cursor_;
+		if (yych == 's') goto yy934;
+		if (yych == 'u') goto yy936;
+		goto yy87;
 yy829:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy938;
-		goto yy87;
-yy830:
-		yych = *++cursor_;
-		if (yych == 't') goto yy939;
-		goto yy87;
-yy831:
-		yych = *++cursor_;
-		if (yych == 's') goto yy940;
-		if (yych == 'u') goto yy942;
-		goto yy87;
-yy832:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 358 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Rotl); }
-#line 5056 "src/prebuilt/wast-lexer-gen.cc"
-yy834:
+#line 5042 "src/prebuilt/wast-lexer-gen.cc"
+yy831:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 360 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32Rotr); }
-#line 5064 "src/prebuilt/wast-lexer-gen.cc"
+#line 5050 "src/prebuilt/wast-lexer-gen.cc"
+yy833:
+		yych = *++cursor_;
+		if (yych == 's') goto yy938;
+		if (yych == 'u') goto yy940;
+		goto yy87;
+yy834:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy942;
+		goto yy87;
+yy835:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy944;
+		goto yy87;
 yy836:
 		yych = *++cursor_;
-		if (yych == 's') goto yy944;
-		if (yych == 'u') goto yy946;
+		if (yych == '/') goto yy945;
 		goto yy87;
 yy837:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy948;
+		if (yych == 'i') goto yy946;
 		goto yy87;
 yy838:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy950;
+		if (yych == 't') goto yy947;
 		goto yy87;
 yy839:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 446 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Wait, I32Wait); }
-#line 5085 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == 's') goto yy949;
+		if (yych == 'u') goto yy951;
+		goto yy87;
+yy840:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy953;
+		goto yy87;
 yy841:
-		yych = *++cursor_;
-		if (yych == '/') goto yy951;
-		goto yy87;
-yy842:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy952;
-		goto yy87;
-yy843:
-		yych = *++cursor_;
-		if (yych == 't') goto yy953;
-		goto yy87;
-yy844:
-		yych = *++cursor_;
-		if (yych == 's') goto yy955;
-		if (yych == 'u') goto yy957;
-		goto yy87;
-yy845:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy959;
-		goto yy87;
-yy846:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 393 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64GeS); }
-#line 5114 "src/prebuilt/wast-lexer-gen.cc"
-yy848:
+#line 5092 "src/prebuilt/wast-lexer-gen.cc"
+yy843:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 395 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64GeU); }
-#line 5122 "src/prebuilt/wast-lexer-gen.cc"
-yy850:
+#line 5100 "src/prebuilt/wast-lexer-gen.cc"
+yy845:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 389 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64GtS); }
-#line 5130 "src/prebuilt/wast-lexer-gen.cc"
-yy852:
+#line 5108 "src/prebuilt/wast-lexer-gen.cc"
+yy847:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 391 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64GtU); }
-#line 5138 "src/prebuilt/wast-lexer-gen.cc"
-yy854:
+#line 5116 "src/prebuilt/wast-lexer-gen.cc"
+yy849:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 385 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64LeS); }
-#line 5146 "src/prebuilt/wast-lexer-gen.cc"
-yy856:
+#line 5124 "src/prebuilt/wast-lexer-gen.cc"
+yy851:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 387 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64LeU); }
-#line 5154 "src/prebuilt/wast-lexer-gen.cc"
-yy858:
+#line 5132 "src/prebuilt/wast-lexer-gen.cc"
+yy853:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy859;
+				if (yych <= ')') goto yy854;
 				if (yych <= '0') goto yy86;
-				goto yy960;
+				goto yy954;
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych == '3') goto yy961;
+				if (yych == '3') goto yy955;
 				if (yych <= '7') goto yy86;
-				goto yy962;
+				goto yy956;
 			} else {
-				if (yych == ';') goto yy859;
+				if (yych == ';') goto yy854;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy859:
+yy854:
 #line 277 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load); }
-#line 5179 "src/prebuilt/wast-lexer-gen.cc"
-yy860:
+#line 5157 "src/prebuilt/wast-lexer-gen.cc"
+yy855:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 381 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64LtS); }
-#line 5187 "src/prebuilt/wast-lexer-gen.cc"
-yy862:
+#line 5165 "src/prebuilt/wast-lexer-gen.cc"
+yy857:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 383 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Compare, I64LtU); }
-#line 5195 "src/prebuilt/wast-lexer-gen.cc"
-yy864:
+#line 5173 "src/prebuilt/wast-lexer-gen.cc"
+yy859:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy963;
+		if (yych == 'n') goto yy957;
 		goto yy87;
-yy865:
+yy860:
 		yych = *++cursor_;
-		if (yych == 't') goto yy964;
+		if (yych == 't') goto yy958;
 		goto yy87;
-yy866:
+yy861:
 		yych = *++cursor_;
-		if (yych == 's') goto yy965;
-		if (yych == 'u') goto yy967;
+		if (yych == 's') goto yy959;
+		if (yych == 'u') goto yy961;
 		goto yy87;
-yy867:
+yy862:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 359 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Rotl); }
-#line 5216 "src/prebuilt/wast-lexer-gen.cc"
-yy869:
+#line 5194 "src/prebuilt/wast-lexer-gen.cc"
+yy864:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 361 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64Rotr); }
-#line 5224 "src/prebuilt/wast-lexer-gen.cc"
-yy871:
+#line 5202 "src/prebuilt/wast-lexer-gen.cc"
+yy866:
 		yych = *++cursor_;
-		if (yych == 's') goto yy969;
-		if (yych == 'u') goto yy971;
+		if (yych == 's') goto yy963;
+		if (yych == 'u') goto yy965;
 		goto yy87;
-yy872:
+yy867:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy973;
+		if (yych == 'e') goto yy967;
 		goto yy87;
-yy873:
+yy868:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy975;
+		if (yych == 'c') goto yy969;
 		goto yy87;
-yy874:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 447 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Wait, I64Wait); }
-#line 5245 "src/prebuilt/wast-lexer-gen.cc"
-yy876:
+yy869:
 		++cursor_;
 		if ((yych = *cursor_) <= '9') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy877;
+				if (yych <= ')') goto yy870;
 				if (yych <= '/') goto yy86;
-				goto yy878;
+				goto yy871;
 			}
 		} else {
 			if (yych <= '_') {
-				if (yych == ';') goto yy877;
+				if (yych == ';') goto yy870;
 				if (yych <= '^') goto yy86;
-				goto yy976;
+				goto yy970;
 			} else {
-				if (yych == 'x') goto yy977;
+				if (yych == 'x') goto yy971;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy877:
+yy870:
 #line 299 "src/wast-lexer.cc"
 		{ RETURN_TEXT_AT(OffsetEqNat, 7); }
-#line 5270 "src/prebuilt/wast-lexer-gen.cc"
-yy878:
+#line 5240 "src/prebuilt/wast-lexer-gen.cc"
+yy871:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= '/') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
-				goto yy877;
+				goto yy870;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy877;
+				if (yych <= ')') goto yy870;
 				goto yy86;
 			}
 		} else {
 			if (yych <= ';') {
-				if (yych <= '9') goto yy878;
+				if (yych <= '9') goto yy871;
 				if (yych <= ':') goto yy86;
-				goto yy877;
+				goto yy870;
 			} else {
-				if (yych == '_') goto yy976;
+				if (yych == '_') goto yy970;
 				if (yych <= '~') goto yy86;
-				goto yy877;
+				goto yy870;
 			}
 		}
-yy880:
+yy873:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 531 "src/wast-lexer.cc"
 		{ RETURN(Register); }
-#line 5302 "src/prebuilt/wast-lexer-gen.cc"
-yy882:
+#line 5272 "src/prebuilt/wast-lexer-gen.cc"
+yy875:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy978;
+		if (yych == 'a') goto yy972;
 		goto yy87;
-yy883:
+yy876:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy979;
+		if (yych == 'l') goto yy973;
 		goto yy87;
-yy884:
+yy877:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy981;
+		if (yych == 'l') goto yy975;
 		goto yy87;
-yy885:
+yy878:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy983;
+		if (yych == 'b') goto yy977;
 		goto yy87;
-yy886:
+yy879:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= ':') {
 			if (yych <= '\'') {
 				if (yych == '!') goto yy86;
-				if (yych <= '"') goto yy613;
+				if (yych <= '"') goto yy610;
 				goto yy86;
 			} else {
-				if (yych <= ')') goto yy613;
+				if (yych <= ')') goto yy610;
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy886;
+				if (yych <= '9') goto yy879;
 				goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
-				if (yych <= ';') goto yy613;
+				if (yych <= ';') goto yy610;
 				if (yych <= '@') goto yy86;
-				if (yych <= 'F') goto yy886;
+				if (yych <= 'F') goto yy879;
 				goto yy86;
 			} else {
 				if (yych <= '`') {
-					if (yych <= '_') goto yy762;
+					if (yych <= '_') goto yy758;
 					goto yy86;
 				} else {
-					if (yych <= 'f') goto yy886;
+					if (yych <= 'f') goto yy879;
 					if (yych <= '~') goto yy86;
-					goto yy613;
+					goto yy610;
 				}
 			}
 		}
+yy881:
+		yych = *++cursor_;
+		if (yych == 'h') goto yy978;
+		goto yy87;
+yy882:
+		yych = *++cursor_;
+		if (yych == 'v') goto yy979;
+		goto yy87;
+yy883:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy980;
+		goto yy87;
+yy884:
+		yych = *++cursor_;
+		if (yych == 't') goto yy981;
+		goto yy87;
+yy885:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy982;
+		goto yy87;
+yy886:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy983;
+		goto yy87;
+yy887:
+		yych = *++cursor_;
+		if (yych == 'k') goto yy984;
+		goto yy87;
 yy888:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy984;
+		if (yych == 'r') goto yy985;
 		goto yy87;
 yy889:
-		yych = *++cursor_;
-		if (yych == 'v') goto yy985;
-		goto yy87;
-yy890:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy986;
-		goto yy87;
-yy891:
-		yych = *++cursor_;
-		if (yych == 't') goto yy987;
-		goto yy87;
-yy892:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy988;
-		goto yy87;
-yy893:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy989;
-		goto yy87;
-yy894:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy990;
-		goto yy87;
-yy895:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 544 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(CatchAll); }
-#line 5386 "src/prebuilt/wast-lexer-gen.cc"
-yy897:
+#line 5360 "src/prebuilt/wast-lexer-gen.cc"
+yy891:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy991;
+		if (yych == 'e') goto yy986;
 		goto yy87;
-yy898:
+yy892:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 303 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Const, F32Const); }
-#line 5398 "src/prebuilt/wast-lexer-gen.cc"
-yy900:
+#line 5372 "src/prebuilt/wast-lexer-gen.cc"
+yy894:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy992;
+		if (yych == 'r') goto yy987;
 		goto yy87;
-yy901:
+yy895:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy993;
+		if (yych == 'i') goto yy988;
 		goto yy87;
-yy902:
+yy896:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy994;
+		if (yych == 'e') goto yy989;
 		goto yy87;
-yy903:
+yy897:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 321 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Floor); }
-#line 5418 "src/prebuilt/wast-lexer-gen.cc"
-yy905:
+#line 5392 "src/prebuilt/wast-lexer-gen.cc"
+yy899:
 		yych = *++cursor_;
-		if (yych == 's') goto yy995;
+		if (yych == 's') goto yy990;
 		goto yy87;
-yy906:
+yy900:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy996;
+		if (yych == 'e') goto yy991;
 		goto yy87;
-yy907:
+yy901:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 282 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, F32Store); }
-#line 5434 "src/prebuilt/wast-lexer-gen.cc"
-yy909:
+#line 5408 "src/prebuilt/wast-lexer-gen.cc"
+yy903:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 323 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Trunc); }
-#line 5442 "src/prebuilt/wast-lexer-gen.cc"
-yy911:
+#line 5416 "src/prebuilt/wast-lexer-gen.cc"
+yy905:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 304 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Const, F64Const); }
-#line 5450 "src/prebuilt/wast-lexer-gen.cc"
-yy913:
+#line 5424 "src/prebuilt/wast-lexer-gen.cc"
+yy907:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy997;
+		if (yych == 'r') goto yy992;
 		goto yy87;
-yy914:
+yy908:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy998;
+		if (yych == 'i') goto yy993;
 		goto yy87;
-yy915:
+yy909:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 322 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Floor); }
-#line 5466 "src/prebuilt/wast-lexer-gen.cc"
-yy917:
+#line 5440 "src/prebuilt/wast-lexer-gen.cc"
+yy911:
 		yych = *++cursor_;
-		if (yych == 's') goto yy999;
+		if (yych == 's') goto yy994;
 		goto yy87;
-yy918:
+yy912:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1000;
+		if (yych == 't') goto yy995;
 		goto yy87;
-yy919:
+yy913:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1001;
+		if (yych == 'e') goto yy996;
 		goto yy87;
-yy920:
+yy914:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 283 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, F64Store); }
-#line 5486 "src/prebuilt/wast-lexer-gen.cc"
-yy922:
+#line 5460 "src/prebuilt/wast-lexer-gen.cc"
+yy916:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 324 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Trunc); }
-#line 5494 "src/prebuilt/wast-lexer-gen.cc"
-yy924:
+#line 5468 "src/prebuilt/wast-lexer-gen.cc"
+yy918:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy1002;
+		if (yych == 'l') goto yy997;
 		goto yy87;
-yy925:
+yy919:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 271 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(GetLocal); }
-#line 5506 "src/prebuilt/wast-lexer-gen.cc"
-yy927:
+#line 5480 "src/prebuilt/wast-lexer-gen.cc"
+yy921:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1004;
+		if (yych == 'r') goto yy999;
 		goto yy87;
-yy928:
+yy922:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1005;
+		if (yych == 'c') goto yy1000;
 		goto yy87;
-yy929:
+yy923:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 301 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Const, I32Const); }
-#line 5522 "src/prebuilt/wast-lexer-gen.cc"
-yy931:
+#line 5496 "src/prebuilt/wast-lexer-gen.cc"
+yy925:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 338 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32DivS); }
-#line 5530 "src/prebuilt/wast-lexer-gen.cc"
-yy933:
+#line 5504 "src/prebuilt/wast-lexer-gen.cc"
+yy927:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 340 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32DivU); }
-#line 5538 "src/prebuilt/wast-lexer-gen.cc"
-yy935:
+#line 5512 "src/prebuilt/wast-lexer-gen.cc"
+yy929:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1006;
+		if (yych == 'd') goto yy1001;
 		goto yy87;
-yy936:
+yy930:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1007;
+		if (yych == '6') goto yy1002;
 		goto yy87;
-yy937:
+yy931:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1008;
+		if (yych == '_') goto yy1003;
 		goto yy87;
-yy938:
+yy932:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1009;
+		if (yych == 't') goto yy1004;
 		goto yy87;
-yy939:
+yy933:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1011;
+		if (yych == 'e') goto yy1006;
 		goto yy87;
-yy940:
+yy934:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 342 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32RemS); }
-#line 5566 "src/prebuilt/wast-lexer-gen.cc"
-yy942:
+#line 5540 "src/prebuilt/wast-lexer-gen.cc"
+yy936:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 344 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32RemU); }
-#line 5574 "src/prebuilt/wast-lexer-gen.cc"
-yy944:
+#line 5548 "src/prebuilt/wast-lexer-gen.cc"
+yy938:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 354 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32ShrS); }
-#line 5582 "src/prebuilt/wast-lexer-gen.cc"
-yy946:
+#line 5556 "src/prebuilt/wast-lexer-gen.cc"
+yy940:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 356 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I32ShrU); }
-#line 5590 "src/prebuilt/wast-lexer-gen.cc"
-yy948:
+#line 5564 "src/prebuilt/wast-lexer-gen.cc"
+yy942:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
 			if (yych <= '"') {
@@ -5598,140 +5572,140 @@ yy948:
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych <= '1') goto yy1012;
+				if (yych <= '1') goto yy1007;
 				if (yych <= '7') goto yy86;
-				goto yy1013;
+				goto yy1008;
 			} else {
-				if (yych == ';') goto yy949;
+				if (yych == ';') goto yy943;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy949:
+yy943:
 #line 280 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I32Store); }
-#line 5613 "src/prebuilt/wast-lexer-gen.cc"
-yy950:
+#line 5587 "src/prebuilt/wast-lexer-gen.cc"
+yy944:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1015;
+		if (yych == '_') goto yy1010;
 		goto yy87;
-yy951:
+yy945:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1016;
+		if (yych == 'i') goto yy1011;
 		goto yy87;
-yy952:
+yy946:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1017;
+		if (yych == 'c') goto yy1012;
 		goto yy87;
-yy953:
+yy947:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 302 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Const, I64Const); }
-#line 5633 "src/prebuilt/wast-lexer-gen.cc"
-yy955:
+#line 5607 "src/prebuilt/wast-lexer-gen.cc"
+yy949:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 339 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64DivS); }
-#line 5641 "src/prebuilt/wast-lexer-gen.cc"
-yy957:
+#line 5615 "src/prebuilt/wast-lexer-gen.cc"
+yy951:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 341 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64DivU); }
-#line 5649 "src/prebuilt/wast-lexer-gen.cc"
+#line 5623 "src/prebuilt/wast-lexer-gen.cc"
+yy953:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1013;
+		goto yy87;
+yy954:
+		yych = *++cursor_;
+		if (yych == '6') goto yy1014;
+		goto yy87;
+yy955:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1015;
+		goto yy87;
+yy956:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1016;
+		goto yy87;
+yy957:
+		yych = *++cursor_;
+		if (yych == 't') goto yy1017;
+		goto yy87;
+yy958:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy1019;
+		goto yy87;
 yy959:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1018;
-		goto yy87;
-yy960:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1019;
-		goto yy87;
-yy961:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1020;
-		goto yy87;
-yy962:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1021;
-		goto yy87;
-yy963:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1022;
-		goto yy87;
-yy964:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1024;
-		goto yy87;
-yy965:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 343 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64RemS); }
-#line 5681 "src/prebuilt/wast-lexer-gen.cc"
-yy967:
+#line 5655 "src/prebuilt/wast-lexer-gen.cc"
+yy961:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 345 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64RemU); }
-#line 5689 "src/prebuilt/wast-lexer-gen.cc"
-yy969:
+#line 5663 "src/prebuilt/wast-lexer-gen.cc"
+yy963:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 355 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64ShrS); }
-#line 5697 "src/prebuilt/wast-lexer-gen.cc"
-yy971:
+#line 5671 "src/prebuilt/wast-lexer-gen.cc"
+yy965:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 357 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, I64ShrU); }
-#line 5705 "src/prebuilt/wast-lexer-gen.cc"
-yy973:
+#line 5679 "src/prebuilt/wast-lexer-gen.cc"
+yy967:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy974;
+				if (yych <= ')') goto yy968;
 				if (yych <= '0') goto yy86;
-				goto yy1025;
+				goto yy1020;
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych == '3') goto yy1026;
+				if (yych == '3') goto yy1021;
 				if (yych <= '7') goto yy86;
-				goto yy1027;
+				goto yy1022;
 			} else {
-				if (yych == ';') goto yy974;
+				if (yych == ';') goto yy968;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy974:
+yy968:
 #line 281 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I64Store); }
-#line 5730 "src/prebuilt/wast-lexer-gen.cc"
-yy975:
+#line 5704 "src/prebuilt/wast-lexer-gen.cc"
+yy969:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1029;
+		if (yych == '_') goto yy1024;
 		goto yy87;
-yy976:
+yy970:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -5747,7 +5721,7 @@ yy976:
 		} else {
 			if (yych <= ':') {
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy878;
+				if (yych <= '9') goto yy871;
 				goto yy86;
 			} else {
 				if (yych <= ';') goto yy88;
@@ -5755,7 +5729,7 @@ yy976:
 				goto yy88;
 			}
 		}
-yy977:
+yy971:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
@@ -5767,850 +5741,876 @@ yy977:
 				if (yych <= '\'') goto yy86;
 				if (yych <= ')') goto yy88;
 				if (yych <= '/') goto yy86;
-				goto yy1030;
+				goto yy1025;
 			}
 		} else {
 			if (yych <= 'F') {
 				if (yych == ';') goto yy88;
 				if (yych <= '@') goto yy86;
-				goto yy1030;
+				goto yy1025;
 			} else {
 				if (yych <= '`') goto yy86;
-				if (yych <= 'f') goto yy1030;
+				if (yych <= 'f') goto yy1025;
 				if (yych <= '~') goto yy86;
 				goto yy88;
 			}
 		}
-yy978:
+yy972:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy1032;
+		if (yych == 'l') goto yy1027;
 		goto yy87;
-yy979:
+yy973:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 272 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(SetLocal); }
-#line 5796 "src/prebuilt/wast-lexer-gen.cc"
-yy981:
+#line 5770 "src/prebuilt/wast-lexer-gen.cc"
+yy975:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 273 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(TeeLocal); }
-#line 5804 "src/prebuilt/wast-lexer-gen.cc"
+#line 5778 "src/prebuilt/wast-lexer-gen.cc"
+yy977:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy1029;
+		goto yy87;
+yy978:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy1030;
+		goto yy87;
+yy979:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy1031;
+		goto yy87;
+yy980:
+		yych = *++cursor_;
+		if (yych == 'f') goto yy1032;
+		goto yy87;
+yy981:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1033;
+		goto yy87;
+yy982:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy1034;
+		goto yy87;
 yy983:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy1034;
+		if (yych == 'i') goto yy1036;
 		goto yy87;
 yy984:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1035;
+		if (yych == 'e') goto yy1037;
 		goto yy87;
 yy985:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1036;
+		if (yych == 'e') goto yy1039;
 		goto yy87;
 yy986:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1037;
+		if (yych == 'm') goto yy1040;
 		goto yy87;
 yy987:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1038;
+		if (yych == 't') goto yy1041;
 		goto yy87;
 yy988:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1039;
+		if (yych == 'g') goto yy1042;
 		goto yy87;
 yy989:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1041;
+		if (yych == '/') goto yy1043;
 		goto yy87;
 yy990:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1042;
+		if (yych == 't') goto yy1044;
 		goto yy87;
 yy991:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy1043;
+		if (yych == 'r') goto yy1046;
 		goto yy87;
 yy992:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1044;
+		if (yych == 't') goto yy1047;
 		goto yy87;
 yy993:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1045;
+		if (yych == 'g') goto yy1048;
 		goto yy87;
 yy994:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1046;
+		if (yych == 't') goto yy1049;
 		goto yy87;
 yy995:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1047;
+		if (yych == 'e') goto yy1051;
 		goto yy87;
 yy996:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1049;
+		if (yych == 'r') goto yy1052;
 		goto yy87;
 yy997:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1050;
-		goto yy87;
-yy998:
-		yych = *++cursor_;
-		if (yych == 'g') goto yy1051;
-		goto yy87;
-yy999:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1052;
-		goto yy87;
-yy1000:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1054;
-		goto yy87;
-yy1001:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1055;
-		goto yy87;
-yy1002:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 274 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(GetGlobal); }
-#line 5888 "src/prebuilt/wast-lexer-gen.cc"
+#line 5866 "src/prebuilt/wast-lexer-gen.cc"
+yy999:
+		yych = *++cursor_;
+		if (yych == 'y') goto yy1053;
+		goto yy87;
+yy1000:
+		yych = *++cursor_;
+		if (yych == '.') goto yy1055;
+		goto yy87;
+yy1001:
+		yych = *++cursor_;
+		if (yych == '1') goto yy1056;
+		if (yych == '8') goto yy1057;
+		goto yy87;
+yy1002:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1058;
+		goto yy87;
+yy1003:
+		yych = *++cursor_;
+		if (yych == 's') goto yy1059;
+		if (yych == 'u') goto yy1061;
+		goto yy87;
 yy1004:
-		yych = *++cursor_;
-		if (yych == 'y') goto yy1056;
-		goto yy87;
-yy1005:
-		yych = *++cursor_;
-		if (yych == '.') goto yy1058;
-		goto yy87;
-yy1006:
-		yych = *++cursor_;
-		if (yych == '1') goto yy1059;
-		if (yych == '8') goto yy1060;
-		goto yy87;
-yy1007:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1061;
-		goto yy87;
-yy1008:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1062;
-		if (yych == 'u') goto yy1064;
-		goto yy87;
-yy1009:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 311 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I32Popcnt); }
-#line 5918 "src/prebuilt/wast-lexer-gen.cc"
-yy1011:
+#line 5896 "src/prebuilt/wast-lexer-gen.cc"
+yy1006:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1066;
+		if (yych == 'r') goto yy1063;
 		goto yy87;
-yy1012:
+yy1007:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1067;
+		if (yych == '6') goto yy1064;
 		goto yy87;
-yy1013:
+yy1008:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 294 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I32Store8); }
-#line 5934 "src/prebuilt/wast-lexer-gen.cc"
-yy1015:
+#line 5912 "src/prebuilt/wast-lexer-gen.cc"
+yy1010:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1069;
-		if (yych == 'u') goto yy1070;
+		if (yych == 's') goto yy1066;
+		if (yych == 'u') goto yy1067;
 		goto yy87;
-yy1016:
+yy1011:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1071;
+		if (yych == '6') goto yy1068;
 		goto yy87;
-yy1017:
+yy1012:
 		yych = *++cursor_;
-		if (yych == '.') goto yy1072;
+		if (yych == '.') goto yy1069;
 		goto yy87;
-yy1018:
+yy1013:
 		yych = *++cursor_;
 		if (yych <= '3') {
-			if (yych == '1') goto yy1073;
+			if (yych == '1') goto yy1070;
 			if (yych <= '2') goto yy87;
-			goto yy1074;
+			goto yy1071;
 		} else {
 			if (yych <= '8') {
 				if (yych <= '7') goto yy87;
-				goto yy1075;
+				goto yy1072;
 			} else {
-				if (yych == '_') goto yy1076;
+				if (yych == '_') goto yy1073;
 				goto yy87;
 			}
 		}
-yy1019:
+yy1014:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1077;
+		if (yych == '_') goto yy1074;
 		goto yy87;
-yy1020:
+yy1015:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1078;
+		if (yych == '_') goto yy1075;
 		goto yy87;
-yy1021:
+yy1016:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1079;
-		if (yych == 'u') goto yy1081;
+		if (yych == 's') goto yy1076;
+		if (yych == 'u') goto yy1078;
 		goto yy87;
-yy1022:
+yy1017:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 312 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I64Popcnt); }
-#line 5983 "src/prebuilt/wast-lexer-gen.cc"
-yy1024:
+#line 5961 "src/prebuilt/wast-lexer-gen.cc"
+yy1019:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1083;
+		if (yych == 'r') goto yy1080;
 		goto yy87;
-yy1025:
+yy1020:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1084;
+		if (yych == '6') goto yy1081;
 		goto yy87;
-yy1026:
+yy1021:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1086;
+		if (yych == '2') goto yy1083;
 		goto yy87;
-yy1027:
+yy1022:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 295 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I64Store8); }
-#line 6003 "src/prebuilt/wast-lexer-gen.cc"
-yy1029:
+#line 5981 "src/prebuilt/wast-lexer-gen.cc"
+yy1024:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1088;
-		if (yych == 'u') goto yy1089;
+		if (yych == 's') goto yy1085;
+		if (yych == 'u') goto yy1086;
 		goto yy87;
-yy1030:
+yy1025:
 		++cursor_;
 		if (limit_ <= cursor_) FILL(1);
 		yych = *cursor_;
 		if (yych <= ':') {
 			if (yych <= '\'') {
 				if (yych == '!') goto yy86;
-				if (yych <= '"') goto yy877;
+				if (yych <= '"') goto yy870;
 				goto yy86;
 			} else {
-				if (yych <= ')') goto yy877;
+				if (yych <= ')') goto yy870;
 				if (yych <= '/') goto yy86;
-				if (yych <= '9') goto yy1030;
+				if (yych <= '9') goto yy1025;
 				goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
-				if (yych <= ';') goto yy877;
+				if (yych <= ';') goto yy870;
 				if (yych <= '@') goto yy86;
-				if (yych <= 'F') goto yy1030;
+				if (yych <= 'F') goto yy1025;
 				goto yy86;
 			} else {
 				if (yych <= '`') {
-					if (yych <= '_') goto yy977;
+					if (yych <= '_') goto yy971;
 					goto yy86;
 				} else {
-					if (yych <= 'f') goto yy1030;
+					if (yych <= 'f') goto yy1025;
 					if (yych <= '~') goto yy86;
-					goto yy877;
+					goto yy870;
 				}
 			}
 		}
-yy1032:
+yy1027:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 275 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(SetGlobal); }
-#line 6048 "src/prebuilt/wast-lexer-gen.cc"
+#line 6026 "src/prebuilt/wast-lexer-gen.cc"
+yy1029:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy1087;
+		goto yy87;
+yy1030:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1089;
+		goto yy87;
+yy1031:
+		yych = *++cursor_;
+		if (yych == 'l') goto yy1090;
+		goto yy87;
+yy1032:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy1091;
+		goto yy87;
+yy1033:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1092;
+		goto yy87;
 yy1034:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1090;
-		goto yy87;
-yy1035:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1092;
-		goto yy87;
-yy1036:
-		yych = *++cursor_;
-		if (yych == 'l') goto yy1093;
-		goto yy87;
-yy1037:
-		yych = *++cursor_;
-		if (yych == 'o') goto yy1094;
-		goto yy87;
-yy1038:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1095;
-		goto yy87;
-yy1039:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 540 "src/wast-lexer.cc"
 		{ RETURN(AssertTrap); }
-#line 6076 "src/prebuilt/wast-lexer-gen.cc"
+#line 6054 "src/prebuilt/wast-lexer-gen.cc"
+yy1036:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy1093;
+		goto yy87;
+yy1037:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 448 "src/wast-lexer.cc"
+		{ RETURN_OPCODE0(AtomicWake); }
+#line 6066 "src/prebuilt/wast-lexer-gen.cc"
+yy1039:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1094;
+		goto yy87;
+yy1040:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy1095;
+		goto yy87;
 yy1041:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy1096;
+		if (yych == '_') goto yy1096;
 		goto yy87;
 yy1042:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1097;
+		if (yych == 'n') goto yy1097;
 		goto yy87;
 yy1043:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy1098;
+		if (yych == 'f') goto yy1099;
 		goto yy87;
 yy1044:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1099;
-		goto yy87;
-yy1045:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy1100;
-		goto yy87;
-yy1046:
-		yych = *++cursor_;
-		if (yych == 'f') goto yy1102;
-		goto yy87;
-yy1047:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 325 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F32Nearest); }
-#line 6108 "src/prebuilt/wast-lexer-gen.cc"
+#line 6094 "src/prebuilt/wast-lexer-gen.cc"
+yy1046:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy1100;
+		goto yy87;
+yy1047:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1101;
+		goto yy87;
+yy1048:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy1102;
+		goto yy87;
 yy1049:
-		yych = *++cursor_;
-		if (yych == 'p') goto yy1103;
-		goto yy87;
-yy1050:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1104;
-		goto yy87;
-yy1051:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy1105;
-		goto yy87;
-yy1052:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 326 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, F64Nearest); }
-#line 6128 "src/prebuilt/wast-lexer-gen.cc"
-yy1054:
+#line 6114 "src/prebuilt/wast-lexer-gen.cc"
+yy1051:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1107;
+		if (yych == '/') goto yy1104;
 		goto yy87;
-yy1055:
+yy1052:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1108;
+		if (yych == 'p') goto yy1105;
 		goto yy87;
-yy1056:
+yy1053:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 444 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(GrowMemory); }
-#line 6144 "src/prebuilt/wast-lexer-gen.cc"
-yy1058:
+#line 6130 "src/prebuilt/wast-lexer-gen.cc"
+yy1055:
 		yych = *++cursor_;
-		if (yych <= 'q') {
-			if (yych == 'l') goto yy1109;
-			goto yy87;
+		if (yych <= 'r') {
+			if (yych == 'l') goto yy1106;
+			if (yych <= 'q') goto yy87;
+			goto yy1107;
 		} else {
-			if (yych <= 'r') goto yy1110;
-			if (yych <= 's') goto yy1111;
+			if (yych <= 's') goto yy1108;
+			if (yych == 'w') goto yy1109;
 			goto yy87;
 		}
+yy1056:
+		yych = *++cursor_;
+		if (yych == '6') goto yy1110;
+		goto yy87;
+yy1057:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1111;
+		goto yy87;
+yy1058:
+		yych = *++cursor_;
+		if (yych == 's') goto yy1112;
+		if (yych == 'u') goto yy1114;
+		goto yy87;
 yy1059:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1112;
-		goto yy87;
-yy1060:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1113;
-		goto yy87;
-yy1061:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1114;
-		if (yych == 'u') goto yy1116;
-		goto yy87;
-yy1062:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 284 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I32Load8S); }
-#line 6175 "src/prebuilt/wast-lexer-gen.cc"
-yy1064:
+#line 6162 "src/prebuilt/wast-lexer-gen.cc"
+yy1061:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 286 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I32Load8U); }
-#line 6183 "src/prebuilt/wast-lexer-gen.cc"
-yy1066:
+#line 6170 "src/prebuilt/wast-lexer-gen.cc"
+yy1063:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1118;
+		if (yych == 'p') goto yy1116;
 		goto yy87;
-yy1067:
+yy1064:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 296 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I32Store16); }
-#line 6195 "src/prebuilt/wast-lexer-gen.cc"
-yy1069:
+#line 6182 "src/prebuilt/wast-lexer-gen.cc"
+yy1066:
+		yych = *++cursor_;
+		if (yych == '/') goto yy1117;
+		if (yych == ':') goto yy1118;
+		goto yy87;
+yy1067:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1119;
 		if (yych == ':') goto yy1120;
 		goto yy87;
+yy1068:
+		yych = *++cursor_;
+		if (yych == '4') goto yy1121;
+		goto yy87;
+yy1069:
+		yych = *++cursor_;
+		if (yych <= 'r') {
+			if (yych == 'l') goto yy1123;
+			if (yych <= 'q') goto yy87;
+			goto yy1124;
+		} else {
+			if (yych <= 's') goto yy1125;
+			if (yych == 'w') goto yy1126;
+			goto yy87;
+		}
 yy1070:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1121;
-		if (yych == ':') goto yy1122;
+		if (yych == '6') goto yy1127;
 		goto yy87;
 yy1071:
 		yych = *++cursor_;
-		if (yych == '4') goto yy1123;
+		if (yych == '2') goto yy1128;
 		goto yy87;
 yy1072:
 		yych = *++cursor_;
-		if (yych <= 'q') {
-			if (yych == 'l') goto yy1125;
-			goto yy87;
-		} else {
-			if (yych <= 'r') goto yy1126;
-			if (yych <= 's') goto yy1127;
-			goto yy87;
-		}
+		if (yych == '_') goto yy1129;
+		goto yy87;
 yy1073:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1128;
+		if (yych == 's') goto yy1130;
+		if (yych == 'u') goto yy1131;
 		goto yy87;
 yy1074:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1129;
+		if (yych == 's') goto yy1132;
+		if (yych == 'u') goto yy1134;
 		goto yy87;
 yy1075:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1130;
+		if (yych == 's') goto yy1136;
+		if (yych == 'u') goto yy1138;
 		goto yy87;
 yy1076:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1131;
-		if (yych == 'u') goto yy1132;
-		goto yy87;
-yy1077:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1133;
-		if (yych == 'u') goto yy1135;
-		goto yy87;
-yy1078:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1137;
-		if (yych == 'u') goto yy1139;
-		goto yy87;
-yy1079:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 285 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load8S); }
-#line 6254 "src/prebuilt/wast-lexer-gen.cc"
-yy1081:
+#line 6242 "src/prebuilt/wast-lexer-gen.cc"
+yy1078:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 287 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load8U); }
-#line 6262 "src/prebuilt/wast-lexer-gen.cc"
-yy1083:
+#line 6250 "src/prebuilt/wast-lexer-gen.cc"
+yy1080:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1141;
+		if (yych == 'p') goto yy1140;
 		goto yy87;
-yy1084:
+yy1081:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 297 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I64Store16); }
-#line 6274 "src/prebuilt/wast-lexer-gen.cc"
-yy1086:
+#line 6262 "src/prebuilt/wast-lexer-gen.cc"
+yy1083:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 298 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Store, I64Store32); }
-#line 6282 "src/prebuilt/wast-lexer-gen.cc"
-yy1088:
+#line 6270 "src/prebuilt/wast-lexer-gen.cc"
+yy1085:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1142;
-		if (yych == ':') goto yy1143;
+		if (yych == '/') goto yy1141;
+		if (yych == ':') goto yy1142;
 		goto yy87;
-yy1089:
+yy1086:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1144;
-		if (yych == ':') goto yy1145;
+		if (yych == '/') goto yy1143;
+		if (yych == ':') goto yy1144;
 		goto yy87;
-yy1090:
+yy1087:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 442 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(Unreachable); }
-#line 6300 "src/prebuilt/wast-lexer-gen.cc"
+#line 6288 "src/prebuilt/wast-lexer-gen.cc"
+yy1089:
+		yych = *++cursor_;
+		if (yych == 's') goto yy1145;
+		goto yy87;
+yy1090:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy1146;
+		goto yy87;
+yy1091:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1147;
+		goto yy87;
 yy1092:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1146;
+		if (yych == 'n') goto yy1148;
 		goto yy87;
 yy1093:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1147;
+		if (yych == 'k') goto yy1150;
 		goto yy87;
 yy1094:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1148;
+		if (yych == 't') goto yy1151;
 		goto yy87;
 yy1095:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy1149;
+		if (yych == 'r') goto yy1153;
 		goto yy87;
 yy1096:
 		yych = *++cursor_;
-		if (yych == 'k') goto yy1151;
+		if (yych == 's') goto yy1154;
+		if (yych == 'u') goto yy1155;
 		goto yy87;
 yy1097:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1152;
-		goto yy87;
-yy1098:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1154;
-		goto yy87;
-yy1099:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1155;
-		if (yych == 'u') goto yy1156;
-		goto yy87;
-yy1100:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 374 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F32Copysign); }
-#line 6341 "src/prebuilt/wast-lexer-gen.cc"
+#line 6329 "src/prebuilt/wast-lexer-gen.cc"
+yy1099:
+		yych = *++cursor_;
+		if (yych == '6') goto yy1156;
+		goto yy87;
+yy1100:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1157;
+		goto yy87;
+yy1101:
+		yych = *++cursor_;
+		if (yych == 's') goto yy1158;
+		if (yych == 'u') goto yy1159;
+		goto yy87;
 yy1102:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1157;
-		goto yy87;
-yy1103:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1158;
-		goto yy87;
-yy1104:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1159;
-		if (yych == 'u') goto yy1160;
-		goto yy87;
-yy1105:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 375 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Binary, F64Copysign); }
-#line 6362 "src/prebuilt/wast-lexer-gen.cc"
+#line 6350 "src/prebuilt/wast-lexer-gen.cc"
+yy1104:
+		yych = *++cursor_;
+		if (yych == 'f') goto yy1160;
+		goto yy87;
+yy1105:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1161;
+		goto yy87;
+yy1106:
+		yych = *++cursor_;
+		if (yych == 'o') goto yy1162;
+		goto yy87;
 yy1107:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1161;
+		if (yych == 'm') goto yy1163;
 		goto yy87;
 yy1108:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1162;
+		if (yych == 't') goto yy1164;
 		goto yy87;
 yy1109:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy1163;
+		if (yych == 'a') goto yy1165;
 		goto yy87;
 yy1110:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy1164;
+		if (yych == '_') goto yy1166;
 		goto yy87;
 yy1111:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1165;
-		goto yy87;
-yy1112:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1166;
-		goto yy87;
-yy1113:
-		yych = *++cursor_;
 		if (yych == 's') goto yy1167;
 		goto yy87;
-yy1114:
+yy1112:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 288 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I32Load16S); }
-#line 6398 "src/prebuilt/wast-lexer-gen.cc"
-yy1116:
+#line 6390 "src/prebuilt/wast-lexer-gen.cc"
+yy1114:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 290 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I32Load16U); }
-#line 6406 "src/prebuilt/wast-lexer-gen.cc"
-yy1118:
+#line 6398 "src/prebuilt/wast-lexer-gen.cc"
+yy1116:
 		yych = *++cursor_;
 		if (yych == 'r') goto yy1169;
 		goto yy87;
-yy1119:
+yy1117:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy1170;
 		goto yy87;
-yy1120:
+yy1118:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1171;
 		goto yy87;
-yy1121:
+yy1119:
 		yych = *++cursor_;
 		if (yych == 'f') goto yy1172;
 		goto yy87;
-yy1122:
+yy1120:
 		yych = *++cursor_;
 		if (yych == 's') goto yy1173;
 		goto yy87;
-yy1123:
+yy1121:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 410 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32WrapI64); }
-#line 6434 "src/prebuilt/wast-lexer-gen.cc"
-yy1125:
+#line 6426 "src/prebuilt/wast-lexer-gen.cc"
+yy1123:
 		yych = *++cursor_;
 		if (yych == 'o') goto yy1174;
 		goto yy87;
-yy1126:
+yy1124:
 		yych = *++cursor_;
 		if (yych == 'm') goto yy1175;
 		goto yy87;
-yy1127:
+yy1125:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1176;
 		goto yy87;
-yy1128:
+yy1126:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1177;
+		if (yych == 'a') goto yy1177;
 		goto yy87;
-yy1129:
+yy1127:
 		yych = *++cursor_;
 		if (yych == '_') goto yy1178;
 		goto yy87;
+yy1128:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1179;
+		goto yy87;
+yy1129:
+		yych = *++cursor_;
+		if (yych == 's') goto yy1180;
+		goto yy87;
 yy1130:
-		yych = *++cursor_;
-		if (yych == 's') goto yy1179;
-		goto yy87;
-yy1131:
-		yych = *++cursor_;
-		if (yych == '/') goto yy1181;
-		goto yy87;
-yy1132:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1182;
 		goto yy87;
-yy1133:
+yy1131:
+		yych = *++cursor_;
+		if (yych == '/') goto yy1183;
+		goto yy87;
+yy1132:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 289 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load16S); }
-#line 6474 "src/prebuilt/wast-lexer-gen.cc"
-yy1135:
+#line 6470 "src/prebuilt/wast-lexer-gen.cc"
+yy1134:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 291 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load16U); }
-#line 6482 "src/prebuilt/wast-lexer-gen.cc"
-yy1137:
+#line 6478 "src/prebuilt/wast-lexer-gen.cc"
+yy1136:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 292 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load32S); }
-#line 6490 "src/prebuilt/wast-lexer-gen.cc"
-yy1139:
+#line 6486 "src/prebuilt/wast-lexer-gen.cc"
+yy1138:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 293 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Load, I64Load32U); }
-#line 6498 "src/prebuilt/wast-lexer-gen.cc"
+#line 6494 "src/prebuilt/wast-lexer-gen.cc"
+yy1140:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1184;
+		goto yy87;
 yy1141:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1183;
+		if (yych == 'f') goto yy1185;
 		goto yy87;
 yy1142:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1184;
+		if (yych == 's') goto yy1186;
 		goto yy87;
 yy1143:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1185;
+		if (yych == 'f') goto yy1187;
 		goto yy87;
 yy1144:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1186;
+		if (yych == 's') goto yy1188;
 		goto yy87;
 yy1145:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1187;
+		if (yych == 't') goto yy1189;
 		goto yy87;
 yy1146:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1188;
+		if (yych == 'd') goto yy1190;
 		goto yy87;
 yy1147:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1189;
+		if (yych == 'm') goto yy1192;
 		goto yy87;
 yy1148:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy1191;
-		goto yy87;
-yy1149:
 		++cursor_;
 		if ((yych = *cursor_) <= ')') {
 			if (yych <= '!') {
 				if (yych >= '!') goto yy86;
 			} else {
-				if (yych <= '"') goto yy1150;
+				if (yych <= '"') goto yy1149;
 				if (yych <= '\'') goto yy86;
 			}
 		} else {
 			if (yych <= '^') {
 				if (yych != ';') goto yy86;
 			} else {
-				if (yych <= '_') goto yy1192;
+				if (yych <= '_') goto yy1193;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy1150:
+yy1149:
 #line 537 "src/wast-lexer.cc"
 		{ RETURN(AssertReturn); }
-#line 6551 "src/prebuilt/wast-lexer-gen.cc"
-yy1151:
+#line 6547 "src/prebuilt/wast-lexer-gen.cc"
+yy1150:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1193;
+		if (yych == 'a') goto yy1194;
 		goto yy87;
-yy1152:
+yy1151:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 267 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(CallIndirect); }
-#line 6563 "src/prebuilt/wast-lexer-gen.cc"
+#line 6559 "src/prebuilt/wast-lexer-gen.cc"
+yy1153:
+		yych = *++cursor_;
+		if (yych == 'y') goto yy1195;
+		goto yy87;
 yy1154:
-		yych = *++cursor_;
-		if (yych == 'y') goto yy1194;
-		goto yy87;
-yy1155:
-		yych = *++cursor_;
-		if (yych == '/') goto yy1196;
-		goto yy87;
-yy1156:
 		yych = *++cursor_;
 		if (yych == '/') goto yy1197;
 		goto yy87;
+yy1155:
+		yych = *++cursor_;
+		if (yych == '/') goto yy1198;
+		goto yy87;
+yy1156:
+		yych = *++cursor_;
+		if (yych == '4') goto yy1199;
+		goto yy87;
 yy1157:
 		yych = *++cursor_;
-		if (yych == '4') goto yy1198;
+		if (yych == 'e') goto yy1201;
 		goto yy87;
 yy1158:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1200;
+		if (yych == '/') goto yy1202;
 		goto yy87;
 yy1159:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1201;
+		if (yych == '/') goto yy1203;
 		goto yy87;
 yy1160:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1202;
+		if (yych == '3') goto yy1204;
 		goto yy87;
 yy1161:
 		yych = *++cursor_;
-		if (yych == '3') goto yy1203;
+		if (yych == 'e') goto yy1205;
 		goto yy87;
 yy1162:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1204;
+		if (yych == 'a') goto yy1206;
 		goto yy87;
 yy1163:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1205;
+		if (yych == 'w') goto yy1207;
 		goto yy87;
 yy1164:
 		yych = *++cursor_;
-		if (yych == 'w') goto yy1206;
+		if (yych == 'o') goto yy1208;
 		goto yy87;
 yy1165:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy1207;
+		if (yych == 'i') goto yy1209;
 		goto yy87;
 yy1166:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1208;
+		if (yych == 's') goto yy1210;
 		goto yy87;
 yy1167:
 		++cursor_;
@@ -6622,333 +6622,345 @@ yy1167:
 #line 6623 "src/prebuilt/wast-lexer-gen.cc"
 yy1169:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1210;
+		if (yych == 'e') goto yy1212;
 		goto yy87;
 yy1170:
 		yych = *++cursor_;
-		if (yych == '3') goto yy1211;
-		if (yych == '6') goto yy1212;
+		if (yych == '3') goto yy1213;
+		if (yych == '6') goto yy1214;
 		goto yy87;
 yy1171:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1213;
+		if (yych == 'a') goto yy1215;
 		goto yy87;
 yy1172:
 		yych = *++cursor_;
-		if (yych == '3') goto yy1214;
-		if (yych == '6') goto yy1215;
+		if (yych == '3') goto yy1216;
+		if (yych == '6') goto yy1217;
 		goto yy87;
 yy1173:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1216;
+		if (yych == 'a') goto yy1218;
 		goto yy87;
 yy1174:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1217;
+		if (yych == 'a') goto yy1219;
 		goto yy87;
 yy1175:
 		yych = *++cursor_;
-		if (yych == 'w') goto yy1218;
+		if (yych == 'w') goto yy1220;
 		goto yy87;
 yy1176:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy1219;
+		if (yych == 'o') goto yy1221;
 		goto yy87;
 yy1177:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1220;
+		if (yych == 'i') goto yy1222;
 		goto yy87;
 yy1178:
 		yych = *++cursor_;
-		if (yych == 's') goto yy1222;
+		if (yych == 's') goto yy1223;
 		goto yy87;
 yy1179:
+		yych = *++cursor_;
+		if (yych == 's') goto yy1225;
+		goto yy87;
+yy1180:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 329 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I64Extend8S); }
-#line 6673 "src/prebuilt/wast-lexer-gen.cc"
-yy1181:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy1224;
-		goto yy87;
+#line 6677 "src/prebuilt/wast-lexer-gen.cc"
 yy1182:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1225;
+		if (yych == 'i') goto yy1227;
 		goto yy87;
 yy1183:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1226;
+		if (yych == 'i') goto yy1228;
 		goto yy87;
 yy1184:
 		yych = *++cursor_;
-		if (yych == '3') goto yy1227;
-		if (yych == '6') goto yy1228;
+		if (yych == 'e') goto yy1229;
 		goto yy87;
 yy1185:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy1229;
-		goto yy87;
-yy1186:
 		yych = *++cursor_;
 		if (yych == '3') goto yy1230;
 		if (yych == '6') goto yy1231;
 		goto yy87;
-yy1187:
+yy1186:
 		yych = *++cursor_;
 		if (yych == 'a') goto yy1232;
 		goto yy87;
+yy1187:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1233;
+		if (yych == '6') goto yy1234;
+		goto yy87;
 yy1188:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1233;
+		if (yych == 'a') goto yy1235;
 		goto yy87;
 yy1189:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy1236;
+		goto yy87;
+yy1190:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 535 "src/wast-lexer.cc"
 		{ RETURN(AssertInvalid); }
-#line 6715 "src/prebuilt/wast-lexer-gen.cc"
-yy1191:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1234;
-		goto yy87;
+#line 6719 "src/prebuilt/wast-lexer-gen.cc"
 yy1192:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1235;
-		if (yych == 'c') goto yy1236;
+		if (yych == 'e') goto yy1237;
 		goto yy87;
 yy1193:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy1237;
+		if (yych == 'a') goto yy1238;
+		if (yych == 'c') goto yy1239;
 		goto yy87;
 yy1194:
+		yych = *++cursor_;
+		if (yych == 'b') goto yy1240;
+		goto yy87;
+yy1195:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 443 "src/wast-lexer.cc"
 		{ RETURN_OPCODE0(CurrentMemory); }
-#line 6736 "src/prebuilt/wast-lexer-gen.cc"
-yy1196:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy1238;
-		goto yy87;
+#line 6740 "src/prebuilt/wast-lexer-gen.cc"
 yy1197:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1239;
+		if (yych == 'i') goto yy1241;
 		goto yy87;
 yy1198:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy1242;
+		goto yy87;
+yy1199:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 436 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, F32DemoteF64); }
-#line 6752 "src/prebuilt/wast-lexer-gen.cc"
-yy1200:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1240;
-		goto yy87;
+#line 6756 "src/prebuilt/wast-lexer-gen.cc"
 yy1201:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1241;
+		if (yych == 't') goto yy1243;
 		goto yy87;
 yy1202:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1242;
+		if (yych == 'i') goto yy1244;
 		goto yy87;
 yy1203:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1243;
+		if (yych == 'i') goto yy1245;
 		goto yy87;
 yy1204:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1245;
+		if (yych == '2') goto yy1246;
 		goto yy87;
 yy1205:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1246;
+		if (yych == 't') goto yy1248;
 		goto yy87;
 yy1206:
 		yych = *++cursor_;
-		if (yych <= '0') {
-			if (yych == '.') goto yy1248;
-			goto yy87;
-		} else {
-			if (yych <= '1') goto yy1249;
-			if (yych == '8') goto yy1250;
-			goto yy87;
-		}
+		if (yych == 'd') goto yy1249;
+		goto yy87;
 yy1207:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1251;
-		goto yy87;
+		if (yych <= '0') {
+			if (yych == '.') goto yy1251;
+			goto yy87;
+		} else {
+			if (yych <= '1') goto yy1252;
+			if (yych == '8') goto yy1253;
+			goto yy87;
+		}
 yy1208:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1254;
+		goto yy87;
+yy1209:
+		yych = *++cursor_;
+		if (yych == 't') goto yy1255;
+		goto yy87;
+yy1210:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 328 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I32Extend16S); }
-#line 6798 "src/prebuilt/wast-lexer-gen.cc"
-yy1210:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1252;
-		goto yy87;
-yy1211:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1253;
-		goto yy87;
+#line 6806 "src/prebuilt/wast-lexer-gen.cc"
 yy1212:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1255;
-		goto yy87;
-yy1213:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1257;
 		goto yy87;
-yy1214:
+yy1213:
 		yych = *++cursor_;
 		if (yych == '2') goto yy1258;
 		goto yy87;
-yy1215:
+yy1214:
 		yych = *++cursor_;
 		if (yych == '4') goto yy1260;
 		goto yy87;
-yy1216:
+yy1215:
 		yych = *++cursor_;
 		if (yych == 't') goto yy1262;
 		goto yy87;
+yy1216:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1263;
+		goto yy87;
 yy1217:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1263;
+		if (yych == '4') goto yy1265;
 		goto yy87;
 yy1218:
 		yych = *++cursor_;
-		switch (yych) {
-		case '.':	goto yy1265;
-		case '1':	goto yy1266;
-		case '3':	goto yy1267;
-		case '8':	goto yy1268;
-		default:	goto yy87;
-		}
+		if (yych == 't') goto yy1267;
+		goto yy87;
 yy1219:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1269;
+		if (yych == 'd') goto yy1268;
 		goto yy87;
 yy1220:
+		yych = *++cursor_;
+		switch (yych) {
+		case '.':	goto yy1270;
+		case '1':	goto yy1271;
+		case '3':	goto yy1272;
+		case '8':	goto yy1273;
+		default:	goto yy87;
+		}
+yy1221:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1274;
+		goto yy87;
+yy1222:
+		yych = *++cursor_;
+		if (yych == 't') goto yy1275;
+		goto yy87;
+yy1223:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 330 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I64Extend16S); }
-#line 6851 "src/prebuilt/wast-lexer-gen.cc"
-yy1222:
+#line 6863 "src/prebuilt/wast-lexer-gen.cc"
+yy1225:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 331 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Unary, I64Extend32S); }
-#line 6859 "src/prebuilt/wast-lexer-gen.cc"
-yy1224:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1270;
-		goto yy87;
-yy1225:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1271;
-		goto yy87;
-yy1226:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1272;
-		goto yy87;
+#line 6871 "src/prebuilt/wast-lexer-gen.cc"
 yy1227:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1273;
+		if (yych == '3') goto yy1277;
 		goto yy87;
 yy1228:
 		yych = *++cursor_;
-		if (yych == '4') goto yy1275;
+		if (yych == '3') goto yy1278;
 		goto yy87;
 yy1229:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1277;
+		if (yych == 't') goto yy1279;
 		goto yy87;
 yy1230:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1278;
+		if (yych == '2') goto yy1280;
 		goto yy87;
 yy1231:
 		yych = *++cursor_;
-		if (yych == '4') goto yy1280;
+		if (yych == '4') goto yy1282;
 		goto yy87;
 yy1232:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1282;
+		if (yych == 't') goto yy1284;
 		goto yy87;
 yy1233:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy1283;
+		if (yych == '2') goto yy1285;
 		goto yy87;
 yy1234:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1284;
+		if (yych == '4') goto yy1287;
 		goto yy87;
 yy1235:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1286;
+		if (yych == 't') goto yy1289;
 		goto yy87;
 yy1236:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1287;
+		if (yych == 'o') goto yy1290;
 		goto yy87;
 yy1237:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy1288;
+		if (yych == 'd') goto yy1291;
 		goto yy87;
 yy1238:
 		yych = *++cursor_;
-		if (yych == '3') goto yy1289;
-		if (yych == '6') goto yy1290;
+		if (yych == 'r') goto yy1293;
 		goto yy87;
 yy1239:
 		yych = *++cursor_;
-		if (yych == '3') goto yy1291;
-		if (yych == '6') goto yy1292;
+		if (yych == 'a') goto yy1294;
 		goto yy87;
 yy1240:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1293;
+		if (yych == 'l') goto yy1295;
 		goto yy87;
 yy1241:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1294;
-		if (yych == '6') goto yy1295;
-		goto yy87;
-yy1242:
 		yych = *++cursor_;
 		if (yych == '3') goto yy1296;
 		if (yych == '6') goto yy1297;
 		goto yy87;
+yy1242:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1298;
+		if (yych == '6') goto yy1299;
+		goto yy87;
 yy1243:
+		yych = *++cursor_;
+		if (yych == '/') goto yy1300;
+		goto yy87;
+yy1244:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1301;
+		if (yych == '6') goto yy1302;
+		goto yy87;
+yy1245:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1303;
+		if (yych == '6') goto yy1304;
+		goto yy87;
+yy1246:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 435 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, F64PromoteF32); }
-#line 6947 "src/prebuilt/wast-lexer-gen.cc"
-yy1245:
+#line 6959 "src/prebuilt/wast-lexer-gen.cc"
+yy1248:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1298;
+		if (yych == '/') goto yy1305;
 		goto yy87;
-yy1246:
+yy1249:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
 			if (yych <= '"') {
@@ -6959,290 +6971,306 @@ yy1246:
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych <= '1') goto yy1299;
+				if (yych <= '1') goto yy1306;
 				if (yych <= '7') goto yy86;
-				goto yy1300;
+				goto yy1307;
 			} else {
-				if (yych == ';') goto yy1247;
+				if (yych == ';') goto yy1250;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy1247:
+yy1250:
 #line 449 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicLoad, I32AtomicLoad); }
-#line 6974 "src/prebuilt/wast-lexer-gen.cc"
-yy1248:
-		yych = *++cursor_;
-		switch (yych) {
-		case 'a':	goto yy1301;
-		case 'c':	goto yy1302;
-		case 'o':	goto yy1303;
-		case 's':	goto yy1304;
-		case 'x':	goto yy1305;
-		default:	goto yy87;
-		}
-yy1249:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1306;
-		goto yy87;
-yy1250:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1307;
-		goto yy87;
+#line 6986 "src/prebuilt/wast-lexer-gen.cc"
 yy1251:
 		yych = *++cursor_;
-		if (yych == 'e') goto yy1308;
-		goto yy87;
+		switch (yych) {
+		case 'a':	goto yy1308;
+		case 'c':	goto yy1309;
+		case 'o':	goto yy1310;
+		case 's':	goto yy1311;
+		case 'x':	goto yy1312;
+		default:	goto yy87;
+		}
 yy1252:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1310;
+		if (yych == '6') goto yy1313;
 		goto yy87;
 yy1253:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 411 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, I32TruncSF32); }
-#line 7008 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '_') goto yy1314;
+		goto yy87;
+yy1254:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy1315;
+		goto yy87;
 yy1255:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 413 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, I32TruncSF64); }
+#line 446 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicWait, I32AtomicWait); }
 #line 7016 "src/prebuilt/wast-lexer-gen.cc"
 yy1257:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1311;
+		if (yych == '/') goto yy1317;
 		goto yy87;
 yy1258:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 415 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, I32TruncUF32); }
+#line 411 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, I32TruncSF32); }
 #line 7028 "src/prebuilt/wast-lexer-gen.cc"
 yy1260:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 417 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, I32TruncUF64); }
+#line 413 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, I32TruncSF64); }
 #line 7036 "src/prebuilt/wast-lexer-gen.cc"
 yy1262:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1312;
+		if (yych == '/') goto yy1318;
 		goto yy87;
 yy1263:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 415 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, I32TruncUF32); }
+#line 7048 "src/prebuilt/wast-lexer-gen.cc"
+yy1265:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 417 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, I32TruncUF64); }
+#line 7056 "src/prebuilt/wast-lexer-gen.cc"
+yy1267:
+		yych = *++cursor_;
+		if (yych == '/') goto yy1319;
+		goto yy87;
+yy1268:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy1264;
+				if (yych <= ')') goto yy1269;
 				if (yych <= '0') goto yy86;
-				goto yy1313;
+				goto yy1320;
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych == '3') goto yy1314;
+				if (yych == '3') goto yy1321;
 				if (yych <= '7') goto yy86;
-				goto yy1315;
+				goto yy1322;
 			} else {
-				if (yych == ';') goto yy1264;
+				if (yych == ';') goto yy1269;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy1264:
+yy1269:
 #line 450 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicLoad, I64AtomicLoad); }
-#line 7065 "src/prebuilt/wast-lexer-gen.cc"
-yy1265:
-		yych = *++cursor_;
-		switch (yych) {
-		case 'a':	goto yy1316;
-		case 'c':	goto yy1317;
-		case 'o':	goto yy1318;
-		case 's':	goto yy1319;
-		case 'x':	goto yy1320;
-		default:	goto yy87;
-		}
-yy1266:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1321;
-		goto yy87;
-yy1267:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1322;
-		goto yy87;
-yy1268:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1323;
-		goto yy87;
-yy1269:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1324;
-		goto yy87;
+#line 7085 "src/prebuilt/wast-lexer-gen.cc"
 yy1270:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1326;
-		goto yy87;
+		switch (yych) {
+		case 'a':	goto yy1323;
+		case 'c':	goto yy1324;
+		case 'o':	goto yy1325;
+		case 's':	goto yy1326;
+		case 'x':	goto yy1327;
+		default:	goto yy87;
+		}
 yy1271:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1328;
+		if (yych == '6') goto yy1328;
 		goto yy87;
 yy1272:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1330;
+		if (yych == '2') goto yy1329;
 		goto yy87;
 yy1273:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1330;
+		goto yy87;
+yy1274:
+		yych = *++cursor_;
+		if (yych == 'e') goto yy1331;
+		goto yy87;
+yy1275:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 447 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicWait, I64AtomicWait); }
+#line 7119 "src/prebuilt/wast-lexer-gen.cc"
+yy1277:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1333;
+		goto yy87;
+yy1278:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1335;
+		goto yy87;
+yy1279:
+		yych = *++cursor_;
+		if (yych == '/') goto yy1337;
+		goto yy87;
+yy1280:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 412 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncSF32); }
-#line 7111 "src/prebuilt/wast-lexer-gen.cc"
-yy1275:
+#line 7139 "src/prebuilt/wast-lexer-gen.cc"
+yy1282:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 414 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncSF64); }
-#line 7119 "src/prebuilt/wast-lexer-gen.cc"
-yy1277:
+#line 7147 "src/prebuilt/wast-lexer-gen.cc"
+yy1284:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1331;
+		if (yych == '/') goto yy1338;
 		goto yy87;
-yy1278:
+yy1285:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 416 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncUF32); }
-#line 7131 "src/prebuilt/wast-lexer-gen.cc"
-yy1280:
+#line 7159 "src/prebuilt/wast-lexer-gen.cc"
+yy1287:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 418 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncUF64); }
-#line 7139 "src/prebuilt/wast-lexer-gen.cc"
-yy1282:
+#line 7167 "src/prebuilt/wast-lexer-gen.cc"
+yy1289:
 		yych = *++cursor_;
-		if (yych == '/') goto yy1332;
+		if (yych == '/') goto yy1339;
 		goto yy87;
-yy1283:
+yy1290:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy1333;
+		if (yych == 'n') goto yy1340;
 		goto yy87;
-yy1284:
+yy1291:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 534 "src/wast-lexer.cc"
 		{ RETURN(AssertMalformed); }
-#line 7155 "src/prebuilt/wast-lexer-gen.cc"
-yy1286:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy1335;
-		goto yy87;
-yy1287:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy1336;
-		goto yy87;
-yy1288:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1337;
-		goto yy87;
-yy1289:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1339;
-		goto yy87;
-yy1290:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1341;
-		goto yy87;
-yy1291:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1343;
-		goto yy87;
-yy1292:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1345;
-		goto yy87;
+#line 7183 "src/prebuilt/wast-lexer-gen.cc"
 yy1293:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1347;
+		if (yych == 'i') goto yy1342;
 		goto yy87;
 yy1294:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1348;
+		if (yych == 'n') goto yy1343;
 		goto yy87;
 yy1295:
 		yych = *++cursor_;
-		if (yych == '4') goto yy1350;
+		if (yych == 'e') goto yy1344;
 		goto yy87;
 yy1296:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1352;
+		if (yych == '2') goto yy1346;
 		goto yy87;
 yy1297:
 		yych = *++cursor_;
-		if (yych == '4') goto yy1354;
+		if (yych == '4') goto yy1348;
 		goto yy87;
 yy1298:
 		yych = *++cursor_;
-		if (yych == 'i') goto yy1356;
+		if (yych == '2') goto yy1350;
 		goto yy87;
 yy1299:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1357;
+		if (yych == '4') goto yy1352;
 		goto yy87;
 yy1300:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1358;
+		if (yych == 'i') goto yy1354;
 		goto yy87;
 yy1301:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1359;
-		if (yych == 'n') goto yy1360;
+		if (yych == '2') goto yy1355;
 		goto yy87;
 yy1302:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy1361;
+		if (yych == '4') goto yy1357;
 		goto yy87;
 yy1303:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1362;
+		if (yych == '2') goto yy1359;
 		goto yy87;
 yy1304:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1364;
+		if (yych == '4') goto yy1361;
 		goto yy87;
 yy1305:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1365;
-		if (yych == 'o') goto yy1366;
+		if (yych == 'i') goto yy1363;
 		goto yy87;
 yy1306:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1367;
+		if (yych == '6') goto yy1364;
 		goto yy87;
 yy1307:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1368;
+		if (yych == '_') goto yy1365;
 		goto yy87;
 yy1308:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1366;
+		if (yych == 'n') goto yy1367;
+		goto yy87;
+yy1309:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1368;
+		goto yy87;
+yy1310:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1369;
+		goto yy87;
+yy1311:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1371;
+		goto yy87;
+yy1312:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1372;
+		if (yych == 'o') goto yy1373;
+		goto yy87;
+yy1313:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1374;
+		goto yy87;
+yy1314:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1375;
+		goto yy87;
+yy1315:
 		++cursor_;
 		if ((yych = *cursor_) <= '0') {
 			if (yych <= '"') {
@@ -7253,1505 +7281,1505 @@ yy1308:
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych <= '1') goto yy1369;
+				if (yych <= '1') goto yy1376;
 				if (yych <= '7') goto yy86;
-				goto yy1370;
+				goto yy1377;
 			} else {
-				if (yych == ';') goto yy1309;
+				if (yych == ';') goto yy1316;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy1309:
+yy1316:
 #line 456 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I32AtomicStore); }
-#line 7268 "src/prebuilt/wast-lexer-gen.cc"
-yy1310:
-		yych = *++cursor_;
-		if (yych == 'f') goto yy1372;
-		goto yy87;
-yy1311:
-		yych = *++cursor_;
-		if (yych == 'f') goto yy1373;
-		goto yy87;
-yy1312:
-		yych = *++cursor_;
-		if (yych == 'f') goto yy1374;
-		goto yy87;
-yy1313:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1375;
-		goto yy87;
-yy1314:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1376;
-		goto yy87;
-yy1315:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1377;
-		goto yy87;
-yy1316:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1378;
-		if (yych == 'n') goto yy1379;
-		goto yy87;
+#line 7296 "src/prebuilt/wast-lexer-gen.cc"
 yy1317:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy1380;
+		if (yych == 'f') goto yy1379;
 		goto yy87;
 yy1318:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1381;
+		if (yych == 'f') goto yy1380;
 		goto yy87;
 yy1319:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1383;
+		if (yych == 'f') goto yy1381;
 		goto yy87;
 yy1320:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1384;
-		if (yych == 'o') goto yy1385;
+		if (yych == '6') goto yy1382;
 		goto yy87;
 yy1321:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1386;
+		if (yych == '2') goto yy1383;
 		goto yy87;
 yy1322:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1387;
+		if (yych == '_') goto yy1384;
 		goto yy87;
 yy1323:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1388;
+		if (yych == 'd') goto yy1385;
+		if (yych == 'n') goto yy1386;
 		goto yy87;
 yy1324:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1387;
+		goto yy87;
+yy1325:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1388;
+		goto yy87;
+yy1326:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1390;
+		goto yy87;
+yy1327:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1391;
+		if (yych == 'o') goto yy1392;
+		goto yy87;
+yy1328:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1393;
+		goto yy87;
+yy1329:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1394;
+		goto yy87;
+yy1330:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1395;
+		goto yy87;
+yy1331:
 		++cursor_;
 		if ((yych = *cursor_) <= '1') {
 			if (yych <= '"') {
 				if (yych == '!') goto yy86;
 			} else {
 				if (yych <= '\'') goto yy86;
-				if (yych <= ')') goto yy1325;
+				if (yych <= ')') goto yy1332;
 				if (yych <= '0') goto yy86;
-				goto yy1389;
+				goto yy1396;
 			}
 		} else {
 			if (yych <= '8') {
-				if (yych == '3') goto yy1390;
+				if (yych == '3') goto yy1397;
 				if (yych <= '7') goto yy86;
-				goto yy1391;
+				goto yy1398;
 			} else {
-				if (yych == ';') goto yy1325;
+				if (yych == ';') goto yy1332;
 				if (yych <= '~') goto yy86;
 			}
 		}
-yy1325:
+yy1332:
 #line 457 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I64AtomicStore); }
-#line 7351 "src/prebuilt/wast-lexer-gen.cc"
-yy1326:
+#line 7379 "src/prebuilt/wast-lexer-gen.cc"
+yy1333:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 408 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64ExtendSI32); }
-#line 7359 "src/prebuilt/wast-lexer-gen.cc"
-yy1328:
+#line 7387 "src/prebuilt/wast-lexer-gen.cc"
+yy1335:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 409 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64ExtendUI32); }
-#line 7367 "src/prebuilt/wast-lexer-gen.cc"
-yy1330:
+#line 7395 "src/prebuilt/wast-lexer-gen.cc"
+yy1337:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1393;
+		if (yych == 'f') goto yy1400;
 		goto yy87;
-yy1331:
+yy1338:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1394;
+		if (yych == 'f') goto yy1401;
 		goto yy87;
-yy1332:
+yy1339:
 		yych = *++cursor_;
-		if (yych == 'f') goto yy1395;
+		if (yych == 'f') goto yy1402;
 		goto yy87;
-yy1333:
+yy1340:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 541 "src/wast-lexer.cc"
 		{ RETURN(AssertExhaustion); }
-#line 7387 "src/prebuilt/wast-lexer-gen.cc"
-yy1335:
+#line 7415 "src/prebuilt/wast-lexer-gen.cc"
+yy1342:
 		yych = *++cursor_;
-		if (yych == 't') goto yy1396;
+		if (yych == 't') goto yy1403;
 		goto yy87;
-yy1336:
+yy1343:
 		yych = *++cursor_;
-		if (yych == 'o') goto yy1397;
+		if (yych == 'o') goto yy1404;
 		goto yy87;
-yy1337:
+yy1344:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 536 "src/wast-lexer.cc"
 		{ RETURN(AssertUnlinkable); }
-#line 7403 "src/prebuilt/wast-lexer-gen.cc"
-yy1339:
+#line 7431 "src/prebuilt/wast-lexer-gen.cc"
+yy1346:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 427 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, F32ConvertSI32); }
-#line 7411 "src/prebuilt/wast-lexer-gen.cc"
-yy1341:
+#line 7439 "src/prebuilt/wast-lexer-gen.cc"
+yy1348:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 429 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, F32ConvertSI64); }
-#line 7419 "src/prebuilt/wast-lexer-gen.cc"
-yy1343:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 431 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F32ConvertUI32); }
-#line 7427 "src/prebuilt/wast-lexer-gen.cc"
-yy1345:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 433 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F32ConvertUI64); }
-#line 7435 "src/prebuilt/wast-lexer-gen.cc"
-yy1347:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1398;
-		goto yy87;
-yy1348:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 428 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F64ConvertSI32); }
 #line 7447 "src/prebuilt/wast-lexer-gen.cc"
 yy1350:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 430 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F64ConvertSI64); }
+#line 431 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F32ConvertUI32); }
 #line 7455 "src/prebuilt/wast-lexer-gen.cc"
 yy1352:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 432 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F64ConvertUI32); }
+#line 433 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F32ConvertUI64); }
 #line 7463 "src/prebuilt/wast-lexer-gen.cc"
 yy1354:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1405;
+		goto yy87;
+yy1355:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 428 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F64ConvertSI32); }
+#line 7475 "src/prebuilt/wast-lexer-gen.cc"
+yy1357:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 430 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F64ConvertSI64); }
+#line 7483 "src/prebuilt/wast-lexer-gen.cc"
+yy1359:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 432 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F64ConvertUI32); }
+#line 7491 "src/prebuilt/wast-lexer-gen.cc"
+yy1361:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 434 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, F64ConvertUI64); }
-#line 7471 "src/prebuilt/wast-lexer-gen.cc"
-yy1356:
+#line 7499 "src/prebuilt/wast-lexer-gen.cc"
+yy1363:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1399;
+		if (yych == '6') goto yy1406;
 		goto yy87;
-yy1357:
+yy1364:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1400;
+		if (yych == '_') goto yy1407;
 		goto yy87;
-yy1358:
+yy1365:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1401;
+		if (yych == 'u') goto yy1408;
 		goto yy87;
-yy1359:
+yy1366:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1403;
+		if (yych == 'd') goto yy1410;
 		goto yy87;
-yy1360:
+yy1367:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1405;
+		if (yych == 'd') goto yy1412;
 		goto yy87;
-yy1361:
+yy1368:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1407;
+		if (yych == 'p') goto yy1414;
 		goto yy87;
-yy1362:
+yy1369:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 484 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwOr); }
-#line 7503 "src/prebuilt/wast-lexer-gen.cc"
-yy1364:
+#line 7531 "src/prebuilt/wast-lexer-gen.cc"
+yy1371:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy1408;
+		if (yych == 'b') goto yy1415;
 		goto yy87;
-yy1365:
+yy1372:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy1410;
+		if (yych == 'h') goto yy1417;
 		goto yy87;
-yy1366:
+yy1373:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1411;
+		if (yych == 'r') goto yy1418;
 		goto yy87;
-yy1367:
+yy1374:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1413;
+		if (yych == 'u') goto yy1420;
 		goto yy87;
-yy1368:
+yy1375:
 		yych = *++cursor_;
-		if (yych == '.') goto yy1414;
+		if (yych == '.') goto yy1421;
 		goto yy87;
-yy1369:
+yy1376:
 		yych = *++cursor_;
-		if (yych == '6') goto yy1415;
+		if (yych == '6') goto yy1422;
 		goto yy87;
-yy1370:
+yy1377:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 458 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I32AtomicStore8); }
-#line 7535 "src/prebuilt/wast-lexer-gen.cc"
-yy1372:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1417;
-		goto yy87;
-yy1373:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1418;
-		if (yych == '6') goto yy1419;
-		goto yy87;
-yy1374:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1420;
-		if (yych == '6') goto yy1421;
-		goto yy87;
-yy1375:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1422;
-		goto yy87;
-yy1376:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1423;
-		goto yy87;
-yy1377:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1424;
-		goto yy87;
-yy1378:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1426;
-		goto yy87;
+#line 7563 "src/prebuilt/wast-lexer-gen.cc"
 yy1379:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1428;
+		if (yych == '3') goto yy1424;
 		goto yy87;
 yy1380:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1430;
+		if (yych == '3') goto yy1425;
+		if (yych == '6') goto yy1426;
 		goto yy87;
 yy1381:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1427;
+		if (yych == '6') goto yy1428;
+		goto yy87;
+yy1382:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1429;
+		goto yy87;
+yy1383:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1430;
+		goto yy87;
+yy1384:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1431;
+		goto yy87;
+yy1385:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1433;
+		goto yy87;
+yy1386:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1435;
+		goto yy87;
+yy1387:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy1437;
+		goto yy87;
+yy1388:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 485 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwOr); }
-#line 7581 "src/prebuilt/wast-lexer-gen.cc"
-yy1383:
-		yych = *++cursor_;
-		if (yych == 'b') goto yy1431;
-		goto yy87;
-yy1384:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1433;
-		goto yy87;
-yy1385:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1434;
-		goto yy87;
-yy1386:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1436;
-		goto yy87;
-yy1387:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1437;
-		goto yy87;
-yy1388:
-		yych = *++cursor_;
-		if (yych == '.') goto yy1438;
-		goto yy87;
-yy1389:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1439;
-		goto yy87;
+#line 7609 "src/prebuilt/wast-lexer-gen.cc"
 yy1390:
 		yych = *++cursor_;
-		if (yych == '2') goto yy1441;
+		if (yych == 'b') goto yy1438;
 		goto yy87;
 yy1391:
+		yych = *++cursor_;
+		if (yych == 'h') goto yy1440;
+		goto yy87;
+yy1392:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1441;
+		goto yy87;
+yy1393:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1443;
+		goto yy87;
+yy1394:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1444;
+		goto yy87;
+yy1395:
+		yych = *++cursor_;
+		if (yych == '.') goto yy1445;
+		goto yy87;
+yy1396:
+		yych = *++cursor_;
+		if (yych == '6') goto yy1446;
+		goto yy87;
+yy1397:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1448;
+		goto yy87;
+yy1398:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 460 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I64AtomicStore8); }
-#line 7621 "src/prebuilt/wast-lexer-gen.cc"
-yy1393:
-		yych = *++cursor_;
-		if (yych == '6') goto yy1443;
-		goto yy87;
-yy1394:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1444;
-		if (yych == '6') goto yy1445;
-		goto yy87;
-yy1395:
-		yych = *++cursor_;
-		if (yych == '3') goto yy1446;
-		if (yych == '6') goto yy1447;
-		goto yy87;
-yy1396:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1448;
-		goto yy87;
-yy1397:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy1449;
-		goto yy87;
-yy1398:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1450;
-		goto yy87;
-yy1399:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1452;
-		goto yy87;
+#line 7649 "src/prebuilt/wast-lexer-gen.cc"
 yy1400:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1454;
+		if (yych == '6') goto yy1450;
 		goto yy87;
 yy1401:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 451 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicLoad, I32AtomicLoad8U); }
-#line 7663 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '3') goto yy1451;
+		if (yych == '6') goto yy1452;
+		goto yy87;
+yy1402:
+		yych = *++cursor_;
+		if (yych == '3') goto yy1453;
+		if (yych == '6') goto yy1454;
+		goto yy87;
 yy1403:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 463 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwAdd); }
-#line 7671 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == 'h') goto yy1455;
+		goto yy87;
+yy1404:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy1456;
+		goto yy87;
 yy1405:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 477 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwAnd); }
-#line 7679 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '2') goto yy1457;
+		goto yy87;
+yy1406:
+		yych = *++cursor_;
+		if (yych == '4') goto yy1459;
+		goto yy87;
 yy1407:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy1456;
+		if (yych == 'u') goto yy1461;
 		goto yy87;
 yy1408:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 470 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwSub); }
+#line 451 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicLoad, I32AtomicLoad8U); }
 #line 7691 "src/prebuilt/wast-lexer-gen.cc"
 yy1410:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 463 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwAdd); }
+#line 7699 "src/prebuilt/wast-lexer-gen.cc"
+yy1412:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 477 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwAnd); }
+#line 7707 "src/prebuilt/wast-lexer-gen.cc"
+yy1414:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1457;
+		if (yych == 'x') goto yy1463;
 		goto yy87;
-yy1411:
+yy1415:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 470 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwSub); }
+#line 7719 "src/prebuilt/wast-lexer-gen.cc"
+yy1417:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1464;
+		goto yy87;
+yy1418:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 491 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwXor); }
-#line 7703 "src/prebuilt/wast-lexer-gen.cc"
-yy1413:
+#line 7731 "src/prebuilt/wast-lexer-gen.cc"
+yy1420:
 		yych = *++cursor_;
-		if (yych == '.') goto yy1459;
+		if (yych == '.') goto yy1466;
 		goto yy87;
-yy1414:
+yy1421:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'a':	goto yy1460;
-		case 'c':	goto yy1461;
-		case 'o':	goto yy1462;
-		case 's':	goto yy1463;
-		case 'x':	goto yy1464;
+		case 'a':	goto yy1467;
+		case 'c':	goto yy1468;
+		case 'o':	goto yy1469;
+		case 's':	goto yy1470;
+		case 'x':	goto yy1471;
 		default:	goto yy87;
 		}
-yy1415:
+yy1422:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 459 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I32AtomicStore16); }
-#line 7725 "src/prebuilt/wast-lexer-gen.cc"
-yy1417:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1465;
-		goto yy87;
-yy1418:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1467;
-		goto yy87;
-yy1419:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1469;
-		goto yy87;
-yy1420:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1471;
-		goto yy87;
-yy1421:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1473;
-		goto yy87;
-yy1422:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1475;
-		goto yy87;
-yy1423:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1477;
-		goto yy87;
+#line 7753 "src/prebuilt/wast-lexer-gen.cc"
 yy1424:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 453 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicLoad, I64AtomicLoad8U); }
-#line 7761 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '2') goto yy1472;
+		goto yy87;
+yy1425:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1474;
+		goto yy87;
 yy1426:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 464 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwAdd); }
-#line 7769 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '4') goto yy1476;
+		goto yy87;
+yy1427:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1478;
+		goto yy87;
 yy1428:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 478 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwAnd); }
-#line 7777 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '4') goto yy1480;
+		goto yy87;
+yy1429:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1482;
+		goto yy87;
 yy1430:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy1479;
+		if (yych == 'u') goto yy1484;
 		goto yy87;
 yy1431:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 471 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwSub); }
+#line 453 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicLoad, I64AtomicLoad8U); }
 #line 7789 "src/prebuilt/wast-lexer-gen.cc"
 yy1433:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 464 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwAdd); }
+#line 7797 "src/prebuilt/wast-lexer-gen.cc"
+yy1435:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 478 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwAnd); }
+#line 7805 "src/prebuilt/wast-lexer-gen.cc"
+yy1437:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1480;
+		if (yych == 'x') goto yy1486;
 		goto yy87;
-yy1434:
+yy1438:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 471 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwSub); }
+#line 7817 "src/prebuilt/wast-lexer-gen.cc"
+yy1440:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1487;
+		goto yy87;
+yy1441:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 492 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwXor); }
-#line 7801 "src/prebuilt/wast-lexer-gen.cc"
-yy1436:
+#line 7829 "src/prebuilt/wast-lexer-gen.cc"
+yy1443:
 		yych = *++cursor_;
-		if (yych == '.') goto yy1482;
+		if (yych == '.') goto yy1489;
 		goto yy87;
-yy1437:
+yy1444:
 		yych = *++cursor_;
-		if (yych == '.') goto yy1483;
+		if (yych == '.') goto yy1490;
 		goto yy87;
-yy1438:
+yy1445:
 		yych = *++cursor_;
 		switch (yych) {
-		case 'a':	goto yy1484;
-		case 'c':	goto yy1485;
-		case 'o':	goto yy1486;
-		case 's':	goto yy1487;
-		case 'x':	goto yy1488;
+		case 'a':	goto yy1491;
+		case 'c':	goto yy1492;
+		case 'o':	goto yy1493;
+		case 's':	goto yy1494;
+		case 'x':	goto yy1495;
 		default:	goto yy87;
 		}
-yy1439:
+yy1446:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 461 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I64AtomicStore16); }
-#line 7827 "src/prebuilt/wast-lexer-gen.cc"
-yy1441:
+#line 7855 "src/prebuilt/wast-lexer-gen.cc"
+yy1448:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 462 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicStore, I64AtomicStore32); }
-#line 7835 "src/prebuilt/wast-lexer-gen.cc"
-yy1443:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1489;
-		goto yy87;
-yy1444:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1491;
-		goto yy87;
-yy1445:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1493;
-		goto yy87;
-yy1446:
-		yych = *++cursor_;
-		if (yych == '2') goto yy1495;
-		goto yy87;
-yy1447:
-		yych = *++cursor_;
-		if (yych == '4') goto yy1497;
-		goto yy87;
-yy1448:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy1499;
-		goto yy87;
-yy1449:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy1500;
-		goto yy87;
+#line 7863 "src/prebuilt/wast-lexer-gen.cc"
 yy1450:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 437 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F32ReinterpretI32); }
-#line 7871 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '4') goto yy1496;
+		goto yy87;
+yy1451:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1498;
+		goto yy87;
 yy1452:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 439 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(Convert, F64ReinterpretI64); }
-#line 7879 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '4') goto yy1500;
+		goto yy87;
+yy1453:
+		yych = *++cursor_;
+		if (yych == '2') goto yy1502;
+		goto yy87;
 yy1454:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 452 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicLoad, I32AtomicLoad16U); }
-#line 7887 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == '4') goto yy1504;
+		goto yy87;
+yy1455:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1506;
+		goto yy87;
 yy1456:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1501;
+		if (yych == 'i') goto yy1507;
 		goto yy87;
 yy1457:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 498 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwXchg); }
+#line 437 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F32ReinterpretI32); }
 #line 7899 "src/prebuilt/wast-lexer-gen.cc"
 yy1459:
-		yych = *++cursor_;
-		switch (yych) {
-		case 'a':	goto yy1502;
-		case 'c':	goto yy1503;
-		case 'o':	goto yy1504;
-		case 's':	goto yy1505;
-		case 'x':	goto yy1506;
-		default:	goto yy87;
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
 		}
-yy1460:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1507;
-		if (yych == 'n') goto yy1508;
-		goto yy87;
+#line 439 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(Convert, F64ReinterpretI64); }
+#line 7907 "src/prebuilt/wast-lexer-gen.cc"
 yy1461:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy1509;
-		goto yy87;
-yy1462:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1510;
-		goto yy87;
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 452 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicLoad, I32AtomicLoad16U); }
+#line 7915 "src/prebuilt/wast-lexer-gen.cc"
 yy1463:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1512;
+		if (yych == 'c') goto yy1508;
 		goto yy87;
 yy1464:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 498 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmwXchg); }
+#line 7927 "src/prebuilt/wast-lexer-gen.cc"
+yy1466:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1513;
-		if (yych == 'o') goto yy1514;
+		switch (yych) {
+		case 'a':	goto yy1509;
+		case 'c':	goto yy1510;
+		case 'o':	goto yy1511;
+		case 's':	goto yy1512;
+		case 'x':	goto yy1513;
+		default:	goto yy87;
+		}
+yy1467:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1514;
+		if (yych == 'n') goto yy1515;
 		goto yy87;
-yy1465:
+yy1468:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1516;
+		goto yy87;
+yy1469:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1517;
+		goto yy87;
+yy1470:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1519;
+		goto yy87;
+yy1471:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1520;
+		if (yych == 'o') goto yy1521;
+		goto yy87;
+yy1472:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 438 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32ReinterpretF32); }
-#line 7939 "src/prebuilt/wast-lexer-gen.cc"
-yy1467:
+#line 7967 "src/prebuilt/wast-lexer-gen.cc"
+yy1474:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 419 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32TruncSSatF32); }
-#line 7947 "src/prebuilt/wast-lexer-gen.cc"
-yy1469:
+#line 7975 "src/prebuilt/wast-lexer-gen.cc"
+yy1476:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 421 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32TruncSSatF64); }
-#line 7955 "src/prebuilt/wast-lexer-gen.cc"
-yy1471:
+#line 7983 "src/prebuilt/wast-lexer-gen.cc"
+yy1478:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 423 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32TruncUSatF32); }
-#line 7963 "src/prebuilt/wast-lexer-gen.cc"
-yy1473:
+#line 7991 "src/prebuilt/wast-lexer-gen.cc"
+yy1480:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 425 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I32TruncUSatF64); }
-#line 7971 "src/prebuilt/wast-lexer-gen.cc"
-yy1475:
+#line 7999 "src/prebuilt/wast-lexer-gen.cc"
+yy1482:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 454 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicLoad, I64AtomicLoad16U); }
-#line 7979 "src/prebuilt/wast-lexer-gen.cc"
-yy1477:
+#line 8007 "src/prebuilt/wast-lexer-gen.cc"
+yy1484:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 455 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicLoad, I64AtomicLoad32U); }
-#line 7987 "src/prebuilt/wast-lexer-gen.cc"
-yy1479:
+#line 8015 "src/prebuilt/wast-lexer-gen.cc"
+yy1486:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1515;
+		if (yych == 'c') goto yy1522;
 		goto yy87;
-yy1480:
+yy1487:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 499 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmwXchg); }
-#line 7999 "src/prebuilt/wast-lexer-gen.cc"
-yy1482:
-		yych = *++cursor_;
-		switch (yych) {
-		case 'a':	goto yy1516;
-		case 'c':	goto yy1517;
-		case 'o':	goto yy1518;
-		case 's':	goto yy1519;
-		case 'x':	goto yy1520;
-		default:	goto yy87;
-		}
-yy1483:
-		yych = *++cursor_;
-		switch (yych) {
-		case 'a':	goto yy1521;
-		case 'c':	goto yy1522;
-		case 'o':	goto yy1523;
-		case 's':	goto yy1524;
-		case 'x':	goto yy1525;
-		default:	goto yy87;
-		}
-yy1484:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1526;
-		if (yych == 'n') goto yy1527;
-		goto yy87;
-yy1485:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy1528;
-		goto yy87;
-yy1486:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1529;
-		goto yy87;
-yy1487:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1531;
-		goto yy87;
-yy1488:
-		yych = *++cursor_;
-		if (yych == 'c') goto yy1532;
-		if (yych == 'o') goto yy1533;
-		goto yy87;
+#line 8027 "src/prebuilt/wast-lexer-gen.cc"
 yy1489:
+		yych = *++cursor_;
+		switch (yych) {
+		case 'a':	goto yy1523;
+		case 'c':	goto yy1524;
+		case 'o':	goto yy1525;
+		case 's':	goto yy1526;
+		case 'x':	goto yy1527;
+		default:	goto yy87;
+		}
+yy1490:
+		yych = *++cursor_;
+		switch (yych) {
+		case 'a':	goto yy1528;
+		case 'c':	goto yy1529;
+		case 'o':	goto yy1530;
+		case 's':	goto yy1531;
+		case 'x':	goto yy1532;
+		default:	goto yy87;
+		}
+yy1491:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1533;
+		if (yych == 'n') goto yy1534;
+		goto yy87;
+yy1492:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1535;
+		goto yy87;
+yy1493:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1536;
+		goto yy87;
+yy1494:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1538;
+		goto yy87;
+yy1495:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1539;
+		if (yych == 'o') goto yy1540;
+		goto yy87;
+yy1496:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 440 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64ReinterpretF64); }
-#line 8049 "src/prebuilt/wast-lexer-gen.cc"
-yy1491:
+#line 8077 "src/prebuilt/wast-lexer-gen.cc"
+yy1498:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 420 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncSSatF32); }
-#line 8057 "src/prebuilt/wast-lexer-gen.cc"
-yy1493:
+#line 8085 "src/prebuilt/wast-lexer-gen.cc"
+yy1500:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 422 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncSSatF64); }
-#line 8065 "src/prebuilt/wast-lexer-gen.cc"
-yy1495:
+#line 8093 "src/prebuilt/wast-lexer-gen.cc"
+yy1502:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 424 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncUSatF32); }
-#line 8073 "src/prebuilt/wast-lexer-gen.cc"
-yy1497:
+#line 8101 "src/prebuilt/wast-lexer-gen.cc"
+yy1504:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 426 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(Convert, I64TruncUSatF64); }
-#line 8081 "src/prebuilt/wast-lexer-gen.cc"
-yy1499:
-		yych = *++cursor_;
-		if (yych == 'e') goto yy1534;
-		goto yy87;
-yy1500:
-		yych = *++cursor_;
-		if (yych == 'c') goto yy1535;
-		goto yy87;
-yy1501:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1536;
-		goto yy87;
-yy1502:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1537;
-		if (yych == 'n') goto yy1538;
-		goto yy87;
-yy1503:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy1539;
-		goto yy87;
-yy1504:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1540;
-		goto yy87;
-yy1505:
-		yych = *++cursor_;
-		if (yych == 'u') goto yy1542;
-		goto yy87;
+#line 8109 "src/prebuilt/wast-lexer-gen.cc"
 yy1506:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1543;
-		if (yych == 'o') goto yy1544;
+		if (yych == 'e') goto yy1541;
 		goto yy87;
 yy1507:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1545;
+		if (yych == 'c') goto yy1542;
 		goto yy87;
 yy1508:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1547;
+		if (yych == 'h') goto yy1543;
 		goto yy87;
 yy1509:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1549;
+		if (yych == 'd') goto yy1544;
+		if (yych == 'n') goto yy1545;
 		goto yy87;
 yy1510:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1546;
+		goto yy87;
+yy1511:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1547;
+		goto yy87;
+yy1512:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1549;
+		goto yy87;
+yy1513:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1550;
+		if (yych == 'o') goto yy1551;
+		goto yy87;
+yy1514:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1552;
+		goto yy87;
+yy1515:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1554;
+		goto yy87;
+yy1516:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy1556;
+		goto yy87;
+yy1517:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 486 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw8UOr); }
-#line 8135 "src/prebuilt/wast-lexer-gen.cc"
-yy1512:
-		yych = *++cursor_;
-		if (yych == 'b') goto yy1550;
-		goto yy87;
-yy1513:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1552;
-		goto yy87;
-yy1514:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1553;
-		goto yy87;
-yy1515:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1555;
-		goto yy87;
-yy1516:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1556;
-		if (yych == 'n') goto yy1557;
-		goto yy87;
-yy1517:
-		yych = *++cursor_;
-		if (yych == 'm') goto yy1558;
-		goto yy87;
-yy1518:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1559;
-		goto yy87;
+#line 8163 "src/prebuilt/wast-lexer-gen.cc"
 yy1519:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1561;
+		if (yych == 'b') goto yy1557;
 		goto yy87;
 yy1520:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1562;
-		if (yych == 'o') goto yy1563;
+		if (yych == 'h') goto yy1559;
 		goto yy87;
 yy1521:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1564;
-		if (yych == 'n') goto yy1565;
+		if (yych == 'r') goto yy1560;
 		goto yy87;
 yy1522:
 		yych = *++cursor_;
-		if (yych == 'm') goto yy1566;
+		if (yych == 'h') goto yy1562;
 		goto yy87;
 yy1523:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1567;
+		if (yych == 'd') goto yy1563;
+		if (yych == 'n') goto yy1564;
 		goto yy87;
 yy1524:
 		yych = *++cursor_;
-		if (yych == 'u') goto yy1569;
+		if (yych == 'm') goto yy1565;
 		goto yy87;
 yy1525:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1570;
-		if (yych == 'o') goto yy1571;
+		if (yych == 'r') goto yy1566;
 		goto yy87;
 yy1526:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1572;
+		if (yych == 'u') goto yy1568;
 		goto yy87;
 yy1527:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1574;
+		if (yych == 'c') goto yy1569;
+		if (yych == 'o') goto yy1570;
 		goto yy87;
 yy1528:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1576;
+		if (yych == 'd') goto yy1571;
+		if (yych == 'n') goto yy1572;
 		goto yy87;
 yy1529:
+		yych = *++cursor_;
+		if (yych == 'm') goto yy1573;
+		goto yy87;
+yy1530:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1574;
+		goto yy87;
+yy1531:
+		yych = *++cursor_;
+		if (yych == 'u') goto yy1576;
+		goto yy87;
+yy1532:
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1577;
+		if (yych == 'o') goto yy1578;
+		goto yy87;
+yy1533:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1579;
+		goto yy87;
+yy1534:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1581;
+		goto yy87;
+yy1535:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy1583;
+		goto yy87;
+yy1536:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 488 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8UOr); }
-#line 8215 "src/prebuilt/wast-lexer-gen.cc"
-yy1531:
-		yych = *++cursor_;
-		if (yych == 'b') goto yy1577;
-		goto yy87;
-yy1532:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1579;
-		goto yy87;
-yy1533:
-		yych = *++cursor_;
-		if (yych == 'r') goto yy1580;
-		goto yy87;
-yy1534:
-		yych = *++cursor_;
-		if (yych == 't') goto yy1582;
-		goto yy87;
-yy1535:
-		yych = *++cursor_;
-		if (yych == 'a') goto yy1583;
-		goto yy87;
-yy1536:
-		yych = *++cursor_;
-		if (yych == 'g') goto yy1584;
-		goto yy87;
-yy1537:
-		yych = *++cursor_;
-		if (yych == 'd') goto yy1586;
-		goto yy87;
+#line 8243 "src/prebuilt/wast-lexer-gen.cc"
 yy1538:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1588;
+		if (yych == 'b') goto yy1584;
 		goto yy87;
 yy1539:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1590;
+		if (yych == 'h') goto yy1586;
 		goto yy87;
 yy1540:
+		yych = *++cursor_;
+		if (yych == 'r') goto yy1587;
+		goto yy87;
+yy1541:
+		yych = *++cursor_;
+		if (yych == 't') goto yy1589;
+		goto yy87;
+yy1542:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy1590;
+		goto yy87;
+yy1543:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1591;
+		goto yy87;
+yy1544:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1593;
+		goto yy87;
+yy1545:
+		yych = *++cursor_;
+		if (yych == 'd') goto yy1595;
+		goto yy87;
+yy1546:
+		yych = *++cursor_;
+		if (yych == 'p') goto yy1597;
+		goto yy87;
+yy1547:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 487 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UOr); }
-#line 8259 "src/prebuilt/wast-lexer-gen.cc"
-yy1542:
+#line 8287 "src/prebuilt/wast-lexer-gen.cc"
+yy1549:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy1591;
+		if (yych == 'b') goto yy1598;
 		goto yy87;
-yy1543:
+yy1550:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy1593;
+		if (yych == 'h') goto yy1600;
 		goto yy87;
-yy1544:
+yy1551:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1594;
+		if (yych == 'r') goto yy1601;
 		goto yy87;
-yy1545:
+yy1552:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 465 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw8UAdd); }
-#line 8279 "src/prebuilt/wast-lexer-gen.cc"
-yy1547:
+#line 8307 "src/prebuilt/wast-lexer-gen.cc"
+yy1554:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 479 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw8UAnd); }
-#line 8287 "src/prebuilt/wast-lexer-gen.cc"
-yy1549:
+#line 8315 "src/prebuilt/wast-lexer-gen.cc"
+yy1556:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy1596;
+		if (yych == 'x') goto yy1603;
 		goto yy87;
-yy1550:
+yy1557:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 472 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw8USub); }
-#line 8299 "src/prebuilt/wast-lexer-gen.cc"
-yy1552:
+#line 8327 "src/prebuilt/wast-lexer-gen.cc"
+yy1559:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1597;
+		if (yych == 'g') goto yy1604;
 		goto yy87;
-yy1553:
+yy1560:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 493 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw8UXor); }
-#line 8311 "src/prebuilt/wast-lexer-gen.cc"
-yy1555:
+#line 8339 "src/prebuilt/wast-lexer-gen.cc"
+yy1562:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1599;
+		if (yych == 'g') goto yy1606;
 		goto yy87;
-yy1556:
+yy1563:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1601;
+		if (yych == 'd') goto yy1608;
 		goto yy87;
-yy1557:
+yy1564:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1603;
+		if (yych == 'd') goto yy1610;
 		goto yy87;
-yy1558:
+yy1565:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1605;
+		if (yych == 'p') goto yy1612;
 		goto yy87;
-yy1559:
+yy1566:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 489 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UOr); }
-#line 8335 "src/prebuilt/wast-lexer-gen.cc"
-yy1561:
+#line 8363 "src/prebuilt/wast-lexer-gen.cc"
+yy1568:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy1606;
+		if (yych == 'b') goto yy1613;
 		goto yy87;
-yy1562:
+yy1569:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy1608;
+		if (yych == 'h') goto yy1615;
 		goto yy87;
-yy1563:
+yy1570:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1609;
+		if (yych == 'r') goto yy1616;
 		goto yy87;
-yy1564:
+yy1571:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1611;
+		if (yych == 'd') goto yy1618;
 		goto yy87;
-yy1565:
+yy1572:
 		yych = *++cursor_;
-		if (yych == 'd') goto yy1613;
+		if (yych == 'd') goto yy1620;
 		goto yy87;
-yy1566:
+yy1573:
 		yych = *++cursor_;
-		if (yych == 'p') goto yy1615;
+		if (yych == 'p') goto yy1622;
 		goto yy87;
-yy1567:
+yy1574:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 490 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UOr); }
-#line 8367 "src/prebuilt/wast-lexer-gen.cc"
-yy1569:
+#line 8395 "src/prebuilt/wast-lexer-gen.cc"
+yy1576:
 		yych = *++cursor_;
-		if (yych == 'b') goto yy1616;
+		if (yych == 'b') goto yy1623;
 		goto yy87;
-yy1570:
+yy1577:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy1618;
+		if (yych == 'h') goto yy1625;
 		goto yy87;
-yy1571:
+yy1578:
 		yych = *++cursor_;
-		if (yych == 'r') goto yy1619;
+		if (yych == 'r') goto yy1626;
 		goto yy87;
-yy1572:
+yy1579:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 467 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8UAdd); }
-#line 8387 "src/prebuilt/wast-lexer-gen.cc"
-yy1574:
+#line 8415 "src/prebuilt/wast-lexer-gen.cc"
+yy1581:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 481 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8UAnd); }
-#line 8395 "src/prebuilt/wast-lexer-gen.cc"
-yy1576:
-		yych = *++cursor_;
-		if (yych == 'x') goto yy1621;
-		goto yy87;
-yy1577:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 474 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8USub); }
-#line 8407 "src/prebuilt/wast-lexer-gen.cc"
-yy1579:
-		yych = *++cursor_;
-		if (yych == 'g') goto yy1622;
-		goto yy87;
-yy1580:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 495 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8UXor); }
-#line 8419 "src/prebuilt/wast-lexer-gen.cc"
-yy1582:
-		yych = *++cursor_;
-		if (yych == 'i') goto yy1624;
-		goto yy87;
+#line 8423 "src/prebuilt/wast-lexer-gen.cc"
 yy1583:
 		yych = *++cursor_;
-		if (yych == 'l') goto yy1625;
+		if (yych == 'x') goto yy1628;
 		goto yy87;
 yy1584:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 505 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmwCmpxchg, I32AtomicRmwCmpxchg); }
+#line 474 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8USub); }
 #line 8435 "src/prebuilt/wast-lexer-gen.cc"
 yy1586:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1629;
+		goto yy87;
+yy1587:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 466 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UAdd); }
-#line 8443 "src/prebuilt/wast-lexer-gen.cc"
-yy1588:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 480 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UAnd); }
-#line 8451 "src/prebuilt/wast-lexer-gen.cc"
+#line 495 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8UXor); }
+#line 8447 "src/prebuilt/wast-lexer-gen.cc"
+yy1589:
+		yych = *++cursor_;
+		if (yych == 'i') goto yy1631;
+		goto yy87;
 yy1590:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy1626;
+		if (yych == 'l') goto yy1632;
 		goto yy87;
 yy1591:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 473 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16USub); }
+#line 505 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmwCmpxchg, I32AtomicRmwCmpxchg); }
 #line 8463 "src/prebuilt/wast-lexer-gen.cc"
 yy1593:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 466 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UAdd); }
+#line 8471 "src/prebuilt/wast-lexer-gen.cc"
+yy1595:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 480 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UAnd); }
+#line 8479 "src/prebuilt/wast-lexer-gen.cc"
+yy1597:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1627;
+		if (yych == 'x') goto yy1633;
 		goto yy87;
-yy1594:
+yy1598:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 473 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16USub); }
+#line 8491 "src/prebuilt/wast-lexer-gen.cc"
+yy1600:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1634;
+		goto yy87;
+yy1601:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 494 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UXor); }
-#line 8475 "src/prebuilt/wast-lexer-gen.cc"
-yy1596:
+#line 8503 "src/prebuilt/wast-lexer-gen.cc"
+yy1603:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1629;
+		if (yych == 'c') goto yy1636;
 		goto yy87;
-yy1597:
+yy1604:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 500 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw8UXchg); }
-#line 8487 "src/prebuilt/wast-lexer-gen.cc"
-yy1599:
+#line 8515 "src/prebuilt/wast-lexer-gen.cc"
+yy1606:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 506 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmwCmpxchg, I64AtomicRmwCmpxchg); }
-#line 8495 "src/prebuilt/wast-lexer-gen.cc"
-yy1601:
+#line 8523 "src/prebuilt/wast-lexer-gen.cc"
+yy1608:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 468 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UAdd); }
-#line 8503 "src/prebuilt/wast-lexer-gen.cc"
-yy1603:
+#line 8531 "src/prebuilt/wast-lexer-gen.cc"
+yy1610:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 482 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UAnd); }
-#line 8511 "src/prebuilt/wast-lexer-gen.cc"
-yy1605:
+#line 8539 "src/prebuilt/wast-lexer-gen.cc"
+yy1612:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy1630;
+		if (yych == 'x') goto yy1637;
 		goto yy87;
-yy1606:
+yy1613:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 475 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16USub); }
-#line 8523 "src/prebuilt/wast-lexer-gen.cc"
-yy1608:
-		yych = *++cursor_;
-		if (yych == 'g') goto yy1631;
-		goto yy87;
-yy1609:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 496 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UXor); }
-#line 8535 "src/prebuilt/wast-lexer-gen.cc"
-yy1611:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 469 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UAdd); }
-#line 8543 "src/prebuilt/wast-lexer-gen.cc"
-yy1613:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 483 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UAnd); }
 #line 8551 "src/prebuilt/wast-lexer-gen.cc"
 yy1615:
 		yych = *++cursor_;
-		if (yych == 'x') goto yy1633;
+		if (yych == 'g') goto yy1638;
 		goto yy87;
 yy1616:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 476 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32USub); }
+#line 496 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UXor); }
 #line 8563 "src/prebuilt/wast-lexer-gen.cc"
 yy1618:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 469 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UAdd); }
+#line 8571 "src/prebuilt/wast-lexer-gen.cc"
+yy1620:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 483 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UAnd); }
+#line 8579 "src/prebuilt/wast-lexer-gen.cc"
+yy1622:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1634;
+		if (yych == 'x') goto yy1640;
 		goto yy87;
-yy1619:
+yy1623:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 476 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32USub); }
+#line 8591 "src/prebuilt/wast-lexer-gen.cc"
+yy1625:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1641;
+		goto yy87;
+yy1626:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 497 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UXor); }
-#line 8575 "src/prebuilt/wast-lexer-gen.cc"
-yy1621:
+#line 8603 "src/prebuilt/wast-lexer-gen.cc"
+yy1628:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1636;
+		if (yych == 'c') goto yy1643;
 		goto yy87;
-yy1622:
+yy1629:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 502 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw8UXchg); }
-#line 8587 "src/prebuilt/wast-lexer-gen.cc"
-yy1624:
-		yych = *++cursor_;
-		if (yych == 'c') goto yy1637;
-		goto yy87;
-yy1625:
-		yych = *++cursor_;
-		if (yych == '_') goto yy1638;
-		goto yy87;
-yy1626:
-		yych = *++cursor_;
-		if (yych == 'c') goto yy1639;
-		goto yy87;
-yy1627:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 501 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UXchg); }
-#line 8607 "src/prebuilt/wast-lexer-gen.cc"
-yy1629:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1640;
-		goto yy87;
-yy1630:
-		yych = *++cursor_;
-		if (yych == 'c') goto yy1641;
-		goto yy87;
+#line 8615 "src/prebuilt/wast-lexer-gen.cc"
 yy1631:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 503 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UXchg); }
-#line 8623 "src/prebuilt/wast-lexer-gen.cc"
+		yych = *++cursor_;
+		if (yych == 'c') goto yy1644;
+		goto yy87;
+yy1632:
+		yych = *++cursor_;
+		if (yych == '_') goto yy1645;
+		goto yy87;
 yy1633:
 		yych = *++cursor_;
-		if (yych == 'c') goto yy1642;
+		if (yych == 'c') goto yy1646;
 		goto yy87;
 yy1634:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 504 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UXchg); }
+#line 501 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I32AtomicRmw16UXchg); }
 #line 8635 "src/prebuilt/wast-lexer-gen.cc"
 yy1636:
 		yych = *++cursor_;
-		if (yych == 'h') goto yy1643;
+		if (yych == 'h') goto yy1647;
 		goto yy87;
 yy1637:
 		yych = *++cursor_;
-		if (yych == '_') goto yy1644;
+		if (yych == 'c') goto yy1648;
 		goto yy87;
 yy1638:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy1645;
-		goto yy87;
-yy1639:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1646;
-		goto yy87;
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 503 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw16UXchg); }
+#line 8651 "src/prebuilt/wast-lexer-gen.cc"
 yy1640:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1647;
+		if (yych == 'c') goto yy1649;
 		goto yy87;
 yy1641:
-		yych = *++cursor_;
-		if (yych == 'h') goto yy1649;
-		goto yy87;
-yy1642:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 504 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmw, I64AtomicRmw32UXchg); }
+#line 8663 "src/prebuilt/wast-lexer-gen.cc"
+yy1643:
 		yych = *++cursor_;
 		if (yych == 'h') goto yy1650;
 		goto yy87;
-yy1643:
-		yych = *++cursor_;
-		if (yych == 'g') goto yy1651;
-		goto yy87;
 yy1644:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy1653;
+		if (yych == '_') goto yy1651;
 		goto yy87;
 yy1645:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1654;
+		if (yych == 'n') goto yy1652;
 		goto yy87;
 yy1646:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1655;
+		if (yych == 'h') goto yy1653;
 		goto yy87;
 yy1647:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1654;
+		goto yy87;
+yy1648:
+		yych = *++cursor_;
+		if (yych == 'h') goto yy1656;
+		goto yy87;
+yy1649:
+		yych = *++cursor_;
+		if (yych == 'h') goto yy1657;
+		goto yy87;
+yy1650:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1658;
+		goto yy87;
+yy1651:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy1660;
+		goto yy87;
+yy1652:
+		yych = *++cursor_;
+		if (yych == 'a') goto yy1661;
+		goto yy87;
+yy1653:
+		yych = *++cursor_;
+		if (yych == 'g') goto yy1662;
+		goto yy87;
+yy1654:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 507 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmwCmpxchg, I32AtomicRmw8UCmpxchg); }
-#line 8687 "src/prebuilt/wast-lexer-gen.cc"
-yy1649:
+#line 8715 "src/prebuilt/wast-lexer-gen.cc"
+yy1656:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1657;
+		if (yych == 'g') goto yy1664;
 		goto yy87;
-yy1650:
+yy1657:
 		yych = *++cursor_;
-		if (yych == 'g') goto yy1659;
+		if (yych == 'g') goto yy1666;
 		goto yy87;
-yy1651:
+yy1658:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
 #line 509 "src/wast-lexer.cc"
 		{ RETURN_OPCODE(AtomicRmwCmpxchg, I64AtomicRmw8UCmpxchg); }
-#line 8703 "src/prebuilt/wast-lexer-gen.cc"
-yy1653:
+#line 8731 "src/prebuilt/wast-lexer-gen.cc"
+yy1660:
 		yych = *++cursor_;
-		if (yych == 'a') goto yy1661;
+		if (yych == 'a') goto yy1668;
 		goto yy87;
-yy1654:
-		yych = *++cursor_;
-		if (yych == 'n') goto yy1662;
-		goto yy87;
-yy1655:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 508 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmwCmpxchg, I32AtomicRmw16UCmpxchg); }
-#line 8719 "src/prebuilt/wast-lexer-gen.cc"
-yy1657:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 510 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmwCmpxchg, I64AtomicRmw16UCmpxchg); }
-#line 8727 "src/prebuilt/wast-lexer-gen.cc"
-yy1659:
-		++cursor_;
-		if (yybm[0+(yych = *cursor_)] & 8) {
-			goto yy86;
-		}
-#line 511 "src/wast-lexer.cc"
-		{ RETURN_OPCODE(AtomicRmwCmpxchg, I64AtomicRmw32UCmpxchg); }
-#line 8735 "src/prebuilt/wast-lexer-gen.cc"
 yy1661:
 		yych = *++cursor_;
-		if (yych == 'n') goto yy1664;
+		if (yych == 'n') goto yy1669;
 		goto yy87;
 yy1662:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
-#line 538 "src/wast-lexer.cc"
-		{ RETURN(AssertReturnCanonicalNan); }
+#line 508 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmwCmpxchg, I32AtomicRmw16UCmpxchg); }
 #line 8747 "src/prebuilt/wast-lexer-gen.cc"
 yy1664:
 		++cursor_;
 		if (yybm[0+(yych = *cursor_)] & 8) {
 			goto yy86;
 		}
+#line 510 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmwCmpxchg, I64AtomicRmw16UCmpxchg); }
+#line 8755 "src/prebuilt/wast-lexer-gen.cc"
+yy1666:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 511 "src/wast-lexer.cc"
+		{ RETURN_OPCODE(AtomicRmwCmpxchg, I64AtomicRmw32UCmpxchg); }
+#line 8763 "src/prebuilt/wast-lexer-gen.cc"
+yy1668:
+		yych = *++cursor_;
+		if (yych == 'n') goto yy1671;
+		goto yy87;
+yy1669:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
+#line 538 "src/wast-lexer.cc"
+		{ RETURN(AssertReturnCanonicalNan); }
+#line 8775 "src/prebuilt/wast-lexer-gen.cc"
+yy1671:
+		++cursor_;
+		if (yybm[0+(yych = *cursor_)] & 8) {
+			goto yy86;
+		}
 #line 539 "src/wast-lexer.cc"
 		{ RETURN(AssertReturnArithmeticNan); }
-#line 8755 "src/prebuilt/wast-lexer-gen.cc"
+#line 8783 "src/prebuilt/wast-lexer-gen.cc"
 	}
 }
 #line 566 "src/wast-lexer.cc"

--- a/src/token.h
+++ b/src/token.h
@@ -86,6 +86,8 @@ enum class TokenType {
   AtomicRmw,
   AtomicRmwCmpxchg,
   AtomicStore,
+  AtomicWait,
+  AtomicWake,
   Binary,
   Block,
   Br,
@@ -120,10 +122,8 @@ enum class TokenType {
   Try,
   Unary,
   Unreachable,
-  Wait,
-  Wake,
   First_Opcode = AtomicLoad,
-  Last_Opcode = Wake,
+  Last_Opcode = Unreachable,
 
   // Tokens with string data.
   AlignEqNat,

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -305,6 +305,14 @@ Result TypeChecker::OnAtomicRmwCmpxchg(Opcode opcode) {
   return CheckOpcode3(opcode);
 }
 
+Result TypeChecker::OnAtomicWait(Opcode opcode) {
+  return CheckOpcode3(opcode);
+}
+
+Result TypeChecker::OnAtomicWake(Opcode opcode) {
+  return CheckOpcode2(opcode);
+}
+
 Result TypeChecker::OnBinary(Opcode opcode) {
   return CheckOpcode2(opcode);
 }
@@ -585,14 +593,6 @@ Result TypeChecker::OnUnary(Opcode opcode) {
 
 Result TypeChecker::OnUnreachable() {
   return SetUnreachable();
-}
-
-Result TypeChecker::OnWait(Opcode opcode) {
-  return CheckOpcode3(opcode);
-}
-
-Result TypeChecker::OnWake(Opcode opcode) {
-  return CheckOpcode2(opcode);
 }
 
 Result TypeChecker::EndFunction() {

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -55,6 +55,8 @@ class TypeChecker {
   Result OnAtomicStore(Opcode);
   Result OnAtomicRmw(Opcode);
   Result OnAtomicRmwCmpxchg(Opcode);
+  Result OnAtomicWait(Opcode);
+  Result OnAtomicWake(Opcode);
   Result OnBinary(Opcode);
   Result OnBlock(const TypeVector* sig);
   Result OnBr(Index depth);
@@ -91,8 +93,6 @@ class TypeChecker {
   Result OnTryBlock(const TypeVector* sig);
   Result OnUnary(Opcode);
   Result OnUnreachable();
-  Result OnWait(Opcode);
-  Result OnWake(Opcode);
   Result EndFunction();
 
  private:

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -457,6 +457,14 @@ void Validator::CheckExpr(const Expr* expr) {
       CheckAtomicExpr(cast<AtomicStoreExpr>(expr), &TypeChecker::OnAtomicStore);
       break;
 
+    case ExprType::AtomicWait:
+      CheckAtomicExpr(cast<AtomicWaitExpr>(expr), &TypeChecker::OnAtomicWait);
+      break;
+
+    case ExprType::AtomicWake:
+      CheckAtomicExpr(cast<AtomicWakeExpr>(expr), &TypeChecker::OnAtomicWake);
+      break;
+
     case ExprType::Binary:
       typechecker_.OnBinary(cast<BinaryExpr>(expr)->opcode);
       break;
@@ -659,14 +667,6 @@ void Validator::CheckExpr(const Expr* expr) {
 
     case ExprType::Unreachable:
       typechecker_.OnUnreachable();
-      break;
-
-    case ExprType::Wait:
-      CheckAtomicExpr(cast<WaitExpr>(expr), &TypeChecker::OnWait);
-      break;
-
-    case ExprType::Wake:
-      CheckAtomicExpr(cast<WakeExpr>(expr), &TypeChecker::OnWake);
       break;
   }
 }

--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -443,9 +443,9 @@ Token WastLexer::GetToken(WastParser* parser) {
       <i> "current_memory"      { RETURN_OPCODE0(CurrentMemory); }
       <i> "grow_memory"         { RETURN_OPCODE0(GrowMemory); }
 
-      <i> "i32.wait"            { RETURN_OPCODE(Wait, I32Wait); }
-      <i> "i64.wait"            { RETURN_OPCODE(Wait, I64Wait); }
-      <i> "wake"                { RETURN_OPCODE0(Wake); }
+      <i> "i32.atomic.wait"     { RETURN_OPCODE(AtomicWait, I32AtomicWait); }
+      <i> "i64.atomic.wait"     { RETURN_OPCODE(AtomicWait, I64AtomicWait); }
+      <i> "atomic.wake"         { RETURN_OPCODE0(AtomicWake); }
       <i> "i32.atomic.load"     { RETURN_OPCODE(AtomicLoad, I32AtomicLoad); }
       <i> "i64.atomic.load"     { RETURN_OPCODE(AtomicLoad, I64AtomicLoad); }
       <i> "i32.atomic.load8_u"  { RETURN_OPCODE(AtomicLoad, I32AtomicLoad8U); }

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -165,12 +165,12 @@ bool IsPlainInstr(TokenType token_type) {
     case TokenType::GrowMemory:
     case TokenType::Throw:
     case TokenType::Rethrow:
-    case TokenType::Wake:
-    case TokenType::Wait:
     case TokenType::AtomicLoad:
     case TokenType::AtomicStore:
     case TokenType::AtomicRmw:
     case TokenType::AtomicRmwCmpxchg:
+    case TokenType::AtomicWake:
+    case TokenType::AtomicWait:
       return true;
     default:
       return false;
@@ -1431,17 +1431,19 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       CHECK_RESULT(ParsePlainInstrVar<RethrowExpr>(loc, out_expr));
       break;
 
-    case TokenType::Wake: {
+    case TokenType::AtomicWake: {
       Token token = Consume();
       ErrorUnlessOpcodeEnabled(token);
-      CHECK_RESULT(ParsePlainLoadStoreInstr<WakeExpr>(loc, token, out_expr));
+      CHECK_RESULT(
+          ParsePlainLoadStoreInstr<AtomicWakeExpr>(loc, token, out_expr));
       break;
     }
 
-    case TokenType::Wait: {
+    case TokenType::AtomicWait: {
       Token token = Consume();
       ErrorUnlessOpcodeEnabled(token);
-      CHECK_RESULT(ParsePlainLoadStoreInstr<WaitExpr>(loc, token, out_expr));
+      CHECK_RESULT(
+          ParsePlainLoadStoreInstr<AtomicWaitExpr>(loc, token, out_expr));
       break;
     }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -488,6 +488,14 @@ void WatWriter::WriteExpr(const Expr* expr) {
       WriteLoadStoreExpr<AtomicRmwCmpxchgExpr>(expr);
       break;
 
+    case ExprType::AtomicWait:
+      WriteLoadStoreExpr<AtomicWaitExpr>(expr);
+      break;
+
+    case ExprType::AtomicWake:
+      WriteLoadStoreExpr<AtomicWakeExpr>(expr);
+      break;
+
     case ExprType::Binary:
       WritePutsNewline(cast<BinaryExpr>(expr)->opcode.GetName());
       break;
@@ -657,14 +665,6 @@ void WatWriter::WriteExpr(const Expr* expr) {
       WritePutsNewline(Opcode::Unreachable_Opcode.GetName());
       break;
 
-    case ExprType::Wait:
-      WriteLoadStoreExpr<WaitExpr>(expr);
-      break;
-
-    case ExprType::Wake:
-      WriteLoadStoreExpr<WakeExpr>(expr);
-      break;
-
     default:
       fprintf(stderr, "bad expr type: %s\n", GetExprTypeName(*expr));
       assert(0);
@@ -712,9 +712,9 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
   WABT_TRACE_ARGS(WriteFoldedExpr, "%s", GetExprTypeName(*expr));
   switch (expr->type()) {
     case ExprType::AtomicRmw:
+    case ExprType::AtomicWake:
     case ExprType::Binary:
     case ExprType::Compare:
-    case ExprType::Wake:
       PushExpr(expr, 2, 1);
       break;
 
@@ -799,8 +799,8 @@ void WatWriter::WriteFoldedExpr(const Expr* expr) {
       break;
 
     case ExprType::AtomicRmwCmpxchg:
+    case ExprType::AtomicWait:
     case ExprType::Select:
-    case ExprType::Wait:
       PushExpr(expr, 3, 1);
       break;
 

--- a/test/dump/atomic.txt
+++ b/test/dump/atomic.txt
@@ -4,9 +4,9 @@
 (module
   (memory 1 1 shared)
   (func
-    i32.const 0 i32.const 0 wake drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
+    i32.const 0 i32.const 0 atomic.wake drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
 
     i32.const 0 i32.atomic.load drop
     i32.const 0 i64.atomic.load drop
@@ -90,17 +90,17 @@ Code Disassembly:
 00001c func[0]:
  00001f: 41 00                      | i32.const 0
  000021: 41 00                      | i32.const 0
- 000024: fe 00 02 00                | wake 2 0
+ 000024: fe 00 02 00                | atomic.wake 2 0
  000027: 1a                         | drop
  000028: 41 00                      | i32.const 0
  00002a: 41 00                      | i32.const 0
  00002c: 42 00                      | i64.const 0
- 00002f: fe 01 02 00                | i32.wait 2 0
+ 00002f: fe 01 02 00                | i32.atomic.wait 2 0
  000032: 1a                         | drop
  000033: 41 00                      | i32.const 0
  000035: 42 00                      | i64.const 0
  000037: 42 00                      | i64.const 0
- 00003a: fe 02 03 00                | i64.wait 3 0
+ 00003a: fe 02 03 00                | i64.atomic.wait 3 0
  00003d: 1a                         | drop
  00003e: 41 00                      | i32.const 0
  000041: fe 10 02 00                | i32.atomic.load 2 0

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -213,9 +213,9 @@
   (; 0xfc 0x07 ;) (func (export "i64.trunc_u:sat/f64") f64.const 1 i64.trunc_u:sat/f64 drop)
 
   ;; --enable-threads
-  (; 0xfe 0x00 ;) (func (export "wake") i32.const 1 i32.const 2 wake offset=3 drop)
-  (; 0xfe 0x01 ;) (func (export "i32.wait") i32.const 1 i32.const 2 i64.const 3 i32.wait offset=3 drop)
-  (; 0xfe 0x02 ;) (func (export "i64.wait") i32.const 1 i64.const 2 i64.const 3 i64.wait offset=3 drop)
+  (; 0xfe 0x00 ;) (func (export "atomic.wake") i32.const 1 i32.const 2 atomic.wake offset=3 drop)
+  (; 0xfe 0x01 ;) (func (export "i32.atomic.wait") i32.const 1 i32.const 2 i64.const 3 i32.atomic.wait offset=3 drop)
+  (; 0xfe 0x02 ;) (func (export "i64.atomic.wait") i32.const 1 i64.const 2 i64.const 3 i64.atomic.wait offset=3 drop)
   (; 0xfe 0x10 ;) (func (export "i32.atomic.load") i32.const 1 i32.atomic.load offset=3 drop)
   (; 0xfe 0x11 ;) (func (export "i64.atomic.load") i32.const 1 i64.atomic.load offset=7 drop)
   (; 0xfe 0x12 ;) (func (export "i32.atomic.load8_u") i32.const 1 i32.atomic.load8_u offset=3 drop)
@@ -1352,3139 +1352,3139 @@
 0000aa3: 6636 34                                  f64  ; export name
 0000aa6: 00                                        ; export kind
 0000aa7: b801                                      ; export func index
-0000aa9: 04                                        ; string length
-0000aaa: 7761 6b65                                wake  ; export name
-0000aae: 00                                        ; export kind
-0000aaf: b901                                      ; export func index
-0000ab1: 08                                        ; string length
-0000ab2: 6933 322e 7761 6974                      i32.wait  ; export name
-0000aba: 00                                        ; export kind
-0000abb: ba01                                      ; export func index
-0000abd: 08                                        ; string length
-0000abe: 6936 342e 7761 6974                      i64.wait  ; export name
-0000ac6: 00                                        ; export kind
-0000ac7: bb01                                      ; export func index
-0000ac9: 0f                                        ; string length
-0000aca: 6933 322e 6174 6f6d 6963 2e6c 6f61 64    i32.atomic.load  ; export name
-0000ad9: 00                                        ; export kind
-0000ada: bc01                                      ; export func index
-0000adc: 0f                                        ; string length
-0000add: 6936 342e 6174 6f6d 6963 2e6c 6f61 64    i64.atomic.load  ; export name
-0000aec: 00                                        ; export kind
-0000aed: bd01                                      ; export func index
-0000aef: 12                                        ; string length
-0000af0: 6933 322e 6174 6f6d 6963 2e6c 6f61 6438  i32.atomic.load8
-0000b00: 5f75                                     _u  ; export name
-0000b02: 00                                        ; export kind
-0000b03: be01                                      ; export func index
-0000b05: 13                                        ; string length
-0000b06: 6933 322e 6174 6f6d 6963 2e6c 6f61 6431  i32.atomic.load1
-0000b16: 365f 75                                  6_u  ; export name
-0000b19: 00                                        ; export kind
-0000b1a: bf01                                      ; export func index
-0000b1c: 12                                        ; string length
-0000b1d: 6936 342e 6174 6f6d 6963 2e6c 6f61 6438  i64.atomic.load8
-0000b2d: 5f75                                     _u  ; export name
-0000b2f: 00                                        ; export kind
-0000b30: c001                                      ; export func index
-0000b32: 13                                        ; string length
-0000b33: 6936 342e 6174 6f6d 6963 2e6c 6f61 6431  i64.atomic.load1
-0000b43: 365f 75                                  6_u  ; export name
-0000b46: 00                                        ; export kind
-0000b47: c101                                      ; export func index
-0000b49: 13                                        ; string length
-0000b4a: 6936 342e 6174 6f6d 6963 2e6c 6f61 6433  i64.atomic.load3
-0000b5a: 325f 75                                  2_u  ; export name
-0000b5d: 00                                        ; export kind
-0000b5e: c201                                      ; export func index
-0000b60: 10                                        ; string length
-0000b61: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store  ; export name
-0000b71: 00                                        ; export kind
-0000b72: c301                                      ; export func index
-0000b74: 10                                        ; string length
-0000b75: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store  ; export name
-0000b85: 00                                        ; export kind
-0000b86: c401                                      ; export func index
-0000b88: 11                                        ; string length
-0000b89: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
-0000b99: 38                                       8  ; export name
+0000aa9: 0b                                        ; string length
+0000aaa: 6174 6f6d 6963 2e77 616b 65              atomic.wake  ; export name
+0000ab5: 00                                        ; export kind
+0000ab6: b901                                      ; export func index
+0000ab8: 0f                                        ; string length
+0000ab9: 6933 322e 6174 6f6d 6963 2e77 6169 74    i32.atomic.wait  ; export name
+0000ac8: 00                                        ; export kind
+0000ac9: ba01                                      ; export func index
+0000acb: 0f                                        ; string length
+0000acc: 6936 342e 6174 6f6d 6963 2e77 6169 74    i64.atomic.wait  ; export name
+0000adb: 00                                        ; export kind
+0000adc: bb01                                      ; export func index
+0000ade: 0f                                        ; string length
+0000adf: 6933 322e 6174 6f6d 6963 2e6c 6f61 64    i32.atomic.load  ; export name
+0000aee: 00                                        ; export kind
+0000aef: bc01                                      ; export func index
+0000af1: 0f                                        ; string length
+0000af2: 6936 342e 6174 6f6d 6963 2e6c 6f61 64    i64.atomic.load  ; export name
+0000b01: 00                                        ; export kind
+0000b02: bd01                                      ; export func index
+0000b04: 12                                        ; string length
+0000b05: 6933 322e 6174 6f6d 6963 2e6c 6f61 6438  i32.atomic.load8
+0000b15: 5f75                                     _u  ; export name
+0000b17: 00                                        ; export kind
+0000b18: be01                                      ; export func index
+0000b1a: 13                                        ; string length
+0000b1b: 6933 322e 6174 6f6d 6963 2e6c 6f61 6431  i32.atomic.load1
+0000b2b: 365f 75                                  6_u  ; export name
+0000b2e: 00                                        ; export kind
+0000b2f: bf01                                      ; export func index
+0000b31: 12                                        ; string length
+0000b32: 6936 342e 6174 6f6d 6963 2e6c 6f61 6438  i64.atomic.load8
+0000b42: 5f75                                     _u  ; export name
+0000b44: 00                                        ; export kind
+0000b45: c001                                      ; export func index
+0000b47: 13                                        ; string length
+0000b48: 6936 342e 6174 6f6d 6963 2e6c 6f61 6431  i64.atomic.load1
+0000b58: 365f 75                                  6_u  ; export name
+0000b5b: 00                                        ; export kind
+0000b5c: c101                                      ; export func index
+0000b5e: 13                                        ; string length
+0000b5f: 6936 342e 6174 6f6d 6963 2e6c 6f61 6433  i64.atomic.load3
+0000b6f: 325f 75                                  2_u  ; export name
+0000b72: 00                                        ; export kind
+0000b73: c201                                      ; export func index
+0000b75: 10                                        ; string length
+0000b76: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store  ; export name
+0000b86: 00                                        ; export kind
+0000b87: c301                                      ; export func index
+0000b89: 10                                        ; string length
+0000b8a: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store  ; export name
 0000b9a: 00                                        ; export kind
-0000b9b: c501                                      ; export func index
-0000b9d: 12                                        ; string length
+0000b9b: c401                                      ; export func index
+0000b9d: 11                                        ; string length
 0000b9e: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
-0000bae: 3136                                     16  ; export name
-0000bb0: 00                                        ; export kind
-0000bb1: c601                                      ; export func index
-0000bb3: 11                                        ; string length
-0000bb4: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
-0000bc4: 38                                       8  ; export name
+0000bae: 38                                       8  ; export name
+0000baf: 00                                        ; export kind
+0000bb0: c501                                      ; export func index
+0000bb2: 12                                        ; string length
+0000bb3: 6933 322e 6174 6f6d 6963 2e73 746f 7265  i32.atomic.store
+0000bc3: 3136                                     16  ; export name
 0000bc5: 00                                        ; export kind
-0000bc6: c701                                      ; export func index
-0000bc8: 12                                        ; string length
+0000bc6: c601                                      ; export func index
+0000bc8: 11                                        ; string length
 0000bc9: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
-0000bd9: 3136                                     16  ; export name
-0000bdb: 00                                        ; export kind
-0000bdc: c801                                      ; export func index
-0000bde: 12                                        ; string length
-0000bdf: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
-0000bef: 3332                                     32  ; export name
-0000bf1: 00                                        ; export kind
-0000bf2: c901                                      ; export func index
-0000bf4: 12                                        ; string length
-0000bf5: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
-0000c05: 6464                                     dd  ; export name
-0000c07: 00                                        ; export kind
-0000c08: ca01                                      ; export func index
-0000c0a: 12                                        ; string length
-0000c0b: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
-0000c1b: 6464                                     dd  ; export name
-0000c1d: 00                                        ; export kind
-0000c1e: cb01                                      ; export func index
-0000c20: 15                                        ; string length
-0000c21: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000c31: 752e 6164 64                             u.add  ; export name
-0000c36: 00                                        ; export kind
-0000c37: cc01                                      ; export func index
-0000c39: 16                                        ; string length
-0000c3a: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000c4a: 5f75 2e61 6464                           _u.add  ; export name
-0000c50: 00                                        ; export kind
-0000c51: cd01                                      ; export func index
-0000c53: 15                                        ; string length
-0000c54: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000c64: 752e 6164 64                             u.add  ; export name
-0000c69: 00                                        ; export kind
-0000c6a: ce01                                      ; export func index
-0000c6c: 16                                        ; string length
-0000c6d: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000c7d: 5f75 2e61 6464                           _u.add  ; export name
-0000c83: 00                                        ; export kind
-0000c84: cf01                                      ; export func index
-0000c86: 16                                        ; string length
-0000c87: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000c97: 5f75 2e61 6464                           _u.add  ; export name
-0000c9d: 00                                        ; export kind
-0000c9e: d001                                      ; export func index
-0000ca0: 12                                        ; string length
-0000ca1: 6933 322e 6174 6f6d 6963 2e72 6d77 2e73  i32.atomic.rmw.s
-0000cb1: 7562                                     ub  ; export name
-0000cb3: 00                                        ; export kind
-0000cb4: d101                                      ; export func index
-0000cb6: 12                                        ; string length
-0000cb7: 6936 342e 6174 6f6d 6963 2e72 6d77 2e73  i64.atomic.rmw.s
-0000cc7: 7562                                     ub  ; export name
-0000cc9: 00                                        ; export kind
-0000cca: d201                                      ; export func index
-0000ccc: 15                                        ; string length
-0000ccd: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000cdd: 752e 7375 62                             u.sub  ; export name
-0000ce2: 00                                        ; export kind
-0000ce3: d301                                      ; export func index
-0000ce5: 16                                        ; string length
-0000ce6: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000cf6: 5f75 2e73 7562                           _u.sub  ; export name
-0000cfc: 00                                        ; export kind
-0000cfd: d401                                      ; export func index
-0000cff: 15                                        ; string length
-0000d00: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000d10: 752e 7375 62                             u.sub  ; export name
-0000d15: 00                                        ; export kind
-0000d16: d501                                      ; export func index
-0000d18: 16                                        ; string length
-0000d19: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000d29: 5f75 2e73 7562                           _u.sub  ; export name
-0000d2f: 00                                        ; export kind
-0000d30: d601                                      ; export func index
-0000d32: 16                                        ; string length
-0000d33: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000d43: 5f75 2e73 7562                           _u.sub  ; export name
-0000d49: 00                                        ; export kind
-0000d4a: d701                                      ; export func index
-0000d4c: 12                                        ; string length
-0000d4d: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
-0000d5d: 6e64                                     nd  ; export name
-0000d5f: 00                                        ; export kind
-0000d60: d801                                      ; export func index
-0000d62: 12                                        ; string length
-0000d63: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
-0000d73: 6e64                                     nd  ; export name
-0000d75: 00                                        ; export kind
-0000d76: d901                                      ; export func index
-0000d78: 15                                        ; string length
-0000d79: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000d89: 752e 616e 64                             u.and  ; export name
-0000d8e: 00                                        ; export kind
-0000d8f: da01                                      ; export func index
-0000d91: 16                                        ; string length
-0000d92: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000da2: 5f75 2e61 6e64                           _u.and  ; export name
-0000da8: 00                                        ; export kind
-0000da9: db01                                      ; export func index
-0000dab: 15                                        ; string length
-0000dac: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000dbc: 752e 616e 64                             u.and  ; export name
-0000dc1: 00                                        ; export kind
-0000dc2: dc01                                      ; export func index
-0000dc4: 16                                        ; string length
-0000dc5: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000dd5: 5f75 2e61 6e64                           _u.and  ; export name
-0000ddb: 00                                        ; export kind
-0000ddc: dd01                                      ; export func index
-0000dde: 16                                        ; string length
-0000ddf: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000def: 5f75 2e61 6e64                           _u.and  ; export name
-0000df5: 00                                        ; export kind
-0000df6: de01                                      ; export func index
-0000df8: 11                                        ; string length
-0000df9: 6933 322e 6174 6f6d 6963 2e72 6d77 2e6f  i32.atomic.rmw.o
-0000e09: 72                                       r  ; export name
+0000bd9: 38                                       8  ; export name
+0000bda: 00                                        ; export kind
+0000bdb: c701                                      ; export func index
+0000bdd: 12                                        ; string length
+0000bde: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
+0000bee: 3136                                     16  ; export name
+0000bf0: 00                                        ; export kind
+0000bf1: c801                                      ; export func index
+0000bf3: 12                                        ; string length
+0000bf4: 6936 342e 6174 6f6d 6963 2e73 746f 7265  i64.atomic.store
+0000c04: 3332                                     32  ; export name
+0000c06: 00                                        ; export kind
+0000c07: c901                                      ; export func index
+0000c09: 12                                        ; string length
+0000c0a: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
+0000c1a: 6464                                     dd  ; export name
+0000c1c: 00                                        ; export kind
+0000c1d: ca01                                      ; export func index
+0000c1f: 12                                        ; string length
+0000c20: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
+0000c30: 6464                                     dd  ; export name
+0000c32: 00                                        ; export kind
+0000c33: cb01                                      ; export func index
+0000c35: 15                                        ; string length
+0000c36: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000c46: 752e 6164 64                             u.add  ; export name
+0000c4b: 00                                        ; export kind
+0000c4c: cc01                                      ; export func index
+0000c4e: 16                                        ; string length
+0000c4f: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000c5f: 5f75 2e61 6464                           _u.add  ; export name
+0000c65: 00                                        ; export kind
+0000c66: cd01                                      ; export func index
+0000c68: 15                                        ; string length
+0000c69: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000c79: 752e 6164 64                             u.add  ; export name
+0000c7e: 00                                        ; export kind
+0000c7f: ce01                                      ; export func index
+0000c81: 16                                        ; string length
+0000c82: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000c92: 5f75 2e61 6464                           _u.add  ; export name
+0000c98: 00                                        ; export kind
+0000c99: cf01                                      ; export func index
+0000c9b: 16                                        ; string length
+0000c9c: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000cac: 5f75 2e61 6464                           _u.add  ; export name
+0000cb2: 00                                        ; export kind
+0000cb3: d001                                      ; export func index
+0000cb5: 12                                        ; string length
+0000cb6: 6933 322e 6174 6f6d 6963 2e72 6d77 2e73  i32.atomic.rmw.s
+0000cc6: 7562                                     ub  ; export name
+0000cc8: 00                                        ; export kind
+0000cc9: d101                                      ; export func index
+0000ccb: 12                                        ; string length
+0000ccc: 6936 342e 6174 6f6d 6963 2e72 6d77 2e73  i64.atomic.rmw.s
+0000cdc: 7562                                     ub  ; export name
+0000cde: 00                                        ; export kind
+0000cdf: d201                                      ; export func index
+0000ce1: 15                                        ; string length
+0000ce2: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000cf2: 752e 7375 62                             u.sub  ; export name
+0000cf7: 00                                        ; export kind
+0000cf8: d301                                      ; export func index
+0000cfa: 16                                        ; string length
+0000cfb: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000d0b: 5f75 2e73 7562                           _u.sub  ; export name
+0000d11: 00                                        ; export kind
+0000d12: d401                                      ; export func index
+0000d14: 15                                        ; string length
+0000d15: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000d25: 752e 7375 62                             u.sub  ; export name
+0000d2a: 00                                        ; export kind
+0000d2b: d501                                      ; export func index
+0000d2d: 16                                        ; string length
+0000d2e: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000d3e: 5f75 2e73 7562                           _u.sub  ; export name
+0000d44: 00                                        ; export kind
+0000d45: d601                                      ; export func index
+0000d47: 16                                        ; string length
+0000d48: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000d58: 5f75 2e73 7562                           _u.sub  ; export name
+0000d5e: 00                                        ; export kind
+0000d5f: d701                                      ; export func index
+0000d61: 12                                        ; string length
+0000d62: 6933 322e 6174 6f6d 6963 2e72 6d77 2e61  i32.atomic.rmw.a
+0000d72: 6e64                                     nd  ; export name
+0000d74: 00                                        ; export kind
+0000d75: d801                                      ; export func index
+0000d77: 12                                        ; string length
+0000d78: 6936 342e 6174 6f6d 6963 2e72 6d77 2e61  i64.atomic.rmw.a
+0000d88: 6e64                                     nd  ; export name
+0000d8a: 00                                        ; export kind
+0000d8b: d901                                      ; export func index
+0000d8d: 15                                        ; string length
+0000d8e: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000d9e: 752e 616e 64                             u.and  ; export name
+0000da3: 00                                        ; export kind
+0000da4: da01                                      ; export func index
+0000da6: 16                                        ; string length
+0000da7: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000db7: 5f75 2e61 6e64                           _u.and  ; export name
+0000dbd: 00                                        ; export kind
+0000dbe: db01                                      ; export func index
+0000dc0: 15                                        ; string length
+0000dc1: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000dd1: 752e 616e 64                             u.and  ; export name
+0000dd6: 00                                        ; export kind
+0000dd7: dc01                                      ; export func index
+0000dd9: 16                                        ; string length
+0000dda: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000dea: 5f75 2e61 6e64                           _u.and  ; export name
+0000df0: 00                                        ; export kind
+0000df1: dd01                                      ; export func index
+0000df3: 16                                        ; string length
+0000df4: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000e04: 5f75 2e61 6e64                           _u.and  ; export name
 0000e0a: 00                                        ; export kind
-0000e0b: df01                                      ; export func index
+0000e0b: de01                                      ; export func index
 0000e0d: 11                                        ; string length
-0000e0e: 6936 342e 6174 6f6d 6963 2e72 6d77 2e6f  i64.atomic.rmw.o
+0000e0e: 6933 322e 6174 6f6d 6963 2e72 6d77 2e6f  i32.atomic.rmw.o
 0000e1e: 72                                       r  ; export name
 0000e1f: 00                                        ; export kind
-0000e20: e001                                      ; export func index
-0000e22: 14                                        ; string length
-0000e23: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000e33: 752e 6f72                                u.or  ; export name
-0000e37: 00                                        ; export kind
-0000e38: e101                                      ; export func index
-0000e3a: 15                                        ; string length
-0000e3b: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000e4b: 5f75 2e6f 72                             _u.or  ; export name
-0000e50: 00                                        ; export kind
-0000e51: e201                                      ; export func index
-0000e53: 14                                        ; string length
-0000e54: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000e64: 752e 6f72                                u.or  ; export name
-0000e68: 00                                        ; export kind
-0000e69: e301                                      ; export func index
-0000e6b: 15                                        ; string length
-0000e6c: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000e7c: 5f75 2e6f 72                             _u.or  ; export name
-0000e81: 00                                        ; export kind
-0000e82: e401                                      ; export func index
-0000e84: 15                                        ; string length
-0000e85: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000e95: 5f75 2e6f 72                             _u.or  ; export name
-0000e9a: 00                                        ; export kind
-0000e9b: e501                                      ; export func index
-0000e9d: 12                                        ; string length
-0000e9e: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
-0000eae: 6f72                                     or  ; export name
-0000eb0: 00                                        ; export kind
-0000eb1: e601                                      ; export func index
-0000eb3: 12                                        ; string length
-0000eb4: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
-0000ec4: 6f72                                     or  ; export name
-0000ec6: 00                                        ; export kind
-0000ec7: e701                                      ; export func index
-0000ec9: 15                                        ; string length
-0000eca: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000eda: 752e 786f 72                             u.xor  ; export name
-0000edf: 00                                        ; export kind
-0000ee0: e801                                      ; export func index
-0000ee2: 16                                        ; string length
-0000ee3: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000ef3: 5f75 2e78 6f72                           _u.xor  ; export name
-0000ef9: 00                                        ; export kind
-0000efa: e901                                      ; export func index
-0000efc: 15                                        ; string length
-0000efd: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000f0d: 752e 786f 72                             u.xor  ; export name
-0000f12: 00                                        ; export kind
-0000f13: ea01                                      ; export func index
-0000f15: 16                                        ; string length
-0000f16: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000f26: 5f75 2e78 6f72                           _u.xor  ; export name
-0000f2c: 00                                        ; export kind
-0000f2d: eb01                                      ; export func index
-0000f2f: 16                                        ; string length
-0000f30: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000f40: 5f75 2e78 6f72                           _u.xor  ; export name
-0000f46: 00                                        ; export kind
-0000f47: ec01                                      ; export func index
-0000f49: 13                                        ; string length
-0000f4a: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
-0000f5a: 6368 67                                  chg  ; export name
-0000f5d: 00                                        ; export kind
-0000f5e: ed01                                      ; export func index
-0000f60: 13                                        ; string length
-0000f61: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
-0000f71: 6368 67                                  chg  ; export name
-0000f74: 00                                        ; export kind
-0000f75: ee01                                      ; export func index
-0000f77: 16                                        ; string length
-0000f78: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0000f88: 752e 7863 6867                           u.xchg  ; export name
-0000f8e: 00                                        ; export kind
-0000f8f: ef01                                      ; export func index
-0000f91: 17                                        ; string length
-0000f92: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-0000fa2: 5f75 2e78 6368 67                        _u.xchg  ; export name
-0000fa9: 00                                        ; export kind
-0000faa: f001                                      ; export func index
-0000fac: 16                                        ; string length
-0000fad: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-0000fbd: 752e 7863 6867                           u.xchg  ; export name
-0000fc3: 00                                        ; export kind
-0000fc4: f101                                      ; export func index
-0000fc6: 17                                        ; string length
-0000fc7: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0000fd7: 5f75 2e78 6368 67                        _u.xchg  ; export name
-0000fde: 00                                        ; export kind
-0000fdf: f201                                      ; export func index
-0000fe1: 17                                        ; string length
-0000fe2: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-0000ff2: 5f75 2e78 6368 67                        _u.xchg  ; export name
-0000ff9: 00                                        ; export kind
-0000ffa: f301                                      ; export func index
-0000ffc: 16                                        ; string length
-0000ffd: 6933 322e 6174 6f6d 6963 2e72 6d77 2e63  i32.atomic.rmw.c
-000100d: 6d70 7863 6867                           mpxchg  ; export name
-0001013: 00                                        ; export kind
-0001014: f401                                      ; export func index
-0001016: 16                                        ; string length
-0001017: 6936 342e 6174 6f6d 6963 2e72 6d77 2e63  i64.atomic.rmw.c
-0001027: 6d70 7863 6867                           mpxchg  ; export name
-000102d: 00                                        ; export kind
-000102e: f501                                      ; export func index
-0001030: 19                                        ; string length
-0001031: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
-0001041: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
-000104a: 00                                        ; export kind
-000104b: f601                                      ; export func index
-000104d: 1a                                        ; string length
-000104e: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
-000105e: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
-0001068: 00                                        ; export kind
-0001069: f701                                      ; export func index
-000106b: 19                                        ; string length
-000106c: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
-000107c: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
-0001085: 00                                        ; export kind
-0001086: f801                                      ; export func index
-0001088: 1a                                        ; string length
-0001089: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
-0001099: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
-00010a3: 00                                        ; export kind
-00010a4: f901                                      ; export func index
-00010a6: 1a                                        ; string length
-00010a7: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
-00010b7: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
-00010c1: 00                                        ; export kind
-00010c2: fa01                                      ; export func index
-; move data: [138, 10c4) -> [139, 10c5)
-0000137: 8c1f                                      ; FIXUP section size
+0000e20: df01                                      ; export func index
+0000e22: 11                                        ; string length
+0000e23: 6936 342e 6174 6f6d 6963 2e72 6d77 2e6f  i64.atomic.rmw.o
+0000e33: 72                                       r  ; export name
+0000e34: 00                                        ; export kind
+0000e35: e001                                      ; export func index
+0000e37: 14                                        ; string length
+0000e38: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000e48: 752e 6f72                                u.or  ; export name
+0000e4c: 00                                        ; export kind
+0000e4d: e101                                      ; export func index
+0000e4f: 15                                        ; string length
+0000e50: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000e60: 5f75 2e6f 72                             _u.or  ; export name
+0000e65: 00                                        ; export kind
+0000e66: e201                                      ; export func index
+0000e68: 14                                        ; string length
+0000e69: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000e79: 752e 6f72                                u.or  ; export name
+0000e7d: 00                                        ; export kind
+0000e7e: e301                                      ; export func index
+0000e80: 15                                        ; string length
+0000e81: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000e91: 5f75 2e6f 72                             _u.or  ; export name
+0000e96: 00                                        ; export kind
+0000e97: e401                                      ; export func index
+0000e99: 15                                        ; string length
+0000e9a: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000eaa: 5f75 2e6f 72                             _u.or  ; export name
+0000eaf: 00                                        ; export kind
+0000eb0: e501                                      ; export func index
+0000eb2: 12                                        ; string length
+0000eb3: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
+0000ec3: 6f72                                     or  ; export name
+0000ec5: 00                                        ; export kind
+0000ec6: e601                                      ; export func index
+0000ec8: 12                                        ; string length
+0000ec9: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
+0000ed9: 6f72                                     or  ; export name
+0000edb: 00                                        ; export kind
+0000edc: e701                                      ; export func index
+0000ede: 15                                        ; string length
+0000edf: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000eef: 752e 786f 72                             u.xor  ; export name
+0000ef4: 00                                        ; export kind
+0000ef5: e801                                      ; export func index
+0000ef7: 16                                        ; string length
+0000ef8: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000f08: 5f75 2e78 6f72                           _u.xor  ; export name
+0000f0e: 00                                        ; export kind
+0000f0f: e901                                      ; export func index
+0000f11: 15                                        ; string length
+0000f12: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000f22: 752e 786f 72                             u.xor  ; export name
+0000f27: 00                                        ; export kind
+0000f28: ea01                                      ; export func index
+0000f2a: 16                                        ; string length
+0000f2b: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000f3b: 5f75 2e78 6f72                           _u.xor  ; export name
+0000f41: 00                                        ; export kind
+0000f42: eb01                                      ; export func index
+0000f44: 16                                        ; string length
+0000f45: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0000f55: 5f75 2e78 6f72                           _u.xor  ; export name
+0000f5b: 00                                        ; export kind
+0000f5c: ec01                                      ; export func index
+0000f5e: 13                                        ; string length
+0000f5f: 6933 322e 6174 6f6d 6963 2e72 6d77 2e78  i32.atomic.rmw.x
+0000f6f: 6368 67                                  chg  ; export name
+0000f72: 00                                        ; export kind
+0000f73: ed01                                      ; export func index
+0000f75: 13                                        ; string length
+0000f76: 6936 342e 6174 6f6d 6963 2e72 6d77 2e78  i64.atomic.rmw.x
+0000f86: 6368 67                                  chg  ; export name
+0000f89: 00                                        ; export kind
+0000f8a: ee01                                      ; export func index
+0000f8c: 16                                        ; string length
+0000f8d: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0000f9d: 752e 7863 6867                           u.xchg  ; export name
+0000fa3: 00                                        ; export kind
+0000fa4: ef01                                      ; export func index
+0000fa6: 17                                        ; string length
+0000fa7: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0000fb7: 5f75 2e78 6368 67                        _u.xchg  ; export name
+0000fbe: 00                                        ; export kind
+0000fbf: f001                                      ; export func index
+0000fc1: 16                                        ; string length
+0000fc2: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0000fd2: 752e 7863 6867                           u.xchg  ; export name
+0000fd8: 00                                        ; export kind
+0000fd9: f101                                      ; export func index
+0000fdb: 17                                        ; string length
+0000fdc: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+0000fec: 5f75 2e78 6368 67                        _u.xchg  ; export name
+0000ff3: 00                                        ; export kind
+0000ff4: f201                                      ; export func index
+0000ff6: 17                                        ; string length
+0000ff7: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+0001007: 5f75 2e78 6368 67                        _u.xchg  ; export name
+000100e: 00                                        ; export kind
+000100f: f301                                      ; export func index
+0001011: 16                                        ; string length
+0001012: 6933 322e 6174 6f6d 6963 2e72 6d77 2e63  i32.atomic.rmw.c
+0001022: 6d70 7863 6867                           mpxchg  ; export name
+0001028: 00                                        ; export kind
+0001029: f401                                      ; export func index
+000102b: 16                                        ; string length
+000102c: 6936 342e 6174 6f6d 6963 2e72 6d77 2e63  i64.atomic.rmw.c
+000103c: 6d70 7863 6867                           mpxchg  ; export name
+0001042: 00                                        ; export kind
+0001043: f501                                      ; export func index
+0001045: 19                                        ; string length
+0001046: 6933 322e 6174 6f6d 6963 2e72 6d77 385f  i32.atomic.rmw8_
+0001056: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
+000105f: 00                                        ; export kind
+0001060: f601                                      ; export func index
+0001062: 1a                                        ; string length
+0001063: 6933 322e 6174 6f6d 6963 2e72 6d77 3136  i32.atomic.rmw16
+0001073: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
+000107d: 00                                        ; export kind
+000107e: f701                                      ; export func index
+0001080: 19                                        ; string length
+0001081: 6936 342e 6174 6f6d 6963 2e72 6d77 385f  i64.atomic.rmw8_
+0001091: 752e 636d 7078 6368 67                   u.cmpxchg  ; export name
+000109a: 00                                        ; export kind
+000109b: f801                                      ; export func index
+000109d: 1a                                        ; string length
+000109e: 6936 342e 6174 6f6d 6963 2e72 6d77 3136  i64.atomic.rmw16
+00010ae: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
+00010b8: 00                                        ; export kind
+00010b9: f901                                      ; export func index
+00010bb: 1a                                        ; string length
+00010bc: 6936 342e 6174 6f6d 6963 2e72 6d77 3332  i64.atomic.rmw32
+00010cc: 5f75 2e63 6d70 7863 6867                 _u.cmpxchg  ; export name
+00010d6: 00                                        ; export kind
+00010d7: fa01                                      ; export func index
+; move data: [138, 10d9) -> [139, 10da)
+0000137: a11f                                      ; FIXUP section size
 ; section "Elem" (9)
-00010c5: 09                                        ; section code
-00010c6: 00                                        ; section size (guess)
-00010c7: 01                                        ; num elem segments
+00010da: 09                                        ; section code
+00010db: 00                                        ; section size (guess)
+00010dc: 01                                        ; num elem segments
 ; elem segment header 0
-00010c8: 00                                        ; table index
-00010c9: 41                                        ; i32.const
-00010ca: 00                                        ; i32 literal
-00010cb: 0b                                        ; end
-00010cc: 02                                        ; num function indices
-00010cd: 01                                        ; function index
-00010ce: 01                                        ; function index
-00010c6: 08                                        ; FIXUP section size
+00010dd: 00                                        ; table index
+00010de: 41                                        ; i32.const
+00010df: 00                                        ; i32 literal
+00010e0: 0b                                        ; end
+00010e1: 02                                        ; num function indices
+00010e2: 01                                        ; function index
+00010e3: 01                                        ; function index
+00010db: 08                                        ; FIXUP section size
 ; section "Code" (10)
-00010cf: 0a                                        ; section code
-00010d0: 00                                        ; section size (guess)
-00010d1: fa01                                      ; num functions
+00010e4: 0a                                        ; section code
+00010e5: 00                                        ; section size (guess)
+00010e6: fa01                                      ; num functions
 ; function body 0
-00010d3: 00                                        ; func body size (guess)
-00010d4: 00                                        ; local decl count
-00010d5: 0b                                        ; end
-00010d3: 02                                        ; FIXUP func body size
-; function body 1
-00010d6: 00                                        ; func body size (guess)
-00010d7: 00                                        ; local decl count
-00010d8: 00                                        ; unreachable
-00010d9: 0b                                        ; end
-00010d6: 03                                        ; FIXUP func body size
-; function body 2
-00010da: 00                                        ; func body size (guess)
-00010db: 00                                        ; local decl count
-00010dc: 0c                                        ; br
-00010dd: 00                                        ; break depth
-00010de: 0b                                        ; end
-00010da: 04                                        ; FIXUP func body size
-; function body 3
-00010df: 00                                        ; func body size (guess)
-00010e0: 00                                        ; local decl count
-00010e1: 41                                        ; i32.const
-00010e2: 01                                        ; i32 literal
-00010e3: 0e                                        ; br_table
-00010e4: 00                                        ; num targets
-00010e5: 00                                        ; break depth for default
-00010e6: 0b                                        ; end
-00010df: 07                                        ; FIXUP func body size
-; function body 4
-00010e7: 00                                        ; func body size (guess)
-00010e8: 00                                        ; local decl count
-00010e9: 0f                                        ; return
+00010e8: 00                                        ; func body size (guess)
+00010e9: 00                                        ; local decl count
 00010ea: 0b                                        ; end
-00010e7: 03                                        ; FIXUP func body size
-; function body 5
+00010e8: 02                                        ; FIXUP func body size
+; function body 1
 00010eb: 00                                        ; func body size (guess)
 00010ec: 00                                        ; local decl count
-00010ed: 10                                        ; call
-00010ee: 01                                        ; function index
-00010ef: 0b                                        ; end
-00010eb: 04                                        ; FIXUP func body size
+00010ed: 00                                        ; unreachable
+00010ee: 0b                                        ; end
+00010eb: 03                                        ; FIXUP func body size
+; function body 2
+00010ef: 00                                        ; func body size (guess)
+00010f0: 00                                        ; local decl count
+00010f1: 0c                                        ; br
+00010f2: 00                                        ; break depth
+00010f3: 0b                                        ; end
+00010ef: 04                                        ; FIXUP func body size
+; function body 3
+00010f4: 00                                        ; func body size (guess)
+00010f5: 00                                        ; local decl count
+00010f6: 41                                        ; i32.const
+00010f7: 01                                        ; i32 literal
+00010f8: 0e                                        ; br_table
+00010f9: 00                                        ; num targets
+00010fa: 00                                        ; break depth for default
+00010fb: 0b                                        ; end
+00010f4: 07                                        ; FIXUP func body size
+; function body 4
+00010fc: 00                                        ; func body size (guess)
+00010fd: 00                                        ; local decl count
+00010fe: 0f                                        ; return
+00010ff: 0b                                        ; end
+00010fc: 03                                        ; FIXUP func body size
+; function body 5
+0001100: 00                                        ; func body size (guess)
+0001101: 00                                        ; local decl count
+0001102: 10                                        ; call
+0001103: 01                                        ; function index
+0001104: 0b                                        ; end
+0001100: 04                                        ; FIXUP func body size
 ; function body 6
-00010f0: 00                                        ; func body size (guess)
-00010f1: 00                                        ; local decl count
-00010f2: 41                                        ; i32.const
-00010f3: 01                                        ; i32 literal
-00010f4: 11                                        ; call_indirect
-00010f5: 00                                        ; signature index
-00010f6: 00                                        ; call_indirect reserved
-00010f7: 0b                                        ; end
-00010f0: 07                                        ; FIXUP func body size
+0001105: 00                                        ; func body size (guess)
+0001106: 00                                        ; local decl count
+0001107: 41                                        ; i32.const
+0001108: 01                                        ; i32 literal
+0001109: 11                                        ; call_indirect
+000110a: 00                                        ; signature index
+000110b: 00                                        ; call_indirect reserved
+000110c: 0b                                        ; end
+0001105: 07                                        ; FIXUP func body size
 ; function body 7
-00010f8: 00                                        ; func body size (guess)
-00010f9: 00                                        ; local decl count
-00010fa: 41                                        ; i32.const
-00010fb: 01                                        ; i32 literal
-00010fc: 1a                                        ; drop
-00010fd: 0b                                        ; end
-00010f8: 05                                        ; FIXUP func body size
+000110d: 00                                        ; func body size (guess)
+000110e: 00                                        ; local decl count
+000110f: 41                                        ; i32.const
+0001110: 01                                        ; i32 literal
+0001111: 1a                                        ; drop
+0001112: 0b                                        ; end
+000110d: 05                                        ; FIXUP func body size
 ; function body 8
-00010fe: 00                                        ; func body size (guess)
-00010ff: 00                                        ; local decl count
-0001100: 41                                        ; i32.const
-0001101: 01                                        ; i32 literal
-0001102: 41                                        ; i32.const
-0001103: 02                                        ; i32 literal
-0001104: 41                                        ; i32.const
-0001105: 03                                        ; i32 literal
-0001106: 1b                                        ; select
-0001107: 1a                                        ; drop
-0001108: 0b                                        ; end
-00010fe: 0a                                        ; FIXUP func body size
-; function body 9
-0001109: 00                                        ; func body size (guess)
-000110a: 01                                        ; local decl count
-000110b: 01                                        ; local type count
-000110c: 7f                                        ; i32
-000110d: 20                                        ; get_local
-000110e: 00                                        ; local index
-000110f: 1a                                        ; drop
-0001110: 0b                                        ; end
-0001109: 07                                        ; FIXUP func body size
-; function body 10
-0001111: 00                                        ; func body size (guess)
-0001112: 01                                        ; local decl count
-0001113: 01                                        ; local type count
-0001114: 7f                                        ; i32
+0001113: 00                                        ; func body size (guess)
+0001114: 00                                        ; local decl count
 0001115: 41                                        ; i32.const
 0001116: 01                                        ; i32 literal
-0001117: 21                                        ; set_local
-0001118: 00                                        ; local index
-0001119: 0b                                        ; end
-0001111: 08                                        ; FIXUP func body size
+0001117: 41                                        ; i32.const
+0001118: 02                                        ; i32 literal
+0001119: 41                                        ; i32.const
+000111a: 03                                        ; i32 literal
+000111b: 1b                                        ; select
+000111c: 1a                                        ; drop
+000111d: 0b                                        ; end
+0001113: 0a                                        ; FIXUP func body size
+; function body 9
+000111e: 00                                        ; func body size (guess)
+000111f: 01                                        ; local decl count
+0001120: 01                                        ; local type count
+0001121: 7f                                        ; i32
+0001122: 20                                        ; get_local
+0001123: 00                                        ; local index
+0001124: 1a                                        ; drop
+0001125: 0b                                        ; end
+000111e: 07                                        ; FIXUP func body size
+; function body 10
+0001126: 00                                        ; func body size (guess)
+0001127: 01                                        ; local decl count
+0001128: 01                                        ; local type count
+0001129: 7f                                        ; i32
+000112a: 41                                        ; i32.const
+000112b: 01                                        ; i32 literal
+000112c: 21                                        ; set_local
+000112d: 00                                        ; local index
+000112e: 0b                                        ; end
+0001126: 08                                        ; FIXUP func body size
 ; function body 11
-000111a: 00                                        ; func body size (guess)
-000111b: 01                                        ; local decl count
-000111c: 01                                        ; local type count
-000111d: 7f                                        ; i32
-000111e: 41                                        ; i32.const
-000111f: 01                                        ; i32 literal
-0001120: 22                                        ; tee_local
-0001121: 00                                        ; local index
-0001122: 1a                                        ; drop
-0001123: 0b                                        ; end
-000111a: 09                                        ; FIXUP func body size
-; function body 12
-0001124: 00                                        ; func body size (guess)
-0001125: 00                                        ; local decl count
-0001126: 23                                        ; get_global
-0001127: 00                                        ; global index
-0001128: 1a                                        ; drop
-0001129: 0b                                        ; end
-0001124: 05                                        ; FIXUP func body size
-; function body 13
-000112a: 00                                        ; func body size (guess)
-000112b: 00                                        ; local decl count
-000112c: 41                                        ; i32.const
-000112d: 01                                        ; i32 literal
-000112e: 24                                        ; set_global
-000112f: 00                                        ; global index
-0001130: 0b                                        ; end
-000112a: 06                                        ; FIXUP func body size
-; function body 14
-0001131: 00                                        ; func body size (guess)
-0001132: 00                                        ; local decl count
+000112f: 00                                        ; func body size (guess)
+0001130: 01                                        ; local decl count
+0001131: 01                                        ; local type count
+0001132: 7f                                        ; i32
 0001133: 41                                        ; i32.const
 0001134: 01                                        ; i32 literal
-0001135: 28                                        ; i32.load
-0001136: 02                                        ; alignment
-0001137: 02                                        ; load offset
-0001138: 1a                                        ; drop
-0001139: 0b                                        ; end
-0001131: 08                                        ; FIXUP func body size
+0001135: 22                                        ; tee_local
+0001136: 00                                        ; local index
+0001137: 1a                                        ; drop
+0001138: 0b                                        ; end
+000112f: 09                                        ; FIXUP func body size
+; function body 12
+0001139: 00                                        ; func body size (guess)
+000113a: 00                                        ; local decl count
+000113b: 23                                        ; get_global
+000113c: 00                                        ; global index
+000113d: 1a                                        ; drop
+000113e: 0b                                        ; end
+0001139: 05                                        ; FIXUP func body size
+; function body 13
+000113f: 00                                        ; func body size (guess)
+0001140: 00                                        ; local decl count
+0001141: 41                                        ; i32.const
+0001142: 01                                        ; i32 literal
+0001143: 24                                        ; set_global
+0001144: 00                                        ; global index
+0001145: 0b                                        ; end
+000113f: 06                                        ; FIXUP func body size
+; function body 14
+0001146: 00                                        ; func body size (guess)
+0001147: 00                                        ; local decl count
+0001148: 41                                        ; i32.const
+0001149: 01                                        ; i32 literal
+000114a: 28                                        ; i32.load
+000114b: 02                                        ; alignment
+000114c: 02                                        ; load offset
+000114d: 1a                                        ; drop
+000114e: 0b                                        ; end
+0001146: 08                                        ; FIXUP func body size
 ; function body 15
-000113a: 00                                        ; func body size (guess)
-000113b: 00                                        ; local decl count
-000113c: 41                                        ; i32.const
-000113d: 01                                        ; i32 literal
-000113e: 29                                        ; i64.load
-000113f: 03                                        ; alignment
-0001140: 02                                        ; load offset
-0001141: 1a                                        ; drop
-0001142: 0b                                        ; end
-000113a: 08                                        ; FIXUP func body size
+000114f: 00                                        ; func body size (guess)
+0001150: 00                                        ; local decl count
+0001151: 41                                        ; i32.const
+0001152: 01                                        ; i32 literal
+0001153: 29                                        ; i64.load
+0001154: 03                                        ; alignment
+0001155: 02                                        ; load offset
+0001156: 1a                                        ; drop
+0001157: 0b                                        ; end
+000114f: 08                                        ; FIXUP func body size
 ; function body 16
-0001143: 00                                        ; func body size (guess)
-0001144: 00                                        ; local decl count
-0001145: 41                                        ; i32.const
-0001146: 01                                        ; i32 literal
-0001147: 2a                                        ; f32.load
-0001148: 02                                        ; alignment
-0001149: 02                                        ; load offset
-000114a: 1a                                        ; drop
-000114b: 0b                                        ; end
-0001143: 08                                        ; FIXUP func body size
+0001158: 00                                        ; func body size (guess)
+0001159: 00                                        ; local decl count
+000115a: 41                                        ; i32.const
+000115b: 01                                        ; i32 literal
+000115c: 2a                                        ; f32.load
+000115d: 02                                        ; alignment
+000115e: 02                                        ; load offset
+000115f: 1a                                        ; drop
+0001160: 0b                                        ; end
+0001158: 08                                        ; FIXUP func body size
 ; function body 17
-000114c: 00                                        ; func body size (guess)
-000114d: 00                                        ; local decl count
-000114e: 41                                        ; i32.const
-000114f: 01                                        ; i32 literal
-0001150: 2b                                        ; f64.load
-0001151: 03                                        ; alignment
-0001152: 02                                        ; load offset
-0001153: 1a                                        ; drop
-0001154: 0b                                        ; end
-000114c: 08                                        ; FIXUP func body size
+0001161: 00                                        ; func body size (guess)
+0001162: 00                                        ; local decl count
+0001163: 41                                        ; i32.const
+0001164: 01                                        ; i32 literal
+0001165: 2b                                        ; f64.load
+0001166: 03                                        ; alignment
+0001167: 02                                        ; load offset
+0001168: 1a                                        ; drop
+0001169: 0b                                        ; end
+0001161: 08                                        ; FIXUP func body size
 ; function body 18
-0001155: 00                                        ; func body size (guess)
-0001156: 00                                        ; local decl count
-0001157: 41                                        ; i32.const
-0001158: 01                                        ; i32 literal
-0001159: 2c                                        ; i32.load8_s
-000115a: 00                                        ; alignment
-000115b: 02                                        ; load offset
-000115c: 1a                                        ; drop
-000115d: 0b                                        ; end
-0001155: 08                                        ; FIXUP func body size
+000116a: 00                                        ; func body size (guess)
+000116b: 00                                        ; local decl count
+000116c: 41                                        ; i32.const
+000116d: 01                                        ; i32 literal
+000116e: 2c                                        ; i32.load8_s
+000116f: 00                                        ; alignment
+0001170: 02                                        ; load offset
+0001171: 1a                                        ; drop
+0001172: 0b                                        ; end
+000116a: 08                                        ; FIXUP func body size
 ; function body 19
-000115e: 00                                        ; func body size (guess)
-000115f: 00                                        ; local decl count
-0001160: 41                                        ; i32.const
-0001161: 01                                        ; i32 literal
-0001162: 2d                                        ; i32.load8_u
-0001163: 00                                        ; alignment
-0001164: 02                                        ; load offset
-0001165: 1a                                        ; drop
-0001166: 0b                                        ; end
-000115e: 08                                        ; FIXUP func body size
+0001173: 00                                        ; func body size (guess)
+0001174: 00                                        ; local decl count
+0001175: 41                                        ; i32.const
+0001176: 01                                        ; i32 literal
+0001177: 2d                                        ; i32.load8_u
+0001178: 00                                        ; alignment
+0001179: 02                                        ; load offset
+000117a: 1a                                        ; drop
+000117b: 0b                                        ; end
+0001173: 08                                        ; FIXUP func body size
 ; function body 20
-0001167: 00                                        ; func body size (guess)
-0001168: 00                                        ; local decl count
-0001169: 41                                        ; i32.const
-000116a: 01                                        ; i32 literal
-000116b: 2e                                        ; i32.load16_s
-000116c: 01                                        ; alignment
-000116d: 02                                        ; load offset
-000116e: 1a                                        ; drop
-000116f: 0b                                        ; end
-0001167: 08                                        ; FIXUP func body size
+000117c: 00                                        ; func body size (guess)
+000117d: 00                                        ; local decl count
+000117e: 41                                        ; i32.const
+000117f: 01                                        ; i32 literal
+0001180: 2e                                        ; i32.load16_s
+0001181: 01                                        ; alignment
+0001182: 02                                        ; load offset
+0001183: 1a                                        ; drop
+0001184: 0b                                        ; end
+000117c: 08                                        ; FIXUP func body size
 ; function body 21
-0001170: 00                                        ; func body size (guess)
-0001171: 00                                        ; local decl count
-0001172: 41                                        ; i32.const
-0001173: 01                                        ; i32 literal
-0001174: 2f                                        ; i32.load16_u
-0001175: 01                                        ; alignment
-0001176: 02                                        ; load offset
-0001177: 1a                                        ; drop
-0001178: 0b                                        ; end
-0001170: 08                                        ; FIXUP func body size
+0001185: 00                                        ; func body size (guess)
+0001186: 00                                        ; local decl count
+0001187: 41                                        ; i32.const
+0001188: 01                                        ; i32 literal
+0001189: 2f                                        ; i32.load16_u
+000118a: 01                                        ; alignment
+000118b: 02                                        ; load offset
+000118c: 1a                                        ; drop
+000118d: 0b                                        ; end
+0001185: 08                                        ; FIXUP func body size
 ; function body 22
-0001179: 00                                        ; func body size (guess)
-000117a: 00                                        ; local decl count
-000117b: 41                                        ; i32.const
-000117c: 01                                        ; i32 literal
-000117d: 30                                        ; i64.load8_s
-000117e: 00                                        ; alignment
-000117f: 02                                        ; load offset
-0001180: 1a                                        ; drop
-0001181: 0b                                        ; end
-0001179: 08                                        ; FIXUP func body size
+000118e: 00                                        ; func body size (guess)
+000118f: 00                                        ; local decl count
+0001190: 41                                        ; i32.const
+0001191: 01                                        ; i32 literal
+0001192: 30                                        ; i64.load8_s
+0001193: 00                                        ; alignment
+0001194: 02                                        ; load offset
+0001195: 1a                                        ; drop
+0001196: 0b                                        ; end
+000118e: 08                                        ; FIXUP func body size
 ; function body 23
-0001182: 00                                        ; func body size (guess)
-0001183: 00                                        ; local decl count
-0001184: 41                                        ; i32.const
-0001185: 01                                        ; i32 literal
-0001186: 31                                        ; i64.load8_u
-0001187: 00                                        ; alignment
-0001188: 02                                        ; load offset
-0001189: 1a                                        ; drop
-000118a: 0b                                        ; end
-0001182: 08                                        ; FIXUP func body size
+0001197: 00                                        ; func body size (guess)
+0001198: 00                                        ; local decl count
+0001199: 41                                        ; i32.const
+000119a: 01                                        ; i32 literal
+000119b: 31                                        ; i64.load8_u
+000119c: 00                                        ; alignment
+000119d: 02                                        ; load offset
+000119e: 1a                                        ; drop
+000119f: 0b                                        ; end
+0001197: 08                                        ; FIXUP func body size
 ; function body 24
-000118b: 00                                        ; func body size (guess)
-000118c: 00                                        ; local decl count
-000118d: 41                                        ; i32.const
-000118e: 01                                        ; i32 literal
-000118f: 32                                        ; i64.load16_s
-0001190: 01                                        ; alignment
-0001191: 02                                        ; load offset
-0001192: 1a                                        ; drop
-0001193: 0b                                        ; end
-000118b: 08                                        ; FIXUP func body size
+00011a0: 00                                        ; func body size (guess)
+00011a1: 00                                        ; local decl count
+00011a2: 41                                        ; i32.const
+00011a3: 01                                        ; i32 literal
+00011a4: 32                                        ; i64.load16_s
+00011a5: 01                                        ; alignment
+00011a6: 02                                        ; load offset
+00011a7: 1a                                        ; drop
+00011a8: 0b                                        ; end
+00011a0: 08                                        ; FIXUP func body size
 ; function body 25
-0001194: 00                                        ; func body size (guess)
-0001195: 00                                        ; local decl count
-0001196: 41                                        ; i32.const
-0001197: 01                                        ; i32 literal
-0001198: 33                                        ; i64.load16_u
-0001199: 01                                        ; alignment
-000119a: 02                                        ; load offset
-000119b: 1a                                        ; drop
-000119c: 0b                                        ; end
-0001194: 08                                        ; FIXUP func body size
+00011a9: 00                                        ; func body size (guess)
+00011aa: 00                                        ; local decl count
+00011ab: 41                                        ; i32.const
+00011ac: 01                                        ; i32 literal
+00011ad: 33                                        ; i64.load16_u
+00011ae: 01                                        ; alignment
+00011af: 02                                        ; load offset
+00011b0: 1a                                        ; drop
+00011b1: 0b                                        ; end
+00011a9: 08                                        ; FIXUP func body size
 ; function body 26
-000119d: 00                                        ; func body size (guess)
-000119e: 00                                        ; local decl count
-000119f: 41                                        ; i32.const
-00011a0: 01                                        ; i32 literal
-00011a1: 34                                        ; i64.load32_s
-00011a2: 02                                        ; alignment
-00011a3: 02                                        ; load offset
-00011a4: 1a                                        ; drop
-00011a5: 0b                                        ; end
-000119d: 08                                        ; FIXUP func body size
+00011b2: 00                                        ; func body size (guess)
+00011b3: 00                                        ; local decl count
+00011b4: 41                                        ; i32.const
+00011b5: 01                                        ; i32 literal
+00011b6: 34                                        ; i64.load32_s
+00011b7: 02                                        ; alignment
+00011b8: 02                                        ; load offset
+00011b9: 1a                                        ; drop
+00011ba: 0b                                        ; end
+00011b2: 08                                        ; FIXUP func body size
 ; function body 27
-00011a6: 00                                        ; func body size (guess)
-00011a7: 00                                        ; local decl count
-00011a8: 41                                        ; i32.const
-00011a9: 01                                        ; i32 literal
-00011aa: 35                                        ; i64.load32_u
-00011ab: 02                                        ; alignment
-00011ac: 02                                        ; load offset
-00011ad: 1a                                        ; drop
-00011ae: 0b                                        ; end
-00011a6: 08                                        ; FIXUP func body size
+00011bb: 00                                        ; func body size (guess)
+00011bc: 00                                        ; local decl count
+00011bd: 41                                        ; i32.const
+00011be: 01                                        ; i32 literal
+00011bf: 35                                        ; i64.load32_u
+00011c0: 02                                        ; alignment
+00011c1: 02                                        ; load offset
+00011c2: 1a                                        ; drop
+00011c3: 0b                                        ; end
+00011bb: 08                                        ; FIXUP func body size
 ; function body 28
-00011af: 00                                        ; func body size (guess)
-00011b0: 00                                        ; local decl count
-00011b1: 41                                        ; i32.const
-00011b2: 01                                        ; i32 literal
-00011b3: 41                                        ; i32.const
-00011b4: 02                                        ; i32 literal
-00011b5: 36                                        ; i32.store
-00011b6: 02                                        ; alignment
-00011b7: 02                                        ; store offset
-00011b8: 0b                                        ; end
-00011af: 09                                        ; FIXUP func body size
+00011c4: 00                                        ; func body size (guess)
+00011c5: 00                                        ; local decl count
+00011c6: 41                                        ; i32.const
+00011c7: 01                                        ; i32 literal
+00011c8: 41                                        ; i32.const
+00011c9: 02                                        ; i32 literal
+00011ca: 36                                        ; i32.store
+00011cb: 02                                        ; alignment
+00011cc: 02                                        ; store offset
+00011cd: 0b                                        ; end
+00011c4: 09                                        ; FIXUP func body size
 ; function body 29
-00011b9: 00                                        ; func body size (guess)
-00011ba: 00                                        ; local decl count
-00011bb: 41                                        ; i32.const
-00011bc: 01                                        ; i32 literal
-00011bd: 42                                        ; i64.const
-00011be: 02                                        ; i64 literal
-00011bf: 37                                        ; i64.store
-00011c0: 03                                        ; alignment
-00011c1: 02                                        ; store offset
-00011c2: 0b                                        ; end
-00011b9: 09                                        ; FIXUP func body size
+00011ce: 00                                        ; func body size (guess)
+00011cf: 00                                        ; local decl count
+00011d0: 41                                        ; i32.const
+00011d1: 01                                        ; i32 literal
+00011d2: 42                                        ; i64.const
+00011d3: 02                                        ; i64 literal
+00011d4: 37                                        ; i64.store
+00011d5: 03                                        ; alignment
+00011d6: 02                                        ; store offset
+00011d7: 0b                                        ; end
+00011ce: 09                                        ; FIXUP func body size
 ; function body 30
-00011c3: 00                                        ; func body size (guess)
-00011c4: 00                                        ; local decl count
-00011c5: 41                                        ; i32.const
-00011c6: 01                                        ; i32 literal
-00011c7: 43                                        ; f32.const
-00011c8: 0000 0040                                 ; f32 literal
-00011cc: 38                                        ; f32.store
-00011cd: 02                                        ; alignment
-00011ce: 02                                        ; store offset
-00011cf: 0b                                        ; end
-00011c3: 0c                                        ; FIXUP func body size
+00011d8: 00                                        ; func body size (guess)
+00011d9: 00                                        ; local decl count
+00011da: 41                                        ; i32.const
+00011db: 01                                        ; i32 literal
+00011dc: 43                                        ; f32.const
+00011dd: 0000 0040                                 ; f32 literal
+00011e1: 38                                        ; f32.store
+00011e2: 02                                        ; alignment
+00011e3: 02                                        ; store offset
+00011e4: 0b                                        ; end
+00011d8: 0c                                        ; FIXUP func body size
 ; function body 31
-00011d0: 00                                        ; func body size (guess)
-00011d1: 00                                        ; local decl count
-00011d2: 41                                        ; i32.const
-00011d3: 01                                        ; i32 literal
-00011d4: 44                                        ; f64.const
-00011d5: 0000 0000 0000 0040                       ; f64 literal
-00011dd: 39                                        ; f64.store
-00011de: 03                                        ; alignment
-00011df: 02                                        ; store offset
-00011e0: 0b                                        ; end
-00011d0: 10                                        ; FIXUP func body size
+00011e5: 00                                        ; func body size (guess)
+00011e6: 00                                        ; local decl count
+00011e7: 41                                        ; i32.const
+00011e8: 01                                        ; i32 literal
+00011e9: 44                                        ; f64.const
+00011ea: 0000 0000 0000 0040                       ; f64 literal
+00011f2: 39                                        ; f64.store
+00011f3: 03                                        ; alignment
+00011f4: 02                                        ; store offset
+00011f5: 0b                                        ; end
+00011e5: 10                                        ; FIXUP func body size
 ; function body 32
-00011e1: 00                                        ; func body size (guess)
-00011e2: 00                                        ; local decl count
-00011e3: 41                                        ; i32.const
-00011e4: 01                                        ; i32 literal
-00011e5: 41                                        ; i32.const
-00011e6: 02                                        ; i32 literal
-00011e7: 3a                                        ; i32.store8
-00011e8: 00                                        ; alignment
-00011e9: 02                                        ; store offset
-00011ea: 0b                                        ; end
-00011e1: 09                                        ; FIXUP func body size
+00011f6: 00                                        ; func body size (guess)
+00011f7: 00                                        ; local decl count
+00011f8: 41                                        ; i32.const
+00011f9: 01                                        ; i32 literal
+00011fa: 41                                        ; i32.const
+00011fb: 02                                        ; i32 literal
+00011fc: 3a                                        ; i32.store8
+00011fd: 00                                        ; alignment
+00011fe: 02                                        ; store offset
+00011ff: 0b                                        ; end
+00011f6: 09                                        ; FIXUP func body size
 ; function body 33
-00011eb: 00                                        ; func body size (guess)
-00011ec: 00                                        ; local decl count
-00011ed: 41                                        ; i32.const
-00011ee: 01                                        ; i32 literal
-00011ef: 41                                        ; i32.const
-00011f0: 02                                        ; i32 literal
-00011f1: 3b                                        ; i32.store16
-00011f2: 01                                        ; alignment
-00011f3: 02                                        ; store offset
-00011f4: 0b                                        ; end
-00011eb: 09                                        ; FIXUP func body size
+0001200: 00                                        ; func body size (guess)
+0001201: 00                                        ; local decl count
+0001202: 41                                        ; i32.const
+0001203: 01                                        ; i32 literal
+0001204: 41                                        ; i32.const
+0001205: 02                                        ; i32 literal
+0001206: 3b                                        ; i32.store16
+0001207: 01                                        ; alignment
+0001208: 02                                        ; store offset
+0001209: 0b                                        ; end
+0001200: 09                                        ; FIXUP func body size
 ; function body 34
-00011f5: 00                                        ; func body size (guess)
-00011f6: 00                                        ; local decl count
-00011f7: 41                                        ; i32.const
-00011f8: 01                                        ; i32 literal
-00011f9: 42                                        ; i64.const
-00011fa: 02                                        ; i64 literal
-00011fb: 3c                                        ; i64.store8
-00011fc: 00                                        ; alignment
-00011fd: 02                                        ; store offset
-00011fe: 0b                                        ; end
-00011f5: 09                                        ; FIXUP func body size
+000120a: 00                                        ; func body size (guess)
+000120b: 00                                        ; local decl count
+000120c: 41                                        ; i32.const
+000120d: 01                                        ; i32 literal
+000120e: 42                                        ; i64.const
+000120f: 02                                        ; i64 literal
+0001210: 3c                                        ; i64.store8
+0001211: 00                                        ; alignment
+0001212: 02                                        ; store offset
+0001213: 0b                                        ; end
+000120a: 09                                        ; FIXUP func body size
 ; function body 35
-00011ff: 00                                        ; func body size (guess)
-0001200: 00                                        ; local decl count
-0001201: 41                                        ; i32.const
-0001202: 01                                        ; i32 literal
-0001203: 42                                        ; i64.const
-0001204: 02                                        ; i64 literal
-0001205: 3d                                        ; i64.store16
-0001206: 01                                        ; alignment
-0001207: 02                                        ; store offset
-0001208: 0b                                        ; end
-00011ff: 09                                        ; FIXUP func body size
+0001214: 00                                        ; func body size (guess)
+0001215: 00                                        ; local decl count
+0001216: 41                                        ; i32.const
+0001217: 01                                        ; i32 literal
+0001218: 42                                        ; i64.const
+0001219: 02                                        ; i64 literal
+000121a: 3d                                        ; i64.store16
+000121b: 01                                        ; alignment
+000121c: 02                                        ; store offset
+000121d: 0b                                        ; end
+0001214: 09                                        ; FIXUP func body size
 ; function body 36
-0001209: 00                                        ; func body size (guess)
-000120a: 00                                        ; local decl count
-000120b: 41                                        ; i32.const
-000120c: 01                                        ; i32 literal
-000120d: 42                                        ; i64.const
-000120e: 02                                        ; i64 literal
-000120f: 3e                                        ; i64.store32
-0001210: 02                                        ; alignment
-0001211: 02                                        ; store offset
-0001212: 0b                                        ; end
-0001209: 09                                        ; FIXUP func body size
+000121e: 00                                        ; func body size (guess)
+000121f: 00                                        ; local decl count
+0001220: 41                                        ; i32.const
+0001221: 01                                        ; i32 literal
+0001222: 42                                        ; i64.const
+0001223: 02                                        ; i64 literal
+0001224: 3e                                        ; i64.store32
+0001225: 02                                        ; alignment
+0001226: 02                                        ; store offset
+0001227: 0b                                        ; end
+000121e: 09                                        ; FIXUP func body size
 ; function body 37
-0001213: 00                                        ; func body size (guess)
-0001214: 00                                        ; local decl count
-0001215: 3f                                        ; current_memory
-0001216: 00                                        ; current_memory reserved
-0001217: 1a                                        ; drop
-0001218: 0b                                        ; end
-0001213: 05                                        ; FIXUP func body size
+0001228: 00                                        ; func body size (guess)
+0001229: 00                                        ; local decl count
+000122a: 3f                                        ; current_memory
+000122b: 00                                        ; current_memory reserved
+000122c: 1a                                        ; drop
+000122d: 0b                                        ; end
+0001228: 05                                        ; FIXUP func body size
 ; function body 38
-0001219: 00                                        ; func body size (guess)
-000121a: 00                                        ; local decl count
-000121b: 41                                        ; i32.const
-000121c: 01                                        ; i32 literal
-000121d: 40                                        ; grow_memory
-000121e: 00                                        ; grow_memory reserved
-000121f: 1a                                        ; drop
-0001220: 0b                                        ; end
-0001219: 07                                        ; FIXUP func body size
-; function body 39
-0001221: 00                                        ; func body size (guess)
-0001222: 00                                        ; local decl count
-0001223: 41                                        ; i32.const
-0001224: 01                                        ; i32 literal
-0001225: 1a                                        ; drop
-0001226: 0b                                        ; end
-0001221: 05                                        ; FIXUP func body size
-; function body 40
-0001227: 00                                        ; func body size (guess)
-0001228: 00                                        ; local decl count
-0001229: 42                                        ; i64.const
-000122a: 01                                        ; i64 literal
-000122b: 1a                                        ; drop
-000122c: 0b                                        ; end
-0001227: 05                                        ; FIXUP func body size
-; function body 41
-000122d: 00                                        ; func body size (guess)
-000122e: 00                                        ; local decl count
-000122f: 43                                        ; f32.const
-0001230: 0000 803f                                 ; f32 literal
+000122e: 00                                        ; func body size (guess)
+000122f: 00                                        ; local decl count
+0001230: 41                                        ; i32.const
+0001231: 01                                        ; i32 literal
+0001232: 40                                        ; grow_memory
+0001233: 00                                        ; grow_memory reserved
 0001234: 1a                                        ; drop
 0001235: 0b                                        ; end
-000122d: 08                                        ; FIXUP func body size
-; function body 42
+000122e: 07                                        ; FIXUP func body size
+; function body 39
 0001236: 00                                        ; func body size (guess)
 0001237: 00                                        ; local decl count
-0001238: 44                                        ; f64.const
-0001239: 0000 0000 0000 f03f                       ; f64 literal
-0001241: 1a                                        ; drop
-0001242: 0b                                        ; end
-0001236: 0c                                        ; FIXUP func body size
+0001238: 41                                        ; i32.const
+0001239: 01                                        ; i32 literal
+000123a: 1a                                        ; drop
+000123b: 0b                                        ; end
+0001236: 05                                        ; FIXUP func body size
+; function body 40
+000123c: 00                                        ; func body size (guess)
+000123d: 00                                        ; local decl count
+000123e: 42                                        ; i64.const
+000123f: 01                                        ; i64 literal
+0001240: 1a                                        ; drop
+0001241: 0b                                        ; end
+000123c: 05                                        ; FIXUP func body size
+; function body 41
+0001242: 00                                        ; func body size (guess)
+0001243: 00                                        ; local decl count
+0001244: 43                                        ; f32.const
+0001245: 0000 803f                                 ; f32 literal
+0001249: 1a                                        ; drop
+000124a: 0b                                        ; end
+0001242: 08                                        ; FIXUP func body size
+; function body 42
+000124b: 00                                        ; func body size (guess)
+000124c: 00                                        ; local decl count
+000124d: 44                                        ; f64.const
+000124e: 0000 0000 0000 f03f                       ; f64 literal
+0001256: 1a                                        ; drop
+0001257: 0b                                        ; end
+000124b: 0c                                        ; FIXUP func body size
 ; function body 43
-0001243: 00                                        ; func body size (guess)
-0001244: 00                                        ; local decl count
-0001245: 41                                        ; i32.const
-0001246: 01                                        ; i32 literal
-0001247: 45                                        ; i32.eqz
-0001248: 1a                                        ; drop
-0001249: 0b                                        ; end
-0001243: 06                                        ; FIXUP func body size
+0001258: 00                                        ; func body size (guess)
+0001259: 00                                        ; local decl count
+000125a: 41                                        ; i32.const
+000125b: 01                                        ; i32 literal
+000125c: 45                                        ; i32.eqz
+000125d: 1a                                        ; drop
+000125e: 0b                                        ; end
+0001258: 06                                        ; FIXUP func body size
 ; function body 44
-000124a: 00                                        ; func body size (guess)
-000124b: 00                                        ; local decl count
-000124c: 41                                        ; i32.const
-000124d: 01                                        ; i32 literal
-000124e: 41                                        ; i32.const
-000124f: 02                                        ; i32 literal
-0001250: 46                                        ; i32.eq
-0001251: 1a                                        ; drop
-0001252: 0b                                        ; end
-000124a: 08                                        ; FIXUP func body size
+000125f: 00                                        ; func body size (guess)
+0001260: 00                                        ; local decl count
+0001261: 41                                        ; i32.const
+0001262: 01                                        ; i32 literal
+0001263: 41                                        ; i32.const
+0001264: 02                                        ; i32 literal
+0001265: 46                                        ; i32.eq
+0001266: 1a                                        ; drop
+0001267: 0b                                        ; end
+000125f: 08                                        ; FIXUP func body size
 ; function body 45
-0001253: 00                                        ; func body size (guess)
-0001254: 00                                        ; local decl count
-0001255: 41                                        ; i32.const
-0001256: 01                                        ; i32 literal
-0001257: 41                                        ; i32.const
-0001258: 02                                        ; i32 literal
-0001259: 47                                        ; i32.ne
-000125a: 1a                                        ; drop
-000125b: 0b                                        ; end
-0001253: 08                                        ; FIXUP func body size
+0001268: 00                                        ; func body size (guess)
+0001269: 00                                        ; local decl count
+000126a: 41                                        ; i32.const
+000126b: 01                                        ; i32 literal
+000126c: 41                                        ; i32.const
+000126d: 02                                        ; i32 literal
+000126e: 47                                        ; i32.ne
+000126f: 1a                                        ; drop
+0001270: 0b                                        ; end
+0001268: 08                                        ; FIXUP func body size
 ; function body 46
-000125c: 00                                        ; func body size (guess)
-000125d: 00                                        ; local decl count
-000125e: 41                                        ; i32.const
-000125f: 01                                        ; i32 literal
-0001260: 41                                        ; i32.const
-0001261: 02                                        ; i32 literal
-0001262: 48                                        ; i32.lt_s
-0001263: 1a                                        ; drop
-0001264: 0b                                        ; end
-000125c: 08                                        ; FIXUP func body size
+0001271: 00                                        ; func body size (guess)
+0001272: 00                                        ; local decl count
+0001273: 41                                        ; i32.const
+0001274: 01                                        ; i32 literal
+0001275: 41                                        ; i32.const
+0001276: 02                                        ; i32 literal
+0001277: 48                                        ; i32.lt_s
+0001278: 1a                                        ; drop
+0001279: 0b                                        ; end
+0001271: 08                                        ; FIXUP func body size
 ; function body 47
-0001265: 00                                        ; func body size (guess)
-0001266: 00                                        ; local decl count
-0001267: 41                                        ; i32.const
-0001268: 01                                        ; i32 literal
-0001269: 41                                        ; i32.const
-000126a: 02                                        ; i32 literal
-000126b: 49                                        ; i32.lt_u
-000126c: 1a                                        ; drop
-000126d: 0b                                        ; end
-0001265: 08                                        ; FIXUP func body size
+000127a: 00                                        ; func body size (guess)
+000127b: 00                                        ; local decl count
+000127c: 41                                        ; i32.const
+000127d: 01                                        ; i32 literal
+000127e: 41                                        ; i32.const
+000127f: 02                                        ; i32 literal
+0001280: 49                                        ; i32.lt_u
+0001281: 1a                                        ; drop
+0001282: 0b                                        ; end
+000127a: 08                                        ; FIXUP func body size
 ; function body 48
-000126e: 00                                        ; func body size (guess)
-000126f: 00                                        ; local decl count
-0001270: 41                                        ; i32.const
-0001271: 01                                        ; i32 literal
-0001272: 41                                        ; i32.const
-0001273: 02                                        ; i32 literal
-0001274: 4a                                        ; i32.gt_s
-0001275: 1a                                        ; drop
-0001276: 0b                                        ; end
-000126e: 08                                        ; FIXUP func body size
+0001283: 00                                        ; func body size (guess)
+0001284: 00                                        ; local decl count
+0001285: 41                                        ; i32.const
+0001286: 01                                        ; i32 literal
+0001287: 41                                        ; i32.const
+0001288: 02                                        ; i32 literal
+0001289: 4a                                        ; i32.gt_s
+000128a: 1a                                        ; drop
+000128b: 0b                                        ; end
+0001283: 08                                        ; FIXUP func body size
 ; function body 49
-0001277: 00                                        ; func body size (guess)
-0001278: 00                                        ; local decl count
-0001279: 41                                        ; i32.const
-000127a: 01                                        ; i32 literal
-000127b: 41                                        ; i32.const
-000127c: 02                                        ; i32 literal
-000127d: 4b                                        ; i32.gt_u
-000127e: 1a                                        ; drop
-000127f: 0b                                        ; end
-0001277: 08                                        ; FIXUP func body size
+000128c: 00                                        ; func body size (guess)
+000128d: 00                                        ; local decl count
+000128e: 41                                        ; i32.const
+000128f: 01                                        ; i32 literal
+0001290: 41                                        ; i32.const
+0001291: 02                                        ; i32 literal
+0001292: 4b                                        ; i32.gt_u
+0001293: 1a                                        ; drop
+0001294: 0b                                        ; end
+000128c: 08                                        ; FIXUP func body size
 ; function body 50
-0001280: 00                                        ; func body size (guess)
-0001281: 00                                        ; local decl count
-0001282: 41                                        ; i32.const
-0001283: 01                                        ; i32 literal
-0001284: 41                                        ; i32.const
-0001285: 02                                        ; i32 literal
-0001286: 4c                                        ; i32.le_s
-0001287: 1a                                        ; drop
-0001288: 0b                                        ; end
-0001280: 08                                        ; FIXUP func body size
+0001295: 00                                        ; func body size (guess)
+0001296: 00                                        ; local decl count
+0001297: 41                                        ; i32.const
+0001298: 01                                        ; i32 literal
+0001299: 41                                        ; i32.const
+000129a: 02                                        ; i32 literal
+000129b: 4c                                        ; i32.le_s
+000129c: 1a                                        ; drop
+000129d: 0b                                        ; end
+0001295: 08                                        ; FIXUP func body size
 ; function body 51
-0001289: 00                                        ; func body size (guess)
-000128a: 00                                        ; local decl count
-000128b: 41                                        ; i32.const
-000128c: 01                                        ; i32 literal
-000128d: 41                                        ; i32.const
-000128e: 02                                        ; i32 literal
-000128f: 4d                                        ; i32.le_u
-0001290: 1a                                        ; drop
-0001291: 0b                                        ; end
-0001289: 08                                        ; FIXUP func body size
+000129e: 00                                        ; func body size (guess)
+000129f: 00                                        ; local decl count
+00012a0: 41                                        ; i32.const
+00012a1: 01                                        ; i32 literal
+00012a2: 41                                        ; i32.const
+00012a3: 02                                        ; i32 literal
+00012a4: 4d                                        ; i32.le_u
+00012a5: 1a                                        ; drop
+00012a6: 0b                                        ; end
+000129e: 08                                        ; FIXUP func body size
 ; function body 52
-0001292: 00                                        ; func body size (guess)
-0001293: 00                                        ; local decl count
-0001294: 41                                        ; i32.const
-0001295: 01                                        ; i32 literal
-0001296: 41                                        ; i32.const
-0001297: 02                                        ; i32 literal
-0001298: 4e                                        ; i32.ge_s
-0001299: 1a                                        ; drop
-000129a: 0b                                        ; end
-0001292: 08                                        ; FIXUP func body size
+00012a7: 00                                        ; func body size (guess)
+00012a8: 00                                        ; local decl count
+00012a9: 41                                        ; i32.const
+00012aa: 01                                        ; i32 literal
+00012ab: 41                                        ; i32.const
+00012ac: 02                                        ; i32 literal
+00012ad: 4e                                        ; i32.ge_s
+00012ae: 1a                                        ; drop
+00012af: 0b                                        ; end
+00012a7: 08                                        ; FIXUP func body size
 ; function body 53
-000129b: 00                                        ; func body size (guess)
-000129c: 00                                        ; local decl count
-000129d: 41                                        ; i32.const
-000129e: 01                                        ; i32 literal
-000129f: 41                                        ; i32.const
-00012a0: 02                                        ; i32 literal
-00012a1: 4f                                        ; i32.ge_u
-00012a2: 1a                                        ; drop
-00012a3: 0b                                        ; end
-000129b: 08                                        ; FIXUP func body size
+00012b0: 00                                        ; func body size (guess)
+00012b1: 00                                        ; local decl count
+00012b2: 41                                        ; i32.const
+00012b3: 01                                        ; i32 literal
+00012b4: 41                                        ; i32.const
+00012b5: 02                                        ; i32 literal
+00012b6: 4f                                        ; i32.ge_u
+00012b7: 1a                                        ; drop
+00012b8: 0b                                        ; end
+00012b0: 08                                        ; FIXUP func body size
 ; function body 54
-00012a4: 00                                        ; func body size (guess)
-00012a5: 00                                        ; local decl count
-00012a6: 42                                        ; i64.const
-00012a7: 01                                        ; i64 literal
-00012a8: 50                                        ; i64.eqz
-00012a9: 1a                                        ; drop
-00012aa: 0b                                        ; end
-00012a4: 06                                        ; FIXUP func body size
+00012b9: 00                                        ; func body size (guess)
+00012ba: 00                                        ; local decl count
+00012bb: 42                                        ; i64.const
+00012bc: 01                                        ; i64 literal
+00012bd: 50                                        ; i64.eqz
+00012be: 1a                                        ; drop
+00012bf: 0b                                        ; end
+00012b9: 06                                        ; FIXUP func body size
 ; function body 55
-00012ab: 00                                        ; func body size (guess)
-00012ac: 00                                        ; local decl count
-00012ad: 42                                        ; i64.const
-00012ae: 01                                        ; i64 literal
-00012af: 42                                        ; i64.const
-00012b0: 02                                        ; i64 literal
-00012b1: 51                                        ; i64.eq
-00012b2: 1a                                        ; drop
-00012b3: 0b                                        ; end
-00012ab: 08                                        ; FIXUP func body size
+00012c0: 00                                        ; func body size (guess)
+00012c1: 00                                        ; local decl count
+00012c2: 42                                        ; i64.const
+00012c3: 01                                        ; i64 literal
+00012c4: 42                                        ; i64.const
+00012c5: 02                                        ; i64 literal
+00012c6: 51                                        ; i64.eq
+00012c7: 1a                                        ; drop
+00012c8: 0b                                        ; end
+00012c0: 08                                        ; FIXUP func body size
 ; function body 56
-00012b4: 00                                        ; func body size (guess)
-00012b5: 00                                        ; local decl count
-00012b6: 42                                        ; i64.const
-00012b7: 01                                        ; i64 literal
-00012b8: 42                                        ; i64.const
-00012b9: 02                                        ; i64 literal
-00012ba: 52                                        ; i64.ne
-00012bb: 1a                                        ; drop
-00012bc: 0b                                        ; end
-00012b4: 08                                        ; FIXUP func body size
+00012c9: 00                                        ; func body size (guess)
+00012ca: 00                                        ; local decl count
+00012cb: 42                                        ; i64.const
+00012cc: 01                                        ; i64 literal
+00012cd: 42                                        ; i64.const
+00012ce: 02                                        ; i64 literal
+00012cf: 52                                        ; i64.ne
+00012d0: 1a                                        ; drop
+00012d1: 0b                                        ; end
+00012c9: 08                                        ; FIXUP func body size
 ; function body 57
-00012bd: 00                                        ; func body size (guess)
-00012be: 00                                        ; local decl count
-00012bf: 42                                        ; i64.const
-00012c0: 01                                        ; i64 literal
-00012c1: 42                                        ; i64.const
-00012c2: 02                                        ; i64 literal
-00012c3: 53                                        ; i64.lt_s
-00012c4: 1a                                        ; drop
-00012c5: 0b                                        ; end
-00012bd: 08                                        ; FIXUP func body size
+00012d2: 00                                        ; func body size (guess)
+00012d3: 00                                        ; local decl count
+00012d4: 42                                        ; i64.const
+00012d5: 01                                        ; i64 literal
+00012d6: 42                                        ; i64.const
+00012d7: 02                                        ; i64 literal
+00012d8: 53                                        ; i64.lt_s
+00012d9: 1a                                        ; drop
+00012da: 0b                                        ; end
+00012d2: 08                                        ; FIXUP func body size
 ; function body 58
-00012c6: 00                                        ; func body size (guess)
-00012c7: 00                                        ; local decl count
-00012c8: 42                                        ; i64.const
-00012c9: 01                                        ; i64 literal
-00012ca: 42                                        ; i64.const
-00012cb: 02                                        ; i64 literal
-00012cc: 54                                        ; i64.lt_u
-00012cd: 1a                                        ; drop
-00012ce: 0b                                        ; end
-00012c6: 08                                        ; FIXUP func body size
+00012db: 00                                        ; func body size (guess)
+00012dc: 00                                        ; local decl count
+00012dd: 42                                        ; i64.const
+00012de: 01                                        ; i64 literal
+00012df: 42                                        ; i64.const
+00012e0: 02                                        ; i64 literal
+00012e1: 54                                        ; i64.lt_u
+00012e2: 1a                                        ; drop
+00012e3: 0b                                        ; end
+00012db: 08                                        ; FIXUP func body size
 ; function body 59
-00012cf: 00                                        ; func body size (guess)
-00012d0: 00                                        ; local decl count
-00012d1: 42                                        ; i64.const
-00012d2: 01                                        ; i64 literal
-00012d3: 42                                        ; i64.const
-00012d4: 02                                        ; i64 literal
-00012d5: 55                                        ; i64.gt_s
-00012d6: 1a                                        ; drop
-00012d7: 0b                                        ; end
-00012cf: 08                                        ; FIXUP func body size
+00012e4: 00                                        ; func body size (guess)
+00012e5: 00                                        ; local decl count
+00012e6: 42                                        ; i64.const
+00012e7: 01                                        ; i64 literal
+00012e8: 42                                        ; i64.const
+00012e9: 02                                        ; i64 literal
+00012ea: 55                                        ; i64.gt_s
+00012eb: 1a                                        ; drop
+00012ec: 0b                                        ; end
+00012e4: 08                                        ; FIXUP func body size
 ; function body 60
-00012d8: 00                                        ; func body size (guess)
-00012d9: 00                                        ; local decl count
-00012da: 42                                        ; i64.const
-00012db: 01                                        ; i64 literal
-00012dc: 42                                        ; i64.const
-00012dd: 02                                        ; i64 literal
-00012de: 56                                        ; i64.gt_u
-00012df: 1a                                        ; drop
-00012e0: 0b                                        ; end
-00012d8: 08                                        ; FIXUP func body size
+00012ed: 00                                        ; func body size (guess)
+00012ee: 00                                        ; local decl count
+00012ef: 42                                        ; i64.const
+00012f0: 01                                        ; i64 literal
+00012f1: 42                                        ; i64.const
+00012f2: 02                                        ; i64 literal
+00012f3: 56                                        ; i64.gt_u
+00012f4: 1a                                        ; drop
+00012f5: 0b                                        ; end
+00012ed: 08                                        ; FIXUP func body size
 ; function body 61
-00012e1: 00                                        ; func body size (guess)
-00012e2: 00                                        ; local decl count
-00012e3: 42                                        ; i64.const
-00012e4: 01                                        ; i64 literal
-00012e5: 42                                        ; i64.const
-00012e6: 02                                        ; i64 literal
-00012e7: 57                                        ; i64.le_s
-00012e8: 1a                                        ; drop
-00012e9: 0b                                        ; end
-00012e1: 08                                        ; FIXUP func body size
+00012f6: 00                                        ; func body size (guess)
+00012f7: 00                                        ; local decl count
+00012f8: 42                                        ; i64.const
+00012f9: 01                                        ; i64 literal
+00012fa: 42                                        ; i64.const
+00012fb: 02                                        ; i64 literal
+00012fc: 57                                        ; i64.le_s
+00012fd: 1a                                        ; drop
+00012fe: 0b                                        ; end
+00012f6: 08                                        ; FIXUP func body size
 ; function body 62
-00012ea: 00                                        ; func body size (guess)
-00012eb: 00                                        ; local decl count
-00012ec: 42                                        ; i64.const
-00012ed: 01                                        ; i64 literal
-00012ee: 42                                        ; i64.const
-00012ef: 02                                        ; i64 literal
-00012f0: 58                                        ; i64.le_u
-00012f1: 1a                                        ; drop
-00012f2: 0b                                        ; end
-00012ea: 08                                        ; FIXUP func body size
+00012ff: 00                                        ; func body size (guess)
+0001300: 00                                        ; local decl count
+0001301: 42                                        ; i64.const
+0001302: 01                                        ; i64 literal
+0001303: 42                                        ; i64.const
+0001304: 02                                        ; i64 literal
+0001305: 58                                        ; i64.le_u
+0001306: 1a                                        ; drop
+0001307: 0b                                        ; end
+00012ff: 08                                        ; FIXUP func body size
 ; function body 63
-00012f3: 00                                        ; func body size (guess)
-00012f4: 00                                        ; local decl count
-00012f5: 42                                        ; i64.const
-00012f6: 01                                        ; i64 literal
-00012f7: 42                                        ; i64.const
-00012f8: 02                                        ; i64 literal
-00012f9: 59                                        ; i64.ge_s
-00012fa: 1a                                        ; drop
-00012fb: 0b                                        ; end
-00012f3: 08                                        ; FIXUP func body size
+0001308: 00                                        ; func body size (guess)
+0001309: 00                                        ; local decl count
+000130a: 42                                        ; i64.const
+000130b: 01                                        ; i64 literal
+000130c: 42                                        ; i64.const
+000130d: 02                                        ; i64 literal
+000130e: 59                                        ; i64.ge_s
+000130f: 1a                                        ; drop
+0001310: 0b                                        ; end
+0001308: 08                                        ; FIXUP func body size
 ; function body 64
-00012fc: 00                                        ; func body size (guess)
-00012fd: 00                                        ; local decl count
-00012fe: 42                                        ; i64.const
-00012ff: 01                                        ; i64 literal
-0001300: 42                                        ; i64.const
-0001301: 02                                        ; i64 literal
-0001302: 5a                                        ; i64.ge_u
-0001303: 1a                                        ; drop
-0001304: 0b                                        ; end
-00012fc: 08                                        ; FIXUP func body size
+0001311: 00                                        ; func body size (guess)
+0001312: 00                                        ; local decl count
+0001313: 42                                        ; i64.const
+0001314: 01                                        ; i64 literal
+0001315: 42                                        ; i64.const
+0001316: 02                                        ; i64 literal
+0001317: 5a                                        ; i64.ge_u
+0001318: 1a                                        ; drop
+0001319: 0b                                        ; end
+0001311: 08                                        ; FIXUP func body size
 ; function body 65
-0001305: 00                                        ; func body size (guess)
-0001306: 00                                        ; local decl count
-0001307: 43                                        ; f32.const
-0001308: 0000 803f                                 ; f32 literal
-000130c: 43                                        ; f32.const
-000130d: 0000 0040                                 ; f32 literal
-0001311: 5b                                        ; f32.eq
-0001312: 1a                                        ; drop
-0001313: 0b                                        ; end
-0001305: 0e                                        ; FIXUP func body size
+000131a: 00                                        ; func body size (guess)
+000131b: 00                                        ; local decl count
+000131c: 43                                        ; f32.const
+000131d: 0000 803f                                 ; f32 literal
+0001321: 43                                        ; f32.const
+0001322: 0000 0040                                 ; f32 literal
+0001326: 5b                                        ; f32.eq
+0001327: 1a                                        ; drop
+0001328: 0b                                        ; end
+000131a: 0e                                        ; FIXUP func body size
 ; function body 66
-0001314: 00                                        ; func body size (guess)
-0001315: 00                                        ; local decl count
-0001316: 43                                        ; f32.const
-0001317: 0000 803f                                 ; f32 literal
-000131b: 43                                        ; f32.const
-000131c: 0000 0040                                 ; f32 literal
-0001320: 5c                                        ; f32.ne
-0001321: 1a                                        ; drop
-0001322: 0b                                        ; end
-0001314: 0e                                        ; FIXUP func body size
+0001329: 00                                        ; func body size (guess)
+000132a: 00                                        ; local decl count
+000132b: 43                                        ; f32.const
+000132c: 0000 803f                                 ; f32 literal
+0001330: 43                                        ; f32.const
+0001331: 0000 0040                                 ; f32 literal
+0001335: 5c                                        ; f32.ne
+0001336: 1a                                        ; drop
+0001337: 0b                                        ; end
+0001329: 0e                                        ; FIXUP func body size
 ; function body 67
-0001323: 00                                        ; func body size (guess)
-0001324: 00                                        ; local decl count
-0001325: 43                                        ; f32.const
-0001326: 0000 803f                                 ; f32 literal
-000132a: 43                                        ; f32.const
-000132b: 0000 0040                                 ; f32 literal
-000132f: 5d                                        ; f32.lt
-0001330: 1a                                        ; drop
-0001331: 0b                                        ; end
-0001323: 0e                                        ; FIXUP func body size
+0001338: 00                                        ; func body size (guess)
+0001339: 00                                        ; local decl count
+000133a: 43                                        ; f32.const
+000133b: 0000 803f                                 ; f32 literal
+000133f: 43                                        ; f32.const
+0001340: 0000 0040                                 ; f32 literal
+0001344: 5d                                        ; f32.lt
+0001345: 1a                                        ; drop
+0001346: 0b                                        ; end
+0001338: 0e                                        ; FIXUP func body size
 ; function body 68
-0001332: 00                                        ; func body size (guess)
-0001333: 00                                        ; local decl count
-0001334: 43                                        ; f32.const
-0001335: 0000 803f                                 ; f32 literal
-0001339: 43                                        ; f32.const
-000133a: 0000 0040                                 ; f32 literal
-000133e: 5e                                        ; f32.gt
-000133f: 1a                                        ; drop
-0001340: 0b                                        ; end
-0001332: 0e                                        ; FIXUP func body size
+0001347: 00                                        ; func body size (guess)
+0001348: 00                                        ; local decl count
+0001349: 43                                        ; f32.const
+000134a: 0000 803f                                 ; f32 literal
+000134e: 43                                        ; f32.const
+000134f: 0000 0040                                 ; f32 literal
+0001353: 5e                                        ; f32.gt
+0001354: 1a                                        ; drop
+0001355: 0b                                        ; end
+0001347: 0e                                        ; FIXUP func body size
 ; function body 69
-0001341: 00                                        ; func body size (guess)
-0001342: 00                                        ; local decl count
-0001343: 43                                        ; f32.const
-0001344: 0000 803f                                 ; f32 literal
-0001348: 43                                        ; f32.const
-0001349: 0000 0040                                 ; f32 literal
-000134d: 5f                                        ; f32.le
-000134e: 1a                                        ; drop
-000134f: 0b                                        ; end
-0001341: 0e                                        ; FIXUP func body size
+0001356: 00                                        ; func body size (guess)
+0001357: 00                                        ; local decl count
+0001358: 43                                        ; f32.const
+0001359: 0000 803f                                 ; f32 literal
+000135d: 43                                        ; f32.const
+000135e: 0000 0040                                 ; f32 literal
+0001362: 5f                                        ; f32.le
+0001363: 1a                                        ; drop
+0001364: 0b                                        ; end
+0001356: 0e                                        ; FIXUP func body size
 ; function body 70
-0001350: 00                                        ; func body size (guess)
-0001351: 00                                        ; local decl count
-0001352: 43                                        ; f32.const
-0001353: 0000 803f                                 ; f32 literal
-0001357: 43                                        ; f32.const
-0001358: 0000 0040                                 ; f32 literal
-000135c: 60                                        ; f32.ge
-000135d: 1a                                        ; drop
-000135e: 0b                                        ; end
-0001350: 0e                                        ; FIXUP func body size
+0001365: 00                                        ; func body size (guess)
+0001366: 00                                        ; local decl count
+0001367: 43                                        ; f32.const
+0001368: 0000 803f                                 ; f32 literal
+000136c: 43                                        ; f32.const
+000136d: 0000 0040                                 ; f32 literal
+0001371: 60                                        ; f32.ge
+0001372: 1a                                        ; drop
+0001373: 0b                                        ; end
+0001365: 0e                                        ; FIXUP func body size
 ; function body 71
-000135f: 00                                        ; func body size (guess)
-0001360: 00                                        ; local decl count
-0001361: 44                                        ; f64.const
-0001362: 0000 0000 0000 f03f                       ; f64 literal
-000136a: 44                                        ; f64.const
-000136b: 0000 0000 0000 0040                       ; f64 literal
-0001373: 61                                        ; f64.eq
-0001374: 1a                                        ; drop
-0001375: 0b                                        ; end
-000135f: 16                                        ; FIXUP func body size
+0001374: 00                                        ; func body size (guess)
+0001375: 00                                        ; local decl count
+0001376: 44                                        ; f64.const
+0001377: 0000 0000 0000 f03f                       ; f64 literal
+000137f: 44                                        ; f64.const
+0001380: 0000 0000 0000 0040                       ; f64 literal
+0001388: 61                                        ; f64.eq
+0001389: 1a                                        ; drop
+000138a: 0b                                        ; end
+0001374: 16                                        ; FIXUP func body size
 ; function body 72
-0001376: 00                                        ; func body size (guess)
-0001377: 00                                        ; local decl count
-0001378: 44                                        ; f64.const
-0001379: 0000 0000 0000 f03f                       ; f64 literal
-0001381: 44                                        ; f64.const
-0001382: 0000 0000 0000 0040                       ; f64 literal
-000138a: 62                                        ; f64.ne
-000138b: 1a                                        ; drop
-000138c: 0b                                        ; end
-0001376: 16                                        ; FIXUP func body size
+000138b: 00                                        ; func body size (guess)
+000138c: 00                                        ; local decl count
+000138d: 44                                        ; f64.const
+000138e: 0000 0000 0000 f03f                       ; f64 literal
+0001396: 44                                        ; f64.const
+0001397: 0000 0000 0000 0040                       ; f64 literal
+000139f: 62                                        ; f64.ne
+00013a0: 1a                                        ; drop
+00013a1: 0b                                        ; end
+000138b: 16                                        ; FIXUP func body size
 ; function body 73
-000138d: 00                                        ; func body size (guess)
-000138e: 00                                        ; local decl count
-000138f: 44                                        ; f64.const
-0001390: 0000 0000 0000 f03f                       ; f64 literal
-0001398: 44                                        ; f64.const
-0001399: 0000 0000 0000 0040                       ; f64 literal
-00013a1: 63                                        ; f64.lt
-00013a2: 1a                                        ; drop
-00013a3: 0b                                        ; end
-000138d: 16                                        ; FIXUP func body size
+00013a2: 00                                        ; func body size (guess)
+00013a3: 00                                        ; local decl count
+00013a4: 44                                        ; f64.const
+00013a5: 0000 0000 0000 f03f                       ; f64 literal
+00013ad: 44                                        ; f64.const
+00013ae: 0000 0000 0000 0040                       ; f64 literal
+00013b6: 63                                        ; f64.lt
+00013b7: 1a                                        ; drop
+00013b8: 0b                                        ; end
+00013a2: 16                                        ; FIXUP func body size
 ; function body 74
-00013a4: 00                                        ; func body size (guess)
-00013a5: 00                                        ; local decl count
-00013a6: 44                                        ; f64.const
-00013a7: 0000 0000 0000 f03f                       ; f64 literal
-00013af: 44                                        ; f64.const
-00013b0: 0000 0000 0000 0040                       ; f64 literal
-00013b8: 64                                        ; f64.gt
-00013b9: 1a                                        ; drop
-00013ba: 0b                                        ; end
-00013a4: 16                                        ; FIXUP func body size
+00013b9: 00                                        ; func body size (guess)
+00013ba: 00                                        ; local decl count
+00013bb: 44                                        ; f64.const
+00013bc: 0000 0000 0000 f03f                       ; f64 literal
+00013c4: 44                                        ; f64.const
+00013c5: 0000 0000 0000 0040                       ; f64 literal
+00013cd: 64                                        ; f64.gt
+00013ce: 1a                                        ; drop
+00013cf: 0b                                        ; end
+00013b9: 16                                        ; FIXUP func body size
 ; function body 75
-00013bb: 00                                        ; func body size (guess)
-00013bc: 00                                        ; local decl count
-00013bd: 44                                        ; f64.const
-00013be: 0000 0000 0000 f03f                       ; f64 literal
-00013c6: 44                                        ; f64.const
-00013c7: 0000 0000 0000 0040                       ; f64 literal
-00013cf: 65                                        ; f64.le
-00013d0: 1a                                        ; drop
-00013d1: 0b                                        ; end
-00013bb: 16                                        ; FIXUP func body size
+00013d0: 00                                        ; func body size (guess)
+00013d1: 00                                        ; local decl count
+00013d2: 44                                        ; f64.const
+00013d3: 0000 0000 0000 f03f                       ; f64 literal
+00013db: 44                                        ; f64.const
+00013dc: 0000 0000 0000 0040                       ; f64 literal
+00013e4: 65                                        ; f64.le
+00013e5: 1a                                        ; drop
+00013e6: 0b                                        ; end
+00013d0: 16                                        ; FIXUP func body size
 ; function body 76
-00013d2: 00                                        ; func body size (guess)
-00013d3: 00                                        ; local decl count
-00013d4: 44                                        ; f64.const
-00013d5: 0000 0000 0000 f03f                       ; f64 literal
-00013dd: 44                                        ; f64.const
-00013de: 0000 0000 0000 0040                       ; f64 literal
-00013e6: 66                                        ; f64.ge
-00013e7: 1a                                        ; drop
-00013e8: 0b                                        ; end
-00013d2: 16                                        ; FIXUP func body size
-; function body 77
-00013e9: 00                                        ; func body size (guess)
-00013ea: 00                                        ; local decl count
-00013eb: 41                                        ; i32.const
-00013ec: 01                                        ; i32 literal
-00013ed: 67                                        ; i32.clz
-00013ee: 1a                                        ; drop
-00013ef: 0b                                        ; end
-00013e9: 06                                        ; FIXUP func body size
-; function body 78
-00013f0: 00                                        ; func body size (guess)
-00013f1: 00                                        ; local decl count
-00013f2: 41                                        ; i32.const
-00013f3: 01                                        ; i32 literal
-00013f4: 68                                        ; i32.ctz
-00013f5: 1a                                        ; drop
-00013f6: 0b                                        ; end
-00013f0: 06                                        ; FIXUP func body size
-; function body 79
-00013f7: 00                                        ; func body size (guess)
-00013f8: 00                                        ; local decl count
-00013f9: 41                                        ; i32.const
-00013fa: 01                                        ; i32 literal
-00013fb: 69                                        ; i32.popcnt
+00013e7: 00                                        ; func body size (guess)
+00013e8: 00                                        ; local decl count
+00013e9: 44                                        ; f64.const
+00013ea: 0000 0000 0000 f03f                       ; f64 literal
+00013f2: 44                                        ; f64.const
+00013f3: 0000 0000 0000 0040                       ; f64 literal
+00013fb: 66                                        ; f64.ge
 00013fc: 1a                                        ; drop
 00013fd: 0b                                        ; end
-00013f7: 06                                        ; FIXUP func body size
-; function body 80
+00013e7: 16                                        ; FIXUP func body size
+; function body 77
 00013fe: 00                                        ; func body size (guess)
 00013ff: 00                                        ; local decl count
 0001400: 41                                        ; i32.const
 0001401: 01                                        ; i32 literal
-0001402: 41                                        ; i32.const
-0001403: 02                                        ; i32 literal
-0001404: 6a                                        ; i32.add
-0001405: 1a                                        ; drop
-0001406: 0b                                        ; end
-00013fe: 08                                        ; FIXUP func body size
+0001402: 67                                        ; i32.clz
+0001403: 1a                                        ; drop
+0001404: 0b                                        ; end
+00013fe: 06                                        ; FIXUP func body size
+; function body 78
+0001405: 00                                        ; func body size (guess)
+0001406: 00                                        ; local decl count
+0001407: 41                                        ; i32.const
+0001408: 01                                        ; i32 literal
+0001409: 68                                        ; i32.ctz
+000140a: 1a                                        ; drop
+000140b: 0b                                        ; end
+0001405: 06                                        ; FIXUP func body size
+; function body 79
+000140c: 00                                        ; func body size (guess)
+000140d: 00                                        ; local decl count
+000140e: 41                                        ; i32.const
+000140f: 01                                        ; i32 literal
+0001410: 69                                        ; i32.popcnt
+0001411: 1a                                        ; drop
+0001412: 0b                                        ; end
+000140c: 06                                        ; FIXUP func body size
+; function body 80
+0001413: 00                                        ; func body size (guess)
+0001414: 00                                        ; local decl count
+0001415: 41                                        ; i32.const
+0001416: 01                                        ; i32 literal
+0001417: 41                                        ; i32.const
+0001418: 02                                        ; i32 literal
+0001419: 6a                                        ; i32.add
+000141a: 1a                                        ; drop
+000141b: 0b                                        ; end
+0001413: 08                                        ; FIXUP func body size
 ; function body 81
-0001407: 00                                        ; func body size (guess)
-0001408: 00                                        ; local decl count
-0001409: 41                                        ; i32.const
-000140a: 01                                        ; i32 literal
-000140b: 41                                        ; i32.const
-000140c: 02                                        ; i32 literal
-000140d: 6b                                        ; i32.sub
-000140e: 1a                                        ; drop
-000140f: 0b                                        ; end
-0001407: 08                                        ; FIXUP func body size
+000141c: 00                                        ; func body size (guess)
+000141d: 00                                        ; local decl count
+000141e: 41                                        ; i32.const
+000141f: 01                                        ; i32 literal
+0001420: 41                                        ; i32.const
+0001421: 02                                        ; i32 literal
+0001422: 6b                                        ; i32.sub
+0001423: 1a                                        ; drop
+0001424: 0b                                        ; end
+000141c: 08                                        ; FIXUP func body size
 ; function body 82
-0001410: 00                                        ; func body size (guess)
-0001411: 00                                        ; local decl count
-0001412: 41                                        ; i32.const
-0001413: 01                                        ; i32 literal
-0001414: 41                                        ; i32.const
-0001415: 02                                        ; i32 literal
-0001416: 6c                                        ; i32.mul
-0001417: 1a                                        ; drop
-0001418: 0b                                        ; end
-0001410: 08                                        ; FIXUP func body size
+0001425: 00                                        ; func body size (guess)
+0001426: 00                                        ; local decl count
+0001427: 41                                        ; i32.const
+0001428: 01                                        ; i32 literal
+0001429: 41                                        ; i32.const
+000142a: 02                                        ; i32 literal
+000142b: 6c                                        ; i32.mul
+000142c: 1a                                        ; drop
+000142d: 0b                                        ; end
+0001425: 08                                        ; FIXUP func body size
 ; function body 83
-0001419: 00                                        ; func body size (guess)
-000141a: 00                                        ; local decl count
-000141b: 41                                        ; i32.const
-000141c: 01                                        ; i32 literal
-000141d: 41                                        ; i32.const
-000141e: 02                                        ; i32 literal
-000141f: 6d                                        ; i32.div_s
-0001420: 1a                                        ; drop
-0001421: 0b                                        ; end
-0001419: 08                                        ; FIXUP func body size
+000142e: 00                                        ; func body size (guess)
+000142f: 00                                        ; local decl count
+0001430: 41                                        ; i32.const
+0001431: 01                                        ; i32 literal
+0001432: 41                                        ; i32.const
+0001433: 02                                        ; i32 literal
+0001434: 6d                                        ; i32.div_s
+0001435: 1a                                        ; drop
+0001436: 0b                                        ; end
+000142e: 08                                        ; FIXUP func body size
 ; function body 84
-0001422: 00                                        ; func body size (guess)
-0001423: 00                                        ; local decl count
-0001424: 41                                        ; i32.const
-0001425: 01                                        ; i32 literal
-0001426: 41                                        ; i32.const
-0001427: 02                                        ; i32 literal
-0001428: 6e                                        ; i32.div_u
-0001429: 1a                                        ; drop
-000142a: 0b                                        ; end
-0001422: 08                                        ; FIXUP func body size
+0001437: 00                                        ; func body size (guess)
+0001438: 00                                        ; local decl count
+0001439: 41                                        ; i32.const
+000143a: 01                                        ; i32 literal
+000143b: 41                                        ; i32.const
+000143c: 02                                        ; i32 literal
+000143d: 6e                                        ; i32.div_u
+000143e: 1a                                        ; drop
+000143f: 0b                                        ; end
+0001437: 08                                        ; FIXUP func body size
 ; function body 85
-000142b: 00                                        ; func body size (guess)
-000142c: 00                                        ; local decl count
-000142d: 41                                        ; i32.const
-000142e: 01                                        ; i32 literal
-000142f: 41                                        ; i32.const
-0001430: 02                                        ; i32 literal
-0001431: 6f                                        ; i32.rem_s
-0001432: 1a                                        ; drop
-0001433: 0b                                        ; end
-000142b: 08                                        ; FIXUP func body size
+0001440: 00                                        ; func body size (guess)
+0001441: 00                                        ; local decl count
+0001442: 41                                        ; i32.const
+0001443: 01                                        ; i32 literal
+0001444: 41                                        ; i32.const
+0001445: 02                                        ; i32 literal
+0001446: 6f                                        ; i32.rem_s
+0001447: 1a                                        ; drop
+0001448: 0b                                        ; end
+0001440: 08                                        ; FIXUP func body size
 ; function body 86
-0001434: 00                                        ; func body size (guess)
-0001435: 00                                        ; local decl count
-0001436: 41                                        ; i32.const
-0001437: 01                                        ; i32 literal
-0001438: 41                                        ; i32.const
-0001439: 02                                        ; i32 literal
-000143a: 70                                        ; i32.rem_u
-000143b: 1a                                        ; drop
-000143c: 0b                                        ; end
-0001434: 08                                        ; FIXUP func body size
+0001449: 00                                        ; func body size (guess)
+000144a: 00                                        ; local decl count
+000144b: 41                                        ; i32.const
+000144c: 01                                        ; i32 literal
+000144d: 41                                        ; i32.const
+000144e: 02                                        ; i32 literal
+000144f: 70                                        ; i32.rem_u
+0001450: 1a                                        ; drop
+0001451: 0b                                        ; end
+0001449: 08                                        ; FIXUP func body size
 ; function body 87
-000143d: 00                                        ; func body size (guess)
-000143e: 00                                        ; local decl count
-000143f: 41                                        ; i32.const
-0001440: 01                                        ; i32 literal
-0001441: 41                                        ; i32.const
-0001442: 02                                        ; i32 literal
-0001443: 71                                        ; i32.and
-0001444: 1a                                        ; drop
-0001445: 0b                                        ; end
-000143d: 08                                        ; FIXUP func body size
+0001452: 00                                        ; func body size (guess)
+0001453: 00                                        ; local decl count
+0001454: 41                                        ; i32.const
+0001455: 01                                        ; i32 literal
+0001456: 41                                        ; i32.const
+0001457: 02                                        ; i32 literal
+0001458: 71                                        ; i32.and
+0001459: 1a                                        ; drop
+000145a: 0b                                        ; end
+0001452: 08                                        ; FIXUP func body size
 ; function body 88
-0001446: 00                                        ; func body size (guess)
-0001447: 00                                        ; local decl count
-0001448: 41                                        ; i32.const
-0001449: 01                                        ; i32 literal
-000144a: 41                                        ; i32.const
-000144b: 02                                        ; i32 literal
-000144c: 72                                        ; i32.or
-000144d: 1a                                        ; drop
-000144e: 0b                                        ; end
-0001446: 08                                        ; FIXUP func body size
+000145b: 00                                        ; func body size (guess)
+000145c: 00                                        ; local decl count
+000145d: 41                                        ; i32.const
+000145e: 01                                        ; i32 literal
+000145f: 41                                        ; i32.const
+0001460: 02                                        ; i32 literal
+0001461: 72                                        ; i32.or
+0001462: 1a                                        ; drop
+0001463: 0b                                        ; end
+000145b: 08                                        ; FIXUP func body size
 ; function body 89
-000144f: 00                                        ; func body size (guess)
-0001450: 00                                        ; local decl count
-0001451: 41                                        ; i32.const
-0001452: 01                                        ; i32 literal
-0001453: 41                                        ; i32.const
-0001454: 02                                        ; i32 literal
-0001455: 73                                        ; i32.xor
-0001456: 1a                                        ; drop
-0001457: 0b                                        ; end
-000144f: 08                                        ; FIXUP func body size
+0001464: 00                                        ; func body size (guess)
+0001465: 00                                        ; local decl count
+0001466: 41                                        ; i32.const
+0001467: 01                                        ; i32 literal
+0001468: 41                                        ; i32.const
+0001469: 02                                        ; i32 literal
+000146a: 73                                        ; i32.xor
+000146b: 1a                                        ; drop
+000146c: 0b                                        ; end
+0001464: 08                                        ; FIXUP func body size
 ; function body 90
-0001458: 00                                        ; func body size (guess)
-0001459: 00                                        ; local decl count
-000145a: 41                                        ; i32.const
-000145b: 01                                        ; i32 literal
-000145c: 41                                        ; i32.const
-000145d: 02                                        ; i32 literal
-000145e: 74                                        ; i32.shl
-000145f: 1a                                        ; drop
-0001460: 0b                                        ; end
-0001458: 08                                        ; FIXUP func body size
+000146d: 00                                        ; func body size (guess)
+000146e: 00                                        ; local decl count
+000146f: 41                                        ; i32.const
+0001470: 01                                        ; i32 literal
+0001471: 41                                        ; i32.const
+0001472: 02                                        ; i32 literal
+0001473: 74                                        ; i32.shl
+0001474: 1a                                        ; drop
+0001475: 0b                                        ; end
+000146d: 08                                        ; FIXUP func body size
 ; function body 91
-0001461: 00                                        ; func body size (guess)
-0001462: 00                                        ; local decl count
-0001463: 41                                        ; i32.const
-0001464: 01                                        ; i32 literal
-0001465: 41                                        ; i32.const
-0001466: 02                                        ; i32 literal
-0001467: 75                                        ; i32.shr_s
-0001468: 1a                                        ; drop
-0001469: 0b                                        ; end
-0001461: 08                                        ; FIXUP func body size
+0001476: 00                                        ; func body size (guess)
+0001477: 00                                        ; local decl count
+0001478: 41                                        ; i32.const
+0001479: 01                                        ; i32 literal
+000147a: 41                                        ; i32.const
+000147b: 02                                        ; i32 literal
+000147c: 75                                        ; i32.shr_s
+000147d: 1a                                        ; drop
+000147e: 0b                                        ; end
+0001476: 08                                        ; FIXUP func body size
 ; function body 92
-000146a: 00                                        ; func body size (guess)
-000146b: 00                                        ; local decl count
-000146c: 41                                        ; i32.const
-000146d: 01                                        ; i32 literal
-000146e: 41                                        ; i32.const
-000146f: 02                                        ; i32 literal
-0001470: 76                                        ; i32.shr_u
-0001471: 1a                                        ; drop
-0001472: 0b                                        ; end
-000146a: 08                                        ; FIXUP func body size
+000147f: 00                                        ; func body size (guess)
+0001480: 00                                        ; local decl count
+0001481: 41                                        ; i32.const
+0001482: 01                                        ; i32 literal
+0001483: 41                                        ; i32.const
+0001484: 02                                        ; i32 literal
+0001485: 76                                        ; i32.shr_u
+0001486: 1a                                        ; drop
+0001487: 0b                                        ; end
+000147f: 08                                        ; FIXUP func body size
 ; function body 93
-0001473: 00                                        ; func body size (guess)
-0001474: 00                                        ; local decl count
-0001475: 41                                        ; i32.const
-0001476: 01                                        ; i32 literal
-0001477: 41                                        ; i32.const
-0001478: 02                                        ; i32 literal
-0001479: 77                                        ; i32.rotl
-000147a: 1a                                        ; drop
-000147b: 0b                                        ; end
-0001473: 08                                        ; FIXUP func body size
+0001488: 00                                        ; func body size (guess)
+0001489: 00                                        ; local decl count
+000148a: 41                                        ; i32.const
+000148b: 01                                        ; i32 literal
+000148c: 41                                        ; i32.const
+000148d: 02                                        ; i32 literal
+000148e: 77                                        ; i32.rotl
+000148f: 1a                                        ; drop
+0001490: 0b                                        ; end
+0001488: 08                                        ; FIXUP func body size
 ; function body 94
-000147c: 00                                        ; func body size (guess)
-000147d: 00                                        ; local decl count
-000147e: 41                                        ; i32.const
-000147f: 01                                        ; i32 literal
-0001480: 41                                        ; i32.const
-0001481: 02                                        ; i32 literal
-0001482: 78                                        ; i32.rotr
-0001483: 1a                                        ; drop
-0001484: 0b                                        ; end
-000147c: 08                                        ; FIXUP func body size
-; function body 95
-0001485: 00                                        ; func body size (guess)
-0001486: 00                                        ; local decl count
-0001487: 42                                        ; i64.const
-0001488: 01                                        ; i64 literal
-0001489: 79                                        ; i64.clz
-000148a: 1a                                        ; drop
-000148b: 0b                                        ; end
-0001485: 06                                        ; FIXUP func body size
-; function body 96
-000148c: 00                                        ; func body size (guess)
-000148d: 00                                        ; local decl count
-000148e: 42                                        ; i64.const
-000148f: 01                                        ; i64 literal
-0001490: 7a                                        ; i64.ctz
-0001491: 1a                                        ; drop
-0001492: 0b                                        ; end
-000148c: 06                                        ; FIXUP func body size
-; function body 97
-0001493: 00                                        ; func body size (guess)
-0001494: 00                                        ; local decl count
-0001495: 42                                        ; i64.const
-0001496: 01                                        ; i64 literal
-0001497: 7b                                        ; i64.popcnt
+0001491: 00                                        ; func body size (guess)
+0001492: 00                                        ; local decl count
+0001493: 41                                        ; i32.const
+0001494: 01                                        ; i32 literal
+0001495: 41                                        ; i32.const
+0001496: 02                                        ; i32 literal
+0001497: 78                                        ; i32.rotr
 0001498: 1a                                        ; drop
 0001499: 0b                                        ; end
-0001493: 06                                        ; FIXUP func body size
-; function body 98
+0001491: 08                                        ; FIXUP func body size
+; function body 95
 000149a: 00                                        ; func body size (guess)
 000149b: 00                                        ; local decl count
 000149c: 42                                        ; i64.const
 000149d: 01                                        ; i64 literal
-000149e: 42                                        ; i64.const
-000149f: 02                                        ; i64 literal
-00014a0: 7c                                        ; i64.add
-00014a1: 1a                                        ; drop
-00014a2: 0b                                        ; end
-000149a: 08                                        ; FIXUP func body size
+000149e: 79                                        ; i64.clz
+000149f: 1a                                        ; drop
+00014a0: 0b                                        ; end
+000149a: 06                                        ; FIXUP func body size
+; function body 96
+00014a1: 00                                        ; func body size (guess)
+00014a2: 00                                        ; local decl count
+00014a3: 42                                        ; i64.const
+00014a4: 01                                        ; i64 literal
+00014a5: 7a                                        ; i64.ctz
+00014a6: 1a                                        ; drop
+00014a7: 0b                                        ; end
+00014a1: 06                                        ; FIXUP func body size
+; function body 97
+00014a8: 00                                        ; func body size (guess)
+00014a9: 00                                        ; local decl count
+00014aa: 42                                        ; i64.const
+00014ab: 01                                        ; i64 literal
+00014ac: 7b                                        ; i64.popcnt
+00014ad: 1a                                        ; drop
+00014ae: 0b                                        ; end
+00014a8: 06                                        ; FIXUP func body size
+; function body 98
+00014af: 00                                        ; func body size (guess)
+00014b0: 00                                        ; local decl count
+00014b1: 42                                        ; i64.const
+00014b2: 01                                        ; i64 literal
+00014b3: 42                                        ; i64.const
+00014b4: 02                                        ; i64 literal
+00014b5: 7c                                        ; i64.add
+00014b6: 1a                                        ; drop
+00014b7: 0b                                        ; end
+00014af: 08                                        ; FIXUP func body size
 ; function body 99
-00014a3: 00                                        ; func body size (guess)
-00014a4: 00                                        ; local decl count
-00014a5: 42                                        ; i64.const
-00014a6: 01                                        ; i64 literal
-00014a7: 42                                        ; i64.const
-00014a8: 02                                        ; i64 literal
-00014a9: 7d                                        ; i64.sub
-00014aa: 1a                                        ; drop
-00014ab: 0b                                        ; end
-00014a3: 08                                        ; FIXUP func body size
+00014b8: 00                                        ; func body size (guess)
+00014b9: 00                                        ; local decl count
+00014ba: 42                                        ; i64.const
+00014bb: 01                                        ; i64 literal
+00014bc: 42                                        ; i64.const
+00014bd: 02                                        ; i64 literal
+00014be: 7d                                        ; i64.sub
+00014bf: 1a                                        ; drop
+00014c0: 0b                                        ; end
+00014b8: 08                                        ; FIXUP func body size
 ; function body 100
-00014ac: 00                                        ; func body size (guess)
-00014ad: 00                                        ; local decl count
-00014ae: 42                                        ; i64.const
-00014af: 01                                        ; i64 literal
-00014b0: 42                                        ; i64.const
-00014b1: 02                                        ; i64 literal
-00014b2: 7e                                        ; i64.mul
-00014b3: 1a                                        ; drop
-00014b4: 0b                                        ; end
-00014ac: 08                                        ; FIXUP func body size
+00014c1: 00                                        ; func body size (guess)
+00014c2: 00                                        ; local decl count
+00014c3: 42                                        ; i64.const
+00014c4: 01                                        ; i64 literal
+00014c5: 42                                        ; i64.const
+00014c6: 02                                        ; i64 literal
+00014c7: 7e                                        ; i64.mul
+00014c8: 1a                                        ; drop
+00014c9: 0b                                        ; end
+00014c1: 08                                        ; FIXUP func body size
 ; function body 101
-00014b5: 00                                        ; func body size (guess)
-00014b6: 00                                        ; local decl count
-00014b7: 42                                        ; i64.const
-00014b8: 01                                        ; i64 literal
-00014b9: 42                                        ; i64.const
-00014ba: 02                                        ; i64 literal
-00014bb: 7f                                        ; i64.div_s
-00014bc: 1a                                        ; drop
-00014bd: 0b                                        ; end
-00014b5: 08                                        ; FIXUP func body size
+00014ca: 00                                        ; func body size (guess)
+00014cb: 00                                        ; local decl count
+00014cc: 42                                        ; i64.const
+00014cd: 01                                        ; i64 literal
+00014ce: 42                                        ; i64.const
+00014cf: 02                                        ; i64 literal
+00014d0: 7f                                        ; i64.div_s
+00014d1: 1a                                        ; drop
+00014d2: 0b                                        ; end
+00014ca: 08                                        ; FIXUP func body size
 ; function body 102
-00014be: 00                                        ; func body size (guess)
-00014bf: 00                                        ; local decl count
-00014c0: 42                                        ; i64.const
-00014c1: 01                                        ; i64 literal
-00014c2: 42                                        ; i64.const
-00014c3: 02                                        ; i64 literal
-00014c4: 80                                        ; i64.div_u
-00014c5: 1a                                        ; drop
-00014c6: 0b                                        ; end
-00014be: 08                                        ; FIXUP func body size
+00014d3: 00                                        ; func body size (guess)
+00014d4: 00                                        ; local decl count
+00014d5: 42                                        ; i64.const
+00014d6: 01                                        ; i64 literal
+00014d7: 42                                        ; i64.const
+00014d8: 02                                        ; i64 literal
+00014d9: 80                                        ; i64.div_u
+00014da: 1a                                        ; drop
+00014db: 0b                                        ; end
+00014d3: 08                                        ; FIXUP func body size
 ; function body 103
-00014c7: 00                                        ; func body size (guess)
-00014c8: 00                                        ; local decl count
-00014c9: 42                                        ; i64.const
-00014ca: 01                                        ; i64 literal
-00014cb: 42                                        ; i64.const
-00014cc: 02                                        ; i64 literal
-00014cd: 81                                        ; i64.rem_s
-00014ce: 1a                                        ; drop
-00014cf: 0b                                        ; end
-00014c7: 08                                        ; FIXUP func body size
+00014dc: 00                                        ; func body size (guess)
+00014dd: 00                                        ; local decl count
+00014de: 42                                        ; i64.const
+00014df: 01                                        ; i64 literal
+00014e0: 42                                        ; i64.const
+00014e1: 02                                        ; i64 literal
+00014e2: 81                                        ; i64.rem_s
+00014e3: 1a                                        ; drop
+00014e4: 0b                                        ; end
+00014dc: 08                                        ; FIXUP func body size
 ; function body 104
-00014d0: 00                                        ; func body size (guess)
-00014d1: 00                                        ; local decl count
-00014d2: 42                                        ; i64.const
-00014d3: 01                                        ; i64 literal
-00014d4: 42                                        ; i64.const
-00014d5: 02                                        ; i64 literal
-00014d6: 82                                        ; i64.rem_u
-00014d7: 1a                                        ; drop
-00014d8: 0b                                        ; end
-00014d0: 08                                        ; FIXUP func body size
+00014e5: 00                                        ; func body size (guess)
+00014e6: 00                                        ; local decl count
+00014e7: 42                                        ; i64.const
+00014e8: 01                                        ; i64 literal
+00014e9: 42                                        ; i64.const
+00014ea: 02                                        ; i64 literal
+00014eb: 82                                        ; i64.rem_u
+00014ec: 1a                                        ; drop
+00014ed: 0b                                        ; end
+00014e5: 08                                        ; FIXUP func body size
 ; function body 105
-00014d9: 00                                        ; func body size (guess)
-00014da: 00                                        ; local decl count
-00014db: 42                                        ; i64.const
-00014dc: 01                                        ; i64 literal
-00014dd: 42                                        ; i64.const
-00014de: 02                                        ; i64 literal
-00014df: 83                                        ; i64.and
-00014e0: 1a                                        ; drop
-00014e1: 0b                                        ; end
-00014d9: 08                                        ; FIXUP func body size
+00014ee: 00                                        ; func body size (guess)
+00014ef: 00                                        ; local decl count
+00014f0: 42                                        ; i64.const
+00014f1: 01                                        ; i64 literal
+00014f2: 42                                        ; i64.const
+00014f3: 02                                        ; i64 literal
+00014f4: 83                                        ; i64.and
+00014f5: 1a                                        ; drop
+00014f6: 0b                                        ; end
+00014ee: 08                                        ; FIXUP func body size
 ; function body 106
-00014e2: 00                                        ; func body size (guess)
-00014e3: 00                                        ; local decl count
-00014e4: 42                                        ; i64.const
-00014e5: 01                                        ; i64 literal
-00014e6: 42                                        ; i64.const
-00014e7: 02                                        ; i64 literal
-00014e8: 84                                        ; i64.or
-00014e9: 1a                                        ; drop
-00014ea: 0b                                        ; end
-00014e2: 08                                        ; FIXUP func body size
+00014f7: 00                                        ; func body size (guess)
+00014f8: 00                                        ; local decl count
+00014f9: 42                                        ; i64.const
+00014fa: 01                                        ; i64 literal
+00014fb: 42                                        ; i64.const
+00014fc: 02                                        ; i64 literal
+00014fd: 84                                        ; i64.or
+00014fe: 1a                                        ; drop
+00014ff: 0b                                        ; end
+00014f7: 08                                        ; FIXUP func body size
 ; function body 107
-00014eb: 00                                        ; func body size (guess)
-00014ec: 00                                        ; local decl count
-00014ed: 42                                        ; i64.const
-00014ee: 01                                        ; i64 literal
-00014ef: 42                                        ; i64.const
-00014f0: 02                                        ; i64 literal
-00014f1: 85                                        ; i64.xor
-00014f2: 1a                                        ; drop
-00014f3: 0b                                        ; end
-00014eb: 08                                        ; FIXUP func body size
+0001500: 00                                        ; func body size (guess)
+0001501: 00                                        ; local decl count
+0001502: 42                                        ; i64.const
+0001503: 01                                        ; i64 literal
+0001504: 42                                        ; i64.const
+0001505: 02                                        ; i64 literal
+0001506: 85                                        ; i64.xor
+0001507: 1a                                        ; drop
+0001508: 0b                                        ; end
+0001500: 08                                        ; FIXUP func body size
 ; function body 108
-00014f4: 00                                        ; func body size (guess)
-00014f5: 00                                        ; local decl count
-00014f6: 42                                        ; i64.const
-00014f7: 01                                        ; i64 literal
-00014f8: 42                                        ; i64.const
-00014f9: 02                                        ; i64 literal
-00014fa: 86                                        ; i64.shl
-00014fb: 1a                                        ; drop
-00014fc: 0b                                        ; end
-00014f4: 08                                        ; FIXUP func body size
+0001509: 00                                        ; func body size (guess)
+000150a: 00                                        ; local decl count
+000150b: 42                                        ; i64.const
+000150c: 01                                        ; i64 literal
+000150d: 42                                        ; i64.const
+000150e: 02                                        ; i64 literal
+000150f: 86                                        ; i64.shl
+0001510: 1a                                        ; drop
+0001511: 0b                                        ; end
+0001509: 08                                        ; FIXUP func body size
 ; function body 109
-00014fd: 00                                        ; func body size (guess)
-00014fe: 00                                        ; local decl count
-00014ff: 42                                        ; i64.const
-0001500: 01                                        ; i64 literal
-0001501: 42                                        ; i64.const
-0001502: 02                                        ; i64 literal
-0001503: 87                                        ; i64.shr_s
-0001504: 1a                                        ; drop
-0001505: 0b                                        ; end
-00014fd: 08                                        ; FIXUP func body size
+0001512: 00                                        ; func body size (guess)
+0001513: 00                                        ; local decl count
+0001514: 42                                        ; i64.const
+0001515: 01                                        ; i64 literal
+0001516: 42                                        ; i64.const
+0001517: 02                                        ; i64 literal
+0001518: 87                                        ; i64.shr_s
+0001519: 1a                                        ; drop
+000151a: 0b                                        ; end
+0001512: 08                                        ; FIXUP func body size
 ; function body 110
-0001506: 00                                        ; func body size (guess)
-0001507: 00                                        ; local decl count
-0001508: 42                                        ; i64.const
-0001509: 01                                        ; i64 literal
-000150a: 42                                        ; i64.const
-000150b: 02                                        ; i64 literal
-000150c: 88                                        ; i64.shr_u
-000150d: 1a                                        ; drop
-000150e: 0b                                        ; end
-0001506: 08                                        ; FIXUP func body size
+000151b: 00                                        ; func body size (guess)
+000151c: 00                                        ; local decl count
+000151d: 42                                        ; i64.const
+000151e: 01                                        ; i64 literal
+000151f: 42                                        ; i64.const
+0001520: 02                                        ; i64 literal
+0001521: 88                                        ; i64.shr_u
+0001522: 1a                                        ; drop
+0001523: 0b                                        ; end
+000151b: 08                                        ; FIXUP func body size
 ; function body 111
-000150f: 00                                        ; func body size (guess)
-0001510: 00                                        ; local decl count
-0001511: 42                                        ; i64.const
-0001512: 01                                        ; i64 literal
-0001513: 42                                        ; i64.const
-0001514: 02                                        ; i64 literal
-0001515: 89                                        ; i64.rotl
-0001516: 1a                                        ; drop
-0001517: 0b                                        ; end
-000150f: 08                                        ; FIXUP func body size
+0001524: 00                                        ; func body size (guess)
+0001525: 00                                        ; local decl count
+0001526: 42                                        ; i64.const
+0001527: 01                                        ; i64 literal
+0001528: 42                                        ; i64.const
+0001529: 02                                        ; i64 literal
+000152a: 89                                        ; i64.rotl
+000152b: 1a                                        ; drop
+000152c: 0b                                        ; end
+0001524: 08                                        ; FIXUP func body size
 ; function body 112
-0001518: 00                                        ; func body size (guess)
-0001519: 00                                        ; local decl count
-000151a: 42                                        ; i64.const
-000151b: 01                                        ; i64 literal
-000151c: 42                                        ; i64.const
-000151d: 02                                        ; i64 literal
-000151e: 8a                                        ; i64.rotr
-000151f: 1a                                        ; drop
-0001520: 0b                                        ; end
-0001518: 08                                        ; FIXUP func body size
+000152d: 00                                        ; func body size (guess)
+000152e: 00                                        ; local decl count
+000152f: 42                                        ; i64.const
+0001530: 01                                        ; i64 literal
+0001531: 42                                        ; i64.const
+0001532: 02                                        ; i64 literal
+0001533: 8a                                        ; i64.rotr
+0001534: 1a                                        ; drop
+0001535: 0b                                        ; end
+000152d: 08                                        ; FIXUP func body size
 ; function body 113
-0001521: 00                                        ; func body size (guess)
-0001522: 00                                        ; local decl count
-0001523: 43                                        ; f32.const
-0001524: 0000 803f                                 ; f32 literal
-0001528: 8b                                        ; f32.abs
-0001529: 1a                                        ; drop
-000152a: 0b                                        ; end
-0001521: 09                                        ; FIXUP func body size
+0001536: 00                                        ; func body size (guess)
+0001537: 00                                        ; local decl count
+0001538: 43                                        ; f32.const
+0001539: 0000 803f                                 ; f32 literal
+000153d: 8b                                        ; f32.abs
+000153e: 1a                                        ; drop
+000153f: 0b                                        ; end
+0001536: 09                                        ; FIXUP func body size
 ; function body 114
-000152b: 00                                        ; func body size (guess)
-000152c: 00                                        ; local decl count
-000152d: 43                                        ; f32.const
-000152e: 0000 803f                                 ; f32 literal
-0001532: 8c                                        ; f32.neg
-0001533: 1a                                        ; drop
-0001534: 0b                                        ; end
-000152b: 09                                        ; FIXUP func body size
+0001540: 00                                        ; func body size (guess)
+0001541: 00                                        ; local decl count
+0001542: 43                                        ; f32.const
+0001543: 0000 803f                                 ; f32 literal
+0001547: 8c                                        ; f32.neg
+0001548: 1a                                        ; drop
+0001549: 0b                                        ; end
+0001540: 09                                        ; FIXUP func body size
 ; function body 115
-0001535: 00                                        ; func body size (guess)
-0001536: 00                                        ; local decl count
-0001537: 43                                        ; f32.const
-0001538: 0000 803f                                 ; f32 literal
-000153c: 8d                                        ; f32.ceil
-000153d: 1a                                        ; drop
-000153e: 0b                                        ; end
-0001535: 09                                        ; FIXUP func body size
+000154a: 00                                        ; func body size (guess)
+000154b: 00                                        ; local decl count
+000154c: 43                                        ; f32.const
+000154d: 0000 803f                                 ; f32 literal
+0001551: 8d                                        ; f32.ceil
+0001552: 1a                                        ; drop
+0001553: 0b                                        ; end
+000154a: 09                                        ; FIXUP func body size
 ; function body 116
-000153f: 00                                        ; func body size (guess)
-0001540: 00                                        ; local decl count
-0001541: 43                                        ; f32.const
-0001542: 0000 803f                                 ; f32 literal
-0001546: 8e                                        ; f32.floor
-0001547: 1a                                        ; drop
-0001548: 0b                                        ; end
-000153f: 09                                        ; FIXUP func body size
+0001554: 00                                        ; func body size (guess)
+0001555: 00                                        ; local decl count
+0001556: 43                                        ; f32.const
+0001557: 0000 803f                                 ; f32 literal
+000155b: 8e                                        ; f32.floor
+000155c: 1a                                        ; drop
+000155d: 0b                                        ; end
+0001554: 09                                        ; FIXUP func body size
 ; function body 117
-0001549: 00                                        ; func body size (guess)
-000154a: 00                                        ; local decl count
-000154b: 43                                        ; f32.const
-000154c: 0000 803f                                 ; f32 literal
-0001550: 8f                                        ; f32.trunc
-0001551: 1a                                        ; drop
-0001552: 0b                                        ; end
-0001549: 09                                        ; FIXUP func body size
+000155e: 00                                        ; func body size (guess)
+000155f: 00                                        ; local decl count
+0001560: 43                                        ; f32.const
+0001561: 0000 803f                                 ; f32 literal
+0001565: 8f                                        ; f32.trunc
+0001566: 1a                                        ; drop
+0001567: 0b                                        ; end
+000155e: 09                                        ; FIXUP func body size
 ; function body 118
-0001553: 00                                        ; func body size (guess)
-0001554: 00                                        ; local decl count
-0001555: 43                                        ; f32.const
-0001556: 0000 803f                                 ; f32 literal
-000155a: 90                                        ; f32.nearest
-000155b: 1a                                        ; drop
-000155c: 0b                                        ; end
-0001553: 09                                        ; FIXUP func body size
+0001568: 00                                        ; func body size (guess)
+0001569: 00                                        ; local decl count
+000156a: 43                                        ; f32.const
+000156b: 0000 803f                                 ; f32 literal
+000156f: 90                                        ; f32.nearest
+0001570: 1a                                        ; drop
+0001571: 0b                                        ; end
+0001568: 09                                        ; FIXUP func body size
 ; function body 119
-000155d: 00                                        ; func body size (guess)
-000155e: 00                                        ; local decl count
-000155f: 43                                        ; f32.const
-0001560: 0000 803f                                 ; f32 literal
-0001564: 91                                        ; f32.sqrt
-0001565: 1a                                        ; drop
-0001566: 0b                                        ; end
-000155d: 09                                        ; FIXUP func body size
+0001572: 00                                        ; func body size (guess)
+0001573: 00                                        ; local decl count
+0001574: 43                                        ; f32.const
+0001575: 0000 803f                                 ; f32 literal
+0001579: 91                                        ; f32.sqrt
+000157a: 1a                                        ; drop
+000157b: 0b                                        ; end
+0001572: 09                                        ; FIXUP func body size
 ; function body 120
-0001567: 00                                        ; func body size (guess)
-0001568: 00                                        ; local decl count
-0001569: 43                                        ; f32.const
-000156a: 0000 803f                                 ; f32 literal
-000156e: 43                                        ; f32.const
-000156f: 0000 0040                                 ; f32 literal
-0001573: 92                                        ; f32.add
-0001574: 1a                                        ; drop
-0001575: 0b                                        ; end
-0001567: 0e                                        ; FIXUP func body size
+000157c: 00                                        ; func body size (guess)
+000157d: 00                                        ; local decl count
+000157e: 43                                        ; f32.const
+000157f: 0000 803f                                 ; f32 literal
+0001583: 43                                        ; f32.const
+0001584: 0000 0040                                 ; f32 literal
+0001588: 92                                        ; f32.add
+0001589: 1a                                        ; drop
+000158a: 0b                                        ; end
+000157c: 0e                                        ; FIXUP func body size
 ; function body 121
-0001576: 00                                        ; func body size (guess)
-0001577: 00                                        ; local decl count
-0001578: 43                                        ; f32.const
-0001579: 0000 803f                                 ; f32 literal
-000157d: 43                                        ; f32.const
-000157e: 0000 0040                                 ; f32 literal
-0001582: 93                                        ; f32.sub
-0001583: 1a                                        ; drop
-0001584: 0b                                        ; end
-0001576: 0e                                        ; FIXUP func body size
+000158b: 00                                        ; func body size (guess)
+000158c: 00                                        ; local decl count
+000158d: 43                                        ; f32.const
+000158e: 0000 803f                                 ; f32 literal
+0001592: 43                                        ; f32.const
+0001593: 0000 0040                                 ; f32 literal
+0001597: 93                                        ; f32.sub
+0001598: 1a                                        ; drop
+0001599: 0b                                        ; end
+000158b: 0e                                        ; FIXUP func body size
 ; function body 122
-0001585: 00                                        ; func body size (guess)
-0001586: 00                                        ; local decl count
-0001587: 43                                        ; f32.const
-0001588: 0000 803f                                 ; f32 literal
-000158c: 43                                        ; f32.const
-000158d: 0000 0040                                 ; f32 literal
-0001591: 94                                        ; f32.mul
-0001592: 1a                                        ; drop
-0001593: 0b                                        ; end
-0001585: 0e                                        ; FIXUP func body size
+000159a: 00                                        ; func body size (guess)
+000159b: 00                                        ; local decl count
+000159c: 43                                        ; f32.const
+000159d: 0000 803f                                 ; f32 literal
+00015a1: 43                                        ; f32.const
+00015a2: 0000 0040                                 ; f32 literal
+00015a6: 94                                        ; f32.mul
+00015a7: 1a                                        ; drop
+00015a8: 0b                                        ; end
+000159a: 0e                                        ; FIXUP func body size
 ; function body 123
-0001594: 00                                        ; func body size (guess)
-0001595: 00                                        ; local decl count
-0001596: 43                                        ; f32.const
-0001597: 0000 803f                                 ; f32 literal
-000159b: 43                                        ; f32.const
-000159c: 0000 0040                                 ; f32 literal
-00015a0: 95                                        ; f32.div
-00015a1: 1a                                        ; drop
-00015a2: 0b                                        ; end
-0001594: 0e                                        ; FIXUP func body size
+00015a9: 00                                        ; func body size (guess)
+00015aa: 00                                        ; local decl count
+00015ab: 43                                        ; f32.const
+00015ac: 0000 803f                                 ; f32 literal
+00015b0: 43                                        ; f32.const
+00015b1: 0000 0040                                 ; f32 literal
+00015b5: 95                                        ; f32.div
+00015b6: 1a                                        ; drop
+00015b7: 0b                                        ; end
+00015a9: 0e                                        ; FIXUP func body size
 ; function body 124
-00015a3: 00                                        ; func body size (guess)
-00015a4: 00                                        ; local decl count
-00015a5: 43                                        ; f32.const
-00015a6: 0000 803f                                 ; f32 literal
-00015aa: 43                                        ; f32.const
-00015ab: 0000 0040                                 ; f32 literal
-00015af: 96                                        ; f32.min
-00015b0: 1a                                        ; drop
-00015b1: 0b                                        ; end
-00015a3: 0e                                        ; FIXUP func body size
+00015b8: 00                                        ; func body size (guess)
+00015b9: 00                                        ; local decl count
+00015ba: 43                                        ; f32.const
+00015bb: 0000 803f                                 ; f32 literal
+00015bf: 43                                        ; f32.const
+00015c0: 0000 0040                                 ; f32 literal
+00015c4: 96                                        ; f32.min
+00015c5: 1a                                        ; drop
+00015c6: 0b                                        ; end
+00015b8: 0e                                        ; FIXUP func body size
 ; function body 125
-00015b2: 00                                        ; func body size (guess)
-00015b3: 00                                        ; local decl count
-00015b4: 43                                        ; f32.const
-00015b5: 0000 803f                                 ; f32 literal
-00015b9: 43                                        ; f32.const
-00015ba: 0000 0040                                 ; f32 literal
-00015be: 97                                        ; f32.max
-00015bf: 1a                                        ; drop
-00015c0: 0b                                        ; end
-00015b2: 0e                                        ; FIXUP func body size
+00015c7: 00                                        ; func body size (guess)
+00015c8: 00                                        ; local decl count
+00015c9: 43                                        ; f32.const
+00015ca: 0000 803f                                 ; f32 literal
+00015ce: 43                                        ; f32.const
+00015cf: 0000 0040                                 ; f32 literal
+00015d3: 97                                        ; f32.max
+00015d4: 1a                                        ; drop
+00015d5: 0b                                        ; end
+00015c7: 0e                                        ; FIXUP func body size
 ; function body 126
-00015c1: 00                                        ; func body size (guess)
-00015c2: 00                                        ; local decl count
-00015c3: 43                                        ; f32.const
-00015c4: 0000 803f                                 ; f32 literal
-00015c8: 43                                        ; f32.const
-00015c9: 0000 0040                                 ; f32 literal
-00015cd: 98                                        ; f32.copysign
-00015ce: 1a                                        ; drop
-00015cf: 0b                                        ; end
-00015c1: 0e                                        ; FIXUP func body size
+00015d6: 00                                        ; func body size (guess)
+00015d7: 00                                        ; local decl count
+00015d8: 43                                        ; f32.const
+00015d9: 0000 803f                                 ; f32 literal
+00015dd: 43                                        ; f32.const
+00015de: 0000 0040                                 ; f32 literal
+00015e2: 98                                        ; f32.copysign
+00015e3: 1a                                        ; drop
+00015e4: 0b                                        ; end
+00015d6: 0e                                        ; FIXUP func body size
 ; function body 127
-00015d0: 00                                        ; func body size (guess)
-00015d1: 00                                        ; local decl count
-00015d2: 44                                        ; f64.const
-00015d3: 0000 0000 0000 f03f                       ; f64 literal
-00015db: 99                                        ; f64.abs
-00015dc: 1a                                        ; drop
-00015dd: 0b                                        ; end
-00015d0: 0d                                        ; FIXUP func body size
+00015e5: 00                                        ; func body size (guess)
+00015e6: 00                                        ; local decl count
+00015e7: 44                                        ; f64.const
+00015e8: 0000 0000 0000 f03f                       ; f64 literal
+00015f0: 99                                        ; f64.abs
+00015f1: 1a                                        ; drop
+00015f2: 0b                                        ; end
+00015e5: 0d                                        ; FIXUP func body size
 ; function body 128
-00015de: 00                                        ; func body size (guess)
-00015df: 00                                        ; local decl count
-00015e0: 44                                        ; f64.const
-00015e1: 0000 0000 0000 f03f                       ; f64 literal
-00015e9: 9a                                        ; f64.neg
-00015ea: 1a                                        ; drop
-00015eb: 0b                                        ; end
-00015de: 0d                                        ; FIXUP func body size
+00015f3: 00                                        ; func body size (guess)
+00015f4: 00                                        ; local decl count
+00015f5: 44                                        ; f64.const
+00015f6: 0000 0000 0000 f03f                       ; f64 literal
+00015fe: 9a                                        ; f64.neg
+00015ff: 1a                                        ; drop
+0001600: 0b                                        ; end
+00015f3: 0d                                        ; FIXUP func body size
 ; function body 129
-00015ec: 00                                        ; func body size (guess)
-00015ed: 00                                        ; local decl count
-00015ee: 44                                        ; f64.const
-00015ef: 0000 0000 0000 f03f                       ; f64 literal
-00015f7: 9b                                        ; f64.ceil
-00015f8: 1a                                        ; drop
-00015f9: 0b                                        ; end
-00015ec: 0d                                        ; FIXUP func body size
+0001601: 00                                        ; func body size (guess)
+0001602: 00                                        ; local decl count
+0001603: 44                                        ; f64.const
+0001604: 0000 0000 0000 f03f                       ; f64 literal
+000160c: 9b                                        ; f64.ceil
+000160d: 1a                                        ; drop
+000160e: 0b                                        ; end
+0001601: 0d                                        ; FIXUP func body size
 ; function body 130
-00015fa: 00                                        ; func body size (guess)
-00015fb: 00                                        ; local decl count
-00015fc: 44                                        ; f64.const
-00015fd: 0000 0000 0000 f03f                       ; f64 literal
-0001605: 9c                                        ; f64.floor
-0001606: 1a                                        ; drop
-0001607: 0b                                        ; end
-00015fa: 0d                                        ; FIXUP func body size
+000160f: 00                                        ; func body size (guess)
+0001610: 00                                        ; local decl count
+0001611: 44                                        ; f64.const
+0001612: 0000 0000 0000 f03f                       ; f64 literal
+000161a: 9c                                        ; f64.floor
+000161b: 1a                                        ; drop
+000161c: 0b                                        ; end
+000160f: 0d                                        ; FIXUP func body size
 ; function body 131
-0001608: 00                                        ; func body size (guess)
-0001609: 00                                        ; local decl count
-000160a: 44                                        ; f64.const
-000160b: 0000 0000 0000 f03f                       ; f64 literal
-0001613: 9d                                        ; f64.trunc
-0001614: 1a                                        ; drop
-0001615: 0b                                        ; end
-0001608: 0d                                        ; FIXUP func body size
+000161d: 00                                        ; func body size (guess)
+000161e: 00                                        ; local decl count
+000161f: 44                                        ; f64.const
+0001620: 0000 0000 0000 f03f                       ; f64 literal
+0001628: 9d                                        ; f64.trunc
+0001629: 1a                                        ; drop
+000162a: 0b                                        ; end
+000161d: 0d                                        ; FIXUP func body size
 ; function body 132
-0001616: 00                                        ; func body size (guess)
-0001617: 00                                        ; local decl count
-0001618: 44                                        ; f64.const
-0001619: 0000 0000 0000 f03f                       ; f64 literal
-0001621: 9e                                        ; f64.nearest
-0001622: 1a                                        ; drop
-0001623: 0b                                        ; end
-0001616: 0d                                        ; FIXUP func body size
+000162b: 00                                        ; func body size (guess)
+000162c: 00                                        ; local decl count
+000162d: 44                                        ; f64.const
+000162e: 0000 0000 0000 f03f                       ; f64 literal
+0001636: 9e                                        ; f64.nearest
+0001637: 1a                                        ; drop
+0001638: 0b                                        ; end
+000162b: 0d                                        ; FIXUP func body size
 ; function body 133
-0001624: 00                                        ; func body size (guess)
-0001625: 00                                        ; local decl count
-0001626: 44                                        ; f64.const
-0001627: 0000 0000 0000 f03f                       ; f64 literal
-000162f: 9f                                        ; f64.sqrt
-0001630: 1a                                        ; drop
-0001631: 0b                                        ; end
-0001624: 0d                                        ; FIXUP func body size
+0001639: 00                                        ; func body size (guess)
+000163a: 00                                        ; local decl count
+000163b: 44                                        ; f64.const
+000163c: 0000 0000 0000 f03f                       ; f64 literal
+0001644: 9f                                        ; f64.sqrt
+0001645: 1a                                        ; drop
+0001646: 0b                                        ; end
+0001639: 0d                                        ; FIXUP func body size
 ; function body 134
-0001632: 00                                        ; func body size (guess)
-0001633: 00                                        ; local decl count
-0001634: 44                                        ; f64.const
-0001635: 0000 0000 0000 f03f                       ; f64 literal
-000163d: 44                                        ; f64.const
-000163e: 0000 0000 0000 0040                       ; f64 literal
-0001646: a0                                        ; f64.add
-0001647: 1a                                        ; drop
-0001648: 0b                                        ; end
-0001632: 16                                        ; FIXUP func body size
+0001647: 00                                        ; func body size (guess)
+0001648: 00                                        ; local decl count
+0001649: 44                                        ; f64.const
+000164a: 0000 0000 0000 f03f                       ; f64 literal
+0001652: 44                                        ; f64.const
+0001653: 0000 0000 0000 0040                       ; f64 literal
+000165b: a0                                        ; f64.add
+000165c: 1a                                        ; drop
+000165d: 0b                                        ; end
+0001647: 16                                        ; FIXUP func body size
 ; function body 135
-0001649: 00                                        ; func body size (guess)
-000164a: 00                                        ; local decl count
-000164b: 44                                        ; f64.const
-000164c: 0000 0000 0000 f03f                       ; f64 literal
-0001654: 44                                        ; f64.const
-0001655: 0000 0000 0000 0040                       ; f64 literal
-000165d: a1                                        ; f64.sub
-000165e: 1a                                        ; drop
-000165f: 0b                                        ; end
-0001649: 16                                        ; FIXUP func body size
+000165e: 00                                        ; func body size (guess)
+000165f: 00                                        ; local decl count
+0001660: 44                                        ; f64.const
+0001661: 0000 0000 0000 f03f                       ; f64 literal
+0001669: 44                                        ; f64.const
+000166a: 0000 0000 0000 0040                       ; f64 literal
+0001672: a1                                        ; f64.sub
+0001673: 1a                                        ; drop
+0001674: 0b                                        ; end
+000165e: 16                                        ; FIXUP func body size
 ; function body 136
-0001660: 00                                        ; func body size (guess)
-0001661: 00                                        ; local decl count
-0001662: 44                                        ; f64.const
-0001663: 0000 0000 0000 f03f                       ; f64 literal
-000166b: 44                                        ; f64.const
-000166c: 0000 0000 0000 0040                       ; f64 literal
-0001674: a2                                        ; f64.mul
-0001675: 1a                                        ; drop
-0001676: 0b                                        ; end
-0001660: 16                                        ; FIXUP func body size
+0001675: 00                                        ; func body size (guess)
+0001676: 00                                        ; local decl count
+0001677: 44                                        ; f64.const
+0001678: 0000 0000 0000 f03f                       ; f64 literal
+0001680: 44                                        ; f64.const
+0001681: 0000 0000 0000 0040                       ; f64 literal
+0001689: a2                                        ; f64.mul
+000168a: 1a                                        ; drop
+000168b: 0b                                        ; end
+0001675: 16                                        ; FIXUP func body size
 ; function body 137
-0001677: 00                                        ; func body size (guess)
-0001678: 00                                        ; local decl count
-0001679: 44                                        ; f64.const
-000167a: 0000 0000 0000 f03f                       ; f64 literal
-0001682: 44                                        ; f64.const
-0001683: 0000 0000 0000 0040                       ; f64 literal
-000168b: a3                                        ; f64.div
-000168c: 1a                                        ; drop
-000168d: 0b                                        ; end
-0001677: 16                                        ; FIXUP func body size
+000168c: 00                                        ; func body size (guess)
+000168d: 00                                        ; local decl count
+000168e: 44                                        ; f64.const
+000168f: 0000 0000 0000 f03f                       ; f64 literal
+0001697: 44                                        ; f64.const
+0001698: 0000 0000 0000 0040                       ; f64 literal
+00016a0: a3                                        ; f64.div
+00016a1: 1a                                        ; drop
+00016a2: 0b                                        ; end
+000168c: 16                                        ; FIXUP func body size
 ; function body 138
-000168e: 00                                        ; func body size (guess)
-000168f: 00                                        ; local decl count
-0001690: 44                                        ; f64.const
-0001691: 0000 0000 0000 f03f                       ; f64 literal
-0001699: 44                                        ; f64.const
-000169a: 0000 0000 0000 0040                       ; f64 literal
-00016a2: a4                                        ; f64.min
-00016a3: 1a                                        ; drop
-00016a4: 0b                                        ; end
-000168e: 16                                        ; FIXUP func body size
+00016a3: 00                                        ; func body size (guess)
+00016a4: 00                                        ; local decl count
+00016a5: 44                                        ; f64.const
+00016a6: 0000 0000 0000 f03f                       ; f64 literal
+00016ae: 44                                        ; f64.const
+00016af: 0000 0000 0000 0040                       ; f64 literal
+00016b7: a4                                        ; f64.min
+00016b8: 1a                                        ; drop
+00016b9: 0b                                        ; end
+00016a3: 16                                        ; FIXUP func body size
 ; function body 139
-00016a5: 00                                        ; func body size (guess)
-00016a6: 00                                        ; local decl count
-00016a7: 44                                        ; f64.const
-00016a8: 0000 0000 0000 f03f                       ; f64 literal
-00016b0: 44                                        ; f64.const
-00016b1: 0000 0000 0000 0040                       ; f64 literal
-00016b9: a5                                        ; f64.max
-00016ba: 1a                                        ; drop
-00016bb: 0b                                        ; end
-00016a5: 16                                        ; FIXUP func body size
+00016ba: 00                                        ; func body size (guess)
+00016bb: 00                                        ; local decl count
+00016bc: 44                                        ; f64.const
+00016bd: 0000 0000 0000 f03f                       ; f64 literal
+00016c5: 44                                        ; f64.const
+00016c6: 0000 0000 0000 0040                       ; f64 literal
+00016ce: a5                                        ; f64.max
+00016cf: 1a                                        ; drop
+00016d0: 0b                                        ; end
+00016ba: 16                                        ; FIXUP func body size
 ; function body 140
-00016bc: 00                                        ; func body size (guess)
-00016bd: 00                                        ; local decl count
-00016be: 44                                        ; f64.const
-00016bf: 0000 0000 0000 f03f                       ; f64 literal
-00016c7: 44                                        ; f64.const
-00016c8: 0000 0000 0000 0040                       ; f64 literal
-00016d0: a6                                        ; f64.copysign
-00016d1: 1a                                        ; drop
-00016d2: 0b                                        ; end
-00016bc: 16                                        ; FIXUP func body size
+00016d1: 00                                        ; func body size (guess)
+00016d2: 00                                        ; local decl count
+00016d3: 44                                        ; f64.const
+00016d4: 0000 0000 0000 f03f                       ; f64 literal
+00016dc: 44                                        ; f64.const
+00016dd: 0000 0000 0000 0040                       ; f64 literal
+00016e5: a6                                        ; f64.copysign
+00016e6: 1a                                        ; drop
+00016e7: 0b                                        ; end
+00016d1: 16                                        ; FIXUP func body size
 ; function body 141
-00016d3: 00                                        ; func body size (guess)
-00016d4: 00                                        ; local decl count
-00016d5: 42                                        ; i64.const
-00016d6: 01                                        ; i64 literal
-00016d7: a7                                        ; i32.wrap/i64
-00016d8: 1a                                        ; drop
-00016d9: 0b                                        ; end
-00016d3: 06                                        ; FIXUP func body size
+00016e8: 00                                        ; func body size (guess)
+00016e9: 00                                        ; local decl count
+00016ea: 42                                        ; i64.const
+00016eb: 01                                        ; i64 literal
+00016ec: a7                                        ; i32.wrap/i64
+00016ed: 1a                                        ; drop
+00016ee: 0b                                        ; end
+00016e8: 06                                        ; FIXUP func body size
 ; function body 142
-00016da: 00                                        ; func body size (guess)
-00016db: 00                                        ; local decl count
-00016dc: 43                                        ; f32.const
-00016dd: 0000 803f                                 ; f32 literal
-00016e1: a8                                        ; i32.trunc_s/f32
-00016e2: 1a                                        ; drop
-00016e3: 0b                                        ; end
-00016da: 09                                        ; FIXUP func body size
+00016ef: 00                                        ; func body size (guess)
+00016f0: 00                                        ; local decl count
+00016f1: 43                                        ; f32.const
+00016f2: 0000 803f                                 ; f32 literal
+00016f6: a8                                        ; i32.trunc_s/f32
+00016f7: 1a                                        ; drop
+00016f8: 0b                                        ; end
+00016ef: 09                                        ; FIXUP func body size
 ; function body 143
-00016e4: 00                                        ; func body size (guess)
-00016e5: 00                                        ; local decl count
-00016e6: 43                                        ; f32.const
-00016e7: 0000 803f                                 ; f32 literal
-00016eb: a9                                        ; i32.trunc_u/f32
-00016ec: 1a                                        ; drop
-00016ed: 0b                                        ; end
-00016e4: 09                                        ; FIXUP func body size
+00016f9: 00                                        ; func body size (guess)
+00016fa: 00                                        ; local decl count
+00016fb: 43                                        ; f32.const
+00016fc: 0000 803f                                 ; f32 literal
+0001700: a9                                        ; i32.trunc_u/f32
+0001701: 1a                                        ; drop
+0001702: 0b                                        ; end
+00016f9: 09                                        ; FIXUP func body size
 ; function body 144
-00016ee: 00                                        ; func body size (guess)
-00016ef: 00                                        ; local decl count
-00016f0: 44                                        ; f64.const
-00016f1: 0000 0000 0000 f03f                       ; f64 literal
-00016f9: aa                                        ; i32.trunc_s/f64
-00016fa: 1a                                        ; drop
-00016fb: 0b                                        ; end
-00016ee: 0d                                        ; FIXUP func body size
-; function body 145
-00016fc: 00                                        ; func body size (guess)
-00016fd: 00                                        ; local decl count
-00016fe: 44                                        ; f64.const
-00016ff: 0000 0000 0000 f03f                       ; f64 literal
-0001707: ab                                        ; i32.trunc_u/f64
-0001708: 1a                                        ; drop
-0001709: 0b                                        ; end
-00016fc: 0d                                        ; FIXUP func body size
-; function body 146
-000170a: 00                                        ; func body size (guess)
-000170b: 00                                        ; local decl count
-000170c: 41                                        ; i32.const
-000170d: 01                                        ; i32 literal
-000170e: ac                                        ; i64.extend_s/i32
+0001703: 00                                        ; func body size (guess)
+0001704: 00                                        ; local decl count
+0001705: 44                                        ; f64.const
+0001706: 0000 0000 0000 f03f                       ; f64 literal
+000170e: aa                                        ; i32.trunc_s/f64
 000170f: 1a                                        ; drop
 0001710: 0b                                        ; end
-000170a: 06                                        ; FIXUP func body size
-; function body 147
+0001703: 0d                                        ; FIXUP func body size
+; function body 145
 0001711: 00                                        ; func body size (guess)
 0001712: 00                                        ; local decl count
-0001713: 41                                        ; i32.const
-0001714: 01                                        ; i32 literal
-0001715: ad                                        ; i64.extend_u/i32
-0001716: 1a                                        ; drop
-0001717: 0b                                        ; end
-0001711: 06                                        ; FIXUP func body size
+0001713: 44                                        ; f64.const
+0001714: 0000 0000 0000 f03f                       ; f64 literal
+000171c: ab                                        ; i32.trunc_u/f64
+000171d: 1a                                        ; drop
+000171e: 0b                                        ; end
+0001711: 0d                                        ; FIXUP func body size
+; function body 146
+000171f: 00                                        ; func body size (guess)
+0001720: 00                                        ; local decl count
+0001721: 41                                        ; i32.const
+0001722: 01                                        ; i32 literal
+0001723: ac                                        ; i64.extend_s/i32
+0001724: 1a                                        ; drop
+0001725: 0b                                        ; end
+000171f: 06                                        ; FIXUP func body size
+; function body 147
+0001726: 00                                        ; func body size (guess)
+0001727: 00                                        ; local decl count
+0001728: 41                                        ; i32.const
+0001729: 01                                        ; i32 literal
+000172a: ad                                        ; i64.extend_u/i32
+000172b: 1a                                        ; drop
+000172c: 0b                                        ; end
+0001726: 06                                        ; FIXUP func body size
 ; function body 148
-0001718: 00                                        ; func body size (guess)
-0001719: 00                                        ; local decl count
-000171a: 43                                        ; f32.const
-000171b: 0000 803f                                 ; f32 literal
-000171f: ae                                        ; i64.trunc_s/f32
-0001720: 1a                                        ; drop
-0001721: 0b                                        ; end
-0001718: 09                                        ; FIXUP func body size
+000172d: 00                                        ; func body size (guess)
+000172e: 00                                        ; local decl count
+000172f: 43                                        ; f32.const
+0001730: 0000 803f                                 ; f32 literal
+0001734: ae                                        ; i64.trunc_s/f32
+0001735: 1a                                        ; drop
+0001736: 0b                                        ; end
+000172d: 09                                        ; FIXUP func body size
 ; function body 149
-0001722: 00                                        ; func body size (guess)
-0001723: 00                                        ; local decl count
-0001724: 43                                        ; f32.const
-0001725: 0000 803f                                 ; f32 literal
-0001729: af                                        ; i64.trunc_u/f32
-000172a: 1a                                        ; drop
-000172b: 0b                                        ; end
-0001722: 09                                        ; FIXUP func body size
+0001737: 00                                        ; func body size (guess)
+0001738: 00                                        ; local decl count
+0001739: 43                                        ; f32.const
+000173a: 0000 803f                                 ; f32 literal
+000173e: af                                        ; i64.trunc_u/f32
+000173f: 1a                                        ; drop
+0001740: 0b                                        ; end
+0001737: 09                                        ; FIXUP func body size
 ; function body 150
-000172c: 00                                        ; func body size (guess)
-000172d: 00                                        ; local decl count
-000172e: 44                                        ; f64.const
-000172f: 0000 0000 0000 f03f                       ; f64 literal
-0001737: b0                                        ; i64.trunc_s/f64
-0001738: 1a                                        ; drop
-0001739: 0b                                        ; end
-000172c: 0d                                        ; FIXUP func body size
-; function body 151
-000173a: 00                                        ; func body size (guess)
-000173b: 00                                        ; local decl count
-000173c: 44                                        ; f64.const
-000173d: 0000 0000 0000 f03f                       ; f64 literal
-0001745: b1                                        ; i64.trunc_u/f64
-0001746: 1a                                        ; drop
-0001747: 0b                                        ; end
-000173a: 0d                                        ; FIXUP func body size
-; function body 152
-0001748: 00                                        ; func body size (guess)
-0001749: 00                                        ; local decl count
-000174a: 41                                        ; i32.const
-000174b: 01                                        ; i32 literal
-000174c: b2                                        ; f32.convert_s/i32
+0001741: 00                                        ; func body size (guess)
+0001742: 00                                        ; local decl count
+0001743: 44                                        ; f64.const
+0001744: 0000 0000 0000 f03f                       ; f64 literal
+000174c: b0                                        ; i64.trunc_s/f64
 000174d: 1a                                        ; drop
 000174e: 0b                                        ; end
-0001748: 06                                        ; FIXUP func body size
-; function body 153
+0001741: 0d                                        ; FIXUP func body size
+; function body 151
 000174f: 00                                        ; func body size (guess)
 0001750: 00                                        ; local decl count
-0001751: 41                                        ; i32.const
-0001752: 01                                        ; i32 literal
-0001753: b3                                        ; f32.convert_u/i32
-0001754: 1a                                        ; drop
-0001755: 0b                                        ; end
-000174f: 06                                        ; FIXUP func body size
-; function body 154
-0001756: 00                                        ; func body size (guess)
-0001757: 00                                        ; local decl count
-0001758: 42                                        ; i64.const
-0001759: 01                                        ; i64 literal
-000175a: b4                                        ; f32.convert_s/i64
+0001751: 44                                        ; f64.const
+0001752: 0000 0000 0000 f03f                       ; f64 literal
+000175a: b1                                        ; i64.trunc_u/f64
 000175b: 1a                                        ; drop
 000175c: 0b                                        ; end
-0001756: 06                                        ; FIXUP func body size
-; function body 155
+000174f: 0d                                        ; FIXUP func body size
+; function body 152
 000175d: 00                                        ; func body size (guess)
 000175e: 00                                        ; local decl count
-000175f: 42                                        ; i64.const
-0001760: 01                                        ; i64 literal
-0001761: b5                                        ; f32.convert_u/i64
+000175f: 41                                        ; i32.const
+0001760: 01                                        ; i32 literal
+0001761: b2                                        ; f32.convert_s/i32
 0001762: 1a                                        ; drop
 0001763: 0b                                        ; end
 000175d: 06                                        ; FIXUP func body size
-; function body 156
+; function body 153
 0001764: 00                                        ; func body size (guess)
 0001765: 00                                        ; local decl count
-0001766: 44                                        ; f64.const
-0001767: 0000 0000 0000 f03f                       ; f64 literal
-000176f: b6                                        ; f32.demote/f64
+0001766: 41                                        ; i32.const
+0001767: 01                                        ; i32 literal
+0001768: b3                                        ; f32.convert_u/i32
+0001769: 1a                                        ; drop
+000176a: 0b                                        ; end
+0001764: 06                                        ; FIXUP func body size
+; function body 154
+000176b: 00                                        ; func body size (guess)
+000176c: 00                                        ; local decl count
+000176d: 42                                        ; i64.const
+000176e: 01                                        ; i64 literal
+000176f: b4                                        ; f32.convert_s/i64
 0001770: 1a                                        ; drop
 0001771: 0b                                        ; end
-0001764: 0d                                        ; FIXUP func body size
-; function body 157
+000176b: 06                                        ; FIXUP func body size
+; function body 155
 0001772: 00                                        ; func body size (guess)
 0001773: 00                                        ; local decl count
-0001774: 41                                        ; i32.const
-0001775: 01                                        ; i32 literal
-0001776: b7                                        ; f64.convert_s/i32
+0001774: 42                                        ; i64.const
+0001775: 01                                        ; i64 literal
+0001776: b5                                        ; f32.convert_u/i64
 0001777: 1a                                        ; drop
 0001778: 0b                                        ; end
 0001772: 06                                        ; FIXUP func body size
-; function body 158
+; function body 156
 0001779: 00                                        ; func body size (guess)
 000177a: 00                                        ; local decl count
-000177b: 41                                        ; i32.const
-000177c: 01                                        ; i32 literal
-000177d: b8                                        ; f64.convert_u/i32
-000177e: 1a                                        ; drop
-000177f: 0b                                        ; end
-0001779: 06                                        ; FIXUP func body size
-; function body 159
-0001780: 00                                        ; func body size (guess)
-0001781: 00                                        ; local decl count
-0001782: 42                                        ; i64.const
-0001783: 01                                        ; i64 literal
-0001784: b9                                        ; f64.convert_s/i64
+000177b: 44                                        ; f64.const
+000177c: 0000 0000 0000 f03f                       ; f64 literal
+0001784: b6                                        ; f32.demote/f64
 0001785: 1a                                        ; drop
 0001786: 0b                                        ; end
-0001780: 06                                        ; FIXUP func body size
-; function body 160
+0001779: 0d                                        ; FIXUP func body size
+; function body 157
 0001787: 00                                        ; func body size (guess)
 0001788: 00                                        ; local decl count
-0001789: 42                                        ; i64.const
-000178a: 01                                        ; i64 literal
-000178b: ba                                        ; f64.convert_u/i64
+0001789: 41                                        ; i32.const
+000178a: 01                                        ; i32 literal
+000178b: b7                                        ; f64.convert_s/i32
 000178c: 1a                                        ; drop
 000178d: 0b                                        ; end
 0001787: 06                                        ; FIXUP func body size
-; function body 161
+; function body 158
 000178e: 00                                        ; func body size (guess)
 000178f: 00                                        ; local decl count
-0001790: 43                                        ; f32.const
-0001791: 0000 803f                                 ; f32 literal
-0001795: bb                                        ; f64.promote/f32
-0001796: 1a                                        ; drop
-0001797: 0b                                        ; end
-000178e: 09                                        ; FIXUP func body size
+0001790: 41                                        ; i32.const
+0001791: 01                                        ; i32 literal
+0001792: b8                                        ; f64.convert_u/i32
+0001793: 1a                                        ; drop
+0001794: 0b                                        ; end
+000178e: 06                                        ; FIXUP func body size
+; function body 159
+0001795: 00                                        ; func body size (guess)
+0001796: 00                                        ; local decl count
+0001797: 42                                        ; i64.const
+0001798: 01                                        ; i64 literal
+0001799: b9                                        ; f64.convert_s/i64
+000179a: 1a                                        ; drop
+000179b: 0b                                        ; end
+0001795: 06                                        ; FIXUP func body size
+; function body 160
+000179c: 00                                        ; func body size (guess)
+000179d: 00                                        ; local decl count
+000179e: 42                                        ; i64.const
+000179f: 01                                        ; i64 literal
+00017a0: ba                                        ; f64.convert_u/i64
+00017a1: 1a                                        ; drop
+00017a2: 0b                                        ; end
+000179c: 06                                        ; FIXUP func body size
+; function body 161
+00017a3: 00                                        ; func body size (guess)
+00017a4: 00                                        ; local decl count
+00017a5: 43                                        ; f32.const
+00017a6: 0000 803f                                 ; f32 literal
+00017aa: bb                                        ; f64.promote/f32
+00017ab: 1a                                        ; drop
+00017ac: 0b                                        ; end
+00017a3: 09                                        ; FIXUP func body size
 ; function body 162
-0001798: 00                                        ; func body size (guess)
-0001799: 00                                        ; local decl count
-000179a: 41                                        ; i32.const
-000179b: 01                                        ; i32 literal
-000179c: be                                        ; f32.reinterpret/i32
-000179d: 1a                                        ; drop
-000179e: 0b                                        ; end
-0001798: 06                                        ; FIXUP func body size
+00017ad: 00                                        ; func body size (guess)
+00017ae: 00                                        ; local decl count
+00017af: 41                                        ; i32.const
+00017b0: 01                                        ; i32 literal
+00017b1: be                                        ; f32.reinterpret/i32
+00017b2: 1a                                        ; drop
+00017b3: 0b                                        ; end
+00017ad: 06                                        ; FIXUP func body size
 ; function body 163
-000179f: 00                                        ; func body size (guess)
-00017a0: 00                                        ; local decl count
-00017a1: 43                                        ; f32.const
-00017a2: 0000 803f                                 ; f32 literal
-00017a6: bc                                        ; i32.reinterpret/f32
-00017a7: 1a                                        ; drop
-00017a8: 0b                                        ; end
-000179f: 09                                        ; FIXUP func body size
-; function body 164
-00017a9: 00                                        ; func body size (guess)
-00017aa: 00                                        ; local decl count
-00017ab: 42                                        ; i64.const
-00017ac: 01                                        ; i64 literal
-00017ad: bf                                        ; f64.reinterpret/i64
-00017ae: 1a                                        ; drop
-00017af: 0b                                        ; end
-00017a9: 06                                        ; FIXUP func body size
-; function body 165
-00017b0: 00                                        ; func body size (guess)
-00017b1: 00                                        ; local decl count
-00017b2: 44                                        ; f64.const
-00017b3: 0000 0000 0000 f03f                       ; f64 literal
-00017bb: bd                                        ; i64.reinterpret/f64
+00017b4: 00                                        ; func body size (guess)
+00017b5: 00                                        ; local decl count
+00017b6: 43                                        ; f32.const
+00017b7: 0000 803f                                 ; f32 literal
+00017bb: bc                                        ; i32.reinterpret/f32
 00017bc: 1a                                        ; drop
 00017bd: 0b                                        ; end
-00017b0: 0d                                        ; FIXUP func body size
-; function body 166
+00017b4: 09                                        ; FIXUP func body size
+; function body 164
 00017be: 00                                        ; func body size (guess)
 00017bf: 00                                        ; local decl count
-00017c0: 41                                        ; i32.const
-00017c1: 01                                        ; i32 literal
-00017c2: c0                                        ; i32.extend8_s
+00017c0: 42                                        ; i64.const
+00017c1: 01                                        ; i64 literal
+00017c2: bf                                        ; f64.reinterpret/i64
 00017c3: 1a                                        ; drop
 00017c4: 0b                                        ; end
 00017be: 06                                        ; FIXUP func body size
-; function body 167
+; function body 165
 00017c5: 00                                        ; func body size (guess)
 00017c6: 00                                        ; local decl count
-00017c7: 41                                        ; i32.const
-00017c8: 01                                        ; i32 literal
-00017c9: c1                                        ; i32.extend16_s
-00017ca: 1a                                        ; drop
-00017cb: 0b                                        ; end
-00017c5: 06                                        ; FIXUP func body size
-; function body 168
-00017cc: 00                                        ; func body size (guess)
-00017cd: 00                                        ; local decl count
-00017ce: 42                                        ; i64.const
-00017cf: 01                                        ; i64 literal
-00017d0: c2                                        ; i64.extend8_s
+00017c7: 44                                        ; f64.const
+00017c8: 0000 0000 0000 f03f                       ; f64 literal
+00017d0: bd                                        ; i64.reinterpret/f64
 00017d1: 1a                                        ; drop
 00017d2: 0b                                        ; end
-00017cc: 06                                        ; FIXUP func body size
-; function body 169
+00017c5: 0d                                        ; FIXUP func body size
+; function body 166
 00017d3: 00                                        ; func body size (guess)
 00017d4: 00                                        ; local decl count
-00017d5: 42                                        ; i64.const
-00017d6: 01                                        ; i64 literal
-00017d7: c3                                        ; i64.extend16_s
+00017d5: 41                                        ; i32.const
+00017d6: 01                                        ; i32 literal
+00017d7: c0                                        ; i32.extend8_s
 00017d8: 1a                                        ; drop
 00017d9: 0b                                        ; end
 00017d3: 06                                        ; FIXUP func body size
-; function body 170
+; function body 167
 00017da: 00                                        ; func body size (guess)
 00017db: 00                                        ; local decl count
-00017dc: 42                                        ; i64.const
-00017dd: 01                                        ; i64 literal
-00017de: c4                                        ; i64.extend32_s
+00017dc: 41                                        ; i32.const
+00017dd: 01                                        ; i32 literal
+00017de: c1                                        ; i32.extend16_s
 00017df: 1a                                        ; drop
 00017e0: 0b                                        ; end
 00017da: 06                                        ; FIXUP func body size
-; function body 171
+; function body 168
 00017e1: 00                                        ; func body size (guess)
-00017e2: 01                                        ; local decl count
-00017e3: 01                                        ; local type count
-00017e4: 7f                                        ; i32
-00017e5: 0b                                        ; end
-00017e1: 04                                        ; FIXUP func body size
+00017e2: 00                                        ; local decl count
+00017e3: 42                                        ; i64.const
+00017e4: 01                                        ; i64 literal
+00017e5: c2                                        ; i64.extend8_s
+00017e6: 1a                                        ; drop
+00017e7: 0b                                        ; end
+00017e1: 06                                        ; FIXUP func body size
+; function body 169
+00017e8: 00                                        ; func body size (guess)
+00017e9: 00                                        ; local decl count
+00017ea: 42                                        ; i64.const
+00017eb: 01                                        ; i64 literal
+00017ec: c3                                        ; i64.extend16_s
+00017ed: 1a                                        ; drop
+00017ee: 0b                                        ; end
+00017e8: 06                                        ; FIXUP func body size
+; function body 170
+00017ef: 00                                        ; func body size (guess)
+00017f0: 00                                        ; local decl count
+00017f1: 42                                        ; i64.const
+00017f2: 01                                        ; i64 literal
+00017f3: c4                                        ; i64.extend32_s
+00017f4: 1a                                        ; drop
+00017f5: 0b                                        ; end
+00017ef: 06                                        ; FIXUP func body size
+; function body 171
+00017f6: 00                                        ; func body size (guess)
+00017f7: 01                                        ; local decl count
+00017f8: 01                                        ; local type count
+00017f9: 7f                                        ; i32
+00017fa: 0b                                        ; end
+00017f6: 04                                        ; FIXUP func body size
 ; function body 172
-00017e6: 00                                        ; func body size (guess)
-00017e7: 00                                        ; local decl count
-00017e8: 41                                        ; i32.const
-00017e9: 01                                        ; i32 literal
-00017ea: 0d                                        ; br_if
-00017eb: 00                                        ; break depth
-00017ec: 0b                                        ; end
-00017e6: 06                                        ; FIXUP func body size
+00017fb: 00                                        ; func body size (guess)
+00017fc: 00                                        ; local decl count
+00017fd: 41                                        ; i32.const
+00017fe: 01                                        ; i32 literal
+00017ff: 0d                                        ; br_if
+0001800: 00                                        ; break depth
+0001801: 0b                                        ; end
+00017fb: 06                                        ; FIXUP func body size
 ; function body 173
-00017ed: 00                                        ; func body size (guess)
-00017ee: 00                                        ; local decl count
-00017ef: 41                                        ; i32.const
-00017f0: 01                                        ; i32 literal
-00017f1: 10                                        ; call
-00017f2: 00                                        ; function index
-00017f3: 0b                                        ; end
-00017ed: 06                                        ; FIXUP func body size
-; function body 174
-00017f4: 00                                        ; func body size (guess)
-00017f5: 00                                        ; local decl count
-00017f6: 41                                        ; i32.const
-00017f7: 01                                        ; i32 literal
-00017f8: 0e                                        ; br_table
-00017f9: 00                                        ; num targets
-00017fa: 00                                        ; break depth for default
-00017fb: 0b                                        ; end
-00017f4: 07                                        ; FIXUP func body size
-; function body 175
-00017fc: 00                                        ; func body size (guess)
-00017fd: 00                                        ; local decl count
-00017fe: 02                                        ; block
-00017ff: 7f                                        ; i32
-0001800: 41                                        ; i32.const
-0001801: 01                                        ; i32 literal
-0001802: 41                                        ; i32.const
-0001803: 02                                        ; i32 literal
-0001804: 0c                                        ; br
-0001805: 00                                        ; break depth
-0001806: 0b                                        ; end
-0001807: 1a                                        ; drop
+0001802: 00                                        ; func body size (guess)
+0001803: 00                                        ; local decl count
+0001804: 41                                        ; i32.const
+0001805: 01                                        ; i32 literal
+0001806: 10                                        ; call
+0001807: 00                                        ; function index
 0001808: 0b                                        ; end
-00017fc: 0c                                        ; FIXUP func body size
-; function body 176
+0001802: 06                                        ; FIXUP func body size
+; function body 174
 0001809: 00                                        ; func body size (guess)
 000180a: 00                                        ; local decl count
-000180b: 43                                        ; f32.const
-000180c: 0000 803f                                 ; f32 literal
-0001810: fc                                        ; prefix
-0001811: 00                                        ; i32.trunc_s:sat/f32
-0001812: 1a                                        ; drop
-0001813: 0b                                        ; end
-0001809: 0a                                        ; FIXUP func body size
+000180b: 41                                        ; i32.const
+000180c: 01                                        ; i32 literal
+000180d: 0e                                        ; br_table
+000180e: 00                                        ; num targets
+000180f: 00                                        ; break depth for default
+0001810: 0b                                        ; end
+0001809: 07                                        ; FIXUP func body size
+; function body 175
+0001811: 00                                        ; func body size (guess)
+0001812: 00                                        ; local decl count
+0001813: 02                                        ; block
+0001814: 7f                                        ; i32
+0001815: 41                                        ; i32.const
+0001816: 01                                        ; i32 literal
+0001817: 41                                        ; i32.const
+0001818: 02                                        ; i32 literal
+0001819: 0c                                        ; br
+000181a: 00                                        ; break depth
+000181b: 0b                                        ; end
+000181c: 1a                                        ; drop
+000181d: 0b                                        ; end
+0001811: 0c                                        ; FIXUP func body size
+; function body 176
+000181e: 00                                        ; func body size (guess)
+000181f: 00                                        ; local decl count
+0001820: 43                                        ; f32.const
+0001821: 0000 803f                                 ; f32 literal
+0001825: fc                                        ; prefix
+0001826: 00                                        ; i32.trunc_s:sat/f32
+0001827: 1a                                        ; drop
+0001828: 0b                                        ; end
+000181e: 0a                                        ; FIXUP func body size
 ; function body 177
-0001814: 00                                        ; func body size (guess)
-0001815: 00                                        ; local decl count
-0001816: 43                                        ; f32.const
-0001817: 0000 803f                                 ; f32 literal
-000181b: fc                                        ; prefix
-000181c: 01                                        ; i32.trunc_u:sat/f32
-000181d: 1a                                        ; drop
-000181e: 0b                                        ; end
-0001814: 0a                                        ; FIXUP func body size
+0001829: 00                                        ; func body size (guess)
+000182a: 00                                        ; local decl count
+000182b: 43                                        ; f32.const
+000182c: 0000 803f                                 ; f32 literal
+0001830: fc                                        ; prefix
+0001831: 01                                        ; i32.trunc_u:sat/f32
+0001832: 1a                                        ; drop
+0001833: 0b                                        ; end
+0001829: 0a                                        ; FIXUP func body size
 ; function body 178
-000181f: 00                                        ; func body size (guess)
-0001820: 00                                        ; local decl count
-0001821: 44                                        ; f64.const
-0001822: 0000 0000 0000 f03f                       ; f64 literal
-000182a: fc                                        ; prefix
-000182b: 02                                        ; i32.trunc_s:sat/f64
-000182c: 1a                                        ; drop
-000182d: 0b                                        ; end
-000181f: 0e                                        ; FIXUP func body size
+0001834: 00                                        ; func body size (guess)
+0001835: 00                                        ; local decl count
+0001836: 44                                        ; f64.const
+0001837: 0000 0000 0000 f03f                       ; f64 literal
+000183f: fc                                        ; prefix
+0001840: 02                                        ; i32.trunc_s:sat/f64
+0001841: 1a                                        ; drop
+0001842: 0b                                        ; end
+0001834: 0e                                        ; FIXUP func body size
 ; function body 179
-000182e: 00                                        ; func body size (guess)
-000182f: 00                                        ; local decl count
-0001830: 44                                        ; f64.const
-0001831: 0000 0000 0000 f03f                       ; f64 literal
-0001839: fc                                        ; prefix
-000183a: 03                                        ; i32.trunc_u:sat/f64
-000183b: 1a                                        ; drop
-000183c: 0b                                        ; end
-000182e: 0e                                        ; FIXUP func body size
+0001843: 00                                        ; func body size (guess)
+0001844: 00                                        ; local decl count
+0001845: 44                                        ; f64.const
+0001846: 0000 0000 0000 f03f                       ; f64 literal
+000184e: fc                                        ; prefix
+000184f: 03                                        ; i32.trunc_u:sat/f64
+0001850: 1a                                        ; drop
+0001851: 0b                                        ; end
+0001843: 0e                                        ; FIXUP func body size
 ; function body 180
-000183d: 00                                        ; func body size (guess)
-000183e: 00                                        ; local decl count
-000183f: 43                                        ; f32.const
-0001840: 0000 803f                                 ; f32 literal
-0001844: fc                                        ; prefix
-0001845: 04                                        ; i64.trunc_s:sat/f32
-0001846: 1a                                        ; drop
-0001847: 0b                                        ; end
-000183d: 0a                                        ; FIXUP func body size
+0001852: 00                                        ; func body size (guess)
+0001853: 00                                        ; local decl count
+0001854: 43                                        ; f32.const
+0001855: 0000 803f                                 ; f32 literal
+0001859: fc                                        ; prefix
+000185a: 04                                        ; i64.trunc_s:sat/f32
+000185b: 1a                                        ; drop
+000185c: 0b                                        ; end
+0001852: 0a                                        ; FIXUP func body size
 ; function body 181
-0001848: 00                                        ; func body size (guess)
-0001849: 00                                        ; local decl count
-000184a: 43                                        ; f32.const
-000184b: 0000 803f                                 ; f32 literal
-000184f: fc                                        ; prefix
-0001850: 05                                        ; i64.trunc_u:sat/f32
-0001851: 1a                                        ; drop
-0001852: 0b                                        ; end
-0001848: 0a                                        ; FIXUP func body size
+000185d: 00                                        ; func body size (guess)
+000185e: 00                                        ; local decl count
+000185f: 43                                        ; f32.const
+0001860: 0000 803f                                 ; f32 literal
+0001864: fc                                        ; prefix
+0001865: 05                                        ; i64.trunc_u:sat/f32
+0001866: 1a                                        ; drop
+0001867: 0b                                        ; end
+000185d: 0a                                        ; FIXUP func body size
 ; function body 182
-0001853: 00                                        ; func body size (guess)
-0001854: 00                                        ; local decl count
-0001855: 44                                        ; f64.const
-0001856: 0000 0000 0000 f03f                       ; f64 literal
-000185e: fc                                        ; prefix
-000185f: 06                                        ; i64.trunc_s:sat/f64
-0001860: 1a                                        ; drop
-0001861: 0b                                        ; end
-0001853: 0e                                        ; FIXUP func body size
+0001868: 00                                        ; func body size (guess)
+0001869: 00                                        ; local decl count
+000186a: 44                                        ; f64.const
+000186b: 0000 0000 0000 f03f                       ; f64 literal
+0001873: fc                                        ; prefix
+0001874: 06                                        ; i64.trunc_s:sat/f64
+0001875: 1a                                        ; drop
+0001876: 0b                                        ; end
+0001868: 0e                                        ; FIXUP func body size
 ; function body 183
-0001862: 00                                        ; func body size (guess)
-0001863: 00                                        ; local decl count
-0001864: 44                                        ; f64.const
-0001865: 0000 0000 0000 f03f                       ; f64 literal
-000186d: fc                                        ; prefix
-000186e: 07                                        ; i64.trunc_u:sat/f64
-000186f: 1a                                        ; drop
-0001870: 0b                                        ; end
-0001862: 0e                                        ; FIXUP func body size
+0001877: 00                                        ; func body size (guess)
+0001878: 00                                        ; local decl count
+0001879: 44                                        ; f64.const
+000187a: 0000 0000 0000 f03f                       ; f64 literal
+0001882: fc                                        ; prefix
+0001883: 07                                        ; i64.trunc_u:sat/f64
+0001884: 1a                                        ; drop
+0001885: 0b                                        ; end
+0001877: 0e                                        ; FIXUP func body size
 ; function body 184
-0001871: 00                                        ; func body size (guess)
-0001872: 00                                        ; local decl count
-0001873: 41                                        ; i32.const
-0001874: 01                                        ; i32 literal
-0001875: 41                                        ; i32.const
-0001876: 02                                        ; i32 literal
-0001877: fe                                        ; prefix
-0001878: 00                                        ; wake
-0001879: 02                                        ; alignment
-000187a: 03                                        ; memory offset
-000187b: 1a                                        ; drop
-000187c: 0b                                        ; end
-0001871: 0b                                        ; FIXUP func body size
+0001886: 00                                        ; func body size (guess)
+0001887: 00                                        ; local decl count
+0001888: 41                                        ; i32.const
+0001889: 01                                        ; i32 literal
+000188a: 41                                        ; i32.const
+000188b: 02                                        ; i32 literal
+000188c: fe                                        ; prefix
+000188d: 00                                        ; atomic.wake
+000188e: 02                                        ; alignment
+000188f: 03                                        ; memory offset
+0001890: 1a                                        ; drop
+0001891: 0b                                        ; end
+0001886: 0b                                        ; FIXUP func body size
 ; function body 185
-000187d: 00                                        ; func body size (guess)
-000187e: 00                                        ; local decl count
-000187f: 41                                        ; i32.const
-0001880: 01                                        ; i32 literal
-0001881: 41                                        ; i32.const
-0001882: 02                                        ; i32 literal
-0001883: 42                                        ; i64.const
-0001884: 03                                        ; i64 literal
-0001885: fe                                        ; prefix
-0001886: 01                                        ; i32.wait
-0001887: 02                                        ; alignment
-0001888: 03                                        ; memory offset
-0001889: 1a                                        ; drop
-000188a: 0b                                        ; end
-000187d: 0d                                        ; FIXUP func body size
+0001892: 00                                        ; func body size (guess)
+0001893: 00                                        ; local decl count
+0001894: 41                                        ; i32.const
+0001895: 01                                        ; i32 literal
+0001896: 41                                        ; i32.const
+0001897: 02                                        ; i32 literal
+0001898: 42                                        ; i64.const
+0001899: 03                                        ; i64 literal
+000189a: fe                                        ; prefix
+000189b: 01                                        ; i32.atomic.wait
+000189c: 02                                        ; alignment
+000189d: 03                                        ; memory offset
+000189e: 1a                                        ; drop
+000189f: 0b                                        ; end
+0001892: 0d                                        ; FIXUP func body size
 ; function body 186
-000188b: 00                                        ; func body size (guess)
-000188c: 00                                        ; local decl count
-000188d: 41                                        ; i32.const
-000188e: 01                                        ; i32 literal
-000188f: 42                                        ; i64.const
-0001890: 02                                        ; i64 literal
-0001891: 42                                        ; i64.const
-0001892: 03                                        ; i64 literal
-0001893: fe                                        ; prefix
-0001894: 02                                        ; i64.wait
-0001895: 03                                        ; alignment
-0001896: 03                                        ; memory offset
-0001897: 1a                                        ; drop
-0001898: 0b                                        ; end
-000188b: 0d                                        ; FIXUP func body size
+00018a0: 00                                        ; func body size (guess)
+00018a1: 00                                        ; local decl count
+00018a2: 41                                        ; i32.const
+00018a3: 01                                        ; i32 literal
+00018a4: 42                                        ; i64.const
+00018a5: 02                                        ; i64 literal
+00018a6: 42                                        ; i64.const
+00018a7: 03                                        ; i64 literal
+00018a8: fe                                        ; prefix
+00018a9: 02                                        ; i64.atomic.wait
+00018aa: 03                                        ; alignment
+00018ab: 03                                        ; memory offset
+00018ac: 1a                                        ; drop
+00018ad: 0b                                        ; end
+00018a0: 0d                                        ; FIXUP func body size
 ; function body 187
-0001899: 00                                        ; func body size (guess)
-000189a: 00                                        ; local decl count
-000189b: 41                                        ; i32.const
-000189c: 01                                        ; i32 literal
-000189d: fe                                        ; prefix
-000189e: 10                                        ; i32.atomic.load
-000189f: 02                                        ; alignment
-00018a0: 03                                        ; memory offset
-00018a1: 1a                                        ; drop
-00018a2: 0b                                        ; end
-0001899: 09                                        ; FIXUP func body size
+00018ae: 00                                        ; func body size (guess)
+00018af: 00                                        ; local decl count
+00018b0: 41                                        ; i32.const
+00018b1: 01                                        ; i32 literal
+00018b2: fe                                        ; prefix
+00018b3: 10                                        ; i32.atomic.load
+00018b4: 02                                        ; alignment
+00018b5: 03                                        ; memory offset
+00018b6: 1a                                        ; drop
+00018b7: 0b                                        ; end
+00018ae: 09                                        ; FIXUP func body size
 ; function body 188
-00018a3: 00                                        ; func body size (guess)
-00018a4: 00                                        ; local decl count
-00018a5: 41                                        ; i32.const
-00018a6: 01                                        ; i32 literal
-00018a7: fe                                        ; prefix
-00018a8: 11                                        ; i64.atomic.load
-00018a9: 03                                        ; alignment
-00018aa: 07                                        ; memory offset
-00018ab: 1a                                        ; drop
-00018ac: 0b                                        ; end
-00018a3: 09                                        ; FIXUP func body size
+00018b8: 00                                        ; func body size (guess)
+00018b9: 00                                        ; local decl count
+00018ba: 41                                        ; i32.const
+00018bb: 01                                        ; i32 literal
+00018bc: fe                                        ; prefix
+00018bd: 11                                        ; i64.atomic.load
+00018be: 03                                        ; alignment
+00018bf: 07                                        ; memory offset
+00018c0: 1a                                        ; drop
+00018c1: 0b                                        ; end
+00018b8: 09                                        ; FIXUP func body size
 ; function body 189
-00018ad: 00                                        ; func body size (guess)
-00018ae: 00                                        ; local decl count
-00018af: 41                                        ; i32.const
-00018b0: 01                                        ; i32 literal
-00018b1: fe                                        ; prefix
-00018b2: 12                                        ; i32.atomic.load8_u
-00018b3: 00                                        ; alignment
-00018b4: 03                                        ; memory offset
-00018b5: 1a                                        ; drop
-00018b6: 0b                                        ; end
-00018ad: 09                                        ; FIXUP func body size
+00018c2: 00                                        ; func body size (guess)
+00018c3: 00                                        ; local decl count
+00018c4: 41                                        ; i32.const
+00018c5: 01                                        ; i32 literal
+00018c6: fe                                        ; prefix
+00018c7: 12                                        ; i32.atomic.load8_u
+00018c8: 00                                        ; alignment
+00018c9: 03                                        ; memory offset
+00018ca: 1a                                        ; drop
+00018cb: 0b                                        ; end
+00018c2: 09                                        ; FIXUP func body size
 ; function body 190
-00018b7: 00                                        ; func body size (guess)
-00018b8: 00                                        ; local decl count
-00018b9: 41                                        ; i32.const
-00018ba: 01                                        ; i32 literal
-00018bb: fe                                        ; prefix
-00018bc: 13                                        ; i32.atomic.load16_u
-00018bd: 01                                        ; alignment
-00018be: 03                                        ; memory offset
-00018bf: 1a                                        ; drop
-00018c0: 0b                                        ; end
-00018b7: 09                                        ; FIXUP func body size
+00018cc: 00                                        ; func body size (guess)
+00018cd: 00                                        ; local decl count
+00018ce: 41                                        ; i32.const
+00018cf: 01                                        ; i32 literal
+00018d0: fe                                        ; prefix
+00018d1: 13                                        ; i32.atomic.load16_u
+00018d2: 01                                        ; alignment
+00018d3: 03                                        ; memory offset
+00018d4: 1a                                        ; drop
+00018d5: 0b                                        ; end
+00018cc: 09                                        ; FIXUP func body size
 ; function body 191
-00018c1: 00                                        ; func body size (guess)
-00018c2: 00                                        ; local decl count
-00018c3: 41                                        ; i32.const
-00018c4: 01                                        ; i32 literal
-00018c5: fe                                        ; prefix
-00018c6: 14                                        ; i64.atomic.load8_u
-00018c7: 00                                        ; alignment
-00018c8: 03                                        ; memory offset
-00018c9: 1a                                        ; drop
-00018ca: 0b                                        ; end
-00018c1: 09                                        ; FIXUP func body size
+00018d6: 00                                        ; func body size (guess)
+00018d7: 00                                        ; local decl count
+00018d8: 41                                        ; i32.const
+00018d9: 01                                        ; i32 literal
+00018da: fe                                        ; prefix
+00018db: 14                                        ; i64.atomic.load8_u
+00018dc: 00                                        ; alignment
+00018dd: 03                                        ; memory offset
+00018de: 1a                                        ; drop
+00018df: 0b                                        ; end
+00018d6: 09                                        ; FIXUP func body size
 ; function body 192
-00018cb: 00                                        ; func body size (guess)
-00018cc: 00                                        ; local decl count
-00018cd: 41                                        ; i32.const
-00018ce: 01                                        ; i32 literal
-00018cf: fe                                        ; prefix
-00018d0: 15                                        ; i64.atomic.load16_u
-00018d1: 01                                        ; alignment
-00018d2: 03                                        ; memory offset
-00018d3: 1a                                        ; drop
-00018d4: 0b                                        ; end
-00018cb: 09                                        ; FIXUP func body size
-; function body 193
-00018d5: 00                                        ; func body size (guess)
-00018d6: 00                                        ; local decl count
-00018d7: 41                                        ; i32.const
-00018d8: 01                                        ; i32 literal
-00018d9: fe                                        ; prefix
-00018da: 16                                        ; i64.atomic.load32_u
-00018db: 02                                        ; alignment
-00018dc: 03                                        ; memory offset
-00018dd: 1a                                        ; drop
-00018de: 0b                                        ; end
-00018d5: 09                                        ; FIXUP func body size
-; function body 194
-00018df: 00                                        ; func body size (guess)
-00018e0: 00                                        ; local decl count
-00018e1: 41                                        ; i32.const
-00018e2: 01                                        ; i32 literal
-00018e3: 41                                        ; i32.const
-00018e4: 02                                        ; i32 literal
-00018e5: fe                                        ; prefix
-00018e6: 17                                        ; i32.atomic.store
-00018e7: 02                                        ; alignment
-00018e8: 03                                        ; memory offset
+00018e0: 00                                        ; func body size (guess)
+00018e1: 00                                        ; local decl count
+00018e2: 41                                        ; i32.const
+00018e3: 01                                        ; i32 literal
+00018e4: fe                                        ; prefix
+00018e5: 15                                        ; i64.atomic.load16_u
+00018e6: 01                                        ; alignment
+00018e7: 03                                        ; memory offset
+00018e8: 1a                                        ; drop
 00018e9: 0b                                        ; end
-00018df: 0a                                        ; FIXUP func body size
-; function body 195
+00018e0: 09                                        ; FIXUP func body size
+; function body 193
 00018ea: 00                                        ; func body size (guess)
 00018eb: 00                                        ; local decl count
 00018ec: 41                                        ; i32.const
 00018ed: 01                                        ; i32 literal
-00018ee: 42                                        ; i64.const
-00018ef: 02                                        ; i64 literal
-00018f0: fe                                        ; prefix
-00018f1: 18                                        ; i64.atomic.store
-00018f2: 03                                        ; alignment
-00018f3: 07                                        ; memory offset
-00018f4: 0b                                        ; end
-00018ea: 0a                                        ; FIXUP func body size
+00018ee: fe                                        ; prefix
+00018ef: 16                                        ; i64.atomic.load32_u
+00018f0: 02                                        ; alignment
+00018f1: 03                                        ; memory offset
+00018f2: 1a                                        ; drop
+00018f3: 0b                                        ; end
+00018ea: 09                                        ; FIXUP func body size
+; function body 194
+00018f4: 00                                        ; func body size (guess)
+00018f5: 00                                        ; local decl count
+00018f6: 41                                        ; i32.const
+00018f7: 01                                        ; i32 literal
+00018f8: 41                                        ; i32.const
+00018f9: 02                                        ; i32 literal
+00018fa: fe                                        ; prefix
+00018fb: 17                                        ; i32.atomic.store
+00018fc: 02                                        ; alignment
+00018fd: 03                                        ; memory offset
+00018fe: 0b                                        ; end
+00018f4: 0a                                        ; FIXUP func body size
+; function body 195
+00018ff: 00                                        ; func body size (guess)
+0001900: 00                                        ; local decl count
+0001901: 41                                        ; i32.const
+0001902: 01                                        ; i32 literal
+0001903: 42                                        ; i64.const
+0001904: 02                                        ; i64 literal
+0001905: fe                                        ; prefix
+0001906: 18                                        ; i64.atomic.store
+0001907: 03                                        ; alignment
+0001908: 07                                        ; memory offset
+0001909: 0b                                        ; end
+00018ff: 0a                                        ; FIXUP func body size
 ; function body 196
-00018f5: 00                                        ; func body size (guess)
-00018f6: 00                                        ; local decl count
-00018f7: 41                                        ; i32.const
-00018f8: 01                                        ; i32 literal
-00018f9: 41                                        ; i32.const
-00018fa: 02                                        ; i32 literal
-00018fb: fe                                        ; prefix
-00018fc: 19                                        ; i32.atomic.store8
-00018fd: 00                                        ; alignment
-00018fe: 03                                        ; memory offset
-00018ff: 0b                                        ; end
-00018f5: 0a                                        ; FIXUP func body size
+000190a: 00                                        ; func body size (guess)
+000190b: 00                                        ; local decl count
+000190c: 41                                        ; i32.const
+000190d: 01                                        ; i32 literal
+000190e: 41                                        ; i32.const
+000190f: 02                                        ; i32 literal
+0001910: fe                                        ; prefix
+0001911: 19                                        ; i32.atomic.store8
+0001912: 00                                        ; alignment
+0001913: 03                                        ; memory offset
+0001914: 0b                                        ; end
+000190a: 0a                                        ; FIXUP func body size
 ; function body 197
-0001900: 00                                        ; func body size (guess)
-0001901: 00                                        ; local decl count
-0001902: 41                                        ; i32.const
-0001903: 01                                        ; i32 literal
-0001904: 41                                        ; i32.const
-0001905: 02                                        ; i32 literal
-0001906: fe                                        ; prefix
-0001907: 1a                                        ; i32.atomic.store16
-0001908: 01                                        ; alignment
-0001909: 03                                        ; memory offset
-000190a: 0b                                        ; end
-0001900: 0a                                        ; FIXUP func body size
+0001915: 00                                        ; func body size (guess)
+0001916: 00                                        ; local decl count
+0001917: 41                                        ; i32.const
+0001918: 01                                        ; i32 literal
+0001919: 41                                        ; i32.const
+000191a: 02                                        ; i32 literal
+000191b: fe                                        ; prefix
+000191c: 1a                                        ; i32.atomic.store16
+000191d: 01                                        ; alignment
+000191e: 03                                        ; memory offset
+000191f: 0b                                        ; end
+0001915: 0a                                        ; FIXUP func body size
 ; function body 198
-000190b: 00                                        ; func body size (guess)
-000190c: 00                                        ; local decl count
-000190d: 41                                        ; i32.const
-000190e: 01                                        ; i32 literal
-000190f: 42                                        ; i64.const
-0001910: 02                                        ; i64 literal
-0001911: fe                                        ; prefix
-0001912: 1b                                        ; i64.atomic.store8
-0001913: 00                                        ; alignment
-0001914: 03                                        ; memory offset
-0001915: 0b                                        ; end
-000190b: 0a                                        ; FIXUP func body size
+0001920: 00                                        ; func body size (guess)
+0001921: 00                                        ; local decl count
+0001922: 41                                        ; i32.const
+0001923: 01                                        ; i32 literal
+0001924: 42                                        ; i64.const
+0001925: 02                                        ; i64 literal
+0001926: fe                                        ; prefix
+0001927: 1b                                        ; i64.atomic.store8
+0001928: 00                                        ; alignment
+0001929: 03                                        ; memory offset
+000192a: 0b                                        ; end
+0001920: 0a                                        ; FIXUP func body size
 ; function body 199
-0001916: 00                                        ; func body size (guess)
-0001917: 00                                        ; local decl count
-0001918: 41                                        ; i32.const
-0001919: 01                                        ; i32 literal
-000191a: 42                                        ; i64.const
-000191b: 02                                        ; i64 literal
-000191c: fe                                        ; prefix
-000191d: 1c                                        ; i64.atomic.store16
-000191e: 01                                        ; alignment
-000191f: 03                                        ; memory offset
-0001920: 0b                                        ; end
-0001916: 0a                                        ; FIXUP func body size
+000192b: 00                                        ; func body size (guess)
+000192c: 00                                        ; local decl count
+000192d: 41                                        ; i32.const
+000192e: 01                                        ; i32 literal
+000192f: 42                                        ; i64.const
+0001930: 02                                        ; i64 literal
+0001931: fe                                        ; prefix
+0001932: 1c                                        ; i64.atomic.store16
+0001933: 01                                        ; alignment
+0001934: 03                                        ; memory offset
+0001935: 0b                                        ; end
+000192b: 0a                                        ; FIXUP func body size
 ; function body 200
-0001921: 00                                        ; func body size (guess)
-0001922: 00                                        ; local decl count
-0001923: 41                                        ; i32.const
-0001924: 01                                        ; i32 literal
-0001925: 42                                        ; i64.const
-0001926: 02                                        ; i64 literal
-0001927: fe                                        ; prefix
-0001928: 1d                                        ; i64.atomic.store32
-0001929: 02                                        ; alignment
-000192a: 03                                        ; memory offset
-000192b: 0b                                        ; end
-0001921: 0a                                        ; FIXUP func body size
+0001936: 00                                        ; func body size (guess)
+0001937: 00                                        ; local decl count
+0001938: 41                                        ; i32.const
+0001939: 01                                        ; i32 literal
+000193a: 42                                        ; i64.const
+000193b: 02                                        ; i64 literal
+000193c: fe                                        ; prefix
+000193d: 1d                                        ; i64.atomic.store32
+000193e: 02                                        ; alignment
+000193f: 03                                        ; memory offset
+0001940: 0b                                        ; end
+0001936: 0a                                        ; FIXUP func body size
 ; function body 201
-000192c: 00                                        ; func body size (guess)
-000192d: 00                                        ; local decl count
-000192e: 41                                        ; i32.const
-000192f: 01                                        ; i32 literal
-0001930: 41                                        ; i32.const
-0001931: 02                                        ; i32 literal
-0001932: fe                                        ; prefix
-0001933: 1e                                        ; i32.atomic.rmw.add
-0001934: 02                                        ; alignment
-0001935: 03                                        ; memory offset
-0001936: 1a                                        ; drop
-0001937: 0b                                        ; end
-000192c: 0b                                        ; FIXUP func body size
+0001941: 00                                        ; func body size (guess)
+0001942: 00                                        ; local decl count
+0001943: 41                                        ; i32.const
+0001944: 01                                        ; i32 literal
+0001945: 41                                        ; i32.const
+0001946: 02                                        ; i32 literal
+0001947: fe                                        ; prefix
+0001948: 1e                                        ; i32.atomic.rmw.add
+0001949: 02                                        ; alignment
+000194a: 03                                        ; memory offset
+000194b: 1a                                        ; drop
+000194c: 0b                                        ; end
+0001941: 0b                                        ; FIXUP func body size
 ; function body 202
-0001938: 00                                        ; func body size (guess)
-0001939: 00                                        ; local decl count
-000193a: 41                                        ; i32.const
-000193b: 01                                        ; i32 literal
-000193c: 42                                        ; i64.const
-000193d: 02                                        ; i64 literal
-000193e: fe                                        ; prefix
-000193f: 1f                                        ; i64.atomic.rmw.add
-0001940: 03                                        ; alignment
-0001941: 07                                        ; memory offset
-0001942: 1a                                        ; drop
-0001943: 0b                                        ; end
-0001938: 0b                                        ; FIXUP func body size
+000194d: 00                                        ; func body size (guess)
+000194e: 00                                        ; local decl count
+000194f: 41                                        ; i32.const
+0001950: 01                                        ; i32 literal
+0001951: 42                                        ; i64.const
+0001952: 02                                        ; i64 literal
+0001953: fe                                        ; prefix
+0001954: 1f                                        ; i64.atomic.rmw.add
+0001955: 03                                        ; alignment
+0001956: 07                                        ; memory offset
+0001957: 1a                                        ; drop
+0001958: 0b                                        ; end
+000194d: 0b                                        ; FIXUP func body size
 ; function body 203
-0001944: 00                                        ; func body size (guess)
-0001945: 00                                        ; local decl count
-0001946: 41                                        ; i32.const
-0001947: 01                                        ; i32 literal
-0001948: 41                                        ; i32.const
-0001949: 02                                        ; i32 literal
-000194a: fe                                        ; prefix
-000194b: 20                                        ; i32.atomic.rmw8_u.add
-000194c: 00                                        ; alignment
-000194d: 03                                        ; memory offset
-000194e: 1a                                        ; drop
-000194f: 0b                                        ; end
-0001944: 0b                                        ; FIXUP func body size
+0001959: 00                                        ; func body size (guess)
+000195a: 00                                        ; local decl count
+000195b: 41                                        ; i32.const
+000195c: 01                                        ; i32 literal
+000195d: 41                                        ; i32.const
+000195e: 02                                        ; i32 literal
+000195f: fe                                        ; prefix
+0001960: 20                                        ; i32.atomic.rmw8_u.add
+0001961: 00                                        ; alignment
+0001962: 03                                        ; memory offset
+0001963: 1a                                        ; drop
+0001964: 0b                                        ; end
+0001959: 0b                                        ; FIXUP func body size
 ; function body 204
-0001950: 00                                        ; func body size (guess)
-0001951: 00                                        ; local decl count
-0001952: 41                                        ; i32.const
-0001953: 01                                        ; i32 literal
-0001954: 41                                        ; i32.const
-0001955: 02                                        ; i32 literal
-0001956: fe                                        ; prefix
-0001957: 21                                        ; i32.atomic.rmw16_u.add
-0001958: 01                                        ; alignment
-0001959: 03                                        ; memory offset
-000195a: 1a                                        ; drop
-000195b: 0b                                        ; end
-0001950: 0b                                        ; FIXUP func body size
+0001965: 00                                        ; func body size (guess)
+0001966: 00                                        ; local decl count
+0001967: 41                                        ; i32.const
+0001968: 01                                        ; i32 literal
+0001969: 41                                        ; i32.const
+000196a: 02                                        ; i32 literal
+000196b: fe                                        ; prefix
+000196c: 21                                        ; i32.atomic.rmw16_u.add
+000196d: 01                                        ; alignment
+000196e: 03                                        ; memory offset
+000196f: 1a                                        ; drop
+0001970: 0b                                        ; end
+0001965: 0b                                        ; FIXUP func body size
 ; function body 205
-000195c: 00                                        ; func body size (guess)
-000195d: 00                                        ; local decl count
-000195e: 41                                        ; i32.const
-000195f: 01                                        ; i32 literal
-0001960: 42                                        ; i64.const
-0001961: 02                                        ; i64 literal
-0001962: fe                                        ; prefix
-0001963: 22                                        ; i64.atomic.rmw8_u.add
-0001964: 00                                        ; alignment
-0001965: 03                                        ; memory offset
-0001966: 1a                                        ; drop
-0001967: 0b                                        ; end
-000195c: 0b                                        ; FIXUP func body size
+0001971: 00                                        ; func body size (guess)
+0001972: 00                                        ; local decl count
+0001973: 41                                        ; i32.const
+0001974: 01                                        ; i32 literal
+0001975: 42                                        ; i64.const
+0001976: 02                                        ; i64 literal
+0001977: fe                                        ; prefix
+0001978: 22                                        ; i64.atomic.rmw8_u.add
+0001979: 00                                        ; alignment
+000197a: 03                                        ; memory offset
+000197b: 1a                                        ; drop
+000197c: 0b                                        ; end
+0001971: 0b                                        ; FIXUP func body size
 ; function body 206
-0001968: 00                                        ; func body size (guess)
-0001969: 00                                        ; local decl count
-000196a: 41                                        ; i32.const
-000196b: 01                                        ; i32 literal
-000196c: 42                                        ; i64.const
-000196d: 02                                        ; i64 literal
-000196e: fe                                        ; prefix
-000196f: 23                                        ; i64.atomic.rmw16_u.add
-0001970: 01                                        ; alignment
-0001971: 03                                        ; memory offset
-0001972: 1a                                        ; drop
-0001973: 0b                                        ; end
-0001968: 0b                                        ; FIXUP func body size
+000197d: 00                                        ; func body size (guess)
+000197e: 00                                        ; local decl count
+000197f: 41                                        ; i32.const
+0001980: 01                                        ; i32 literal
+0001981: 42                                        ; i64.const
+0001982: 02                                        ; i64 literal
+0001983: fe                                        ; prefix
+0001984: 23                                        ; i64.atomic.rmw16_u.add
+0001985: 01                                        ; alignment
+0001986: 03                                        ; memory offset
+0001987: 1a                                        ; drop
+0001988: 0b                                        ; end
+000197d: 0b                                        ; FIXUP func body size
 ; function body 207
-0001974: 00                                        ; func body size (guess)
-0001975: 00                                        ; local decl count
-0001976: 41                                        ; i32.const
-0001977: 01                                        ; i32 literal
-0001978: 42                                        ; i64.const
-0001979: 02                                        ; i64 literal
-000197a: fe                                        ; prefix
-000197b: 24                                        ; i64.atomic.rmw32_u.add
-000197c: 02                                        ; alignment
-000197d: 03                                        ; memory offset
-000197e: 1a                                        ; drop
-000197f: 0b                                        ; end
-0001974: 0b                                        ; FIXUP func body size
+0001989: 00                                        ; func body size (guess)
+000198a: 00                                        ; local decl count
+000198b: 41                                        ; i32.const
+000198c: 01                                        ; i32 literal
+000198d: 42                                        ; i64.const
+000198e: 02                                        ; i64 literal
+000198f: fe                                        ; prefix
+0001990: 24                                        ; i64.atomic.rmw32_u.add
+0001991: 02                                        ; alignment
+0001992: 03                                        ; memory offset
+0001993: 1a                                        ; drop
+0001994: 0b                                        ; end
+0001989: 0b                                        ; FIXUP func body size
 ; function body 208
-0001980: 00                                        ; func body size (guess)
-0001981: 00                                        ; local decl count
-0001982: 41                                        ; i32.const
-0001983: 01                                        ; i32 literal
-0001984: 41                                        ; i32.const
-0001985: 02                                        ; i32 literal
-0001986: fe                                        ; prefix
-0001987: 25                                        ; i32.atomic.rmw.sub
-0001988: 02                                        ; alignment
-0001989: 03                                        ; memory offset
-000198a: 1a                                        ; drop
-000198b: 0b                                        ; end
-0001980: 0b                                        ; FIXUP func body size
+0001995: 00                                        ; func body size (guess)
+0001996: 00                                        ; local decl count
+0001997: 41                                        ; i32.const
+0001998: 01                                        ; i32 literal
+0001999: 41                                        ; i32.const
+000199a: 02                                        ; i32 literal
+000199b: fe                                        ; prefix
+000199c: 25                                        ; i32.atomic.rmw.sub
+000199d: 02                                        ; alignment
+000199e: 03                                        ; memory offset
+000199f: 1a                                        ; drop
+00019a0: 0b                                        ; end
+0001995: 0b                                        ; FIXUP func body size
 ; function body 209
-000198c: 00                                        ; func body size (guess)
-000198d: 00                                        ; local decl count
-000198e: 41                                        ; i32.const
-000198f: 01                                        ; i32 literal
-0001990: 42                                        ; i64.const
-0001991: 02                                        ; i64 literal
-0001992: fe                                        ; prefix
-0001993: 26                                        ; i64.atomic.rmw.sub
-0001994: 03                                        ; alignment
-0001995: 07                                        ; memory offset
-0001996: 1a                                        ; drop
-0001997: 0b                                        ; end
-000198c: 0b                                        ; FIXUP func body size
+00019a1: 00                                        ; func body size (guess)
+00019a2: 00                                        ; local decl count
+00019a3: 41                                        ; i32.const
+00019a4: 01                                        ; i32 literal
+00019a5: 42                                        ; i64.const
+00019a6: 02                                        ; i64 literal
+00019a7: fe                                        ; prefix
+00019a8: 26                                        ; i64.atomic.rmw.sub
+00019a9: 03                                        ; alignment
+00019aa: 07                                        ; memory offset
+00019ab: 1a                                        ; drop
+00019ac: 0b                                        ; end
+00019a1: 0b                                        ; FIXUP func body size
 ; function body 210
-0001998: 00                                        ; func body size (guess)
-0001999: 00                                        ; local decl count
-000199a: 41                                        ; i32.const
-000199b: 01                                        ; i32 literal
-000199c: 41                                        ; i32.const
-000199d: 02                                        ; i32 literal
-000199e: fe                                        ; prefix
-000199f: 27                                        ; i32.atomic.rmw8_u.sub
-00019a0: 00                                        ; alignment
-00019a1: 03                                        ; memory offset
-00019a2: 1a                                        ; drop
-00019a3: 0b                                        ; end
-0001998: 0b                                        ; FIXUP func body size
+00019ad: 00                                        ; func body size (guess)
+00019ae: 00                                        ; local decl count
+00019af: 41                                        ; i32.const
+00019b0: 01                                        ; i32 literal
+00019b1: 41                                        ; i32.const
+00019b2: 02                                        ; i32 literal
+00019b3: fe                                        ; prefix
+00019b4: 27                                        ; i32.atomic.rmw8_u.sub
+00019b5: 00                                        ; alignment
+00019b6: 03                                        ; memory offset
+00019b7: 1a                                        ; drop
+00019b8: 0b                                        ; end
+00019ad: 0b                                        ; FIXUP func body size
 ; function body 211
-00019a4: 00                                        ; func body size (guess)
-00019a5: 00                                        ; local decl count
-00019a6: 41                                        ; i32.const
-00019a7: 01                                        ; i32 literal
-00019a8: 41                                        ; i32.const
-00019a9: 02                                        ; i32 literal
-00019aa: fe                                        ; prefix
-00019ab: 28                                        ; i32.atomic.rmw16_u.sub
-00019ac: 01                                        ; alignment
-00019ad: 03                                        ; memory offset
-00019ae: 1a                                        ; drop
-00019af: 0b                                        ; end
-00019a4: 0b                                        ; FIXUP func body size
+00019b9: 00                                        ; func body size (guess)
+00019ba: 00                                        ; local decl count
+00019bb: 41                                        ; i32.const
+00019bc: 01                                        ; i32 literal
+00019bd: 41                                        ; i32.const
+00019be: 02                                        ; i32 literal
+00019bf: fe                                        ; prefix
+00019c0: 28                                        ; i32.atomic.rmw16_u.sub
+00019c1: 01                                        ; alignment
+00019c2: 03                                        ; memory offset
+00019c3: 1a                                        ; drop
+00019c4: 0b                                        ; end
+00019b9: 0b                                        ; FIXUP func body size
 ; function body 212
-00019b0: 00                                        ; func body size (guess)
-00019b1: 00                                        ; local decl count
-00019b2: 41                                        ; i32.const
-00019b3: 01                                        ; i32 literal
-00019b4: 42                                        ; i64.const
-00019b5: 02                                        ; i64 literal
-00019b6: fe                                        ; prefix
-00019b7: 29                                        ; i64.atomic.rmw8_u.sub
-00019b8: 00                                        ; alignment
-00019b9: 03                                        ; memory offset
-00019ba: 1a                                        ; drop
-00019bb: 0b                                        ; end
-00019b0: 0b                                        ; FIXUP func body size
+00019c5: 00                                        ; func body size (guess)
+00019c6: 00                                        ; local decl count
+00019c7: 41                                        ; i32.const
+00019c8: 01                                        ; i32 literal
+00019c9: 42                                        ; i64.const
+00019ca: 02                                        ; i64 literal
+00019cb: fe                                        ; prefix
+00019cc: 29                                        ; i64.atomic.rmw8_u.sub
+00019cd: 00                                        ; alignment
+00019ce: 03                                        ; memory offset
+00019cf: 1a                                        ; drop
+00019d0: 0b                                        ; end
+00019c5: 0b                                        ; FIXUP func body size
 ; function body 213
-00019bc: 00                                        ; func body size (guess)
-00019bd: 00                                        ; local decl count
-00019be: 41                                        ; i32.const
-00019bf: 01                                        ; i32 literal
-00019c0: 42                                        ; i64.const
-00019c1: 02                                        ; i64 literal
-00019c2: fe                                        ; prefix
-00019c3: 2a                                        ; i64.atomic.rmw16_u.sub
-00019c4: 01                                        ; alignment
-00019c5: 03                                        ; memory offset
-00019c6: 1a                                        ; drop
-00019c7: 0b                                        ; end
-00019bc: 0b                                        ; FIXUP func body size
+00019d1: 00                                        ; func body size (guess)
+00019d2: 00                                        ; local decl count
+00019d3: 41                                        ; i32.const
+00019d4: 01                                        ; i32 literal
+00019d5: 42                                        ; i64.const
+00019d6: 02                                        ; i64 literal
+00019d7: fe                                        ; prefix
+00019d8: 2a                                        ; i64.atomic.rmw16_u.sub
+00019d9: 01                                        ; alignment
+00019da: 03                                        ; memory offset
+00019db: 1a                                        ; drop
+00019dc: 0b                                        ; end
+00019d1: 0b                                        ; FIXUP func body size
 ; function body 214
-00019c8: 00                                        ; func body size (guess)
-00019c9: 00                                        ; local decl count
-00019ca: 41                                        ; i32.const
-00019cb: 01                                        ; i32 literal
-00019cc: 42                                        ; i64.const
-00019cd: 02                                        ; i64 literal
-00019ce: fe                                        ; prefix
-00019cf: 2b                                        ; i64.atomic.rmw32_u.sub
-00019d0: 02                                        ; alignment
-00019d1: 03                                        ; memory offset
-00019d2: 1a                                        ; drop
-00019d3: 0b                                        ; end
-00019c8: 0b                                        ; FIXUP func body size
+00019dd: 00                                        ; func body size (guess)
+00019de: 00                                        ; local decl count
+00019df: 41                                        ; i32.const
+00019e0: 01                                        ; i32 literal
+00019e1: 42                                        ; i64.const
+00019e2: 02                                        ; i64 literal
+00019e3: fe                                        ; prefix
+00019e4: 2b                                        ; i64.atomic.rmw32_u.sub
+00019e5: 02                                        ; alignment
+00019e6: 03                                        ; memory offset
+00019e7: 1a                                        ; drop
+00019e8: 0b                                        ; end
+00019dd: 0b                                        ; FIXUP func body size
 ; function body 215
-00019d4: 00                                        ; func body size (guess)
-00019d5: 00                                        ; local decl count
-00019d6: 41                                        ; i32.const
-00019d7: 01                                        ; i32 literal
-00019d8: 41                                        ; i32.const
-00019d9: 02                                        ; i32 literal
-00019da: fe                                        ; prefix
-00019db: 2c                                        ; i32.atomic.rmw.and
-00019dc: 02                                        ; alignment
-00019dd: 03                                        ; memory offset
-00019de: 1a                                        ; drop
-00019df: 0b                                        ; end
-00019d4: 0b                                        ; FIXUP func body size
+00019e9: 00                                        ; func body size (guess)
+00019ea: 00                                        ; local decl count
+00019eb: 41                                        ; i32.const
+00019ec: 01                                        ; i32 literal
+00019ed: 41                                        ; i32.const
+00019ee: 02                                        ; i32 literal
+00019ef: fe                                        ; prefix
+00019f0: 2c                                        ; i32.atomic.rmw.and
+00019f1: 02                                        ; alignment
+00019f2: 03                                        ; memory offset
+00019f3: 1a                                        ; drop
+00019f4: 0b                                        ; end
+00019e9: 0b                                        ; FIXUP func body size
 ; function body 216
-00019e0: 00                                        ; func body size (guess)
-00019e1: 00                                        ; local decl count
-00019e2: 41                                        ; i32.const
-00019e3: 01                                        ; i32 literal
-00019e4: 42                                        ; i64.const
-00019e5: 02                                        ; i64 literal
-00019e6: fe                                        ; prefix
-00019e7: 2d                                        ; i64.atomic.rmw.and
-00019e8: 03                                        ; alignment
-00019e9: 07                                        ; memory offset
-00019ea: 1a                                        ; drop
-00019eb: 0b                                        ; end
-00019e0: 0b                                        ; FIXUP func body size
+00019f5: 00                                        ; func body size (guess)
+00019f6: 00                                        ; local decl count
+00019f7: 41                                        ; i32.const
+00019f8: 01                                        ; i32 literal
+00019f9: 42                                        ; i64.const
+00019fa: 02                                        ; i64 literal
+00019fb: fe                                        ; prefix
+00019fc: 2d                                        ; i64.atomic.rmw.and
+00019fd: 03                                        ; alignment
+00019fe: 07                                        ; memory offset
+00019ff: 1a                                        ; drop
+0001a00: 0b                                        ; end
+00019f5: 0b                                        ; FIXUP func body size
 ; function body 217
-00019ec: 00                                        ; func body size (guess)
-00019ed: 00                                        ; local decl count
-00019ee: 41                                        ; i32.const
-00019ef: 01                                        ; i32 literal
-00019f0: 41                                        ; i32.const
-00019f1: 02                                        ; i32 literal
-00019f2: fe                                        ; prefix
-00019f3: 2e                                        ; i32.atomic.rmw8_u.and
-00019f4: 00                                        ; alignment
-00019f5: 03                                        ; memory offset
-00019f6: 1a                                        ; drop
-00019f7: 0b                                        ; end
-00019ec: 0b                                        ; FIXUP func body size
+0001a01: 00                                        ; func body size (guess)
+0001a02: 00                                        ; local decl count
+0001a03: 41                                        ; i32.const
+0001a04: 01                                        ; i32 literal
+0001a05: 41                                        ; i32.const
+0001a06: 02                                        ; i32 literal
+0001a07: fe                                        ; prefix
+0001a08: 2e                                        ; i32.atomic.rmw8_u.and
+0001a09: 00                                        ; alignment
+0001a0a: 03                                        ; memory offset
+0001a0b: 1a                                        ; drop
+0001a0c: 0b                                        ; end
+0001a01: 0b                                        ; FIXUP func body size
 ; function body 218
-00019f8: 00                                        ; func body size (guess)
-00019f9: 00                                        ; local decl count
-00019fa: 41                                        ; i32.const
-00019fb: 01                                        ; i32 literal
-00019fc: 41                                        ; i32.const
-00019fd: 02                                        ; i32 literal
-00019fe: fe                                        ; prefix
-00019ff: 2f                                        ; i32.atomic.rmw16_u.and
-0001a00: 01                                        ; alignment
-0001a01: 03                                        ; memory offset
-0001a02: 1a                                        ; drop
-0001a03: 0b                                        ; end
-00019f8: 0b                                        ; FIXUP func body size
+0001a0d: 00                                        ; func body size (guess)
+0001a0e: 00                                        ; local decl count
+0001a0f: 41                                        ; i32.const
+0001a10: 01                                        ; i32 literal
+0001a11: 41                                        ; i32.const
+0001a12: 02                                        ; i32 literal
+0001a13: fe                                        ; prefix
+0001a14: 2f                                        ; i32.atomic.rmw16_u.and
+0001a15: 01                                        ; alignment
+0001a16: 03                                        ; memory offset
+0001a17: 1a                                        ; drop
+0001a18: 0b                                        ; end
+0001a0d: 0b                                        ; FIXUP func body size
 ; function body 219
-0001a04: 00                                        ; func body size (guess)
-0001a05: 00                                        ; local decl count
-0001a06: 41                                        ; i32.const
-0001a07: 01                                        ; i32 literal
-0001a08: 42                                        ; i64.const
-0001a09: 02                                        ; i64 literal
-0001a0a: fe                                        ; prefix
-0001a0b: 30                                        ; i64.atomic.rmw8_u.and
-0001a0c: 00                                        ; alignment
-0001a0d: 03                                        ; memory offset
-0001a0e: 1a                                        ; drop
-0001a0f: 0b                                        ; end
-0001a04: 0b                                        ; FIXUP func body size
+0001a19: 00                                        ; func body size (guess)
+0001a1a: 00                                        ; local decl count
+0001a1b: 41                                        ; i32.const
+0001a1c: 01                                        ; i32 literal
+0001a1d: 42                                        ; i64.const
+0001a1e: 02                                        ; i64 literal
+0001a1f: fe                                        ; prefix
+0001a20: 30                                        ; i64.atomic.rmw8_u.and
+0001a21: 00                                        ; alignment
+0001a22: 03                                        ; memory offset
+0001a23: 1a                                        ; drop
+0001a24: 0b                                        ; end
+0001a19: 0b                                        ; FIXUP func body size
 ; function body 220
-0001a10: 00                                        ; func body size (guess)
-0001a11: 00                                        ; local decl count
-0001a12: 41                                        ; i32.const
-0001a13: 01                                        ; i32 literal
-0001a14: 42                                        ; i64.const
-0001a15: 02                                        ; i64 literal
-0001a16: fe                                        ; prefix
-0001a17: 31                                        ; i64.atomic.rmw16_u.and
-0001a18: 01                                        ; alignment
-0001a19: 03                                        ; memory offset
-0001a1a: 1a                                        ; drop
-0001a1b: 0b                                        ; end
-0001a10: 0b                                        ; FIXUP func body size
+0001a25: 00                                        ; func body size (guess)
+0001a26: 00                                        ; local decl count
+0001a27: 41                                        ; i32.const
+0001a28: 01                                        ; i32 literal
+0001a29: 42                                        ; i64.const
+0001a2a: 02                                        ; i64 literal
+0001a2b: fe                                        ; prefix
+0001a2c: 31                                        ; i64.atomic.rmw16_u.and
+0001a2d: 01                                        ; alignment
+0001a2e: 03                                        ; memory offset
+0001a2f: 1a                                        ; drop
+0001a30: 0b                                        ; end
+0001a25: 0b                                        ; FIXUP func body size
 ; function body 221
-0001a1c: 00                                        ; func body size (guess)
-0001a1d: 00                                        ; local decl count
-0001a1e: 41                                        ; i32.const
-0001a1f: 01                                        ; i32 literal
-0001a20: 42                                        ; i64.const
-0001a21: 02                                        ; i64 literal
-0001a22: fe                                        ; prefix
-0001a23: 32                                        ; i64.atomic.rmw32_u.and
-0001a24: 02                                        ; alignment
-0001a25: 03                                        ; memory offset
-0001a26: 1a                                        ; drop
-0001a27: 0b                                        ; end
-0001a1c: 0b                                        ; FIXUP func body size
+0001a31: 00                                        ; func body size (guess)
+0001a32: 00                                        ; local decl count
+0001a33: 41                                        ; i32.const
+0001a34: 01                                        ; i32 literal
+0001a35: 42                                        ; i64.const
+0001a36: 02                                        ; i64 literal
+0001a37: fe                                        ; prefix
+0001a38: 32                                        ; i64.atomic.rmw32_u.and
+0001a39: 02                                        ; alignment
+0001a3a: 03                                        ; memory offset
+0001a3b: 1a                                        ; drop
+0001a3c: 0b                                        ; end
+0001a31: 0b                                        ; FIXUP func body size
 ; function body 222
-0001a28: 00                                        ; func body size (guess)
-0001a29: 00                                        ; local decl count
-0001a2a: 41                                        ; i32.const
-0001a2b: 01                                        ; i32 literal
-0001a2c: 41                                        ; i32.const
-0001a2d: 02                                        ; i32 literal
-0001a2e: fe                                        ; prefix
-0001a2f: 33                                        ; i32.atomic.rmw.or
-0001a30: 02                                        ; alignment
-0001a31: 03                                        ; memory offset
-0001a32: 1a                                        ; drop
-0001a33: 0b                                        ; end
-0001a28: 0b                                        ; FIXUP func body size
+0001a3d: 00                                        ; func body size (guess)
+0001a3e: 00                                        ; local decl count
+0001a3f: 41                                        ; i32.const
+0001a40: 01                                        ; i32 literal
+0001a41: 41                                        ; i32.const
+0001a42: 02                                        ; i32 literal
+0001a43: fe                                        ; prefix
+0001a44: 33                                        ; i32.atomic.rmw.or
+0001a45: 02                                        ; alignment
+0001a46: 03                                        ; memory offset
+0001a47: 1a                                        ; drop
+0001a48: 0b                                        ; end
+0001a3d: 0b                                        ; FIXUP func body size
 ; function body 223
-0001a34: 00                                        ; func body size (guess)
-0001a35: 00                                        ; local decl count
-0001a36: 41                                        ; i32.const
-0001a37: 01                                        ; i32 literal
-0001a38: 42                                        ; i64.const
-0001a39: 02                                        ; i64 literal
-0001a3a: fe                                        ; prefix
-0001a3b: 34                                        ; i64.atomic.rmw.or
-0001a3c: 03                                        ; alignment
-0001a3d: 07                                        ; memory offset
-0001a3e: 1a                                        ; drop
-0001a3f: 0b                                        ; end
-0001a34: 0b                                        ; FIXUP func body size
+0001a49: 00                                        ; func body size (guess)
+0001a4a: 00                                        ; local decl count
+0001a4b: 41                                        ; i32.const
+0001a4c: 01                                        ; i32 literal
+0001a4d: 42                                        ; i64.const
+0001a4e: 02                                        ; i64 literal
+0001a4f: fe                                        ; prefix
+0001a50: 34                                        ; i64.atomic.rmw.or
+0001a51: 03                                        ; alignment
+0001a52: 07                                        ; memory offset
+0001a53: 1a                                        ; drop
+0001a54: 0b                                        ; end
+0001a49: 0b                                        ; FIXUP func body size
 ; function body 224
-0001a40: 00                                        ; func body size (guess)
-0001a41: 00                                        ; local decl count
-0001a42: 41                                        ; i32.const
-0001a43: 01                                        ; i32 literal
-0001a44: 41                                        ; i32.const
-0001a45: 02                                        ; i32 literal
-0001a46: fe                                        ; prefix
-0001a47: 35                                        ; i32.atomic.rmw8_u.or
-0001a48: 00                                        ; alignment
-0001a49: 03                                        ; memory offset
-0001a4a: 1a                                        ; drop
-0001a4b: 0b                                        ; end
-0001a40: 0b                                        ; FIXUP func body size
+0001a55: 00                                        ; func body size (guess)
+0001a56: 00                                        ; local decl count
+0001a57: 41                                        ; i32.const
+0001a58: 01                                        ; i32 literal
+0001a59: 41                                        ; i32.const
+0001a5a: 02                                        ; i32 literal
+0001a5b: fe                                        ; prefix
+0001a5c: 35                                        ; i32.atomic.rmw8_u.or
+0001a5d: 00                                        ; alignment
+0001a5e: 03                                        ; memory offset
+0001a5f: 1a                                        ; drop
+0001a60: 0b                                        ; end
+0001a55: 0b                                        ; FIXUP func body size
 ; function body 225
-0001a4c: 00                                        ; func body size (guess)
-0001a4d: 00                                        ; local decl count
-0001a4e: 41                                        ; i32.const
-0001a4f: 01                                        ; i32 literal
-0001a50: 41                                        ; i32.const
-0001a51: 02                                        ; i32 literal
-0001a52: fe                                        ; prefix
-0001a53: 36                                        ; i32.atomic.rmw16_u.or
-0001a54: 01                                        ; alignment
-0001a55: 03                                        ; memory offset
-0001a56: 1a                                        ; drop
-0001a57: 0b                                        ; end
-0001a4c: 0b                                        ; FIXUP func body size
+0001a61: 00                                        ; func body size (guess)
+0001a62: 00                                        ; local decl count
+0001a63: 41                                        ; i32.const
+0001a64: 01                                        ; i32 literal
+0001a65: 41                                        ; i32.const
+0001a66: 02                                        ; i32 literal
+0001a67: fe                                        ; prefix
+0001a68: 36                                        ; i32.atomic.rmw16_u.or
+0001a69: 01                                        ; alignment
+0001a6a: 03                                        ; memory offset
+0001a6b: 1a                                        ; drop
+0001a6c: 0b                                        ; end
+0001a61: 0b                                        ; FIXUP func body size
 ; function body 226
-0001a58: 00                                        ; func body size (guess)
-0001a59: 00                                        ; local decl count
-0001a5a: 41                                        ; i32.const
-0001a5b: 01                                        ; i32 literal
-0001a5c: 42                                        ; i64.const
-0001a5d: 02                                        ; i64 literal
-0001a5e: fe                                        ; prefix
-0001a5f: 37                                        ; i64.atomic.rmw8_u.or
-0001a60: 00                                        ; alignment
-0001a61: 03                                        ; memory offset
-0001a62: 1a                                        ; drop
-0001a63: 0b                                        ; end
-0001a58: 0b                                        ; FIXUP func body size
+0001a6d: 00                                        ; func body size (guess)
+0001a6e: 00                                        ; local decl count
+0001a6f: 41                                        ; i32.const
+0001a70: 01                                        ; i32 literal
+0001a71: 42                                        ; i64.const
+0001a72: 02                                        ; i64 literal
+0001a73: fe                                        ; prefix
+0001a74: 37                                        ; i64.atomic.rmw8_u.or
+0001a75: 00                                        ; alignment
+0001a76: 03                                        ; memory offset
+0001a77: 1a                                        ; drop
+0001a78: 0b                                        ; end
+0001a6d: 0b                                        ; FIXUP func body size
 ; function body 227
-0001a64: 00                                        ; func body size (guess)
-0001a65: 00                                        ; local decl count
-0001a66: 41                                        ; i32.const
-0001a67: 01                                        ; i32 literal
-0001a68: 42                                        ; i64.const
-0001a69: 02                                        ; i64 literal
-0001a6a: fe                                        ; prefix
-0001a6b: 38                                        ; i64.atomic.rmw16_u.or
-0001a6c: 01                                        ; alignment
-0001a6d: 03                                        ; memory offset
-0001a6e: 1a                                        ; drop
-0001a6f: 0b                                        ; end
-0001a64: 0b                                        ; FIXUP func body size
+0001a79: 00                                        ; func body size (guess)
+0001a7a: 00                                        ; local decl count
+0001a7b: 41                                        ; i32.const
+0001a7c: 01                                        ; i32 literal
+0001a7d: 42                                        ; i64.const
+0001a7e: 02                                        ; i64 literal
+0001a7f: fe                                        ; prefix
+0001a80: 38                                        ; i64.atomic.rmw16_u.or
+0001a81: 01                                        ; alignment
+0001a82: 03                                        ; memory offset
+0001a83: 1a                                        ; drop
+0001a84: 0b                                        ; end
+0001a79: 0b                                        ; FIXUP func body size
 ; function body 228
-0001a70: 00                                        ; func body size (guess)
-0001a71: 00                                        ; local decl count
-0001a72: 41                                        ; i32.const
-0001a73: 01                                        ; i32 literal
-0001a74: 42                                        ; i64.const
-0001a75: 02                                        ; i64 literal
-0001a76: fe                                        ; prefix
-0001a77: 39                                        ; i64.atomic.rmw32_u.or
-0001a78: 02                                        ; alignment
-0001a79: 03                                        ; memory offset
-0001a7a: 1a                                        ; drop
-0001a7b: 0b                                        ; end
-0001a70: 0b                                        ; FIXUP func body size
+0001a85: 00                                        ; func body size (guess)
+0001a86: 00                                        ; local decl count
+0001a87: 41                                        ; i32.const
+0001a88: 01                                        ; i32 literal
+0001a89: 42                                        ; i64.const
+0001a8a: 02                                        ; i64 literal
+0001a8b: fe                                        ; prefix
+0001a8c: 39                                        ; i64.atomic.rmw32_u.or
+0001a8d: 02                                        ; alignment
+0001a8e: 03                                        ; memory offset
+0001a8f: 1a                                        ; drop
+0001a90: 0b                                        ; end
+0001a85: 0b                                        ; FIXUP func body size
 ; function body 229
-0001a7c: 00                                        ; func body size (guess)
-0001a7d: 00                                        ; local decl count
-0001a7e: 41                                        ; i32.const
-0001a7f: 01                                        ; i32 literal
-0001a80: 41                                        ; i32.const
-0001a81: 02                                        ; i32 literal
-0001a82: fe                                        ; prefix
-0001a83: 3a                                        ; i32.atomic.rmw.xor
-0001a84: 02                                        ; alignment
-0001a85: 03                                        ; memory offset
-0001a86: 1a                                        ; drop
-0001a87: 0b                                        ; end
-0001a7c: 0b                                        ; FIXUP func body size
+0001a91: 00                                        ; func body size (guess)
+0001a92: 00                                        ; local decl count
+0001a93: 41                                        ; i32.const
+0001a94: 01                                        ; i32 literal
+0001a95: 41                                        ; i32.const
+0001a96: 02                                        ; i32 literal
+0001a97: fe                                        ; prefix
+0001a98: 3a                                        ; i32.atomic.rmw.xor
+0001a99: 02                                        ; alignment
+0001a9a: 03                                        ; memory offset
+0001a9b: 1a                                        ; drop
+0001a9c: 0b                                        ; end
+0001a91: 0b                                        ; FIXUP func body size
 ; function body 230
-0001a88: 00                                        ; func body size (guess)
-0001a89: 00                                        ; local decl count
-0001a8a: 41                                        ; i32.const
-0001a8b: 01                                        ; i32 literal
-0001a8c: 42                                        ; i64.const
-0001a8d: 02                                        ; i64 literal
-0001a8e: fe                                        ; prefix
-0001a8f: 3b                                        ; i64.atomic.rmw.xor
-0001a90: 03                                        ; alignment
-0001a91: 07                                        ; memory offset
-0001a92: 1a                                        ; drop
-0001a93: 0b                                        ; end
-0001a88: 0b                                        ; FIXUP func body size
+0001a9d: 00                                        ; func body size (guess)
+0001a9e: 00                                        ; local decl count
+0001a9f: 41                                        ; i32.const
+0001aa0: 01                                        ; i32 literal
+0001aa1: 42                                        ; i64.const
+0001aa2: 02                                        ; i64 literal
+0001aa3: fe                                        ; prefix
+0001aa4: 3b                                        ; i64.atomic.rmw.xor
+0001aa5: 03                                        ; alignment
+0001aa6: 07                                        ; memory offset
+0001aa7: 1a                                        ; drop
+0001aa8: 0b                                        ; end
+0001a9d: 0b                                        ; FIXUP func body size
 ; function body 231
-0001a94: 00                                        ; func body size (guess)
-0001a95: 00                                        ; local decl count
-0001a96: 41                                        ; i32.const
-0001a97: 01                                        ; i32 literal
-0001a98: 41                                        ; i32.const
-0001a99: 02                                        ; i32 literal
-0001a9a: fe                                        ; prefix
-0001a9b: 3c                                        ; i32.atomic.rmw8_u.xor
-0001a9c: 00                                        ; alignment
-0001a9d: 03                                        ; memory offset
-0001a9e: 1a                                        ; drop
-0001a9f: 0b                                        ; end
-0001a94: 0b                                        ; FIXUP func body size
+0001aa9: 00                                        ; func body size (guess)
+0001aaa: 00                                        ; local decl count
+0001aab: 41                                        ; i32.const
+0001aac: 01                                        ; i32 literal
+0001aad: 41                                        ; i32.const
+0001aae: 02                                        ; i32 literal
+0001aaf: fe                                        ; prefix
+0001ab0: 3c                                        ; i32.atomic.rmw8_u.xor
+0001ab1: 00                                        ; alignment
+0001ab2: 03                                        ; memory offset
+0001ab3: 1a                                        ; drop
+0001ab4: 0b                                        ; end
+0001aa9: 0b                                        ; FIXUP func body size
 ; function body 232
-0001aa0: 00                                        ; func body size (guess)
-0001aa1: 00                                        ; local decl count
-0001aa2: 41                                        ; i32.const
-0001aa3: 01                                        ; i32 literal
-0001aa4: 41                                        ; i32.const
-0001aa5: 02                                        ; i32 literal
-0001aa6: fe                                        ; prefix
-0001aa7: 3d                                        ; i32.atomic.rmw16_u.xor
-0001aa8: 01                                        ; alignment
-0001aa9: 03                                        ; memory offset
-0001aaa: 1a                                        ; drop
-0001aab: 0b                                        ; end
-0001aa0: 0b                                        ; FIXUP func body size
+0001ab5: 00                                        ; func body size (guess)
+0001ab6: 00                                        ; local decl count
+0001ab7: 41                                        ; i32.const
+0001ab8: 01                                        ; i32 literal
+0001ab9: 41                                        ; i32.const
+0001aba: 02                                        ; i32 literal
+0001abb: fe                                        ; prefix
+0001abc: 3d                                        ; i32.atomic.rmw16_u.xor
+0001abd: 01                                        ; alignment
+0001abe: 03                                        ; memory offset
+0001abf: 1a                                        ; drop
+0001ac0: 0b                                        ; end
+0001ab5: 0b                                        ; FIXUP func body size
 ; function body 233
-0001aac: 00                                        ; func body size (guess)
-0001aad: 00                                        ; local decl count
-0001aae: 41                                        ; i32.const
-0001aaf: 01                                        ; i32 literal
-0001ab0: 42                                        ; i64.const
-0001ab1: 02                                        ; i64 literal
-0001ab2: fe                                        ; prefix
-0001ab3: 3e                                        ; i64.atomic.rmw8_u.xor
-0001ab4: 00                                        ; alignment
-0001ab5: 03                                        ; memory offset
-0001ab6: 1a                                        ; drop
-0001ab7: 0b                                        ; end
-0001aac: 0b                                        ; FIXUP func body size
+0001ac1: 00                                        ; func body size (guess)
+0001ac2: 00                                        ; local decl count
+0001ac3: 41                                        ; i32.const
+0001ac4: 01                                        ; i32 literal
+0001ac5: 42                                        ; i64.const
+0001ac6: 02                                        ; i64 literal
+0001ac7: fe                                        ; prefix
+0001ac8: 3e                                        ; i64.atomic.rmw8_u.xor
+0001ac9: 00                                        ; alignment
+0001aca: 03                                        ; memory offset
+0001acb: 1a                                        ; drop
+0001acc: 0b                                        ; end
+0001ac1: 0b                                        ; FIXUP func body size
 ; function body 234
-0001ab8: 00                                        ; func body size (guess)
-0001ab9: 00                                        ; local decl count
-0001aba: 41                                        ; i32.const
-0001abb: 01                                        ; i32 literal
-0001abc: 42                                        ; i64.const
-0001abd: 02                                        ; i64 literal
-0001abe: fe                                        ; prefix
-0001abf: 3f                                        ; i64.atomic.rmw16_u.xor
-0001ac0: 01                                        ; alignment
-0001ac1: 03                                        ; memory offset
-0001ac2: 1a                                        ; drop
-0001ac3: 0b                                        ; end
-0001ab8: 0b                                        ; FIXUP func body size
+0001acd: 00                                        ; func body size (guess)
+0001ace: 00                                        ; local decl count
+0001acf: 41                                        ; i32.const
+0001ad0: 01                                        ; i32 literal
+0001ad1: 42                                        ; i64.const
+0001ad2: 02                                        ; i64 literal
+0001ad3: fe                                        ; prefix
+0001ad4: 3f                                        ; i64.atomic.rmw16_u.xor
+0001ad5: 01                                        ; alignment
+0001ad6: 03                                        ; memory offset
+0001ad7: 1a                                        ; drop
+0001ad8: 0b                                        ; end
+0001acd: 0b                                        ; FIXUP func body size
 ; function body 235
-0001ac4: 00                                        ; func body size (guess)
-0001ac5: 00                                        ; local decl count
-0001ac6: 41                                        ; i32.const
-0001ac7: 01                                        ; i32 literal
-0001ac8: 42                                        ; i64.const
-0001ac9: 02                                        ; i64 literal
-0001aca: fe                                        ; prefix
-0001acb: 40                                        ; i64.atomic.rmw32_u.xor
-0001acc: 02                                        ; alignment
-0001acd: 03                                        ; memory offset
-0001ace: 1a                                        ; drop
-0001acf: 0b                                        ; end
-0001ac4: 0b                                        ; FIXUP func body size
+0001ad9: 00                                        ; func body size (guess)
+0001ada: 00                                        ; local decl count
+0001adb: 41                                        ; i32.const
+0001adc: 01                                        ; i32 literal
+0001add: 42                                        ; i64.const
+0001ade: 02                                        ; i64 literal
+0001adf: fe                                        ; prefix
+0001ae0: 40                                        ; i64.atomic.rmw32_u.xor
+0001ae1: 02                                        ; alignment
+0001ae2: 03                                        ; memory offset
+0001ae3: 1a                                        ; drop
+0001ae4: 0b                                        ; end
+0001ad9: 0b                                        ; FIXUP func body size
 ; function body 236
-0001ad0: 00                                        ; func body size (guess)
-0001ad1: 00                                        ; local decl count
-0001ad2: 41                                        ; i32.const
-0001ad3: 01                                        ; i32 literal
-0001ad4: 41                                        ; i32.const
-0001ad5: 02                                        ; i32 literal
-0001ad6: fe                                        ; prefix
-0001ad7: 41                                        ; i32.atomic.rmw.xchg
-0001ad8: 02                                        ; alignment
-0001ad9: 03                                        ; memory offset
-0001ada: 1a                                        ; drop
-0001adb: 0b                                        ; end
-0001ad0: 0b                                        ; FIXUP func body size
+0001ae5: 00                                        ; func body size (guess)
+0001ae6: 00                                        ; local decl count
+0001ae7: 41                                        ; i32.const
+0001ae8: 01                                        ; i32 literal
+0001ae9: 41                                        ; i32.const
+0001aea: 02                                        ; i32 literal
+0001aeb: fe                                        ; prefix
+0001aec: 41                                        ; i32.atomic.rmw.xchg
+0001aed: 02                                        ; alignment
+0001aee: 03                                        ; memory offset
+0001aef: 1a                                        ; drop
+0001af0: 0b                                        ; end
+0001ae5: 0b                                        ; FIXUP func body size
 ; function body 237
-0001adc: 00                                        ; func body size (guess)
-0001add: 00                                        ; local decl count
-0001ade: 41                                        ; i32.const
-0001adf: 01                                        ; i32 literal
-0001ae0: 42                                        ; i64.const
-0001ae1: 02                                        ; i64 literal
-0001ae2: fe                                        ; prefix
-0001ae3: 42                                        ; i64.atomic.rmw.xchg
-0001ae4: 03                                        ; alignment
-0001ae5: 07                                        ; memory offset
-0001ae6: 1a                                        ; drop
-0001ae7: 0b                                        ; end
-0001adc: 0b                                        ; FIXUP func body size
+0001af1: 00                                        ; func body size (guess)
+0001af2: 00                                        ; local decl count
+0001af3: 41                                        ; i32.const
+0001af4: 01                                        ; i32 literal
+0001af5: 42                                        ; i64.const
+0001af6: 02                                        ; i64 literal
+0001af7: fe                                        ; prefix
+0001af8: 42                                        ; i64.atomic.rmw.xchg
+0001af9: 03                                        ; alignment
+0001afa: 07                                        ; memory offset
+0001afb: 1a                                        ; drop
+0001afc: 0b                                        ; end
+0001af1: 0b                                        ; FIXUP func body size
 ; function body 238
-0001ae8: 00                                        ; func body size (guess)
-0001ae9: 00                                        ; local decl count
-0001aea: 41                                        ; i32.const
-0001aeb: 01                                        ; i32 literal
-0001aec: 41                                        ; i32.const
-0001aed: 02                                        ; i32 literal
-0001aee: fe                                        ; prefix
-0001aef: 43                                        ; i32.atomic.rmw8_u.xchg
-0001af0: 00                                        ; alignment
-0001af1: 03                                        ; memory offset
-0001af2: 1a                                        ; drop
-0001af3: 0b                                        ; end
-0001ae8: 0b                                        ; FIXUP func body size
+0001afd: 00                                        ; func body size (guess)
+0001afe: 00                                        ; local decl count
+0001aff: 41                                        ; i32.const
+0001b00: 01                                        ; i32 literal
+0001b01: 41                                        ; i32.const
+0001b02: 02                                        ; i32 literal
+0001b03: fe                                        ; prefix
+0001b04: 43                                        ; i32.atomic.rmw8_u.xchg
+0001b05: 00                                        ; alignment
+0001b06: 03                                        ; memory offset
+0001b07: 1a                                        ; drop
+0001b08: 0b                                        ; end
+0001afd: 0b                                        ; FIXUP func body size
 ; function body 239
-0001af4: 00                                        ; func body size (guess)
-0001af5: 00                                        ; local decl count
-0001af6: 41                                        ; i32.const
-0001af7: 01                                        ; i32 literal
-0001af8: 41                                        ; i32.const
-0001af9: 02                                        ; i32 literal
-0001afa: fe                                        ; prefix
-0001afb: 44                                        ; i32.atomic.rmw16_u.xchg
-0001afc: 01                                        ; alignment
-0001afd: 03                                        ; memory offset
-0001afe: 1a                                        ; drop
-0001aff: 0b                                        ; end
-0001af4: 0b                                        ; FIXUP func body size
+0001b09: 00                                        ; func body size (guess)
+0001b0a: 00                                        ; local decl count
+0001b0b: 41                                        ; i32.const
+0001b0c: 01                                        ; i32 literal
+0001b0d: 41                                        ; i32.const
+0001b0e: 02                                        ; i32 literal
+0001b0f: fe                                        ; prefix
+0001b10: 44                                        ; i32.atomic.rmw16_u.xchg
+0001b11: 01                                        ; alignment
+0001b12: 03                                        ; memory offset
+0001b13: 1a                                        ; drop
+0001b14: 0b                                        ; end
+0001b09: 0b                                        ; FIXUP func body size
 ; function body 240
-0001b00: 00                                        ; func body size (guess)
-0001b01: 00                                        ; local decl count
-0001b02: 41                                        ; i32.const
-0001b03: 01                                        ; i32 literal
-0001b04: 42                                        ; i64.const
-0001b05: 02                                        ; i64 literal
-0001b06: fe                                        ; prefix
-0001b07: 45                                        ; i64.atomic.rmw8_u.xchg
-0001b08: 00                                        ; alignment
-0001b09: 03                                        ; memory offset
-0001b0a: 1a                                        ; drop
-0001b0b: 0b                                        ; end
-0001b00: 0b                                        ; FIXUP func body size
+0001b15: 00                                        ; func body size (guess)
+0001b16: 00                                        ; local decl count
+0001b17: 41                                        ; i32.const
+0001b18: 01                                        ; i32 literal
+0001b19: 42                                        ; i64.const
+0001b1a: 02                                        ; i64 literal
+0001b1b: fe                                        ; prefix
+0001b1c: 45                                        ; i64.atomic.rmw8_u.xchg
+0001b1d: 00                                        ; alignment
+0001b1e: 03                                        ; memory offset
+0001b1f: 1a                                        ; drop
+0001b20: 0b                                        ; end
+0001b15: 0b                                        ; FIXUP func body size
 ; function body 241
-0001b0c: 00                                        ; func body size (guess)
-0001b0d: 00                                        ; local decl count
-0001b0e: 41                                        ; i32.const
-0001b0f: 01                                        ; i32 literal
-0001b10: 42                                        ; i64.const
-0001b11: 02                                        ; i64 literal
-0001b12: fe                                        ; prefix
-0001b13: 46                                        ; i64.atomic.rmw16_u.xchg
-0001b14: 01                                        ; alignment
-0001b15: 03                                        ; memory offset
-0001b16: 1a                                        ; drop
-0001b17: 0b                                        ; end
-0001b0c: 0b                                        ; FIXUP func body size
+0001b21: 00                                        ; func body size (guess)
+0001b22: 00                                        ; local decl count
+0001b23: 41                                        ; i32.const
+0001b24: 01                                        ; i32 literal
+0001b25: 42                                        ; i64.const
+0001b26: 02                                        ; i64 literal
+0001b27: fe                                        ; prefix
+0001b28: 46                                        ; i64.atomic.rmw16_u.xchg
+0001b29: 01                                        ; alignment
+0001b2a: 03                                        ; memory offset
+0001b2b: 1a                                        ; drop
+0001b2c: 0b                                        ; end
+0001b21: 0b                                        ; FIXUP func body size
 ; function body 242
-0001b18: 00                                        ; func body size (guess)
-0001b19: 00                                        ; local decl count
-0001b1a: 41                                        ; i32.const
-0001b1b: 01                                        ; i32 literal
-0001b1c: 42                                        ; i64.const
-0001b1d: 02                                        ; i64 literal
-0001b1e: fe                                        ; prefix
-0001b1f: 47                                        ; i64.atomic.rmw32_u.xchg
-0001b20: 02                                        ; alignment
-0001b21: 03                                        ; memory offset
-0001b22: 1a                                        ; drop
-0001b23: 0b                                        ; end
-0001b18: 0b                                        ; FIXUP func body size
+0001b2d: 00                                        ; func body size (guess)
+0001b2e: 00                                        ; local decl count
+0001b2f: 41                                        ; i32.const
+0001b30: 01                                        ; i32 literal
+0001b31: 42                                        ; i64.const
+0001b32: 02                                        ; i64 literal
+0001b33: fe                                        ; prefix
+0001b34: 47                                        ; i64.atomic.rmw32_u.xchg
+0001b35: 02                                        ; alignment
+0001b36: 03                                        ; memory offset
+0001b37: 1a                                        ; drop
+0001b38: 0b                                        ; end
+0001b2d: 0b                                        ; FIXUP func body size
 ; function body 243
-0001b24: 00                                        ; func body size (guess)
-0001b25: 00                                        ; local decl count
-0001b26: 41                                        ; i32.const
-0001b27: 01                                        ; i32 literal
-0001b28: 41                                        ; i32.const
-0001b29: 02                                        ; i32 literal
-0001b2a: 41                                        ; i32.const
-0001b2b: 03                                        ; i32 literal
-0001b2c: fe                                        ; prefix
-0001b2d: 48                                        ; i32.atomic.rmw.cmpxchg
-0001b2e: 02                                        ; alignment
-0001b2f: 03                                        ; memory offset
-0001b30: 1a                                        ; drop
-0001b31: 0b                                        ; end
-0001b24: 0d                                        ; FIXUP func body size
+0001b39: 00                                        ; func body size (guess)
+0001b3a: 00                                        ; local decl count
+0001b3b: 41                                        ; i32.const
+0001b3c: 01                                        ; i32 literal
+0001b3d: 41                                        ; i32.const
+0001b3e: 02                                        ; i32 literal
+0001b3f: 41                                        ; i32.const
+0001b40: 03                                        ; i32 literal
+0001b41: fe                                        ; prefix
+0001b42: 48                                        ; i32.atomic.rmw.cmpxchg
+0001b43: 02                                        ; alignment
+0001b44: 03                                        ; memory offset
+0001b45: 1a                                        ; drop
+0001b46: 0b                                        ; end
+0001b39: 0d                                        ; FIXUP func body size
 ; function body 244
-0001b32: 00                                        ; func body size (guess)
-0001b33: 00                                        ; local decl count
-0001b34: 41                                        ; i32.const
-0001b35: 01                                        ; i32 literal
-0001b36: 42                                        ; i64.const
-0001b37: 02                                        ; i64 literal
-0001b38: 42                                        ; i64.const
-0001b39: 03                                        ; i64 literal
-0001b3a: fe                                        ; prefix
-0001b3b: 49                                        ; i64.atomic.rmw.cmpxchg
-0001b3c: 03                                        ; alignment
-0001b3d: 07                                        ; memory offset
-0001b3e: 1a                                        ; drop
-0001b3f: 0b                                        ; end
-0001b32: 0d                                        ; FIXUP func body size
+0001b47: 00                                        ; func body size (guess)
+0001b48: 00                                        ; local decl count
+0001b49: 41                                        ; i32.const
+0001b4a: 01                                        ; i32 literal
+0001b4b: 42                                        ; i64.const
+0001b4c: 02                                        ; i64 literal
+0001b4d: 42                                        ; i64.const
+0001b4e: 03                                        ; i64 literal
+0001b4f: fe                                        ; prefix
+0001b50: 49                                        ; i64.atomic.rmw.cmpxchg
+0001b51: 03                                        ; alignment
+0001b52: 07                                        ; memory offset
+0001b53: 1a                                        ; drop
+0001b54: 0b                                        ; end
+0001b47: 0d                                        ; FIXUP func body size
 ; function body 245
-0001b40: 00                                        ; func body size (guess)
-0001b41: 00                                        ; local decl count
-0001b42: 41                                        ; i32.const
-0001b43: 01                                        ; i32 literal
-0001b44: 41                                        ; i32.const
-0001b45: 02                                        ; i32 literal
-0001b46: 41                                        ; i32.const
-0001b47: 03                                        ; i32 literal
-0001b48: fe                                        ; prefix
-0001b49: 4a                                        ; i32.atomic.rmw8_u.cmpxchg
-0001b4a: 00                                        ; alignment
-0001b4b: 03                                        ; memory offset
-0001b4c: 1a                                        ; drop
-0001b4d: 0b                                        ; end
-0001b40: 0d                                        ; FIXUP func body size
+0001b55: 00                                        ; func body size (guess)
+0001b56: 00                                        ; local decl count
+0001b57: 41                                        ; i32.const
+0001b58: 01                                        ; i32 literal
+0001b59: 41                                        ; i32.const
+0001b5a: 02                                        ; i32 literal
+0001b5b: 41                                        ; i32.const
+0001b5c: 03                                        ; i32 literal
+0001b5d: fe                                        ; prefix
+0001b5e: 4a                                        ; i32.atomic.rmw8_u.cmpxchg
+0001b5f: 00                                        ; alignment
+0001b60: 03                                        ; memory offset
+0001b61: 1a                                        ; drop
+0001b62: 0b                                        ; end
+0001b55: 0d                                        ; FIXUP func body size
 ; function body 246
-0001b4e: 00                                        ; func body size (guess)
-0001b4f: 00                                        ; local decl count
-0001b50: 41                                        ; i32.const
-0001b51: 01                                        ; i32 literal
-0001b52: 41                                        ; i32.const
-0001b53: 02                                        ; i32 literal
-0001b54: 41                                        ; i32.const
-0001b55: 03                                        ; i32 literal
-0001b56: fe                                        ; prefix
-0001b57: 4b                                        ; i32.atomic.rmw16_u.cmpxchg
-0001b58: 01                                        ; alignment
-0001b59: 03                                        ; memory offset
-0001b5a: 1a                                        ; drop
-0001b5b: 0b                                        ; end
-0001b4e: 0d                                        ; FIXUP func body size
+0001b63: 00                                        ; func body size (guess)
+0001b64: 00                                        ; local decl count
+0001b65: 41                                        ; i32.const
+0001b66: 01                                        ; i32 literal
+0001b67: 41                                        ; i32.const
+0001b68: 02                                        ; i32 literal
+0001b69: 41                                        ; i32.const
+0001b6a: 03                                        ; i32 literal
+0001b6b: fe                                        ; prefix
+0001b6c: 4b                                        ; i32.atomic.rmw16_u.cmpxchg
+0001b6d: 01                                        ; alignment
+0001b6e: 03                                        ; memory offset
+0001b6f: 1a                                        ; drop
+0001b70: 0b                                        ; end
+0001b63: 0d                                        ; FIXUP func body size
 ; function body 247
-0001b5c: 00                                        ; func body size (guess)
-0001b5d: 00                                        ; local decl count
-0001b5e: 41                                        ; i32.const
-0001b5f: 01                                        ; i32 literal
-0001b60: 42                                        ; i64.const
-0001b61: 02                                        ; i64 literal
-0001b62: 42                                        ; i64.const
-0001b63: 03                                        ; i64 literal
-0001b64: fe                                        ; prefix
-0001b65: 4c                                        ; i64.atomic.rmw8_u.cmpxchg
-0001b66: 00                                        ; alignment
-0001b67: 03                                        ; memory offset
-0001b68: 1a                                        ; drop
-0001b69: 0b                                        ; end
-0001b5c: 0d                                        ; FIXUP func body size
+0001b71: 00                                        ; func body size (guess)
+0001b72: 00                                        ; local decl count
+0001b73: 41                                        ; i32.const
+0001b74: 01                                        ; i32 literal
+0001b75: 42                                        ; i64.const
+0001b76: 02                                        ; i64 literal
+0001b77: 42                                        ; i64.const
+0001b78: 03                                        ; i64 literal
+0001b79: fe                                        ; prefix
+0001b7a: 4c                                        ; i64.atomic.rmw8_u.cmpxchg
+0001b7b: 00                                        ; alignment
+0001b7c: 03                                        ; memory offset
+0001b7d: 1a                                        ; drop
+0001b7e: 0b                                        ; end
+0001b71: 0d                                        ; FIXUP func body size
 ; function body 248
-0001b6a: 00                                        ; func body size (guess)
-0001b6b: 00                                        ; local decl count
-0001b6c: 41                                        ; i32.const
-0001b6d: 01                                        ; i32 literal
-0001b6e: 42                                        ; i64.const
-0001b6f: 02                                        ; i64 literal
-0001b70: 42                                        ; i64.const
-0001b71: 03                                        ; i64 literal
-0001b72: fe                                        ; prefix
-0001b73: 4d                                        ; i64.atomic.rmw16_u.cmpxchg
-0001b74: 01                                        ; alignment
-0001b75: 03                                        ; memory offset
-0001b76: 1a                                        ; drop
-0001b77: 0b                                        ; end
-0001b6a: 0d                                        ; FIXUP func body size
+0001b7f: 00                                        ; func body size (guess)
+0001b80: 00                                        ; local decl count
+0001b81: 41                                        ; i32.const
+0001b82: 01                                        ; i32 literal
+0001b83: 42                                        ; i64.const
+0001b84: 02                                        ; i64 literal
+0001b85: 42                                        ; i64.const
+0001b86: 03                                        ; i64 literal
+0001b87: fe                                        ; prefix
+0001b88: 4d                                        ; i64.atomic.rmw16_u.cmpxchg
+0001b89: 01                                        ; alignment
+0001b8a: 03                                        ; memory offset
+0001b8b: 1a                                        ; drop
+0001b8c: 0b                                        ; end
+0001b7f: 0d                                        ; FIXUP func body size
 ; function body 249
-0001b78: 00                                        ; func body size (guess)
-0001b79: 00                                        ; local decl count
-0001b7a: 41                                        ; i32.const
-0001b7b: 01                                        ; i32 literal
-0001b7c: 42                                        ; i64.const
-0001b7d: 02                                        ; i64 literal
-0001b7e: 42                                        ; i64.const
-0001b7f: 03                                        ; i64 literal
-0001b80: fe                                        ; prefix
-0001b81: 4e                                        ; i64.atomic.rmw32_u.cmpxchg
-0001b82: 02                                        ; alignment
-0001b83: 03                                        ; memory offset
-0001b84: 1a                                        ; drop
-0001b85: 0b                                        ; end
-0001b78: 0d                                        ; FIXUP func body size
-; move data: [10d1, 1b86) -> [10d2, 1b87)
-00010d0: b515                                      ; FIXUP section size
+0001b8d: 00                                        ; func body size (guess)
+0001b8e: 00                                        ; local decl count
+0001b8f: 41                                        ; i32.const
+0001b90: 01                                        ; i32 literal
+0001b91: 42                                        ; i64.const
+0001b92: 02                                        ; i64 literal
+0001b93: 42                                        ; i64.const
+0001b94: 03                                        ; i64 literal
+0001b95: fe                                        ; prefix
+0001b96: 4e                                        ; i64.atomic.rmw32_u.cmpxchg
+0001b97: 02                                        ; alignment
+0001b98: 03                                        ; memory offset
+0001b99: 1a                                        ; drop
+0001b9a: 0b                                        ; end
+0001b8d: 0d                                        ; FIXUP func body size
+; move data: [10e6, 1b9b) -> [10e7, 1b9c)
+00010e5: b515                                      ; FIXUP section size
 BeginModule(version: 1)
   BeginTypeSection(8)
     OnTypeCount(2)
@@ -4765,7 +4765,7 @@ BeginModule(version: 1)
     EndGlobalInitExpr(0)
     EndGlobal(0)
   EndGlobalSection
-  BeginExportSection(3980)
+  BeginExportSection(4001)
     OnExportCount(249)
     OnExport(index: 0, kind: func, item_index: 2, name: "unreachable")
     OnExport(index: 1, kind: func, item_index: 3, name: "br")
@@ -4950,9 +4950,9 @@ BeginModule(version: 1)
     OnExport(index: 180, kind: func, item_index: 182, name: "i64.trunc_u:sat/f32")
     OnExport(index: 181, kind: func, item_index: 183, name: "i64.trunc_s:sat/f64")
     OnExport(index: 182, kind: func, item_index: 184, name: "i64.trunc_u:sat/f64")
-    OnExport(index: 183, kind: func, item_index: 185, name: "wake")
-    OnExport(index: 184, kind: func, item_index: 186, name: "i32.wait")
-    OnExport(index: 185, kind: func, item_index: 187, name: "i64.wait")
+    OnExport(index: 183, kind: func, item_index: 185, name: "atomic.wake")
+    OnExport(index: 184, kind: func, item_index: 186, name: "i32.atomic.wait")
+    OnExport(index: 185, kind: func, item_index: 187, name: "i64.atomic.wait")
     OnExport(index: 186, kind: func, item_index: 188, name: "i32.atomic.load")
     OnExport(index: 187, kind: func, item_index: 189, name: "i64.atomic.load")
     OnExport(index: 188, kind: func, item_index: 190, name: "i32.atomic.load8_u")
@@ -6194,7 +6194,7 @@ BeginModule(version: 1)
     OnLocalDeclCount(0)
     OnI32ConstExpr(1 (0x1))
     OnI32ConstExpr(2 (0x2))
-    OnWakeExpr(opcode: "wake" (0), align log2: 2, offset: 3)
+    OnAtomicWakeExpr(opcode: "atomic.wake" (0), align log2: 2, offset: 3)
     OnDropExpr
     EndFunctionBody(185)
     BeginFunctionBody(186)
@@ -6202,7 +6202,7 @@ BeginModule(version: 1)
     OnI32ConstExpr(1 (0x1))
     OnI32ConstExpr(2 (0x2))
     OnI64ConstExpr(3 (0x3))
-    OnWaitExpr(opcode: "i32.wait" (1), align log2: 2, offset: 3)
+    OnAtomicWaitExpr(opcode: "i32.atomic.wait" (1), align log2: 2, offset: 3)
     OnDropExpr
     EndFunctionBody(186)
     BeginFunctionBody(187)
@@ -6210,7 +6210,7 @@ BeginModule(version: 1)
     OnI32ConstExpr(1 (0x1))
     OnI64ConstExpr(2 (0x2))
     OnI64ConstExpr(3 (0x3))
-    OnWaitExpr(opcode: "i64.wait" (2), align log2: 3, offset: 3)
+    OnAtomicWaitExpr(opcode: "i64.atomic.wait" (2), align log2: 3, offset: 3)
     OnDropExpr
     EndFunctionBody(187)
     BeginFunctionBody(188)
@@ -7451,19 +7451,19 @@ EndModule
 2616| return
 2617| i32.const $1
 2622| i32.const $2
-2627| wake $0:%[-2]+$3, %[-1]
+2627| atomic.wake $0:%[-2]+$3, %[-1]
 2637| drop
 2638| return
 2639| i32.const $1
 2644| i32.const $2
 2649| i64.const $3
-2658| i32.wait $0:%[-3]+$3, %[-2], %[-1]
+2658| i32.atomic.wait $0:%[-3]+$3, %[-2], %[-1]
 2668| drop
 2669| return
 2670| i32.const $1
 2675| i64.const $2
 2684| i64.const $3
-2693| i64.wait $0:%[-3]+$3, %[-2], %[-1]
+2693| i64.atomic.wait $0:%[-3]+$3, %[-2], %[-1]
 2703| drop
 2704| return
 2705| i32.const $1
@@ -7958,9 +7958,9 @@ i64.trunc_s:sat/f32() =>
 i64.trunc_u:sat/f32() =>
 i64.trunc_s:sat/f64() =>
 i64.trunc_u:sat/f64() =>
-wake() => error: unreachable executed
-i32.wait() => error: unreachable executed
-i64.wait() => error: unreachable executed
+atomic.wake() => error: unreachable executed
+i32.atomic.wait() => error: unreachable executed
+i64.atomic.wait() => error: unreachable executed
 i32.atomic.load() =>
 i64.atomic.load() =>
 i32.atomic.load8_u() =>

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -213,9 +213,9 @@
   (; 0xfc 0x07 ;) (func (export "i64.trunc_u:sat/f64") f64.const 1 i64.trunc_u:sat/f64 drop)
 
   ;; --enable-threads
-  (; 0xfe 0x00 ;) (func (export "wake") i32.const 1 i32.const 2 wake offset=3 drop)
-  (; 0xfe 0x01 ;) (func (export "i32.wait") i32.const 1 i32.const 2 i64.const 3 i32.wait offset=3 drop)
-  (; 0xfe 0x02 ;) (func (export "i64.wait") i32.const 1 i64.const 2 i64.const 3 i64.wait offset=3 drop)
+  (; 0xfe 0x00 ;) (func (export "atomic.wake") i32.const 1 i32.const 2 atomic.wake offset=3 drop)
+  (; 0xfe 0x01 ;) (func (export "i32.atomic.wait") i32.const 1 i32.const 2 i64.const 3 i32.atomic.wait offset=3 drop)
+  (; 0xfe 0x02 ;) (func (export "i64.atomic.wait") i32.const 1 i64.const 2 i64.const 3 i64.atomic.wait offset=3 drop)
   (; 0xfe 0x10 ;) (func (export "i32.atomic.load") i32.const 1 i32.atomic.load offset=3 drop)
   (; 0xfe 0x11 ;) (func (export "i64.atomic.load") i32.const 1 i64.atomic.load offset=7 drop)
   (; 0xfe 0x12 ;) (func (export "i32.atomic.load8_u") i32.const 1 i32.atomic.load8_u offset=3 drop)
@@ -1439,23 +1439,23 @@ i64.trunc_s:sat/f64() =>
 #0. 2586: V:1  | drop
 #0. 2587: V:0  | return
 i64.trunc_u:sat/f64() =>
->>> running export "wake":
+>>> running export "atomic.wake":
 #0. 2588: V:0  | i32.const $1
 #0. 2593: V:1  | i32.const $2
-#0. 2598: V:2  | wake $0:1+$3, 2
-wake() => error: unreachable executed
->>> running export "i32.wait":
+#0. 2598: V:2  | atomic.wake $0:1+$3, 2
+atomic.wake() => error: unreachable executed
+>>> running export "i32.atomic.wait":
 #0. 2610: V:0  | i32.const $1
 #0. 2615: V:1  | i32.const $2
 #0. 2620: V:2  | i64.const $3
-#0. 2629: V:3  | i32.wait $0:1+$3, 2, 3
-i32.wait() => error: unreachable executed
->>> running export "i64.wait":
+#0. 2629: V:3  | i32.atomic.wait $0:1+$3, 2, 3
+i32.atomic.wait() => error: unreachable executed
+>>> running export "i64.atomic.wait":
 #0. 2641: V:0  | i32.const $1
 #0. 2646: V:1  | i64.const $2
 #0. 2655: V:2  | i64.const $3
-#0. 2664: V:3  | i64.wait $0:1+$3, 2, 3
-i64.wait() => error: unreachable executed
+#0. 2664: V:3  | i64.atomic.wait $0:1+$3, 2, 3
+i64.atomic.wait() => error: unreachable executed
 >>> running export "i32.atomic.load":
 #0. 2676: V:0  | i32.const $1
 #0. 2681: V:1  | i32.atomic.load $0:1+$3

--- a/test/parse/expr/atomic-align.txt
+++ b/test/parse/expr/atomic-align.txt
@@ -2,9 +2,9 @@
 (module
   (memory 1 1 shared)
   (func
-    i32.const 0 i32.const 0 wake align=4 drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait align=4 drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait align=8 drop
+    i32.const 0 i32.const 0 atomic.wake align=4 drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait align=4 drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait align=8 drop
 
     i32.const 0 i32.atomic.load align=4 drop
     i32.const 0 i64.atomic.load align=8 drop

--- a/test/parse/expr/atomic-disabled.txt
+++ b/test/parse/expr/atomic-disabled.txt
@@ -3,9 +3,9 @@
 (module
   (memory 1)
   (func
-    i32.const 0 i32.const 0 wake drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
+    i32.const 0 i32.const 0 atomic.wake drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
 
     i32.const 0 i32.atomic.load drop
     i32.const 0 i64.atomic.load drop
@@ -81,15 +81,15 @@
 
 ))
 (;; STDERR ;;;
-out/test/parse/expr/atomic-disabled.txt:6:29: error: opcode not allowed: wake
-    i32.const 0 i32.const 0 wake drop
-                            ^^^^
-out/test/parse/expr/atomic-disabled.txt:7:41: error: opcode not allowed: i32.wait
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-                                        ^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:8:41: error: opcode not allowed: i64.wait
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
-                                        ^^^^^^^^
+out/test/parse/expr/atomic-disabled.txt:6:29: error: opcode not allowed: atomic.wake
+    i32.const 0 i32.const 0 atomic.wake drop
+                            ^^^^^^^^^^^
+out/test/parse/expr/atomic-disabled.txt:7:41: error: opcode not allowed: i32.atomic.wait
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+                                        ^^^^^^^^^^^^^^^
+out/test/parse/expr/atomic-disabled.txt:8:41: error: opcode not allowed: i64.atomic.wait
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
+                                        ^^^^^^^^^^^^^^^
 out/test/parse/expr/atomic-disabled.txt:10:17: error: opcode not allowed: i32.atomic.load
     i32.const 0 i32.atomic.load drop
                 ^^^^^^^^^^^^^^^

--- a/test/parse/expr/atomic.txt
+++ b/test/parse/expr/atomic.txt
@@ -2,9 +2,9 @@
 (module
   (memory 1 1 shared)
   (func
-    i32.const 0 i32.const 0 wake drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
+    i32.const 0 i32.const 0 atomic.wake drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
 
     i32.const 0 i32.atomic.load drop
     i32.const 0 i64.atomic.load drop

--- a/test/parse/expr/bad-atomic-unnatural-align.txt
+++ b/test/parse/expr/bad-atomic-unnatural-align.txt
@@ -3,9 +3,9 @@
 (module
   (memory 1 1 shared)
   (func
-    i32.const 0 i32.const 0 wake align=8 drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait align=8 drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait align=16 drop
+    i32.const 0 i32.const 0 atomic.wake align=8 drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait align=8 drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait align=16 drop
 
     i32.const 0 i32.atomic.load align=8 drop
     i32.const 0 i64.atomic.load align=16 drop
@@ -83,14 +83,14 @@
 
 (;; STDERR ;;;
 out/test/parse/expr/bad-atomic-unnatural-align.txt:6:29: error: alignment must be equal to natural alignment (4)
-    i32.const 0 i32.const 0 wake align=8 drop
-                            ^^^^
+    i32.const 0 i32.const 0 atomic.wake align=8 drop
+                            ^^^^^^^^^^^
 out/test/parse/expr/bad-atomic-unnatural-align.txt:7:41: error: alignment must be equal to natural alignment (4)
-    i32.const 0 i32.const 0 i64.const 0 i32.wait align=8 drop
-                                        ^^^^^^^^
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait align=8 drop
+                                        ^^^^^^^^^^^^^^^
 out/test/parse/expr/bad-atomic-unnatural-align.txt:8:41: error: alignment must be equal to natural alignment (8)
-    i32.const 0 i64.const 0 i64.const 0 i64.wait align=16 drop
-                                        ^^^^^^^^
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait align=16 drop
+                                        ^^^^^^^^^^^^^^^
 out/test/parse/expr/bad-atomic-unnatural-align.txt:10:17: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.atomic.load align=8 drop
                 ^^^^^^^^^^^^^^^

--- a/test/roundtrip/fold-atomic.txt
+++ b/test/roundtrip/fold-atomic.txt
@@ -4,9 +4,9 @@
 (module
   (memory 1 1 shared)
   (func
-    i32.const 0 i32.const 0 wake drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
+    i32.const 0 i32.const 0 atomic.wake drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
 
     i32.const 0 i32.atomic.load drop
     i32.const 0 i64.atomic.load drop
@@ -86,16 +86,16 @@
   (type (;0;) (func))
   (func (;0;) (type 0)
     (drop
-      (wake
+      (atomic.wake
         (i32.const 0)
         (i32.const 0)))
     (drop
-      (i32.wait
+      (i32.atomic.wait
         (i32.const 0)
         (i32.const 0)
         (i64.const 0)))
     (drop
-      (i64.wait
+      (i64.atomic.wait
         (i32.const 0)
         (i64.const 0)
         (i64.const 0)))

--- a/test/typecheck/bad-atomic-no-shared-memory.txt
+++ b/test/typecheck/bad-atomic-no-shared-memory.txt
@@ -4,9 +4,9 @@
 (module
   (memory 1)
   (func
-    i32.const 0 i32.const 0 wake drop
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
+    i32.const 0 i32.const 0 atomic.wake drop
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
 
     i32.const 0 i32.atomic.load drop
     i32.const 0 i64.atomic.load drop
@@ -82,15 +82,15 @@
 
 ))
 (;; STDERR ;;;
-out/test/typecheck/bad-atomic-no-shared-memory.txt:7:29: error: wake requires memory to be shared.
-    i32.const 0 i32.const 0 wake drop
-                            ^^^^
-out/test/typecheck/bad-atomic-no-shared-memory.txt:8:41: error: i32.wait requires memory to be shared.
-    i32.const 0 i32.const 0 i64.const 0 i32.wait drop
-                                        ^^^^^^^^
-out/test/typecheck/bad-atomic-no-shared-memory.txt:9:41: error: i64.wait requires memory to be shared.
-    i32.const 0 i64.const 0 i64.const 0 i64.wait drop
-                                        ^^^^^^^^
+out/test/typecheck/bad-atomic-no-shared-memory.txt:7:29: error: atomic.wake requires memory to be shared.
+    i32.const 0 i32.const 0 atomic.wake drop
+                            ^^^^^^^^^^^
+out/test/typecheck/bad-atomic-no-shared-memory.txt:8:41: error: i32.atomic.wait requires memory to be shared.
+    i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
+                                        ^^^^^^^^^^^^^^^
+out/test/typecheck/bad-atomic-no-shared-memory.txt:9:41: error: i64.atomic.wait requires memory to be shared.
+    i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
+                                        ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-no-shared-memory.txt:11:17: error: i32.atomic.load requires memory to be shared.
     i32.const 0 i32.atomic.load drop
                 ^^^^^^^^^^^^^^^

--- a/test/typecheck/bad-atomic-type-mismatch.txt
+++ b/test/typecheck/bad-atomic-type-mismatch.txt
@@ -5,9 +5,9 @@
   (memory 1 1 shared)
 
   ;; Mismatch address.
-  (func f32.const 0 i32.const 0 wake drop)
-  (func f32.const 0 i32.const 0 i64.const 0 i32.wait drop)
-  (func f32.const 0 i64.const 0 i64.const 0 i64.wait drop)
+  (func f32.const 0 i32.const 0 atomic.wake drop)
+  (func f32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop)
+  (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop)
   (func f32.const 0 i32.atomic.load drop)
   (func f32.const 0 i64.atomic.load drop)
   (func f32.const 0 i32.atomic.load8_u drop)
@@ -73,9 +73,9 @@
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
 
   ;; Mismatch first value operand.
-  (func i32.const 0 f32.const 0 wake drop)
-  (func i32.const 0 f32.const 0 i64.const 0 i32.wait drop)
-  (func i32.const 0 f64.const 0 i64.const 0 i64.wait drop)
+  (func i32.const 0 f32.const 0 atomic.wake drop)
+  (func i32.const 0 f32.const 0 i64.const 0 i32.atomic.wait drop)
+  (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.wait drop)
   (func i32.const 0 f32.const 0 i32.atomic.store)
   (func i32.const 0 f64.const 0 i64.atomic.store)
   (func i32.const 0 f32.const 0 i32.atomic.store8)
@@ -134,8 +134,8 @@
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
 
   ;; Mismatch second value operand.
-  (func i32.const 0 i32.const 0 f64.const 0 i32.wait drop)
-  (func i32.const 0 i64.const 0 f64.const 0 i64.wait drop)
+  (func i32.const 0 i32.const 0 f64.const 0 i32.atomic.wait drop)
+  (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.wait drop)
   (func i32.const 0 i32.const 0 f32.const 0 i32.atomic.rmw.cmpxchg drop)
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw.cmpxchg drop)
   (func i32.const 0 i32.const 0 f32.const 0 i32.atomic.rmw8_u.cmpxchg drop)
@@ -145,9 +145,9 @@
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
 
   ;; Mismatch result.
-  (func (result f32) i32.const 0 i32.const 0 wake)
-  (func (result f32) i32.const 0 i32.const 0 i64.const 0 i32.wait)
-  (func (result f32) i32.const 0 i64.const 0 i64.const 0 i64.wait)
+  (func (result f32) i32.const 0 i32.const 0 atomic.wake)
+  (func (result f32) i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait)
+  (func (result f32) i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait)
   (func (result f32) i32.const 0 i32.atomic.load)
   (func (result f64) i32.const 0 i64.atomic.load)
   (func (result f32) i32.const 0 i32.atomic.load8_u)
@@ -207,15 +207,15 @@
 
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-atomic-type-mismatch.txt:8:33: error: type mismatch in wake, expected [i32, i32] but got [f32, i32]
-  (func f32.const 0 i32.const 0 wake drop)
-                                ^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:9:45: error: type mismatch in i32.wait, expected [i32, i32, i64] but got [f32, i32, i64]
-  (func f32.const 0 i32.const 0 i64.const 0 i32.wait drop)
-                                            ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:10:45: error: type mismatch in i64.wait, expected [i32, i64, i64] but got [f32, i64, i64]
-  (func f32.const 0 i64.const 0 i64.const 0 i64.wait drop)
-                                            ^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:8:33: error: type mismatch in atomic.wake, expected [i32, i32] but got [f32, i32]
+  (func f32.const 0 i32.const 0 atomic.wake drop)
+                                ^^^^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:9:45: error: type mismatch in i32.atomic.wait, expected [i32, i32, i64] but got [f32, i32, i64]
+  (func f32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop)
+                                            ^^^^^^^^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:10:45: error: type mismatch in i64.atomic.wait, expected [i32, i64, i64] but got [f32, i64, i64]
+  (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop)
+                                            ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:11:21: error: type mismatch in i32.atomic.load, expected [i32] but got [f32]
   (func f32.const 0 i32.atomic.load drop)
                     ^^^^^^^^^^^^^^^
@@ -405,15 +405,15 @@ out/test/typecheck/bad-atomic-type-mismatch.txt:72:45: error: type mismatch in i
 out/test/typecheck/bad-atomic-type-mismatch.txt:73:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:76:33: error: type mismatch in wake, expected [i32, i32] but got [i32, f32]
-  (func i32.const 0 f32.const 0 wake drop)
-                                ^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:77:45: error: type mismatch in i32.wait, expected [i32, i32, i64] but got [i32, f32, i64]
-  (func i32.const 0 f32.const 0 i64.const 0 i32.wait drop)
-                                            ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:78:45: error: type mismatch in i64.wait, expected [i32, i64, i64] but got [i32, f64, i64]
-  (func i32.const 0 f64.const 0 i64.const 0 i64.wait drop)
-                                            ^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:76:33: error: type mismatch in atomic.wake, expected [i32, i32] but got [i32, f32]
+  (func i32.const 0 f32.const 0 atomic.wake drop)
+                                ^^^^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:77:45: error: type mismatch in i32.atomic.wait, expected [i32, i32, i64] but got [i32, f32, i64]
+  (func i32.const 0 f32.const 0 i64.const 0 i32.atomic.wait drop)
+                                            ^^^^^^^^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:78:45: error: type mismatch in i64.atomic.wait, expected [i32, i64, i64] but got [i32, f64, i64]
+  (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.wait drop)
+                                            ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:79:33: error: type mismatch in i32.atomic.store, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 i32.atomic.store)
                                 ^^^^^^^^^^^^^^^^
@@ -582,12 +582,12 @@ out/test/typecheck/bad-atomic-type-mismatch.txt:133:45: error: type mismatch in 
 out/test/typecheck/bad-atomic-type-mismatch.txt:134:45: error: type mismatch in i64.atomic.rmw32_u.cmpxchg, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:137:45: error: type mismatch in i32.wait, expected [i32, i32, i64] but got [i32, i32, f64]
-  (func i32.const 0 i32.const 0 f64.const 0 i32.wait drop)
-                                            ^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:138:45: error: type mismatch in i64.wait, expected [i32, i64, i64] but got [i32, i64, f64]
-  (func i32.const 0 i64.const 0 f64.const 0 i64.wait drop)
-                                            ^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:137:45: error: type mismatch in i32.atomic.wait, expected [i32, i32, i64] but got [i32, i32, f64]
+  (func i32.const 0 i32.const 0 f64.const 0 i32.atomic.wait drop)
+                                            ^^^^^^^^^^^^^^^
+out/test/typecheck/bad-atomic-type-mismatch.txt:138:45: error: type mismatch in i64.atomic.wait, expected [i32, i64, i64] but got [i32, i64, f64]
+  (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.wait drop)
+                                            ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:139:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected [i32, i32, i32] but got [i32, i32, f32]
   (func i32.const 0 i32.const 0 f32.const 0 i32.atomic.rmw.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^
@@ -610,14 +610,14 @@ out/test/typecheck/bad-atomic-type-mismatch.txt:145:45: error: type mismatch in 
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.rmw32_u.cmpxchg drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:148:46: error: type mismatch in implicit return, expected [f32] but got [i32]
-  (func (result f32) i32.const 0 i32.const 0 wake)
-                                             ^^^^
+  (func (result f32) i32.const 0 i32.const 0 atomic.wake)
+                                             ^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:149:58: error: type mismatch in implicit return, expected [f32] but got [i32]
-  (func (result f32) i32.const 0 i32.const 0 i64.const 0 i32.wait)
-                                                         ^^^^^^^^
+  (func (result f32) i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait)
+                                                         ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:150:58: error: type mismatch in implicit return, expected [f32] but got [i32]
-  (func (result f32) i32.const 0 i64.const 0 i64.const 0 i64.wait)
-                                                         ^^^^^^^^
+  (func (result f32) i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait)
+                                                         ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:151:34: error: type mismatch in implicit return, expected [f32] but got [i32]
   (func (result f32) i32.const 0 i32.atomic.load)
                                  ^^^^^^^^^^^^^^^


### PR DESCRIPTION
This was recently changed in the spec.