### PR TITLE
Use `section` in gen-wasm tests for subsections

### DIFF
--- a/src/binary.h
+++ b/src/binary.h
@@ -58,6 +58,11 @@ enum class BinarySection {
 /* clang-format on */
 static const int kBinarySectionCount = WABT_ENUM_COUNT(BinarySection);
 
+enum class NameSectionSubsection {
+  Function = 1,
+  Local = 2,
+};
+
 extern const char* g_section_name[];
 
 static WABT_INLINE const char* GetSectionName(BinarySection sec) {

--- a/src/common.h
+++ b/src/common.h
@@ -263,11 +263,6 @@ enum class LimitsShareable { Allowed, NotAllowed };
 
 enum { WABT_USE_NATURAL_ALIGNMENT = 0xFFFFFFFF };
 
-enum class NameSectionSubsection {
-  Function = 1,
-  Local = 2,
-};
-
 Result ReadFile(string_view filename, std::vector<uint8_t>* out_data);
 
 void InitStdio();

--- a/test/binary/bad-duplicate-subsection.txt
+++ b/test/binary/bad-duplicate-subsection.txt
@@ -12,12 +12,12 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection_type[1]
-  subsection_length[1]
-  count[0]
-  subsection_type[1]
-  subsection_length[1]
-  count[0]
+  section(NAME_FUNCTION) {
+    count[0]
+  }
+  section(NAME_FUNCTION) {
+    count[0]
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -6,13 +6,13 @@ section(TYPE) { count[1] function params[0] results[0] }
 section(FUNCTION) { count[1] sig[0] }
 section(CODE) { count[1] func { locals[0] nop } }
 section("name") {
-  subsection[1]
-  length[1]
-  count[2]
-  index[0]
-  str("f")
-  index[1]
-  str("g")
+  section(NAME_FUNCTION) {
+    count[2]
+    index[0]
+    str("f")
+    index[1]
+    str("g")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-name-section-invalid-index.txt
+++ b/test/binary/bad-name-section-invalid-index.txt
@@ -12,11 +12,11 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[6]
-  func_count[1]
-  index[8]
-  str("$F0")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[8]
+    str("$F0")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-name-section-location.txt
+++ b/test/binary/bad-name-section-location.txt
@@ -5,11 +5,11 @@ version
 section(TYPE) { count[1] function params[0] results[0] }
 section(FUNCTION) { count[1] type[0] }
 section("name") {
-  subsection[1]
-  length[5]
-  func_count[1]
-  index[0]
-  str("F0")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("F0")
+  }
 }
 section(CODE) {
   count[1]

--- a/test/binary/bad-names-duplicate-locals.txt
+++ b/test/binary/bad-names-duplicate-locals.txt
@@ -12,20 +12,20 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[5]
-  func_count[1]
-  index[0]
-  str("F0")
-  subsection[2]
-  length[11]
-  func_count[1]
-  index[0]
-  local_count[2]
-  index[0]
-  str("L0")
-  index[0]
-  str("L1")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("F0")
+  }
+  section(NAME_LOCALS) {
+    func_count[1]
+    index[0]
+    local_count[2]
+    index[0]
+    str("L0")
+    index[0]
+    str("L1")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-names-duplicates.txt
+++ b/test/binary/bad-names-duplicates.txt
@@ -11,13 +11,13 @@ section(CODE) {
   func { locals[decl_count[0]] }
 }
 section("name") {
-  subsection[1]
-  length[9]
-  func_count[2]
-  index[0]
-  str("F0")
-  index[0]
-  str("F1")
+  section(NAME_FUNCTION) {
+    func_count[2]
+    index[0]
+    str("F0")
+    index[0]
+    str("F1")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-names-function-locals-out-of-order.txt
+++ b/test/binary/bad-names-function-locals-out-of-order.txt
@@ -10,25 +10,26 @@ section(CODE) {
   func { locals[decl_count[1] i32_count[2] i32] }
 }
 section("name") {
-  subsection[1]
-  length[9]
-  func_count[2]
-  index[0]
-  str("F0")
-  index[1]
-  str("F2")
+  section(NAME_FUNCTION) {
+    func_count[2]
+    index[0]
+    str("F0")
+    index[1]
+    str("F2")
+  }
 
-  subsection[2]
-  length[13]
-  func_count[2]
-  index[1]
-  local_count[1]
-  index[0]
-  str("L0")
-  index[0]
-  local_count[1]
-  index[0]
-  str("L0")
+  section(NAME_LOCALS) {
+    func_count[2]
+    func_index[1]
+    local_count[1]
+    local_index[0]
+    str("L0")
+
+    func_index[0]
+    local_count[1]
+    local_index[0]
+    str("L0")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-names-locals-out-of-order.txt
+++ b/test/binary/bad-names-locals-out-of-order.txt
@@ -12,20 +12,22 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[5]
-  func_count[1]
-  index[0]
-  str("F0")
-  subsection[2]
-  length[11]
-  func_count[1]
-  index[0]
-  local_count[2]
-  index[1]
-  str("L1")
-  index[0]
-  str("L0")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("F0")
+  }
+
+  section(NAME_LOCALS) {
+    func_count[1]
+    func_index[0]
+
+    local_count[2]
+    local_index[1]
+    str("L1")
+    local_index[0]
+    str("L0")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-names-out-of-order.txt
+++ b/test/binary/bad-names-out-of-order.txt
@@ -12,13 +12,13 @@ section(CODE) {
   func { locals[decl_count[0]] }
 }
 section("name") {
-  subsection[1]
-  length[9]
-  func_count[2]
-  index[1]
-  str("F1")
-  index[0]
-  str("F0")
+  section(NAME_FUNCTION) {
+    func_count[2]
+    index[1]
+    str("F1")
+    index[0]
+    str("F0")
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-subsection-out-of-order.txt
+++ b/test/binary/bad-subsection-out-of-order.txt
@@ -12,12 +12,13 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection_type[2]
-  subsection_length[1]
-  count[0]
-  subsection_type[1]
-  subsection_length[1]
-  count[0]
+  section(NAME_LOCALS) {
+    count[0]
+  }
+
+  section(NAME_FUNCTION) {
+    count[0]
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":

--- a/test/binary/bad-subsection-size.txt
+++ b/test/binary/bad-subsection-size.txt
@@ -13,7 +13,7 @@ section(CODE) {
 }
 section("name") {
   subsection[1]
-  length[1]
+  length[1]  ;; length is too short
   func_count[1]
   index[0]
   str("$F0")

--- a/test/binary/bad-subsection-unfinished.txt
+++ b/test/binary/bad-subsection-unfinished.txt
@@ -12,21 +12,19 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[10]
-  func_count[1]
-  index[0]
-  str("$F0")
-  subsection[1]
-  data[1]
-  data[1]
-  data[1]
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("$F0")
+
+    data[1]  ;; extra unused data
+  }
 }
 (;; STDERR ;;;
 Error running "wasm-validate":
-000002c: error: unfinished sub-section (expected end: 0x30)
+000002c: error: unfinished sub-section (expected end: 0x2d)
 
 Error running "wasm2wat":
-000002c: error: unfinished sub-section (expected end: 0x30)
+000002c: error: unfinished sub-section (expected end: 0x2d)
 
 ;;; STDERR ;;)

--- a/test/binary/duplicate-names.txt
+++ b/test/binary/duplicate-names.txt
@@ -10,13 +10,12 @@ section(CODE) {
   func { locals[decl_count[0]] }
 }
 section("name") {
-  subsection[1]
-  length[13]
-  func_count[3]
-
-  index[0] str("F1")
-  index[1] str("F1")
-  index[2] str("F1")
+  section(NAME_FUNCTION) {
+    func_count[3]
+    index[0] str("F1")
+    index[1] str("F1")
+    index[2] str("F1")
+  }
 }
 (;; STDOUT ;;;
 (module

--- a/test/binary/invalid-name.txt
+++ b/test/binary/invalid-name.txt
@@ -11,11 +11,11 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[15]
-  func_count[1]
-  index[0]
-  str("hi hello hey")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("hi hello hey")
+  }
 }
 (;; STDOUT ;;;
 (module

--- a/test/binary/linking-section.txt
+++ b/test/binary/linking-section.txt
@@ -3,34 +3,37 @@
 magic
 version
 section("linking") {
-  subsection[1]
-  length[1]
-  stack_global[3]
-  subsection[2]
-  length[16]
-  num_symbols[3]
-  str("foo")
-  flags[1]
-  str("bar")
-  flags[2]
-  str("baz")
-  flags[0]
-  subsection[5]
-  length[17]
-  count[2]
-  str("data1")
-  align[4]
-  flags[0]
-  str("data2")
-  align[8]
-  flags[0]
-  subsection[6]
-  length[5]
-  count[2]
-  priority[5]
-  func[1]
-  priority[6]
-  func[0]
+  section(LINKING_STACK_POINTER) {
+    stack_global[3]
+  }
+
+  section(LINKING_SYMBOL_INFO) {
+    num_symbols[3]
+    str("foo")
+    flags[1]
+    str("bar")
+    flags[2]
+    str("baz")
+    flags[0]
+  }
+
+  section(LINKING_SEGMENT_INFO) {
+    count[2]
+    str("data1")
+    align[4]
+    flags[0]
+    str("data2")
+    align[8]
+    flags[0]
+  }
+
+  section(LINKING_INIT_FUNCTIONS) {
+    count[2]
+    priority[5]
+    func[1]
+    priority[6]
+    func[0]
+  }
 }
 (;; STDOUT ;;;
 

--- a/test/binary/names.txt
+++ b/test/binary/names.txt
@@ -11,18 +11,19 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[5]
-  func_count[1]
-  index[0]
-  str("F0")
-  subsection[2]
-  length[7]
-  func_count[1]
-  index[0]
-  local_count[1]
-  index[0]
-  str("L0")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("F0")
+  }
+
+  section(NAME_LOCALS) {
+    func_count[1]
+    index[0]
+    local_count[1]
+    index[0]
+    str("L0")
+  }
 }
 (;; STDOUT ;;;
 (module

--- a/test/binary/no-global-names.txt
+++ b/test/binary/no-global-names.txt
@@ -20,11 +20,11 @@ section(CODE) {
   }
 }
 section("name") {
-  subsection[1]
-  length[6]
-  func_count[1]
-  index[0]
-  str("bar")
+  section(NAME_FUNCTION) {
+    func_count[1]
+    index[0]
+    str("bar")
+  }
 }
 (;; STDOUT ;;;
 (module

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -62,6 +62,17 @@ NAMED_VALUES = {
     'CODE': 10,
     'DATA': 11,
 
+    # name subsection codes
+    'NAME_FUNCTION': 1,
+    'NAME_LOCALS': 2,
+
+    # linking subsection codes
+    'LINKING_STACK_POINTER': 1,
+    'LINKING_SYMBOL_INFO': 2,
+    'LINKING_DATA_SIZE': 3,
+    'LINKING_SEGMENT_INFO': 5,
+    'LINKING_INIT_FUNCTIONS': 6,
+
     # external kinds
     'func_kind': 0,
     'table_kind': 1,


### PR DESCRIPTION
This is easier to read and handles the byte length automatically.