### PR TITLE
Use default clang install on travis for ubsan

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,16 +39,7 @@ matrix:
       dist: trusty
       sudo: required
       compiler: clang
-      # ubsan requires a newer clang for blacklisting to work.
-      addons:
-        apt:
-          sources:
-            - ubuntu-toolchain-r-test
-            - llvm-toolchain-precise-3.6
-          packages:
-            - clang-3.6
-          env:
-            - SANITIZER=ubsan MATRIX_EVAL="CC=clang-3.6 && CC=clang++-3.6"
+      env: SANITIZER=ubsan
     - os: osx
       compiler: clang
 

--- a/src/string-view.cc
+++ b/src/string-view.cc
@@ -173,7 +173,7 @@ string_view::size_type string_view::find_last_of(string_view s,
                                                  size_type pos) const noexcept {
   pos = std::min(pos, size_ - 1);
   reverse_iterator iter = std::find_first_of(
-      reverse_iterator(begin() + pos + 1), rend(), s.begin(), s.end());
+      reverse_iterator(begin() + (pos + 1)), rend(), s.begin(), s.end());
   return iter == rend() ? npos : (rend() - iter - 1);
 }
 


### PR DESCRIPTION
The Travis image was updated recently (blog says Dec 12th), which
updates clang to 5.0.0.