### PR TITLE
fix path for windows cmake build

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ So, for example, if you want to build the debug configuration on Visual Studio 2
 > mkdir build
 > cd build
 > cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=..\bin -G "Visual Studio 14 2015"
-> cmake --build .. --config DEBUG --target install
+> cmake --build . --config DEBUG --target install
 ```
 
 ## Changing the lexer


### PR DESCRIPTION
cmake --build .. --config DEBUG --target install
should be
cmake --build . --config DEBUG --target install

It was produsing error otherwise: Error: could not load cache, because it pointer to wabt directory and not wabt\build