### PR TITLE
Fixes for building libwabt.js with latest Emscripten

### DIFF
--- a/src/wabt.post.js
+++ b/src/wabt.post.js
@@ -47,7 +47,7 @@ function allocateBuffer(buf) {
   if (buf instanceof ArrayBuffer) {
     size = buf.byteLength;
     addr = malloc(size);
-     (new Uint8Array(HEAP8.buffer, addr, size)).set(new Uint8Array(buf))
+    (new Uint8Array(HEAP8.buffer, addr, size)).set(new Uint8Array(buf))
   } else if (ArrayBuffer.isView(buf)) {
     size = buf.buffer.byteLength;
     addr = malloc(size);

--- a/src/wabt.post.js
+++ b/src/wabt.post.js
@@ -47,15 +47,15 @@ function allocateBuffer(buf) {
   if (buf instanceof ArrayBuffer) {
     size = buf.byteLength;
     addr = malloc(size);
-    (new Uint8Array(Module.buffer, addr, size)).set(new Uint8Array(buf))
+     (new Uint8Array(HEAP8.buffer, addr, size)).set(new Uint8Array(buf))
   } else if (ArrayBuffer.isView(buf)) {
     size = buf.buffer.byteLength;
     addr = malloc(size);
-    (new Uint8Array(Module.buffer, addr, size)).set(buf);
+    (new Uint8Array(HEAP8.buffer, addr, size)).set(buf);
   } else if (typeof buf == 'string') {
     size = buf.length;
     addr = malloc(size);
-    Module.writeAsciiToMemory(buf, addr, true);  // don't null-terminate
+    writeAsciiToMemory(buf, addr, true);  // don't null-terminate
   } else {
     throw new Error('unknown buffer type: ' + buf);
   }
@@ -65,7 +65,7 @@ function allocateBuffer(buf) {
 function allocateCString(s) {
   var size = s.length;
   var addr = malloc(size);
-  Module.writeAsciiToMemory(s, addr);
+  writeAsciiToMemory(s, addr);
   return {addr: addr, size: size};
 }
 
@@ -111,7 +111,7 @@ OutputBuffer.prototype.toString = function() {
 
   var addr = Module._wabt_output_buffer_get_data(this.addr);
   var size = Module._wabt_output_buffer_get_size(this.addr);
-  return Module.Pointer_stringify(addr, size);
+  return Pointer_stringify(addr, size);
 };
 
 OutputBuffer.prototype.destroy = function() {
@@ -134,7 +134,7 @@ ErrorHandler.prototype = Object.create(Object.prototype);
 ErrorHandler.prototype.getMessage = function() {
   var addr = Module._wabt_error_handler_buffer_get_data(this.addr);
   var size = Module._wabt_error_handler_buffer_get_size(this.addr);
-  return Module.Pointer_stringify(addr, size);
+  return Pointer_stringify(addr, size);
 }
 
 ErrorHandler.prototype.destroy = function() {


### PR DESCRIPTION
Seems that some of the library functions are no longer exported by default. This PR should fix their uses in `wabt.post.js` by calling them directly.