### PR TITLE
wat2wasm: Always write output to a file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -219,6 +219,7 @@ add_library(libwabt STATIC
   src/opcode.cc
   src/error-handler.cc
   src/hash-util.cc
+  src/filenames.cc
   src/string-view.cc
   src/ir.cc
   src/expr-visitor.cc
@@ -354,6 +355,7 @@ if (NOT EMSCRIPTEN)
       src/test-circular-array.cc
       src/test-intrusive-list.cc
       src/test-string-view.cc
+      src/test-filenames.cc
       src/test-utf8.cc
       src/test-wast-parser.cc
       third_party/gtest/googletest/src/gtest_main.cc

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -24,6 +24,7 @@
 #include <vector>
 
 #include "src/binary-reader-nop.h"
+#include "src/filenames.h"
 #include "src/literal.h"
 
 namespace wabt {
@@ -102,20 +103,9 @@ Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
       printf("Code Disassembly:\n\n");
       break;
     case ObjdumpMode::Prepass: {
-      const char* last_slash = strrchr(options_->filename, '/');
-      const char* last_backslash = strrchr(options_->filename, '\\');
-      const char* basename;
-      if (last_slash && last_backslash) {
-        basename = std::max(last_slash, last_backslash) + 1;
-      } else if (last_slash) {
-        basename = last_slash + 1;
-      } else if (last_backslash) {
-        basename = last_backslash + 1;
-      } else {
-        basename = options_->filename;
-      }
-
-      printf("%s:\tfile format wasm %#x\n", basename, version);
+      string_view basename = GetBasename(options_->filename);
+      printf("%s:\tfile format wasm %#x\n", basename.to_string().c_str(),
+             version);
       break;
     }
     case ObjdumpMode::RawData:

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -24,38 +24,12 @@
 #include "src/binary.h"
 #include "src/binary-writer.h"
 #include "src/cast.h"
+#include "src/filenames.h"
 #include "src/ir.h"
 #include "src/stream.h"
 #include "src/string-view.h"
 
 namespace wabt {
-
-static string_view strip_extension(string_view s) {
-  // Strip .json or .wasm, but leave other extensions, e.g.:
-  //
-  // s = "foo", => "foo"
-  // s = "foo.json" => "foo"
-  // s = "foo.wasm" => "foo"
-  // s = "foo.bar" => "foo.bar"
-  string_view ext = s.substr(s.find_last_of('.'));
-  string_view result = s;
-
-  if (ext == ".json" || ext == ".wasm")
-    result.remove_suffix(ext.length());
-  return result;
-}
-
-static string_view get_basename(string_view s) {
-  // Strip everything up to and including the last slash, e.g.:
-  //
-  // s = "/foo/bar/baz", => "baz"
-  // s = "/usr/local/include/stdio.h", => "stdio.h"
-  // s = "foo.bar", => "foo.bar"
-  size_t last_slash = s.find_last_of('/');
-  if (last_slash != string_view::npos)
-    return s.substr(last_slash + 1);
-  return s;
-}
 
 namespace {
 
@@ -93,24 +67,16 @@ class BinaryWriterSpec {
   const WriteBinarySpecOptions* spec_options_ = nullptr;
   Result result_ = Result::Ok;
   size_t num_modules_ = 0;
-
-  static const char* kWasmExtension;
-  static const char* kWatExtension;
 };
-
-// static
-const char* BinaryWriterSpec::kWasmExtension = ".wasm";
-// static
-const char* BinaryWriterSpec::kWatExtension = ".wat";
 
 BinaryWriterSpec::BinaryWriterSpec(const char* source_filename,
                                    const WriteBinarySpecOptions* spec_options)
     : spec_options_(spec_options) {
   source_filename_ = source_filename;
-  module_filename_noext_ = strip_extension(spec_options_->json_filename
-                                               ? spec_options_->json_filename
-                                               : source_filename)
-                               .to_string();
+  module_filename_noext_ =
+      StripExtension(spec_options_->json_filename ? spec_options_->json_filename
+                                                  : source_filename)
+          .to_string();
   write_modules_ = !!spec_options_->json_filename;
 }
 
@@ -370,7 +336,7 @@ void BinaryWriterSpec::WriteInvalidModule(const ScriptModule& module,
   WriteSeparator();
   std::string filename = GetModuleFilename(extension);
   WriteKey("filename");
-  WriteEscapedString(get_basename(filename));
+  WriteEscapedString(GetBasename(filename));
   WriteSeparator();
   WriteKey("text");
   WriteEscapedString(text);
@@ -409,7 +375,7 @@ void BinaryWriterSpec::WriteCommands(const Script& script) {
           WriteSeparator();
         }
         WriteKey("filename");
-        WriteEscapedString(get_basename(filename));
+        WriteEscapedString(GetBasename(filename));
         WriteModule(filename, module);
         num_modules_++;
         last_module_index = i;

--- a/src/filenames.cc
+++ b/src/filenames.cc
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/filenames.h"
+
+namespace wabt {
+
+const char* kWasmExtension = ".wasm";
+
+const char* kWatExtension = ".wat";
+
+string_view StripExtension(string_view filename) {
+  return filename.substr(0, filename.find_last_of('.'));
+}
+
+string_view GetBasename(string_view filename) {
+  size_t last_slash = filename.find_last_of('/');
+  size_t last_backslash = filename.find_last_of('\\');
+  if (last_slash == string_view::npos && last_backslash == string_view::npos)
+    return filename;
+
+  if (last_slash == string_view::npos) {
+    if (last_backslash == string_view::npos)
+      return filename;
+    last_slash = last_backslash;
+  } else if (last_backslash != string_view::npos) {
+    last_slash = std::max(last_slash, last_backslash);
+  }
+
+  return filename.substr(last_slash + 1);
+}
+
+string_view GetExtension(string_view filename) {
+  size_t pos = filename.find_last_of('.');
+  if (pos == string_view::npos)
+    return "";
+  return filename.substr(pos);
+}
+
+}  // namespace wabt

--- a/src/filenames.h
+++ b/src/filenames.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_FILENAMES_H_
+#define WABT_FILENAMES_H_
+
+#include "src/common.h"
+
+namespace wabt {
+
+extern const char* kWasmExtension;
+extern const char* kWatExtension;
+
+// Return only the file extension, e.g.:
+//
+// "foo.txt", => ".txt"
+// "foo" => ""
+// "/foo/bar/foo.wasm" => ".wasm"
+string_view GetExtension(string_view filename);
+
+// Strip extension, e.g.:
+//
+// "foo", => "foo"
+// "foo.bar" => "foo"
+// "/path/to/foo.bar" => "/path/to/foo"
+// "\\path\\to\\foo.bar" => "\\path\\to\\foo"
+string_view StripExtension(string_view s);
+
+// Strip everything up to and including the last slash, e.g.:
+//
+// "/foo/bar/baz", => "baz"
+// "/usr/local/include/stdio.h", => "stdio.h"
+// "foo.bar", => "foo.bar"
+string_view GetBasename(string_view filename);
+
+}  // namespace wabt
+
+#endif /* WABT_FILENAMES_H_ */

--- a/src/test-filenames.cc
+++ b/src/test-filenames.cc
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/filenames.h"
+
+using namespace wabt;
+
+namespace {
+
+void assert_string_view_eq(const char* s, string_view sv) {
+  size_t len = std::strlen(s);
+  ASSERT_EQ(len, sv.size());
+  for (size_t i = 0; i < len; ++i) {
+    ASSERT_EQ(s[i], sv[i]);
+  }
+}
+
+}  // end anonymous namespace
+
+TEST(filenames, GetBasename) {
+  assert_string_view_eq("foo.txt", GetBasename("/bar/dir/foo.txt"));
+  assert_string_view_eq("foo.txt", GetBasename("bar/dir/foo.txt"));
+  assert_string_view_eq("foo.txt", GetBasename("/foo.txt"));
+  assert_string_view_eq("foo.txt", GetBasename("\\bar\\dir\\foo.txt"));
+  assert_string_view_eq("foo.txt", GetBasename("bar\\dir\\foo.txt"));
+  assert_string_view_eq("foo.txt", GetBasename("\\foo.txt"));
+  assert_string_view_eq("foo.txt", GetBasename("foo.txt"));
+  assert_string_view_eq("foo", GetBasename("foo"));
+  assert_string_view_eq("", GetBasename(""));
+}
+
+TEST(filenames, GetExtension) {
+  assert_string_view_eq(".txt", GetExtension("/bar/dir/foo.txt"));
+  assert_string_view_eq(".txt", GetExtension("bar/dir/foo.txt"));
+  assert_string_view_eq(".txt", GetExtension("foo.txt"));
+  assert_string_view_eq("", GetExtension("foo"));
+  assert_string_view_eq("", GetExtension(""));
+}
+
+TEST(filenames, StripExtension) {
+  assert_string_view_eq("/bar/dir/foo", StripExtension("/bar/dir/foo.txt"));
+  assert_string_view_eq("bar/dir/foo", StripExtension("bar/dir/foo.txt"));
+  assert_string_view_eq("foo", StripExtension("foo.txt"));
+  assert_string_view_eq("foo", StripExtension("foo"));
+  assert_string_view_eq("", StripExtension(""));
+}

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -43,6 +43,7 @@ SLOW_TIMEOUT_MULTIPLIER = 2
 TOOLS = {
     'wat2wasm': {
         'EXE': '%(wat2wasm)s',
+        'FLAGS': [ '-o', '%(out_dir)s/out.wasm'],
         'VERBOSE-FLAGS': ['-v']
     },
     'wast2json': {


### PR DESCRIPTION
This involves deriving the output filename from the input
filename when none is otherwise specified.

Also split out filename handling utilities and add unittests
for them.