### PR TITLE
Fix bug with --ignore-custom-section-errors flag

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1984,12 +1984,15 @@ Result BinaryReader::ReadSections() {
 
     CALLBACK(BeginSection, section, section_size);
 
+    bool stop_on_first_error = options_->stop_on_first_error;
     Result section_result = Result::Error;
     switch (section) {
       case BinarySection::Custom:
         section_result = ReadCustomSection(section_size);
         if (options_->fail_on_custom_section_error) {
           result |= section_result;
+        } else {
+          stop_on_first_error = false;
         }
         break;
       case BinarySection::Type:
@@ -2041,7 +2044,7 @@ Result BinaryReader::ReadSections() {
     }
 
     if (Failed(section_result)) {
-      if (options_->stop_on_first_error) {
+      if (stop_on_first_error) {
         return Result::Error;
       }
 

--- a/test/binary/ignore-custom-section-error-objdump.txt
+++ b/test/binary/ignore-custom-section-error-objdump.txt
@@ -22,7 +22,7 @@ section(CODE) {
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
-ignore-custom-section-error.wasm:	file format wasm 0x1
+ignore-custom-section-error-objdump.wasm:	file format wasm 0x1
 
 Section Details:
 

--- a/test/binary/ignore-custom-section-error-wasm2wat.txt
+++ b/test/binary/ignore-custom-section-error-wasm2wat.txt
@@ -1,0 +1,30 @@
+;;; TOOL: run-gen-wasm
+;;; ARGS1: --ignore-custom-section-errors
+;;; ARGS2: --ignore-custom-section-errors
+magic
+version
+section("linking") {
+  1 2 3 4 5 6 7
+}
+
+;; Some dummy data to make sure the module is still parsed after the invalid
+;; linking section.
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    return
+  }
+}
+(;; STDERR ;;;
+0000019: error: unable to read u32 leb128: subsection size
+0000019: error: unable to read u32 leb128: subsection size
+;;; STDERR ;;)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    return))
+;;; STDOUT ;;)


### PR DESCRIPTION
If the `stop_on_first_error` flag was set, it would still stop
reading the wasm file, even if `--ignore-custom-section-errors` flag was
set.

Fixes issue #836.