### PR TITLE
Support different returncodes per command in tests

### DIFF
--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm-interp
+;;; ERROR: 1
 magic
 version
 section(MEMORY) {

--- a/test/binary/bad-duplicate-section-around-custom.txt
+++ b/test/binary/bad-duplicate-section-around-custom.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[0] }

--- a/test/binary/bad-duplicate-section.txt
+++ b/test/binary/bad-duplicate-section.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[0] }

--- a/test/binary/bad-duplicate-subsection.txt
+++ b/test/binary/bad-duplicate-subsection.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-export-func.txt
+++ b/test/binary/bad-export-func.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-extra-end.txt
+++ b/test/binary/bad-extra-end.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-function-body-count.txt
+++ b/test/binary/bad-function-body-count.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-function-body-size.txt
+++ b/test/binary/bad-function-body-size.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm-interp
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-function-local-type.txt
+++ b/test/binary/bad-function-local-type.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-function-names-too-many.txt
+++ b/test/binary/bad-function-names-too-many.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-function-param-type.txt
+++ b/test/binary/bad-function-param-type.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) {

--- a/test/binary/bad-function-result-type.txt
+++ b/test/binary/bad-function-result-type.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) {

--- a/test/binary/bad-function-sig.txt
+++ b/test/binary/bad-function-sig.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[1] i32 results[1] i32 }

--- a/test/binary/bad-function-too-many-results.txt
+++ b/test/binary/bad-function-too-many-results.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[2] i32 i32 }

--- a/test/binary/bad-import-sig.txt
+++ b/test/binary/bad-import-sig.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-magic.txt
+++ b/test/binary/bad-magic.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 0 "ASM"
 version
 (;; STDERR ;;;

--- a/test/binary/bad-memory-init-max-size.txt
+++ b/test/binary/bad-memory-init-max-size.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(MEMORY) {

--- a/test/binary/bad-memory-init-size.txt
+++ b/test/binary/bad-memory-init-size.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(MEMORY) {

--- a/test/binary/bad-memory-max-size.txt
+++ b/test/binary/bad-memory-max-size.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(MEMORY) {

--- a/test/binary/bad-name-section-invalid-index.txt
+++ b/test/binary/bad-name-section-invalid-index.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-name-section-location.txt
+++ b/test/binary/bad-name-section-location.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-names-duplicate-locals.txt
+++ b/test/binary/bad-names-duplicate-locals.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-names-duplicates.txt
+++ b/test/binary/bad-names-duplicates.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 ;; This test file contains a name section that names that same function twice
 magic
 version

--- a/test/binary/bad-names-function-locals-out-of-order.txt
+++ b/test/binary/bad-names-function-locals-out-of-order.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-names-locals-out-of-order.txt
+++ b/test/binary/bad-names-locals-out-of-order.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-names-out-of-order.txt
+++ b/test/binary/bad-names-out-of-order.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 ;; This test file contains two functions, but their names are listed in the
 ;; names section out of order (1 first, then 0) which is an error.
 magic

--- a/test/binary/bad-op-after-end.txt
+++ b/test/binary/bad-op-after-end.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-section-ends-early.txt
+++ b/test/binary/bad-section-ends-early.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section_code[TYPE]

--- a/test/binary/bad-section-size-zero.txt
+++ b/test/binary/bad-section-size-zero.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section_code[1] section_size[0]

--- a/test/binary/bad-segment-no-memory.txt
+++ b/test/binary/bad-segment-no-memory.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(DATA) {

--- a/test/binary/bad-start-func.txt
+++ b/test/binary/bad-start-func.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-subsection-out-of-order.txt
+++ b/test/binary/bad-subsection-out-of-order.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-subsection-size.txt
+++ b/test/binary/bad-subsection-size.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-subsection-unfinished.txt
+++ b/test/binary/bad-subsection-unfinished.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }

--- a/test/binary/bad-type-form.txt
+++ b/test/binary/bad-type-form.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) {

--- a/test/binary/bad-typecheck-missing-drop.txt
+++ b/test/binary/bad-typecheck-missing-drop.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 version
 section(TYPE) { count[1] function params[0] results[0] }

--- a/test/binary/bad-version.txt
+++ b/test/binary/bad-version.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 magic
 0xe 0 0 0
 (;; STDERR ;;;

--- a/test/binary/gen-wasm-parse-error.txt
+++ b/test/binary/gen-wasm-parse-error.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-gen-wasm
+;;; ERROR: 1
 section(TYPE) { foo }
 (;; STDERR ;;;
 Error running "gen-wasm.py":

--- a/test/dump/bad-version-logging.txt
+++ b/test/dump/bad-version-logging.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: run-objdump-gen-wasm
 ;;; ARGS1: --debug
+;;; ERROR1: 1
 magic
 0xe 0 0 0
 (;; STDERR ;;;

--- a/test/dump/bad-version.txt
+++ b/test/dump/bad-version.txt
@@ -1,5 +1,5 @@
-;;; ERROR: 1
 ;;; TOOL: run-objdump-gen-wasm
+;;; ERROR1: 1
 magic
 0xe 0 0 0
 (;; STDERR ;;;

--- a/test/parse/expr/bad-const-v128-nat-expected.txt
+++ b/test/parse/expr/bad-const-v128-nat-expected.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: wat2wasm
 ;;; ARGS: --enable-simd
+;;; ERROR: 1
 (module
   (func v128.const i32 0x12345678 -123 0x00000000 0xabcd3478))
 (module

--- a/test/parse/expr/bad-const-v128-nat-overflow.txt
+++ b/test/parse/expr/bad-const-v128-nat-overflow.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: wat2wasm
 ;;; ARGS: --enable-simd
+;;; ERROR: 1
 (module
   (func v128.const i32 0x12345678 0x123 4294967296 0xabcd3478))
 (;; STDERR ;;;

--- a/test/parse/expr/bad-const-v128-type-i32-expected.txt
+++ b/test/parse/expr/bad-const-v128-type-i32-expected.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: wat2wasm
 ;;; ARGS: --enable-simd
+;;; ERROR: 1
 (module (func v128.const 0x12345678 0x00000000 0x00000000 0xabcd3478))
 (module (func v128.const i64 0x12345678 0x00000000 0x00000000 0xabcd3478))
 (;; STDERR ;;;

--- a/test/parse/force-color.txt
+++ b/test/parse/force-color.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: wat2wasm
 ;;; ENV: FORCE_COLOR=1
+;;; ERROR: 1
 (module
   (func badname (param i32) (result badtype)
     drop))

--- a/test/regress/regress-17.txt
+++ b/test/regress/regress-17.txt
@@ -1,5 +1,5 @@
+;;; RUN: %(wast2json)s %(in_file)s
 ;;; ERROR: 1
-;;; TOOL: run-interp-spec
 (module (func (export "foo") (param i64)))
 
 ;; Make sure that the error below has the correct location.

--- a/test/typecheck/bad-atomic-no-shared-memory.txt
+++ b/test/typecheck/bad-atomic-no-shared-memory.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: wat2wasm
 ;;; ARGS: --enable-threads
+;;; ERROR: 1
 
 (module
   (memory 1)

--- a/test/typecheck/bad-atomic-type-mismatch.txt
+++ b/test/typecheck/bad-atomic-type-mismatch.txt
@@ -1,6 +1,6 @@
-;;; ERROR: 1
 ;;; TOOL: wat2wasm
 ;;; ARGS: --enable-threads
+;;; ERROR: 1
 
 (module
   (memory 1 1 shared)


### PR DESCRIPTION
Each command can specify its expected returncode. If the returncode
doesn't match when the command is run, then no further commands are run
for that test.

This change also requires all ERROR directives to be specified after the
RUN commands, since they are added to a command in the same way as ARGS.