### PR TITLE
Windows warn unused annotation build break

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -103,7 +103,7 @@
 #include <cstring>
 
 #define WABT_UNUSED
-#define WABT_WARN_UNUSED _Check_return_
+#define WABT_WARN_UNUSED
 #define WABT_INLINE __inline
 #define WABT_STATIC_ASSERT(x) _STATIC_ASSERT(x)
 #define WABT_UNLIKELY(x) (x)


### PR DESCRIPTION
Remove _Check_Return_ annotation on Windows because that annotation must be a prefix to the function not a suffix which was breaking the code analysis on binary-reader.cc.

Couldn't find a way to reconcile clang/gcc/msvc to all use a prefix or suffix for that annotation, furthermore it is not used a lot in the project anyway.