### PR TITLE
Fix bug when writing inline exports for import

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -112,6 +112,28 @@ Index Module::GetExceptIndex(const Var& var) const {
   return except_bindings.FindIndex(var);
 }
 
+bool Module::IsImport(ExternalKind kind, const Var& var) const {
+  switch (kind) {
+    case ExternalKind::Func:
+      return GetFuncIndex(var) < num_func_imports;
+
+    case ExternalKind::Global:
+      return GetGlobalIndex(var) < num_global_imports;
+
+    case ExternalKind::Memory:
+      return GetMemoryIndex(var) < num_memory_imports;
+
+    case ExternalKind::Table:
+      return GetTableIndex(var) < num_table_imports;
+
+    case ExternalKind::Except:
+      return GetExceptIndex(var) < num_except_imports;
+
+    default:
+      return false;
+  }
+}
+
 Index Func::GetLocalIndex(const Var& var) const {
   if (var.is_index()) {
     return var.index();

--- a/src/ir.h
+++ b/src/ir.h
@@ -684,6 +684,11 @@ struct Module {
   Exception* GetExcept(const Var&) const;
   Index GetExceptIndex(const Var&) const;
 
+  bool IsImport(ExternalKind kind, const Var&) const;
+  bool IsImport(const Export& export_) const {
+    return IsImport(export_.kind, export_.var);
+  }
+
   // TODO(binji): move this into a builder class?
   void AppendField(std::unique_ptr<DataSegmentModuleField>);
   void AppendField(std::unique_ptr<ElemSegmentModuleField>);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1180,7 +1180,10 @@ void WatWriter::WriteImport(const Import& import) {
 
 void WatWriter::WriteExport(const Export& export_) {
   if (options_->inline_export) {
-    return;
+    // Exported imports can't be written with inline exports.
+    if (!module_->IsImport(export_)) {
+      return;
+    }
   }
   WriteOpenSpace("export");
   WriteQuotedString(export_.name, NextChar::Space);

--- a/test/regress/regress-19.txt
+++ b/test/regress/regress-19.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --inline-export --stdout
+(module
+  (import "foo" "bar" (func))
+  (export "baz" (func 0))
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (import "foo" "bar" (func (;0;) (type 0)))
+  (export "baz" (func 0)))
+;;; STDOUT ;;)


### PR DESCRIPTION
The `(import...` syntax doesn't allow for inline exports, but the wat
writer assumed that all exports would be written inline, so the exports
would be omitted.

This CL fixes it by writing the exports normally:

```
(module
  (import "foo" "bar" (func))
  (export "baz" (func 0))
)
```

It is also possible to fix this by writing the imports inline, but this
is not currently supported by the .wat writer:

```
(module
  (func (export "baz") (import "foo" "bar"))
)
```