### PR TITLE
Some fixes for binary releases

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -44,13 +44,14 @@ test_script:
   - "%APPVEYOR_BUILD_FOLDER%\\bin\\wabt-unittests"
   - python test\run-tests.py -v --bindir %APPVEYOR_BUILD_FOLDER%\bin
 
+# Must happen before artifacts step.
+after_test:
+  - ren "%APPVEYOR_BUILD_FOLDER%\\bin" "wabt-%APPVEYOR_REPO_TAG_NAME%"
+  - 7z a %DEPLOY_NAME% "%APPVEYOR_BUILD_FOLDER%\\wabt-%APPVEYOR_REPO_TAG_NAME%\\*.exe"
+
 artifacts:
   - path: "%DEPLOY_NAME%"
     name: wabt
-
-before_deploy:
-  - ren "%APPVEYOR_BUILD_FOLDER%\\bin" "wabt-%APPVEYOR_REPO_TAG_NAME%"
-  - 7z a %DEPLOY_NAME% "%APPVEYOR_BUILD_FOLDER%\\wabt-%APPVEYOR_REPO_TAG_NAME%\\*.exe"
 
 deploy:
   description: 'wabt release'

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -46,8 +46,7 @@ test_script:
 
 # Must happen before artifacts step.
 after_test:
-  - ren "%APPVEYOR_BUILD_FOLDER%\\bin" "wabt-%APPVEYOR_REPO_TAG_NAME%"
-  - 7z a %DEPLOY_NAME% "%APPVEYOR_BUILD_FOLDER%\\wabt-%APPVEYOR_REPO_TAG_NAME%\\*.exe"
+  - call scripts\appveyor-after-test.bat
 
 artifacts:
   - path: "%DEPLOY_NAME%"

--- a/scripts/appveyor-after-test.bat
+++ b/scripts/appveyor-after-test.bat
@@ -14,7 +14,7 @@ REM limitations under the License.
 
 REM Set up the artifact for this build, but only if this is a tag build.
 
-IF NOT "%APPVEYOR_REPO_TAG%" == "" (
+IF "%APPVEYOR_REPO_TAG%" == "true" (
   ren "%APPVEYOR_BUILD_FOLDER%\\bin" "wabt-%APPVEYOR_REPO_TAG_NAME%"
   7z a %DEPLOY_NAME% "%APPVEYOR_BUILD_FOLDER%\\wabt-%APPVEYOR_REPO_TAG_NAME%\\*.exe"
 )

--- a/scripts/appveyor-after-test.bat
+++ b/scripts/appveyor-after-test.bat
@@ -1,0 +1,20 @@
+REM Copyright 2018 WebAssembly Community Group participants
+REM
+REM Licensed under the Apache License, Version 2.0 (the "License");
+REM you may not use this file except in compliance with the License.
+REM You may obtain a copy of the License at
+REM
+REM     http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM Unless required by applicable law or agreed to in writing, software
+REM distributed under the License is distributed on an "AS IS" BASIS,
+REM WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM See the License for the specific language governing permissions and
+REM limitations under the License.
+
+REM Set up the artifact for this build, but only if this is a tag build.
+
+IF NOT %APPVEYOR_REPO_TAG%=="" (
+  ren "%APPVEYOR_BUILD_FOLDER%\\bin" "wabt-%APPVEYOR_REPO_TAG_NAME%"
+  7z a %DEPLOY_NAME% "%APPVEYOR_BUILD_FOLDER%\\wabt-%APPVEYOR_REPO_TAG_NAME%\\*.exe"
+)

--- a/scripts/appveyor-after-test.bat
+++ b/scripts/appveyor-after-test.bat
@@ -14,7 +14,7 @@ REM limitations under the License.
 
 REM Set up the artifact for this build, but only if this is a tag build.
 
-IF NOT %APPVEYOR_REPO_TAG%=="" (
+IF NOT "%APPVEYOR_REPO_TAG%" == "" (
   ren "%APPVEYOR_BUILD_FOLDER%\\bin" "wabt-%APPVEYOR_REPO_TAG_NAME%"
   7z a %DEPLOY_NAME% "%APPVEYOR_BUILD_FOLDER%\\wabt-%APPVEYOR_REPO_TAG_NAME%\\*.exe"
 )

--- a/scripts/sha256sum.py
+++ b/scripts/sha256sum.py
@@ -19,6 +19,7 @@ import argparse
 import hashlib
 import sys
 
+
 def main(args):
   parser = argparse.ArgumentParser()
   parser.add_argument('file', nargs='?')
@@ -32,6 +33,7 @@ def main(args):
     m.update(f.read())
   print('%s  %s' % (m.hexdigest(), options.file))
   return 0
+
 
 if __name__ == '__main__':
   sys.exit(main(sys.argv[1:]))

--- a/scripts/sha256sum.py
+++ b/scripts/sha256sum.py
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python
 #
 # Copyright 2018 WebAssembly Community Group participants
 #
@@ -13,20 +13,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-#
 
-set -o nounset
-set -o errexit
+from __future__ import print_function
+import argparse
+import hashlib
+import sys
 
-SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd -P)"
-source "${SCRIPT_DIR}/travis-common.sh"
+def main(args):
+  parser = argparse.ArgumentParser()
+  parser.add_argument('file', nargs='?')
+  options = parser.parse_args(args)
 
-if [[ -n ${WABT_DEPLOY:-} ]]; then
-  # Rebuild the WABT_DEPLOY target so it copies the results into bin/
-  make ${WABT_DEPLOY}
+  if options.file is None:
+    parser.error('Expected a file')
 
-  PKGNAME="wabt-${TRAVIS_TAG}-${TRAVIS_OS_NAME}"
-  mv bin wabt-${TRAVIS_TAG}
-  tar -czf ${PKGNAME}.tar.gz wabt-${TRAVIS_TAG}
-  ${SCRIPT_DIR}/sha256sum.py ${PKGNAME}.tar.gz > ${PKGNAME}.tar.gz.sha256
-fi
+  m = hashlib.sha256()
+  with open(options.file, 'rb') as f:
+    m.update(f.read())
+  print('%s  %s' % (m.hexdigest(), options.file))
+  return 0
+
+if __name__ == '__main__':
+  sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
* Create the artifacts before they are packaged (`before_deploy` happens
afterward)
* MacOS doesn't have sha256, so use python