### PR TITLE
Fix integer overflow w/ too many locals

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1925,6 +1925,7 @@ Result BinaryReader::ReadCodeSection(Offset section_size) {
     Offset body_start_offset = state_.offset;
     Offset end_offset = body_start_offset + body_size;
 
+    uint64_t total_locals = 0;
     Index num_local_decls;
     CHECK_RESULT(ReadCount(&num_local_decls, "local declaration count"));
     CALLBACK(OnLocalDeclCount, num_local_decls);
@@ -1932,6 +1933,9 @@ Result BinaryReader::ReadCodeSection(Offset section_size) {
       Index num_local_types;
       CHECK_RESULT(ReadIndex(&num_local_types, "local type count"));
       ERROR_UNLESS(num_local_types > 0, "local count must be > 0");
+      total_locals += num_local_types;
+      ERROR_UNLESS(total_locals < UINT32_MAX,
+                   "local count must be < 0x10000000");
       Type local_type;
       CHECK_RESULT(ReadType(&local_type, "local type"));
       ERROR_UNLESS(IsConcreteType(local_type), "expected valid local type");

--- a/test/binary/bad-too-many-locals.txt
+++ b/test/binary/bad-too-many-locals.txt
@@ -1,0 +1,35 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS: -x
+;;; ERROR: 1
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals [
+      decl_count[2]
+      leb_u32(0xffffffff) i32
+      leb_u32(1) i64
+    ]
+  }
+}
+(;; STDERR ;;;
+000001c: error: local count must be < 0x10000000
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+bad-too-many-locals.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type:
+ - type[0] () -> nil
+Function:
+ - func[0] sig=0
+
+Code Disassembly:
+
+000015 func[0]:
+;;; STDOUT ;;)


### PR DESCRIPTION
The maximum number of locals in a function is 2**32-1.