### PR TITLE
[emscripten] Use long instead of int for ssize_t

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,14 +61,9 @@ if (WIN32)
   check_symbol_exists(ENABLE_VIRTUAL_TERMINAL_PROCESSING "windows.h" HAVE_WIN32_VT100)
 endif ()
 
-if (EMSCRIPTEN)
-  set(SIZEOF_SSIZE_T 4)
-  set(SIZEOF_SIZE_T 4)
-else ()
-  include(CheckTypeSize)
-  check_type_size(ssize_t SSIZE_T)
-  check_type_size(size_t SIZEOF_SIZE_T)
-endif ()
+include(CheckTypeSize)
+check_type_size(ssize_t SSIZE_T)
+check_type_size(size_t SIZEOF_SIZE_T)
 
 configure_file(
   ${WABT_SOURCE_DIR}/src/config.h.in

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -33,9 +33,6 @@
 /* Whether sysconf is defined by unistd.h */
 #cmakedefine01 HAVE_SYSCONF
 
-/* Whether ssize_t is defined by stddef.h */
-#cmakedefine01 HAVE_SSIZE_T
-
 /* Whether strcasecmp is defined by strings.h */
 #cmakedefine01 HAVE_STRCASECMP
 
@@ -276,10 +273,6 @@ int wabt_snprintf(char* str, size_t size, const char* format, ...);
 int wabt_vsnprintf(char* str, size_t size, const char* format, va_list ap);
 #else
 #define wabt_vsnprintf vsnprintf
-#endif
-
-#if !HAVE_SSIZE_T
-typedef long ssize_t;
 #endif
 
 #if !HAVE_STRCASECMP

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -33,6 +33,9 @@
 /* Whether sysconf is defined by unistd.h */
 #cmakedefine01 HAVE_SYSCONF
 
+/* Whether ssize_t is defined by stddef.h */
+#cmakedefine01 HAVE_SSIZE_T
+
 /* Whether strcasecmp is defined by strings.h */
 #cmakedefine01 HAVE_STRCASECMP
 
@@ -273,6 +276,10 @@ int wabt_snprintf(char* str, size_t size, const char* format, ...);
 int wabt_vsnprintf(char* str, size_t size, const char* format, va_list ap);
 #else
 #define wabt_vsnprintf vsnprintf
+#endif
+
+#if !HAVE_SSIZE_T
+typedef long ssize_t;
 #endif
 
 #if !HAVE_STRCASECMP

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -279,7 +279,7 @@ int wabt_vsnprintf(char* str, size_t size, const char* format, va_list ap);
 #endif
 
 #if !HAVE_SSIZE_T
-typedef int ssize_t;
+typedef long ssize_t;
 #endif
 
 #if !HAVE_STRCASECMP


### PR DESCRIPTION
This was recently changed in emscripten.