### PR TITLE
Fix: don't allow a test with an empty command list

### DIFF
--- a/test/parse/basic.txt
+++ b/test/parse/basic.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 42

--- a/test/parse/expr/binary.txt
+++ b/test/parse/expr/binary.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 0

--- a/test/parse/expr/block-named.txt
+++ b/test/parse/expr/block-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block $foo

--- a/test/parse/expr/block-return.txt
+++ b/test/parse/expr/block-return.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     block (result i32)

--- a/test/parse/expr/block.txt
+++ b/test/parse/expr/block.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func 
     block 

--- a/test/parse/expr/br-block.txt
+++ b/test/parse/expr/br-block.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block $exit1

--- a/test/parse/expr/br-loop.txt
+++ b/test/parse/expr/br-loop.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     loop $exit

--- a/test/parse/expr/br-named.txt
+++ b/test/parse/expr/br-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module (func
   block $foo
     br $foo

--- a/test/parse/expr/br.txt
+++ b/test/parse/expr/br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block

--- a/test/parse/expr/brif-named.txt
+++ b/test/parse/expr/brif-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block $foo

--- a/test/parse/expr/brif.txt
+++ b/test/parse/expr/brif.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block $foo

--- a/test/parse/expr/brtable-multi.txt
+++ b/test/parse/expr/brtable-multi.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block

--- a/test/parse/expr/brtable-named.txt
+++ b/test/parse/expr/brtable-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block $exit

--- a/test/parse/expr/brtable.txt
+++ b/test/parse/expr/brtable.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block

--- a/test/parse/expr/call-defined-later.txt
+++ b/test/parse/expr/call-defined-later.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func $foo
     i32.const 1

--- a/test/parse/expr/call-name-prefix.txt
+++ b/test/parse/expr/call-name-prefix.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func $foomore
     i32.const 0

--- a/test/parse/expr/call-named.txt
+++ b/test/parse/expr/call-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func $foo (param f32)
     f32.const 0.0

--- a/test/parse/expr/call.txt
+++ b/test/parse/expr/call.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func (param i32)
   i32.const 1

--- a/test/parse/expr/callimport-named.txt
+++ b/test/parse/expr/callimport-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "bar" (func $bar (param f32)))
   (func

--- a/test/parse/expr/callimport-type.txt
+++ b/test/parse/expr/callimport-type.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (type (func (param i32) (result i32)))
   (import "foo" "bar" (func (type 0)))

--- a/test/parse/expr/callimport.txt
+++ b/test/parse/expr/callimport.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "bar" (func (param i32) (result i32)))
   (func (param i32) (result i32)

--- a/test/parse/expr/callindirect-named.txt
+++ b/test/parse/expr/callindirect-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (table anyfunc (elem 0))
   (type $t (func (param i32)))

--- a/test/parse/expr/callindirect.txt
+++ b/test/parse/expr/callindirect.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (table anyfunc (elem 0))
   (type (func (param i32)))

--- a/test/parse/expr/cast.txt
+++ b/test/parse/expr/cast.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 0

--- a/test/parse/expr/compare.txt
+++ b/test/parse/expr/compare.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 0

--- a/test/parse/expr/convert.txt
+++ b/test/parse/expr/convert.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i64.const 0

--- a/test/parse/expr/current-memory.txt
+++ b/test/parse/expr/current-memory.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/drop.txt
+++ b/test/parse/expr/drop.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 0

--- a/test/parse/expr/expr-br.txt
+++ b/test/parse/expr/expr-br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     block $exit (result i32)

--- a/test/parse/expr/expr-brif.txt
+++ b/test/parse/expr/expr-brif.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     block $exit (result i32)

--- a/test/parse/expr/getglobal-named.txt
+++ b/test/parse/expr/getglobal-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (global $g i32 (i32.const 1))
   (func (result i32)

--- a/test/parse/expr/getglobal.txt
+++ b/test/parse/expr/getglobal.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (global i32 (i32.const 1))
   (func (result i32)

--- a/test/parse/expr/getlocal-index-after-param.txt
+++ b/test/parse/expr/getlocal-index-after-param.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (param i32) (local i32)
     get_local 1

--- a/test/parse/expr/getlocal-index-mixed-named-unnamed.txt
+++ b/test/parse/expr/getlocal-index-mixed-named-unnamed.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (param i32) (param $n f32)
     (local i32 i64)

--- a/test/parse/expr/getlocal-named.txt
+++ b/test/parse/expr/getlocal-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (local $foo i32)
     get_local $foo

--- a/test/parse/expr/getlocal-param-named.txt
+++ b/test/parse/expr/getlocal-param-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (param $n i32)
     get_local $n

--- a/test/parse/expr/getlocal-param.txt
+++ b/test/parse/expr/getlocal-param.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (param i32)
     get_local 0

--- a/test/parse/expr/getlocal.txt
+++ b/test/parse/expr/getlocal.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (local i32)
     get_local 0

--- a/test/parse/expr/grow-memory.txt
+++ b/test/parse/expr/grow-memory.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/if-return.txt
+++ b/test/parse/expr/if-return.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 1

--- a/test/parse/expr/if-then-br-named.txt
+++ b/test/parse/expr/if-then-br-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 1

--- a/test/parse/expr/if-then-br.txt
+++ b/test/parse/expr/if-then-br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 1

--- a/test/parse/expr/if-then-else-br-named.txt
+++ b/test/parse/expr/if-then-else-br-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 1

--- a/test/parse/expr/if-then-else-br.txt
+++ b/test/parse/expr/if-then-else-br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 1

--- a/test/parse/expr/if-then-else-list.txt
+++ b/test/parse/expr/if-then-else-list.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 1

--- a/test/parse/expr/if-then-else.txt
+++ b/test/parse/expr/if-then-else.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func
     (i32.const 0) 

--- a/test/parse/expr/if.txt
+++ b/test/parse/expr/if.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func 
     i32.const 1

--- a/test/parse/expr/load-aligned.txt
+++ b/test/parse/expr/load-aligned.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/load-offset.txt
+++ b/test/parse/expr/load-offset.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/load.txt
+++ b/test/parse/expr/load.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/loop-named.txt
+++ b/test/parse/expr/loop-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     loop 

--- a/test/parse/expr/loop.txt
+++ b/test/parse/expr/loop.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     loop 

--- a/test/parse/expr/nop.txt
+++ b/test/parse/expr/nop.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func nop))

--- a/test/parse/expr/return-block.txt
+++ b/test/parse/expr/return-block.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
      block (result i32)

--- a/test/parse/expr/return-if.txt
+++ b/test/parse/expr/return-if.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 1

--- a/test/parse/expr/return-void.txt
+++ b/test/parse/expr/return-void.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func return))

--- a/test/parse/expr/return.txt
+++ b/test/parse/expr/return.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 42

--- a/test/parse/expr/select.txt
+++ b/test/parse/expr/select.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     i32.const 2

--- a/test/parse/expr/setglobal-named.txt
+++ b/test/parse/expr/setglobal-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (global $g f32 (f32.const 1))
   (func

--- a/test/parse/expr/setglobal.txt
+++ b/test/parse/expr/setglobal.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (global f32 (f32.const 1))
   (func

--- a/test/parse/expr/setlocal-index-after-param.txt
+++ b/test/parse/expr/setlocal-index-after-param.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func (param i32) 
     (local i32) 

--- a/test/parse/expr/setlocal-index-mixed-named-unnamed.txt
+++ b/test/parse/expr/setlocal-index-mixed-named-unnamed.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (param i32) (param $n f32)
     (local i32 i64)

--- a/test/parse/expr/setlocal-named.txt
+++ b/test/parse/expr/setlocal-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module (func
   (local $n i32)
   i32.const 12

--- a/test/parse/expr/setlocal-param-named.txt
+++ b/test/parse/expr/setlocal-param-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func (param $n i32) 
     i32.const 0

--- a/test/parse/expr/setlocal-param.txt
+++ b/test/parse/expr/setlocal-param.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module 
   (func (param i32) 
     i32.const 0

--- a/test/parse/expr/setlocal.txt
+++ b/test/parse/expr/setlocal.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module (func (local i32)
   i32.const 0
   set_local 0))

--- a/test/parse/expr/store-aligned.txt
+++ b/test/parse/expr/store-aligned.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/store-offset.txt
+++ b/test/parse/expr/store-offset.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/store.txt
+++ b/test/parse/expr/store.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (func

--- a/test/parse/expr/tee_local.txt
+++ b/test/parse/expr/tee_local.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     (local i32)

--- a/test/parse/expr/unary.txt
+++ b/test/parse/expr/unary.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     f32.const 0

--- a/test/parse/expr/unreachable.txt
+++ b/test/parse/expr/unreachable.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func unreachable))

--- a/test/parse/func/func-named.txt
+++ b/test/parse/func/func-named.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func $foo))

--- a/test/parse/func/local-empty.txt
+++ b/test/parse/func/local-empty.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (local)))

--- a/test/parse/func/local-multi.txt
+++ b/test/parse/func/local-multi.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (local i32) (local $n i64)))

--- a/test/parse/func/local.txt
+++ b/test/parse/func/local.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (local i32)))

--- a/test/parse/func/no-space.txt
+++ b/test/parse/func/no-space.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func $foomore
     i32.const 0x0

--- a/test/parse/func/param-binding.txt
+++ b/test/parse/func/param-binding.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (param $foo i32)))

--- a/test/parse/func/param-multi.txt
+++ b/test/parse/func/param-multi.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (param i32) (param $n f64)))

--- a/test/parse/func/param-type-1.txt
+++ b/test/parse/func/param-type-1.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (param i32)))

--- a/test/parse/func/param-type-2.txt
+++ b/test/parse/func/param-type-2.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (param i32 f32)))

--- a/test/parse/func/result-empty.txt
+++ b/test/parse/func/result-empty.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (result)))

--- a/test/parse/func/result.txt
+++ b/test/parse/func/result.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func (result i32) i32.const 0))

--- a/test/parse/func/sig-match.txt
+++ b/test/parse/func/sig-match.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (type $empty (func))
   (type $i_v (func (param i32)))

--- a/test/parse/func/sig.txt
+++ b/test/parse/func/sig.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (type $t (func (param i32) (result i32)))
   (func (type $t) (i32.const 0)))

--- a/test/parse/line-comment.txt
+++ b/test/parse/line-comment.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;; here is a comment
 (module)
 ;; here is another

--- a/test/parse/module/binary-module.txt
+++ b/test/parse/module/binary-module.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module binary
   "\00asm"            ;; magic
   "\01\00\00\00"      ;; version

--- a/test/parse/module/data-offset.txt
+++ b/test/parse/module/data-offset.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "bar" (global i32))
   (memory 1)

--- a/test/parse/module/elem-offset.txt
+++ b/test/parse/module/elem-offset.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "bar" (global i32))
   (global i32 i32.const 1)

--- a/test/parse/module/export-func-multi.txt
+++ b/test/parse/module/export-func-multi.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (nop))
   (export "a" (func 0))

--- a/test/parse/module/export-func-named.txt
+++ b/test/parse/module/export-func-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func $n (result i32) (i32.const 0))
   (export "n" (func $n)))

--- a/test/parse/module/export-func.txt
+++ b/test/parse/module/export-func.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (nop))
   (export "nop" (func 0)))

--- a/test/parse/module/export-global.txt
+++ b/test/parse/module/export-global.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (global i32 (i32.const 0))
   (global (mut f32) (f32.const 0))

--- a/test/parse/module/export-memory-multi.txt
+++ b/test/parse/module/export-memory-multi.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (export "mem1" (memory 0))

--- a/test/parse/module/export-memory.txt
+++ b/test/parse/module/export-memory.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (export "mem" (memory 0)))

--- a/test/parse/module/export-table.txt
+++ b/test/parse/module/export-table.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (table 0 anyfunc)
   (export "my_table" (table 0)))

--- a/test/parse/module/global.txt
+++ b/test/parse/module/global.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "i32_global" (global i32))
   (import "foo" "i64_global" (global i64))

--- a/test/parse/module/import-func-no-param.txt
+++ b/test/parse/module/import-func-no-param.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (import "foo" "bar" (func)))

--- a/test/parse/module/import-func-type.txt
+++ b/test/parse/module/import-func-type.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (type (func (param i32 i64 f32 f64) (result i32)))
   (import "foo" "bar" (func (type 0))))

--- a/test/parse/module/import-func.txt
+++ b/test/parse/module/import-func.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   ;; unnamed
   (import "foo" "bar" (func (param i32) (result i64)))

--- a/test/parse/module/import-global-getglobal.txt
+++ b/test/parse/module/import-global-getglobal.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "a" "global" (global i32))
   (global i32 (get_global 0)))

--- a/test/parse/module/import-global.txt
+++ b/test/parse/module/import-global.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "1" (global i32))
   (import "foo" "2" (global i64))

--- a/test/parse/module/import-memory-shared.txt
+++ b/test/parse/module/import-memory-shared.txt
@@ -1,2 +1,3 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "2" (memory 0 2 shared)))

--- a/test/parse/module/import-memory.txt
+++ b/test/parse/module/import-memory.txt
@@ -1,2 +1,3 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "2" (memory 0 2)))

--- a/test/parse/module/import-table.txt
+++ b/test/parse/module/import-table.txt
@@ -1,2 +1,3 @@
+;;; TOOL: wat2wasm
 (module
   (import "foo" "2" (table 0 10 anyfunc)))

--- a/test/parse/module/memory-init-max-size.txt
+++ b/test/parse/module/memory-init-max-size.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (memory 1 2))

--- a/test/parse/module/memory-init-size.txt
+++ b/test/parse/module/memory-init-size.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (memory 1))

--- a/test/parse/module/memory-segment-1.txt
+++ b/test/parse/module/memory-segment-1.txt
@@ -1,2 +1,3 @@
+;;; TOOL: wat2wasm
 (module
   (memory (data "hello, world!")))

--- a/test/parse/module/memory-segment-long.txt
+++ b/test/parse/module/memory-segment-long.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;; This is a regression test to ensure we read and parse integer tokens ASAP.
 ;; Otherwise the memory that is used to store them may be reused. In this case,
 ;; the very long data segment strings were causing the strings that store the

--- a/test/parse/module/memory-segment-many.txt
+++ b/test/parse/module/memory-segment-many.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory 1)
   (data (i32.const 0) "hi")

--- a/test/parse/module/memory-segment-multi-string.txt
+++ b/test/parse/module/memory-segment-multi-string.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (memory
     (data "hi" "there" "how" "are" "you")))

--- a/test/parse/module/memory-shared.txt
+++ b/test/parse/module/memory-shared.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (memory 1 1 shared))

--- a/test/parse/module/module-empty.txt
+++ b/test/parse/module/module-empty.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module)

--- a/test/parse/module/start-named.txt
+++ b/test/parse/module/start-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (start $foo)
   (func $foo))

--- a/test/parse/module/start.txt
+++ b/test/parse/module/start.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (start 0)
   (func))

--- a/test/parse/module/table-named.txt
+++ b/test/parse/module/table-named.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func $f (param i32))
   (func $g (param i32 i64))

--- a/test/parse/module/table.txt
+++ b/test/parse/module/table.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (param i32))
   (func (param i32 i64))

--- a/test/parse/module/type-empty-param.txt
+++ b/test/parse/module/type-empty-param.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (type (func (param))))

--- a/test/parse/module/type-empty.txt
+++ b/test/parse/module/type-empty.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (type (func)))

--- a/test/parse/module/type-multi-param.txt
+++ b/test/parse/module/type-multi-param.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (type (func (param i32 f32 f64) (result f32))))

--- a/test/parse/module/type-no-param.txt
+++ b/test/parse/module/type-no-param.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (type (func (result i32))))

--- a/test/parse/module/type.txt
+++ b/test/parse/module/type.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (type (func (param i32) (result i32))))

--- a/test/parse/nested-comments.txt
+++ b/test/parse/nested-comments.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (; foo bar
     (; baz

--- a/test/parse/string-escape.txt
+++ b/test/parse/string-escape.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func) (export "tab:\t newline:\n slash:\\ quote:\' double:\"" (func 0)))

--- a/test/parse/string-hex.txt
+++ b/test/parse/string-hex.txt
@@ -1,1 +1,2 @@
+;;; TOOL: wat2wasm
 (module (func) (export "foo\de\ad\ca\bb" (func 0)))

--- a/test/regress/regress-3.txt
+++ b/test/regress/regress-3.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 ;;; NOTE: bug when calling function defined with type after call
 (module
   (type $t (func (result i32)))

--- a/test/regress/regress-6.txt
+++ b/test/regress/regress-6.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     block (result i32)

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -512,6 +512,9 @@ class TestInfo(object):
     self.expected_stdout = ''.join(stdout_lines)
     self.expected_stderr = ''.join(stderr_lines)
 
+    if not self.cmds:
+      raise Error('test has no commands')
+
   def CreateInputFile(self):
     gen_input_path = self.GetGeneratedInputFilename()
     gen_input_dir = os.path.dirname(gen_input_path)

--- a/test/typecheck/br-table-loop.txt
+++ b/test/typecheck/br-table-loop.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
  (table 0 anyfunc)
  (memory $0 17)

--- a/test/typecheck/if-then-br.txt
+++ b/test/typecheck/if-then-br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func
     block

--- a/test/typecheck/if-value.txt
+++ b/test/typecheck/if-value.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 0

--- a/test/typecheck/label-redefinition.txt
+++ b/test/typecheck/label-redefinition.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     block $l1 (result i32)

--- a/test/typecheck/nested-br.txt
+++ b/test/typecheck/nested-br.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     block $outer

--- a/test/typecheck/return-drop-value-2.txt
+++ b/test/typecheck/return-drop-value-2.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func 
     i32.const 0

--- a/test/typecheck/return-drop-value.txt
+++ b/test/typecheck/return-drop-value.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func 
     nop

--- a/test/typecheck/return-value.txt
+++ b/test/typecheck/return-value.txt
@@ -1,3 +1,4 @@
+;;; TOOL: wat2wasm
 (module
   (func (result i32)
     i32.const 1


### PR DESCRIPTION
Since `wat2wasm` is no longer the default TOOL, it must be specified in
all tests without a RUN or TOOL directive. The previous CL removed the
default, but didn't fix the tests that had no directives.