### PR TITLE
`wat2wasm` is no longer default TOOL for tests

### DIFF
--- a/test/dump/invalid-data-segment-no-memory.txt
+++ b/test/dump/invalid-data-segment-no-memory.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: -v --no-check
 (module
   (data (i32.const 0) "hello"))

--- a/test/dump/invalid-data-segment-offset.txt
+++ b/test/dump/invalid-data-segment-offset.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: -v --no-check
 (module
   (memory 1)

--- a/test/dump/invalid-elem-segment-no-table.txt
+++ b/test/dump/invalid-elem-segment-no-table.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: -v --no-check
 (module
   (func)

--- a/test/dump/invalid-elem-segment-offset.txt
+++ b/test/dump/invalid-elem-segment-offset.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: -v --no-check
 (module
   (table 1 anyfunc)

--- a/test/parse/bad-crlf.txt
+++ b/test/parse/bad-crlf.txt
@@ -1,11 +1,12 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 modulez
 funcz
 (;; STDERR ;;;
-out/test/parse/bad-crlf.txt:2:1: error: unexpected token "modulez", expected a module field or a module.
+out/test/parse/bad-crlf.txt:3:1: error: unexpected token "modulez", expected a module field or a module.
 modulez
 ^^^^^^^
-out/test/parse/bad-crlf.txt:3:1: error: unexpected token funcz, expected EOF.
+out/test/parse/bad-crlf.txt:4:1: error: unexpected token funcz, expected EOF.
 funcz
 ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/bad-error-long-line.txt
+++ b/test/parse/bad-error-long-line.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
                                                                                                                                                                          whoops                      (; some text at the end of the line ;)
 (;; STDERR ;;;
-out/test/parse/bad-error-long-line.txt:2:170: error: unexpected token "whoops", expected a module field or a module.
+out/test/parse/bad-error-long-line.txt:3:170: error: unexpected token "whoops", expected a module field or a module.
 ...                                  whoops                      (; some text...
                                      ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/bad-error-long-token.txt
+++ b/test/parse/bad-error-long-token.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
               abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz                                                   
 (;; STDERR ;;;
-out/test/parse/bad-error-long-token.txt:2:15: error: unexpected token "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxy...", expected a module field or a module.
+out/test/parse/bad-error-long-token.txt:3:15: error: unexpected token "abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxy...", expected a module field or a module.
               abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghijk...
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/bad-single-semicolon.txt
+++ b/test/parse/bad-single-semicolon.txt
@@ -1,14 +1,15 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 ; foo bar
 (module)
 (;; STDERR ;;;
-out/test/parse/bad-single-semicolon.txt:2:1: error: unexpected char
+out/test/parse/bad-single-semicolon.txt:3:1: error: unexpected char
 ; foo bar
 ^
-out/test/parse/bad-single-semicolon.txt:2:3: error: unexpected token "foo", expected a module field or a module.
+out/test/parse/bad-single-semicolon.txt:3:3: error: unexpected token "foo", expected a module field or a module.
 ; foo bar
   ^^^
-out/test/parse/bad-single-semicolon.txt:2:7: error: unexpected token bar, expected EOF.
+out/test/parse/bad-single-semicolon.txt:3:7: error: unexpected token bar, expected EOF.
 ; foo bar
       ^^^
 ;;; STDERR ;;)

--- a/test/parse/bad-string-eof.txt
+++ b/test/parse/bad-string-eof.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func) (export "
 (;; STDERR ;;;
-out/test/parse/bad-string-eof.txt:2:25: error: newline in string
+out/test/parse/bad-string-eof.txt:3:25: error: newline in string
 (module (func) (export "
                         ^
-out/test/parse/bad-string-eof.txt:3:2: error: unexpected token "EOF", expected a quoted string (e.g. "foo").
+out/test/parse/bad-string-eof.txt:4:2: error: unexpected token "EOF", expected a quoted string (e.g. "foo").
 ;;; STDERR ;;)

--- a/test/parse/bad-string-escape.txt
+++ b/test/parse/bad-string-escape.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func) (export "foobar\x\n" (func 0)))
 (;; STDERR ;;;
-out/test/parse/bad-string-escape.txt:2:31: error: bad escape "\x"
+out/test/parse/bad-string-escape.txt:3:31: error: bad escape "\x"
 (module (func) (export "foobar\x\n" (func 0)))
                               ^^
 ;;; STDERR ;;)

--- a/test/parse/bad-string-hex-escape.txt
+++ b/test/parse/bad-string-hex-escape.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func) (export "foo\az" (func 0)))
 (;; STDERR ;;;
-out/test/parse/bad-string-hex-escape.txt:2:28: error: bad escape "\a"
+out/test/parse/bad-string-hex-escape.txt:3:28: error: bad escape "\a"
 (module (func) (export "foo\az" (func 0)))
                            ^^
 ;;; STDERR ;;)

--- a/test/parse/bad-toplevel.txt
+++ b/test/parse/bad-toplevel.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (foo bar)
 (;; STDERR ;;;
-out/test/parse/bad-toplevel.txt:2:2: error: unexpected token "foo", expected a module field or a module.
+out/test/parse/bad-toplevel.txt:3:2: error: unexpected token "foo", expected a module field or a module.
 (foo bar)
  ^^^
-out/test/parse/bad-toplevel.txt:2:6: error: unexpected token bar, expected EOF.
+out/test/parse/bad-toplevel.txt:3:6: error: unexpected token bar, expected EOF.
 (foo bar)
      ^^^
 ;;; STDERR ;;)

--- a/test/parse/empty-file.txt
+++ b/test/parse/empty-file.txt
@@ -1,5 +1,6 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 ;; empty file
 (;; STDERR ;;;
-out/test/parse/empty-file.txt:3:2: error: unexpected token "EOF", expected a module field or a module.
+out/test/parse/empty-file.txt:4:2: error: unexpected token "EOF", expected a module field or a module.
 ;;; STDERR ;;)

--- a/test/parse/export-mutable-global.txt
+++ b/test/parse/export-mutable-global.txt
@@ -1,2 +1,3 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: --enable-mutable-globals
 (module (global (export "g") (mut f32) (f32.const 1.5)))

--- a/test/parse/expr/atomic-align.txt
+++ b/test/parse/expr/atomic-align.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: --enable-threads
 (module
   (memory 1 1 shared)

--- a/test/parse/expr/atomic-disabled.txt
+++ b/test/parse/expr/atomic-disabled.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 
 (module
@@ -81,202 +82,202 @@
 
 ))
 (;; STDERR ;;;
-out/test/parse/expr/atomic-disabled.txt:6:29: error: opcode not allowed: atomic.wake
+out/test/parse/expr/atomic-disabled.txt:7:29: error: opcode not allowed: atomic.wake
     i32.const 0 i32.const 0 atomic.wake drop
                             ^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:7:41: error: opcode not allowed: i32.atomic.wait
+out/test/parse/expr/atomic-disabled.txt:8:41: error: opcode not allowed: i32.atomic.wait
     i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
                                         ^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:8:41: error: opcode not allowed: i64.atomic.wait
+out/test/parse/expr/atomic-disabled.txt:9:41: error: opcode not allowed: i64.atomic.wait
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
                                         ^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:10:17: error: opcode not allowed: i32.atomic.load
+out/test/parse/expr/atomic-disabled.txt:11:17: error: opcode not allowed: i32.atomic.load
     i32.const 0 i32.atomic.load drop
                 ^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:11:17: error: opcode not allowed: i64.atomic.load
+out/test/parse/expr/atomic-disabled.txt:12:17: error: opcode not allowed: i64.atomic.load
     i32.const 0 i64.atomic.load drop
                 ^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:12:17: error: opcode not allowed: i32.atomic.load8_u
+out/test/parse/expr/atomic-disabled.txt:13:17: error: opcode not allowed: i32.atomic.load8_u
     i32.const 0 i32.atomic.load8_u drop
                 ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:13:17: error: opcode not allowed: i32.atomic.load16_u
+out/test/parse/expr/atomic-disabled.txt:14:17: error: opcode not allowed: i32.atomic.load16_u
     i32.const 0 i32.atomic.load16_u drop
                 ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:14:17: error: opcode not allowed: i64.atomic.load8_u
+out/test/parse/expr/atomic-disabled.txt:15:17: error: opcode not allowed: i64.atomic.load8_u
     i32.const 0 i64.atomic.load8_u drop
                 ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:15:17: error: opcode not allowed: i64.atomic.load16_u
+out/test/parse/expr/atomic-disabled.txt:16:17: error: opcode not allowed: i64.atomic.load16_u
     i32.const 0 i64.atomic.load16_u drop
                 ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:16:17: error: opcode not allowed: i64.atomic.load32_u
+out/test/parse/expr/atomic-disabled.txt:17:17: error: opcode not allowed: i64.atomic.load32_u
     i32.const 0 i64.atomic.load32_u drop
                 ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:18:29: error: opcode not allowed: i32.atomic.store
+out/test/parse/expr/atomic-disabled.txt:19:29: error: opcode not allowed: i32.atomic.store
     i32.const 0 i32.const 0 i32.atomic.store
                             ^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:19:29: error: opcode not allowed: i64.atomic.store
+out/test/parse/expr/atomic-disabled.txt:20:29: error: opcode not allowed: i64.atomic.store
     i32.const 0 i64.const 0 i64.atomic.store
                             ^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:20:29: error: opcode not allowed: i32.atomic.store8
+out/test/parse/expr/atomic-disabled.txt:21:29: error: opcode not allowed: i32.atomic.store8
     i32.const 0 i32.const 0 i32.atomic.store8
                             ^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:21:29: error: opcode not allowed: i32.atomic.store16
+out/test/parse/expr/atomic-disabled.txt:22:29: error: opcode not allowed: i32.atomic.store16
     i32.const 0 i32.const 0 i32.atomic.store16
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:22:29: error: opcode not allowed: i64.atomic.store8
+out/test/parse/expr/atomic-disabled.txt:23:29: error: opcode not allowed: i64.atomic.store8
     i32.const 0 i64.const 0 i64.atomic.store8
                             ^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:23:29: error: opcode not allowed: i64.atomic.store16
+out/test/parse/expr/atomic-disabled.txt:24:29: error: opcode not allowed: i64.atomic.store16
     i32.const 0 i64.const 0 i64.atomic.store16
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:24:29: error: opcode not allowed: i64.atomic.store32
+out/test/parse/expr/atomic-disabled.txt:25:29: error: opcode not allowed: i64.atomic.store32
     i32.const 0 i64.const 0 i64.atomic.store32
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:26:29: error: opcode not allowed: i32.atomic.rmw.add
+out/test/parse/expr/atomic-disabled.txt:27:29: error: opcode not allowed: i32.atomic.rmw.add
     i32.const 0 i32.const 0 i32.atomic.rmw.add drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:27:29: error: opcode not allowed: i64.atomic.rmw.add
+out/test/parse/expr/atomic-disabled.txt:28:29: error: opcode not allowed: i64.atomic.rmw.add
     i32.const 0 i64.const 0 i64.atomic.rmw.add drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:28:29: error: opcode not allowed: i32.atomic.rmw8_u.add
+out/test/parse/expr/atomic-disabled.txt:29:29: error: opcode not allowed: i32.atomic.rmw8_u.add
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.add drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:29:29: error: opcode not allowed: i32.atomic.rmw16_u.add
+out/test/parse/expr/atomic-disabled.txt:30:29: error: opcode not allowed: i32.atomic.rmw16_u.add
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.add drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:30:29: error: opcode not allowed: i64.atomic.rmw8_u.add
+out/test/parse/expr/atomic-disabled.txt:31:29: error: opcode not allowed: i64.atomic.rmw8_u.add
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.add drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:31:29: error: opcode not allowed: i64.atomic.rmw16_u.add
+out/test/parse/expr/atomic-disabled.txt:32:29: error: opcode not allowed: i64.atomic.rmw16_u.add
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.add drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:32:29: error: opcode not allowed: i64.atomic.rmw32_u.add
+out/test/parse/expr/atomic-disabled.txt:33:29: error: opcode not allowed: i64.atomic.rmw32_u.add
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.add drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:34:29: error: opcode not allowed: i32.atomic.rmw.sub
+out/test/parse/expr/atomic-disabled.txt:35:29: error: opcode not allowed: i32.atomic.rmw.sub
     i32.const 0 i32.const 0 i32.atomic.rmw.sub drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:35:29: error: opcode not allowed: i64.atomic.rmw.sub
+out/test/parse/expr/atomic-disabled.txt:36:29: error: opcode not allowed: i64.atomic.rmw.sub
     i32.const 0 i64.const 0 i64.atomic.rmw.sub drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:36:29: error: opcode not allowed: i32.atomic.rmw8_u.sub
+out/test/parse/expr/atomic-disabled.txt:37:29: error: opcode not allowed: i32.atomic.rmw8_u.sub
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.sub drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:37:29: error: opcode not allowed: i32.atomic.rmw16_u.sub
+out/test/parse/expr/atomic-disabled.txt:38:29: error: opcode not allowed: i32.atomic.rmw16_u.sub
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.sub drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:38:29: error: opcode not allowed: i64.atomic.rmw8_u.sub
+out/test/parse/expr/atomic-disabled.txt:39:29: error: opcode not allowed: i64.atomic.rmw8_u.sub
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.sub drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:39:29: error: opcode not allowed: i64.atomic.rmw16_u.sub
+out/test/parse/expr/atomic-disabled.txt:40:29: error: opcode not allowed: i64.atomic.rmw16_u.sub
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.sub drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:40:29: error: opcode not allowed: i64.atomic.rmw32_u.sub
+out/test/parse/expr/atomic-disabled.txt:41:29: error: opcode not allowed: i64.atomic.rmw32_u.sub
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.sub drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:42:29: error: opcode not allowed: i32.atomic.rmw.and
+out/test/parse/expr/atomic-disabled.txt:43:29: error: opcode not allowed: i32.atomic.rmw.and
     i32.const 0 i32.const 0 i32.atomic.rmw.and drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:43:29: error: opcode not allowed: i64.atomic.rmw.and
+out/test/parse/expr/atomic-disabled.txt:44:29: error: opcode not allowed: i64.atomic.rmw.and
     i32.const 0 i64.const 0 i64.atomic.rmw.and drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:44:29: error: opcode not allowed: i32.atomic.rmw8_u.and
+out/test/parse/expr/atomic-disabled.txt:45:29: error: opcode not allowed: i32.atomic.rmw8_u.and
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.and drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:45:29: error: opcode not allowed: i32.atomic.rmw16_u.and
+out/test/parse/expr/atomic-disabled.txt:46:29: error: opcode not allowed: i32.atomic.rmw16_u.and
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.and drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:46:29: error: opcode not allowed: i64.atomic.rmw8_u.and
+out/test/parse/expr/atomic-disabled.txt:47:29: error: opcode not allowed: i64.atomic.rmw8_u.and
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.and drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:47:29: error: opcode not allowed: i64.atomic.rmw16_u.and
+out/test/parse/expr/atomic-disabled.txt:48:29: error: opcode not allowed: i64.atomic.rmw16_u.and
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.and drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:48:29: error: opcode not allowed: i64.atomic.rmw32_u.and
+out/test/parse/expr/atomic-disabled.txt:49:29: error: opcode not allowed: i64.atomic.rmw32_u.and
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.and drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:50:29: error: opcode not allowed: i32.atomic.rmw.or
+out/test/parse/expr/atomic-disabled.txt:51:29: error: opcode not allowed: i32.atomic.rmw.or
     i32.const 0 i32.const 0 i32.atomic.rmw.or drop
                             ^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:51:29: error: opcode not allowed: i64.atomic.rmw.or
+out/test/parse/expr/atomic-disabled.txt:52:29: error: opcode not allowed: i64.atomic.rmw.or
     i32.const 0 i64.const 0 i64.atomic.rmw.or drop
                             ^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:52:29: error: opcode not allowed: i32.atomic.rmw8_u.or
+out/test/parse/expr/atomic-disabled.txt:53:29: error: opcode not allowed: i32.atomic.rmw8_u.or
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.or drop
                             ^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:53:29: error: opcode not allowed: i32.atomic.rmw16_u.or
+out/test/parse/expr/atomic-disabled.txt:54:29: error: opcode not allowed: i32.atomic.rmw16_u.or
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.or drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:54:29: error: opcode not allowed: i64.atomic.rmw8_u.or
+out/test/parse/expr/atomic-disabled.txt:55:29: error: opcode not allowed: i64.atomic.rmw8_u.or
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.or drop
                             ^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:55:29: error: opcode not allowed: i64.atomic.rmw16_u.or
+out/test/parse/expr/atomic-disabled.txt:56:29: error: opcode not allowed: i64.atomic.rmw16_u.or
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.or drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:56:29: error: opcode not allowed: i64.atomic.rmw32_u.or
+out/test/parse/expr/atomic-disabled.txt:57:29: error: opcode not allowed: i64.atomic.rmw32_u.or
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.or drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:58:29: error: opcode not allowed: i32.atomic.rmw.xor
+out/test/parse/expr/atomic-disabled.txt:59:29: error: opcode not allowed: i32.atomic.rmw.xor
     i32.const 0 i32.const 0 i32.atomic.rmw.xor drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:59:29: error: opcode not allowed: i64.atomic.rmw.xor
+out/test/parse/expr/atomic-disabled.txt:60:29: error: opcode not allowed: i64.atomic.rmw.xor
     i32.const 0 i64.const 0 i64.atomic.rmw.xor drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:60:29: error: opcode not allowed: i32.atomic.rmw8_u.xor
+out/test/parse/expr/atomic-disabled.txt:61:29: error: opcode not allowed: i32.atomic.rmw8_u.xor
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.xor drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:61:29: error: opcode not allowed: i32.atomic.rmw16_u.xor
+out/test/parse/expr/atomic-disabled.txt:62:29: error: opcode not allowed: i32.atomic.rmw16_u.xor
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.xor drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:62:29: error: opcode not allowed: i64.atomic.rmw8_u.xor
+out/test/parse/expr/atomic-disabled.txt:63:29: error: opcode not allowed: i64.atomic.rmw8_u.xor
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.xor drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:63:29: error: opcode not allowed: i64.atomic.rmw16_u.xor
+out/test/parse/expr/atomic-disabled.txt:64:29: error: opcode not allowed: i64.atomic.rmw16_u.xor
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.xor drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:64:29: error: opcode not allowed: i64.atomic.rmw32_u.xor
+out/test/parse/expr/atomic-disabled.txt:65:29: error: opcode not allowed: i64.atomic.rmw32_u.xor
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.xor drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:66:29: error: opcode not allowed: i32.atomic.rmw.xchg
+out/test/parse/expr/atomic-disabled.txt:67:29: error: opcode not allowed: i32.atomic.rmw.xchg
     i32.const 0 i32.const 0 i32.atomic.rmw.xchg drop
                             ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:67:29: error: opcode not allowed: i64.atomic.rmw.xchg
+out/test/parse/expr/atomic-disabled.txt:68:29: error: opcode not allowed: i64.atomic.rmw.xchg
     i32.const 0 i64.const 0 i64.atomic.rmw.xchg drop
                             ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:68:29: error: opcode not allowed: i32.atomic.rmw8_u.xchg
+out/test/parse/expr/atomic-disabled.txt:69:29: error: opcode not allowed: i32.atomic.rmw8_u.xchg
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.xchg drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:69:29: error: opcode not allowed: i32.atomic.rmw16_u.xchg
+out/test/parse/expr/atomic-disabled.txt:70:29: error: opcode not allowed: i32.atomic.rmw16_u.xchg
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.xchg drop
                             ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:70:29: error: opcode not allowed: i64.atomic.rmw8_u.xchg
+out/test/parse/expr/atomic-disabled.txt:71:29: error: opcode not allowed: i64.atomic.rmw8_u.xchg
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.xchg drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:71:29: error: opcode not allowed: i64.atomic.rmw16_u.xchg
+out/test/parse/expr/atomic-disabled.txt:72:29: error: opcode not allowed: i64.atomic.rmw16_u.xchg
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.xchg drop
                             ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:72:29: error: opcode not allowed: i64.atomic.rmw32_u.xchg
+out/test/parse/expr/atomic-disabled.txt:73:29: error: opcode not allowed: i64.atomic.rmw32_u.xchg
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.xchg drop
                             ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:74:41: error: opcode not allowed: i32.atomic.rmw.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:75:41: error: opcode not allowed: i32.atomic.rmw.cmpxchg
     i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:75:41: error: opcode not allowed: i64.atomic.rmw.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:76:41: error: opcode not allowed: i64.atomic.rmw.cmpxchg
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:76:41: error: opcode not allowed: i32.atomic.rmw8_u.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:77:41: error: opcode not allowed: i32.atomic.rmw8_u.cmpxchg
     i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8_u.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:77:41: error: opcode not allowed: i32.atomic.rmw16_u.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:78:41: error: opcode not allowed: i32.atomic.rmw16_u.cmpxchg
     i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16_u.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:78:41: error: opcode not allowed: i64.atomic.rmw8_u.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:79:41: error: opcode not allowed: i64.atomic.rmw8_u.cmpxchg
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8_u.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:79:41: error: opcode not allowed: i64.atomic.rmw16_u.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:80:41: error: opcode not allowed: i64.atomic.rmw16_u.cmpxchg
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16_u.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:80:41: error: opcode not allowed: i64.atomic.rmw32_u.cmpxchg
+out/test/parse/expr/atomic-disabled.txt:81:41: error: opcode not allowed: i64.atomic.rmw32_u.cmpxchg
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/atomic.txt
+++ b/test/parse/expr/atomic.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ARGS: --enable-threads
 (module
   (memory 1 1 shared)

--- a/test/parse/expr/bad-atomic-unnatural-align.txt
+++ b/test/parse/expr/bad-atomic-unnatural-align.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 ;;; ARGS: --enable-threads
 (module
@@ -82,196 +83,196 @@
 ))
 
 (;; STDERR ;;;
-out/test/parse/expr/bad-atomic-unnatural-align.txt:6:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:7:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 atomic.wake align=8 drop
                             ^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:7:41: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:8:41: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait align=8 drop
                                         ^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:8:41: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:9:41: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait align=16 drop
                                         ^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:10:17: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:11:17: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.atomic.load align=8 drop
                 ^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:11:17: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:12:17: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.atomic.load align=16 drop
                 ^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:12:17: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:13:17: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.atomic.load8_u align=2 drop
                 ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:13:17: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:14:17: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.atomic.load16_u align=4 drop
                 ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:14:17: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:15:17: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.atomic.load8_u align=2 drop
                 ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:15:17: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:16:17: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.atomic.load16_u align=4 drop
                 ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:16:17: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:17:17: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.atomic.load32_u align=8 drop
                 ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:18:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:19:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.store align=8
                             ^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:19:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:20:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.store align=16
                             ^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:21:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:22:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.store16 align=4
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:23:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:24:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.store16 align=4
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:24:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:25:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.store32 align=8
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:26:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:27:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.rmw.add align=8 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:27:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:28:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.rmw.add align=16 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:28:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:29:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.add align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:29:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:30:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.add align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:30:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:31:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.add align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:31:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:32:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.add align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:32:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:33:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.add align=8 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:34:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:35:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.rmw.sub align=8 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:35:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:36:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.rmw.sub align=16 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:36:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:37:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.sub align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:37:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:38:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.sub align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:38:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:39:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.sub align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:39:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:40:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.sub align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:40:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:41:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.sub align=8 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:42:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:43:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.rmw.and align=8 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:43:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:44:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.rmw.and align=16 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:44:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:45:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.and align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:45:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:46:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.and align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:46:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:47:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.and align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:47:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:48:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.and align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:48:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:49:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.and align=8 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:50:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:51:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.rmw.or align=8 drop
                             ^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:51:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:52:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.rmw.or align=16 drop
                             ^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:52:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:53:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.or align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:53:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:54:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.or align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:54:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:55:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.or align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:55:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:56:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.or align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:56:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:57:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.or align=8 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:58:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:59:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.rmw.xor align=8 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:59:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:60:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.rmw.xor align=16 drop
                             ^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:60:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:61:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.xor align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:61:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:62:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.xor align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:62:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:63:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.xor align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:63:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:64:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.xor align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:64:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:65:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.xor align=8 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:66:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:67:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.atomic.rmw.xchg align=8 drop
                             ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:67:29: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:68:29: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.atomic.rmw.xchg align=16 drop
                             ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:68:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:69:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.atomic.rmw8_u.xchg align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:69:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:70:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.atomic.rmw16_u.xchg align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:70:29: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:71:29: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.atomic.rmw8_u.xchg align=2 drop
                             ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:71:29: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:72:29: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.atomic.rmw16_u.xchg align=4 drop
                             ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:72:29: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:73:29: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.atomic.rmw32_u.xchg align=8 drop
                             ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:74:41: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:75:41: error: alignment must be equal to natural alignment (4)
     i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw.cmpxchg align=8 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:75:41: error: alignment must be equal to natural alignment (8)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:76:41: error: alignment must be equal to natural alignment (8)
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw.cmpxchg align=16 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:76:41: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:77:41: error: alignment must be equal to natural alignment (1)
     i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw8_u.cmpxchg align=2 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:77:41: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:78:41: error: alignment must be equal to natural alignment (2)
     i32.const 0 i32.const 0 i32.const 0 i32.atomic.rmw16_u.cmpxchg align=4 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:78:41: error: alignment must be equal to natural alignment (1)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:79:41: error: alignment must be equal to natural alignment (1)
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw8_u.cmpxchg align=2 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:79:41: error: alignment must be equal to natural alignment (2)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:80:41: error: alignment must be equal to natural alignment (2)
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw16_u.cmpxchg align=4 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/bad-atomic-unnatural-align.txt:80:41: error: alignment must be equal to natural alignment (4)
+out/test/parse/expr/bad-atomic-unnatural-align.txt:81:41: error: alignment must be equal to natural alignment (4)
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32_u.cmpxchg align=8 drop
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-binary-one-expr.txt
+++ b/test/parse/expr/bad-binary-one-expr.txt
@@ -1,12 +1,13 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
    i32.const 0 
    i32.add))
 (;; STDERR ;;;
-out/test/parse/expr/bad-binary-one-expr.txt:4:4: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+out/test/parse/expr/bad-binary-one-expr.txt:5:4: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
    i32.add))
    ^^^^^^^
-out/test/parse/expr/bad-binary-one-expr.txt:4:4: error: type mismatch in function, expected [] but got [i32, i32]
+out/test/parse/expr/bad-binary-one-expr.txt:5:4: error: type mismatch in function, expected [] but got [i32, i32]
    i32.add))
    ^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-block-end-label.txt
+++ b/test/parse/expr/bad-block-end-label.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     block
     end $foo))
 (;; STDERR ;;;
-out/test/parse/expr/bad-block-end-label.txt:5:9: error: unexpected label "$foo"
+out/test/parse/expr/bad-block-end-label.txt:6:9: error: unexpected label "$foo"
     end $foo))
         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-block-mismatch-label.txt
+++ b/test/parse/expr/bad-block-mismatch-label.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     block $foo
     end $bar))
 (;; STDERR ;;;
-out/test/parse/expr/bad-block-mismatch-label.txt:5:9: error: mismatching label "$foo" != "$bar"
+out/test/parse/expr/bad-block-mismatch-label.txt:6:9: error: mismatching label "$foo" != "$bar"
     end $bar))
         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-block-sig-multi.txt
+++ b/test/parse/expr/bad-block-sig-multi.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -8,7 +9,7 @@
     drop
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-block-sig-multi.txt:4:5: error: multiple block signature result types not currently supported.
+out/test/parse/expr/bad-block-sig-multi.txt:5:5: error: multiple block signature result types not currently supported.
     block (result i32 i32)
     ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-bad-depth.txt
+++ b/test/parse/expr/bad-br-bad-depth.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func     ;; 2 (implicit)
@@ -7,7 +8,7 @@
       end
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-br-bad-depth.txt:6:9: error: invalid depth: 3 (max 2)
+out/test/parse/expr/bad-br-bad-depth.txt:7:9: error: invalid depth: 3 (max 2)
         br 3
         ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-defined-later.txt
+++ b/test/parse/expr/bad-br-defined-later.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,7 +7,7 @@
       nop
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-br-defined-later.txt:4:5: error: invalid depth: 1 (max 0)
+out/test/parse/expr/bad-br-defined-later.txt:5:5: error: invalid depth: 1 (max 0)
     br 1
     ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-name-undefined.txt
+++ b/test/parse/expr/bad-br-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func br $n))
 (;; STDERR ;;;
-out/test/parse/expr/bad-br-name-undefined.txt:2:18: error: undefined label variable "$n"
+out/test/parse/expr/bad-br-name-undefined.txt:3:18: error: undefined label variable "$n"
 (module (func br $n))
                  ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-name.txt
+++ b/test/parse/expr/bad-br-name.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func 
           block $foo 
             br foo 
           end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-br-name.txt:4:16: error: unexpected token "foo", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/parse/expr/bad-br-name.txt:5:16: error: unexpected token "foo", expected a numeric index or a name (e.g. 12 or $foo).
             br foo 
                ^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-no-depth.txt
+++ b/test/parse/expr/bad-br-no-depth.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -5,7 +6,7 @@
       br
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-br-no-depth.txt:6:5: error: unexpected token "end", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/parse/expr/bad-br-no-depth.txt:7:5: error: unexpected token "end", expected a numeric index or a name (e.g. 12 or $foo).
     end))
     ^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-br-undefined.txt
+++ b/test/parse/expr/bad-br-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func br 1))
 (;; STDERR ;;;
-out/test/parse/expr/bad-br-undefined.txt:2:15: error: invalid depth: 1 (max 0)
+out/test/parse/expr/bad-br-undefined.txt:3:15: error: invalid depth: 1 (max 0)
 (module (func br 1))
               ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-brtable-bad-depth.txt
+++ b/test/parse/expr/bad-brtable-bad-depth.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func    ;; depth 1 (implicit)
@@ -6,7 +7,7 @@
       br_table 2
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-brtable-bad-depth.txt:6:7: error: invalid depth: 2 (max 1)
+out/test/parse/expr/bad-brtable-bad-depth.txt:7:7: error: invalid depth: 2 (max 1)
       br_table 2
       ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-compare-one-expr.txt
+++ b/test/parse/expr/bad-compare-one-expr.txt
@@ -1,12 +1,13 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0 
           i32.lt_s))
 (;; STDERR ;;;
-out/test/parse/expr/bad-compare-one-expr.txt:4:11: error: type mismatch in i32.lt_s, expected [i32, i32] but got [i32]
+out/test/parse/expr/bad-compare-one-expr.txt:5:11: error: type mismatch in i32.lt_s, expected [i32, i32] but got [i32]
           i32.lt_s))
           ^^^^^^^^
-out/test/parse/expr/bad-compare-one-expr.txt:4:11: error: type mismatch in function, expected [] but got [i32, i32]
+out/test/parse/expr/bad-compare-one-expr.txt:5:11: error: type mismatch in function, expected [] but got [i32, i32]
           i32.lt_s))
           ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-f32-trailing.txt
+++ b/test/parse/expr/bad-const-f32-trailing.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func f32.const 1234.5678foo))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-f32-trailing.txt:2:25: error: unexpected token "1234.5678foo", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-f32-trailing.txt:3:25: error: unexpected token "1234.5678foo", expected a numeric literal (e.g. 123, -45, 6.7e8).
 (module (func f32.const 1234.5678foo))
                         ^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-i32-garbage.txt
+++ b/test/parse/expr/bad-const-i32-garbage.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func i32.const one-hundred))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-i32-garbage.txt:2:25: error: unexpected token "one-hundred", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-i32-garbage.txt:3:25: error: unexpected token "one-hundred", expected a numeric literal (e.g. 123, -45, 6.7e8).
 (module (func i32.const one-hundred))
                         ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-i32-just-negative-sign.txt
+++ b/test/parse/expr/bad-const-i32-just-negative-sign.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func i32.const -))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-i32-just-negative-sign.txt:3:19: error: unexpected token "-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-i32-just-negative-sign.txt:4:19: error: unexpected token "-", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (func i32.const -))
                   ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-i32-overflow.txt
+++ b/test/parse/expr/bad-const-i32-overflow.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func i32.const 4294967296))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-i32-overflow.txt:2:25: error: invalid literal "4294967296"
+out/test/parse/expr/bad-const-i32-overflow.txt:3:25: error: invalid literal "4294967296"
 (module (func i32.const 4294967296))
                         ^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-i32-trailing.txt
+++ b/test/parse/expr/bad-const-i32-trailing.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func i32.const 100x))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-i32-trailing.txt:2:25: error: unexpected token "100x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-i32-trailing.txt:3:25: error: unexpected token "100x", expected a numeric literal (e.g. 123, -45, 6.7e8).
 (module (func i32.const 100x))
                         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-i32-underflow.txt
+++ b/test/parse/expr/bad-const-i32-underflow.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func i32.const -2147483649))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-i32-underflow.txt:2:25: error: invalid literal "-2147483649"
+out/test/parse/expr/bad-const-i32-underflow.txt:3:25: error: invalid literal "-2147483649"
 (module (func i32.const -2147483649))
                         ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-i64-overflow.txt
+++ b/test/parse/expr/bad-const-i64-overflow.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func i64.const 18446744073709551616))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-i64-overflow.txt:2:25: error: invalid literal "18446744073709551616"
+out/test/parse/expr/bad-const-i64-overflow.txt:3:25: error: invalid literal "18446744073709551616"
 (module (func i64.const 18446744073709551616))
                         ^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt
+++ b/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt
@@ -1,19 +1,20 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func i32.const i32 100))
 (module (func i64.const i32 100))
 (module (func f32.const i32 100))
 (module (func f64.const i32 100))
 (;; STDERR ;;;
-out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:2:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:3:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
 (module (func i32.const i32 100))
                         ^^^
-out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:3:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:4:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
 (module (func i64.const i32 100))
                         ^^^
-out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:4:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:5:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
 (module (func f32.const i32 100))
                         ^^^
-out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:5:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-const-type-i32-in-non-simd-const.txt:6:25: error: unexpected token "i32", expected a numeric literal for non-simd const opcode (e.g. 123, -45, 6.7e8).
 (module (func f64.const i32 100))
                         ^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-convert-float-sign.txt
+++ b/test/parse/expr/bad-convert-float-sign.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           f32.const 0 
           f32.converts.f64))
 (;; STDERR ;;;
-out/test/parse/expr/bad-convert-float-sign.txt:4:11: error: unexpected token f32.converts.f64, expected ).
+out/test/parse/expr/bad-convert-float-sign.txt:5:11: error: unexpected token f32.converts.f64, expected ).
           f32.converts.f64))
           ^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-convert-int-no-sign.txt
+++ b/test/parse/expr/bad-convert-int-no-sign.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 
           i32.convert.i32))
 (;; STDERR ;;;
-out/test/parse/expr/bad-convert-int-no-sign.txt:4:11: error: unexpected token "i32.convert.i32", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/parse/expr/bad-convert-int-no-sign.txt:5:11: error: unexpected token "i32.convert.i32", expected a numeric literal (e.g. 123, -45, 6.7e8).
           i32.convert.i32))
           ^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-getglobal-name-undefined.txt
+++ b/test/parse/expr/bad-getglobal-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func get_global $n))
 (;; STDERR ;;;
-out/test/parse/expr/bad-getglobal-name-undefined.txt:2:26: error: undefined global variable "$n"
+out/test/parse/expr/bad-getglobal-name-undefined.txt:3:26: error: undefined global variable "$n"
 (module (func get_global $n))
                          ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-getglobal-undefined.txt
+++ b/test/parse/expr/bad-getglobal-undefined.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     get_global 0
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-getglobal-undefined.txt:4:16: error: global variable out of range (max 0)
+out/test/parse/expr/bad-getglobal-undefined.txt:5:16: error: global variable out of range (max 0)
     get_global 0
                ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-getlocal-name-undefined.txt
+++ b/test/parse/expr/bad-getlocal-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func get_local $n))
 (;; STDERR ;;;
-out/test/parse/expr/bad-getlocal-name-undefined.txt:2:25: error: undefined local variable "$n"
+out/test/parse/expr/bad-getlocal-name-undefined.txt:3:25: error: undefined local variable "$n"
 (module (func get_local $n))
                         ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-getlocal-name.txt
+++ b/test/parse/expr/bad-getlocal-name.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (local $f f32) get_local f))
 (;; STDERR ;;;
-out/test/parse/expr/bad-getlocal-name.txt:2:40: error: unexpected token "f", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/parse/expr/bad-getlocal-name.txt:3:40: error: unexpected token "f", expected a numeric index or a name (e.g. 12 or $foo).
 (module (func (local $f f32) get_local f))
                                        ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-getlocal-undefined.txt
+++ b/test/parse/expr/bad-getlocal-undefined.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     get_local 0
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-getlocal-undefined.txt:4:15: error: local variable out of range (max 0)
+out/test/parse/expr/bad-getlocal-undefined.txt:5:15: error: local variable out of range (max 0)
     get_local 0
               ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-if-end-label.txt
+++ b/test/parse/expr/bad-if-end-label.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,10 +7,10 @@
     else $foo
     end $bar))
 (;; STDERR ;;;
-out/test/parse/expr/bad-if-end-label.txt:6:10: error: unexpected label "$foo"
+out/test/parse/expr/bad-if-end-label.txt:7:10: error: unexpected label "$foo"
     else $foo
          ^^^^
-out/test/parse/expr/bad-if-end-label.txt:7:9: error: unexpected label "$bar"
+out/test/parse/expr/bad-if-end-label.txt:8:9: error: unexpected label "$bar"
     end $bar))
         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-if-mismatch-label.txt
+++ b/test/parse/expr/bad-if-mismatch-label.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,10 +7,10 @@
     else $bar
     end $baz))
 (;; STDERR ;;;
-out/test/parse/expr/bad-if-mismatch-label.txt:6:10: error: mismatching label "$foo" != "$bar"
+out/test/parse/expr/bad-if-mismatch-label.txt:7:10: error: mismatching label "$foo" != "$bar"
     else $bar
          ^^^^
-out/test/parse/expr/bad-if-mismatch-label.txt:7:9: error: mismatching label "$foo" != "$baz"
+out/test/parse/expr/bad-if-mismatch-label.txt:8:9: error: mismatching label "$foo" != "$baz"
     end $baz))
         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-if-no-then.txt
+++ b/test/parse/expr/bad-if-no-then.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (if (i32.const 0))))
 (;; STDERR ;;;
-out/test/parse/expr/bad-if-no-then.txt:2:32: error: unexpected token ")", expected then block (e.g. (then ...)).
+out/test/parse/expr/bad-if-no-then.txt:3:32: error: unexpected token ")", expected then block (e.g. (then ...)).
 (module (func (if (i32.const 0))))
                                ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-if-sig-multi.txt
+++ b/test/parse/expr/bad-if-sig-multi.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -12,7 +13,7 @@
     drop
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-if-sig-multi.txt:5:5: error: multiple if signature result types not currently supported.
+out/test/parse/expr/bad-if-sig-multi.txt:6:5: error: multiple if signature result types not currently supported.
     if (result i32 i32)
     ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-align-misspelled.txt
+++ b/test/parse/expr/bad-load-align-misspelled.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     i32.const 0
     i32.load aline=64))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-align-misspelled.txt:5:14: error: unexpected token aline=64, expected ).
+out/test/parse/expr/bad-load-align-misspelled.txt:6:14: error: unexpected token aline=64, expected ).
     i32.load aline=64))
              ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-align-negative.txt
+++ b/test/parse/expr/bad-load-align-negative.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func 
           i32.const 0 
           i32.load8_s align=-1))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-align-negative.txt:4:23: error: unexpected token align=-1, expected ).
+out/test/parse/expr/bad-load-align-negative.txt:5:23: error: unexpected token align=-1, expected ).
           i32.load8_s align=-1))
                       ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-align-not-pot.txt
+++ b/test/parse/expr/bad-load-align-not-pot.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 1)
@@ -6,7 +7,7 @@
     i32.load align=3 
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-align-not-pot.txt:6:14: error: alignment must be power-of-two
+out/test/parse/expr/bad-load-align-not-pot.txt:7:14: error: alignment must be power-of-two
     i32.load align=3 
              ^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-align.txt
+++ b/test/parse/expr/bad-load-align.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (i32.load align=foo (i32.const 0))))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-align.txt:2:25: error: unexpected token align=foo, expected ).
+out/test/parse/expr/bad-load-align.txt:3:25: error: unexpected token align=foo, expected ).
 (module (func (i32.load align=foo (i32.const 0))))
                         ^^^^^^^^^
-out/test/parse/expr/bad-load-align.txt:2:50: error: unexpected token ), expected EOF.
+out/test/parse/expr/bad-load-align.txt:3:50: error: unexpected token ), expected EOF.
 (module (func (i32.load align=foo (i32.const 0))))
                                                  ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-float-sign.txt
+++ b/test/parse/expr/bad-load-float-sign.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0
           f32.loads))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-float-sign.txt:4:11: error: unexpected token f32.loads, expected ).
+out/test/parse/expr/bad-load-float-sign.txt:5:11: error: unexpected token f32.loads, expected ).
           f32.loads))
           ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-offset-negative.txt
+++ b/test/parse/expr/bad-load-offset-negative.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0 
           i32.load8_s offset=-1))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-offset-negative.txt:4:23: error: unexpected token offset=-1, expected ).
+out/test/parse/expr/bad-load-offset-negative.txt:5:23: error: unexpected token offset=-1, expected ).
           i32.load8_s offset=-1))
                       ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-load-type.txt
+++ b/test/parse/expr/bad-load-type.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0
           load.x32))
 (;; STDERR ;;;
-out/test/parse/expr/bad-load-type.txt:4:11: error: unexpected token load.x32, expected ).
+out/test/parse/expr/bad-load-type.txt:5:11: error: unexpected token load.x32, expected ).
           load.x32))
           ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-loop-end-label.txt
+++ b/test/parse/expr/bad-loop-end-label.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     loop
     end $foo))
 (;; STDERR ;;;
-out/test/parse/expr/bad-loop-end-label.txt:5:9: error: unexpected label "$foo"
+out/test/parse/expr/bad-loop-end-label.txt:6:9: error: unexpected label "$foo"
     end $foo))
         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-loop-mismatch-label.txt
+++ b/test/parse/expr/bad-loop-mismatch-label.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
     loop $foo
     end $bar))
 (;; STDERR ;;;
-out/test/parse/expr/bad-loop-mismatch-label.txt:5:9: error: mismatching label "$foo" != "$bar"
+out/test/parse/expr/bad-loop-mismatch-label.txt:6:9: error: mismatching label "$foo" != "$bar"
     end $bar))
         ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-loop-sig-multi.txt
+++ b/test/parse/expr/bad-loop-sig-multi.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -8,7 +9,7 @@
     drop
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-loop-sig-multi.txt:4:5: error: multiple loop signature result types not currently supported.
+out/test/parse/expr/bad-loop-sig-multi.txt:5:5: error: multiple loop signature result types not currently supported.
     loop (result i32 i32)
     ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-nop.txt
+++ b/test/parse/expr/bad-nop.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func 
           nop
           foo))
 (;; STDERR ;;;
-out/test/parse/expr/bad-nop.txt:4:11: error: unexpected token foo, expected ).
+out/test/parse/expr/bad-nop.txt:5:11: error: unexpected token foo, expected ).
           foo))
           ^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-return-multi.txt
+++ b/test/parse/expr/bad-return-multi.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (result f32 f32)
           f32.const 0
           f32.const 3.14
           return))
 (;; STDERR ;;;
-out/test/parse/expr/bad-return-multi.txt:2:10: error: multiple result values not currently supported.
+out/test/parse/expr/bad-return-multi.txt:3:10: error: multiple result values not currently supported.
 (module (func (result f32 f32)
          ^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setglobal-name-undefined.txt
+++ b/test/parse/expr/bad-setglobal-name-undefined.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 1 
           set_global $f))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setglobal-name-undefined.txt:4:22: error: undefined global variable "$f"
+out/test/parse/expr/bad-setglobal-name-undefined.txt:5:22: error: undefined global variable "$f"
           set_global $f))
                      ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setglobal-undefined.txt
+++ b/test/parse/expr/bad-setglobal-undefined.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func 
           i32.const 1
           set_global 0))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setglobal-undefined.txt:4:22: error: global variable out of range (max 0)
+out/test/parse/expr/bad-setglobal-undefined.txt:5:22: error: global variable out of range (max 0)
           set_global 0))
                      ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setlocal-name-undefined.txt
+++ b/test/parse/expr/bad-setlocal-name-undefined.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func 
           i32.const 0
           set_local $n))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setlocal-name-undefined.txt:4:21: error: undefined local variable "$n"
+out/test/parse/expr/bad-setlocal-name-undefined.txt:5:21: error: undefined local variable "$n"
           set_local $n))
                     ^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setlocal-name.txt
+++ b/test/parse/expr/bad-setlocal-name.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
   (local $n i32)
   i32.const 0
   set_local n))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setlocal-name.txt:5:13: error: unexpected token "n", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/parse/expr/bad-setlocal-name.txt:6:13: error: unexpected token "n", expected a numeric index or a name (e.g. 12 or $foo).
   set_local n))
             ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setlocal-no-value.txt
+++ b/test/parse/expr/bad-setlocal-no-value.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
   (local i32)
   set_local 0))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setlocal-no-value.txt:4:3: error: type mismatch in set_local, expected [i32] but got []
+out/test/parse/expr/bad-setlocal-no-value.txt:5:3: error: type mismatch in set_local, expected [i32] but got []
   set_local 0))
   ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setlocal-undefined.txt
+++ b/test/parse/expr/bad-setlocal-undefined.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0 
           set_local 0))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setlocal-undefined.txt:4:21: error: local variable out of range (max 0)
+out/test/parse/expr/bad-setlocal-undefined.txt:5:21: error: local variable out of range (max 0)
           set_local 0))
                     ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-store-align-not-pot.txt
+++ b/test/parse/expr/bad-store-align-not-pot.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 1)
@@ -6,7 +7,7 @@
     f32.const 0.0
     f32.store align=3))
 (;; STDERR ;;;
-out/test/parse/expr/bad-store-align-not-pot.txt:7:15: error: alignment must be power-of-two
+out/test/parse/expr/bad-store-align-not-pot.txt:8:15: error: alignment must be power-of-two
     f32.store align=3))
               ^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-store-align.txt
+++ b/test/parse/expr/bad-store-align.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0 
           i32.const 0
           i32.store align=foo))
 (;; STDERR ;;;
-out/test/parse/expr/bad-store-align.txt:5:21: error: unexpected token align=foo, expected ).
+out/test/parse/expr/bad-store-align.txt:6:21: error: unexpected token align=foo, expected ).
           i32.store align=foo))
                     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-store-float.sign.txt
+++ b/test/parse/expr/bad-store-float.sign.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0
           f32.const 0 
           f32.storeu))
 (;; STDERR ;;;
-out/test/parse/expr/bad-store-float.sign.txt:5:11: error: unexpected token f32.storeu, expected ).
+out/test/parse/expr/bad-store-float.sign.txt:6:11: error: unexpected token f32.storeu, expected ).
           f32.storeu))
           ^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-store-offset-negative.txt
+++ b/test/parse/expr/bad-store-offset-negative.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func 
           i32.const 0
           i32.const 0
           i32.store8 offset=-1))
 (;; STDERR ;;;
-out/test/parse/expr/bad-store-offset-negative.txt:5:22: error: unexpected token offset=-1, expected ).
+out/test/parse/expr/bad-store-offset-negative.txt:6:22: error: unexpected token offset=-1, expected ).
           i32.store8 offset=-1))
                      ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-store-type.txt
+++ b/test/parse/expr/bad-store-type.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func
           i32.const 0
           f32.const 0 
           store.float32))
 (;; STDERR ;;;
-out/test/parse/expr/bad-store-type.txt:5:11: error: unexpected token store.float32, expected ).
+out/test/parse/expr/bad-store-type.txt:6:11: error: unexpected token store.float32, expected ).
           store.float32))
           ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-unexpected.txt
+++ b/test/parse/expr/bad-unexpected.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (module)))
 (;; STDERR ;;;
-out/test/parse/expr/bad-unexpected.txt:2:16: error: unexpected token "module", expected an instr.
+out/test/parse/expr/bad-unexpected.txt:3:16: error: unexpected token "module", expected an instr.
 (module (func (module)))
                ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/callimport-defined-later.txt
+++ b/test/parse/expr/callimport-defined-later.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -5,7 +6,7 @@
     call $baz)
   (import "foo" "bar" (func $baz (param f32))))
 (;; STDERR ;;;
-out/test/parse/expr/callimport-defined-later.txt:6:4: error: imports must occur before all non-import definitions
+out/test/parse/expr/callimport-defined-later.txt:7:4: error: imports must occur before all non-import definitions
   (import "foo" "bar" (func $baz (param f32))))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/convert-sat-disabled.txt
+++ b/test/parse/expr/convert-sat-disabled.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -33,28 +34,28 @@
     i64.trunc_u:sat/f64
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/convert-sat-disabled.txt:5:5: error: opcode not allowed: i32.trunc_s:sat/f32
+out/test/parse/expr/convert-sat-disabled.txt:6:5: error: opcode not allowed: i32.trunc_s:sat/f32
     i32.trunc_s:sat/f32
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:9:5: error: opcode not allowed: i32.trunc_u:sat/f32
+out/test/parse/expr/convert-sat-disabled.txt:10:5: error: opcode not allowed: i32.trunc_u:sat/f32
     i32.trunc_u:sat/f32
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:13:5: error: opcode not allowed: i32.trunc_s:sat/f64
+out/test/parse/expr/convert-sat-disabled.txt:14:5: error: opcode not allowed: i32.trunc_s:sat/f64
     i32.trunc_s:sat/f64
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:17:5: error: opcode not allowed: i32.trunc_u:sat/f64
+out/test/parse/expr/convert-sat-disabled.txt:18:5: error: opcode not allowed: i32.trunc_u:sat/f64
     i32.trunc_u:sat/f64
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:21:5: error: opcode not allowed: i64.trunc_s:sat/f32
+out/test/parse/expr/convert-sat-disabled.txt:22:5: error: opcode not allowed: i64.trunc_s:sat/f32
     i64.trunc_s:sat/f32
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:25:5: error: opcode not allowed: i64.trunc_u:sat/f32
+out/test/parse/expr/convert-sat-disabled.txt:26:5: error: opcode not allowed: i64.trunc_u:sat/f32
     i64.trunc_u:sat/f32
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:29:5: error: opcode not allowed: i64.trunc_s:sat/f64
+out/test/parse/expr/convert-sat-disabled.txt:30:5: error: opcode not allowed: i64.trunc_s:sat/f64
     i64.trunc_s:sat/f64
     ^^^^^^^^^^^^^^^^^^^
-out/test/parse/expr/convert-sat-disabled.txt:33:5: error: opcode not allowed: i64.trunc_u:sat/f64
+out/test/parse/expr/convert-sat-disabled.txt:34:5: error: opcode not allowed: i64.trunc_u:sat/f64
     i64.trunc_u:sat/f64
     ^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/unary-extend-disabled.txt
+++ b/test/parse/expr/unary-extend-disabled.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -21,19 +22,19 @@
     i64.extend32_s
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/unary-extend-disabled.txt:5:5: error: opcode not allowed: i32.extend8_s
+out/test/parse/expr/unary-extend-disabled.txt:6:5: error: opcode not allowed: i32.extend8_s
     i32.extend8_s
     ^^^^^^^^^^^^^
-out/test/parse/expr/unary-extend-disabled.txt:9:5: error: opcode not allowed: i32.extend16_s
+out/test/parse/expr/unary-extend-disabled.txt:10:5: error: opcode not allowed: i32.extend16_s
     i32.extend16_s
     ^^^^^^^^^^^^^^
-out/test/parse/expr/unary-extend-disabled.txt:13:5: error: opcode not allowed: i64.extend8_s
+out/test/parse/expr/unary-extend-disabled.txt:14:5: error: opcode not allowed: i64.extend8_s
     i64.extend8_s
     ^^^^^^^^^^^^^
-out/test/parse/expr/unary-extend-disabled.txt:17:5: error: opcode not allowed: i64.extend16_s
+out/test/parse/expr/unary-extend-disabled.txt:18:5: error: opcode not allowed: i64.extend16_s
     i64.extend16_s
     ^^^^^^^^^^^^^^
-out/test/parse/expr/unary-extend-disabled.txt:21:5: error: opcode not allowed: i64.extend32_s
+out/test/parse/expr/unary-extend-disabled.txt:22:5: error: opcode not allowed: i64.extend32_s
     i64.extend32_s
     ^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-func-name.txt
+++ b/test/parse/func/bad-func-name.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func foo))
 (;; STDERR ;;;
-out/test/parse/func/bad-func-name.txt:3:9: error: unexpected token foo, expected ).
+out/test/parse/func/bad-func-name.txt:4:9: error: unexpected token foo, expected ).
   (func foo))
         ^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-local-binding-no-type.txt
+++ b/test/parse/func/bad-local-binding-no-type.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (local $n)))
 (;; STDERR ;;;
-out/test/parse/func/bad-local-binding-no-type.txt:2:24: error: unexpected token ")", expected i32, i64, f32, f64 or v128.
+out/test/parse/func/bad-local-binding-no-type.txt:3:24: error: unexpected token ")", expected i32, i64, f32, f64 or v128.
 (module (func (local $n)))
                        ^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-local-binding.txt
+++ b/test/parse/func/bad-local-binding.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (local $foo $bar)))
 (;; STDERR ;;;
-out/test/parse/func/bad-local-binding.txt:2:27: error: unexpected token "$bar", expected i32, i64, f32, f64 or v128.
+out/test/parse/func/bad-local-binding.txt:3:27: error: unexpected token "$bar", expected i32, i64, f32, f64 or v128.
 (module (func (local $foo $bar)))
                           ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-local-name.txt
+++ b/test/parse/func/bad-local-name.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (local 0 i32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-local-name.txt:2:22: error: unexpected token 0, expected ).
+out/test/parse/func/bad-local-name.txt:3:22: error: unexpected token 0, expected ).
 (module (func (local 0 i32)))
                      ^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-local-type-list.txt
+++ b/test/parse/func/bad-local-type-list.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (local i32 i64 foo f32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-local-type-list.txt:2:30: error: unexpected token foo, expected ).
+out/test/parse/func/bad-local-type-list.txt:3:30: error: unexpected token foo, expected ).
 (module (func (local i32 i64 foo f32)))
                              ^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-local-type.txt
+++ b/test/parse/func/bad-local-type.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (local foo)))
 (;; STDERR ;;;
-out/test/parse/func/bad-local-type.txt:2:22: error: unexpected token foo, expected ).
+out/test/parse/func/bad-local-type.txt:3:22: error: unexpected token foo, expected ).
 (module (func (local foo)))
                      ^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-param-binding.txt
+++ b/test/parse/func/bad-param-binding.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (param $bar $baz)))
 (;; STDERR ;;;
-out/test/parse/func/bad-param-binding.txt:2:27: error: unexpected token "$baz", expected i32, i64, f32, f64 or v128.
+out/test/parse/func/bad-param-binding.txt:3:27: error: unexpected token "$baz", expected i32, i64, f32, f64 or v128.
 (module (func (param $bar $baz)))
                           ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-param-name.txt
+++ b/test/parse/func/bad-param-name.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (param 0 i32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-param-name.txt:2:22: error: unexpected token 0, expected ).
+out/test/parse/func/bad-param-name.txt:3:22: error: unexpected token 0, expected ).
 (module (func (param 0 i32)))
                      ^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-param-redefinition.txt
+++ b/test/parse/func/bad-param-redefinition.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (param $n i32) (param $n f32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-param-redefinition.txt:2:37: error: redefinition of parameter "$n"
+out/test/parse/func/bad-param-redefinition.txt:3:37: error: redefinition of parameter "$n"
 (module (func (param $n i32) (param $n f32)))
                                     ^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-param-type-list.txt
+++ b/test/parse/func/bad-param-type-list.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (param i32 i64 foo f32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-param-type-list.txt:2:30: error: unexpected token foo, expected ).
+out/test/parse/func/bad-param-type-list.txt:3:30: error: unexpected token foo, expected ).
 (module (func (param i32 i64 foo f32)))
                              ^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-param.txt
+++ b/test/parse/func/bad-param.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (param foo)))
 (;; STDERR ;;;
-out/test/parse/func/bad-param.txt:2:22: error: unexpected token foo, expected ).
+out/test/parse/func/bad-param.txt:3:22: error: unexpected token foo, expected ).
 (module (func (param foo)))
                      ^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-result-multi.txt
+++ b/test/parse/func/bad-result-multi.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (result i32 i64)))
 (;; STDERR ;;;
-out/test/parse/func/bad-result-multi.txt:2:10: error: multiple result values not currently supported.
+out/test/parse/func/bad-result-multi.txt:3:10: error: multiple result values not currently supported.
 (module (func (result i32 i64)))
          ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-result-type.txt
+++ b/test/parse/func/bad-result-type.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (result foo)))
 (;; STDERR ;;;
-out/test/parse/func/bad-result-type.txt:2:23: error: unexpected token foo, expected ).
+out/test/parse/func/bad-result-type.txt:3:23: error: unexpected token foo, expected ).
 (module (func (result foo)))
                       ^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-param-type-mismatch.txt
+++ b/test/parse/func/bad-sig-param-type-mismatch.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32 f32)))
   (func (type $t) (param f32 f32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-param-type-mismatch.txt:4:4: error: type mismatch for argument 0 of function. got f32, expected i32
+out/test/parse/func/bad-sig-param-type-mismatch.txt:5:4: error: type mismatch for argument 0 of function. got f32, expected i32
   (func (type $t) (param f32 f32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-params-empty.txt
+++ b/test/parse/func/bad-sig-params-empty.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func))
   (func (type $t) (param i32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-params-empty.txt:4:4: error: expected 0 arguments, got 1
+out/test/parse/func/bad-sig-params-empty.txt:5:4: error: expected 0 arguments, got 1
   (func (type $t) (param i32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-mismatch.txt
+++ b/test/parse/func/bad-sig-result-type-mismatch.txt
@@ -1,12 +1,13 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32) (result f32)))
   (func (type $t) (param i32) (result i64)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-result-type-mismatch.txt:4:4: error: type mismatch for result 0 of function. got i64, expected f32
+out/test/parse/func/bad-sig-result-type-mismatch.txt:5:4: error: type mismatch for result 0 of function. got i64, expected f32
   (func (type $t) (param i32) (result i64)))
    ^^^^
-out/test/parse/func/bad-sig-result-type-mismatch.txt:4:4: error: type mismatch in implicit return, expected [i64] but got []
+out/test/parse/func/bad-sig-result-type-mismatch.txt:5:4: error: type mismatch in implicit return, expected [i64] but got []
   (func (type $t) (param i32) (result i64)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-not-void.txt
+++ b/test/parse/func/bad-sig-result-type-not-void.txt
@@ -1,12 +1,13 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32)))
   (func (type $t) (param i32) (result f32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-result-type-not-void.txt:4:4: error: expected 0 results, got 1
+out/test/parse/func/bad-sig-result-type-not-void.txt:5:4: error: expected 0 results, got 1
   (func (type $t) (param i32) (result f32)))
    ^^^^
-out/test/parse/func/bad-sig-result-type-not-void.txt:4:4: error: type mismatch in implicit return, expected [f32] but got []
+out/test/parse/func/bad-sig-result-type-not-void.txt:5:4: error: type mismatch in implicit return, expected [f32] but got []
   (func (type $t) (param i32) (result f32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-void.txt
+++ b/test/parse/func/bad-sig-result-type-void.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32) (result f32)))
   (func (type $t) (param i32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-result-type-void.txt:4:4: error: expected 1 results, got 0
+out/test/parse/func/bad-sig-result-type-void.txt:5:4: error: expected 1 results, got 0
   (func (type $t) (param i32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-too-few-params.txt
+++ b/test/parse/func/bad-sig-too-few-params.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32 f32)))
   (func (type $t) (param i32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-too-few-params.txt:4:4: error: expected 2 arguments, got 1
+out/test/parse/func/bad-sig-too-few-params.txt:5:4: error: expected 2 arguments, got 1
   (func (type $t) (param i32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-too-many-params.txt
+++ b/test/parse/func/bad-sig-too-many-params.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32)))
   (func (type $t) (param i32 i32)))
 (;; STDERR ;;;
-out/test/parse/func/bad-sig-too-many-params.txt:4:4: error: expected 1 arguments, got 2
+out/test/parse/func/bad-sig-too-many-params.txt:5:4: error: expected 1 arguments, got 2
   (func (type $t) (param i32 i32)))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-binary-module-magic.txt
+++ b/test/parse/module/bad-binary-module-magic.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module binary
   "\00ASM"
   "\0b\00\00\00")
 (;; STDERR ;;;
-out/test/parse/module/bad-binary-module-magic.txt:2:2: error: error in binary module: @0x00000004: bad magic value
+out/test/parse/module/bad-binary-module-magic.txt:3:2: error: error in binary module: @0x00000004: bad magic value
 (module binary
  ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-empty.txt
+++ b/test/parse/module/bad-export-func-empty.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-empty.txt:2:16: error: unexpected token ")", expected a quoted string (e.g. "foo").
+out/test/parse/module/bad-export-func-empty.txt:3:16: error: unexpected token ")", expected a quoted string (e.g. "foo").
 (module (export))
                ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-name-undefined.txt
+++ b/test/parse/module/bad-export-func-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (func $foo)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-name-undefined.txt:2:29: error: undefined function variable "$foo"
+out/test/parse/module/bad-export-func-name-undefined.txt:3:29: error: undefined function variable "$foo"
 (module (export "foo" (func $foo)))
                             ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-name.txt
+++ b/test/parse/module/bad-export-func-name.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (func foo)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-name.txt:2:29: error: unexpected token "foo", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/parse/module/bad-export-func-name.txt:3:29: error: unexpected token "foo", expected a numeric index or a name (e.g. 12 or $foo).
 (module (export "foo" (func foo)))
                             ^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-no-string.txt
+++ b/test/parse/module/bad-export-func-no-string.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func nop) (export nop nop))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-no-string.txt:2:28: error: unexpected token "nop", expected a quoted string (e.g. "foo").
+out/test/parse/module/bad-export-func-no-string.txt:3:28: error: unexpected token "nop", expected a quoted string (e.g. "foo").
 (module (func nop) (export nop nop))
                            ^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-too-many.txt
+++ b/test/parse/module/bad-export-func-too-many.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func nop) (export "nop" (func 0 foo)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-too-many.txt:2:42: error: unexpected token foo, expected ).
+out/test/parse/module/bad-export-func-too-many.txt:3:42: error: unexpected token foo, expected ).
 (module (func nop) (export "nop" (func 0 foo)))
                                          ^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-undefined.txt
+++ b/test/parse/module/bad-export-func-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (func 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-undefined.txt:2:29: error: function variable out of range (max 0)
+out/test/parse/module/bad-export-func-undefined.txt:3:29: error: function variable out of range (max 0)
 (module (export "foo" (func 0)))
                             ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-global-name-undefined.txt
+++ b/test/parse/module/bad-export-global-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (global $bar)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-global-name-undefined.txt:2:31: error: undefined global variable "$bar"
+out/test/parse/module/bad-export-global-name-undefined.txt:3:31: error: undefined global variable "$bar"
 (module (export "foo" (global $bar)))
                               ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-global-undefined.txt
+++ b/test/parse/module/bad-export-global-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (global 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-global-undefined.txt:2:31: error: global variable out of range (max 0)
+out/test/parse/module/bad-export-global-undefined.txt:3:31: error: global variable out of range (max 0)
 (module (export "foo" (global 0)))
                               ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-memory-name-undefined.txt
+++ b/test/parse/module/bad-export-memory-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (memory $bar)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-memory-name-undefined.txt:2:31: error: undefined memory variable "$bar"
+out/test/parse/module/bad-export-memory-name-undefined.txt:3:31: error: undefined memory variable "$bar"
 (module (export "foo" (memory $bar)))
                               ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-memory-undefined.txt
+++ b/test/parse/module/bad-export-memory-undefined.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (export "mem" (memory 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-memory-undefined.txt:3:25: error: memory variable out of range (max 0)
+out/test/parse/module/bad-export-memory-undefined.txt:4:25: error: memory variable out of range (max 0)
   (export "mem" (memory 0)))
                         ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-table-name-undefined.txt
+++ b/test/parse/module/bad-export-table-name-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (table $bar)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-table-name-undefined.txt:2:30: error: undefined table variable "$bar"
+out/test/parse/module/bad-export-table-name-undefined.txt:3:30: error: undefined table variable "$bar"
 (module (export "foo" (table $bar)))
                              ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-table-undefined.txt
+++ b/test/parse/module/bad-export-table-undefined.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (export "foo" (table 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-table-undefined.txt:2:30: error: table variable out of range (max 0)
+out/test/parse/module/bad-export-table-undefined.txt:3:30: error: table variable out of range (max 0)
 (module (export "foo" (table 0)))
                              ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-func-redefinition.txt
+++ b/test/parse/module/bad-func-redefinition.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func $n nop)
   (func $n nop))
 (;; STDERR ;;;
-out/test/parse/module/bad-func-redefinition.txt:4:4: error: redefinition of function "$n"
+out/test/parse/module/bad-func-redefinition.txt:5:4: error: redefinition of function "$n"
   (func $n nop))
    ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-global-invalid-expr.txt
+++ b/test/parse/module/bad-global-invalid-expr.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (global i32 
@@ -5,7 +6,7 @@
     i32.const 2
     i32.add))
 (;; STDERR ;;;
-out/test/parse/module/bad-global-invalid-expr.txt:3:4: error: invalid global initializer expression, must be a constant expression; either *.const or get_global.
+out/test/parse/module/bad-global-invalid-expr.txt:4:4: error: invalid global initializer expression, must be a constant expression; either *.const or get_global.
   (global i32 
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-global-invalid-getglobal.txt
+++ b/test/parse/module/bad-global-invalid-getglobal.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (global i32 (get_global 1)))
 (;; STDERR ;;;
-out/test/parse/module/bad-global-invalid-getglobal.txt:3:27: error: global variable out of range (max 1)
+out/test/parse/module/bad-global-invalid-getglobal.txt:4:27: error: global variable out of range (max 1)
   (global i32 (get_global 1)))
                           ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-func-not-param.txt
+++ b/test/parse/module/bad-import-func-not-param.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (import "foo" "bar" (func (parump i32))))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-func-not-param.txt:2:36: error: unexpected token "parump", expected param or result.
+out/test/parse/module/bad-import-func-not-param.txt:3:36: error: unexpected token "parump", expected param or result.
 (module (import "foo" "bar" (func (parump i32))))
                                    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-func-not-result.txt
+++ b/test/parse/module/bad-import-func-not-result.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (import "foo" "bar" (func (param i32) (resalt i32))))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-func-not-result.txt:2:48: error: unexpected token "resalt", expected param or result.
+out/test/parse/module/bad-import-func-not-result.txt:3:48: error: unexpected token "resalt", expected param or result.
 (module (import "foo" "bar" (func (param i32) (resalt i32))))
                                                ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-func-one-string.txt
+++ b/test/parse/module/bad-import-func-one-string.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (import "foo" (param i32)))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-func-one-string.txt:2:23: error: unexpected token "(", expected a quoted string (e.g. "foo").
+out/test/parse/module/bad-import-func-one-string.txt:3:23: error: unexpected token "(", expected a quoted string (e.g. "foo").
 (module (import "foo" (param i32)))
                       ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-func-redefinition.txt
+++ b/test/parse/module/bad-import-func-redefinition.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "bar" "baz" (func $foo (param i32)))
   (import "quux" "blorf" (func $foo (param f32))))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-func-redefinition.txt:4:4: error: redefinition of function "$foo"
+out/test/parse/module/bad-import-func-redefinition.txt:5:4: error: redefinition of function "$foo"
   (import "quux" "blorf" (func $foo (param f32))))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-global-redefinition.txt
+++ b/test/parse/module/bad-import-global-redefinition.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (global $baz i32))
   (import "oof" "rab" (global $baz i32)))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-global-redefinition.txt:4:4: error: redefinition of global "$baz"
+out/test/parse/module/bad-import-global-redefinition.txt:5:4: error: redefinition of global "$baz"
   (import "oof" "rab" (global $baz i32)))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-memory-redefinition.txt
+++ b/test/parse/module/bad-import-memory-redefinition.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (memory $baz 0))
   (import "foo" "blah" (memory $baz 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-memory-redefinition.txt:4:4: error: redefinition of memory "$baz"
+out/test/parse/module/bad-import-memory-redefinition.txt:5:4: error: redefinition of memory "$baz"
   (import "foo" "blah" (memory $baz 0)))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-table-redefinition.txt
+++ b/test/parse/module/bad-import-table-redefinition.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (table $baz 0 anyfunc))
   (import "foo" "blah" (table $baz 0 anyfunc)))
 (;; STDERR ;;;
-out/test/parse/module/bad-import-table-redefinition.txt:4:4: error: redefinition of table "$baz"
+out/test/parse/module/bad-import-table-redefinition.txt:5:4: error: redefinition of table "$baz"
   (import "foo" "blah" (table $baz 0 anyfunc)))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-import-table-shared.txt
+++ b/test/parse/module/bad-import-table-shared.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (table 0 3 shared anyfunc))
 )
 (;; STDERR ;;;
-out/test/parse/module/bad-import-table-shared.txt:3:4: error: tables may not be shared
+out/test/parse/module/bad-import-table-shared.txt:4:4: error: tables may not be shared
   (import "foo" "bar" (table 0 3 shared anyfunc))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-empty.txt
+++ b/test/parse/module/bad-memory-empty.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-empty.txt:2:16: error: unexpected token ")", expected a natural number (e.g. 123).
+out/test/parse/module/bad-memory-empty.txt:3:16: error: unexpected token ")", expected a natural number (e.g. 123).
 (module (memory))
                ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-init-size-negative.txt
+++ b/test/parse/module/bad-memory-init-size-negative.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory -100))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-init-size-negative.txt:2:17: error: unexpected token "-100", expected a natural number (e.g. 123).
+out/test/parse/module/bad-memory-init-size-negative.txt:3:17: error: unexpected token "-100", expected a natural number (e.g. 123).
 (module (memory -100))
                 ^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-init-size-too-big.txt
+++ b/test/parse/module/bad-memory-init-size-too-big.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory 65537))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-init-size-too-big.txt:2:10: error: initial pages (65537) must be <= (65536)
+out/test/parse/module/bad-memory-init-size-too-big.txt:3:10: error: initial pages (65537) must be <= (65536)
 (module (memory 65537))
          ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-init-size.txt
+++ b/test/parse/module/bad-memory-init-size.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory foo))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-init-size.txt:2:17: error: unexpected token "foo", expected a natural number (e.g. 123).
+out/test/parse/module/bad-memory-init-size.txt:3:17: error: unexpected token "foo", expected a natural number (e.g. 123).
 (module (memory foo))
                 ^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-max-less-than-init.txt
+++ b/test/parse/module/bad-memory-max-less-than-init.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory 2 1))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-max-less-than-init.txt:2:10: error: max pages (1) must be >= initial pages (2)
+out/test/parse/module/bad-memory-max-less-than-init.txt:3:10: error: max pages (1) must be >= initial pages (2)
 (module (memory 2 1))
          ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-max-size-negative.txt
+++ b/test/parse/module/bad-memory-max-size-negative.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory 100 -5))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-max-size-negative.txt:2:21: error: unexpected token -5, expected ).
+out/test/parse/module/bad-memory-max-size-negative.txt:3:21: error: unexpected token -5, expected ).
 (module (memory 100 -5))
                     ^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-max-size-too-big.txt
+++ b/test/parse/module/bad-memory-max-size-too-big.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory 0 65537))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-max-size-too-big.txt:2:10: error: max pages (65537) must be <= (65536)
+out/test/parse/module/bad-memory-max-size-too-big.txt:3:10: error: max pages (65537) must be <= (65536)
 (module (memory 0 65537))
          ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-max-size.txt
+++ b/test/parse/module/bad-memory-max-size.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory 100 foo))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-max-size.txt:2:21: error: unexpected token foo, expected ).
+out/test/parse/module/bad-memory-max-size.txt:3:21: error: unexpected token foo, expected ).
 (module (memory 100 foo))
                     ^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-segment-address.txt
+++ b/test/parse/module/bad-memory-segment-address.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 100)
   (data foo))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-segment-address.txt:4:9: error: unexpected token "foo", expected an offset expr (e.g. (i32.const 123)).
+out/test/parse/module/bad-memory-segment-address.txt:5:9: error: unexpected token "foo", expected an offset expr (e.g. (i32.const 123)).
   (data foo))
         ^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-shared-nomax.txt
+++ b/test/parse/module/bad-memory-shared-nomax.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (memory 1 shared))
 
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-shared-nomax.txt:2:10: error: shared memories must have max sizes
+out/test/parse/module/bad-memory-shared-nomax.txt:3:10: error: shared memories must have max sizes
 (module (memory 1 shared))
          ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-memory-too-many.txt
+++ b/test/parse/module/bad-memory-too-many.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 1)
   (memory 2))
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-too-many.txt:4:4: error: only one memory block allowed
+out/test/parse/module/bad-memory-too-many.txt:5:4: error: only one memory block allowed
   (memory 2))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-module-multi.txt
+++ b/test/parse/module/bad-module-multi.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func))
 
 ;; Can't have two modules in a .wat file.
 (module)
 (;; STDERR ;;;
-out/test/parse/module/bad-module-multi.txt:5:1: error: unexpected token (, expected EOF.
+out/test/parse/module/bad-module-multi.txt:6:1: error: unexpected token (, expected EOF.
 (module)
 ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-module-no-close.txt
+++ b/test/parse/module/bad-module-no-close.txt
@@ -1,5 +1,6 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
 (;; STDERR ;;;
-out/test/parse/module/bad-module-no-close.txt:3:2: error: unexpected token "EOF", expected a module field.
+out/test/parse/module/bad-module-no-close.txt:4:2: error: unexpected token "EOF", expected a module field.
 ;;; STDERR ;;)

--- a/test/parse/module/bad-module-with-assert.txt
+++ b/test/parse/module/bad-module-with-assert.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (func (export "f")))
 
 ;; Can't use assert_return when parsing a .wat file.
 (assert_return (invoke "f"))
 (;; STDERR ;;;
-out/test/parse/module/bad-module-with-assert.txt:5:1: error: unexpected token (, expected EOF.
+out/test/parse/module/bad-module-with-assert.txt:6:1: error: unexpected token (, expected EOF.
 (assert_return (invoke "f"))
 ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-start-not-nullary.txt
+++ b/test/parse/module/bad-start-not-nullary.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (start 0)
   (func (param i32)))
 (;; STDERR ;;;
-out/test/parse/module/bad-start-not-nullary.txt:3:4: error: start function must be nullary
+out/test/parse/module/bad-start-not-nullary.txt:4:4: error: start function must be nullary
   (start 0)
    ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-start-not-void.txt
+++ b/test/parse/module/bad-start-not-void.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (start 0)
   (func (result i32)
     i32.const 0))
 (;; STDERR ;;;
-out/test/parse/module/bad-start-not-void.txt:3:4: error: start function must not return anything
+out/test/parse/module/bad-start-not-void.txt:4:4: error: start function must not return anything
   (start 0)
    ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-start-too-many.txt
+++ b/test/parse/module/bad-start-too-many.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (start 0)
@@ -5,7 +6,7 @@
   (func)
   (func))
 (;; STDERR ;;;
-out/test/parse/module/bad-start-too-many.txt:4:4: error: only one start function allowed
+out/test/parse/module/bad-start-too-many.txt:5:4: error: only one start function allowed
   (start 1)
    ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-table-invalid-function.txt
+++ b/test/parse/module/bad-table-invalid-function.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (table 1 anyfunc)
   (func $f)
   (elem (i32.const 0) $f 1))
 (;; STDERR ;;;
-out/test/parse/module/bad-table-invalid-function.txt:5:26: error: function variable out of range (max 1)
+out/test/parse/module/bad-table-invalid-function.txt:6:26: error: function variable out of range (max 1)
   (elem (i32.const 0) $f 1))
                          ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-table-too-many.txt
+++ b/test/parse/module/bad-table-too-many.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (param i32))
   (table anyfunc (elem 0))
   (table anyfunc (elem 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-table-too-many.txt:5:4: error: only one table allowed
+out/test/parse/module/bad-table-too-many.txt:6:4: error: only one table allowed
   (table anyfunc (elem 0)))
    ^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-1.txt
+++ b/test/regress/regress-1.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func(call $i32 ))
   (func $UemoOy_size ))
 (;; STDERR ;;;
-out/test/regress/regress-1.txt:3:14: error: undefined function variable "$i32"
+out/test/regress/regress-1.txt:4:14: error: undefined function variable "$i32"
   (func(call $i32 ))
              ^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-10.txt
+++ b/test/regress/regress-10.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -7,7 +8,7 @@
       tee_local 0
     end))
 (;; STDERR ;;;
-out/test/regress/regress-10.txt:7:7: error: type mismatch in block, expected [] but got [i32]
+out/test/regress/regress-10.txt:8:7: error: type mismatch in block, expected [] but got [i32]
       tee_local 0
       ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-11.txt
+++ b/test/regress/regress-11.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
@@ -9,7 +10,7 @@
       i32.const 1
     end))
 (;; STDERR ;;;
-out/test/regress/regress-11.txt:7:9: error: type mismatch in block, expected [] but got [i32]
+out/test/regress/regress-11.txt:8:9: error: type mismatch in block, expected [] but got [i32]
         br_if 1
         ^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-12.txt
+++ b/test/regress/regress-12.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func)
@@ -5,7 +6,7 @@
 
 (func))
 (;; STDERR ;;;
-out/test/regress/regress-12.txt:6:1: error: unexpected token (, expected EOF.
+out/test/regress/regress-12.txt:7:1: error: unexpected token (, expected EOF.
 (func))
 ^
 ;;; STDERR ;;)

--- a/test/regress/regress-13.txt
+++ b/test/regress/regress-13.txt
@@ -1,7 +1,8 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module (test))
 (;; STDERR ;;;
-out/test/regress/regress-13.txt:2:10: error: unexpected token "test", expected a module field.
+out/test/regress/regress-13.txt:3:10: error: unexpected token "test", expected a module field.
 (module (test))
          ^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-14.txt
+++ b/test/regress/regress-14.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result(i32)
     (return (i32.const 42))))
 
 (;; STDERR ;;;
-out/test/regress/regress-14.txt:3:16: error: unexpected token (, expected ).
+out/test/regress/regress-14.txt:4:16: error: unexpected token (, expected ).
   (func (result(i32)
                ^
 ;;; STDERR ;;)

--- a/test/regress/regress-15.txt
+++ b/test/regress/regress-15.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
     (return (i32.const 42)))(
 (;; STDERR ;;;
-out/test/regress/regress-15.txt:4:29: error: unexpected token (, expected ).
+out/test/regress/regress-15.txt:5:29: error: unexpected token (, expected ).
     (return (i32.const 42)))(
                             ^
 ;;; STDERR ;;)

--- a/test/regress/regress-16.txt
+++ b/test/regress/regress-16.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (start $2)
 (start 42)
 (;; STDERR ;;;
-out/test/regress/regress-16.txt:2:8: error: undefined function variable "$2"
+out/test/regress/regress-16.txt:3:8: error: undefined function variable "$2"
 (start $2)
        ^^
 ;;; STDERR ;;)

--- a/test/regress/regress-17.txt
+++ b/test/regress/regress-17.txt
@@ -8,5 +8,4 @@
 out/test/regress/regress-17.txt:6:26: error: type mismatch for argument 0 of invoke. got i32, expected i64
 (invoke "foo" (i32.const 1))
                          ^
-
 ;;; STDERR ;;)

--- a/test/regress/regress-2.txt
+++ b/test/regress/regress-2.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func(call 2 ))
@@ -10,10 +11,10 @@
   (func $memory(param f32)(call 332 ))
   (func $memorGe ))
 (;; STDERR ;;;
-out/test/regress/regress-2.txt:6:4: error: redefinition of function "$memor"
+out/test/regress/regress-2.txt:7:4: error: redefinition of function "$memor"
   (func $memor(call 2 ))
    ^^^^
-out/test/regress/regress-2.txt:10:4: error: redefinition of function "$memory"
+out/test/regress/regress-2.txt:11:4: error: redefinition of function "$memory"
   (func $memory(param f32)(call 332 ))
    ^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-4.txt
+++ b/test/regress/regress-4.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 ;; bug where looking up an undefined name would not produce an error if there
 ;; was any name at all.
@@ -5,7 +6,7 @@
   (func (param $p i32)
     (get_local $n)))
 (;; STDERR ;;;
-out/test/regress/regress-4.txt:6:16: error: undefined local variable "$n"
+out/test/regress/regress-4.txt:7:16: error: undefined local variable "$n"
     (get_local $n)))
                ^^
 ;;; STDERR ;;)

--- a/test/regress/regress-5.txt
+++ b/test/regress/regress-5.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 ;; error when displaying source line when the line wasn't in the first 8192
 ;; bytes.
@@ -117,7 +118,7 @@
     (i64.const 0))  ;; deliberate type-check error
 )
 (;; STDERR ;;;
-out/test/regress/regress-5.txt:117:6: error: type mismatch in implicit return, expected [i32] but got [i64]
+out/test/regress/regress-5.txt:118:6: error: type mismatch in implicit return, expected [i32] but got [i64]
     (i64.const 0))  ;; deliberate type-check error
      ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -416,8 +416,6 @@ class TestInfo(object):
     return self.cmds[index]
 
   def GetLastCommand(self):
-    if not self.cmds:
-      self.SetTool('wat2wasm')
     return self.cmds[-1]
 
   def AppendArgsToAllCommands(self, args):
@@ -513,11 +511,6 @@ class TestInfo(object):
     self.input_ = ''.join(input_lines)
     self.expected_stdout = ''.join(stdout_lines)
     self.expected_stderr = ''.join(stderr_lines)
-
-    # If the test didn't specify a executable (either via RUN or indirectly
-    # via TOOL, then use the default tool)
-    if not self.cmds:
-      self.SetTool('wat2wasm')
 
   def CreateInputFile(self):
     gen_input_path = self.GetGeneratedInputFilename()
@@ -924,7 +917,8 @@ def main(args):
   if status.failed:
     sys.stderr.write('**** FAILED %s\n' % ('*' * (80 - 14)))
     for info, result in status.failed_tests:
-      sys.stderr.write('- %s\n    %s\n' % (info.GetName(), result.last_cmd))
+      last_cmd = result.last_cmd if result is not None else ''
+      sys.stderr.write('- %s\n    %s\n' % (info.GetName(), last_cmd))
     ret = 1
 
   return ret

--- a/test/typecheck/bad-binary-type-mismatch-1.txt
+++ b/test/typecheck/bad-binary-type-mismatch-1.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,7 +7,7 @@
     i32.add  
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-binary-type-mismatch-1.txt:6:5: error: type mismatch in i32.add, expected [i32, i32] but got [f32, i32]
+out/test/typecheck/bad-binary-type-mismatch-1.txt:7:5: error: type mismatch in i32.add, expected [i32, i32] but got [f32, i32]
     i32.add  
     ^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-binary-type-mismatch-2.txt
+++ b/test/typecheck/bad-binary-type-mismatch-2.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,7 +7,7 @@
     i32.add 
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-binary-type-mismatch-2.txt:6:5: error: type mismatch in i32.add, expected [i32, i32] but got [i32, f32]
+out/test/typecheck/bad-binary-type-mismatch-2.txt:7:5: error: type mismatch in i32.add, expected [i32, i32] but got [i32, f32]
     i32.add 
     ^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-brtable-type-mismatch.txt
+++ b/test/typecheck/bad-brtable-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
@@ -11,7 +12,7 @@
     end
     i32.const 2))
 (;; STDERR ;;;
-out/test/typecheck/bad-brtable-type-mismatch.txt:7:9: error: type mismatch in br_table, expected [i32] but got [f32]
+out/test/typecheck/bad-brtable-type-mismatch.txt:8:9: error: type mismatch in br_table, expected [i32] but got [f32]
         br_table 0 1 
         ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-call-result-mismatch.txt
+++ b/test/typecheck/bad-call-result-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (func $import (result f32)))
@@ -23,22 +24,22 @@
       nop
     end))
 (;; STDERR ;;;
-out/test/typecheck/bad-call-result-mismatch.txt:9:5: error: type mismatch in if, expected [i32] but got []
+out/test/typecheck/bad-call-result-mismatch.txt:10:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:10:7: error: type mismatch in if true branch, expected [] but got [i64]
+out/test/typecheck/bad-call-result-mismatch.txt:11:7: error: type mismatch in if true branch, expected [] but got [i64]
       call $direct
       ^^^^
-out/test/typecheck/bad-call-result-mismatch.txt:14:5: error: type mismatch in if, expected [i32] but got []
+out/test/typecheck/bad-call-result-mismatch.txt:15:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:15:7: error: type mismatch in if true branch, expected [] but got [f32]
+out/test/typecheck/bad-call-result-mismatch.txt:16:7: error: type mismatch in if true branch, expected [] but got [f32]
       call $import
       ^^^^
-out/test/typecheck/bad-call-result-mismatch.txt:19:5: error: type mismatch in if, expected [i32] but got []
+out/test/typecheck/bad-call-result-mismatch.txt:20:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:21:7: error: type mismatch in if true branch, expected [] but got [i64]
+out/test/typecheck/bad-call-result-mismatch.txt:22:7: error: type mismatch in if true branch, expected [] but got [i64]
       call_indirect (type $indirect)
       ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-call-type-mismatch.txt
+++ b/test/typecheck/bad-call-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (param i32 i64)
@@ -5,7 +6,7 @@
     i64.const 0
     call 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-call-type-mismatch.txt:6:5: error: type mismatch in call, expected [i32, i64] but got [i64, i64]
+out/test/typecheck/bad-call-type-mismatch.txt:7:5: error: type mismatch in call, expected [i32, i64] but got [i64, i64]
     call 0))
     ^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callimport-type-mismatch.txt
+++ b/test/typecheck/bad-callimport-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (func (param i32)))
@@ -5,7 +6,7 @@
     f32.const 0
     call 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-callimport-type-mismatch.txt:6:5: error: type mismatch in call, expected [i32] but got [f32]
+out/test/typecheck/bad-callimport-type-mismatch.txt:7:5: error: type mismatch in call, expected [i32] but got [f32]
     call 0))
     ^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callindirect-func-type-mismatch.txt
+++ b/test/typecheck/bad-callindirect-func-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (table anyfunc (elem 0))
@@ -6,7 +7,7 @@
     f32.const 0
     call_indirect (type $t)))
 (;; STDERR ;;;
-out/test/typecheck/bad-callindirect-func-type-mismatch.txt:7:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
+out/test/typecheck/bad-callindirect-func-type-mismatch.txt:8:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
     call_indirect (type $t)))
     ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-callindirect-type-mismatch.txt
+++ b/test/typecheck/bad-callindirect-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (type $t (func (param i32) (result i32)))
@@ -9,7 +10,7 @@
     call_indirect (type $t)
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-callindirect-type-mismatch.txt:9:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
+out/test/typecheck/bad-callindirect-type-mismatch.txt:10:5: error: type mismatch in call_indirect, expected [i32] but got [f32]
     call_indirect (type $t)
     ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-cast-type-mismatch.txt
+++ b/test/typecheck/bad-cast-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -5,7 +6,7 @@
     f32.reinterpret/i32
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-cast-type-mismatch.txt:5:5: error: type mismatch in f32.reinterpret/i32, expected [i32] but got [f32]
+out/test/typecheck/bad-cast-type-mismatch.txt:6:5: error: type mismatch in f32.reinterpret/i32, expected [i32] but got [f32]
     f32.reinterpret/i32
     ^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-compare-type-mismatch-1.txt
+++ b/test/typecheck/bad-compare-type-mismatch-1.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,7 +7,7 @@
     i32.eq
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-compare-type-mismatch-1.txt:6:5: error: type mismatch in i32.eq, expected [i32, i32] but got [f32, i32]
+out/test/typecheck/bad-compare-type-mismatch-1.txt:7:5: error: type mismatch in i32.eq, expected [i32, i32] but got [f32, i32]
     i32.eq
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-compare-type-mismatch-2.txt
+++ b/test/typecheck/bad-compare-type-mismatch-2.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -6,7 +7,7 @@
     f32.lt
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-compare-type-mismatch-2.txt:6:5: error: type mismatch in f32.lt, expected [f32, f32] but got [f32, i32]
+out/test/typecheck/bad-compare-type-mismatch-2.txt:7:5: error: type mismatch in f32.lt, expected [f32, f32] but got [f32, i32]
     f32.lt
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-convert-type-mismatch.txt
+++ b/test/typecheck/bad-convert-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -5,7 +6,7 @@
     i32.trunc_s/f32 
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-convert-type-mismatch.txt:5:5: error: type mismatch in i32.trunc_s/f32, expected [f32] but got [i32]
+out/test/typecheck/bad-convert-type-mismatch.txt:6:5: error: type mismatch in i32.trunc_s/f32, expected [f32] but got [i32]
     i32.trunc_s/f32 
     ^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-expr-if.txt
+++ b/test/typecheck/bad-expr-if.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
@@ -9,10 +10,10 @@
     end
     i32.add))
 (;; STDERR ;;;
-out/test/typecheck/bad-expr-if.txt:10:5: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+out/test/typecheck/bad-expr-if.txt:11:5: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
     i32.add))
     ^^^^^^^
-out/test/typecheck/bad-expr-if.txt:10:5: error: type mismatch in function, expected [] but got [i32]
+out/test/typecheck/bad-expr-if.txt:11:5: error: type mismatch in function, expected [] but got [i32]
     i32.add))
     ^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-function-result-type-mismatch.txt
+++ b/test/typecheck/bad-function-result-type-mismatch.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
     f32.const 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-function-result-type-mismatch.txt:4:5: error: type mismatch in implicit return, expected [i32] but got [f32]
+out/test/typecheck/bad-function-result-type-mismatch.txt:5:5: error: type mismatch in implicit return, expected [i32] but got [f32]
     f32.const 0))
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-getglobal-type-mismatch.txt
+++ b/test/typecheck/bad-global-getglobal-type-mismatch.txt
@@ -1,9 +1,10 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (import "foo" "bar" (global i32))
   (global f32 (get_global 0)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-getglobal-type-mismatch.txt:4:16: error: type mismatch at global initializer expression. got i32, expected f32
+out/test/typecheck/bad-global-getglobal-type-mismatch.txt:5:16: error: type mismatch at global initializer expression. got i32, expected f32
   (global f32 (get_global 0)))
                ^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-no-init-expr.txt
+++ b/test/typecheck/bad-global-no-init-expr.txt
@@ -1,12 +1,13 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (global i32)
   (global (mut f32)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-no-init-expr.txt:3:4: error: type mismatch at global initializer expression. got void, expected i32
+out/test/typecheck/bad-global-no-init-expr.txt:4:4: error: type mismatch at global initializer expression. got void, expected i32
   (global i32)
    ^^^^^^
-out/test/typecheck/bad-global-no-init-expr.txt:4:4: error: type mismatch at global initializer expression. got void, expected f32
+out/test/typecheck/bad-global-no-init-expr.txt:5:4: error: type mismatch at global initializer expression. got void, expected f32
   (global (mut f32)))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-type-mismatch.txt
+++ b/test/typecheck/bad-global-type-mismatch.txt
@@ -1,8 +1,9 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (global i32 (f32.const 1)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-type-mismatch.txt:3:16: error: type mismatch at global initializer expression. got f32, expected i32
+out/test/typecheck/bad-global-type-mismatch.txt:4:16: error: type mismatch at global initializer expression. got f32, expected i32
   (global i32 (f32.const 1)))
                ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-grow-memory-type-mismatch.txt
+++ b/test/typecheck/bad-grow-memory-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 0)
@@ -6,7 +7,7 @@
     grow_memory
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-grow-memory-type-mismatch.txt:6:5: error: type mismatch in grow_memory, expected [i32] but got [f32]
+out/test/typecheck/bad-grow-memory-type-mismatch.txt:7:5: error: type mismatch in grow_memory, expected [i32] but got [f32]
     grow_memory
     ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-condition-type-mismatch.txt
+++ b/test/typecheck/bad-if-condition-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -10,7 +11,7 @@
     drop)
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-if-condition-type-mismatch.txt:5:5: error: type mismatch in if, expected [i32] but got [f32]
+out/test/typecheck/bad-if-condition-type-mismatch.txt:6:5: error: type mismatch in if, expected [i32] but got [f32]
     if (result i32)
     ^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-type-mismatch.txt
+++ b/test/typecheck/bad-if-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -9,7 +10,7 @@
     end
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-if-type-mismatch.txt:6:7: error: type mismatch in if true branch, expected [i32] but got [f32]
+out/test/typecheck/bad-if-type-mismatch.txt:7:7: error: type mismatch in if true branch, expected [i32] but got [f32]
       f32.const 0
       ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-value-void.txt
+++ b/test/typecheck/bad-if-value-void.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -11,7 +12,7 @@
       drop
     end))
 (;; STDERR ;;;
-out/test/typecheck/bad-if-value-void.txt:7:9: error: type mismatch in if true branch, expected [f32] but got []
+out/test/typecheck/bad-if-value-void.txt:8:9: error: type mismatch in if true branch, expected [f32] but got []
         nop
         ^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-load-type-mismatch.txt
+++ b/test/typecheck/bad-load-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 1)
@@ -6,7 +7,7 @@
     i32.load
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-load-type-mismatch.txt:6:5: error: type mismatch in i32.load, expected [i32] but got [f32]
+out/test/typecheck/bad-load-type-mismatch.txt:7:5: error: type mismatch in i32.load, expected [i32] but got [f32]
     i32.load
     ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-nested-br.txt
+++ b/test/typecheck/bad-nested-br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
@@ -18,7 +19,7 @@
     ;; return statement here, or a value returned from (br $outer).
   ))
 (;; STDERR ;;;
-out/test/typecheck/bad-nested-br.txt:15:7: error: type mismatch in implicit return, expected [i32] but got []
+out/test/typecheck/bad-nested-br.txt:16:7: error: type mismatch in implicit return, expected [i32] but got []
       return
       ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-return-type-mismatch.txt
+++ b/test/typecheck/bad-return-type-mismatch.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
     f32.const 0
     return))
 (;; STDERR ;;;
-out/test/typecheck/bad-return-type-mismatch.txt:5:5: error: type mismatch in return, expected [i32] but got [f32]
+out/test/typecheck/bad-return-type-mismatch.txt:6:5: error: type mismatch in return, expected [i32] but got [f32]
     return))
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-cond.txt
+++ b/test/typecheck/bad-select-cond.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (result i32)
@@ -6,7 +7,7 @@
     i32.const 0
     select))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-cond.txt:7:5: error: type mismatch in select, expected [i32, i32, i32] but got [f32, i32, i32]
+out/test/typecheck/bad-select-cond.txt:8:5: error: type mismatch in select, expected [i32, i32, i32] but got [f32, i32, i32]
     select))
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value0.txt
+++ b/test/typecheck/bad-select-value0.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -7,7 +8,7 @@
     select
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-value0.txt:7:5: error: type mismatch in select, expected [i32, f64, f64] but got [i32, f64, f32]
+out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in select, expected [i32, f64, f64] but got [i32, f64, f32]
     select
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value1.txt
+++ b/test/typecheck/bad-select-value1.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -7,7 +8,7 @@
     select
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-value1.txt:7:5: error: type mismatch in select, expected [i32, i64, i64] but got [i32, i64, f32]
+out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in select, expected [i32, i64, i64] but got [i32, i64, f32]
     select
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-setlocal-type-mismatch.txt
+++ b/test/typecheck/bad-setlocal-type-mismatch.txt
@@ -1,10 +1,11 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func (local i32)
     f32.const 0
     set_local 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-setlocal-type-mismatch.txt:5:5: error: type mismatch in set_local, expected [i32] but got [f32]
+out/test/typecheck/bad-setlocal-type-mismatch.txt:6:5: error: type mismatch in set_local, expected [i32] but got [f32]
     set_local 0))
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-store-index-type-mismatch.txt
+++ b/test/typecheck/bad-store-index-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (memory 1)
@@ -6,7 +7,7 @@
     f32.const 0
     i32.store))
 (;; STDERR ;;;
-out/test/typecheck/bad-store-index-type-mismatch.txt:7:5: error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
+out/test/typecheck/bad-store-index-type-mismatch.txt:8:5: error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
     i32.store))
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-unary-type-mismatch.txt
+++ b/test/typecheck/bad-unary-type-mismatch.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
   (func
@@ -5,7 +6,7 @@
     f32.neg
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-unary-type-mismatch.txt:5:5: error: type mismatch in f32.neg, expected [f32] but got [f64]
+out/test/typecheck/bad-unary-type-mismatch.txt:6:5: error: type mismatch in f32.neg, expected [f32] but got [f64]
     f32.neg
     ^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
The TOOL must specified explicitly.