### PR TITLE
Match value type enum to spec values and read/write as uint8_t

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -268,12 +268,8 @@ Result BinaryReader::ReadS64Leb128(uint64_t* out_value, const char* desc) {
 }
 
 Result BinaryReader::ReadType(Type* out_value, const char* desc) {
-  uint32_t type = 0;
-  CHECK_RESULT(ReadS32Leb128(&type, desc));
-  // Must be in the vs7 range: [-128, 127).
-  ERROR_UNLESS(
-      static_cast<int32_t>(type) >= -128 && static_cast<int32_t>(type) <= 127,
-      "invalid type: %d", type);
+  uint8_t type = 0;
+  CHECK_RESULT(ReadU8(&type, desc));
   *out_value = static_cast<Type>(type);
   return Result::Ok;
 }
@@ -1516,7 +1512,7 @@ Result BinaryReader::ReadTypeSection(Offset section_size) {
       Type param_type;
       CHECK_RESULT(ReadType(&param_type, "function param type"));
       ERROR_UNLESS(is_concrete_type(param_type),
-                   "expected valid param type (got %d)",
+                   "expected valid param type (got %#x)",
                    static_cast<int>(param_type));
       param_types_[j] = param_type;
     }
@@ -1529,7 +1525,7 @@ Result BinaryReader::ReadTypeSection(Offset section_size) {
     if (num_results) {
       CHECK_RESULT(ReadType(&result_type, "function result type"));
       ERROR_UNLESS(is_concrete_type(result_type),
-                   "expected valid result type: %d",
+                   "expected valid result type: %#x",
                    static_cast<int>(result_type));
     }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -55,7 +55,7 @@ void WriteOpcode(Stream* stream, Opcode opcode) {
 }
 
 void WriteType(Stream* stream, Type type) {
-  WriteS32Leb128(stream, type, GetTypeName(type));
+  stream->WriteU8Enum(type, GetTypeName(type));
 }
 
 void WriteLimits(Stream* stream, const Limits* limits) {

--- a/src/common.h
+++ b/src/common.h
@@ -194,14 +194,14 @@ struct Location {
 
 /* matches binary format, do not change */
 enum class Type {
-  I32 = -0x01,
-  I64 = -0x02,
-  F32 = -0x03,
-  F64 = -0x04,
-  V128 = -0x05,
-  Anyfunc = -0x10,
-  Func = -0x20,
-  Void = -0x40,
+  I32 = 0x7F,
+  I64 = 0x7E,
+  F32 = 0x7D,
+  F64 = 0x7C,
+  V128 = 0x7B,
+  Anyfunc = 0x70,
+  Func = 0x60,
+  Void = 0x40,
   ___ = Void, /* convenient for the opcode table in opcode.h */
   Any = 0,    /* Not actually specified, but useful for type-checking */
 };

--- a/test/binary/bad-function-param-type.txt
+++ b/test/binary/bad-function-param-type.txt
@@ -6,6 +6,6 @@ section(TYPE) {
   function params[1] void results[0]
 }
 (;; STDERR ;;;
-000000e: error: expected valid param type (got -64)
-000000e: error: expected valid param type (got -64)
+000000e: error: expected valid param type (got 0x40)
+000000e: error: expected valid param type (got 0x40)
 ;;; STDERR ;;)

--- a/test/binary/bad-function-result-type.txt
+++ b/test/binary/bad-function-result-type.txt
@@ -6,6 +6,6 @@ section(TYPE) {
   function params[1] i32 results[1] void
 }
 (;; STDERR ;;;
-0000010: error: expected valid result type: -64
-0000010: error: expected valid result type: -64
+0000010: error: expected valid result type: 0x40
+0000010: error: expected valid result type: 0x40
 ;;; STDERR ;;)


### PR DESCRIPTION
These seems to match what is in the spec where these values
are specified as single type terminals.

See: https://webassembly.github.io/spec/core/binary/types.html