### PR TITLE
Don't allow memory to be shared by default

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -259,7 +259,6 @@ struct Limits {
   bool has_max = false;
   bool is_shared = false;
 };
-enum class LimitsShareable { Allowed, NotAllowed };
 
 enum { WABT_USE_NATURAL_ALIGNMENT = 0xFFFFFFFF };
 

--- a/test/parse/module/bad-memory-shared-nomax.txt
+++ b/test/parse/module/bad-memory-shared-nomax.txt
@@ -1,9 +1,10 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --enable-threads
 ;;; ERROR: 1
 (module (memory 1 shared))
 
 (;; STDERR ;;;
-out/test/parse/module/bad-memory-shared-nomax.txt:3:10: error: shared memories must have max sizes
+out/test/parse/module/bad-memory-shared-nomax.txt:4:10: error: shared memories must have max sizes
 (module (memory 1 shared))
          ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/import-memory-shared.txt
+++ b/test/parse/module/import-memory-shared.txt
@@ -1,3 +1,4 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --enable-threads
 (module
   (import "foo" "2" (memory 0 2 shared)))

--- a/test/parse/module/memory-shared.txt
+++ b/test/parse/module/memory-shared.txt
@@ -1,2 +1,3 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --enable-threads
 (module (memory 1 1 shared))

--- a/test/typecheck/bad-no-shared-memory.txt
+++ b/test/typecheck/bad-no-shared-memory.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (memory 1 1 shared))
+(;; STDERR ;;;
+out/test/typecheck/bad-no-shared-memory.txt:3:10: error: memories may not be shared
+(module (memory 1 1 shared))
+         ^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
Shared memory is only allowed with the `--enable-threads` flag.