### PR TITLE
Fix one bug for converting v128.shuffle from wasm format to wat format.

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -869,7 +869,7 @@ Result WatWriter::ExprVisitorDelegate::OnSimdLaneOpExpr(SimdLaneOpExpr* expr) {
 Result WatWriter::ExprVisitorDelegate::OnSimdShuffleOpExpr(
     SimdShuffleOpExpr* expr) {
   writer_->WritePutsSpace(expr->opcode.GetName());
-  writer_->Writef(" $0x%08x %08x %08x %08x", (expr->val.v[0]), (expr->val.v[1]),
+  writer_->Writef(" 0x%08x 0x%08x 0x%08x 0x%08x", (expr->val.v[0]), (expr->val.v[1]),
                   (expr->val.v[2]), (expr->val.v[3]));
   writer_->WritePutsNewline("");
   return Result::Ok;

--- a/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt
+++ b/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt
@@ -1,0 +1,24 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-simd
+;;; ERROR: 1
+(module
+  (func
+    v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
+    v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
+    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
+    ))
+
+(;; STDERR ;;;
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: lane index must be less than 32 (got 100)
+    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
+    ^^^^^^^^^^^^^
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: lane index must be less than 32 (got 56)
+    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
+    ^^^^^^^^^^^^^
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: lane index must be less than 32 (got 77)
+    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
+    ^^^^^^^^^^^^^
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: type mismatch in function, expected [] but got [v128]
+    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
+    ^^^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/parse/expr/bad-simd-shuffle-nat-expected.txt
+++ b/test/parse/expr/bad-simd-shuffle-nat-expected.txt
@@ -1,0 +1,15 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-simd
+;;; ERROR: 1
+(module
+  (func
+    v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
+    v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
+    v8x16.shuffle $0x01020304 0x05060708 0x090a0b0c 0x00000000
+    ))
+
+(;; STDERR ;;;
+out/test/parse/expr/bad-simd-shuffle-nat-expected.txt:8:19: error: unexpected token "$0x01020304", expected an Nat literal (e.g. 123).
+    v8x16.shuffle $0x01020304 0x05060708 0x090a0b0c 0x00000000
+                  ^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/parse/expr/simd.txt
+++ b/test/parse/expr/simd.txt
@@ -1,0 +1,9 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-simd
+(module
+  (func
+    v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
+    v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
+    v8x16.shuffle 0x01020304 0x05060708 0x090a0b0c 0x00000000
+    drop
+    ))


### PR DESCRIPTION
When converting v128.shuffle from wasm format to wat format, the '$' char
must be removed as the const value in v128.shuffle instruction expects
a valid simd v128 const format,
i.e. 0xXXX 0xXXX 0xXXX 0xXXX or Int32 Int32 Int32 Int32

otherwise it will encounter errors when converting
v128.shuffle from wat format back to wasm format again.