### PR TITLE
Store local types as Type+Count pairs

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -328,10 +328,10 @@ Result NameApplier::VisitFunc(Index func_index, Func* func) {
     CHECK_RESULT(UseNameForFuncTypeVar(&func->decl.type_var));
   }
 
-  MakeTypeBindingReverseMapping(func->decl.sig.param_types,
+  MakeTypeBindingReverseMapping(func->decl.sig.param_types.size(),
                                 func->param_bindings, &param_index_to_name_);
 
-  MakeTypeBindingReverseMapping(func->local_types, func->local_bindings,
+  MakeTypeBindingReverseMapping(func->local_types.size(), func->local_bindings,
                                 &local_index_to_name_);
 
   CHECK_RESULT(visitor_.VisitFunc(func));

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -541,12 +541,7 @@ Result BinaryReaderIR::BeginFunctionBody(Index index) {
 }
 
 Result BinaryReaderIR::OnLocalDecl(Index decl_index, Index count, Type type) {
-  TypeVector& types = current_func_->local_types;
-  WABT_TRY
-  types.reserve(types.size() + count);
-  WABT_CATCH_BAD_ALLOC
-  for (size_t i = 0; i < count; ++i)
-    types.push_back(type);
+  current_func_->local_types.decls.emplace_back(type, count);
   return Result::Ok;
 }
 

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1314,7 +1314,7 @@ void CWriter::WriteParams() {
     Write("void");
   } else {
     std::vector<std::string> index_to_name;
-    MakeTypeBindingReverseMapping(func_->decl.sig.param_types,
+    MakeTypeBindingReverseMapping(func_->decl.sig.param_types.size(),
                                   func_->param_bindings, &index_to_name);
     Indent(4);
     for (Index i = 0; i < func_->GetNumParams(); ++i) {
@@ -1333,8 +1333,8 @@ void CWriter::WriteParams() {
 
 void CWriter::WriteLocals() {
   std::vector<std::string> index_to_name;
-  MakeTypeBindingReverseMapping(func_->local_types, func_->local_bindings,
-                                &index_to_name);
+  MakeTypeBindingReverseMapping(func_->local_types.size(),
+                                func_->local_bindings, &index_to_name);
   for (Type type : {Type::I32, Type::I64, Type::F32, Type::F64}) {
     Index local_index = 0;
     size_t count = 0;

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -217,11 +217,11 @@ Result NameGenerator::VisitFunc(Index func_index, Func* func) {
   MaybeGenerateAndBindName(&module_->func_bindings, "$f", func_index,
                            &func->name);
 
-  MakeTypeBindingReverseMapping(func->decl.sig.param_types,
+  MakeTypeBindingReverseMapping(func->decl.sig.param_types.size(),
                                 func->param_bindings, &index_to_name_);
   GenerateAndBindLocalNames(&func->param_bindings, "$p");
 
-  MakeTypeBindingReverseMapping(func->local_types, func->local_bindings,
+  MakeTypeBindingReverseMapping(func->local_types.size(), func->local_bindings,
                                 &index_to_name_);
   GenerateAndBindLocalNames(&func->local_bindings, "$l");
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -862,8 +862,10 @@ Result WastParser::ParseFuncModuleField(Module* module) {
     Func& func = field->func;
     CHECK_RESULT(ParseTypeUseOpt(&func.decl));
     CHECK_RESULT(ParseFuncSignature(&func.decl.sig, &func.param_bindings));
-    CHECK_RESULT(ParseBoundValueTypeList(TokenType::Local, &func.local_types,
+    TypeVector local_types;
+    CHECK_RESULT(ParseBoundValueTypeList(TokenType::Local, &local_types,
                                          &func.local_bindings));
+    func.local_types.Set(local_types);
     CHECK_RESULT(ParseTerminatingInstrList(&func.exprs));
     module->AppendField(std::move(field));
   }

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -150,9 +150,10 @@ class WatWriter {
   void WriteLoadStoreExpr(const Expr* expr);
   void WriteExprList(const ExprList& exprs);
   void WriteInitExpr(const ExprList& expr);
+  template <typename T>
   void WriteTypeBindings(const char* prefix,
                          const Func& func,
-                         const TypeVector& types,
+                         const T& types,
                          const BindingHash& bindings);
   void WriteBeginFunc(const Func& func);
   void WriteFunc(const Func& func);
@@ -1216,11 +1217,12 @@ void WatWriter::WriteInitExpr(const ExprList& expr) {
   }
 }
 
+template <typename T>
 void WatWriter::WriteTypeBindings(const char* prefix,
                                   const Func& func,
-                                  const TypeVector& types,
+                                  const T& types,
                                   const BindingHash& bindings) {
-  MakeTypeBindingReverseMapping(types, bindings, &index_to_name_);
+  MakeTypeBindingReverseMapping(types.size(), bindings, &index_to_name_);
 
   /* named params/locals must be specified by themselves, but nameless
    * params/locals can be compressed, e.g.:
@@ -1228,21 +1230,23 @@ void WatWriter::WriteTypeBindings(const char* prefix,
    *   (param i32 i64 f32)
    */
   bool is_open = false;
-  for (size_t i = 0; i < types.size(); ++i) {
+  size_t index = 0;
+  for (Type type : types) {
     if (!is_open) {
       WriteOpenSpace(prefix);
       is_open = true;
     }
 
-    const std::string& name = index_to_name_[i];
+    const std::string& name = index_to_name_[index];
     if (!name.empty()) {
       WriteString(name, NextChar::Space);
     }
-    WriteType(types[i], NextChar::Space);
+    WriteType(type, NextChar::Space);
     if (!name.empty()) {
       WriteCloseSpace();
       is_open = false;
     }
+    ++index;
   }
   if (is_open) {
     WriteCloseSpace();

--- a/test/regress/regress-20.txt
+++ b/test/regress/regress-20.txt
@@ -1,0 +1,19 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] i32 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[
+      decl_count[1]
+      local_count[leb_i32(3334443763)]  ;; <- huge number of locals
+      42  ;; <- invalid type
+    ]
+  }
+}
+(;; STDERR ;;;
+000001e: error: expected valid local type
+000001e: error: expected valid local type
+;;; STDERR ;;)


### PR DESCRIPTION
Since the binary format stores locals as Type+Count pairs, it is easy to
generate a function with a huge number of locals. The text format has
no way to compress this, so the resulting file will be huge.

However, if the binary file has an error, it would be useful to be able
to catch it without allocating a huge number of locals.

To do so, we store all locals as Type+Count pairs in the IR as well, and
provide accessor functions for getting the number of local types, the
type of a particular local index, etc.

This fixes issue #819.