### PR TITLE
Print symbol names when dumping table relocations

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -135,6 +135,8 @@ void BinaryReaderObjdumpBase::PrintRelocation(const Reloc& reloc,
       printf(" + %d", reloc.addend);
       break;
     case RelocType::FuncIndexLEB:
+    case RelocType::TableIndexSLEB:
+    case RelocType::TableIndexI32:
       if (const char* name = GetFunctionName(reloc.index)) {
         printf(" <%s>", name);
       }


### PR DESCRIPTION
These relocations point to function index space so we
can print the name of the function here.