### PR TITLE
Add flag to ignore errors in custom sections

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1425,8 +1425,9 @@ Result ReadBinaryObjdump(const uint8_t* data,
   features.EnableAll();
   const bool kReadDebugNames = true;
   const bool kStopOnFirstError = false;
+  const bool kFailOnCustomSectionError = false;
   ReadBinaryOptions read_options(features, options->log_stream, kReadDebugNames,
-                                 kStopOnFirstError);
+                                 kStopOnFirstError, kFailOnCustomSectionError);
 
   switch (options->mode) {
     case ObjdumpMode::Prepass: {

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -35,16 +35,19 @@ struct ReadBinaryOptions {
   ReadBinaryOptions(const Features& features,
                     Stream* log_stream,
                     bool read_debug_names,
-                    bool stop_on_first_error)
+                    bool stop_on_first_error,
+                    bool fail_on_custom_section_error)
       : features(features),
         log_stream(log_stream),
         read_debug_names(read_debug_names),
-        stop_on_first_error(stop_on_first_error) {}
+        stop_on_first_error(stop_on_first_error),
+        fail_on_custom_section_error(fail_on_custom_section_error) {}
 
   Features features;
   Stream* log_stream = nullptr;
   bool read_debug_names = false;
   bool stop_on_first_error = true;
+  bool fail_on_custom_section_error = true;
 };
 
 class BinaryReaderDelegate {

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1091,8 +1091,9 @@ static wabt::Result ReadModule(string_view module_filename,
   if (Succeeded(result)) {
     const bool kReadDebugNames = true;
     const bool kStopOnFirstError = true;
+    const bool kFailOnCustomSectionError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
-                              kStopOnFirstError);
+                              kStopOnFirstError, kFailOnCustomSectionError);
     result = ReadBinaryInterp(env, file_data.data(), file_data.size(),
                               &options, error_handler, out_module);
 

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -139,8 +139,9 @@ static wabt::Result ReadModule(const char* module_filename,
   if (Succeeded(result)) {
     const bool kReadDebugNames = true;
     const bool kStopOnFirstError = true;
+    const bool kFailOnCustomSectionError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
-                              kStopOnFirstError);
+                              kStopOnFirstError, kFailOnCustomSectionError);
     result = ReadBinaryInterp(env, file_data.data(), file_data.size(),
                               &options, error_handler, out_module);
 

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -34,6 +34,7 @@ static int s_verbose;
 static std::string s_infile;
 static Features s_features;
 static bool s_read_debug_names = true;
+static bool s_fail_on_custom_section_error = true;
 static std::unique_ptr<FileStream> s_log_stream;
 
 static const char s_description[] =
@@ -55,6 +56,9 @@ static void ParseOptions(int argc, char** argv) {
   s_features.AddOptions(&parser);
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });
+  parser.AddOption("ignore-custom-section-errors",
+                   "Ignore errors in custom sections",
+                   []() { s_fail_on_custom_section_error = false; });
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) {
                        s_infile = argument;
@@ -76,7 +80,8 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
-                              s_read_debug_names, kStopOnFirstError);
+                              s_read_debug_names, kStopOnFirstError,
+                              s_fail_on_custom_section_error);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(),
                           file_data.size(), &options, &error_handler, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -115,8 +115,10 @@ int ProgramMain(int argc, char** argv) {
     ErrorHandlerFile error_handler(Location::Type::Binary);
     Module module;
     const bool kStopOnFirstError = true;
+    const bool kFailOnCustomSectionError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
-                              s_read_debug_names, kStopOnFirstError);
+                              s_read_debug_names, kStopOnFirstError,
+                              kFailOnCustomSectionError);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           &options, &error_handler, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -41,6 +41,7 @@ static Features s_features;
 static WriteWatOptions s_write_wat_options;
 static bool s_generate_names;
 static bool s_read_debug_names = true;
+static bool s_fail_on_custom_section_error = true;
 static std::unique_ptr<FileStream> s_log_stream;
 static bool s_validate = true;
 
@@ -80,6 +81,9 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_write_wat_options.inline_import = true; });
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });
+  parser.AddOption("ignore-custom-section-errors",
+                   "Ignore errors in custom sections",
+                   []() { s_fail_on_custom_section_error = false; });
   parser.AddOption(
       "generate-names",
       "Give auto-generated names to non-named functions, types, etc.",
@@ -107,7 +111,8 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
-                              s_read_debug_names, kStopOnFirstError);
+                              s_read_debug_names, kStopOnFirstError,
+                              s_fail_on_custom_section_error);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(),
                           file_data.size(), &options, &error_handler, &module);
     if (Succeeded(result)) {

--- a/test/binary/ignore-custom-section-error.txt
+++ b/test/binary/ignore-custom-section-error.txt
@@ -18,7 +18,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-*ERROR*: @0x00000015: unfinished sub-section (expected end: 0x16)
+*ERROR*: @0x00000019: unable to read u32 leb128: subsection size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
@@ -28,7 +28,6 @@ Section Details:
 
 Custom:
  - name: "linking"
-  - stack pointer global: 3
 Type:
  - type[0] () -> nil
 Function:

--- a/test/binary/ignore-custom-section-error.txt
+++ b/test/binary/ignore-custom-section-error.txt
@@ -1,0 +1,42 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS: -x
+magic
+version
+section("linking") {
+  1 2 3 4 5 6 7
+}
+
+;; Some dummy data to make sure the module is still parsed after the invalid
+;; linking section.
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    return
+  }
+}
+(;; STDERR ;;;
+*ERROR*: @0x00000015: unfinished sub-section (expected end: 0x16)
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+ignore-custom-section-error.wasm:	file format wasm 0x1
+
+Section Details:
+
+Custom:
+ - name: "linking"
+  - stack pointer global: 3
+Type:
+ - type[0] () -> nil
+Function:
+ - func[0] sig=0
+
+Code Disassembly:
+
+000026 func[0]:
+ 000028: 0f                         | return
+ 000029: 0b                         | end
+;;; STDOUT ;;)

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -19,4 +19,5 @@ options:
       --enable-simd                           SIMD support
       --enable-threads                        Threading support
       --no-debug-names                        Ignore debug names in the binary file
+      --ignore-custom-section-errors          Ignore errors in custom sections
 ;;; STDOUT ;;)

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -27,6 +27,7 @@ options:
       --inline-exports                        Write all exports inline
       --inline-imports                        Write all imports inline
       --no-debug-names                        Ignore debug names in the binary file
+      --ignore-custom-section-errors          Ignore errors in custom sections
       --generate-names                        Give auto-generated names to non-named functions, types, etc.
       --no-check                              Don't check for invalid modules
 ;;; STDOUT ;;)


### PR DESCRIPTION
If a wasm engine fails to parse a custom section, it must not be an
error. In wabt we often won't want to continue if a custom section can't
be parsed, but it still may be useful to be able to continue.

This change adds a new flag `--ignore-custom-section-errors` to
`wasm2wat` and `wasm-validate`, which will partially parse a custom
section with errors. This could lead to some strange behavior (partially
completed data structures), but generally should be safe to do.

See issue #378 and the discussion on pull #830 for more info.