### PR TITLE
Use the wasm-objdump option -h for --help only, not for --headers

### DIFF
--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -42,7 +42,7 @@ static std::unique_ptr<FileStream> s_log_stream;
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-objdump", s_description);
 
-  parser.AddOption('h', "headers", "Print headers",
+  parser.AddOption("headers", "Print headers",
                    []() { s_objdump_options.headers = true; });
   parser.AddOption(
       'j', "section", "SECTION", "Select just one section",

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -42,7 +42,7 @@ static std::unique_ptr<FileStream> s_log_stream;
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-objdump", s_description);
 
-  parser.AddOption("headers", "Print headers",
+  parser.AddOption('h', "headers", "Print headers",
                    []() { s_objdump_options.headers = true; });
   parser.AddOption(
       'j', "section", "SECTION", "Select just one section",
@@ -60,7 +60,10 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_objdump_options.details = true; });
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",
                    []() { s_objdump_options.relocs = true; });
-  parser.AddHelpOption();
+  parser.AddOption('H', "help", "Print this help message", [&parser]() {
+    parser.PrintHelp();
+    exit(0);
+  });
   parser.AddArgument(
       "filename", OptionParser::ArgumentCount::OneOrMore,
       [](const char* argument) { s_infiles.push_back(argument); });

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -9,12 +9,12 @@ examples:
   $ wasm-objdump test.wasm
 
 options:
-      --headers                Print headers
+  -h, --headers                Print headers
   -j, --section=SECTION        Select just one section
   -s, --full-contents          Print raw section contents
   -d, --disassemble            Disassemble function bodies
       --debug                  Print extra debug information
   -x, --details                Show section details
   -r, --reloc                  Show relocations inline with disassembly
-  -h, --help                   Print this help message
+  -H, --help                   Print this help message
 ;;; STDOUT ;;)

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -9,7 +9,7 @@ examples:
   $ wasm-objdump test.wasm
 
 options:
-  -h, --headers                Print headers
+      --headers                Print headers
   -j, --section=SECTION        Select just one section
   -s, --full-contents          Print raw section contents
   -d, --disassemble            Disassemble function bodies


### PR DESCRIPTION
Resolves #872