### PR TITLE
Better type-check errors locs @ end of block

### DIFF
--- a/src/ir.h
+++ b/src/ir.h
@@ -215,6 +215,7 @@ struct Block {
   std::string label;
   BlockSignature sig;
   ExprList exprs;
+  Location end_loc;
 };
 
 class Expr : public intrusive_list_base<Expr> {
@@ -332,6 +333,7 @@ class IfExpr : public ExprMixin<ExprType::If> {
 
   Block true_;
   ExprList false_;
+  Location false_end_loc;
 };
 
 class IfExceptExpr : public ExprMixin<ExprType::IfExcept> {
@@ -341,6 +343,7 @@ class IfExceptExpr : public ExprMixin<ExprType::IfExcept> {
 
   Block true_;
   ExprList false_;
+  Location false_end_loc;
   Var except_var;
 };
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -521,6 +521,7 @@ Result Validator::BeginBlockExpr(BlockExpr* expr) {
 }
 
 Result Validator::EndBlockExpr(BlockExpr* expr) {
+  expr_loc_ = &expr->block.end_loc;
   typechecker_.OnEnd();
   return Result::Ok;
 }
@@ -623,6 +624,8 @@ Result Validator::AfterIfTrueExpr(IfExpr* expr) {
 }
 
 Result Validator::EndIfExpr(IfExpr* expr) {
+  expr_loc_ =
+      expr->false_.empty() ? &expr->true_.end_loc : &expr->false_end_loc;
   typechecker_.OnEnd();
   return Result::Ok;
 }
@@ -647,6 +650,8 @@ Result Validator::AfterIfExceptTrueExpr(IfExceptExpr* expr) {
 }
 
 Result Validator::EndIfExceptExpr(IfExceptExpr* expr) {
+  expr_loc_ =
+      expr->false_.empty() ? &expr->true_.end_loc : &expr->false_end_loc;
   typechecker_.OnEnd();
   return Result::Ok;
 }
@@ -668,6 +673,7 @@ Result Validator::BeginLoopExpr(LoopExpr* expr) {
 }
 
 Result Validator::EndLoopExpr(LoopExpr* expr) {
+  expr_loc_ = &expr->block.end_loc;
   typechecker_.OnEnd();
   return Result::Ok;
 }
@@ -755,6 +761,7 @@ Result Validator::OnCatchExpr(TryExpr* expr) {
 }
 
 Result Validator::EndTryExpr(TryExpr* expr) {
+  expr_loc_ = &expr->block.end_loc;
   typechecker_.OnEnd();
   return Result::Ok;
 }

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1710,6 +1710,7 @@ Result WastParser::ParseBlockInstr(std::unique_ptr<Expr>* out_expr) {
       if (Match(TokenType::Else)) {
         CHECK_RESULT(ParseEndLabelOpt(expr->true_.label));
         CHECK_RESULT(ParseTerminatingInstrList(&expr->false_));
+        expr->false_end_loc = GetLocation();
       }
       EXPECT(End);
       CHECK_RESULT(ParseEndLabelOpt(expr->true_.label));
@@ -1722,9 +1723,11 @@ Result WastParser::ParseBlockInstr(std::unique_ptr<Expr>* out_expr) {
       auto expr = MakeUnique<IfExceptExpr>(loc);
       CHECK_RESULT(ParseIfExceptHeader(expr.get()));
       CHECK_RESULT(ParseInstrList(&expr->true_.exprs));
+      expr->true_.end_loc = GetLocation();
       if (Match(TokenType::Else)) {
         CHECK_RESULT(ParseEndLabelOpt(expr->true_.label));
         CHECK_RESULT(ParseTerminatingInstrList(&expr->false_));
+        expr->false_end_loc = GetLocation();
       }
       EXPECT(End);
       CHECK_RESULT(ParseEndLabelOpt(expr->true_.label));
@@ -1785,6 +1788,7 @@ Result WastParser::ParseBlock(Block* block) {
   WABT_TRACE(ParseBlock);
   CHECK_RESULT(ParseResultList(&block->sig));
   CHECK_RESULT(ParseInstrList(&block->exprs));
+  block->end_loc = GetLocation();
   return Result::Ok;
 }
 
@@ -1966,6 +1970,7 @@ Result WastParser::ParseExpr(ExprList* exprs) {
         CHECK_RESULT(ParseLabelOpt(&expr->block.label));
         CHECK_RESULT(ParseResultList(&expr->block.sig));
         CHECK_RESULT(ParseInstrList(&expr->block.exprs));
+        expr->block.end_loc = GetLocation();
         EXPECT(Lpar);
         EXPECT(Catch);
         CHECK_RESULT(ParseTerminatingInstrList(&expr->catch_));

--- a/test/binary/bad-extra-end.txt
+++ b/test/binary/bad-extra-end.txt
@@ -12,8 +12,8 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: popping empty label stack
-000001a: error: OnEndExpr callback failed
-error: popping empty label stack
-000001a: error: OnEndExpr callback failed
+error: accessing stack depth: 1 >= max: 1
+0000019: error: OnEndExpr callback failed
+error: accessing stack depth: 1 >= max: 1
+0000019: error: OnEndExpr callback failed
 ;;; STDERR ;;)

--- a/test/binary/bad-op-after-end.txt
+++ b/test/binary/bad-op-after-end.txt
@@ -12,8 +12,8 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: accessing stack depth: 0 >= max: 0
-000001a: error: OnNopExpr callback failed
-error: accessing stack depth: 0 >= max: 0
-000001a: error: OnNopExpr callback failed
+error: accessing stack depth: 1 >= max: 1
+0000019: error: OnEndExpr callback failed
+error: accessing stack depth: 1 >= max: 1
+0000019: error: OnEndExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-10.txt
+++ b/test/regress/regress-10.txt
@@ -8,7 +8,7 @@
       tee_local 0
     end))
 (;; STDERR ;;;
-out/test/regress/regress-10.txt:8:7: error: type mismatch in block, expected [] but got [i32]
-      tee_local 0
-      ^^^^^^^^^
+out/test/regress/regress-10.txt:9:5: error: type mismatch in block, expected [] but got [i32]
+    end))
+    ^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-11.txt
+++ b/test/regress/regress-11.txt
@@ -10,7 +10,7 @@
       i32.const 1
     end))
 (;; STDERR ;;;
-out/test/regress/regress-11.txt:8:9: error: type mismatch in block, expected [] but got [i32]
-        br_if 1
-        ^^^^^
+out/test/regress/regress-11.txt:9:7: error: type mismatch in block, expected [] but got [i32]
+      end
+      ^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-nested-br.txt
+++ b/test/typecheck/bad-nested-br.txt
@@ -19,7 +19,7 @@
     ;; return statement here, or a value returned from (br $outer).
   ))
 (;; STDERR ;;;
-out/test/typecheck/bad-nested-br.txt:16:7: error: type mismatch in implicit return, expected [i32] but got []
-      return
-      ^^^^^^
+out/test/typecheck/bad-nested-br.txt:17:5: error: type mismatch in implicit return, expected [i32] but got []
+    end
+    ^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
Some type-checking only occurs at the end of a block, but the location
that is generated uses the last expression of that block. This can be
confusing if there are nested blocks, e.g.

```
1  block (result i32)
2    block
3      nop
4    end
5  end
```

This should produce an error at line 5, not line 3.

This PR stores the locations of the end of a block (either the `end` or
the closing parenthesis) so its easier to understand where the error
occurred.