### PR TITLE
Add WatWriter option for inline imports

### DIFF
--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -76,6 +76,8 @@ static void ParseOptions(int argc, char** argv) {
   s_features.AddOptions(&parser);
   parser.AddOption("inline-exports", "Write all exports inline",
                    []() { s_write_wat_options.inline_export = true; });
+  parser.AddOption("inline-imports", "Write all imports inline",
+                   []() { s_write_wat_options.inline_import = true; });
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });
   parser.AddOption(

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -167,7 +167,6 @@ class WatWriter {
   void WriteMemory(const Memory& memory);
   void WriteDataSegment(const DataSegment& segment);
   void WriteImport(const Import& import);
-  void WriteInlineImport(const Import& import);
   void WriteExport(const Export& export_);
   void WriteFuncType(const FuncType& func_type);
   void WriteStartFunction(const Var& start);
@@ -1204,43 +1203,6 @@ void WatWriter::WriteImport(const Import& import) {
     WriteNewline(NO_FORCE_NEWLINE);
   } else {
     WriteCloseNewline();
-  }
-}
-
-void WatWriter::WriteInlineImport(const Import& import) {
-  switch (import.kind()) {
-    case ExternalKind::Func: {
-      auto* func_import = cast<FuncImport>(&import);
-      WriteOpenSpace("func");
-      WriteNameOrIndex(func_import->func.name, func_index_++, NextChar::Space);
-      if (func_import->func.decl.has_func_type) {
-        WriteOpenSpace("type");
-        WriteVar(func_import->func.decl.type_var, NextChar::None);
-        WriteCloseSpace();
-      } else {
-        WriteFuncSigSpace(func_import->func.decl.sig);
-      }
-      WriteCloseSpace();
-      break;
-    }
-
-    case ExternalKind::Table:
-      WriteTable(cast<TableImport>(&import)->table);
-      break;
-
-    case ExternalKind::Memory:
-      WriteMemory(cast<MemoryImport>(&import)->memory);
-      break;
-
-    case ExternalKind::Global:
-      WriteBeginGlobal(cast<GlobalImport>(&import)->global);
-      WriteCloseSpace();
-      break;
-
-    case ExternalKind::Except:
-      WriteBeginException(cast<ExceptionImport>(&import)->except);
-      WriteCloseSpace();
-      break;
   }
 }
 

--- a/src/wat-writer.h
+++ b/src/wat-writer.h
@@ -27,6 +27,7 @@ class Stream;
 struct WriteWatOptions {
   bool fold_exprs = false;  // Write folded expressions.
   bool inline_export = false;
+  bool inline_import = false;
 };
 
 Result WriteWat(Stream*, const Module*, const WriteWatOptions*);

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -23,6 +23,7 @@ options:
       --enable-threads                        Threading support
       --enable-simd                           SIMD support
       --inline-exports                        Write all exports inline
+      --inline-imports                        Write all imports inline
       --no-debug-names                        Ignore debug names in the binary file
       --generate-names                        Give auto-generated names to non-named functions, types, etc.
       --no-check                              Don't check for invalid modules

--- a/test/roundtrip/inline-import-export.txt
+++ b/test/roundtrip/inline-import-export.txt
@@ -1,0 +1,21 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --inline-import --inline-export
+(module
+  (import "mod" "f" (func $f (param i32)))
+  (import "mod" "g" (global $g f32))
+  (import "mod" "t" (table $t 1 2 anyfunc))
+  (import "mod" "m" (memory $m 3))
+
+  (export "F" (func $f))
+  (export "G" (global $g))
+  (export "T" (table $t))
+  (export "M" (memory $m))
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (param i32)))
+  (func (;0;) (export "F") (import "mod" "f") (type 0) (param i32))
+  (global (;0;) (export "G") (import "mod" "g") f32)
+  (table (;0;) (export "T") (import "mod" "t") 1 2 anyfunc)
+  (memory (;0;) (export "M") (import "mod" "m") 3))
+;;; STDOUT ;;)

--- a/test/roundtrip/inline-import-func.txt
+++ b/test/roundtrip/inline-import-func.txt
@@ -1,0 +1,13 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --inline-import
+(module
+  (import "mod" "f1" (func (param i32 f32) (result f64)))
+  (import "mod" "f2" (func (result i64)))
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (param i32 f32) (result f64)))
+  (type (;1;) (func (result i64)))
+  (func (;0;) (import "mod" "f1") (type 0) (param i32 f32) (result f64))
+  (func (;1;) (import "mod" "f2") (type 1) (result i64)))
+;;; STDOUT ;;)

--- a/test/roundtrip/inline-import-global.txt
+++ b/test/roundtrip/inline-import-global.txt
@@ -1,0 +1,15 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --inline-import
+(module
+  (import "mod" "g1" (global i32))
+  (import "mod" "g2" (global f32))
+  (import "mod" "g3" (global i64))
+  (import "mod" "g4" (global f64))
+)
+(;; STDOUT ;;;
+(module
+  (global (;0;) (import "mod" "g1") i32)
+  (global (;1;) (import "mod" "g2") f32)
+  (global (;2;) (import "mod" "g3") i64)
+  (global (;3;) (import "mod" "g4") f64))
+;;; STDOUT ;;)

--- a/test/roundtrip/inline-import-memory.txt
+++ b/test/roundtrip/inline-import-memory.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --inline-import
+(module
+  (import "mod" "m1" (memory 2 3))
+)
+(;; STDOUT ;;;
+(module
+  (memory (;0;) (import "mod" "m1") 2 3))
+;;; STDOUT ;;)

--- a/test/roundtrip/inline-import-table.txt
+++ b/test/roundtrip/inline-import-table.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-roundtrip
+;;; FLAGS: --stdout --inline-import
+(module
+  (import "mod" "t1" (table 1 anyfunc))
+)
+(;; STDOUT ;;;
+(module
+  (table (;0;) (import "mod" "t1") 1 anyfunc))
+;;; STDOUT ;;)

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -120,6 +120,7 @@ def main(args):
   parser.add_argument('--enable-threads', action='store_true')
   parser.add_argument('--enable-simd', action='store_true')
   parser.add_argument('--inline-exports', action='store_true')
+  parser.add_argument('--inline-imports', action='store_true')
   parser.add_argument('file', help='test file.')
   options = parser.parse_args(args)
 
@@ -143,6 +144,7 @@ def main(args):
       '--enable-threads': options.enable_threads,
       '--enable-simd': options.enable_simd,
       '--inline-exports': options.inline_exports,
+      '--inline-imports': options.inline_imports,
       '--no-debug-names': not options.debug_names,
       '--generate-names': options.generate_names,
       '--no-check': options.no_check,


### PR DESCRIPTION
Inline imports are more flexible than regular imports, since they can be
combined with inline exports. For example:

```
(func (export "baz") (import "foo" "bar") (param i32))
```