### PR TITLE
Fix for SIMD i8x16.neg / i16x8.neg / i32x4.neg / i64x2.neg implementation. (#723)

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -3194,10 +3194,6 @@ void Environment::Disassemble(Stream* stream,
       case Opcode::I8X16Mul:
       case Opcode::I16X8Mul:
       case Opcode::I32X4Mul:
-      case Opcode::I8X16Neg:
-      case Opcode::I16X8Neg:
-      case Opcode::I32X4Neg:
-      case Opcode::I64X2Neg:
         stream->Writef("%s %%[-2], %%[-1]\n", opcode.GetName());
         break;
 
@@ -3267,6 +3263,10 @@ void Environment::Disassemble(Stream* stream,
       case Opcode::I64X2Splat:
       case Opcode::F32X4Splat:
       case Opcode::F64X2Splat:
+      case Opcode::I8X16Neg:
+      case Opcode::I16X8Neg:
+      case Opcode::I32X4Neg:
+      case Opcode::I64X2Neg:
         stream->Writef("%s %%[-1]\n", opcode.GetName());
         break;
 


### PR DESCRIPTION
SIMD neg are unary instructions and at wrong place in Disassemble() in interp.cc, This
Fix move them to the right place.