### PR TITLE
Don't allow a local decl count of 0

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -541,7 +541,7 @@ Result BinaryReaderIR::BeginFunctionBody(Index index) {
 }
 
 Result BinaryReaderIR::OnLocalDecl(Index decl_index, Index count, Type type) {
-  current_func_->local_types.decls.emplace_back(type, count);
+  current_func_->local_types.AppendDecl(type, count);
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1899,6 +1899,7 @@ Result BinaryReader::ReadCodeSection(Offset section_size) {
     for (Index k = 0; k < num_local_decls; ++k) {
       Index num_local_types;
       CHECK_RESULT(ReadIndex(&num_local_types, "local type count"));
+      ERROR_UNLESS(num_local_types > 0, "local count must be > 0");
       Type local_type;
       CHECK_RESULT(ReadType(&local_type, "local type"));
       ERROR_UNLESS(is_concrete_type(local_type), "expected valid local type");

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -628,9 +628,9 @@ void BinaryWriter::WriteFuncLocals(const Func* func,
     return;
   }
 
-  Index local_decl_count = local_types.decls.size();
+  Index local_decl_count = local_types.decls().size();
   WriteU32Leb128(stream_, local_decl_count, "local decl count");
-  for (auto decl : local_types.decls) {
+  for (auto decl : local_types.decls()) {
     WriteU32Leb128(stream_, decl.second, "local type count");
     WriteType(stream_, decl.first);
   }

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -140,7 +140,7 @@ bool Module::IsImport(ExternalKind kind, const Var& var) const {
 }
 
 void LocalTypes::Set(const TypeVector& types) {
-  decls.clear();
+  decls_.clear();
   if (types.empty()) {
     return;
   }
@@ -149,25 +149,25 @@ void LocalTypes::Set(const TypeVector& types) {
   Index count = 1;
   for (Index i = 1; i < types.size(); ++i) {
     if (types[i] != type) {
-      decls.emplace_back(type, count);
+      decls_.emplace_back(type, count);
       type = types[i];
       count = 1;
     } else {
       ++count;
     }
   }
-  decls.emplace_back(type, count);
+  decls_.emplace_back(type, count);
 }
 
 Index LocalTypes::size() const {
   return std::accumulate(
-      decls.begin(), decls.end(), 0,
+      decls_.begin(), decls_.end(), 0,
       [](Index sum, const Decl& decl) { return sum + decl.second; });
 }
 
 Type LocalTypes::operator[](Index i) const {
   Index count = 0;
-  for (auto decl: decls) {
+  for (auto decl: decls_) {
     if (i < count + decl.second) {
       return decl.first;
     }

--- a/src/ir.h
+++ b/src/ir.h
@@ -404,7 +404,8 @@ struct Exception {
   TypeVector sig;
 };
 
-struct LocalTypes {
+class LocalTypes {
+ public:
   typedef std::pair<Type, Index> Decl;
   typedef std::vector<Decl> Decls;
 
@@ -421,13 +422,21 @@ struct LocalTypes {
 
   void Set(const TypeVector&);
 
+  const Decls& decls() const { return decls_; }
+
+  void AppendDecl(Type type, Index count) {
+    assert(count > 0);
+    decls_.emplace_back(type, count);
+  }
+
   Index size() const;
   Type operator[](Index) const;
 
-  const_iterator begin() const { return {decls.begin(), 0}; }
-  const_iterator end() const { return {decls.end(), 0}; }
+  const_iterator begin() const { return {decls_.begin(), 0}; }
+  const_iterator end() const { return {decls_.end(), 0}; }
 
-  Decls decls;
+ private:
+  Decls decls_;
 };
 
 inline LocalTypes::const_iterator& LocalTypes::const_iterator::operator++() {

--- a/test/binary/bad-function-local-count.txt
+++ b/test/binary/bad-function-local-count.txt
@@ -1,0 +1,16 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] sig[0] }
+section(CODE) {
+  count[1]
+  func {
+    local_decls[1]
+    locals[0] i32
+  }
+}
+(;; STDERR ;;;
+0000018: error: local count must be > 0
+0000018: error: local count must be > 0
+;;; STDERR ;;)


### PR DESCRIPTION
Also clean up `LocalTypes` a bit, so we can ensure that `decls_` never
has a count of 0.

Fixes issue #826. Thanks for finding @opticaliqlusion!