### PR TITLE
Fix run-tests.py when STDIN_FILE is used > 1 times

### DIFF
--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -288,11 +288,18 @@ class TestInfo(object):
     return name
 
   def GetGeneratedInputFilename(self):
+    # All tests should be generated in their own directories, even if they
+    # share the same input filename. We want the input filename to be correct,
+    # though, so we use the directory of the test (.txt) file, but the basename
+    # of the input file (likely a .wast).
+
     path = OUT_DIR
     if self.input_filename:
-      path = os.path.join(path, self.input_filename)
+      basename = os.path.basename(self.input_filename)
     else:
-      path = os.path.join(path, self.filename)
+      basename = os.path.basename(self.filename)
+
+    path = os.path.join(path, os.path.dirname(self.filename), basename)
 
     if self.is_roundtrip:
       dirname = os.path.dirname(path)

--- a/test/spec/address.txt
+++ b/test/spec/address.txt
@@ -1,8 +1,8 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/address.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/address.wast:98: assert_malformed passed:
-  out/third_party/testsuite/address/address.1.wat:1:33: error: offset must be less than or equal to 0xffffffff
+out/test/spec/address.wast:98: assert_malformed passed:
+  out/test/spec/address/address.1.wat:1:33: error: offset must be less than or equal to 0xffffffff
   (memory 1)(func (drop (i32.load offset=4294967296 (i32.const 0))))
                                   ^^^^^^^^^^^^^^^^^
 42/42 tests passed.

--- a/test/spec/align.txt
+++ b/test/spec/align.txt
@@ -1,26 +1,26 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/align.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/align.wast:2: assert_malformed passed:
-  out/third_party/testsuite/align/align.0.wat:1:42: error: alignment must be power-of-two
+out/test/spec/align.wast:2: assert_malformed passed:
+  out/test/spec/align/align.0.wat:1:42: error: alignment must be power-of-two
   (module (memory 0) (func (drop (i64.load align=0 (i32.const 0)))))
                                            ^^^^^^^
-out/third_party/testsuite/align.wast:8: assert_malformed passed:
-  out/third_party/testsuite/align/align.1.wat:1:42: error: alignment must be power-of-two
+out/test/spec/align.wast:8: assert_malformed passed:
+  out/test/spec/align/align.1.wat:1:42: error: alignment must be power-of-two
   (module (memory 0) (func (drop (i64.load align=7 (i32.const 0)))))
                                            ^^^^^^^
-out/third_party/testsuite/align.wast:14: assert_invalid passed:
+out/test/spec/align.wast:14: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/align.wast:19: assert_malformed passed:
-  out/third_party/testsuite/align/align.3.wat:1:37: error: alignment must be power-of-two
+out/test/spec/align.wast:19: assert_malformed passed:
+  out/test/spec/align/align.3.wat:1:37: error: alignment must be power-of-two
   (module (memory 0) (func (i64.store align=0 (i32.const 0) (i64.const 0))))
                                       ^^^^^^^
-out/third_party/testsuite/align.wast:25: assert_malformed passed:
-  out/third_party/testsuite/align/align.4.wat:1:37: error: alignment must be power-of-two
+out/test/spec/align.wast:25: assert_malformed passed:
+  out/test/spec/align/align.4.wat:1:37: error: alignment must be power-of-two
   (module (memory 0) (func (i64.store align=5 (i32.const 0) (i64.const 0))))
                                       ^^^^^^^
-out/third_party/testsuite/align.wast:31: assert_invalid passed:
+out/test/spec/align.wast:31: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
   0000023: error: OnStoreExpr callback failed
 6/6 tests passed.

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -1,61 +1,61 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/binary.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/binary.wast:6: assert_malformed passed:
+out/test/spec/binary.wast:6: assert_malformed passed:
   0000000: error: unable to read uint32_t: magic
-out/third_party/testsuite/binary.wast:7: assert_malformed passed:
+out/test/spec/binary.wast:7: assert_malformed passed:
   0000000: error: unable to read uint32_t: magic
-out/third_party/testsuite/binary.wast:8: assert_malformed passed:
+out/test/spec/binary.wast:8: assert_malformed passed:
   0000000: error: unable to read uint32_t: magic
-out/third_party/testsuite/binary.wast:9: assert_malformed passed:
+out/test/spec/binary.wast:9: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:10: assert_malformed passed:
+out/test/spec/binary.wast:10: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:11: assert_malformed passed:
+out/test/spec/binary.wast:11: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:12: assert_malformed passed:
+out/test/spec/binary.wast:12: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:13: assert_malformed passed:
+out/test/spec/binary.wast:13: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:14: assert_malformed passed:
+out/test/spec/binary.wast:14: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:15: assert_malformed passed:
+out/test/spec/binary.wast:15: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:16: assert_malformed passed:
+out/test/spec/binary.wast:16: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:17: assert_malformed passed:
+out/test/spec/binary.wast:17: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:18: assert_malformed passed:
+out/test/spec/binary.wast:18: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:21: assert_malformed passed:
+out/test/spec/binary.wast:21: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:24: assert_malformed passed:
+out/test/spec/binary.wast:24: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:25: assert_malformed passed:
+out/test/spec/binary.wast:25: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:28: assert_malformed passed:
+out/test/spec/binary.wast:28: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:31: assert_malformed passed:
+out/test/spec/binary.wast:31: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:34: assert_malformed passed:
+out/test/spec/binary.wast:34: assert_malformed passed:
   0000004: error: bad magic value
-out/third_party/testsuite/binary.wast:36: assert_malformed passed:
+out/test/spec/binary.wast:36: assert_malformed passed:
   0000004: error: unable to read uint32_t: version
-out/third_party/testsuite/binary.wast:37: assert_malformed passed:
+out/test/spec/binary.wast:37: assert_malformed passed:
   0000004: error: unable to read uint32_t: version
-out/third_party/testsuite/binary.wast:38: assert_malformed passed:
+out/test/spec/binary.wast:38: assert_malformed passed:
   0000004: error: unable to read uint32_t: version
-out/third_party/testsuite/binary.wast:39: assert_malformed passed:
+out/test/spec/binary.wast:39: assert_malformed passed:
   0000008: error: bad wasm file version: 0 (expected 0x1)
-out/third_party/testsuite/binary.wast:40: assert_malformed passed:
+out/test/spec/binary.wast:40: assert_malformed passed:
   0000008: error: bad wasm file version: 0xd (expected 0x1)
-out/third_party/testsuite/binary.wast:41: assert_malformed passed:
+out/test/spec/binary.wast:41: assert_malformed passed:
   0000008: error: bad wasm file version: 0xe (expected 0x1)
-out/third_party/testsuite/binary.wast:42: assert_malformed passed:
+out/test/spec/binary.wast:42: assert_malformed passed:
   0000008: error: bad wasm file version: 0x100 (expected 0x1)
-out/third_party/testsuite/binary.wast:43: assert_malformed passed:
+out/test/spec/binary.wast:43: assert_malformed passed:
   0000008: error: bad wasm file version: 0x10000 (expected 0x1)
-out/third_party/testsuite/binary.wast:44: assert_malformed passed:
+out/test/spec/binary.wast:44: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
 28/28 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -1,78 +1,78 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/block.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/block.wast:159: assert_invalid passed:
+out/test/spec/block.wast:159: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/block.wast:163: assert_invalid passed:
+out/test/spec/block.wast:163: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/block.wast:167: assert_invalid passed:
+out/test/spec/block.wast:167: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/block.wast:171: assert_invalid passed:
+out/test/spec/block.wast:171: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/block.wast:176: assert_invalid passed:
+out/test/spec/block.wast:176: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/third_party/testsuite/block.wast:182: assert_invalid passed:
+out/test/spec/block.wast:182: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/third_party/testsuite/block.wast:188: assert_invalid passed:
+out/test/spec/block.wast:188: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/third_party/testsuite/block.wast:194: assert_invalid passed:
+out/test/spec/block.wast:194: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/block.wast:200: assert_invalid passed:
+out/test/spec/block.wast:200: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/third_party/testsuite/block.wast:207: assert_invalid passed:
+out/test/spec/block.wast:207: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:213: assert_invalid passed:
+out/test/spec/block.wast:213: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:220: assert_invalid passed:
+out/test/spec/block.wast:220: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:226: assert_invalid passed:
+out/test/spec/block.wast:226: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:232: assert_invalid passed:
+out/test/spec/block.wast:232: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:238: assert_invalid passed:
+out/test/spec/block.wast:238: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:245: assert_invalid passed:
+out/test/spec/block.wast:245: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
-out/third_party/testsuite/block.wast:251: assert_invalid passed:
+out/test/spec/block.wast:251: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:258: assert_invalid passed:
+out/test/spec/block.wast:258: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:264: assert_invalid passed:
+out/test/spec/block.wast:264: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/third_party/testsuite/block.wast:273: assert_invalid passed:
+out/test/spec/block.wast:273: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/block.wast:279: assert_invalid passed:
+out/test/spec/block.wast:279: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001f: error: OnUnaryExpr callback failed
-out/third_party/testsuite/block.wast:285: assert_invalid passed:
+out/test/spec/block.wast:285: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/third_party/testsuite/block.wast:293: assert_malformed passed:
-  out/third_party/testsuite/block/block.23.wat:1:17: error: unexpected label "$l"
+out/test/spec/block.wast:293: assert_malformed passed:
+  out/test/spec/block/block.23.wat:1:17: error: unexpected label "$l"
   (func block end $l)
                   ^^
-out/third_party/testsuite/block.wast:297: assert_malformed passed:
-  out/third_party/testsuite/block/block.24.wat:1:20: error: mismatching label "$a" != "$l"
+out/test/spec/block.wast:297: assert_malformed passed:
+  out/test/spec/block/block.24.wat:1:20: error: mismatching label "$a" != "$l"
   (func block $a end $l)
                      ^^
 38/38 tests passed.

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -1,25 +1,25 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/br.wast:411: assert_invalid passed:
+out/test/spec/br.wast:411: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/third_party/testsuite/br.wast:418: assert_invalid passed:
+out/test/spec/br.wast:418: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/third_party/testsuite/br.wast:424: assert_invalid passed:
+out/test/spec/br.wast:424: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
-out/third_party/testsuite/br.wast:430: assert_invalid passed:
+out/test/spec/br.wast:430: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/br.wast:437: assert_invalid passed:
+out/test/spec/br.wast:437: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   0000019: error: OnBrExpr callback failed
-out/third_party/testsuite/br.wast:441: assert_invalid passed:
+out/test/spec/br.wast:441: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   000001d: error: OnBrExpr callback failed
-out/third_party/testsuite/br.wast:445: assert_invalid passed:
+out/test/spec/br.wast:445: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
   000001d: error: OnBrExpr callback failed
 68/68 tests passed.

--- a/test/spec/br_if.txt
+++ b/test/spec/br_if.txt
@@ -1,76 +1,76 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br_if.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/br_if.wast:191: assert_invalid passed:
+out/test/spec/br_if.wast:191: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/br_if.wast:195: assert_invalid passed:
+out/test/spec/br_if.wast:195: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/br_if.wast:199: assert_invalid passed:
+out/test/spec/br_if.wast:199: assert_invalid passed:
   error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/br_if.wast:203: assert_invalid passed:
+out/test/spec/br_if.wast:203: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/br_if.wast:208: assert_invalid passed:
+out/test/spec/br_if.wast:208: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/br_if.wast:212: assert_invalid passed:
+out/test/spec/br_if.wast:212: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:216: assert_invalid passed:
+out/test/spec/br_if.wast:216: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [f32]
   0000020: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:220: assert_invalid passed:
+out/test/spec/br_if.wast:220: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:225: assert_invalid passed:
+out/test/spec/br_if.wast:225: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:231: assert_invalid passed:
+out/test/spec/br_if.wast:231: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:237: assert_invalid passed:
+out/test/spec/br_if.wast:237: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/br_if.wast:243: assert_invalid passed:
+out/test/spec/br_if.wast:243: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/br_if.wast:250: assert_invalid passed:
+out/test/spec/br_if.wast:250: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:256: assert_invalid passed:
+out/test/spec/br_if.wast:256: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:262: assert_invalid passed:
+out/test/spec/br_if.wast:262: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:270: assert_invalid passed:
+out/test/spec/br_if.wast:270: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:279: assert_invalid passed:
+out/test/spec/br_if.wast:279: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001c: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:285: assert_invalid passed:
+out/test/spec/br_if.wast:285: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:291: assert_invalid passed:
+out/test/spec/br_if.wast:291: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:297: assert_invalid passed:
+out/test/spec/br_if.wast:297: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   0000022: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:303: assert_invalid passed:
+out/test/spec/br_if.wast:303: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [... i64]
   0000020: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:310: assert_invalid passed:
+out/test/spec/br_if.wast:310: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   000001b: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:314: assert_invalid passed:
+out/test/spec/br_if.wast:314: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   000001f: error: OnBrIfExpr callback failed
-out/third_party/testsuite/br_if.wast:318: assert_invalid passed:
+out/test/spec/br_if.wast:318: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
   000001f: error: OnBrIfExpr callback failed
 58/58 tests passed.

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -1,49 +1,49 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/br_table.wast:1413: assert_invalid passed:
+out/test/spec/br_table.wast:1413: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
-out/third_party/testsuite/br_table.wast:1420: assert_invalid passed:
+out/test/spec/br_table.wast:1420: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   0000020: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1426: assert_invalid passed:
+out/test/spec/br_table.wast:1426: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1434: assert_invalid passed:
+out/test/spec/br_table.wast:1434: assert_invalid passed:
   error: br_table labels have inconsistent types: expected f32, got void
   0000026: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1446: assert_invalid passed:
+out/test/spec/br_table.wast:1446: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   000001f: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1452: assert_invalid passed:
+out/test/spec/br_table.wast:1452: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
   000001e: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1458: assert_invalid passed:
+out/test/spec/br_table.wast:1458: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   0000021: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1464: assert_invalid passed:
+out/test/spec/br_table.wast:1464: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   0000023: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1470: assert_invalid passed:
+out/test/spec/br_table.wast:1470: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [... i64]
   0000022: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1479: assert_invalid passed:
+out/test/spec/br_table.wast:1479: assert_invalid passed:
   error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1485: assert_invalid passed:
+out/test/spec/br_table.wast:1485: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1491: assert_invalid passed:
+out/test/spec/br_table.wast:1491: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1498: assert_invalid passed:
+out/test/spec/br_table.wast:1498: assert_invalid passed:
   error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1504: assert_invalid passed:
+out/test/spec/br_table.wast:1504: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
-out/third_party/testsuite/br_table.wast:1510: assert_invalid passed:
+out/test/spec/br_table.wast:1510: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
 159/159 tests passed.

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -1,39 +1,39 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/call.wast:160: assert_invalid passed:
+out/test/spec/call.wast:160: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001b: error: OnConvertExpr callback failed
-out/third_party/testsuite/call.wast:167: assert_invalid passed:
+out/test/spec/call.wast:167: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001f: error: OnConvertExpr callback failed
-out/third_party/testsuite/call.wast:175: assert_invalid passed:
+out/test/spec/call.wast:175: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   000001e: error: OnCallExpr callback failed
-out/third_party/testsuite/call.wast:182: assert_invalid passed:
+out/test/spec/call.wast:182: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
-out/third_party/testsuite/call.wast:189: assert_invalid passed:
+out/test/spec/call.wast:189: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/third_party/testsuite/call.wast:196: assert_invalid passed:
+out/test/spec/call.wast:196: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/call.wast:204: assert_invalid passed:
+out/test/spec/call.wast:204: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/third_party/testsuite/call.wast:211: assert_invalid passed:
+out/test/spec/call.wast:211: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/third_party/testsuite/call.wast:218: assert_invalid passed:
+out/test/spec/call.wast:218: assert_invalid passed:
   error: type mismatch in call, expected [i32, f64] but got [f64, i32]
   000002a: error: OnCallExpr callback failed
-out/third_party/testsuite/call.wast:225: assert_invalid passed:
+out/test/spec/call.wast:225: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got [i32, f64]
   000002a: error: OnCallExpr callback failed
-out/third_party/testsuite/call.wast:236: assert_invalid passed:
+out/test/spec/call.wast:236: assert_invalid passed:
   0000019: error: invalid call function index: 1
-out/third_party/testsuite/call.wast:240: assert_invalid passed:
+out/test/spec/call.wast:240: assert_invalid passed:
   000001d: error: invalid call function index: 1012321300
 47/47 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -1,115 +1,115 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call_indirect.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/call_indirect.wast:273: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.1.wat:1:122: error: unexpected token "param", expected an expr.
+out/test/spec/call_indirect.wast:273: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.1.wat:1:122: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
-  out/third_party/testsuite/call_indirect/call_indirect.1.wat:1:166: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.1.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:285: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.2.wat:1:109: error: unexpected token "type", expected an expr.
+out/test/spec/call_indirect.wast:285: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.2.wat:1:109: error: unexpected token "type", expected an expr.
   ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
-  out/third_party/testsuite/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:297: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.3.wat:1:122: error: unexpected token "type", expected an expr.
+out/test/spec/call_indirect.wast:297: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.3.wat:1:122: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
-  out/third_party/testsuite/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:309: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.4.wat:1:110: error: unexpected token "type", expected an expr.
+out/test/spec/call_indirect.wast:309: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.4.wat:1:110: error: unexpected token "type", expected an expr.
   ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
-  out/third_party/testsuite/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:321: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "param", expected an expr.
+out/test/spec/call_indirect.wast:321: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "param", expected an expr.
   ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
-  out/third_party/testsuite/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:333: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.6.wat:1:67: error: unexpected token "param", expected an expr.
+out/test/spec/call_indirect.wast:333: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.6.wat:1:67: error: unexpected token "param", expected an expr.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                           ^^^^^
-  out/third_party/testsuite/call_indirect/call_indirect.6.wat:1:106: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.6.wat:1:106: error: unexpected token ), expected EOF.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:343: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.7.wat:1:46: error: unexpected token $x, expected ).
+out/test/spec/call_indirect.wast:343: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.7.wat:1:46: error: unexpected token $x, expected ).
   ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
-  out/third_party/testsuite/call_indirect/call_indirect.7.wat:1:82: error: unexpected token ), expected EOF.
+  out/test/spec/call_indirect/call_indirect.7.wat:1:82: error: unexpected token ), expected EOF.
   ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/third_party/testsuite/call_indirect.wast:350: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.8.wat:1:57: error: expected 0 results, got 1
+out/test/spec/call_indirect.wast:350: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.8.wat:1:57: error: expected 0 results, got 1
   ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/third_party/testsuite/call_indirect.wast:360: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.9.wat:1:82: error: expected 1 arguments, got 0
+out/test/spec/call_indirect.wast:360: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.9.wat:1:82: error: expected 1 arguments, got 0
   ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/third_party/testsuite/call_indirect.wast:370: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.10.wat:1:69: error: expected 1 results, got 0
+out/test/spec/call_indirect.wast:370: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.10.wat:1:69: error: expected 1 results, got 0
   ...i32)))(table 0 anyfunc)(func  (call_indirect (type $sig) (param i32) (i32....
                                     ^^^^^^^^^^^^^
-out/third_party/testsuite/call_indirect.wast:380: assert_malformed passed:
-  out/third_party/testsuite/call_indirect/call_indirect.11.wat:1:86: error: expected 2 arguments, got 1
+out/test/spec/call_indirect.wast:380: assert_malformed passed:
+  out/test/spec/call_indirect/call_indirect.11.wat:1:86: error: expected 2 arguments, got 1
   ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
-out/third_party/testsuite/call_indirect.wast:395: assert_invalid passed:
+out/test/spec/call_indirect.wast:395: assert_invalid passed:
   error: found call_indirect operator, but no table
   000001c: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:403: assert_invalid passed:
+out/test/spec/call_indirect.wast:403: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
-out/third_party/testsuite/call_indirect.wast:411: assert_invalid passed:
+out/test/spec/call_indirect.wast:411: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
-out/third_party/testsuite/call_indirect.wast:420: assert_invalid passed:
+out/test/spec/call_indirect.wast:420: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:428: assert_invalid passed:
+out/test/spec/call_indirect.wast:428: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:436: assert_invalid passed:
+out/test/spec/call_indirect.wast:436: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
-out/third_party/testsuite/call_indirect.wast:444: assert_invalid passed:
+out/test/spec/call_indirect.wast:444: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
-out/third_party/testsuite/call_indirect.wast:455: assert_invalid passed:
+out/test/spec/call_indirect.wast:455: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:463: assert_invalid passed:
+out/test/spec/call_indirect.wast:463: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:472: assert_invalid passed:
+out/test/spec/call_indirect.wast:472: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:482: assert_invalid passed:
+out/test/spec/call_indirect.wast:482: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:492: assert_invalid passed:
+out/test/spec/call_indirect.wast:492: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:502: assert_invalid passed:
+out/test/spec/call_indirect.wast:502: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/call_indirect.wast:516: assert_invalid passed:
+out/test/spec/call_indirect.wast:516: assert_invalid passed:
   0000021: error: invalid call_indirect signature index
-out/third_party/testsuite/call_indirect.wast:523: assert_invalid passed:
+out/test/spec/call_indirect.wast:523: assert_invalid passed:
   0000025: error: invalid call_indirect signature index
-out/third_party/testsuite/call_indirect.wast:534: assert_invalid passed:
+out/test/spec/call_indirect.wast:534: assert_invalid passed:
   error: invalid func_index: 0 (max 0)
   0000018: error: OnElemSegmentFunctionIndex callback failed
 75/75 tests passed.

--- a/test/spec/const.txt
+++ b/test/spec/const.txt
@@ -1,100 +1,100 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/const.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/const.wast:8: assert_malformed passed:
-  out/third_party/testsuite/const/const.2.wat:1:18: error: invalid literal "0x100000000"
+out/test/spec/const.wast:8: assert_malformed passed:
+  out/test/spec/const/const.2.wat:1:18: error: invalid literal "0x100000000"
   (func (i32.const 0x100000000) drop)
                    ^^^^^^^^^^^
-out/third_party/testsuite/const.wast:12: assert_malformed passed:
-  out/third_party/testsuite/const/const.3.wat:1:18: error: invalid literal "-0x80000001"
+out/test/spec/const.wast:12: assert_malformed passed:
+  out/test/spec/const/const.3.wat:1:18: error: invalid literal "-0x80000001"
   (func (i32.const -0x80000001) drop)
                    ^^^^^^^^^^^
-out/third_party/testsuite/const.wast:19: assert_malformed passed:
-  out/third_party/testsuite/const/const.6.wat:1:18: error: invalid literal "4294967296"
+out/test/spec/const.wast:19: assert_malformed passed:
+  out/test/spec/const/const.6.wat:1:18: error: invalid literal "4294967296"
   (func (i32.const 4294967296) drop)
                    ^^^^^^^^^^
-out/third_party/testsuite/const.wast:23: assert_malformed passed:
-  out/third_party/testsuite/const/const.7.wat:1:18: error: invalid literal "-2147483649"
+out/test/spec/const.wast:23: assert_malformed passed:
+  out/test/spec/const/const.7.wat:1:18: error: invalid literal "-2147483649"
   (func (i32.const -2147483649) drop)
                    ^^^^^^^^^^^
-out/third_party/testsuite/const.wast:30: assert_malformed passed:
-  out/third_party/testsuite/const/const.10.wat:1:18: error: invalid literal "0x10000000000000000"
+out/test/spec/const.wast:30: assert_malformed passed:
+  out/test/spec/const/const.10.wat:1:18: error: invalid literal "0x10000000000000000"
   (func (i64.const 0x10000000000000000) drop)
                    ^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:34: assert_malformed passed:
-  out/third_party/testsuite/const/const.11.wat:1:18: error: invalid literal "-0x8000000000000001"
+out/test/spec/const.wast:34: assert_malformed passed:
+  out/test/spec/const/const.11.wat:1:18: error: invalid literal "-0x8000000000000001"
   (func (i64.const -0x8000000000000001) drop)
                    ^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:41: assert_malformed passed:
-  out/third_party/testsuite/const/const.14.wat:1:18: error: invalid literal "18446744073709551616"
+out/test/spec/const.wast:41: assert_malformed passed:
+  out/test/spec/const/const.14.wat:1:18: error: invalid literal "18446744073709551616"
   (func (i64.const 18446744073709551616) drop)
                    ^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:45: assert_malformed passed:
-  out/third_party/testsuite/const/const.15.wat:1:18: error: invalid literal "-9223372036854775809"
+out/test/spec/const.wast:45: assert_malformed passed:
+  out/test/spec/const/const.15.wat:1:18: error: invalid literal "-9223372036854775809"
   (func (i64.const -9223372036854775809) drop)
                    ^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:56: assert_malformed passed:
-  out/third_party/testsuite/const/const.22.wat:1:18: error: invalid literal "0x1p128"
+out/test/spec/const.wast:56: assert_malformed passed:
+  out/test/spec/const/const.22.wat:1:18: error: invalid literal "0x1p128"
   (func (f32.const 0x1p128) drop)
                    ^^^^^^^
-out/third_party/testsuite/const.wast:60: assert_malformed passed:
-  out/third_party/testsuite/const/const.23.wat:1:18: error: invalid literal "-0x1p128"
+out/test/spec/const.wast:60: assert_malformed passed:
+  out/test/spec/const/const.23.wat:1:18: error: invalid literal "-0x1p128"
   (func (f32.const -0x1p128) drop)
                    ^^^^^^^^
-out/third_party/testsuite/const.wast:64: assert_malformed passed:
-  out/third_party/testsuite/const/const.24.wat:1:18: error: invalid literal "0x1.ffffffp127"
+out/test/spec/const.wast:64: assert_malformed passed:
+  out/test/spec/const/const.24.wat:1:18: error: invalid literal "0x1.ffffffp127"
   (func (f32.const 0x1.ffffffp127) drop)
                    ^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:68: assert_malformed passed:
-  out/third_party/testsuite/const/const.25.wat:1:18: error: invalid literal "-0x1.ffffffp127"
+out/test/spec/const.wast:68: assert_malformed passed:
+  out/test/spec/const/const.25.wat:1:18: error: invalid literal "-0x1.ffffffp127"
   (func (f32.const -0x1.ffffffp127) drop)
                    ^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:75: assert_malformed passed:
-  out/third_party/testsuite/const/const.28.wat:1:18: error: invalid literal "1e39"
+out/test/spec/const.wast:75: assert_malformed passed:
+  out/test/spec/const/const.28.wat:1:18: error: invalid literal "1e39"
   (func (f32.const 1e39) drop)
                    ^^^^
-out/third_party/testsuite/const.wast:79: assert_malformed passed:
-  out/third_party/testsuite/const/const.29.wat:1:18: error: invalid literal "-1e39"
+out/test/spec/const.wast:79: assert_malformed passed:
+  out/test/spec/const/const.29.wat:1:18: error: invalid literal "-1e39"
   (func (f32.const -1e39) drop)
                    ^^^^^
-out/third_party/testsuite/const.wast:86: assert_malformed passed:
-  out/third_party/testsuite/const/const.32.wat:1:18: error: invalid literal "340282356779733661637539395458142568448"
+out/test/spec/const.wast:86: assert_malformed passed:
+  out/test/spec/const/const.32.wat:1:18: error: invalid literal "340282356779733661637539395458142568448"
   (func (f32.const 340282356779733661637539395458142568448) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:90: assert_malformed passed:
-  out/third_party/testsuite/const/const.33.wat:1:18: error: invalid literal "-340282356779733661637539395458142568448"
+out/test/spec/const.wast:90: assert_malformed passed:
+  out/test/spec/const/const.33.wat:1:18: error: invalid literal "-340282356779733661637539395458142568448"
   (func (f32.const -340282356779733661637539395458142568448) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:101: assert_malformed passed:
-  out/third_party/testsuite/const/const.40.wat:1:18: error: invalid literal "0x1p1024"
+out/test/spec/const.wast:101: assert_malformed passed:
+  out/test/spec/const/const.40.wat:1:18: error: invalid literal "0x1p1024"
   (func (f64.const 0x1p1024) drop)
                    ^^^^^^^^
-out/third_party/testsuite/const.wast:105: assert_malformed passed:
-  out/third_party/testsuite/const/const.41.wat:1:18: error: invalid literal "-0x1p1024"
+out/test/spec/const.wast:105: assert_malformed passed:
+  out/test/spec/const/const.41.wat:1:18: error: invalid literal "-0x1p1024"
   (func (f64.const -0x1p1024) drop)
                    ^^^^^^^^^
-out/third_party/testsuite/const.wast:109: assert_malformed passed:
-  out/third_party/testsuite/const/const.42.wat:1:18: error: invalid literal "0x1.fffffffffffff8p1023"
+out/test/spec/const.wast:109: assert_malformed passed:
+  out/test/spec/const/const.42.wat:1:18: error: invalid literal "0x1.fffffffffffff8p1023"
   (func (f64.const 0x1.fffffffffffff8p1023) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:113: assert_malformed passed:
-  out/third_party/testsuite/const/const.43.wat:1:18: error: invalid literal "-0x1.fffffffffffff8p1023"
+out/test/spec/const.wast:113: assert_malformed passed:
+  out/test/spec/const/const.43.wat:1:18: error: invalid literal "-0x1.fffffffffffff8p1023"
   (func (f64.const -0x1.fffffffffffff8p1023) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:120: assert_malformed passed:
-  out/third_party/testsuite/const/const.46.wat:1:18: error: invalid literal "1e309"
+out/test/spec/const.wast:120: assert_malformed passed:
+  out/test/spec/const/const.46.wat:1:18: error: invalid literal "1e309"
   (func (f64.const 1e309) drop)
                    ^^^^^
-out/third_party/testsuite/const.wast:124: assert_malformed passed:
-  out/third_party/testsuite/const/const.47.wat:1:18: error: invalid literal "-1e309"
+out/test/spec/const.wast:124: assert_malformed passed:
+  out/test/spec/const/const.47.wat:1:18: error: invalid literal "-1e309"
   (func (f64.const -1e309) drop)
                    ^^^^^^
-out/third_party/testsuite/const.wast:131: assert_malformed passed:
-  out/third_party/testsuite/const/const.50.wat:1:18: error: invalid literal "269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
+out/test/spec/const.wast:131: assert_malformed passed:
+  out/test/spec/const/const.50.wat:1:18: error: invalid literal "269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
   (func (f64.const 269653970229347356221791135597556535197105851288767494898376...
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/const.wast:135: assert_malformed passed:
-  out/third_party/testsuite/const/const.51.wat:1:18: error: invalid literal "-269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
+out/test/spec/const.wast:135: assert_malformed passed:
+  out/test/spec/const/const.51.wat:1:18: error: invalid literal "-269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
   (func (f64.const -26965397022934735622179113559755653519710585128876749489837...
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 24/24 tests passed.

--- a/test/spec/custom_section.txt
+++ b/test/spec/custom_section.txt
@@ -1,17 +1,17 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/custom_section.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/custom_section.wast:61: assert_malformed passed:
+out/test/spec/custom_section.wast:61: assert_malformed passed:
   0000009: error: unable to read u32 leb128: section size
-out/third_party/testsuite/custom_section.wast:69: assert_malformed passed:
+out/test/spec/custom_section.wast:69: assert_malformed passed:
   000000a: error: unable to read u32 leb128: string length
-out/third_party/testsuite/custom_section.wast:77: assert_malformed passed:
+out/test/spec/custom_section.wast:77: assert_malformed passed:
   000000a: error: invalid section size: extends past end
-out/third_party/testsuite/custom_section.wast:85: assert_malformed passed:
+out/test/spec/custom_section.wast:85: assert_malformed passed:
   0000031: error: invalid section code: 36; max is 11
-out/third_party/testsuite/custom_section.wast:94: assert_malformed passed:
+out/test/spec/custom_section.wast:94: assert_malformed passed:
   000003e: error: function signature count != function body count
-out/third_party/testsuite/custom_section.wast:107: assert_malformed passed:
+out/test/spec/custom_section.wast:107: assert_malformed passed:
   000000a: error: invalid section size: extends past end
 6/6 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exports.txt
+++ b/test/spec/exports.txt
@@ -1,66 +1,66 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/exports.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/exports.wast:29: assert_invalid passed:
+out/test/spec/exports.wast:29: assert_invalid passed:
   0000019: error: invalid export func index: 1
-out/third_party/testsuite/exports.wast:33: assert_invalid passed:
+out/test/spec/exports.wast:33: assert_invalid passed:
   error: duplicate export "a"
   000001d: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:37: assert_invalid passed:
+out/test/spec/exports.wast:37: assert_invalid passed:
   error: duplicate export "a"
   000001e: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:41: assert_invalid passed:
+out/test/spec/exports.wast:41: assert_invalid passed:
   error: duplicate export "a"
   0000025: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:45: assert_invalid passed:
+out/test/spec/exports.wast:45: assert_invalid passed:
   error: duplicate export "a"
   0000023: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:49: assert_invalid passed:
+out/test/spec/exports.wast:49: assert_invalid passed:
   error: duplicate export "a"
   0000022: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:78: assert_invalid passed:
+out/test/spec/exports.wast:78: assert_invalid passed:
   0000017: error: invalid export global index: 1
-out/third_party/testsuite/exports.wast:82: assert_invalid passed:
+out/test/spec/exports.wast:82: assert_invalid passed:
   error: duplicate export "a"
   000001b: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:86: assert_invalid passed:
+out/test/spec/exports.wast:86: assert_invalid passed:
   error: duplicate export "a"
   0000020: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:90: assert_invalid passed:
+out/test/spec/exports.wast:90: assert_invalid passed:
   error: duplicate export "a"
   0000025: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:94: assert_invalid passed:
+out/test/spec/exports.wast:94: assert_invalid passed:
   error: duplicate export "a"
   0000021: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:98: assert_invalid passed:
+out/test/spec/exports.wast:98: assert_invalid passed:
   error: duplicate export "a"
   0000020: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:126: assert_invalid passed:
+out/test/spec/exports.wast:126: assert_invalid passed:
   0000015: error: invalid export table index: 1
-out/third_party/testsuite/exports.wast:130: assert_invalid passed:
+out/test/spec/exports.wast:130: assert_invalid passed:
   error: duplicate export "a"
   0000019: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:139: assert_invalid passed:
+out/test/spec/exports.wast:139: assert_invalid passed:
   error: duplicate export "a"
   0000023: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:143: assert_invalid passed:
+out/test/spec/exports.wast:143: assert_invalid passed:
   error: duplicate export "a"
   0000021: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:147: assert_invalid passed:
+out/test/spec/exports.wast:147: assert_invalid passed:
   error: duplicate export "a"
   000001e: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:175: assert_invalid passed:
+out/test/spec/exports.wast:175: assert_invalid passed:
   0000014: error: invalid export memory index: 1
-out/third_party/testsuite/exports.wast:179: assert_invalid passed:
+out/test/spec/exports.wast:179: assert_invalid passed:
   error: duplicate export "a"
   0000018: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:188: assert_invalid passed:
+out/test/spec/exports.wast:188: assert_invalid passed:
   error: duplicate export "a"
   0000022: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:192: assert_invalid passed:
+out/test/spec/exports.wast:192: assert_invalid passed:
   error: duplicate export "a"
   0000020: error: OnExport callback failed
-out/third_party/testsuite/exports.wast:196: assert_invalid passed:
+out/test/spec/exports.wast:196: assert_invalid passed:
   error: duplicate export "a"
   000001e: error: OnExport callback failed
 28/28 tests passed.

--- a/test/spec/float_literals.txt
+++ b/test/spec/float_literals.txt
@@ -1,308 +1,308 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/float_literals.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/float_literals.wast:196: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.2.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:196: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.2.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _100))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:200: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.3.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:200: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.3.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const +_100))
                          ^^^^^
-out/third_party/testsuite/float_literals.wast:204: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.4.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:204: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.4.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const -_100))
                          ^^^^^
-out/third_party/testsuite/float_literals.wast:208: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.5.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:208: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.5.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 99_))
                          ^^^
-out/third_party/testsuite/float_literals.wast:212: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.6.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:212: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.6.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1__000))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:216: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.7.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:216: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.7.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _1.0))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:220: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.8.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:220: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.8.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0_))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:224: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.9.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:224: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.9.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1_.0))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:228: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.10.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:228: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.10.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1._0))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:232: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.11.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:232: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.11.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _1e1))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:236: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.12.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:236: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.12.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1e1_))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:240: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.13.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:240: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.13.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1_e1))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:244: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.14.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:244: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.14.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1e_1))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:248: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.15.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:248: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.15.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _1.0e1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:252: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.16.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:252: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.16.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e1_))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:256: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.17.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:256: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.17.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0_e1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:260: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.18.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:260: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.18.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e_1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:264: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.19.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:264: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.19.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e+_1))
                          ^^^^^^^
-out/third_party/testsuite/float_literals.wast:268: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.20.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:268: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.20.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e_+1))
                          ^^^^^^^
-out/third_party/testsuite/float_literals.wast:272: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.21.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:272: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.21.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _0x100))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:276: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.22.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:276: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.22.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0_x100))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:280: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.23.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:280: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.23.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_100))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:284: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.24.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:284: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.24.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x00_))
                          ^^^^^
-out/third_party/testsuite/float_literals.wast:288: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.25.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:288: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.25.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0xff__ffff))
                          ^^^^^^^^^^
-out/third_party/testsuite/float_literals.wast:292: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.26.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:292: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.26.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_1.0))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:296: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.27.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:296: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.27.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0_))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:300: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.28.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:300: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.28.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1_.0))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:304: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.29.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:304: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.29.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1._0))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:308: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.30.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:308: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.30.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_1p1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:312: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.31.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:312: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.31.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1p1_))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:316: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.32.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:316: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.32.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1_p1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:320: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.33.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:320: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.33.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1p_1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:324: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.34.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:324: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.34.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_1.0p1))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:328: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.35.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:328: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.35.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p1_))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:332: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.36.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:332: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.36.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0_p1))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:336: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.37.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:336: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.37.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p_1))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:340: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.38.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:340: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.38.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p+_1))
                          ^^^^^^^^^
-out/third_party/testsuite/float_literals.wast:344: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.39.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:344: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.39.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p_+1))
                          ^^^^^^^^^
-out/third_party/testsuite/float_literals.wast:349: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.40.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:349: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.40.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _100))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:353: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.41.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:353: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.41.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const +_100))
                          ^^^^^
-out/third_party/testsuite/float_literals.wast:357: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.42.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:357: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.42.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const -_100))
                          ^^^^^
-out/third_party/testsuite/float_literals.wast:361: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.43.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:361: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.43.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 99_))
                          ^^^
-out/third_party/testsuite/float_literals.wast:365: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.44.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:365: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.44.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1__000))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:369: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.45.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:369: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.45.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1.0))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:373: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.46.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:373: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.46.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0_))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:377: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.47.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:377: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.47.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1_.0))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:381: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.48.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:381: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.48.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1._0))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:385: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.49.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:385: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.49.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1e1))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:389: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.50.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:389: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.50.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1e1_))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:393: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.51.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:393: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.51.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1_e1))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:397: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.52.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:397: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.52.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1e_1))
                          ^^^^
-out/third_party/testsuite/float_literals.wast:401: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.53.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:401: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.53.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1.0e1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:405: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.54.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:405: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.54.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e1_))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:409: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.55.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:409: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.55.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0_e1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:413: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.56.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:413: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.56.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e_1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:417: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.57.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:417: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.57.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e+_1))
                          ^^^^^^^
-out/third_party/testsuite/float_literals.wast:421: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.58.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:421: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.58.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e_+1))
                          ^^^^^^^
-out/third_party/testsuite/float_literals.wast:425: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.59.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:425: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.59.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _0x100))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:429: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.60.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:429: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.60.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0_x100))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:433: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.61.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:433: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.61.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_100))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:437: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.62.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:437: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.62.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x00_))
                          ^^^^^
-out/third_party/testsuite/float_literals.wast:441: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.63.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:441: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.63.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0xff__ffff))
                          ^^^^^^^^^^
-out/third_party/testsuite/float_literals.wast:445: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.64.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:445: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.64.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1.0))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:449: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.65.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:449: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.65.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0_))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:453: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.66.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:453: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.66.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1_.0))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:457: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.67.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:457: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.67.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1._0))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:461: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.68.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:461: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.68.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1p1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:465: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.69.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:465: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.69.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1p1_))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:469: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.70.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:469: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.70.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1_p1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:473: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.71.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:473: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.71.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1p_1))
                          ^^^^^^
-out/third_party/testsuite/float_literals.wast:477: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.72.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:477: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.72.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1.0p1))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:481: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.73.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:481: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.73.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p1_))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:485: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.74.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:485: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.74.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0_p1))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:489: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.75.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:489: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.75.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p_1))
                          ^^^^^^^^
-out/third_party/testsuite/float_literals.wast:493: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.76.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:493: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.76.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p+_1))
                          ^^^^^^^^^
-out/third_party/testsuite/float_literals.wast:497: assert_malformed passed:
-  out/third_party/testsuite/float_literals/float_literals.77.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/float_literals.wast:497: assert_malformed passed:
+  out/test/spec/float_literals/float_literals.77.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p_+1))
                          ^^^^^^^^^
 157/157 tests passed.

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -1,161 +1,161 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/func.wast:303: assert_invalid passed:
+out/test/spec/func.wast:303: assert_invalid passed:
   000001a: error: invalid function signature index: 2
-out/third_party/testsuite/func.wast:387: assert_malformed passed:
-  out/third_party/testsuite/func/func.4.wat:1:76: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:387: assert_malformed passed:
+  out/test/spec/func/func.4.wat:1:76: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (type $sig) (result i32) (param i32) (i32.const 0))
                                                          ^^^^^
-out/third_party/testsuite/func.wast:394: assert_malformed passed:
-  out/third_party/testsuite/func/func.5.wat:1:63: error: unexpected token "type", expected an instr.
+out/test/spec/func.wast:394: assert_malformed passed:
+  out/test/spec/func/func.5.wat:1:63: error: unexpected token "type", expected an instr.
   ... i32) (result i32)))(func (param i32) (type $sig) (result i32) (i32.const 0))
                                             ^^^^
-out/third_party/testsuite/func.wast:401: assert_malformed passed:
-  out/third_party/testsuite/func/func.6.wat:1:76: error: unexpected token "type", expected an instr.
+out/test/spec/func.wast:401: assert_malformed passed:
+  out/test/spec/func/func.6.wat:1:76: error: unexpected token "type", expected an instr.
   ... i32) (result i32)))(func (param i32) (result i32) (type $sig) (i32.const 0))
                                                          ^^^^
-out/third_party/testsuite/func.wast:408: assert_malformed passed:
-  out/third_party/testsuite/func/func.7.wat:1:64: error: unexpected token "type", expected an instr.
+out/test/spec/func.wast:408: assert_malformed passed:
+  out/test/spec/func/func.7.wat:1:64: error: unexpected token "type", expected an instr.
   ... i32) (result i32)))(func (result i32) (type $sig) (param i32) (i32.const 0))
                                              ^^^^
-out/third_party/testsuite/func.wast:415: assert_malformed passed:
-  out/third_party/testsuite/func/func.8.wat:1:64: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:415: assert_malformed passed:
+  out/test/spec/func/func.8.wat:1:64: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (result i32) (param i32) (type $sig) (i32.const 0))
                                              ^^^^^
-  out/third_party/testsuite/func/func.8.wat:1:85: error: unexpected token ), expected (.
+  out/test/spec/func/func.8.wat:1:85: error: unexpected token ), expected (.
   ... i32) (result i32)))(func (result i32) (param i32) (type $sig) (i32.const 0))
                                                                   ^
-out/third_party/testsuite/func.wast:422: assert_malformed passed:
-  out/third_party/testsuite/func/func.9.wat:1:21: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:422: assert_malformed passed:
+  out/test/spec/func/func.9.wat:1:21: error: unexpected token "param", expected an instr.
   (func (result i32) (param i32) (i32.const 0))
                       ^^^^^
-out/third_party/testsuite/func.wast:429: assert_malformed passed:
-  out/third_party/testsuite/func/func.10.wat:1:20: error: expected 0 results, got 1
+out/test/spec/func.wast:429: assert_malformed passed:
+  out/test/spec/func/func.10.wat:1:20: error: expected 0 results, got 1
   (type $sig (func))(func (type $sig) (result i32) (i32.const 0))
                      ^^^^
-out/third_party/testsuite/func.wast:436: assert_malformed passed:
-  out/third_party/testsuite/func/func.11.wat:1:45: error: expected 1 arguments, got 0
+out/test/spec/func.wast:436: assert_malformed passed:
+  out/test/spec/func/func.11.wat:1:45: error: expected 1 arguments, got 0
   ...g (func (param i32) (result i32)))(func (type $sig) (result i32) (i32.cons...
                                         ^^^^
-out/third_party/testsuite/func.wast:443: assert_malformed passed:
-  out/third_party/testsuite/func/func.12.wat:1:45: error: expected 1 results, got 0
+out/test/spec/func.wast:443: assert_malformed passed:
+  out/test/spec/func/func.12.wat:1:45: error: expected 1 results, got 0
   ...g (func (param i32) (result i32)))(func (type $sig) (param i32) (i32.const...
                                         ^^^^
-out/third_party/testsuite/func.wast:450: assert_malformed passed:
-  out/third_party/testsuite/func/func.13.wat:1:49: error: expected 2 arguments, got 1
+out/test/spec/func.wast:450: assert_malformed passed:
+  out/test/spec/func/func.13.wat:1:49: error: expected 2 arguments, got 1
   ...unc (param i32 i32) (result i32)))(func (type $sig) (param i32) (result i3...
                                         ^^^^
-out/third_party/testsuite/func.wast:461: assert_invalid passed:
+out/test/spec/func.wast:461: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:465: assert_invalid passed:
+out/test/spec/func.wast:465: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/func.wast:469: assert_invalid passed:
+out/test/spec/func.wast:469: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/func.wast:477: assert_invalid passed:
+out/test/spec/func.wast:477: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:481: assert_invalid passed:
+out/test/spec/func.wast:481: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
-out/third_party/testsuite/func.wast:485: assert_invalid passed:
+out/test/spec/func.wast:485: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
-out/third_party/testsuite/func.wast:493: assert_invalid passed:
+out/test/spec/func.wast:493: assert_invalid passed:
   000000e: error: result count must be 0 or 1
-out/third_party/testsuite/func.wast:497: assert_invalid passed:
+out/test/spec/func.wast:497: assert_invalid passed:
   000000e: error: result count must be 0 or 1
-out/third_party/testsuite/func.wast:506: assert_invalid passed:
+out/test/spec/func.wast:506: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000019: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:510: assert_invalid passed:
+out/test/spec/func.wast:510: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   0000019: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:514: assert_invalid passed:
+out/test/spec/func.wast:514: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   0000019: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:518: assert_invalid passed:
+out/test/spec/func.wast:518: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   0000019: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:523: assert_invalid passed:
+out/test/spec/func.wast:523: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:529: assert_invalid passed:
+out/test/spec/func.wast:529: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:535: assert_invalid passed:
+out/test/spec/func.wast:535: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/func.wast:542: assert_invalid passed:
+out/test/spec/func.wast:542: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:548: assert_invalid passed:
+out/test/spec/func.wast:548: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:554: assert_invalid passed:
+out/test/spec/func.wast:554: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:561: assert_invalid passed:
+out/test/spec/func.wast:561: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:567: assert_invalid passed:
+out/test/spec/func.wast:567: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:573: assert_invalid passed:
+out/test/spec/func.wast:573: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:579: assert_invalid passed:
+out/test/spec/func.wast:579: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
-out/third_party/testsuite/func.wast:586: assert_invalid passed:
+out/test/spec/func.wast:586: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:592: assert_invalid passed:
+out/test/spec/func.wast:592: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   000001f: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:598: assert_invalid passed:
+out/test/spec/func.wast:598: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:604: assert_invalid passed:
+out/test/spec/func.wast:604: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:610: assert_invalid passed:
+out/test/spec/func.wast:610: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:617: assert_invalid passed:
+out/test/spec/func.wast:617: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:623: assert_invalid passed:
+out/test/spec/func.wast:623: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:629: assert_invalid passed:
+out/test/spec/func.wast:629: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/func.wast:639: assert_malformed passed:
-  out/third_party/testsuite/func/func.44.wat:1:14: error: unexpected token "local", expected an instr.
+out/test/spec/func.wast:639: assert_malformed passed:
+  out/test/spec/func/func.44.wat:1:14: error: unexpected token "local", expected an instr.
   (func (nop) (local i32))
                ^^^^^
-out/third_party/testsuite/func.wast:643: assert_malformed passed:
-  out/third_party/testsuite/func/func.45.wat:1:14: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:643: assert_malformed passed:
+  out/test/spec/func/func.45.wat:1:14: error: unexpected token "param", expected an instr.
   (func (nop) (param i32))
                ^^^^^
-out/third_party/testsuite/func.wast:647: assert_malformed passed:
-  out/third_party/testsuite/func/func.46.wat:1:14: error: unexpected token "result", expected an instr.
+out/test/spec/func.wast:647: assert_malformed passed:
+  out/test/spec/func/func.46.wat:1:14: error: unexpected token "result", expected an instr.
   (func (nop) (result i32))
                ^^^^^^
-out/third_party/testsuite/func.wast:651: assert_malformed passed:
-  out/third_party/testsuite/func/func.47.wat:1:20: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:651: assert_malformed passed:
+  out/test/spec/func/func.47.wat:1:20: error: unexpected token "param", expected an instr.
   (func (local i32) (param i32))
                      ^^^^^
-out/third_party/testsuite/func.wast:655: assert_malformed passed:
-  out/third_party/testsuite/func/func.48.wat:1:20: error: unexpected token "result", expected an instr.
+out/test/spec/func.wast:655: assert_malformed passed:
+  out/test/spec/func/func.48.wat:1:20: error: unexpected token "result", expected an instr.
   (func (local i32) (result i32) (get_local 0))
                      ^^^^^^
-out/third_party/testsuite/func.wast:659: assert_malformed passed:
-  out/third_party/testsuite/func/func.49.wat:1:21: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:659: assert_malformed passed:
+  out/test/spec/func/func.49.wat:1:21: error: unexpected token "param", expected an instr.
   (func (result i32) (param i32) (get_local 0))
                       ^^^^^
 120/120 tests passed.

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -3,19 +3,19 @@
 (;; STDOUT ;;;
 called host spectest.print(i32:83) =>
 four(i32:83) =>
-out/third_party/testsuite/func_ptrs.wast:32: assert_invalid passed:
+out/test/spec/func_ptrs.wast:32: assert_invalid passed:
   000000b: error: elem section without table section
-out/third_party/testsuite/func_ptrs.wast:33: assert_invalid passed:
+out/test/spec/func_ptrs.wast:33: assert_invalid passed:
   0000015: error: elem section without table section
-out/third_party/testsuite/func_ptrs.wast:36: assert_invalid passed:
+out/test/spec/func_ptrs.wast:36: assert_invalid passed:
   0000014: error: expected i32 init_expr
-out/third_party/testsuite/func_ptrs.wast:40: assert_invalid passed:
+out/test/spec/func_ptrs.wast:40: assert_invalid passed:
   0000015: error: expected END opcode after initializer expression
-out/third_party/testsuite/func_ptrs.wast:44: assert_invalid passed:
+out/test/spec/func_ptrs.wast:44: assert_invalid passed:
   0000013: error: unexpected opcode in initializer expression: 1 (0x1)
-out/third_party/testsuite/func_ptrs.wast:48: assert_invalid passed:
+out/test/spec/func_ptrs.wast:48: assert_invalid passed:
   000000c: error: invalid function signature index: 42
-out/third_party/testsuite/func_ptrs.wast:49: assert_invalid passed:
+out/test/spec/func_ptrs.wast:49: assert_invalid passed:
   000001c: error: invalid import signature index
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/get_local.txt
+++ b/test/spec/get_local.txt
@@ -1,40 +1,40 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/get_local.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/get_local.wast:91: assert_invalid passed:
+out/test/spec/get_local.wast:91: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/third_party/testsuite/get_local.wast:95: assert_invalid passed:
+out/test/spec/get_local.wast:95: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/get_local.wast:99: assert_invalid passed:
+out/test/spec/get_local.wast:99: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/get_local.wast:107: assert_invalid passed:
+out/test/spec/get_local.wast:107: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/get_local.wast:111: assert_invalid passed:
+out/test/spec/get_local.wast:111: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
-out/third_party/testsuite/get_local.wast:115: assert_invalid passed:
+out/test/spec/get_local.wast:115: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
-out/third_party/testsuite/get_local.wast:123: assert_invalid passed:
+out/test/spec/get_local.wast:123: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
   000001d: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/get_local.wast:127: assert_invalid passed:
+out/test/spec/get_local.wast:127: assert_invalid passed:
   error: invalid local_index: 14324343 (max 2)
   0000020: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/get_local.wast:132: assert_invalid passed:
+out/test/spec/get_local.wast:132: assert_invalid passed:
   error: invalid local_index: 2 (max 2)
   000001b: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/get_local.wast:136: assert_invalid passed:
+out/test/spec/get_local.wast:136: assert_invalid passed:
   error: invalid local_index: 714324343 (max 2)
   0000021: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/get_local.wast:141: assert_invalid passed:
+out/test/spec/get_local.wast:141: assert_invalid passed:
   error: invalid local_index: 3 (max 3)
   000001e: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/get_local.wast:145: assert_invalid passed:
+out/test/spec/get_local.wast:145: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
   0000021: error: OnGetLocalExpr callback failed
 22/22 tests passed.

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -1,52 +1,52 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/globals.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/globals.wast:50: assert_invalid passed:
+out/test/spec/globals.wast:50: assert_invalid passed:
   error: can't set_global on immutable global at index 0.
   0000026: error: OnSetGlobalExpr callback failed
-out/third_party/testsuite/globals.wast:55: assert_invalid passed:
+out/test/spec/globals.wast:55: assert_invalid passed:
   error: unknown import module "m"
   0000012: error: OnImportGlobal callback failed
-out/third_party/testsuite/globals.wast:60: assert_invalid passed:
+out/test/spec/globals.wast:60: assert_invalid passed:
   error: unknown import module "m"
   0000012: error: OnImportGlobal callback failed
-out/third_party/testsuite/globals.wast:65: assert_invalid passed:
+out/test/spec/globals.wast:65: assert_invalid passed:
   error: mutable globals cannot be exported
   000001a: error: OnExport callback failed
-out/third_party/testsuite/globals.wast:70: assert_invalid passed:
+out/test/spec/globals.wast:70: assert_invalid passed:
   error: mutable globals cannot be exported
   000001a: error: OnExport callback failed
-out/third_party/testsuite/globals.wast:75: assert_invalid passed:
+out/test/spec/globals.wast:75: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
-out/third_party/testsuite/globals.wast:80: assert_invalid passed:
+out/test/spec/globals.wast:80: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 32 (0x20)
-out/third_party/testsuite/globals.wast:85: assert_invalid passed:
+out/test/spec/globals.wast:85: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
-out/third_party/testsuite/globals.wast:90: assert_invalid passed:
+out/test/spec/globals.wast:90: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
-out/third_party/testsuite/globals.wast:95: assert_invalid passed:
+out/test/spec/globals.wast:95: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 1 (0x1)
-out/third_party/testsuite/globals.wast:100: assert_invalid passed:
+out/test/spec/globals.wast:100: assert_invalid passed:
   error: type mismatch in global, expected i32 but got f32.
   0000013: error: EndGlobalInitExpr callback failed
-out/third_party/testsuite/globals.wast:105: assert_invalid passed:
+out/test/spec/globals.wast:105: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
-out/third_party/testsuite/globals.wast:110: assert_invalid passed:
+out/test/spec/globals.wast:110: assert_invalid passed:
   error: type mismatch in global, expected i32 but got void.
   000000e: error: EndGlobalInitExpr callback failed
-out/third_party/testsuite/globals.wast:115: assert_invalid passed:
+out/test/spec/globals.wast:115: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
-out/third_party/testsuite/globals.wast:120: assert_invalid passed:
+out/test/spec/globals.wast:120: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
-out/third_party/testsuite/globals.wast:128: assert_malformed passed:
+out/test/spec/globals.wast:128: assert_malformed passed:
   0000022: error: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:141: assert_malformed passed:
+out/test/spec/globals.wast:141: assert_malformed passed:
   0000022: error: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:158: assert_malformed passed:
+out/test/spec/globals.wast:158: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/third_party/testsuite/globals.wast:170: assert_malformed passed:
+out/test/spec/globals.wast:170: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
 35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -1,156 +1,156 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/if.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/if.wast:183: assert_invalid passed:
+out/test/spec/if.wast:183: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:187: assert_invalid passed:
+out/test/spec/if.wast:187: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:191: assert_invalid passed:
+out/test/spec/if.wast:191: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:195: assert_invalid passed:
+out/test/spec/if.wast:195: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:200: assert_invalid passed:
+out/test/spec/if.wast:200: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:204: assert_invalid passed:
+out/test/spec/if.wast:204: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:208: assert_invalid passed:
+out/test/spec/if.wast:208: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:212: assert_invalid passed:
+out/test/spec/if.wast:212: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:217: assert_invalid passed:
+out/test/spec/if.wast:217: assert_invalid passed:
   error: type mismatch in if, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:223: assert_invalid passed:
+out/test/spec/if.wast:223: assert_invalid passed:
   error: type mismatch in if, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:229: assert_invalid passed:
+out/test/spec/if.wast:229: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:235: assert_invalid passed:
+out/test/spec/if.wast:235: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:242: assert_invalid passed:
+out/test/spec/if.wast:242: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:248: assert_invalid passed:
+out/test/spec/if.wast:248: assert_invalid passed:
   error: if without else cannot have type signature.
   000001f: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:254: assert_invalid passed:
+out/test/spec/if.wast:254: assert_invalid passed:
   error: if without else cannot have type signature.
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:260: assert_invalid passed:
+out/test/spec/if.wast:260: assert_invalid passed:
   error: if without else cannot have type signature.
   000001f: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:267: assert_invalid passed:
+out/test/spec/if.wast:267: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:273: assert_invalid passed:
+out/test/spec/if.wast:273: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:279: assert_invalid passed:
+out/test/spec/if.wast:279: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:286: assert_invalid passed:
+out/test/spec/if.wast:286: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:292: assert_invalid passed:
+out/test/spec/if.wast:292: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
-out/third_party/testsuite/if.wast:298: assert_invalid passed:
+out/test/spec/if.wast:298: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:304: assert_invalid passed:
+out/test/spec/if.wast:304: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/third_party/testsuite/if.wast:311: assert_invalid passed:
+out/test/spec/if.wast:311: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:321: assert_invalid passed:
+out/test/spec/if.wast:321: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:331: assert_invalid passed:
+out/test/spec/if.wast:331: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
-out/third_party/testsuite/if.wast:342: assert_invalid passed:
+out/test/spec/if.wast:342: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:348: assert_invalid passed:
+out/test/spec/if.wast:348: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:354: assert_invalid passed:
+out/test/spec/if.wast:354: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:363: assert_invalid passed:
+out/test/spec/if.wast:363: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:372: assert_invalid passed:
+out/test/spec/if.wast:372: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:381: assert_invalid passed:
+out/test/spec/if.wast:381: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:391: assert_invalid passed:
+out/test/spec/if.wast:391: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:400: assert_invalid passed:
+out/test/spec/if.wast:400: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
-out/third_party/testsuite/if.wast:411: assert_malformed passed:
-  out/third_party/testsuite/if/if.35.wat:1:14: error: unexpected label "$l"
+out/test/spec/if.wast:411: assert_malformed passed:
+  out/test/spec/if/if.35.wat:1:14: error: unexpected label "$l"
   (func if end $l)
                ^^
-out/third_party/testsuite/if.wast:415: assert_malformed passed:
-  out/third_party/testsuite/if/if.36.wat:1:17: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:415: assert_malformed passed:
+  out/test/spec/if/if.36.wat:1:17: error: mismatching label "$a" != "$l"
   (func if $a end $l)
                   ^^
-out/third_party/testsuite/if.wast:419: assert_malformed passed:
-  out/third_party/testsuite/if/if.37.wat:1:15: error: unexpected label "$l"
+out/test/spec/if.wast:419: assert_malformed passed:
+  out/test/spec/if/if.37.wat:1:15: error: unexpected label "$l"
   (func if else $l end)
                 ^^
-out/third_party/testsuite/if.wast:423: assert_malformed passed:
-  out/third_party/testsuite/if/if.38.wat:1:18: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:423: assert_malformed passed:
+  out/test/spec/if/if.38.wat:1:18: error: mismatching label "$a" != "$l"
   (func if $a else $l end)
                    ^^
-out/third_party/testsuite/if.wast:427: assert_malformed passed:
-  out/third_party/testsuite/if/if.39.wat:1:19: error: unexpected label "$l"
+out/test/spec/if.wast:427: assert_malformed passed:
+  out/test/spec/if/if.39.wat:1:19: error: unexpected label "$l"
   (func if else end $l)
                     ^^
-out/third_party/testsuite/if.wast:431: assert_malformed passed:
-  out/third_party/testsuite/if/if.40.wat:1:15: error: unexpected label "$l"
+out/test/spec/if.wast:431: assert_malformed passed:
+  out/test/spec/if/if.40.wat:1:15: error: unexpected label "$l"
   (func if else $l end $l)
                 ^^
-  out/third_party/testsuite/if/if.40.wat:1:22: error: unexpected label "$l"
+  out/test/spec/if/if.40.wat:1:22: error: unexpected label "$l"
   (func if else $l end $l)
                        ^^
-out/third_party/testsuite/if.wast:435: assert_malformed passed:
-  out/third_party/testsuite/if/if.41.wat:1:15: error: unexpected label "$l1"
+out/test/spec/if.wast:435: assert_malformed passed:
+  out/test/spec/if/if.41.wat:1:15: error: unexpected label "$l1"
   (func if else $l1 end $l2)
                 ^^^
-  out/third_party/testsuite/if/if.41.wat:1:23: error: unexpected label "$l2"
+  out/test/spec/if/if.41.wat:1:23: error: unexpected label "$l2"
   (func if else $l1 end $l2)
                         ^^^
-out/third_party/testsuite/if.wast:439: assert_malformed passed:
-  out/third_party/testsuite/if/if.42.wat:1:22: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:439: assert_malformed passed:
+  out/test/spec/if/if.42.wat:1:22: error: mismatching label "$a" != "$l"
   (func if $a else end $l)
                        ^^
-out/third_party/testsuite/if.wast:443: assert_malformed passed:
-  out/third_party/testsuite/if/if.43.wat:1:25: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:443: assert_malformed passed:
+  out/test/spec/if/if.43.wat:1:25: error: mismatching label "$a" != "$l"
   (func if $a else $a end $l)
                           ^^
-out/third_party/testsuite/if.wast:447: assert_malformed passed:
-  out/third_party/testsuite/if/if.44.wat:1:18: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:447: assert_malformed passed:
+  out/test/spec/if/if.44.wat:1:18: error: mismatching label "$a" != "$l"
   (func if $a else $l end $l)
                    ^^
-  out/third_party/testsuite/if/if.44.wat:1:25: error: mismatching label "$a" != "$l"
+  out/test/spec/if/if.44.wat:1:25: error: mismatching label "$a" != "$l"
   (func if $a else $l end $l)
                           ^^
 82/82 tests passed.

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -11,252 +11,252 @@ called host spectest.print(f64:25.000000, f64:53.000000) =>
 called host spectest.print(f64:24.000000) =>
 called host spectest.print(f64:24.000000) =>
 called host spectest.print(f64:24.000000) =>
-out/third_party/testsuite/imports.wast:99: assert_unlinkable passed:
+out/test/spec/imports.wast:99: assert_unlinkable passed:
   error: unknown module field "unknown"
   0000020: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:103: assert_unlinkable passed:
+out/test/spec/imports.wast:103: assert_unlinkable passed:
   error: unknown host function import "spectest.unknown"
   0000024: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:108: assert_unlinkable passed:
+out/test/spec/imports.wast:108: assert_unlinkable passed:
   error: import signature mismatch
   000001e: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:112: assert_unlinkable passed:
+out/test/spec/imports.wast:112: assert_unlinkable passed:
   error: import signature mismatch
   000001e: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:116: assert_unlinkable passed:
+out/test/spec/imports.wast:116: assert_unlinkable passed:
   error: import signature mismatch
   000001f: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:120: assert_unlinkable passed:
+out/test/spec/imports.wast:120: assert_unlinkable passed:
   error: import signature mismatch
   0000021: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:124: assert_unlinkable passed:
+out/test/spec/imports.wast:124: assert_unlinkable passed:
   error: import signature mismatch
   0000022: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:128: assert_unlinkable passed:
+out/test/spec/imports.wast:128: assert_unlinkable passed:
   error: import signature mismatch
   0000022: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:132: assert_unlinkable passed:
+out/test/spec/imports.wast:132: assert_unlinkable passed:
   error: import signature mismatch
   0000022: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:136: assert_unlinkable passed:
+out/test/spec/imports.wast:136: assert_unlinkable passed:
   error: import signature mismatch
   0000023: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:140: assert_unlinkable passed:
+out/test/spec/imports.wast:140: assert_unlinkable passed:
   error: import signature mismatch
   0000022: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:144: assert_unlinkable passed:
+out/test/spec/imports.wast:144: assert_unlinkable passed:
   error: import signature mismatch
   0000023: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:148: assert_unlinkable passed:
+out/test/spec/imports.wast:148: assert_unlinkable passed:
   error: import signature mismatch
   0000023: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:152: assert_unlinkable passed:
+out/test/spec/imports.wast:152: assert_unlinkable passed:
   error: import signature mismatch
   0000023: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:156: assert_unlinkable passed:
+out/test/spec/imports.wast:156: assert_unlinkable passed:
   error: import signature mismatch
   0000024: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:160: assert_unlinkable passed:
+out/test/spec/imports.wast:160: assert_unlinkable passed:
   error: import signature mismatch
   0000026: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:164: assert_unlinkable passed:
+out/test/spec/imports.wast:164: assert_unlinkable passed:
   error: import signature mismatch
   0000027: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:168: assert_unlinkable passed:
+out/test/spec/imports.wast:168: assert_unlinkable passed:
   error: import signature mismatch
   0000027: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:173: assert_unlinkable passed:
+out/test/spec/imports.wast:173: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind func, not global
   0000024: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:177: assert_unlinkable passed:
+out/test/spec/imports.wast:177: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind func, not table
   0000025: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:181: assert_unlinkable passed:
+out/test/spec/imports.wast:181: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind func, not memory
   0000025: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:185: assert_unlinkable passed:
+out/test/spec/imports.wast:185: assert_unlinkable passed:
   error: unknown host function import "spectest.global"
   0000023: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:189: assert_unlinkable passed:
+out/test/spec/imports.wast:189: assert_unlinkable passed:
   error: unknown host function import "spectest.table"
   0000022: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:193: assert_unlinkable passed:
+out/test/spec/imports.wast:193: assert_unlinkable passed:
   error: unknown host function import "spectest.memory"
   0000023: error: OnImportFunc callback failed
-out/third_party/testsuite/imports.wast:227: assert_unlinkable passed:
+out/test/spec/imports.wast:227: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001b: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:231: assert_unlinkable passed:
+out/test/spec/imports.wast:231: assert_unlinkable passed:
   error: unknown host global import "spectest.unknown"
   000001f: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:236: assert_unlinkable passed:
+out/test/spec/imports.wast:236: assert_unlinkable passed:
   error: expected import "test.func" to have kind global, not func
   0000018: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:240: assert_unlinkable passed:
+out/test/spec/imports.wast:240: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind global, not table
   0000020: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:244: assert_unlinkable passed:
+out/test/spec/imports.wast:244: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind global, not memory
   0000020: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:248: assert_unlinkable passed:
+out/test/spec/imports.wast:248: assert_unlinkable passed:
   error: unknown host global import "spectest.print"
   000001d: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:252: assert_unlinkable passed:
+out/test/spec/imports.wast:252: assert_unlinkable passed:
   error: unknown host global import "spectest.table"
   000001d: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:256: assert_unlinkable passed:
+out/test/spec/imports.wast:256: assert_unlinkable passed:
   error: unknown host global import "spectest.memory"
   000001e: error: OnImportGlobal callback failed
-out/third_party/testsuite/imports.wast:302: assert_invalid passed:
+out/test/spec/imports.wast:302: assert_invalid passed:
   error: unknown import module ""
   0000011: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:306: assert_invalid passed:
+out/test/spec/imports.wast:306: assert_invalid passed:
   error: unknown import module ""
   0000011: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:310: assert_invalid passed:
+out/test/spec/imports.wast:310: assert_invalid passed:
   000000b: error: table count (2) must be 0 or 1
-out/third_party/testsuite/imports.wast:327: assert_unlinkable passed:
+out/test/spec/imports.wast:327: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001c: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:331: assert_unlinkable passed:
+out/test/spec/imports.wast:331: assert_unlinkable passed:
   error: unknown host table import "spectest.unknown"
   0000020: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:336: assert_unlinkable passed:
+out/test/spec/imports.wast:336: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
   0000021: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:340: assert_unlinkable passed:
+out/test/spec/imports.wast:340: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (20)
   0000022: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:344: assert_unlinkable passed:
+out/test/spec/imports.wast:344: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
   000001e: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:348: assert_unlinkable passed:
+out/test/spec/imports.wast:348: assert_unlinkable passed:
   error: max size (20) larger than declared (15)
   000001f: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:353: assert_unlinkable passed:
+out/test/spec/imports.wast:353: assert_unlinkable passed:
   error: expected import "test.func" to have kind table, not func
   0000019: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:357: assert_unlinkable passed:
+out/test/spec/imports.wast:357: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind table, not global
   000001f: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:361: assert_unlinkable passed:
+out/test/spec/imports.wast:361: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind table, not memory
   0000021: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:365: assert_unlinkable passed:
+out/test/spec/imports.wast:365: assert_unlinkable passed:
   error: unknown host table import "spectest.print"
   000001e: error: OnImportTable callback failed
-out/third_party/testsuite/imports.wast:397: assert_invalid passed:
+out/test/spec/imports.wast:397: assert_invalid passed:
   error: unknown import module ""
   0000010: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:401: assert_invalid passed:
+out/test/spec/imports.wast:401: assert_invalid passed:
   error: unknown import module ""
   0000010: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:405: assert_invalid passed:
+out/test/spec/imports.wast:405: assert_invalid passed:
   000000b: error: memory count must be 0 or 1
-out/third_party/testsuite/imports.wast:420: assert_unlinkable passed:
+out/test/spec/imports.wast:420: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001b: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:424: assert_unlinkable passed:
+out/test/spec/imports.wast:424: assert_unlinkable passed:
   error: unknown host memory import "spectest.unknown"
   000001f: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:429: assert_unlinkable passed:
+out/test/spec/imports.wast:429: assert_unlinkable passed:
   error: actual size (2) smaller than declared (3)
   0000020: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:433: assert_unlinkable passed:
+out/test/spec/imports.wast:433: assert_unlinkable passed:
   error: max size (unspecified) larger than declared (3)
   0000021: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:437: assert_unlinkable passed:
+out/test/spec/imports.wast:437: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:441: assert_unlinkable passed:
+out/test/spec/imports.wast:441: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
   000001f: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:446: assert_unlinkable passed:
+out/test/spec/imports.wast:446: assert_unlinkable passed:
   error: expected import "test.func-i32" to have kind memory, not func
   000001c: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:450: assert_unlinkable passed:
+out/test/spec/imports.wast:450: assert_unlinkable passed:
   error: expected import "test.global-i32" to have kind memory, not global
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:454: assert_unlinkable passed:
+out/test/spec/imports.wast:454: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind memory, not table
   0000020: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:458: assert_unlinkable passed:
+out/test/spec/imports.wast:458: assert_unlinkable passed:
   error: unknown host memory import "spectest.print"
   000001d: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:462: assert_unlinkable passed:
+out/test/spec/imports.wast:462: assert_unlinkable passed:
   error: unknown host memory import "spectest.global"
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:466: assert_unlinkable passed:
+out/test/spec/imports.wast:466: assert_unlinkable passed:
   error: unknown host memory import "spectest.table"
   000001d: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:471: assert_unlinkable passed:
+out/test/spec/imports.wast:471: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)
   000001e: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:475: assert_unlinkable passed:
+out/test/spec/imports.wast:475: assert_unlinkable passed:
   error: max size (2) larger than declared (1)
   000001f: error: OnImportMemory callback failed
-out/third_party/testsuite/imports.wast:493: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.99.wat:1:9: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:493: assert_malformed passed:
+  out/test/spec/imports/imports.99.wat:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (func))
           ^^^^^^
-out/third_party/testsuite/imports.wast:497: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.100.wat:1:9: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:497: assert_malformed passed:
+  out/test/spec/imports/imports.100.wat:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (global i64))
           ^^^^^^
-out/third_party/testsuite/imports.wast:501: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.101.wat:1:9: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:501: assert_malformed passed:
+  out/test/spec/imports/imports.101.wat:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (table 0 anyfunc))
           ^^^^^^
-out/third_party/testsuite/imports.wast:505: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.102.wat:1:9: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:505: assert_malformed passed:
+  out/test/spec/imports/imports.102.wat:1:9: error: imports must occur before all non-import definitions
   (func) (import "" "" (memory 0))
           ^^^^^^
-out/third_party/testsuite/imports.wast:510: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.103.wat:1:29: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:510: assert_malformed passed:
+  out/test/spec/imports/imports.103.wat:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (func))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:514: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.104.wat:1:29: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:514: assert_malformed passed:
+  out/test/spec/imports/imports.104.wat:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (global f32))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:518: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.105.wat:1:29: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:518: assert_malformed passed:
+  out/test/spec/imports/imports.105.wat:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (table 0 anyfunc))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:522: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.106.wat:1:29: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:522: assert_malformed passed:
+  out/test/spec/imports/imports.106.wat:1:29: error: imports must occur before all non-import definitions
   (global i64 (i64.const 0)) (import "" "" (memory 0))
                               ^^^^^^
-out/third_party/testsuite/imports.wast:527: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.107.wat:1:20: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:527: assert_malformed passed:
+  out/test/spec/imports/imports.107.wat:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (func))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:531: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.108.wat:1:20: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:531: assert_malformed passed:
+  out/test/spec/imports/imports.108.wat:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (global i32))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:535: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.109.wat:1:20: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:535: assert_malformed passed:
+  out/test/spec/imports/imports.109.wat:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (table 0 anyfunc))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:539: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.110.wat:1:20: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:539: assert_malformed passed:
+  out/test/spec/imports/imports.110.wat:1:20: error: imports must occur before all non-import definitions
   (table 0 anyfunc) (import "" "" (memory 0))
                      ^^^^^^
-out/third_party/testsuite/imports.wast:544: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.111.wat:1:13: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:544: assert_malformed passed:
+  out/test/spec/imports/imports.111.wat:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (func))
               ^^^^^^
-out/third_party/testsuite/imports.wast:548: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.112.wat:1:13: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:548: assert_malformed passed:
+  out/test/spec/imports/imports.112.wat:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (global i32))
               ^^^^^^
-out/third_party/testsuite/imports.wast:552: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.113.wat:1:13: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:552: assert_malformed passed:
+  out/test/spec/imports/imports.113.wat:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (table 1 3 anyfunc))
               ^^^^^^
-out/third_party/testsuite/imports.wast:556: assert_malformed passed:
-  out/third_party/testsuite/imports/imports.114.wat:1:13: error: imports must occur before all non-import definitions
+out/test/spec/imports.wast:556: assert_malformed passed:
+  out/test/spec/imports/imports.114.wat:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (memory 1 2))
               ^^^^^^
 107/107 tests passed.

--- a/test/spec/int_literals.txt
+++ b/test/spec/int_literals.txt
@@ -1,84 +1,84 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/int_literals.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/int_literals.wast:72: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.1.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:72: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.1.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const _100))
                          ^^^^
-out/third_party/testsuite/int_literals.wast:76: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.2.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:76: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.2.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const +_100))
                          ^^^^^
-out/third_party/testsuite/int_literals.wast:80: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.3.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:80: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.3.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const -_100))
                          ^^^^^
-out/third_party/testsuite/int_literals.wast:84: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.4.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:84: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.4.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const 99_))
                          ^^^
-out/third_party/testsuite/int_literals.wast:88: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.5.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:88: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.5.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const 1__000))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:92: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.6.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:92: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.6.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const _0x100))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:96: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.7.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:96: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.7.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const 0_x100))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:100: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.8.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:100: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.8.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const 0x_100))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:104: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.9.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:104: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.9.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const 0x00_))
                          ^^^^^
-out/third_party/testsuite/int_literals.wast:108: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.10.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:108: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.10.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i32 (i32.const 0xff__ffff))
                          ^^^^^^^^^^
-out/third_party/testsuite/int_literals.wast:113: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.11.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:113: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.11.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const _100))
                          ^^^^
-out/third_party/testsuite/int_literals.wast:117: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.12.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:117: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.12.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const +_100))
                          ^^^^^
-out/third_party/testsuite/int_literals.wast:121: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.13.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:121: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.13.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const -_100))
                          ^^^^^
-out/third_party/testsuite/int_literals.wast:125: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.14.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:125: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.14.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const 99_))
                          ^^^
-out/third_party/testsuite/int_literals.wast:129: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.15.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:129: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.15.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const 1__000))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:133: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.16.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:133: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.16.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const _0x100))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:137: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.17.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:137: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.17.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const 0_x100))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:141: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.18.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:141: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.18.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const 0x_100))
                          ^^^^^^
-out/third_party/testsuite/int_literals.wast:145: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.19.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:145: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.19.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const 0x00_))
                          ^^^^^
-out/third_party/testsuite/int_literals.wast:149: assert_malformed passed:
-  out/third_party/testsuite/int_literals/int_literals.20.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/int_literals.wast:149: assert_malformed passed:
+  out/test/spec/int_literals/int_literals.20.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global i64 (i64.const 0xff__ffff))
                          ^^^^^^^^^^
 50/50 tests passed.

--- a/test/spec/labels.txt
+++ b/test/spec/labels.txt
@@ -1,13 +1,13 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/labels.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/labels.wast:303: assert_invalid passed:
+out/test/spec/labels.wast:303: assert_invalid passed:
   error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/third_party/testsuite/labels.wast:307: assert_invalid passed:
+out/test/spec/labels.wast:307: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
-out/third_party/testsuite/labels.wast:311: assert_invalid passed:
+out/test/spec/labels.wast:311: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 27/27 tests passed.

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -1,35 +1,35 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/linking.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/linking.wast:28: assert_unlinkable passed:
+out/test/spec/linking.wast:28: assert_unlinkable passed:
   error: import signature mismatch
   0000025: error: OnImportFunc callback failed
-out/third_party/testsuite/linking.wast:32: assert_unlinkable passed:
+out/test/spec/linking.wast:32: assert_unlinkable passed:
   error: import signature mismatch
   0000026: error: OnImportFunc callback failed
-out/third_party/testsuite/linking.wast:174: assert_unlinkable passed:
+out/test/spec/linking.wast:174: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 10 >= max value 10
   0000029: error: OnElemSegmentFunctionIndex callback failed
-out/third_party/testsuite/linking.wast:183: assert_unlinkable passed:
+out/test/spec/linking.wast:183: assert_unlinkable passed:
   error: unknown module field "mem"
   0000027: error: OnImportMemory callback failed
-out/third_party/testsuite/linking.wast:195: assert_unlinkable passed:
+out/test/spec/linking.wast:195: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 12 >= max value 10
   0000030: error: OnElemSegmentFunctionIndex callback failed
-out/third_party/testsuite/linking.wast:206: assert_unlinkable passed:
+out/test/spec/linking.wast:206: assert_unlinkable passed:
   error: data segment is out of bounds: [65536, 65537) >= max value 65536
   0000042: error: OnDataSegmentData callback failed
-out/third_party/testsuite/linking.wast:266: assert_unlinkable passed:
+out/test/spec/linking.wast:266: assert_unlinkable passed:
   error: data segment is out of bounds: [65536, 65537) >= max value 65536
   0000020: error: OnDataSegmentData callback failed
-out/third_party/testsuite/linking.wast:291: assert_unlinkable passed:
+out/test/spec/linking.wast:291: assert_unlinkable passed:
   error: duplicate export "print"
   error: unknown module field "tab"
   0000037: error: OnImportTable callback failed
-out/third_party/testsuite/linking.wast:302: assert_unlinkable passed:
+out/test/spec/linking.wast:302: assert_unlinkable passed:
   error: data segment is out of bounds: [327680, 327681) >= max value 327680
   0000028: error: OnDataSegmentData callback failed
-out/third_party/testsuite/linking.wast:312: assert_unlinkable passed:
+out/test/spec/linking.wast:312: assert_unlinkable passed:
   error: elem segment offset is out of bounds: 0 >= max value 0
   000002e: error: OnElemSegmentFunctionIndex callback failed
 80/80 tests passed.

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -1,39 +1,39 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/loop.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/loop.wast:254: assert_invalid passed:
+out/test/spec/loop.wast:254: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/loop.wast:258: assert_invalid passed:
+out/test/spec/loop.wast:258: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/loop.wast:262: assert_invalid passed:
+out/test/spec/loop.wast:262: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/loop.wast:266: assert_invalid passed:
+out/test/spec/loop.wast:266: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/loop.wast:271: assert_invalid passed:
+out/test/spec/loop.wast:271: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/third_party/testsuite/loop.wast:277: assert_invalid passed:
+out/test/spec/loop.wast:277: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/third_party/testsuite/loop.wast:283: assert_invalid passed:
+out/test/spec/loop.wast:283: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/third_party/testsuite/loop.wast:289: assert_invalid passed:
+out/test/spec/loop.wast:289: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/loop.wast:295: assert_invalid passed:
+out/test/spec/loop.wast:295: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/third_party/testsuite/loop.wast:303: assert_malformed passed:
-  out/third_party/testsuite/loop/loop.10.wat:1:16: error: unexpected label "$l"
+out/test/spec/loop.wast:303: assert_malformed passed:
+  out/test/spec/loop/loop.10.wat:1:16: error: unexpected label "$l"
   (func loop end $l)
                  ^^
-out/third_party/testsuite/loop.wast:307: assert_malformed passed:
-  out/third_party/testsuite/loop/loop.11.wat:1:19: error: mismatching label "$a" != "$l"
+out/test/spec/loop.wast:307: assert_malformed passed:
+  out/test/spec/loop/loop.11.wat:1:19: error: mismatching label "$a" != "$l"
   (func loop $a end $l)
                     ^^
 53/53 tests passed.

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -1,188 +1,188 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/memory.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/memory.wast:19: assert_invalid passed:
+out/test/spec/memory.wast:19: assert_invalid passed:
   000000b: error: memory count must be 0 or 1
-out/third_party/testsuite/memory.wast:20: assert_invalid passed:
+out/test/spec/memory.wast:20: assert_invalid passed:
   error: only one memory allowed
   0000023: error: OnMemory callback failed
-out/third_party/testsuite/memory.wast:29: assert_invalid passed:
+out/test/spec/memory.wast:29: assert_invalid passed:
   000000b: error: data section without memory section
-out/third_party/testsuite/memory.wast:30: assert_invalid passed:
+out/test/spec/memory.wast:30: assert_invalid passed:
   000000b: error: data section without memory section
-out/third_party/testsuite/memory.wast:31: assert_invalid passed:
+out/test/spec/memory.wast:31: assert_invalid passed:
   000000b: error: data section without memory section
-out/third_party/testsuite/memory.wast:34: assert_invalid passed:
+out/test/spec/memory.wast:34: assert_invalid passed:
   error: f32.load requires an imported or defined memory.
   000001c: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:38: assert_invalid passed:
+out/test/spec/memory.wast:38: assert_invalid passed:
   error: f32.store requires an imported or defined memory.
   0000021: error: OnStoreExpr callback failed
-out/third_party/testsuite/memory.wast:42: assert_invalid passed:
+out/test/spec/memory.wast:42: assert_invalid passed:
   error: i32.load8_s requires an imported or defined memory.
   000001c: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:46: assert_invalid passed:
+out/test/spec/memory.wast:46: assert_invalid passed:
   error: i32.store8 requires an imported or defined memory.
   000001e: error: OnStoreExpr callback failed
-out/third_party/testsuite/memory.wast:50: assert_invalid passed:
+out/test/spec/memory.wast:50: assert_invalid passed:
   error: current_memory requires an imported or defined memory.
   0000019: error: OnCurrentMemoryExpr callback failed
-out/third_party/testsuite/memory.wast:54: assert_invalid passed:
+out/test/spec/memory.wast:54: assert_invalid passed:
   error: grow_memory requires an imported or defined memory.
   000001b: error: OnGrowMemoryExpr callback failed
-out/third_party/testsuite/memory.wast:59: assert_invalid passed:
+out/test/spec/memory.wast:59: assert_invalid passed:
   0000013: error: expected i32 init_expr
-out/third_party/testsuite/memory.wast:63: assert_invalid passed:
+out/test/spec/memory.wast:63: assert_invalid passed:
   0000014: error: expected END opcode after initializer expression
-out/third_party/testsuite/memory.wast:67: assert_invalid passed:
+out/test/spec/memory.wast:67: assert_invalid passed:
   0000012: error: unexpected opcode in initializer expression: 1 (0x1)
-out/third_party/testsuite/memory.wast:77: assert_unlinkable passed:
+out/test/spec/memory.wast:77: assert_unlinkable passed:
   error: data segment is out of bounds: [0, 1) >= max value 0
   0000017: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:81: assert_unlinkable passed:
+out/test/spec/memory.wast:81: assert_unlinkable passed:
   error: data segment is out of bounds: [0, 1) >= max value 0
   0000017: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:85: assert_unlinkable passed:
+out/test/spec/memory.wast:85: assert_unlinkable passed:
   error: data segment is out of bounds: [4294967295, 4294967296) >= max value 65536
   0000017: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:89: assert_unlinkable passed:
+out/test/spec/memory.wast:89: assert_unlinkable passed:
   error: data segment is out of bounds: [4294966296, 4294966297) >= max value 65536
   0000018: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:93: assert_unlinkable passed:
+out/test/spec/memory.wast:93: assert_unlinkable passed:
   error: data segment is out of bounds: [98304, 98305) >= max value 65536
   000001f: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:97: assert_unlinkable passed:
+out/test/spec/memory.wast:97: assert_unlinkable passed:
   error: data segment is out of bounds: [1, 1) >= max value 0
   0000016: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:101: assert_unlinkable passed:
+out/test/spec/memory.wast:101: assert_unlinkable passed:
   error: data segment is out of bounds: [73728, 73728) >= max value 65536
   0000017: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:105: assert_unlinkable passed:
+out/test/spec/memory.wast:105: assert_unlinkable passed:
   error: data segment is out of bounds: [4294967295, 4294967295) >= max value 65536
   0000016: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:114: assert_unlinkable passed:
+out/test/spec/memory.wast:114: assert_unlinkable passed:
   error: duplicate export "global"
   error: data segment is out of bounds: [666, 667) >= max value 0
   000002c: error: OnDataSegmentData callback failed
-out/third_party/testsuite/memory.wast:131: assert_invalid passed:
+out/test/spec/memory.wast:131: assert_invalid passed:
   000000e: error: memory initial size must be <= max size
-out/third_party/testsuite/memory.wast:135: assert_invalid passed:
+out/test/spec/memory.wast:135: assert_invalid passed:
   000000f: error: invalid memory initial size
-out/third_party/testsuite/memory.wast:139: assert_invalid passed:
+out/test/spec/memory.wast:139: assert_invalid passed:
   0000011: error: invalid memory initial size
-out/third_party/testsuite/memory.wast:143: assert_invalid passed:
+out/test/spec/memory.wast:143: assert_invalid passed:
   0000011: error: invalid memory initial size
-out/third_party/testsuite/memory.wast:147: assert_invalid passed:
+out/test/spec/memory.wast:147: assert_invalid passed:
   0000010: error: invalid memory max size
-out/third_party/testsuite/memory.wast:151: assert_invalid passed:
+out/test/spec/memory.wast:151: assert_invalid passed:
   0000012: error: invalid memory max size
-out/third_party/testsuite/memory.wast:155: assert_invalid passed:
+out/test/spec/memory.wast:155: assert_invalid passed:
   0000012: error: invalid memory max size
-out/third_party/testsuite/memory.wast:166: assert_invalid passed:
+out/test/spec/memory.wast:166: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:170: assert_invalid passed:
+out/test/spec/memory.wast:170: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:174: assert_invalid passed:
+out/test/spec/memory.wast:174: assert_invalid passed:
   error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:178: assert_invalid passed:
+out/test/spec/memory.wast:178: assert_invalid passed:
   error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:182: assert_invalid passed:
+out/test/spec/memory.wast:182: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:186: assert_invalid passed:
+out/test/spec/memory.wast:186: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
   0000023: error: OnStoreExpr callback failed
-out/third_party/testsuite/memory.wast:190: assert_invalid passed:
+out/test/spec/memory.wast:190: assert_invalid passed:
   error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:194: assert_invalid passed:
+out/test/spec/memory.wast:194: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
-out/third_party/testsuite/memory.wast:198: assert_invalid passed:
+out/test/spec/memory.wast:198: assert_invalid passed:
   error: alignment must not be larger than natural alignment (1)
   0000023: error: OnStoreExpr callback failed
-out/third_party/testsuite/memory.wast:390: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.63.wat:1:43: error: unexpected token "i32.load32", expected an instr.
+out/test/spec/memory.wast:390: assert_malformed passed:
+  out/test/spec/memory/memory.63.wat:1:43: error: unexpected token "i32.load32", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load32 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:397: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.64.wat:1:43: error: unexpected token "i32.load32_u", expected an instr.
+out/test/spec/memory.wast:397: assert_malformed passed:
+  out/test/spec/memory/memory.64.wat:1:43: error: unexpected token "i32.load32_u", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load32_u (get_local 0)))
                                             ^^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:404: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.65.wat:1:43: error: unexpected token "i32.load32_s", expected an instr.
+out/test/spec/memory.wast:404: assert_malformed passed:
+  out/test/spec/memory/memory.65.wat:1:43: error: unexpected token "i32.load32_s", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load32_s (get_local 0)))
                                             ^^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:411: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.66.wat:1:43: error: unexpected token "i32.load64", expected an instr.
+out/test/spec/memory.wast:411: assert_malformed passed:
+  out/test/spec/memory/memory.66.wat:1:43: error: unexpected token "i32.load64", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:418: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.67.wat:1:43: error: unexpected token "i32.load64_u", expected an instr.
+out/test/spec/memory.wast:418: assert_malformed passed:
+  out/test/spec/memory/memory.67.wat:1:43: error: unexpected token "i32.load64_u", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load64_u (get_local 0)))
                                             ^^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:425: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.68.wat:1:43: error: unexpected token "i32.load64_s", expected an instr.
+out/test/spec/memory.wast:425: assert_malformed passed:
+  out/test/spec/memory/memory.68.wat:1:43: error: unexpected token "i32.load64_s", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load64_s (get_local 0)))
                                             ^^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:432: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.69.wat:1:30: error: unexpected token "i32.store32", expected an instr.
+out/test/spec/memory.wast:432: assert_malformed passed:
+  out/test/spec/memory/memory.69.wat:1:30: error: unexpected token "i32.store32", expected an instr.
   (memory 1)(func (param i32) (i32.store32 (get_local 0) (i32.const 0)))
                                ^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:439: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.70.wat:1:30: error: unexpected token "i32.store64", expected an instr.
+out/test/spec/memory.wast:439: assert_malformed passed:
+  out/test/spec/memory/memory.70.wat:1:30: error: unexpected token "i32.store64", expected an instr.
   (memory 1)(func (param i32) (i32.store64 (get_local 0) (i64.const 0)))
                                ^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:447: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.71.wat:1:43: error: unexpected token "i64.load64", expected an instr.
+out/test/spec/memory.wast:447: assert_malformed passed:
+  out/test/spec/memory/memory.71.wat:1:43: error: unexpected token "i64.load64", expected an instr.
   (memory 1)(func (param i32) (result i64) (i64.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:454: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.72.wat:1:43: error: unexpected token "i64.load64_u", expected an instr.
+out/test/spec/memory.wast:454: assert_malformed passed:
+  out/test/spec/memory/memory.72.wat:1:43: error: unexpected token "i64.load64_u", expected an instr.
   (memory 1)(func (param i32) (result i64) (i64.load64_u (get_local 0)))
                                             ^^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:461: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.73.wat:1:43: error: unexpected token "i64.load64_s", expected an instr.
+out/test/spec/memory.wast:461: assert_malformed passed:
+  out/test/spec/memory/memory.73.wat:1:43: error: unexpected token "i64.load64_s", expected an instr.
   (memory 1)(func (param i32) (result i64) (i64.load64_s (get_local 0)))
                                             ^^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:468: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.74.wat:1:30: error: unexpected token "i64.store64", expected an instr.
+out/test/spec/memory.wast:468: assert_malformed passed:
+  out/test/spec/memory/memory.74.wat:1:30: error: unexpected token "i64.store64", expected an instr.
   (memory 1)(func (param i32) (i64.store64 (get_local 0) (i64.const 0)))
                                ^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:476: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.75.wat:1:43: error: unexpected token "f32.load32", expected an instr.
+out/test/spec/memory.wast:476: assert_malformed passed:
+  out/test/spec/memory/memory.75.wat:1:43: error: unexpected token "f32.load32", expected an instr.
   (memory 1)(func (param i32) (result f32) (f32.load32 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:483: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.76.wat:1:43: error: unexpected token "f32.load64", expected an instr.
+out/test/spec/memory.wast:483: assert_malformed passed:
+  out/test/spec/memory/memory.76.wat:1:43: error: unexpected token "f32.load64", expected an instr.
   (memory 1)(func (param i32) (result f32) (f32.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:490: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.77.wat:1:30: error: unexpected token "f32.store32", expected an instr.
+out/test/spec/memory.wast:490: assert_malformed passed:
+  out/test/spec/memory/memory.77.wat:1:30: error: unexpected token "f32.store32", expected an instr.
   (memory 1)(func (param i32) (f32.store32 (get_local 0) (f32.const 0)))
                                ^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:497: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.78.wat:1:30: error: unexpected token "f32.store64", expected an instr.
+out/test/spec/memory.wast:497: assert_malformed passed:
+  out/test/spec/memory/memory.78.wat:1:30: error: unexpected token "f32.store64", expected an instr.
   (memory 1)(func (param i32) (f32.store64 (get_local 0) (f64.const 0)))
                                ^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:505: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.79.wat:1:43: error: unexpected token "f64.load32", expected an instr.
+out/test/spec/memory.wast:505: assert_malformed passed:
+  out/test/spec/memory/memory.79.wat:1:43: error: unexpected token "f64.load32", expected an instr.
   (memory 1)(func (param i32) (result f64) (f64.load32 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:512: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.80.wat:1:43: error: unexpected token "f64.load64", expected an instr.
+out/test/spec/memory.wast:512: assert_malformed passed:
+  out/test/spec/memory/memory.80.wat:1:43: error: unexpected token "f64.load64", expected an instr.
   (memory 1)(func (param i32) (result f64) (f64.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/third_party/testsuite/memory.wast:519: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.81.wat:1:30: error: unexpected token "f64.store32", expected an instr.
+out/test/spec/memory.wast:519: assert_malformed passed:
+  out/test/spec/memory/memory.81.wat:1:30: error: unexpected token "f64.store32", expected an instr.
   (memory 1)(func (param i32) (f64.store32 (get_local 0) (f32.const 0)))
                                ^^^^^^^^^^^
-out/third_party/testsuite/memory.wast:526: assert_malformed passed:
-  out/third_party/testsuite/memory/memory.82.wat:1:30: error: unexpected token "f64.store64", expected an instr.
+out/test/spec/memory.wast:526: assert_malformed passed:
+  out/test/spec/memory/memory.82.wat:1:30: error: unexpected token "f64.store64", expected an instr.
   (memory 1)(func (param i32) (f64.store64 (get_local 0) (f64.const 0)))
                                ^^^^^^^^^^^
 106/106 tests passed.

--- a/test/spec/nop.txt
+++ b/test/spec/nop.txt
@@ -1,16 +1,16 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/nop.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/nop.wast:250: assert_invalid passed:
+out/test/spec/nop.wast:250: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/nop.wast:254: assert_invalid passed:
+out/test/spec/nop.wast:254: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/nop.wast:258: assert_invalid passed:
+out/test/spec/nop.wast:258: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/nop.wast:262: assert_invalid passed:
+out/test/spec/nop.wast:262: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001a: error: EndFunctionBody callback failed
 54/54 tests passed.

--- a/test/spec/return.txt
+++ b/test/spec/return.txt
@@ -1,13 +1,13 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/return.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/return.wast:284: assert_invalid passed:
+out/test/spec/return.wast:284: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got []
   0000019: error: OnReturnExpr callback failed
-out/third_party/testsuite/return.wast:288: assert_invalid passed:
+out/test/spec/return.wast:288: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got []
   000001a: error: OnReturnExpr callback failed
-out/third_party/testsuite/return.wast:292: assert_invalid passed:
+out/test/spec/return.wast:292: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got [i64]
   000001b: error: OnReturnExpr callback failed
 60/60 tests passed.

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/select.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/select.wast:65: assert_invalid passed:
+out/test/spec/select.wast:65: assert_invalid passed:
   error: type mismatch in select, expected [i32, any, any] but got [i32]
   000001c: error: OnSelectExpr callback failed
 29/29 tests passed.

--- a/test/spec/set_local.txt
+++ b/test/spec/set_local.txt
@@ -1,73 +1,73 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/set_local.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/set_local.wast:95: assert_invalid passed:
+out/test/spec/set_local.wast:95: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001f: error: EndFunctionBody callback failed
-out/third_party/testsuite/set_local.wast:101: assert_invalid passed:
+out/test/spec/set_local.wast:101: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000021: error: OnConvertExpr callback failed
-out/third_party/testsuite/set_local.wast:107: assert_invalid passed:
+out/test/spec/set_local.wast:107: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/third_party/testsuite/set_local.wast:114: assert_invalid passed:
+out/test/spec/set_local.wast:114: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got []
   000001c: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:118: assert_invalid passed:
+out/test/spec/set_local.wast:118: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got [f32]
   0000020: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:122: assert_invalid passed:
+out/test/spec/set_local.wast:122: assert_invalid passed:
   error: type mismatch in set_local, expected [f32] but got [f64]
   0000024: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:126: assert_invalid passed:
+out/test/spec/set_local.wast:126: assert_invalid passed:
   error: type mismatch in set_local, expected [i64] but got [f64]
   0000026: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:134: assert_invalid passed:
+out/test/spec/set_local.wast:134: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/set_local.wast:138: assert_invalid passed:
+out/test/spec/set_local.wast:138: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
-out/third_party/testsuite/set_local.wast:142: assert_invalid passed:
+out/test/spec/set_local.wast:142: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
-out/third_party/testsuite/set_local.wast:147: assert_invalid passed:
+out/test/spec/set_local.wast:147: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got []
   000001b: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:151: assert_invalid passed:
+out/test/spec/set_local.wast:151: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got [f32]
   000001f: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:155: assert_invalid passed:
+out/test/spec/set_local.wast:155: assert_invalid passed:
   error: type mismatch in set_local, expected [f32] but got [f64]
   0000023: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:159: assert_invalid passed:
+out/test/spec/set_local.wast:159: assert_invalid passed:
   error: type mismatch in set_local, expected [i64] but got [f64]
   0000024: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:167: assert_invalid passed:
+out/test/spec/set_local.wast:167: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
   000001d: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:171: assert_invalid passed:
+out/test/spec/set_local.wast:171: assert_invalid passed:
   error: invalid local_index: 14324343 (max 2)
   0000020: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:176: assert_invalid passed:
+out/test/spec/set_local.wast:176: assert_invalid passed:
   error: invalid local_index: 2 (max 2)
   000001b: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:180: assert_invalid passed:
+out/test/spec/set_local.wast:180: assert_invalid passed:
   error: invalid local_index: 714324343 (max 2)
   0000021: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:185: assert_invalid passed:
+out/test/spec/set_local.wast:185: assert_invalid passed:
   error: invalid local_index: 3 (max 3)
   000001e: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:189: assert_invalid passed:
+out/test/spec/set_local.wast:189: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
   0000021: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:194: assert_invalid passed:
+out/test/spec/set_local.wast:194: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got [f32]
   0000021: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:198: assert_invalid passed:
+out/test/spec/set_local.wast:198: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got [f32]
   0000022: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/set_local.wast:202: assert_invalid passed:
+out/test/spec/set_local.wast:202: assert_invalid passed:
   error: type mismatch in set_local, expected [f64] but got [i64]
   0000020: error: OnSetLocalExpr callback failed
 33/33 tests passed.

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -1,12 +1,12 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/start.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/start.wast:2: assert_invalid passed:
+out/test/spec/start.wast:2: assert_invalid passed:
   0000015: error: invalid start function index: 1
-out/third_party/testsuite/start.wast:7: assert_invalid passed:
+out/test/spec/start.wast:7: assert_invalid passed:
   error: start function must not return anything
   0000016: error: OnStartFunction callback failed
-out/third_party/testsuite/start.wast:14: assert_invalid passed:
+out/test/spec/start.wast:14: assert_invalid passed:
   error: start function must be nullary
   0000016: error: OnStartFunction callback failed
 inc() =>

--- a/test/spec/store_retval.txt
+++ b/test/spec/store_retval.txt
@@ -1,43 +1,43 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/store_retval.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/store_retval.wast:2: assert_invalid passed:
+out/test/spec/store_retval.wast:2: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:6: assert_invalid passed:
+out/test/spec/store_retval.wast:6: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:10: assert_invalid passed:
+out/test/spec/store_retval.wast:10: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   0000021: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:14: assert_invalid passed:
+out/test/spec/store_retval.wast:14: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   0000025: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:19: assert_invalid passed:
+out/test/spec/store_retval.wast:19: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:23: assert_invalid passed:
+out/test/spec/store_retval.wast:23: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:27: assert_invalid passed:
+out/test/spec/store_retval.wast:27: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   0000029: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:31: assert_invalid passed:
+out/test/spec/store_retval.wast:31: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000002d: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:36: assert_invalid passed:
+out/test/spec/store_retval.wast:36: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:40: assert_invalid passed:
+out/test/spec/store_retval.wast:40: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:44: assert_invalid passed:
+out/test/spec/store_retval.wast:44: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:48: assert_invalid passed:
+out/test/spec/store_retval.wast:48: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
-out/third_party/testsuite/store_retval.wast:52: assert_invalid passed:
+out/test/spec/store_retval.wast:52: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 13/13 tests passed.

--- a/test/spec/switch.txt
+++ b/test/spec/switch.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/switch.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/switch.wast:150: assert_invalid passed:
+out/test/spec/switch.wast:150: assert_invalid passed:
   error: invalid depth: 3 (max 0)
   000001c: error: OnBrTableExpr callback failed
 27/27 tests passed.

--- a/test/spec/tee_local.txt
+++ b/test/spec/tee_local.txt
@@ -1,73 +1,73 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/tee_local.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/tee_local.wast:132: assert_invalid passed:
+out/test/spec/tee_local.wast:132: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001f: error: EndFunctionBody callback failed
-out/third_party/testsuite/tee_local.wast:136: assert_invalid passed:
+out/test/spec/tee_local.wast:136: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
-out/third_party/testsuite/tee_local.wast:140: assert_invalid passed:
+out/test/spec/tee_local.wast:140: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   0000020: error: OnUnaryExpr callback failed
-out/third_party/testsuite/tee_local.wast:145: assert_invalid passed:
+out/test/spec/tee_local.wast:145: assert_invalid passed:
   error: type mismatch in tee_local, expected [i32] but got []
   000001c: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:149: assert_invalid passed:
+out/test/spec/tee_local.wast:149: assert_invalid passed:
   error: type mismatch in tee_local, expected [i32] but got [f32]
   0000020: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:153: assert_invalid passed:
+out/test/spec/tee_local.wast:153: assert_invalid passed:
   error: type mismatch in tee_local, expected [f32] but got [f64]
   0000024: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:157: assert_invalid passed:
+out/test/spec/tee_local.wast:157: assert_invalid passed:
   error: type mismatch in tee_local, expected [i64] but got [f64]
   0000026: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:165: assert_invalid passed:
+out/test/spec/tee_local.wast:165: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/tee_local.wast:169: assert_invalid passed:
+out/test/spec/tee_local.wast:169: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
-out/third_party/testsuite/tee_local.wast:173: assert_invalid passed:
+out/test/spec/tee_local.wast:173: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
-out/third_party/testsuite/tee_local.wast:178: assert_invalid passed:
+out/test/spec/tee_local.wast:178: assert_invalid passed:
   error: type mismatch in tee_local, expected [i32] but got []
   000001b: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:182: assert_invalid passed:
+out/test/spec/tee_local.wast:182: assert_invalid passed:
   error: type mismatch in tee_local, expected [i32] but got [f32]
   000001f: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:186: assert_invalid passed:
+out/test/spec/tee_local.wast:186: assert_invalid passed:
   error: type mismatch in tee_local, expected [f32] but got [f64]
   0000023: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:190: assert_invalid passed:
+out/test/spec/tee_local.wast:190: assert_invalid passed:
   error: type mismatch in tee_local, expected [i64] but got [f64]
   0000024: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:198: assert_invalid passed:
+out/test/spec/tee_local.wast:198: assert_invalid passed:
   error: invalid local_index: 3 (max 2)
   000001d: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:202: assert_invalid passed:
+out/test/spec/tee_local.wast:202: assert_invalid passed:
   error: invalid local_index: 14324343 (max 2)
   0000020: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:207: assert_invalid passed:
+out/test/spec/tee_local.wast:207: assert_invalid passed:
   error: invalid local_index: 2 (max 2)
   000001b: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:211: assert_invalid passed:
+out/test/spec/tee_local.wast:211: assert_invalid passed:
   error: invalid local_index: 714324343 (max 2)
   0000021: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:216: assert_invalid passed:
+out/test/spec/tee_local.wast:216: assert_invalid passed:
   error: invalid local_index: 3 (max 3)
   000001e: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:220: assert_invalid passed:
+out/test/spec/tee_local.wast:220: assert_invalid passed:
   error: invalid local_index: 214324343 (max 3)
   0000021: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:225: assert_invalid passed:
+out/test/spec/tee_local.wast:225: assert_invalid passed:
   error: type mismatch in tee_local, expected [i32] but got [f32]
   0000021: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:229: assert_invalid passed:
+out/test/spec/tee_local.wast:229: assert_invalid passed:
   error: type mismatch in tee_local, expected [i32] but got [f32]
   0000022: error: OnTeeLocalExpr callback failed
-out/third_party/testsuite/tee_local.wast:233: assert_invalid passed:
+out/test/spec/tee_local.wast:233: assert_invalid passed:
   error: type mismatch in tee_local, expected [f64] but got [i64]
   0000020: error: OnTeeLocalExpr callback failed
 34/34 tests passed.

--- a/test/spec/token.txt
+++ b/test/spec/token.txt
@@ -1,12 +1,12 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/token.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/token.wast:4: assert_malformed passed:
-  out/third_party/testsuite/token/token.0.wat:1:14: error: unexpected token "i32.const0", expected an expr.
+out/test/spec/token.wast:4: assert_malformed passed:
+  out/test/spec/token/token.0.wat:1:14: error: unexpected token "i32.const0", expected an expr.
   (func (drop (i32.const0)))
                ^^^^^^^^^^
-out/third_party/testsuite/token.wast:8: assert_malformed passed:
-  out/third_party/testsuite/token/token.1.wat:1:10: error: unexpected token "0drop", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/spec/token.wast:8: assert_malformed passed:
+  out/test/spec/token/token.1.wat:1:10: error: unexpected token "0drop", expected a numeric index or a name (e.g. 12 or $foo).
   (func br 0drop)
            ^^^^^
 2/2 tests passed.

--- a/test/spec/type.txt
+++ b/test/spec/type.txt
@@ -2,17 +2,17 @@
 ;;; STDIN_FILE: third_party/testsuite/type.wast
 ;;; NOTE: Two tests don't pass because they use quoted modules with assert_invalid, which isn't currently supported by wabt.
 (;; STDOUT ;;;
-out/third_party/testsuite/type.wast:44: assert_malformed passed:
-  out/third_party/testsuite/type/type.1.wat:1:27: error: unexpected token "param", expected param or result.
+out/test/spec/type.wast:44: assert_malformed passed:
+  out/test/spec/type/type.1.wat:1:27: error: unexpected token "param", expected param or result.
   (type (func (result i32) (param i32)))
                             ^^^^^
-out/third_party/testsuite/type.wast:48: assert_malformed passed:
-  out/third_party/testsuite/type/type.2.wat:1:21: error: unexpected token $x, expected ).
+out/test/spec/type.wast:48: assert_malformed passed:
+  out/test/spec/type/type.2.wat:1:21: error: unexpected token $x, expected ).
   (type (func (result $x i32)))
                       ^^
-out/third_party/testsuite/type.wast:53: assert_invalid passed:
+out/test/spec/type.wast:53: assert_invalid passed:
   000000e: error: result count must be 0 or 1
-out/third_party/testsuite/type.wast:57: assert_invalid passed:
+out/test/spec/type.wast:57: assert_invalid passed:
   000000e: error: result count must be 0 or 1
 4/4 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/typecheck.txt
+++ b/test/spec/typecheck.txt
@@ -1,583 +1,583 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/typecheck.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/typecheck.wast:4: assert_invalid passed:
+out/test/spec/typecheck.wast:4: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:10: assert_invalid passed:
+out/test/spec/typecheck.wast:10: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:17: assert_invalid passed:
+out/test/spec/typecheck.wast:17: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:24: assert_invalid passed:
+out/test/spec/typecheck.wast:24: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:31: assert_invalid passed:
+out/test/spec/typecheck.wast:31: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000021: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:39: assert_invalid passed:
+out/test/spec/typecheck.wast:39: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:45: assert_invalid passed:
+out/test/spec/typecheck.wast:45: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:51: assert_invalid passed:
+out/test/spec/typecheck.wast:51: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:58: assert_invalid passed:
+out/test/spec/typecheck.wast:58: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:65: assert_invalid passed:
+out/test/spec/typecheck.wast:65: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:72: assert_invalid passed:
+out/test/spec/typecheck.wast:72: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:79: assert_invalid passed:
+out/test/spec/typecheck.wast:79: assert_invalid passed:
   error: type mismatch in drop, expected [any] but got []
   0000021: error: OnDropExpr callback failed
-out/third_party/testsuite/typecheck.wast:86: assert_invalid passed:
+out/test/spec/typecheck.wast:86: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000020: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:93: assert_invalid passed:
+out/test/spec/typecheck.wast:93: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:101: assert_invalid passed:
+out/test/spec/typecheck.wast:101: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000021: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:110: assert_invalid passed:
+out/test/spec/typecheck.wast:110: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:116: assert_invalid passed:
+out/test/spec/typecheck.wast:116: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:123: assert_invalid passed:
+out/test/spec/typecheck.wast:123: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:130: assert_invalid passed:
+out/test/spec/typecheck.wast:130: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:137: assert_invalid passed:
+out/test/spec/typecheck.wast:137: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000022: error: OnIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:146: assert_invalid passed:
+out/test/spec/typecheck.wast:146: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001b: error: OnBrExpr callback failed
-out/third_party/testsuite/typecheck.wast:153: assert_invalid passed:
+out/test/spec/typecheck.wast:153: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/third_party/testsuite/typecheck.wast:161: assert_invalid passed:
+out/test/spec/typecheck.wast:161: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/third_party/testsuite/typecheck.wast:171: assert_invalid passed:
+out/test/spec/typecheck.wast:171: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000024: error: OnBrExpr callback failed
-out/third_party/testsuite/typecheck.wast:182: assert_invalid passed:
+out/test/spec/typecheck.wast:182: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
-out/third_party/testsuite/typecheck.wast:188: assert_invalid passed:
+out/test/spec/typecheck.wast:188: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
-out/third_party/testsuite/typecheck.wast:195: assert_invalid passed:
+out/test/spec/typecheck.wast:195: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
-out/third_party/testsuite/typecheck.wast:202: assert_invalid passed:
+out/test/spec/typecheck.wast:202: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001f: error: OnReturnExpr callback failed
-out/third_party/testsuite/typecheck.wast:209: assert_invalid passed:
+out/test/spec/typecheck.wast:209: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   0000022: error: OnReturnExpr callback failed
-out/third_party/testsuite/typecheck.wast:219: assert_invalid passed:
+out/test/spec/typecheck.wast:219: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got [f32]
   000001e: error: OnIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:222: assert_invalid passed:
+out/test/spec/typecheck.wast:222: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [f32]
   0000020: error: OnBrIfExpr callback failed
-out/third_party/testsuite/typecheck.wast:226: assert_invalid passed:
+out/test/spec/typecheck.wast:226: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
   0000021: error: OnBrTableExpr callback failed
-out/third_party/testsuite/typecheck.wast:230: assert_invalid passed:
+out/test/spec/typecheck.wast:230: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got [f32]
   0000026: error: OnCallExpr callback failed
-out/third_party/testsuite/typecheck.wast:232: assert_invalid passed:
+out/test/spec/typecheck.wast:232: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [... f32]
   000002f: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/typecheck.wast:242: assert_invalid passed:
+out/test/spec/typecheck.wast:242: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [f32]
   0000029: error: OnCallIndirectExpr callback failed
-out/third_party/testsuite/typecheck.wast:250: assert_invalid passed:
+out/test/spec/typecheck.wast:250: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [f32]
   000001e: error: OnReturnExpr callback failed
-out/third_party/testsuite/typecheck.wast:253: assert_invalid passed:
+out/test/spec/typecheck.wast:253: assert_invalid passed:
   error: type mismatch in set_local, expected [i32] but got [f32]
   0000020: error: OnSetLocalExpr callback failed
-out/third_party/testsuite/typecheck.wast:256: assert_invalid passed:
+out/test/spec/typecheck.wast:256: assert_invalid passed:
   error: type mismatch in i32.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:257: assert_invalid passed:
+out/test/spec/typecheck.wast:257: assert_invalid passed:
   error: type mismatch in i32.load8_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:258: assert_invalid passed:
+out/test/spec/typecheck.wast:258: assert_invalid passed:
   error: type mismatch in i32.load8_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:259: assert_invalid passed:
+out/test/spec/typecheck.wast:259: assert_invalid passed:
   error: type mismatch in i32.load16_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:260: assert_invalid passed:
+out/test/spec/typecheck.wast:260: assert_invalid passed:
   error: type mismatch in i32.load16_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:261: assert_invalid passed:
+out/test/spec/typecheck.wast:261: assert_invalid passed:
   error: type mismatch in i64.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:262: assert_invalid passed:
+out/test/spec/typecheck.wast:262: assert_invalid passed:
   error: type mismatch in i64.load8_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:263: assert_invalid passed:
+out/test/spec/typecheck.wast:263: assert_invalid passed:
   error: type mismatch in i64.load8_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:264: assert_invalid passed:
+out/test/spec/typecheck.wast:264: assert_invalid passed:
   error: type mismatch in i64.load16_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:265: assert_invalid passed:
+out/test/spec/typecheck.wast:265: assert_invalid passed:
   error: type mismatch in i64.load16_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:266: assert_invalid passed:
+out/test/spec/typecheck.wast:266: assert_invalid passed:
   error: type mismatch in i64.load32_s, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:267: assert_invalid passed:
+out/test/spec/typecheck.wast:267: assert_invalid passed:
   error: type mismatch in i64.load32_u, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:268: assert_invalid passed:
+out/test/spec/typecheck.wast:268: assert_invalid passed:
   error: type mismatch in f32.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:269: assert_invalid passed:
+out/test/spec/typecheck.wast:269: assert_invalid passed:
   error: type mismatch in f64.load, expected [i32] but got [f32]
   0000024: error: OnLoadExpr callback failed
-out/third_party/testsuite/typecheck.wast:272: assert_invalid passed:
+out/test/spec/typecheck.wast:272: assert_invalid passed:
   error: type mismatch in i32.store, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:273: assert_invalid passed:
+out/test/spec/typecheck.wast:273: assert_invalid passed:
   error: type mismatch in i32.store8, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:274: assert_invalid passed:
+out/test/spec/typecheck.wast:274: assert_invalid passed:
   error: type mismatch in i32.store16, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:275: assert_invalid passed:
+out/test/spec/typecheck.wast:275: assert_invalid passed:
   error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:276: assert_invalid passed:
+out/test/spec/typecheck.wast:276: assert_invalid passed:
   error: type mismatch in i64.store8, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:277: assert_invalid passed:
+out/test/spec/typecheck.wast:277: assert_invalid passed:
   error: type mismatch in i64.store16, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:278: assert_invalid passed:
+out/test/spec/typecheck.wast:278: assert_invalid passed:
   error: type mismatch in i64.store32, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:279: assert_invalid passed:
+out/test/spec/typecheck.wast:279: assert_invalid passed:
   error: type mismatch in f32.store, expected [i32, f32] but got [f32, f32]
   0000029: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:280: assert_invalid passed:
+out/test/spec/typecheck.wast:280: assert_invalid passed:
   error: type mismatch in f64.store, expected [i32, f64] but got [f32, f64]
   000002d: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:283: assert_invalid passed:
+out/test/spec/typecheck.wast:283: assert_invalid passed:
   error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:284: assert_invalid passed:
+out/test/spec/typecheck.wast:284: assert_invalid passed:
   error: type mismatch in i32.store8, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:285: assert_invalid passed:
+out/test/spec/typecheck.wast:285: assert_invalid passed:
   error: type mismatch in i32.store16, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:286: assert_invalid passed:
+out/test/spec/typecheck.wast:286: assert_invalid passed:
   error: type mismatch in i64.store, expected [i32, i64] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:287: assert_invalid passed:
+out/test/spec/typecheck.wast:287: assert_invalid passed:
   error: type mismatch in i64.store8, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:288: assert_invalid passed:
+out/test/spec/typecheck.wast:288: assert_invalid passed:
   error: type mismatch in i64.store16, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:289: assert_invalid passed:
+out/test/spec/typecheck.wast:289: assert_invalid passed:
   error: type mismatch in i64.store32, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:290: assert_invalid passed:
+out/test/spec/typecheck.wast:290: assert_invalid passed:
   error: type mismatch in f32.store, expected [i32, f32] but got [i32, i32]
   0000023: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:291: assert_invalid passed:
+out/test/spec/typecheck.wast:291: assert_invalid passed:
   error: type mismatch in f64.store, expected [i32, f64] but got [i32, i64]
   0000023: error: OnStoreExpr callback failed
-out/third_party/testsuite/typecheck.wast:294: assert_invalid passed:
+out/test/spec/typecheck.wast:294: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:295: assert_invalid passed:
+out/test/spec/typecheck.wast:295: assert_invalid passed:
   error: type mismatch in i32.and, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:296: assert_invalid passed:
+out/test/spec/typecheck.wast:296: assert_invalid passed:
   error: type mismatch in i32.div_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:297: assert_invalid passed:
+out/test/spec/typecheck.wast:297: assert_invalid passed:
   error: type mismatch in i32.div_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:298: assert_invalid passed:
+out/test/spec/typecheck.wast:298: assert_invalid passed:
   error: type mismatch in i32.mul, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:299: assert_invalid passed:
+out/test/spec/typecheck.wast:299: assert_invalid passed:
   error: type mismatch in i32.or, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:300: assert_invalid passed:
+out/test/spec/typecheck.wast:300: assert_invalid passed:
   error: type mismatch in i32.rem_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:301: assert_invalid passed:
+out/test/spec/typecheck.wast:301: assert_invalid passed:
   error: type mismatch in i32.rem_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:302: assert_invalid passed:
+out/test/spec/typecheck.wast:302: assert_invalid passed:
   error: type mismatch in i32.rotl, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:303: assert_invalid passed:
+out/test/spec/typecheck.wast:303: assert_invalid passed:
   error: type mismatch in i32.rotr, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:304: assert_invalid passed:
+out/test/spec/typecheck.wast:304: assert_invalid passed:
   error: type mismatch in i32.shl, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:305: assert_invalid passed:
+out/test/spec/typecheck.wast:305: assert_invalid passed:
   error: type mismatch in i32.shr_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:306: assert_invalid passed:
+out/test/spec/typecheck.wast:306: assert_invalid passed:
   error: type mismatch in i32.shr_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:307: assert_invalid passed:
+out/test/spec/typecheck.wast:307: assert_invalid passed:
   error: type mismatch in i32.sub, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:308: assert_invalid passed:
+out/test/spec/typecheck.wast:308: assert_invalid passed:
   error: type mismatch in i32.xor, expected [i32, i32] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:309: assert_invalid passed:
+out/test/spec/typecheck.wast:309: assert_invalid passed:
   error: type mismatch in i64.add, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:310: assert_invalid passed:
+out/test/spec/typecheck.wast:310: assert_invalid passed:
   error: type mismatch in i64.and, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:311: assert_invalid passed:
+out/test/spec/typecheck.wast:311: assert_invalid passed:
   error: type mismatch in i64.div_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:312: assert_invalid passed:
+out/test/spec/typecheck.wast:312: assert_invalid passed:
   error: type mismatch in i64.div_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:313: assert_invalid passed:
+out/test/spec/typecheck.wast:313: assert_invalid passed:
   error: type mismatch in i64.mul, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:314: assert_invalid passed:
+out/test/spec/typecheck.wast:314: assert_invalid passed:
   error: type mismatch in i64.or, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:315: assert_invalid passed:
+out/test/spec/typecheck.wast:315: assert_invalid passed:
   error: type mismatch in i64.rem_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:316: assert_invalid passed:
+out/test/spec/typecheck.wast:316: assert_invalid passed:
   error: type mismatch in i64.rem_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:317: assert_invalid passed:
+out/test/spec/typecheck.wast:317: assert_invalid passed:
   error: type mismatch in i64.rotl, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:318: assert_invalid passed:
+out/test/spec/typecheck.wast:318: assert_invalid passed:
   error: type mismatch in i64.rotr, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:319: assert_invalid passed:
+out/test/spec/typecheck.wast:319: assert_invalid passed:
   error: type mismatch in i64.shl, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:320: assert_invalid passed:
+out/test/spec/typecheck.wast:320: assert_invalid passed:
   error: type mismatch in i64.shr_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:321: assert_invalid passed:
+out/test/spec/typecheck.wast:321: assert_invalid passed:
   error: type mismatch in i64.shr_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:322: assert_invalid passed:
+out/test/spec/typecheck.wast:322: assert_invalid passed:
   error: type mismatch in i64.sub, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:323: assert_invalid passed:
+out/test/spec/typecheck.wast:323: assert_invalid passed:
   error: type mismatch in i64.xor, expected [i64, i64] but got [i32, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:324: assert_invalid passed:
+out/test/spec/typecheck.wast:324: assert_invalid passed:
   error: type mismatch in f32.add, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:325: assert_invalid passed:
+out/test/spec/typecheck.wast:325: assert_invalid passed:
   error: type mismatch in f32.copysign, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:326: assert_invalid passed:
+out/test/spec/typecheck.wast:326: assert_invalid passed:
   error: type mismatch in f32.div, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:327: assert_invalid passed:
+out/test/spec/typecheck.wast:327: assert_invalid passed:
   error: type mismatch in f32.max, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:328: assert_invalid passed:
+out/test/spec/typecheck.wast:328: assert_invalid passed:
   error: type mismatch in f32.min, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:329: assert_invalid passed:
+out/test/spec/typecheck.wast:329: assert_invalid passed:
   error: type mismatch in f32.mul, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:330: assert_invalid passed:
+out/test/spec/typecheck.wast:330: assert_invalid passed:
   error: type mismatch in f32.sub, expected [f32, f32] but got [i64, f64]
   0000023: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:331: assert_invalid passed:
+out/test/spec/typecheck.wast:331: assert_invalid passed:
   error: type mismatch in f64.add, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:332: assert_invalid passed:
+out/test/spec/typecheck.wast:332: assert_invalid passed:
   error: type mismatch in f64.copysign, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:333: assert_invalid passed:
+out/test/spec/typecheck.wast:333: assert_invalid passed:
   error: type mismatch in f64.div, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:334: assert_invalid passed:
+out/test/spec/typecheck.wast:334: assert_invalid passed:
   error: type mismatch in f64.max, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:335: assert_invalid passed:
+out/test/spec/typecheck.wast:335: assert_invalid passed:
   error: type mismatch in f64.min, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:336: assert_invalid passed:
+out/test/spec/typecheck.wast:336: assert_invalid passed:
   error: type mismatch in f64.mul, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:337: assert_invalid passed:
+out/test/spec/typecheck.wast:337: assert_invalid passed:
   error: type mismatch in f64.sub, expected [f64, f64] but got [i64, f32]
   000001f: error: OnBinaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:340: assert_invalid passed:
+out/test/spec/typecheck.wast:340: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:341: assert_invalid passed:
+out/test/spec/typecheck.wast:341: assert_invalid passed:
   error: type mismatch in i32.clz, expected [i32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:342: assert_invalid passed:
+out/test/spec/typecheck.wast:342: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:343: assert_invalid passed:
+out/test/spec/typecheck.wast:343: assert_invalid passed:
   error: type mismatch in i32.popcnt, expected [i32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:344: assert_invalid passed:
+out/test/spec/typecheck.wast:344: assert_invalid passed:
   error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:345: assert_invalid passed:
+out/test/spec/typecheck.wast:345: assert_invalid passed:
   error: type mismatch in i64.clz, expected [i64] but got [i32]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:346: assert_invalid passed:
+out/test/spec/typecheck.wast:346: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got [i32]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:347: assert_invalid passed:
+out/test/spec/typecheck.wast:347: assert_invalid passed:
   error: type mismatch in i64.popcnt, expected [i64] but got [i32]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:348: assert_invalid passed:
+out/test/spec/typecheck.wast:348: assert_invalid passed:
   error: type mismatch in f32.abs, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:349: assert_invalid passed:
+out/test/spec/typecheck.wast:349: assert_invalid passed:
   error: type mismatch in f32.ceil, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:350: assert_invalid passed:
+out/test/spec/typecheck.wast:350: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:351: assert_invalid passed:
+out/test/spec/typecheck.wast:351: assert_invalid passed:
   error: type mismatch in f32.nearest, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:352: assert_invalid passed:
+out/test/spec/typecheck.wast:352: assert_invalid passed:
   error: type mismatch in f32.neg, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:353: assert_invalid passed:
+out/test/spec/typecheck.wast:353: assert_invalid passed:
   error: type mismatch in f32.sqrt, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:354: assert_invalid passed:
+out/test/spec/typecheck.wast:354: assert_invalid passed:
   error: type mismatch in f32.trunc, expected [f32] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:355: assert_invalid passed:
+out/test/spec/typecheck.wast:355: assert_invalid passed:
   error: type mismatch in f64.abs, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:356: assert_invalid passed:
+out/test/spec/typecheck.wast:356: assert_invalid passed:
   error: type mismatch in f64.ceil, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:357: assert_invalid passed:
+out/test/spec/typecheck.wast:357: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:358: assert_invalid passed:
+out/test/spec/typecheck.wast:358: assert_invalid passed:
   error: type mismatch in f64.nearest, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:359: assert_invalid passed:
+out/test/spec/typecheck.wast:359: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:360: assert_invalid passed:
+out/test/spec/typecheck.wast:360: assert_invalid passed:
   error: type mismatch in f64.sqrt, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:361: assert_invalid passed:
+out/test/spec/typecheck.wast:361: assert_invalid passed:
   error: type mismatch in f64.trunc, expected [f64] but got [i64]
   000001a: error: OnUnaryExpr callback failed
-out/third_party/testsuite/typecheck.wast:364: assert_invalid passed:
+out/test/spec/typecheck.wast:364: assert_invalid passed:
   error: type mismatch in i32.eq, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:365: assert_invalid passed:
+out/test/spec/typecheck.wast:365: assert_invalid passed:
   error: type mismatch in i32.ge_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:366: assert_invalid passed:
+out/test/spec/typecheck.wast:366: assert_invalid passed:
   error: type mismatch in i32.ge_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:367: assert_invalid passed:
+out/test/spec/typecheck.wast:367: assert_invalid passed:
   error: type mismatch in i32.gt_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:368: assert_invalid passed:
+out/test/spec/typecheck.wast:368: assert_invalid passed:
   error: type mismatch in i32.gt_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:369: assert_invalid passed:
+out/test/spec/typecheck.wast:369: assert_invalid passed:
   error: type mismatch in i32.le_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:370: assert_invalid passed:
+out/test/spec/typecheck.wast:370: assert_invalid passed:
   error: type mismatch in i32.le_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:371: assert_invalid passed:
+out/test/spec/typecheck.wast:371: assert_invalid passed:
   error: type mismatch in i32.lt_s, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:372: assert_invalid passed:
+out/test/spec/typecheck.wast:372: assert_invalid passed:
   error: type mismatch in i32.lt_u, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:373: assert_invalid passed:
+out/test/spec/typecheck.wast:373: assert_invalid passed:
   error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:374: assert_invalid passed:
+out/test/spec/typecheck.wast:374: assert_invalid passed:
   error: type mismatch in i64.eq, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:375: assert_invalid passed:
+out/test/spec/typecheck.wast:375: assert_invalid passed:
   error: type mismatch in i64.ge_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:376: assert_invalid passed:
+out/test/spec/typecheck.wast:376: assert_invalid passed:
   error: type mismatch in i64.ge_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:377: assert_invalid passed:
+out/test/spec/typecheck.wast:377: assert_invalid passed:
   error: type mismatch in i64.gt_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:378: assert_invalid passed:
+out/test/spec/typecheck.wast:378: assert_invalid passed:
   error: type mismatch in i64.gt_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:379: assert_invalid passed:
+out/test/spec/typecheck.wast:379: assert_invalid passed:
   error: type mismatch in i64.le_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:380: assert_invalid passed:
+out/test/spec/typecheck.wast:380: assert_invalid passed:
   error: type mismatch in i64.le_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:381: assert_invalid passed:
+out/test/spec/typecheck.wast:381: assert_invalid passed:
   error: type mismatch in i64.lt_s, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:382: assert_invalid passed:
+out/test/spec/typecheck.wast:382: assert_invalid passed:
   error: type mismatch in i64.lt_u, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:383: assert_invalid passed:
+out/test/spec/typecheck.wast:383: assert_invalid passed:
   error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:384: assert_invalid passed:
+out/test/spec/typecheck.wast:384: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:385: assert_invalid passed:
+out/test/spec/typecheck.wast:385: assert_invalid passed:
   error: type mismatch in f32.ge, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:386: assert_invalid passed:
+out/test/spec/typecheck.wast:386: assert_invalid passed:
   error: type mismatch in f32.gt, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:387: assert_invalid passed:
+out/test/spec/typecheck.wast:387: assert_invalid passed:
   error: type mismatch in f32.le, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:388: assert_invalid passed:
+out/test/spec/typecheck.wast:388: assert_invalid passed:
   error: type mismatch in f32.lt, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:389: assert_invalid passed:
+out/test/spec/typecheck.wast:389: assert_invalid passed:
   error: type mismatch in f32.ne, expected [f32, f32] but got [i64, f64]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:390: assert_invalid passed:
+out/test/spec/typecheck.wast:390: assert_invalid passed:
   error: type mismatch in f64.eq, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:391: assert_invalid passed:
+out/test/spec/typecheck.wast:391: assert_invalid passed:
   error: type mismatch in f64.ge, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:392: assert_invalid passed:
+out/test/spec/typecheck.wast:392: assert_invalid passed:
   error: type mismatch in f64.gt, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:393: assert_invalid passed:
+out/test/spec/typecheck.wast:393: assert_invalid passed:
   error: type mismatch in f64.le, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:394: assert_invalid passed:
+out/test/spec/typecheck.wast:394: assert_invalid passed:
   error: type mismatch in f64.lt, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:395: assert_invalid passed:
+out/test/spec/typecheck.wast:395: assert_invalid passed:
   error: type mismatch in f64.ne, expected [f64, f64] but got [i64, f32]
   000001f: error: OnCompareExpr callback failed
-out/third_party/testsuite/typecheck.wast:398: assert_invalid passed:
+out/test/spec/typecheck.wast:398: assert_invalid passed:
   error: type mismatch in i32.wrap/i64, expected [i64] but got [f32]
   000001d: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:399: assert_invalid passed:
+out/test/spec/typecheck.wast:399: assert_invalid passed:
   error: type mismatch in i32.trunc_s/f32, expected [f32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:400: assert_invalid passed:
+out/test/spec/typecheck.wast:400: assert_invalid passed:
   error: type mismatch in i32.trunc_u/f32, expected [f32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:401: assert_invalid passed:
+out/test/spec/typecheck.wast:401: assert_invalid passed:
   error: type mismatch in i32.trunc_s/f64, expected [f64] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:402: assert_invalid passed:
+out/test/spec/typecheck.wast:402: assert_invalid passed:
   error: type mismatch in i32.trunc_u/f64, expected [f64] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:403: assert_invalid passed:
+out/test/spec/typecheck.wast:403: assert_invalid passed:
   error: type mismatch in i32.reinterpret/f32, expected [f32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:404: assert_invalid passed:
+out/test/spec/typecheck.wast:404: assert_invalid passed:
   error: type mismatch in i64.extend_s/i32, expected [i32] but got [f32]
   000001d: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:405: assert_invalid passed:
+out/test/spec/typecheck.wast:405: assert_invalid passed:
   error: type mismatch in i64.extend_u/i32, expected [i32] but got [f32]
   000001d: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:406: assert_invalid passed:
+out/test/spec/typecheck.wast:406: assert_invalid passed:
   error: type mismatch in i64.trunc_s/f32, expected [f32] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:407: assert_invalid passed:
+out/test/spec/typecheck.wast:407: assert_invalid passed:
   error: type mismatch in i64.trunc_u/f32, expected [f32] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:408: assert_invalid passed:
+out/test/spec/typecheck.wast:408: assert_invalid passed:
   error: type mismatch in i64.trunc_s/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:409: assert_invalid passed:
+out/test/spec/typecheck.wast:409: assert_invalid passed:
   error: type mismatch in i64.trunc_u/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:410: assert_invalid passed:
+out/test/spec/typecheck.wast:410: assert_invalid passed:
   error: type mismatch in i64.reinterpret/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:411: assert_invalid passed:
+out/test/spec/typecheck.wast:411: assert_invalid passed:
   error: type mismatch in f32.convert_s/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:412: assert_invalid passed:
+out/test/spec/typecheck.wast:412: assert_invalid passed:
   error: type mismatch in f32.convert_u/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:413: assert_invalid passed:
+out/test/spec/typecheck.wast:413: assert_invalid passed:
   error: type mismatch in f32.convert_s/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:414: assert_invalid passed:
+out/test/spec/typecheck.wast:414: assert_invalid passed:
   error: type mismatch in f32.convert_u/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:415: assert_invalid passed:
+out/test/spec/typecheck.wast:415: assert_invalid passed:
   error: type mismatch in f32.demote/f64, expected [f64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:416: assert_invalid passed:
+out/test/spec/typecheck.wast:416: assert_invalid passed:
   error: type mismatch in f32.reinterpret/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:417: assert_invalid passed:
+out/test/spec/typecheck.wast:417: assert_invalid passed:
   error: type mismatch in f64.convert_s/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:418: assert_invalid passed:
+out/test/spec/typecheck.wast:418: assert_invalid passed:
   error: type mismatch in f64.convert_u/i32, expected [i32] but got [i64]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:419: assert_invalid passed:
+out/test/spec/typecheck.wast:419: assert_invalid passed:
   error: type mismatch in f64.convert_s/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:420: assert_invalid passed:
+out/test/spec/typecheck.wast:420: assert_invalid passed:
   error: type mismatch in f64.convert_u/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:421: assert_invalid passed:
+out/test/spec/typecheck.wast:421: assert_invalid passed:
   error: type mismatch in f64.promote/f32, expected [f32] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:422: assert_invalid passed:
+out/test/spec/typecheck.wast:422: assert_invalid passed:
   error: type mismatch in f64.reinterpret/i64, expected [i64] but got [i32]
   000001a: error: OnConvertExpr callback failed
-out/third_party/testsuite/typecheck.wast:425: assert_invalid passed:
+out/test/spec/typecheck.wast:425: assert_invalid passed:
   error: type mismatch in grow_memory, expected [i32] but got [f32]
   0000023: error: OnGrowMemoryExpr callback failed
 193/193 tests passed.

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -1,336 +1,336 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/unreached-invalid.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/unreached-invalid.wast:4: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:4: assert_invalid passed:
   error: invalid local_index: 0 (max 0)
   000001a: error: OnGetLocalExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:8: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:8: assert_invalid passed:
   error: invalid global_index: 0 (max 0)
   000001a: error: OnGetGlobalExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:12: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:12: assert_invalid passed:
   000001a: error: invalid call function index: 1
-out/third_party/testsuite/unreached-invalid.wast:16: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:16: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   000001a: error: OnBrExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:21: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:21: assert_invalid passed:
   error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:27: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:27: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:33: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:33: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
   0000023: error: OnSelectExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:42: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:42: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:46: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:46: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:50: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:50: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:56: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:56: assert_invalid passed:
   error: type mismatch in function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:60: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:60: assert_invalid passed:
   error: type mismatch in function, expected [] but got [any]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:64: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:64: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:71: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:71: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:77: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:77: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:83: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:83: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000020: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:89: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:89: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:95: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:95: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:101: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:101: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:107: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:107: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:113: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:113: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:119: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:119: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:125: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:125: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:132: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:132: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:138: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:138: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:144: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:144: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001d: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:150: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:150: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:156: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:156: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:162: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:162: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:168: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:168: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:174: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:174: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:180: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:180: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:186: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:186: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   0000021: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:193: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:193: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:199: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:199: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:205: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:205: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:211: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:211: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:217: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:217: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001d: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:223: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:223: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:229: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:229: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:235: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:235: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:241: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:241: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:247: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:247: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000021: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:253: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:253: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:259: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:259: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   000001f: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:265: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:265: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:271: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:271: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:277: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:277: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:284: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:284: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:290: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:290: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:296: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:296: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000020: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:302: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:302: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:308: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:308: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:314: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:314: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [... f32]
   error: type mismatch in block, expected [] but got [i32]
   0000026: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:321: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:321: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:327: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:327: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:334: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:334: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:340: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:340: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:348: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:348: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:354: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:354: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000022: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:360: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:360: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000021: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:366: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:366: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000024: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:372: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:372: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:378: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:378: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [... f32]
   error: type mismatch in block, expected [] but got [i32]
   0000027: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:384: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:384: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:390: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:390: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:396: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:396: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:402: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:402: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   0000023: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:409: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:409: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:415: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:415: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:421: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:421: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001e: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:427: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:427: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:433: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:433: assert_invalid passed:
   error: type mismatch in if, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:439: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:439: assert_invalid passed:
   error: if without else cannot have type signature.
   error: type mismatch in if, expected [i32] but got [f32]
   0000022: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:445: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:445: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:451: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:451: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:457: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:457: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:463: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:463: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:470: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:470: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [f64]
   0000025: error: OnReturnExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:477: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:477: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000029: error: OnBrExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:484: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:484: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [f32]
   0000021: error: OnBrIfExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:490: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:490: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:498: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:498: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [i32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:507: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:507: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:515: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:515: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
   0000022: error: OnBrTableExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:521: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:521: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
   0000025: error: OnBrTableExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:527: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:527: assert_invalid passed:
   error: br_table labels have inconsistent types: expected f32, got void
   0000023: error: OnBrTableExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:539: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:539: assert_invalid passed:
   error: br_table labels have inconsistent types: expected f32, got f64
   0000023: error: OnBrTableExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:554: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:554: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:560: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:560: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:566: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:566: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:572: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:572: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:579: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:579: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:585: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:585: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   0000022: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:591: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:591: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [i64]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:598: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:598: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:604: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:604: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   0000025: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:610: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:610: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [i64]
   0000027: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:618: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:618: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:625: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:625: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:631: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:631: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000022: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:637: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:637: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000024: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:643: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:643: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000025: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:651: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:651: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/third_party/testsuite/unreached-invalid.wast:657: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:657: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:663: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:663: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:670: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:670: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001f: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:676: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:676: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:683: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:683: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/third_party/testsuite/unreached-invalid.wast:690: assert_invalid passed:
+out/test/spec/unreached-invalid.wast:690: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 110/110 tests passed.

--- a/test/spec/utf8-custom-section-id.txt
+++ b/test/spec/utf8-custom-section-id.txt
@@ -1,357 +1,357 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/utf8-custom-section-id.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/utf8-custom-section-id.wast:7: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:7: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:17: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:17: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:27: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:27: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:37: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:37: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:47: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:47: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:57: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:57: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:69: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:69: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:79: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:79: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:89: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:89: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:101: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:101: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:111: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:111: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:121: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:121: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:131: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:131: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:141: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:141: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:151: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:151: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:161: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:161: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:171: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:171: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:181: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:181: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:191: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:191: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:201: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:201: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:211: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:211: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:223: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:223: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:233: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:233: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:243: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:243: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:253: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:253: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:263: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:263: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:275: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:275: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:285: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:285: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:295: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:295: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:305: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:305: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:315: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:315: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:325: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:325: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:335: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:335: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:345: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:345: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:355: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:355: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:365: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:365: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:375: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:375: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:385: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:385: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:395: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:395: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:405: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:405: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:415: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:415: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:425: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:425: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:435: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:435: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:445: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:445: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:455: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:455: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:465: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:465: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:475: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:475: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:485: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:485: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:495: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:495: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:505: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:505: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:515: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:515: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:525: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:525: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:535: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:535: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:545: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:545: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:555: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:555: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:565: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:565: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:575: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:575: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:585: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:585: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:597: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:597: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:607: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:607: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:617: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:617: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:627: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:627: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:637: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:637: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:647: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:647: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:657: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:657: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:667: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:667: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:677: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:677: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:687: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:687: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:697: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:697: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:707: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:707: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:717: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:717: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:727: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:727: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:737: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:737: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:747: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:747: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:757: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:757: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:767: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:767: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:777: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:777: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:787: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:787: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:797: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:797: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:807: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:807: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:817: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:817: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:827: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:827: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:839: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:839: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:849: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:849: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:859: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:859: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:869: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:869: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:879: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:879: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:889: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:889: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:899: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:899: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:911: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:911: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:921: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:921: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:931: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:931: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:941: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:941: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:951: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:951: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:961: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:961: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:971: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:971: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:981: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:981: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:991: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:991: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1001: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1001: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1011: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1011: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1021: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1021: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1031: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1031: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1041: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1041: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1051: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1051: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1061: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1061: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1071: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1071: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1081: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1081: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1091: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1091: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1101: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1101: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1111: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1111: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1121: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1121: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1131: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1131: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1141: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1141: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1151: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1151: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1163: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1163: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1173: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1173: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1183: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1183: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1193: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1193: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1203: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1203: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1213: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1213: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1223: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1223: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1233: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1233: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1243: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1243: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1253: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1253: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1263: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1263: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1273: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1273: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1283: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1283: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1293: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1293: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1303: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1303: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1313: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1313: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1325: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1325: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1335: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1335: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1345: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1345: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1355: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1355: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1365: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1365: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1375: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1375: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1385: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1385: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1395: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1395: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1405: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1405: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1415: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1415: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1425: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1425: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1435: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1435: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1445: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1445: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1455: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1455: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1465: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1465: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1475: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1475: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1487: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1487: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1497: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1497: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1507: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1507: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1517: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1517: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1527: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1527: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1537: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1537: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1547: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1547: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1557: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1557: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1567: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1567: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1579: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1579: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1589: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1589: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1601: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1601: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1611: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1611: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1621: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1621: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1631: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1631: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1641: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1641: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1651: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1651: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1661: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1661: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1671: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1671: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1681: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1681: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1691: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1691: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1701: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1701: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1713: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1713: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1723: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1723: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1735: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1735: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1745: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1745: assert_malformed passed:
   000000c: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1755: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1755: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1765: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1765: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1775: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1775: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: section name
-out/third_party/testsuite/utf8-custom-section-id.wast:1785: assert_malformed passed:
+out/test/spec/utf8-custom-section-id.wast:1785: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: section name
 176/176 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/utf8-import-field.txt
+++ b/test/spec/utf8-import-field.txt
@@ -1,357 +1,357 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/utf8-import-field.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/utf8-import-field.wast:7: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:7: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:22: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:22: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:37: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:37: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:52: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:52: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:67: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:67: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:82: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:82: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:99: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:99: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:114: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:114: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:129: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:129: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:146: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:146: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:161: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:161: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:176: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:176: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:191: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:191: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:206: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:206: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:221: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:221: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:236: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:236: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:251: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:251: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:266: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:266: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:281: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:281: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:296: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:296: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:311: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:311: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:328: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:328: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:343: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:343: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:358: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:358: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:373: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:373: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:388: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:388: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:405: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:405: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:420: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:420: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:435: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:435: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:450: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:450: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:465: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:465: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:480: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:480: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:495: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:495: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:510: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:510: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:525: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:525: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:540: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:540: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:555: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:555: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:570: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:570: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:585: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:585: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:600: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:600: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:615: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:615: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:630: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:630: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:645: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:645: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:660: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:660: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:675: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:675: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:690: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:690: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:705: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:705: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:720: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:720: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:735: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:735: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:750: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:750: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:765: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:765: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:780: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:780: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:795: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:795: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:810: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:810: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:825: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:825: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:840: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:840: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:855: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:855: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:870: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:870: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:887: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:887: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:902: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:902: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:917: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:917: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:932: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:932: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:947: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:947: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:962: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:962: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:977: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:977: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:992: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:992: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1007: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1007: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1022: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1022: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1037: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1037: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1052: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1052: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1067: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1067: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1082: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1082: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1097: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1097: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1112: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1112: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1127: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1127: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1142: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1142: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1157: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1157: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1172: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1172: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1187: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1187: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1202: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1202: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1217: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1217: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1232: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1232: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1249: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1249: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1264: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1264: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1279: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1279: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1294: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1294: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1309: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1309: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1324: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1324: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1339: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1339: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1356: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1356: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1371: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1371: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1386: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1386: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1401: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1401: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1416: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1416: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1431: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1431: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1446: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1446: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1461: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1461: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1476: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1476: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1491: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1491: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1506: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1506: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1521: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1521: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1536: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1536: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1551: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1551: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1566: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1566: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1581: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1581: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1596: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1596: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1611: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1611: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1626: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1626: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1641: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1641: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1656: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1656: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1671: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1671: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1686: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1686: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1701: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1701: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1716: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1716: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1733: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1733: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1748: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1748: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1763: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1763: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1778: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1778: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1793: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1793: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1808: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1808: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1823: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1823: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1838: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1838: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1853: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1853: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1868: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1868: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1883: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1883: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1898: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1898: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1913: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1913: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1928: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1928: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1943: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1943: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1958: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1958: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1975: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1975: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:1990: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:1990: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2005: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2005: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2020: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2020: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2035: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2035: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2050: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2050: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2065: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2065: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2080: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2080: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2095: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2095: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2110: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2110: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2125: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2125: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2140: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2140: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2155: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2155: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2170: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2170: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2185: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2185: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2200: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2200: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2217: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2217: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2232: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2232: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2247: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2247: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2262: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2262: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2277: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2277: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2292: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2292: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2307: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2307: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2322: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2322: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2337: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2337: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2354: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2354: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2369: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2369: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2386: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2386: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2401: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2401: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2416: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2416: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2431: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2431: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2446: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2446: assert_malformed passed:
   0000011: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2461: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2461: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2476: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2476: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2491: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2491: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2506: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2506: assert_malformed passed:
   000000f: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2521: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2521: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2536: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2536: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2553: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2553: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2568: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2568: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2585: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2585: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2600: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2600: assert_malformed passed:
   000000d: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2615: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2615: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2630: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2630: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2645: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2645: assert_malformed passed:
   000000e: error: invalid utf-8 encoding: import module name
-out/third_party/testsuite/utf8-import-field.wast:2660: assert_malformed passed:
+out/test/spec/utf8-import-field.wast:2660: assert_malformed passed:
   0000010: error: invalid utf-8 encoding: import module name
 176/176 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/utf8-import-module.txt
+++ b/test/spec/utf8-import-module.txt
@@ -1,357 +1,357 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/utf8-import-module.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/utf8-import-module.wast:7: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:7: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:22: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:22: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:37: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:37: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:52: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:52: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:67: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:67: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:82: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:82: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:99: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:99: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:114: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:114: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:129: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:129: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:146: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:146: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:161: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:161: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:176: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:176: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:191: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:191: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:206: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:206: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:221: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:221: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:236: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:236: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:251: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:251: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:266: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:266: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:281: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:281: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:296: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:296: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:311: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:311: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:328: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:328: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:343: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:343: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:358: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:358: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:373: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:373: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:388: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:388: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:405: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:405: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:420: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:420: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:435: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:435: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:450: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:450: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:465: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:465: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:480: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:480: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:495: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:495: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:510: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:510: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:525: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:525: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:540: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:540: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:555: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:555: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:570: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:570: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:585: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:585: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:600: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:600: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:615: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:615: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:630: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:630: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:645: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:645: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:660: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:660: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:675: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:675: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:690: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:690: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:705: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:705: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:720: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:720: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:735: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:735: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:750: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:750: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:765: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:765: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:780: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:780: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:795: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:795: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:810: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:810: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:825: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:825: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:840: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:840: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:855: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:855: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:870: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:870: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:887: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:887: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:902: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:902: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:917: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:917: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:932: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:932: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:947: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:947: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:962: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:962: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:977: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:977: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:992: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:992: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1007: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1007: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1022: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1022: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1037: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1037: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1052: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1052: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1067: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1067: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1082: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1082: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1097: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1097: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1112: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1112: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1127: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1127: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1142: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1142: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1157: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1157: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1172: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1172: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1187: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1187: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1202: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1202: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1217: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1217: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1232: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1232: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1249: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1249: assert_malformed passed:
   0000016: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1264: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1264: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1279: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1279: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1294: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1294: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1309: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1309: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1324: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1324: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1339: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1339: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1356: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1356: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1371: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1371: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1386: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1386: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1401: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1401: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1416: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1416: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1431: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1431: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1446: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1446: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1461: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1461: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1476: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1476: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1491: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1491: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1506: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1506: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1521: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1521: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1536: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1536: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1551: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1551: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1566: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1566: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1581: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1581: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1596: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1596: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1611: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1611: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1626: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1626: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1641: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1641: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1656: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1656: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1671: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1671: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1686: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1686: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1701: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1701: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1716: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1716: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1733: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1733: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1748: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1748: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1763: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1763: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1778: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1778: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1793: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1793: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1808: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1808: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1823: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1823: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1838: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1838: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1853: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1853: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1868: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1868: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1883: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1883: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1898: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1898: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1913: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1913: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1928: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1928: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1943: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1943: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1958: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1958: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1975: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1975: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:1990: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:1990: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2005: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2005: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2020: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2020: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2035: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2035: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2050: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2050: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2065: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2065: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2080: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2080: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2095: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2095: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2110: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2110: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2125: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2125: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2140: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2140: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2155: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2155: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2170: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2170: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2185: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2185: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2200: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2200: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2217: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2217: assert_malformed passed:
   0000017: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2232: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2232: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2247: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2247: assert_malformed passed:
   0000016: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2262: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2262: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2277: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2277: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2292: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2292: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2307: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2307: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2322: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2322: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2337: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2337: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2354: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2354: assert_malformed passed:
   0000016: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2369: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2369: assert_malformed passed:
   0000016: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2386: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2386: assert_malformed passed:
   0000018: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2401: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2401: assert_malformed passed:
   0000016: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2416: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2416: assert_malformed passed:
   0000017: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2431: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2431: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2446: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2446: assert_malformed passed:
   0000016: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2461: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2461: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2476: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2476: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2491: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2491: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2506: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2506: assert_malformed passed:
   0000014: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2521: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2521: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2536: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2536: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2553: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2553: assert_malformed passed:
   0000017: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2568: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2568: assert_malformed passed:
   0000017: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2585: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2585: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2600: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2600: assert_malformed passed:
   0000012: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2615: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2615: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2630: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2630: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2645: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2645: assert_malformed passed:
   0000013: error: invalid utf-8 encoding: import field name
-out/third_party/testsuite/utf8-import-module.wast:2660: assert_malformed passed:
+out/test/spec/utf8-import-module.wast:2660: assert_malformed passed:
   0000015: error: invalid utf-8 encoding: import field name
 176/176 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/utf8-invalid-encoding.txt
+++ b/test/spec/utf8-invalid-encoding.txt
@@ -1,708 +1,708 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/utf8-invalid-encoding.wast
 (;; STDOUT ;;;
-out/third_party/testsuite/utf8-invalid-encoding.wast:1: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.0.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:1: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.0.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\00\00\fe\ff"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:2: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.1.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:2: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.1.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\80"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:3: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.2.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:3: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.2.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\8f"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:4: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.3.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:4: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.3.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\90"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:5: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.4.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:5: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.4.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\9f"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:6: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.5.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:6: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.5.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\a0"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:7: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.6.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:7: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.6.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\bf"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:8: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.7.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:8: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.7.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c0\80"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:9: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.8.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:9: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.8.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c0\bf"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:10: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.9.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:10: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.9.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c1\80"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:11: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.10.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:11: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.10.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c1\bf"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:12: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.11.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:12: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.11.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2\00"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:13: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.12.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:13: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.12.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2\2e"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:14: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.13.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:14: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.13.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2\7f"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:15: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.14.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:15: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.14.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2\80\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:16: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.15.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:16: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.15.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2\c0"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:17: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.16.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:17: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.16.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:18: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.17.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:18: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.17.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\c2\fd"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:19: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.18.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:19: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.18.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\df\00"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:20: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.19.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:20: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.19.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\df\7f"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:21: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.20.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:21: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.20.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\df\c0"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:22: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.21.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:22: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.21.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\df\fd"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:23: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.22.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:23: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.22.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\00\a0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:24: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.23.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:24: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.23.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\7f\a0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:25: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.24.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:25: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.24.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\80\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:26: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.25.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:26: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.25.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\80\a0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:27: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.26.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:27: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.26.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\9f\a0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:28: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.27.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:28: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.27.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\9f\bf"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:29: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.28.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:29: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.28.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\a0\00"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:30: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.29.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:30: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.29.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\a0\7f"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:31: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.30.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:31: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.30.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\a0\c0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:32: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.31.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:32: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.31.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\a0\fd"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:33: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.32.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:33: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.32.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\c0\a0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:34: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.33.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:34: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.33.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e0\fd\a0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:35: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.34.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:35: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.34.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\00\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:36: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.35.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:36: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.35.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\2e"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:37: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.36.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:37: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.36.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\7f\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:38: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.37.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:38: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.37.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80\00"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:39: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.38.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:39: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.38.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80\2e"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:40: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.39.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:40: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.39.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80\7f"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:41: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.40.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:41: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.40.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:42: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.41.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:42: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.41.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80\c0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:43: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.42.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:43: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.42.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:44: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.43.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:44: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.43.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\80\fd"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:45: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.44.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:45: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.44.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\c0\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:46: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.45.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:46: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.45.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:47: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.46.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:47: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.46.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\e1\fd\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:48: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.47.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:48: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.47.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\00\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:49: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.48.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:49: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.48.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\7f\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:50: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.49.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:50: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.49.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\80\00"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:51: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.50.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:51: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.50.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\80\7f"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:52: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.51.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:52: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.51.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\80\c0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:53: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.52.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:53: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.52.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\80\fd"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:54: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.53.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:54: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.53.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\c0\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:55: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.54.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:55: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.54.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ec\fd\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:56: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.55.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:56: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.55.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\00\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:57: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.56.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:57: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.56.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\7f\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:58: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.57.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:58: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.57.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\80\00"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:59: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.58.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:59: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.58.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\80\7f"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:60: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.59.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:60: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.59.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\80\c0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:61: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.60.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:61: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.60.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\80\fd"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:62: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.61.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:62: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.61.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\a0\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:63: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.62.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:63: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.62.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\a0\bf"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:64: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.63.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:64: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.63.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\bf\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:65: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.64.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:65: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.64.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\bf\bf"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:66: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.65.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:66: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.65.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\c0\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:67: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.66.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:67: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.66.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ed\fd\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:68: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.67.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:68: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.67.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\00\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:69: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.68.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:69: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.68.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\7f\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:70: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.69.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:70: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.69.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\80\00"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:71: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.70.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:71: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.70.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\80\7f"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:72: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.71.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:72: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.71.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\80\c0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:73: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.72.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:73: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.72.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\80\fd"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:74: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.73.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:74: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.73.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\c0\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:75: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.74.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:75: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.74.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ee\fd\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:76: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.75.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:76: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.75.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\00\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:77: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.76.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:77: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.76.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\7f\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:78: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.77.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:78: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.77.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\80\00"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:79: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.78.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:79: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.78.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\80\7f"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:80: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.79.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:80: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.79.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\80\c0"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:81: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.80.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:81: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.80.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\80\fd"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:82: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.81.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:82: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.81.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\c0\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:83: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.82.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:83: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.82.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ef\fd\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:84: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.83.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:84: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.83.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\00\90\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:85: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.84.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:85: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.84.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\7f\90\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:86: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.85.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:86: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.85.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\80\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:87: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.86.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:87: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.86.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\80\90\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:88: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.87.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:88: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.87.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\8f\90\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:89: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.88.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:89: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.88.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\8f\bf\bf"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:90: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.89.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:90: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.89.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\00\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:91: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.90.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:91: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.90.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\7f\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:92: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.91.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:92: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.91.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\90\00"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:93: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.92.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:93: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.92.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\90\7f"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:94: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.93.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:94: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.93.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\90\c0"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:95: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.94.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:95: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.94.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\90\fd"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:96: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.95.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:96: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.95.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\c0\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:97: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.96.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:97: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.96.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\90\fd\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:98: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.97.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:98: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.97.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\c0\90\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:99: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.98.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:99: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.98.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f0\fd\90\90"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:100: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.99.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:100: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.99.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\00\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:101: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.100.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:101: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.100.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\23"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:102: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.101.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:102: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.101.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\7f\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:103: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.102.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:103: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.102.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\00\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:104: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.103.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:104: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.103.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\23"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:105: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.104.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:105: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.104.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\7f\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:106: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.105.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:106: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.105.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80\00"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:107: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.106.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:107: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.106.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80\23"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:108: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.107.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:108: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.107.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80\7f"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:109: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.108.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:109: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.108.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80\80\80"))
                 ^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:110: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.109.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:110: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.109.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80\c0"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:111: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.110.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:111: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.110.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:112: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.111.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:112: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.111.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\80\fd"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:113: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.112.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:113: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.112.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\c0\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:114: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.113.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:114: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.113.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:115: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.114.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:115: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.114.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\80\fd\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:116: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.115.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:116: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.115.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\c0\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:117: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.116.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:117: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.116.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:118: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.117.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:118: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.117.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f1\fd\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:119: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.118.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:119: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.118.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\00\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:120: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.119.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:120: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.119.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\7f\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:121: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.120.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:121: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.120.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\00\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:122: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.121.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:122: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.121.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\7f\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:123: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.122.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:123: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.122.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\80\00"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:124: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.123.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:124: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.123.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\80\7f"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:125: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.124.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:125: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.124.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\80\c0"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:126: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.125.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:126: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.125.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\80\fd"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:127: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.126.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:127: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.126.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\c0\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:128: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.127.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:128: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.127.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\80\fd\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:129: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.128.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:129: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.128.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\c0\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:130: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.129.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:130: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.129.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f3\fd\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:131: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.130.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:131: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.130.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\00\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:132: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.131.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:132: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.131.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\7f\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:133: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.132.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:133: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.132.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\00\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:134: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.133.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:134: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.133.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\7f\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:135: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.134.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:135: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.134.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\80\00"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:136: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.135.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:136: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.135.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\80\7f"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:137: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.136.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:137: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.136.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\80\c0"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:138: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.137.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:138: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.137.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\80\fd"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:139: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.138.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:139: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.138.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\c0\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:140: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.139.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:140: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.139.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\80\fd\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:141: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.140.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:141: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.140.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\90\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:142: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.141.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:142: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.141.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\bf\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:143: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.142.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:143: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.142.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\c0\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:144: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.143.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:144: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.143.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f4\fd\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:145: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.144.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:145: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.144.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f5\80\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:146: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.145.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:146: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.145.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f7\80\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:147: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.146.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:147: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.146.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f7\bf\bf\bf"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:148: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.147.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:148: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.147.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\23"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:149: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.148.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:149: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.148.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\23"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:150: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.149.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:150: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.149.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\80\23"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:151: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.150.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:151: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.150.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\80\80\23"))
                 ^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:152: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.151.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:152: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.151.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\80\80\80\80"))
                 ^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:153: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.152.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:153: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.152.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\80\80\80"))
                 ^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:154: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.153.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:154: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.153.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:155: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.154.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:155: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.154.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:156: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.155.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:156: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.155.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8\80"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:157: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.156.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:157: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.156.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\f8"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:158: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.157.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:158: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.157.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fb\bf\bf\bf\bf"))
                 ^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:159: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.158.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:159: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.158.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\23"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:160: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.159.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:160: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.159.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\23"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:161: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.160.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:161: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.160.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\23"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:162: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.161.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:162: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.161.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\80\23"))
                 ^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:163: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.162.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:163: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.162.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\80\80\23"))
                 ^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:164: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.163.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:164: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.163.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\80\80\80\80"))
                 ^^^^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:165: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.164.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:165: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.164.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\80\80\80"))
                 ^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:166: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.165.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:166: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.165.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\80\80"))
                 ^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:167: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.166.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:167: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.166.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80\80"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:168: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.167.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:168: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.167.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80\80"))
                 ^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:169: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.168.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:169: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.168.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc\80"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:170: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.169.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:170: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.169.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fc"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:171: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.170.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:171: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.170.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fd\bf\bf\bf\bf\bf"))
                 ^^^^^^^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:172: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.171.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:172: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.171.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fe"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:173: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.172.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:173: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.172.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\fe\ff"))
                 ^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:174: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.173.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:174: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.173.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ff"))
                 ^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:175: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.174.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:175: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.174.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ff\fe\00\00"))
                 ^^^^^^^^^^^^^^
-out/third_party/testsuite/utf8-invalid-encoding.wast:176: assert_malformed passed:
-  out/third_party/testsuite/utf8-invalid-encoding/utf8-invalid-encoding.175.wat:1:15: error: quoted string has an invalid utf-8 encoding
+out/test/spec/utf8-invalid-encoding.wast:176: assert_malformed passed:
+  out/test/spec/utf8-invalid-encoding/utf8-invalid-encoding.175.wat:1:15: error: quoted string has an invalid utf-8 encoding
   (func (export "\ff\fe"))
                 ^^^^^^^^
 176/176 tests passed.


### PR DESCRIPTION
Each test should be run with its own directory of outputs, so the tests
can be run in parallel without clobbering results. Since I added wasm2c,
the spec `.wast` files were being used twice, but using the same output
directory. This would often work properly in a full run, but was flaky,
since they both write `.json` and `.wasm` files with the same names.

This fix gives them their own directories by always using the directory
name of the test.