### PR TITLE
Add support for init function in linking metadata

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -460,6 +460,12 @@ Result BinaryReaderLogging::OnSegmentInfo(Index index,
   return reader_->OnSegmentInfo(index, name, alignment, flags);
 }
 
+Result BinaryReaderLogging::OnInitFunction(uint32_t priority,
+                                           Index func_index) {
+  LOGF("(OnInitFunction %d priority: %d)\n", func_index, priority);
+  return reader_->OnInitFunction(priority, func_index);
+}
+
 #define DEFINE_BEGIN(name)                        \
   Result BinaryReaderLogging::name(Offset size) { \
     LOGF(#name "(%" PRIzd ")\n", size);           \
@@ -625,8 +631,8 @@ DEFINE_BEGIN(BeginLinkingSection)
 DEFINE_INDEX(OnSymbolInfoCount)
 DEFINE_INDEX(OnStackGlobal)
 DEFINE_INDEX(OnDataSize)
-DEFINE_INDEX(OnDataAlignment)
 DEFINE_INDEX(OnSegmentInfoCount)
+DEFINE_INDEX(OnInitFunctionCount)
 DEFINE_END(EndLinkingSection)
 
 DEFINE_BEGIN(BeginExceptionSection);

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -256,12 +256,13 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnSymbolInfoCount(Index count) override;
   Result OnSymbolInfo(string_view name, uint32_t flags) override;
   Result OnDataSize(uint32_t data_size) override;
-  Result OnDataAlignment(uint32_t data_alignment) override;
   Result OnSegmentInfoCount(Index count) override;
   Result OnSegmentInfo(Index index,
                        string_view name,
                        uint32_t alignment,
                        uint32_t flags) override;
+  Result OnInitFunctionCount(Index count) override;
+  Result OnInitFunction(uint32_t priority, Index function_index) override;
   Result EndLinkingSection() override;
 
   Result BeginExceptionSection(Offset size) override;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -361,14 +361,15 @@ class BinaryReaderNop : public BinaryReaderDelegate {
     return Result::Ok;
   }
   Result OnDataSize(uint32_t data_size) override { return Result::Ok; }
-  Result OnDataAlignment(uint32_t data_alignment) override {
-    return Result::Ok;
-  }
   Result OnSegmentInfoCount(Index count) override { return Result::Ok; }
   Result OnSegmentInfo(Index index,
                        string_view name,
                        uint32_t alignment,
                        uint32_t flags) override {
+    return Result::Ok;
+  }
+  Result OnInitFunctionCount(Index count) override { return Result::Ok; }
+  Result OnInitFunction(uint32_t priority, Index function_index) override {
     return Result::Ok;
   }
   Result EndLinkingSection() override { return Result::Ok; }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -553,12 +553,13 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnSymbolInfoCount(Index count) override;
   Result OnSymbolInfo(string_view name, uint32_t flags) override;
   Result OnDataSize(uint32_t data_size) override;
-  Result OnDataAlignment(uint32_t data_alignment) override;
   Result OnSegmentInfoCount(Index count) override;
   Result OnSegmentInfo(Index index,
                        string_view name,
                        uint32_t alignment,
                        uint32_t flags) override;
+  Result OnInitFunctionCount(Index count) override;
+  Result OnInitFunction(uint32_t priority, Index function_index) override;
 
   Result OnExceptionCount(Index count) override;
   Result OnExceptionType(Index index, TypeVector& sig) override;
@@ -1145,6 +1146,18 @@ Result BinaryReaderObjdump::OnSegmentInfo(Index index,
   return Result::Ok;
 }
 
+
+Result BinaryReaderObjdump::OnInitFunctionCount(Index count) {
+  PrintDetails("  - init functions [count=%d]\n", count);
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdump::OnInitFunction(uint32_t priority,
+                                           Index function_index) {
+  PrintDetails("   - %d: priority=%d\n", function_index, priority);
+  return Result::Ok;
+}
+
 Result BinaryReaderObjdump::OnExceptionCount(Index count) {
   return OnCount(count);
 }
@@ -1166,11 +1179,6 @@ Result BinaryReaderObjdump::OnExceptionType(Index index, TypeVector& sig) {
 
 Result BinaryReaderObjdump::OnDataSize(uint32_t data_size) {
   PrintDetails("  - data size : %d\n", data_size);
-  return Result::Ok;
-}
-
-Result BinaryReaderObjdump::OnDataAlignment(uint32_t data_alignment) {
-  PrintDetails("  - data align: %d\n", data_alignment);
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1320,6 +1320,7 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
           CHECK_RESULT(ReadU32Leb128(&func, "function index"));
           CALLBACK(OnInitFunction, priority, func);
         }
+        break;
       default:
         // Unknown subsection, skip it.
         state_.offset = subsection_end;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1272,6 +1272,7 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
                  "invalid sub-section size: extends past end");
     read_end_ = subsection_end;
 
+    uint32_t count;
     switch (static_cast<LinkingEntryType>(linking_type)) {
       case LinkingEntryType::StackPointer: {
         uint32_t stack_ptr;
@@ -1279,11 +1280,10 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
         CALLBACK(OnStackGlobal, stack_ptr);
         break;
       }
-      case LinkingEntryType::SymbolInfo: {
-        uint32_t info_count;
-        CHECK_RESULT(ReadU32Leb128(&info_count, "info count"));
-        CALLBACK(OnSymbolInfoCount, info_count);
-        while (info_count--) {
+      case LinkingEntryType::SymbolInfo:
+        CHECK_RESULT(ReadU32Leb128(&count, "info count"));
+        CALLBACK(OnSymbolInfoCount, count);
+        while (count--) {
           string_view name;
           uint32_t info;
           CHECK_RESULT(ReadStr(&name, "symbol name"));
@@ -1291,24 +1291,16 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
           CALLBACK(OnSymbolInfo, name, info);
         }
         break;
-      }
       case LinkingEntryType::DataSize: {
         uint32_t data_size;
         CHECK_RESULT(ReadU32Leb128(&data_size, "data size"));
         CALLBACK(OnDataSize, data_size);
         break;
       }
-      case LinkingEntryType::DataAlignment: {
-        uint32_t data_alignment;
-        CHECK_RESULT(ReadU32Leb128(&data_alignment, "data alignment"));
-        CALLBACK(OnDataAlignment, data_alignment);
-        break;
-      }
-      case LinkingEntryType::SegmentInfo: {
-        uint32_t info_count;
-        CHECK_RESULT(ReadU32Leb128(&info_count, "info count"));
-        CALLBACK(OnSegmentInfoCount, info_count);
-        for (Index i = 0; i < info_count; i++) {
+      case LinkingEntryType::SegmentInfo:
+        CHECK_RESULT(ReadU32Leb128(&count, "info count"));
+        CALLBACK(OnSegmentInfoCount, count);
+        for (Index i = 0; i < count; i++) {
           string_view name;
           uint32_t alignment;
           uint32_t flags;
@@ -1318,7 +1310,16 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
           CALLBACK(OnSegmentInfo, i, name, alignment, flags);
         }
         break;
-      }
+      case LinkingEntryType::InitFunctions:
+        CHECK_RESULT(ReadU32Leb128(&count, "info count"));
+        CALLBACK(OnInitFunctionCount, count);
+        while (count--) {
+          uint32_t priority;
+          uint32_t func;
+          CHECK_RESULT(ReadU32Leb128(&priority, "priority"));
+          CHECK_RESULT(ReadU32Leb128(&func, "function index"));
+          CALLBACK(OnInitFunction, priority, func);
+        }
       default:
         // Unknown subsection, skip it.
         state_.offset = subsection_end;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -307,12 +307,13 @@ class BinaryReaderDelegate {
   virtual Result OnSymbolInfoCount(Index count) = 0;
   virtual Result OnSymbolInfo(string_view name, uint32_t flags) = 0;
   virtual Result OnDataSize(uint32_t data_size) = 0;
-  virtual Result OnDataAlignment(uint32_t data_alignment) = 0;
   virtual Result OnSegmentInfoCount(Index count) = 0;
   virtual Result OnSegmentInfo(Index index,
                                string_view name,
                                uint32_t alignment,
                                uint32_t flags) = 0;
+  virtual Result OnInitFunctionCount(Index count) = 0;
+  virtual Result OnInitFunction(uint32_t priority, Index function_index) = 0;
   virtual Result EndLinkingSection() = 0;
 
   /* Exception section */

--- a/src/common.h
+++ b/src/common.h
@@ -230,8 +230,8 @@ enum class LinkingEntryType {
   StackPointer = 1,
   SymbolInfo = 2,
   DataSize = 3,
-  DataAlignment = 4,
   SegmentInfo = 5,
+  InitFunctions = 6,
 };
 
 enum class SymbolBinding {

--- a/src/tools/wasm-link.cc
+++ b/src/tools/wasm-link.cc
@@ -502,17 +502,10 @@ void Linker::WriteLinkingSection(uint32_t data_size, uint32_t data_alignment) {
 
   WriteStr(&stream_, "linking", "linking section name");
 
-  {
+  if (data_size) {
     WriteU32Leb128(&stream_, LinkingEntryType::DataSize, "subsection code");
     Fixup fixup_subsection = WriteUnknownSize();
     WriteU32Leb128(&stream_, data_size, "data size");
-    FixupSize(fixup_subsection);
-  }
-
-  {
-    WriteU32Leb128(&stream_, LinkingEntryType::DataAlignment, "subsection code");
-    Fixup fixup_subsection = WriteUnknownSize();
-    WriteU32Leb128(&stream_, data_alignment, "data alignment");
     FixupSize(fixup_subsection);
   }
 

--- a/test/binary/linking-section.txt
+++ b/test/binary/linking-section.txt
@@ -24,6 +24,13 @@ section("linking") {
   str("data2")
   align[8]
   flags[0]
+  subsection[6]
+  length[5]
+  count[2]
+  priority[5]
+  func[1]
+  priority[6]
+  func[0]
 }
 (;; STDOUT ;;;
 
@@ -41,4 +48,7 @@ Custom:
   - segment info [count=2]
    - 0: data1 align=4 flags=0
    - 1: data2 align=8 flags=0
+  - init functions [count=2]
+   - 1: priority=5
+   - 0: priority=6
 ;;; STDOUT ;;)

--- a/test/link/function_calls.txt
+++ b/test/link/function_calls.txt
@@ -34,8 +34,8 @@ Sections:
    Export start=0x00000050 end=0x00000057 (size=0x00000007) count: 1
      Code start=0x00000059 end=0x0000008b (size=0x00000032) count: 2
    Custom start=0x00000091 end=0x000000cd (size=0x0000003c) "name"
-   Custom start=0x000000d3 end=0x000000e9 (size=0x00000016) "linking"
-   Custom start=0x000000ef end=0x0000010b (size=0x0000001c) "reloc.Code"
+   Custom start=0x000000d3 end=0x000000db (size=0x00000008) "linking"
+   Custom start=0x000000e1 end=0x000000fd (size=0x0000001c) "reloc.Code"
 
 Section Details:
 
@@ -60,8 +60,6 @@ Custom:
  - func[3] m2_local_func
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Code"
   - section: Code

--- a/test/link/function_calls_incremental.txt
+++ b/test/link/function_calls_incremental.txt
@@ -45,8 +45,8 @@ Sections:
    Import start=0x0000002a end=0x00000069 (size=0x0000003f) count: 3
  Function start=0x0000006f end=0x00000073 (size=0x00000004) count: 3
      Code start=0x00000075 end=0x000000b7 (size=0x00000042) count: 3
-   Custom start=0x000000bd end=0x000000d3 (size=0x00000016) "linking"
-   Custom start=0x000000d9 end=0x000000f8 (size=0x0000001f) "reloc.Code"
+   Custom start=0x000000bd end=0x000000c5 (size=0x00000008) "linking"
+   Custom start=0x000000cb end=0x000000ea (size=0x0000001f) "reloc.Code"
 
 Section Details:
 
@@ -67,8 +67,6 @@ Function:
  - func[5] sig=5
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Code"
   - section: Code

--- a/test/link/globals.txt
+++ b/test/link/globals.txt
@@ -35,8 +35,8 @@ Sections:
  Function start=0x00000041 end=0x00000044 (size=0x00000003) count: 2
    Global start=0x00000046 end=0x00000056 (size=0x00000010) count: 3
      Code start=0x00000058 end=0x0000008b (size=0x00000033) count: 2
-   Custom start=0x00000091 end=0x000000a7 (size=0x00000016) "linking"
-   Custom start=0x000000ad end=0x000000cf (size=0x00000022) "reloc.Code"
+   Custom start=0x00000091 end=0x00000099 (size=0x00000008) "linking"
+   Custom start=0x0000009f end=0x000000c1 (size=0x00000022) "reloc.Code"
 
 Section Details:
 
@@ -55,8 +55,6 @@ Global:
  - global[4] i64 mutable=0 - init i64=2
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Code"
   - section: Code

--- a/test/link/incremental.txt
+++ b/test/link/incremental.txt
@@ -51,9 +51,9 @@ Sections:
      Elem start=0x00000084 end=0x000000ad (size=0x00000029) count: 1
      Code start=0x000000af end=0x000000f1 (size=0x00000042) count: 3
    Custom start=0x000000f7 end=0x00000118 (size=0x00000021) "name"
-   Custom start=0x0000011e end=0x00000134 (size=0x00000016) "linking"
-   Custom start=0x0000013a end=0x0000015c (size=0x00000022) "reloc.Elem"
-   Custom start=0x00000162 end=0x00000181 (size=0x0000001f) "reloc.Code"
+   Custom start=0x0000011e end=0x00000126 (size=0x00000008) "linking"
+   Custom start=0x0000012c end=0x0000014e (size=0x00000022) "reloc.Elem"
+   Custom start=0x00000154 end=0x00000173 (size=0x0000001f) "reloc.Code"
 
 Section Details:
 
@@ -91,8 +91,6 @@ Custom:
  - func[5] func3
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Elem"
   - section: Elem

--- a/test/link/large_code_section.txt
+++ b/test/link/large_code_section.txt
@@ -83,8 +83,8 @@ Sections:
  Function start=0x00000015 end=0x00000017 (size=0x00000002) count: 1
      Code start=0x0000001a end=0x000000a1 (size=0x00000087) count: 1
    Custom start=0x000000a7 end=0x000000bf (size=0x00000018) "name"
-   Custom start=0x000000c5 end=0x000000db (size=0x00000016) "linking"
-   Custom start=0x000000e1 end=0x000000f1 (size=0x00000010) "reloc.Code"
+   Custom start=0x000000c5 end=0x000000cd (size=0x00000008) "linking"
+   Custom start=0x000000d3 end=0x000000e3 (size=0x00000010) "reloc.Code"
 
 Section Details:
 
@@ -97,8 +97,6 @@ Custom:
  - func[0] local_func
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Code"
   - section: Code

--- a/test/link/names.txt
+++ b/test/link/names.txt
@@ -36,8 +36,8 @@ Sections:
    Export start=0x0000006d end=0x0000007a (size=0x0000000d) count: 2
      Code start=0x0000007c end=0x000000a1 (size=0x00000025) count: 4
    Custom start=0x000000a7 end=0x000000e4 (size=0x0000003d) "name"
-   Custom start=0x000000ea end=0x00000100 (size=0x00000016) "linking"
-   Custom start=0x00000106 end=0x0000011c (size=0x00000016) "reloc.Code"
+   Custom start=0x000000ea end=0x000000f2 (size=0x00000008) "linking"
+   Custom start=0x000000f8 end=0x0000010e (size=0x00000016) "reloc.Code"
 
 Section Details:
 
@@ -67,8 +67,6 @@ Custom:
  - func[6] name3
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Code"
   - section: Code

--- a/test/link/names_import_only.txt
+++ b/test/link/names_import_only.txt
@@ -16,7 +16,7 @@ Sections:
      Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    Import start=0x00000014 end=0x00000024 (size=0x00000010) count: 1
    Custom start=0x0000002a end=0x00000044 (size=0x0000001a) "name"
-   Custom start=0x0000004a end=0x00000060 (size=0x00000016) "linking"
+   Custom start=0x0000004a end=0x00000052 (size=0x00000008) "linking"
 
 Section Details:
 
@@ -29,8 +29,6 @@ Custom:
  - func[0] import_func1
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 
 Code Disassembly:
 

--- a/test/link/names_import_only_module_env.txt
+++ b/test/link/names_import_only_module_env.txt
@@ -16,7 +16,7 @@ Sections:
      Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
    Import start=0x00000014 end=0x0000001f (size=0x0000000b) count: 1
    Custom start=0x00000025 end=0x0000003f (size=0x0000001a) "name"
-   Custom start=0x00000045 end=0x0000005b (size=0x00000016) "linking"
+   Custom start=0x00000045 end=0x0000004d (size=0x00000008) "linking"
 
 Section Details:
 
@@ -29,8 +29,6 @@ Custom:
  - func[0] import_func1
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 
 Code Disassembly:
 

--- a/test/link/table.txt
+++ b/test/link/table.txt
@@ -30,9 +30,9 @@ Sections:
      Elem start=0x00000036 end=0x00000055 (size=0x0000001f) count: 1
      Code start=0x00000057 end=0x0000006d (size=0x00000016) count: 4
    Custom start=0x00000073 end=0x0000009b (size=0x00000028) "name"
-   Custom start=0x000000a1 end=0x000000b7 (size=0x00000016) "linking"
-   Custom start=0x000000bd end=0x000000d9 (size=0x0000001c) "reloc.Elem"
-   Custom start=0x000000df end=0x000000ef (size=0x00000010) "reloc.Code"
+   Custom start=0x000000a1 end=0x000000a9 (size=0x00000008) "linking"
+   Custom start=0x000000af end=0x000000cb (size=0x0000001c) "reloc.Elem"
+   Custom start=0x000000d1 end=0x000000e1 (size=0x00000010) "reloc.Code"
 
 Section Details:
 
@@ -64,8 +64,6 @@ Custom:
  - func[3] func4
 Custom:
  - name: "linking"
-  - data size : 0
-  - data align: 0
 Custom:
  - name: "reloc.Elem"
   - section: Elem


### PR DESCRIPTION
Add support for init function in linking metadata
    
Also remove support for DataAlignment which was removed
from the "spec" (Linking.md) and only output DataSize
if its non-zero.
