### PR TITLE
Add SIMD suppor in run-interp.py/run-objdump.py/run-roundtrip.py

### DIFF
--- a/test/run-interp.py
+++ b/test/run-interp.py
@@ -50,6 +50,7 @@ def main(args):
   parser.add_argument('file', help='test file.')
   parser.add_argument('--enable-saturating-float-to-int', action='store_true')
   parser.add_argument('--enable-threads', action='store_true')
+  parser.add_argument('--enable-simd', action='store_true')
   options = parser.parse_args(args)
 
   wast_tool = None
@@ -78,6 +79,7 @@ def main(args):
       '--enable-saturating-float-to-int':
           options.enable_saturating_float_to_int,
       '--enable-threads': options.enable_threads,
+      '--enable-simd': options.enable_simd,
   })
 
   interp_tool.AppendOptionalArgs({
@@ -87,6 +89,7 @@ def main(args):
       '--enable-saturating-float-to-int':
           options.enable_saturating_float_to_int,
       '--enable-threads': options.enable_threads,
+      '--enable-simd': options.enable_simd,
   })
 
   wast_tool.verbose = options.print_cmd

--- a/test/run-objdump.py
+++ b/test/run-objdump.py
@@ -49,6 +49,7 @@ def main(args):
   parser.add_argument('--enable-exceptions', action='store_true')
   parser.add_argument('--enable-saturating-float-to-int', action='store_true')
   parser.add_argument('--enable-threads', action='store_true')
+  parser.add_argument('--enable-simd', action='store_true')
   parser.add_argument('--gen-wasm', action='store_true',
                       help='parse with gen-wasm')
   parser.add_argument('--spec', action='store_true')
@@ -80,6 +81,7 @@ def main(args):
       '--enable-saturating-float-to-int':
           options.enable_saturating_float_to_int,
       '--enable-threads': options.enable_threads,
+      '--enable-simd': options.enable_simd,
       '--no-check': options.no_check,
       '--no-canonicalize-leb128s': options.no_canonicalize_leb128s,
       '-v': options.verbose,

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -118,6 +118,7 @@ def main(args):
   parser.add_argument('--fold-exprs', action='store_true')
   parser.add_argument('--enable-exceptions', action='store_true')
   parser.add_argument('--enable-threads', action='store_true')
+  parser.add_argument('--enable-simd', action='store_true')
   parser.add_argument('--inline-exports', action='store_true')
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
@@ -129,6 +130,7 @@ def main(args):
       '--debug-names': options.debug_names,
       '--enable-exceptions': options.enable_exceptions,
       '--enable-threads': options.enable_threads,
+      '--enable-simd': options.enable_simd,
       '--no-check': options.no_check,
   })
 
@@ -139,6 +141,7 @@ def main(args):
       '--fold-exprs': options.fold_exprs,
       '--enable-exceptions': options.enable_exceptions,
       '--enable-threads': options.enable_threads,
+      '--enable-simd': options.enable_simd,
       '--inline-exports': options.inline_exports,
       '--no-debug-names': not options.debug_names,
       '--generate-names': options.generate_names,


### PR DESCRIPTION
Currently run-interp.py doesn't recongize --enable-simd flag in test file.

This PR add SIMD suppor in run-interp.py/run-objdump.py/run-roundtrip.py.