### PR TITLE
Print "warning" for ignored custom section errors

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -50,7 +50,7 @@ class BinaryReaderIR : public BinaryReaderNop {
                  const char* filename,
                  ErrorHandler* error_handler);
 
-  bool OnError(const char* message) override;
+  bool OnError(ErrorLevel, const char* message) override;
 
   Result OnTypeCount(Index count) override;
   Result OnType(Index index,
@@ -222,7 +222,7 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
 
  private:
-  bool HandleError(Offset offset, const char* message);
+  bool HandleError(ErrorLevel, Offset offset, const char* message);
   Location GetLocation() const;
   void PrintError(const char* format, ...);
   void PushLabel(LabelType label_type,
@@ -257,7 +257,7 @@ Location BinaryReaderIR::GetLocation() const {
 void WABT_PRINTF_FORMAT(2, 3) BinaryReaderIR::PrintError(const char* format,
                                                          ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  HandleError(kInvalidOffset, buffer);
+  HandleError(ErrorLevel::Error, kInvalidOffset, buffer);
 }
 
 void BinaryReaderIR::PushLabel(LabelType label_type,
@@ -299,12 +299,14 @@ Result BinaryReaderIR::AppendExpr(std::unique_ptr<Expr> expr) {
   return Result::Ok;
 }
 
-bool BinaryReaderIR::HandleError(Offset offset, const char* message) {
-  return error_handler_->OnError(offset, message);
+bool BinaryReaderIR::HandleError(ErrorLevel error_level,
+                                 Offset offset,
+                                 const char* message) {
+  return error_handler_->OnError(error_level, offset, message);
 }
 
-bool BinaryReaderIR::OnError(const char* message) {
-  return HandleError(state->offset, message);
+bool BinaryReaderIR::OnError(ErrorLevel error_level, const char* message) {
+  return HandleError(error_level, state->offset, message);
 }
 
 Result BinaryReaderIR::OnTypeCount(Index count) {

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -91,8 +91,8 @@ void BinaryReaderLogging::LogTypes(TypeVector& types) {
   LogTypes(types.size(), types.data());
 }
 
-bool BinaryReaderLogging::OnError(const char* message) {
-  return reader_->OnError(message);
+bool BinaryReaderLogging::OnError(ErrorLevel error_level, const char* message) {
+  return reader_->OnError(error_level, message);
 }
 
 void BinaryReaderLogging::OnSetState(const State* s) {

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -27,7 +27,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
  public:
   BinaryReaderLogging(Stream*, BinaryReaderDelegate* forward);
 
-  bool OnError(const char* message) override;
+  bool OnError(ErrorLevel, const char* message) override;
   void OnSetState(const State* s) override;
 
   Result BeginModule(uint32_t version) override;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -23,7 +23,7 @@ namespace wabt {
 
 class BinaryReaderNop : public BinaryReaderDelegate {
  public:
-  bool OnError(const char* message) override { return false; }
+  bool OnError(ErrorLevel, const char* message) override { return false; }
 
   /* Module */
   Result BeginModule(uint32_t version) override { return Result::Ok; }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -38,7 +38,7 @@ class BinaryReaderObjdumpBase : public BinaryReaderNop {
                           ObjdumpOptions* options,
                           ObjdumpState* state);
 
-  bool OnError(const char* message) override;
+  bool OnError(ErrorLevel, const char* message) override;
 
   Result BeginModule(uint32_t version) override;
   Result BeginSection(BinarySection section_type, Offset size) override;
@@ -85,7 +85,8 @@ Result BinaryReaderObjdumpBase::BeginSection(BinarySection section_code,
   return Result::Ok;
 }
 
-bool BinaryReaderObjdumpBase::OnError(const char* message) {
+bool BinaryReaderObjdumpBase::OnError(ErrorLevel error_level,
+                                      const char* message) {
   // Tell the BinaryReader that this error is "handled" for all passes other
   // than the prepass. When the error is handled the default message will be
   // suppressed.

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -63,7 +63,7 @@ class BinaryReaderDelegate {
 
   virtual ~BinaryReaderDelegate() {}
 
-  virtual bool OnError(const char* message) = 0;
+  virtual bool OnError(ErrorLevel, const char* message) = 0;
   virtual void OnSetState(const State* s) { state = s; }
 
   /* Module */

--- a/src/common.h
+++ b/src/common.h
@@ -102,6 +102,11 @@ struct v128 {
 
 namespace wabt {
 
+enum class ErrorLevel {
+  Warning,
+  Error,
+};
+
 typedef uint32_t Index;    // An index into one of the many index spaces.
 typedef uint32_t Address;  // An address or size in linear memory.
 typedef size_t Offset;     // An offset into a host's file or memory buffer.
@@ -347,6 +352,18 @@ static WABT_INLINE const char* GetTypeName(Type type) {
       return "void";
     case Type::Any:
       return "any";
+  }
+  WABT_UNREACHABLE;
+}
+
+/* error level */
+
+static WABT_INLINE const char* GetErrorLevelName(ErrorLevel error_level) {
+  switch (error_level) {
+    case ErrorLevel::Warning:
+      return "warning";
+    case ErrorLevel::Error:
+      return "error";
   }
   WABT_UNREACHABLE;
 }

--- a/src/error-handler.cc
+++ b/src/error-handler.cc
@@ -23,7 +23,8 @@ namespace wabt {
 ErrorHandler::ErrorHandler(Location::Type location_type)
     : location_type_(location_type) {}
 
-std::string ErrorHandler::DefaultErrorMessage(const Color& color,
+std::string ErrorHandler::DefaultErrorMessage(ErrorLevel error_level,
+                                              const Color& color,
                                               const Location& loc,
                                               const std::string& error,
                                               const std::string& source_line,
@@ -46,7 +47,8 @@ std::string ErrorHandler::DefaultErrorMessage(const Color& color,
   }
 
   result += color.MaybeRedCode();
-  result += "error: ";
+  result += GetErrorLevelName(error_level);
+  result += ": ";
   result += color.MaybeDefaultCode();
 
   result += error;
@@ -89,15 +91,17 @@ ErrorHandlerFile::ErrorHandlerFile(Location::Type location_type,
       source_line_max_length_(source_line_max_length),
       color_(file) {}
 
-bool ErrorHandlerFile::OnError(const Location& loc,
+bool ErrorHandlerFile::OnError(ErrorLevel level,
+                               const Location& loc,
                                const std::string& error,
                                const std::string& source_line,
                                size_t source_line_column_offset) {
   PrintErrorHeader();
   int indent = header_.empty() ? 0 : 2;
 
-  std::string message = DefaultErrorMessage(color_, loc, error, source_line,
-                                            source_line_column_offset, indent);
+  std::string message =
+      DefaultErrorMessage(level, color_, loc, error, source_line,
+                          source_line_column_offset, indent);
   fwrite(message.data(), 1, message.size(), file_);
   return true;
 }
@@ -127,11 +131,12 @@ ErrorHandlerBuffer::ErrorHandlerBuffer(Location::Type location_type,
       source_line_max_length_(source_line_max_length),
       color_(nullptr, false) {}
 
-bool ErrorHandlerBuffer::OnError(const Location& loc,
+bool ErrorHandlerBuffer::OnError(ErrorLevel level,
+                                 const Location& loc,
                                  const std::string& error,
                                  const std::string& source_line,
                                  size_t source_line_column_offset) {
-  buffer_ += DefaultErrorMessage(color_, loc, error, source_line,
+  buffer_ += DefaultErrorMessage(level, color_, loc, error, source_line,
                                  source_line_column_offset, 0);
   return true;
 }

--- a/src/error-handler.h
+++ b/src/error-handler.h
@@ -31,20 +31,24 @@ class ErrorHandler {
   virtual ~ErrorHandler() {}
 
   // Returns true if the error was handled.
-  virtual bool OnError(const Location&,
+  virtual bool OnError(ErrorLevel,
+                       const Location&,
                        const std::string& error,
                        const std::string& source_line,
                        size_t source_line_column_offset) = 0;
 
   // Helper function for binary locations.
-  bool OnError(size_t offset, const std::string& error) {
-    return OnError(Location(offset), error, std::string(), 0);
+  bool OnError(ErrorLevel error_level,
+               size_t offset,
+               const std::string& error) {
+    return OnError(error_level, Location(offset), error, std::string(), 0);
   }
 
   // OnError will be called with with source_line trimmed to this length.
   virtual size_t source_line_max_length() const = 0;
 
-  std::string DefaultErrorMessage(const Color&,
+  std::string DefaultErrorMessage(ErrorLevel,
+                                  const Color&,
                                   const Location&,
                                   const std::string& error,
                                   const std::string& source_line,
@@ -59,7 +63,8 @@ class ErrorHandlerNop : public ErrorHandler {
  public:
   ErrorHandlerNop();
 
-  bool OnError(const Location&,
+  bool OnError(ErrorLevel,
+               const Location&,
                const std::string& error,
                const std::string& source_line,
                size_t source_line_column_offset) override {
@@ -83,7 +88,8 @@ class ErrorHandlerFile : public ErrorHandler {
                             PrintHeader print_header = PrintHeader::Never,
                             size_t source_line_max_length = 80);
 
-  bool OnError(const Location&,
+  bool OnError(ErrorLevel,
+               const Location&,
                const std::string& error,
                const std::string& source_line,
                size_t source_line_column_offset) override;
@@ -107,7 +113,8 @@ class ErrorHandlerBuffer : public ErrorHandler {
   explicit ErrorHandlerBuffer(Location::Type,
                               size_t source_line_max_length = 80);
 
-  bool OnError(const Location&,
+  bool OnError(ErrorLevel,
+               const Location&,
                const std::string& error,
                const std::string& source_line,
                size_t source_line_column_offset) override;

--- a/src/wast-parser-lexer-shared.cc
+++ b/src/wast-parser-lexer-shared.cc
@@ -49,8 +49,8 @@ void WastFormatError(ErrorHandler* error_handler,
     }
   }
 
-  error_handler->OnError(*loc, std::string(buffer), source_line.line,
-                         source_line.column_offset);
+  error_handler->OnError(ErrorLevel::Error, *loc, std::string(buffer),
+                         source_line.line, source_line.column_offset);
   va_end(args_copy);
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -108,7 +108,8 @@ void RemoveEscapes(const TextVector& texts, OutputIter out) {
 class BinaryErrorHandlerModule : public ErrorHandler {
  public:
   BinaryErrorHandlerModule(Location* loc, WastParser* parser);
-  bool OnError(const Location&,
+  bool OnError(ErrorLevel,
+               const Location&,
                const std::string& error,
                const std::string& source_line,
                size_t source_line_column_offset) override;
@@ -125,10 +126,12 @@ BinaryErrorHandlerModule::BinaryErrorHandlerModule(Location* loc,
                                                    WastParser* parser)
     : ErrorHandler(Location::Type::Binary), loc_(loc), parser_(parser) {}
 
-bool BinaryErrorHandlerModule::OnError(const Location& binary_loc,
+bool BinaryErrorHandlerModule::OnError(ErrorLevel error_level,
+                                       const Location& binary_loc,
                                        const std::string& error,
                                        const std::string& source_line,
                                        size_t source_line_column_offset) {
+  assert(error_level == ErrorLevel::Error);
   if (binary_loc.offset == kInvalidOffset) {
     parser_->Error(*loc_, "error in binary module: %s", error.c_str());
   } else {

--- a/test/binary/bad-opcode-prefix.txt
+++ b/test/binary/bad-opcode-prefix.txt
@@ -12,7 +12,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-*ERROR*: @0x0000001a: unexpected opcode: 254 127 (0xfe 0x7f)
+000001a: error: unexpected opcode: 254 127 (0xfe 0x7f)
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -13,7 +13,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-*ERROR*: @0x00000019: unexpected opcode: 255 (0xff)
+0000019: error: unexpected opcode: 255 (0xff)
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/binary/ignore-custom-section-error-objdump.txt
+++ b/test/binary/ignore-custom-section-error-objdump.txt
@@ -18,7 +18,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-*ERROR*: @0x00000019: unable to read u32 leb128: subsection size
+0000019: warning: unable to read u32 leb128: subsection size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/binary/ignore-custom-section-error-wasm2wat.txt
+++ b/test/binary/ignore-custom-section-error-wasm2wat.txt
@@ -19,8 +19,8 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-0000019: error: unable to read u32 leb128: subsection size
-0000019: error: unable to read u32 leb128: subsection size
+0000019: warning: unable to read u32 leb128: subsection size
+0000019: warning: unable to read u32 leb128: subsection size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 (module

--- a/test/dump/bad-version-logging.txt
+++ b/test/dump/bad-version-logging.txt
@@ -4,7 +4,7 @@
 magic
 0xe 0 0 0
 (;; STDERR ;;;
-*ERROR*: @0x00000008: bad wasm file version: 0xe (expected 0x1)
+0000008: error: bad wasm file version: 0xe (expected 0x1)
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/bad-version.txt
+++ b/test/dump/bad-version.txt
@@ -3,7 +3,7 @@
 magic
 0xe 0 0 0
 (;; STDERR ;;;
-*ERROR*: @0x00000008: bad wasm file version: 0xe (expected 0x1)
+0000008: error: bad wasm file version: 0xe (expected 0x1)
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 


### PR DESCRIPTION
The previous message said "error", which makes it look like the output
is not created, so change the message to "warning" instead.

The error handling code is pretty ugly and can use a refactor, but that
would be a much larger change.