### PR TITLE
Don't allow the `v128` type without the simd flag

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -95,6 +95,9 @@ class BinaryReader {
   Result ReadOffset(Offset* offset, const char* desc) WABT_WARN_UNUSED;
   Result ReadCount(Index* index, const char* desc) WABT_WARN_UNUSED;
 
+  bool is_concrete_type(Type);
+  bool is_inline_sig_type(Type);
+
   Index NumTotalFuncs();
   Index NumTotalTables();
   Index NumTotalMemories();
@@ -340,21 +343,23 @@ static bool is_valid_external_kind(uint8_t kind) {
   return kind < kExternalKindCount;
 }
 
-static bool is_concrete_type(Type type) {
+bool BinaryReader::is_concrete_type(Type type) {
   switch (type) {
     case Type::I32:
     case Type::I64:
     case Type::F32:
     case Type::F64:
-    case Type::V128:
       return true;
+
+    case Type::V128:
+      return options_->features.simd_enabled();
 
     default:
       return false;
   }
 }
 
-static bool is_inline_sig_type(Type type) {
+bool BinaryReader::is_inline_sig_type(Type type) {
   return is_concrete_type(type) || type == Type::Void;
 }
 

--- a/test/binary/bad-simd-type.txt
+++ b/test/binary/bad-simd-type.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) {
+  count[1] function params[1] v128 results[0]
+}
+(;; STDERR ;;;
+000000e: error: expected valid param type (got 0x7b)
+000000e: error: expected valid param type (got 0x7b)
+;;; STDERR ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -42,6 +42,7 @@ NAMED_VALUES = {
     'i64': 0x7e,  # -2
     'f32': 0x7d,  # -3
     'f64': 0x7c,  # -4
+    'v128': 0x7b,  # -5
     'anyfunc': 0x70,  # -0x10
     'function': 0x60,  # -0x20
     'void': 0x40,  # -0x40


### PR DESCRIPTION
See issue #823.