### PR TITLE
Update testsuite

### DIFF
--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -847,7 +847,11 @@ class SpectestHostImportDelegate : public HostImportDelegate {
                           interp::Func* func,
                           interp::FuncSignature* func_sig,
                           const ErrorCallback& callback) override {
-    if (import->field_name == "print") {
+    if (import->field_name == "print" || import->field_name == "print_i32" ||
+        import->field_name == "print_f32" ||
+        import->field_name == "print_f64" ||
+        import->field_name == "print_i32_f32" ||
+        import->field_name == "print_f64_f64") {
       cast<HostFunc>(func)->callback = DefaultHostCallback;
       return wabt::Result::Ok;
     } else {
@@ -891,34 +895,23 @@ class SpectestHostImportDelegate : public HostImportDelegate {
   wabt::Result ImportGlobal(interp::GlobalImport* import,
                             interp::Global* global,
                             const ErrorCallback& callback) override {
-    if (import->field_name == "global") {
-      switch (global->typed_value.type) {
-        case Type::I32:
-          global->typed_value.value.i32 = 666;
-          break;
-
-        case Type::F32: {
-          float value = 666.6f;
-          memcpy(&global->typed_value.value.f32_bits, &value, sizeof(value));
-          break;
-        }
-
-        case Type::I64:
-          global->typed_value.value.i64 = 666;
-          break;
-
-        case Type::F64: {
-          double value = 666.6;
-          memcpy(&global->typed_value.value.f64_bits, &value, sizeof(value));
-          break;
-        }
-
-        default:
-          PrintError(callback, "bad type for host global import " PRIimport,
-                     PRINTF_IMPORT_ARG(*import));
-          return wabt::Result::Error;
-      }
-
+    if (import->field_name == "global_i32") {
+      global->typed_value.type = Type::I32;
+      global->typed_value.value.i32 = 666;
+      return wabt::Result::Ok;
+    } else if (import->field_name == "global_f32") {
+      global->typed_value.type = Type::F32;
+      float value = 666.6f;
+      memcpy(&global->typed_value.value.f32_bits, &value, sizeof(value));
+      return wabt::Result::Ok;
+    } else if (import->field_name == "global_i64") {
+      global->typed_value.type = Type::I64;
+      global->typed_value.value.i64 = 666;
+      return wabt::Result::Ok;
+    } else if (import->field_name == "global_f64") {
+      global->typed_value.type = Type::F64;
+      double value = 666.6;
+      memcpy(&global->typed_value.value.f64_bits, &value, sizeof(value));
       return wabt::Result::Ok;
     } else {
       PrintError(callback, "unknown host global import " PRIimport,

--- a/test/spec-wasm2c-prefix.c
+++ b/test/spec-wasm2c-prefix.c
@@ -270,43 +270,45 @@ void wasm_rt_allocate_table(wasm_rt_table_t* table,
 /*
  * spectest implementations
  */
-static void spectest_print_vv(void) {
+static void spectest_print(void) {
   printf("spectest.print()\n");
 }
 
-static void spectest_print_vi(uint32_t i) {
-  printf("spectest.print(%d)\n", i);
+static void spectest_print_i32(uint32_t i) {
+  printf("spectest.print_i32(%d)\n", i);
 }
 
-static void spectest_print_vf(float f) {
-  printf("spectest.print(%g)\n", f);
+static void spectest_print_f32(float f) {
+  printf("spectest.print_f32(%g)\n", f);
 }
 
-static void spectest_print_vif(uint32_t i, float f) {
-  printf("spectest.print(%d %g)\n", i, f);
+static void spectest_print_i32_f32(uint32_t i, float f) {
+  printf("spectest.print_i32_f32(%d %g)\n", i, f);
 }
 
-static void spectest_print_vd(double d) {
-  printf("spectest.print(%g)\n", d);
+static void spectest_print_f64(double d) {
+  printf("spectest.print_f64(%g)\n", d);
 }
 
-static void spectest_print_vdd(double d1, double d2) {
-  printf("spectest.print(%g %g)\n", d1, d2);
+static void spectest_print_f64_f64(double d1, double d2) {
+  printf("spectest.print_f64_f64(%g %g)\n", d1, d2);
 }
 
 static wasm_rt_table_t spectest_table;
 static wasm_rt_memory_t spectest_memory;
-static uint32_t spectest_global = 666;
+static uint32_t spectest_global_i32 = 666;
 
-void (*Z_spectestZ_printZ_vv)(void) = &spectest_print_vv;
-void (*Z_spectestZ_printZ_vi)(uint32_t) = &spectest_print_vi;
-void (*Z_spectestZ_printZ_vf)(float) = &spectest_print_vf;
-void (*Z_spectestZ_printZ_vif)(uint32_t, float) = &spectest_print_vif;
-void (*Z_spectestZ_printZ_vd)(double) = &spectest_print_vd;
-void (*Z_spectestZ_printZ_vdd)(double, double) = &spectest_print_vdd;
+void (*Z_spectestZ_printZ_vv)(void) = &spectest_print;
+void (*Z_spectestZ_print_i32Z_vi)(uint32_t) = &spectest_print_i32;
+void (*Z_spectestZ_print_f32Z_vf)(float) = &spectest_print_f32;
+void (*Z_spectestZ_print_i32_f32Z_vif)(uint32_t,
+                                       float) = &spectest_print_i32_f32;
+void (*Z_spectestZ_print_f64Z_vd)(double) = &spectest_print_f64;
+void (*Z_spectestZ_print_f64_f64Z_vdd)(double,
+                                       double) = &spectest_print_f64_f64;
 wasm_rt_table_t* Z_spectestZ_table = &spectest_table;
 wasm_rt_memory_t* Z_spectestZ_memory = &spectest_memory;
-uint32_t* Z_spectestZ_globalZ_i = &spectest_global;
+uint32_t* Z_spectestZ_global_i32Z_i = &spectest_global_i32;
 
 static void init_spectest_module(void) {
   wasm_rt_allocate_memory(&spectest_memory, 1, 2);

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func_ptrs.wast
 (;; STDOUT ;;;
-called host spectest.print(i32:83) =>
+called host spectest.print_i32(i32:83) =>
 four(i32:83) =>
 out/test/spec/func_ptrs.wast:32: assert_invalid passed:
   000000b: error: elem section without table section
@@ -16,6 +16,6 @@ out/test/spec/func_ptrs.wast:44: assert_invalid passed:
 out/test/spec/func_ptrs.wast:48: assert_invalid passed:
   000000c: error: invalid function signature index: 42
 out/test/spec/func_ptrs.wast:49: assert_invalid passed:
-  000001c: error: invalid import signature index
+  0000020: error: invalid import signature index
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -41,9 +41,9 @@ out/test/spec/globals.wast:120: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
 out/test/spec/globals.wast:128: assert_malformed passed:
-  0000022: error: global mutability must be 0 or 1
+  0000019: error: unable to read string: import field name
 out/test/spec/globals.wast:141: assert_malformed passed:
-  0000022: error: global mutability must be 0 or 1
+  0000019: error: unable to read string: import field name
 out/test/spec/globals.wast:158: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
 out/test/spec/globals.wast:170: assert_malformed passed:

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -1,16 +1,16 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/imports.wast
 (;; STDOUT ;;;
-called host spectest.print(i32:13) =>
-called host spectest.print(i32:14, f32:42.000000) =>
-called host spectest.print(i32:13) =>
-called host spectest.print(i32:13) =>
-called host spectest.print(f32:13.000000) =>
-called host spectest.print(i32:13) =>
-called host spectest.print(f64:25.000000, f64:53.000000) =>
-called host spectest.print(f64:24.000000) =>
-called host spectest.print(f64:24.000000) =>
-called host spectest.print(f64:24.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32_f32(i32:14, f32:42.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f32(f32:13.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f64_f64(f64:25.000000, f64:53.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/imports.wast:99: assert_unlinkable passed:
   error: unknown module field "unknown"
   0000020: error: OnImportFunc callback failed
@@ -75,8 +75,8 @@ out/test/spec/imports.wast:181: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind func, not memory
   0000025: error: OnImportFunc callback failed
 out/test/spec/imports.wast:185: assert_unlinkable passed:
-  error: unknown host function import "spectest.global"
-  0000023: error: OnImportFunc callback failed
+  error: unknown host function import "spectest.global_i32"
+  0000027: error: OnImportFunc callback failed
 out/test/spec/imports.wast:189: assert_unlinkable passed:
   error: unknown host function import "spectest.table"
   0000022: error: OnImportFunc callback failed
@@ -99,8 +99,8 @@ out/test/spec/imports.wast:244: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind global, not memory
   0000020: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:248: assert_unlinkable passed:
-  error: unknown host global import "spectest.print"
-  000001d: error: OnImportGlobal callback failed
+  error: unknown host global import "spectest.print_i32"
+  0000021: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:252: assert_unlinkable passed:
   error: unknown host global import "spectest.table"
   000001d: error: OnImportGlobal callback failed
@@ -143,8 +143,8 @@ out/test/spec/imports.wast:361: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind table, not memory
   0000021: error: OnImportTable callback failed
 out/test/spec/imports.wast:365: assert_unlinkable passed:
-  error: unknown host table import "spectest.print"
-  000001e: error: OnImportTable callback failed
+  error: unknown host table import "spectest.print_i32"
+  0000022: error: OnImportTable callback failed
 out/test/spec/imports.wast:397: assert_invalid passed:
   error: unknown import module ""
   0000010: error: OnImportMemory callback failed
@@ -181,11 +181,11 @@ out/test/spec/imports.wast:454: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind memory, not table
   0000020: error: OnImportMemory callback failed
 out/test/spec/imports.wast:458: assert_unlinkable passed:
-  error: unknown host memory import "spectest.print"
-  000001d: error: OnImportMemory callback failed
+  error: unknown host memory import "spectest.print_i32"
+  0000021: error: OnImportMemory callback failed
 out/test/spec/imports.wast:462: assert_unlinkable passed:
-  error: unknown host memory import "spectest.global"
-  000001e: error: OnImportMemory callback failed
+  error: unknown host memory import "spectest.global_i32"
+  0000022: error: OnImportMemory callback failed
 out/test/spec/imports.wast:466: assert_unlinkable passed:
   error: unknown host memory import "spectest.table"
   000001d: error: OnImportMemory callback failed
@@ -259,5 +259,8 @@ out/test/spec/imports.wast:556: assert_malformed passed:
   out/test/spec/imports/imports.114.wat:1:13: error: imports must occur before all non-import definitions
   (memory 0) (import "" "" (memory 1 2))
               ^^^^^^
-107/107 tests passed.
+out/test/spec/imports.wast:564: assert_unlinkable passed:
+  error: unknown import module "not wasm"
+  000004d: error: OnImportFunc callback failed
+108/108 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/labels.txt
+++ b/test/spec/labels.txt
@@ -1,14 +1,14 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/labels.wast
 (;; STDOUT ;;;
-out/test/spec/labels.wast:303: assert_invalid passed:
+out/test/spec/labels.wast:311: assert_invalid passed:
   error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/labels.wast:307: assert_invalid passed:
+out/test/spec/labels.wast:315: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
-out/test/spec/labels.wast:311: assert_invalid passed:
+out/test/spec/labels.wast:319: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
-27/27 tests passed.
+28/28 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -62,7 +62,7 @@ out/test/spec/memory.wast:105: assert_unlinkable passed:
   0000016: error: OnDataSegmentData callback failed
 out/test/spec/memory.wast:114: assert_unlinkable passed:
   error: data segment is out of bounds: [666, 667) >= max value 0
-  000002c: error: OnDataSegmentData callback failed
+  0000030: error: OnDataSegmentData callback failed
 out/test/spec/memory.wast:131: assert_invalid passed:
   000000e: error: memory initial size must be <= max size
 out/test/spec/memory.wast:135: assert_invalid passed:

--- a/test/spec/names.txt
+++ b/test/spec/names.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/names.wast
 (;; STDOUT ;;;
-called host spectest.print(i32:42) =>
-called host spectest.print(i32:123) =>
+called host spectest.print_i32(i32:42) =>
+called host spectest.print_i32(i32:123) =>
 475/475 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -13,8 +13,8 @@ inc() =>
 inc() =>
 inc() =>
 inc() =>
-called host spectest.print(i32:1) =>
-called host spectest.print(i32:2) =>
+called host spectest.print_i32(i32:1) =>
+called host spectest.print_i32(i32:2) =>
 called host spectest.print() =>
 14/14 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/func_ptrs.txt
+++ b/test/wasm2c/spec/func_ptrs.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/func_ptrs.wast
 (;; STDOUT ;;;
-spectest.print(83)
+spectest.print_i32(83)
 25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/imports.txt
+++ b/test/wasm2c/spec/imports.txt
@@ -2,15 +2,15 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/imports.wast
 (;; STDOUT ;;;
-spectest.print(13)
-spectest.print(14 42)
-spectest.print(13)
-spectest.print(13)
-spectest.print(13)
-spectest.print(13)
-spectest.print(25 53)
-spectest.print(24)
-spectest.print(24)
-spectest.print(24)
+spectest.print_i32(13)
+spectest.print_i32_f32(14 42)
+spectest.print_i32(13)
+spectest.print_i32(13)
+spectest.print_f32(13)
+spectest.print_i32(13)
+spectest.print_f64_f64(25 53)
+spectest.print_f64(24)
+spectest.print_f64(24)
+spectest.print_f64(24)
 29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/labels.txt
+++ b/test/wasm2c/spec/labels.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/labels.wast
 (;; STDOUT ;;;
-24/24 tests passed.
+25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/names.txt
+++ b/test/wasm2c/spec/names.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/names.wast
 (;; STDOUT ;;;
-spectest.print(42)
-spectest.print(123)
+spectest.print_i32(42)
+spectest.print_i32(123)
 475/475 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/start.txt
+++ b/test/wasm2c/spec/start.txt
@@ -1,8 +1,8 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/start.wast
 (;; STDOUT ;;;
-spectest.print(1)
-spectest.print(2)
+spectest.print_i32(1)
+spectest.print_i32(2)
 spectest.print()
 6/6 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
The spectest module's functions and globals are no longer overloaded, so
their implementations in `spectest-interp` and `spec-wasm2c-prefix.c`
have to be changed as well.