### PR TITLE
Use `ReadCount` function in BinaryReader

### DIFF
--- a/test/binary/bad-subsection-size.txt
+++ b/test/binary/bad-subsection-size.txt
@@ -18,6 +18,6 @@ section("name") {
   str("$F0")
 }
 (;; STDERR ;;;
-0000027: error: unable to read u32 leb128: function index
-0000027: error: unable to read u32 leb128: function index
+0000027: error: invalid name count 1, only 0 bytes left in section
+0000027: error: invalid name count 1, only 0 bytes left in section
 ;;; STDERR ;;)


### PR DESCRIPTION
See https://github.com/WebAssembly/wabt/issues/760 for more info.

We assume that a count precedes a list of items that are at least one
byte that are all contained in the same section. As a result, we can do
an up-front check to prevent over-allocation. This is the same technique
that the spec interpreter uses.