### PR TITLE
Update testsuite; enable mut. globals by default

### DIFF
--- a/src/feature.cc
+++ b/src/feature.cc
@@ -21,8 +21,14 @@
 namespace wabt {
 
 void Features::AddOptions(OptionParser* parser) {
-#define WABT_FEATURE(variable, flag, help) \
-  parser->AddOption("enable-" flag, help, [this]() { enable_##variable(); });
+#define WABT_FEATURE(variable, flag, default_, help)       \
+  if (default_ == true) {                                  \
+    parser->AddOption("disable-" flag, "Disable " help,    \
+                      [this]() { disable_##variable(); }); \
+  } else {                                                 \
+    parser->AddOption("enable-" flag, "Enable " help,      \
+                      [this]() { enable_##variable(); });  \
+  }
 
 #include "src/feature.def"
 #undef WABT_FEATURE

--- a/src/feature.def
+++ b/src/feature.def
@@ -19,13 +19,13 @@
 #endif
 
 /*
- *           variable          flag                       help
+ *           variable          flag                       default  help
  * ========================================================================= */
 
-WABT_FEATURE(exceptions,       "exceptions",              "Experimental exception handling")
-WABT_FEATURE(mutable_globals,  "mutable-globals",         "Import/export mutable globals")
-WABT_FEATURE(sat_float_to_int, "saturating-float-to-int", "Saturating float-to-int operators")
-WABT_FEATURE(sign_extension,   "sign-extension",          "Sign-extension operators")
-WABT_FEATURE(simd,             "simd",                    "SIMD support")
-WABT_FEATURE(threads,          "threads",                 "Threading support")
-WABT_FEATURE(multi_value,      "multi-value",             "Multi-value")
+WABT_FEATURE(exceptions,       "exceptions",              false,   "Experimental exception handling")
+WABT_FEATURE(mutable_globals,  "mutable-globals",         true,    "Import/export mutable globals")
+WABT_FEATURE(sat_float_to_int, "saturating-float-to-int", false,   "Saturating float-to-int operators")
+WABT_FEATURE(sign_extension,   "sign-extension",          false,   "Sign-extension operators")
+WABT_FEATURE(simd,             "simd",                    false,   "SIMD support")
+WABT_FEATURE(threads,          "threads",                 false,   "Threading support")
+WABT_FEATURE(multi_value,      "multi-value",             false,   "Multi-value")

--- a/src/feature.h
+++ b/src/feature.h
@@ -28,19 +28,21 @@ class Features {
   void AddOptions(OptionParser*);
 
   void EnableAll() {
-#define WABT_FEATURE(variable, flag, help) enable_##variable();
+#define WABT_FEATURE(variable, flag, default_, help) enable_##variable();
 #include "src/feature.def"
 #undef WABT_FEATURE
   }
 
-#define WABT_FEATURE(variable, flag, help)                        \
+#define WABT_FEATURE(variable, flag, default_, help)              \
   bool variable##_enabled() const { return variable##_enabled_; } \
-  void enable_##variable() { variable##_enabled_ = true; }
+  void enable_##variable() { variable##_enabled_ = true; }        \
+  void disable_##variable() { variable##_enabled_ = false; }
 #include "src/feature.def"
 #undef WABT_FEATURE
 
  private:
-#define WABT_FEATURE(variable, flag, help) bool variable##_enabled_ = false;
+#define WABT_FEATURE(variable, flag, default_, help) \
+  bool variable##_enabled_ = default_;
 #include "src/feature.def"
 #undef WABT_FEATURE
 };

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -80,15 +80,16 @@ static void ParseOptions(int argc, char** argv) {
                      });
   parser.Parse(argc, argv);
 
-  // TODO(binji): currently wasm2c doesn't support any feature flags.
-  bool any_feature_enabled = false;
-#define WABT_FEATURE(variable, flag, help) \
-  any_feature_enabled |= s_features.variable##_enabled();
+  // TODO(binji): currently wasm2c doesn't support any non-default feature
+  // flags.
+  bool any_non_default_feature = false;
+#define WABT_FEATURE(variable, flag, default_, help) \
+  any_non_default_feature |= (s_features.variable##_enabled() != default_);
 #include "src/feature.def"
 #undef WABT_FEATURE
 
-  if (any_feature_enabled) {
-    fprintf(stderr, "wasm2c doesn't currently support any --enable-* flags.\n");
+  if (any_non_default_feature) {
+    fprintf(stderr, "wasm2c currently support only default feature flags.\n");
     exit(1);
   }
 }

--- a/test/dump/mutable-global.txt
+++ b/test/dump/mutable-global.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-objdump
-;;; ARGS0: -v --enable-mutable-globals
+;;; ARGS0: -v
 ;;; ARGS1: -x
 (module
   (import "foo" "imported" (global (mut i32)))

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -11,7 +11,7 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -11,14 +11,14 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-      --help                                  Print this help message
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+  -h, --help                                  Print this help message
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
   -V, --value-stack-size=SIZE                 Size in elements of the value stack
   -C, --call-stack-size=SIZE                  Size in elements of the call stack
   -t, --trace                                 Trace execution

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -22,7 +22,7 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -22,14 +22,14 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-      --help                                  Print this help message
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+  -h, --help                                  Print this help message
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
   -V, --value-stack-size=SIZE                 Size in elements of the value stack
   -C, --call-stack-size=SIZE                  Size in elements of the call stack
   -t, --trace                                 Trace execution

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -16,5 +16,5 @@ options:
       --debug                  Print extra debug information
   -x, --details                Show section details
   -r, --reloc                  Show relocations inline with disassembly
-  -h, --help                   Print this help message
+      --help                   Print this help message
 ;;; STDOUT ;;)

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -16,5 +16,5 @@ options:
       --debug                  Print extra debug information
   -x, --details                Show section details
   -r, --reloc                  Show relocations inline with disassembly
-      --help                   Print this help message
+  -h, --help                   Print this help message
 ;;; STDOUT ;;)

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -12,7 +12,7 @@ examples:
 
 options:
   -v, --verbose                    Use multiple times for more info
-      --help                       Print this help message
+  -h, --help                       Print this help message
   -o, --output=FILENAME            Output file for the opcode counts, by default use stdout
   -c, --cutoff=N                   Cutoff for reporting counts less than N
   -s, --separator=SEPARATOR        Separator text between element and count when reporting counts

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -12,7 +12,7 @@ examples:
 
 options:
   -v, --verbose                    Use multiple times for more info
-  -h, --help                       Print this help message
+      --help                       Print this help message
   -o, --output=FILENAME            Output file for the opcode counts, by default use stdout
   -c, --cutoff=N                   Cutoff for reporting counts less than N
   -s, --separator=SEPARATOR        Separator text between element and count when reporting counts

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -11,14 +11,14 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-      --help                                  Print this help message
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+  -h, --help                                  Print this help message
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
       --no-debug-names                        Ignore debug names in the binary file
       --ignore-custom-section-errors          Ignore errors in custom sections
 ;;; STDOUT ;;)

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -11,7 +11,7 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -15,16 +15,16 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-      --help                                  Print this help message
+  -h, --help                                  Print this help message
   -o, --output=FILENAME                       Output file for the generated wast file, by default use stdout
   -f, --fold-exprs                            Write folded expressions where possible
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
       --inline-exports                        Write all exports inline
       --inline-imports                        Write all imports inline
       --no-debug-names                        Ignore debug names in the binary file

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -15,7 +15,7 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
   -o, --output=FILENAME                       Output file for the generated wast file, by default use stdout
   -f, --fold-exprs                            Write folded expressions where possible
       --enable-exceptions                     Enable Experimental exception handling

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -13,15 +13,15 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-      --help                                  Print this help message
+  -h, --help                                  Print this help message
       --debug-parser                          Turn on debugging the parser of wast files
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
   -o, --output=FILE                           output wasm binary file
   -r, --relocatable                           Create a relocatable wasm binary (suitable for linking with e.g. lld)
       --no-canonicalize-leb128s               Write all LEB128 sizes as 5-bytes instead of their minimal size

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -13,7 +13,7 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
       --debug-parser                          Turn on debugging the parser of wast files
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -16,16 +16,16 @@ examples:
   $ wat-desugar --generate-names test.wat
 
 options:
-      --help                                  Print this help message
+  -h, --help                                  Print this help message
   -o, --output=FILE                           Output file for the formatted file
       --debug-parser                          Turn on debugging the parser of wat files
   -f, --fold-exprs                            Write folded expressions where possible
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
       --generate-names                        Give auto-generated names to non-named functions, types, etc.
 ;;; STDOUT ;;)

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -16,7 +16,7 @@ examples:
   $ wat-desugar --generate-names test.wat
 
 options:
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
   -o, --output=FILE                           Output file for the formatted file
       --debug-parser                          Turn on debugging the parser of wat files
   -f, --fold-exprs                            Write folded expressions where possible

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -19,7 +19,7 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-  -h, --help                                  Print this help message
+      --help                                  Print this help message
       --debug-parser                          Turn on debugging the parser of wat files
   -d, --dump-module                           Print a hexdump of the module to stdout
       --enable-exceptions                     Enable Experimental exception handling

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -19,16 +19,16 @@ examples:
 
 options:
   -v, --verbose                               Use multiple times for more info
-      --help                                  Print this help message
+  -h, --help                                  Print this help message
       --debug-parser                          Turn on debugging the parser of wat files
   -d, --dump-module                           Print a hexdump of the module to stdout
-      --enable-exceptions                     Experimental exception handling
-      --enable-mutable-globals                Import/export mutable globals
-      --enable-saturating-float-to-int        Saturating float-to-int operators
-      --enable-sign-extension                 Sign-extension operators
-      --enable-simd                           SIMD support
-      --enable-threads                        Threading support
-      --enable-multi-value                    Multi-value
+      --enable-exceptions                     Enable Experimental exception handling
+      --disable-mutable-globals               Disable Import/export mutable globals
+      --enable-saturating-float-to-int        Enable Saturating float-to-int operators
+      --enable-sign-extension                 Enable Sign-extension operators
+      --enable-simd                           Enable SIMD support
+      --enable-threads                        Enable Threading support
+      --enable-multi-value                    Enable Multi-value
   -o, --output=FILE                           output wasm binary file
   -r, --relocatable                           Create a relocatable wasm binary (suitable for linking with e.g. lld)
       --no-canonicalize-leb128s               Write all LEB128 sizes as 5-bytes instead of their minimal size

--- a/test/parse/export-mutable-global.txt
+++ b/test/parse/export-mutable-global.txt
@@ -1,3 +1,2 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-mutable-globals
 (module (global (export "g") (mut f32) (f32.const 1.5)))

--- a/test/parse/module/import-mutable-global.txt
+++ b/test/parse/module/import-mutable-global.txt
@@ -1,3 +1,2 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-mutable-globals
 (module (import "mod" "field" (global (mut f32))))

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -121,7 +121,6 @@ def main(args):
   parser.add_argument('--enable-threads', action='store_true')
   parser.add_argument('--enable-simd', action='store_true')
   parser.add_argument('--enable-sign-extension', action='store_true')
-  parser.add_argument('--enable-mutable-globals', action='store_true')
   parser.add_argument('--enable-multi-value', action='store_true')
   parser.add_argument('--inline-exports', action='store_true')
   parser.add_argument('--inline-imports', action='store_true')
@@ -135,7 +134,6 @@ def main(args):
       '--debug-names': options.debug_names,
       '--enable-exceptions': options.enable_exceptions,
       '--enable-multi-value': options.enable_multi_value,
-      '--enable-mutable-globals': options.enable_mutable_globals,
       '--enable-saturating-float-to-int':
           options.enable_saturating_float_to_int,
       '--enable-sign-extension': options.enable_sign_extension,
@@ -151,7 +149,6 @@ def main(args):
       '--fold-exprs': options.fold_exprs,
       '--enable-exceptions': options.enable_exceptions,
       '--enable-multi-value': options.enable_multi_value,
-      '--enable-mutable-globals': options.enable_mutable_globals,
       '--enable-saturating-float-to-int':
           options.enable_saturating_float_to_int,
       '--enable-sign-extension': options.enable_sign_extension,

--- a/test/spec/address.txt
+++ b/test/spec/address.txt
@@ -1,9 +1,9 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/address.wast
 (;; STDOUT ;;;
-out/test/spec/address.wast:98: assert_malformed passed:
+out/test/spec/address.wast:207: assert_malformed passed:
   out/test/spec/address/address.1.wat:1:33: error: offset must be less than or equal to 0xffffffff
   (memory 1)(func (drop (i32.load offset=4294967296 (i32.const 0))))
                                   ^^^^^^^^^^^^^^^^^
-42/42 tests passed.
+239/239 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/align.txt
+++ b/test/spec/align.txt
@@ -1,27 +1,300 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/align.wast
 (;; STDOUT ;;;
-out/test/spec/align.wast:2: assert_malformed passed:
-  out/test/spec/align/align.0.wat:1:42: error: alignment must be power-of-two
+out/test/spec/align.wast:28: assert_malformed passed:
+  out/test/spec/align/align.23.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load8_s align=0 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:34: assert_malformed passed:
+  out/test/spec/align/align.24.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load8_s align=7 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:40: assert_malformed passed:
+  out/test/spec/align/align.25.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load8_u align=0 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:46: assert_malformed passed:
+  out/test/spec/align/align.26.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load8_u align=7 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:52: assert_malformed passed:
+  out/test/spec/align/align.27.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load16_s align=0 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:58: assert_malformed passed:
+  out/test/spec/align/align.28.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load16_s align=7 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:64: assert_malformed passed:
+  out/test/spec/align/align.29.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load16_u align=0 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:70: assert_malformed passed:
+  out/test/spec/align/align.30.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load16_u align=7 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:76: assert_malformed passed:
+  out/test/spec/align/align.31.wat:1:42: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load align=0 (i32.const 0)))))
+                                           ^^^^^^^
+out/test/spec/align.wast:82: assert_malformed passed:
+  out/test/spec/align/align.32.wat:1:42: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i32.load align=7 (i32.const 0)))))
+                                           ^^^^^^^
+out/test/spec/align.wast:88: assert_malformed passed:
+  out/test/spec/align/align.33.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load8_s align=0 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:94: assert_malformed passed:
+  out/test/spec/align/align.34.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load8_s align=7 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:100: assert_malformed passed:
+  out/test/spec/align/align.35.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load8_u align=0 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:106: assert_malformed passed:
+  out/test/spec/align/align.36.wat:1:45: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load8_u align=7 (i32.const 0)))))
+                                              ^^^^^^^
+out/test/spec/align.wast:112: assert_malformed passed:
+  out/test/spec/align/align.37.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load16_s align=0 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:118: assert_malformed passed:
+  out/test/spec/align/align.38.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load16_s align=7 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:124: assert_malformed passed:
+  out/test/spec/align/align.39.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load16_u align=0 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:130: assert_malformed passed:
+  out/test/spec/align/align.40.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load16_u align=7 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:136: assert_malformed passed:
+  out/test/spec/align/align.41.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load32_s align=0 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:142: assert_malformed passed:
+  out/test/spec/align/align.42.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load32_s align=7 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:148: assert_malformed passed:
+  out/test/spec/align/align.43.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load32_u align=0 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:154: assert_malformed passed:
+  out/test/spec/align/align.44.wat:1:46: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (i64.load32_u align=7 (i32.const 0)))))
+                                               ^^^^^^^
+out/test/spec/align.wast:160: assert_malformed passed:
+  out/test/spec/align/align.45.wat:1:42: error: alignment must be power-of-two
   (module (memory 0) (func (drop (i64.load align=0 (i32.const 0)))))
                                            ^^^^^^^
-out/test/spec/align.wast:8: assert_malformed passed:
-  out/test/spec/align/align.1.wat:1:42: error: alignment must be power-of-two
+out/test/spec/align.wast:166: assert_malformed passed:
+  out/test/spec/align/align.46.wat:1:42: error: alignment must be power-of-two
   (module (memory 0) (func (drop (i64.load align=7 (i32.const 0)))))
                                            ^^^^^^^
-out/test/spec/align.wast:14: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/align.wast:19: assert_malformed passed:
-  out/test/spec/align/align.3.wat:1:37: error: alignment must be power-of-two
+out/test/spec/align.wast:172: assert_malformed passed:
+  out/test/spec/align/align.47.wat:1:42: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (f32.load align=0 (i32.const 0)))))
+                                           ^^^^^^^
+out/test/spec/align.wast:178: assert_malformed passed:
+  out/test/spec/align/align.48.wat:1:42: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (f32.load align=7 (i32.const 0)))))
+                                           ^^^^^^^
+out/test/spec/align.wast:184: assert_malformed passed:
+  out/test/spec/align/align.49.wat:1:42: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (f64.load align=0 (i32.const 0)))))
+                                           ^^^^^^^
+out/test/spec/align.wast:190: assert_malformed passed:
+  out/test/spec/align/align.50.wat:1:42: error: alignment must be power-of-two
+  (module (memory 0) (func (drop (f64.load align=7 (i32.const 0)))))
+                                           ^^^^^^^
+out/test/spec/align.wast:197: assert_malformed passed:
+  out/test/spec/align/align.51.wat:1:38: error: alignment must be power-of-two
+  (module (memory 0) (func (i32.store8 align=0 (i32.const 0) (i32.const 0))))
+                                       ^^^^^^^
+out/test/spec/align.wast:203: assert_malformed passed:
+  out/test/spec/align/align.52.wat:1:38: error: alignment must be power-of-two
+  (module (memory 0) (func (i32.store8 align=7 (i32.const 0) (i32.const 0))))
+                                       ^^^^^^^
+out/test/spec/align.wast:209: assert_malformed passed:
+  out/test/spec/align/align.53.wat:1:39: error: alignment must be power-of-two
+  (module (memory 0) (func (i32.store16 align=0 (i32.const 0) (i32.const 0))))
+                                        ^^^^^^^
+out/test/spec/align.wast:215: assert_malformed passed:
+  out/test/spec/align/align.54.wat:1:39: error: alignment must be power-of-two
+  (module (memory 0) (func (i32.store16 align=7 (i32.const 0) (i32.const 0))))
+                                        ^^^^^^^
+out/test/spec/align.wast:221: assert_malformed passed:
+  out/test/spec/align/align.55.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (i32.store align=0 (i32.const 0) (i32.const 0))))
+                                      ^^^^^^^
+out/test/spec/align.wast:227: assert_malformed passed:
+  out/test/spec/align/align.56.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (i32.store align=7 (i32.const 0) (i32.const 0))))
+                                      ^^^^^^^
+out/test/spec/align.wast:233: assert_malformed passed:
+  out/test/spec/align/align.57.wat:1:38: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store8 align=0 (i32.const 0) (i64.const 0))))
+                                       ^^^^^^^
+out/test/spec/align.wast:239: assert_malformed passed:
+  out/test/spec/align/align.58.wat:1:38: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store8 align=7 (i32.const 0) (i64.const 0))))
+                                       ^^^^^^^
+out/test/spec/align.wast:245: assert_malformed passed:
+  out/test/spec/align/align.59.wat:1:39: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store16 align=0 (i32.const 0) (i64.const 0))))
+                                        ^^^^^^^
+out/test/spec/align.wast:251: assert_malformed passed:
+  out/test/spec/align/align.60.wat:1:39: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store16 align=7 (i32.const 0) (i64.const 0))))
+                                        ^^^^^^^
+out/test/spec/align.wast:257: assert_malformed passed:
+  out/test/spec/align/align.61.wat:1:39: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store32 align=0 (i32.const 0) (i64.const 0))))
+                                        ^^^^^^^
+out/test/spec/align.wast:263: assert_malformed passed:
+  out/test/spec/align/align.62.wat:1:39: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store32 align=7 (i32.const 0) (i64.const 0))))
+                                        ^^^^^^^
+out/test/spec/align.wast:269: assert_malformed passed:
+  out/test/spec/align/align.63.wat:1:37: error: alignment must be power-of-two
   (module (memory 0) (func (i64.store align=0 (i32.const 0) (i64.const 0))))
                                       ^^^^^^^
-out/test/spec/align.wast:25: assert_malformed passed:
-  out/test/spec/align/align.4.wat:1:37: error: alignment must be power-of-two
-  (module (memory 0) (func (i64.store align=5 (i32.const 0) (i64.const 0))))
+out/test/spec/align.wast:275: assert_malformed passed:
+  out/test/spec/align/align.64.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (i64.store align=7 (i32.const 0) (i64.const 0))))
                                       ^^^^^^^
-out/test/spec/align.wast:31: assert_invalid passed:
+out/test/spec/align.wast:281: assert_malformed passed:
+  out/test/spec/align/align.65.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (f32.store align=0 (i32.const 0) (f32.const 0))))
+                                      ^^^^^^^
+out/test/spec/align.wast:287: assert_malformed passed:
+  out/test/spec/align/align.66.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (f32.store align=7 (i32.const 0) (f32.const 0))))
+                                      ^^^^^^^
+out/test/spec/align.wast:293: assert_malformed passed:
+  out/test/spec/align/align.67.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (f64.store align=0 (i32.const 0) (f32.const 0))))
+                                      ^^^^^^^
+out/test/spec/align.wast:299: assert_malformed passed:
+  out/test/spec/align/align.68.wat:1:37: error: alignment must be power-of-two
+  (module (memory 0) (func (f64.store align=7 (i32.const 0) (f32.const 0))))
+                                      ^^^^^^^
+out/test/spec/align.wast:306: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:310: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:314: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:318: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:322: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:326: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:330: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:334: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:338: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:342: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:346: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:350: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:354: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:358: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:363: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:367: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:371: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:375: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:379: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:383: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:387: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:391: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:395: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:399: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:403: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:407: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:411: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:415: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000021: error: OnLoadExpr callback failed
+out/test/spec/align.wast:420: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000023: error: OnStoreExpr callback failed
+out/test/spec/align.wast:424: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000023: error: OnStoreExpr callback failed
+out/test/spec/align.wast:428: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000023: error: OnStoreExpr callback failed
+out/test/spec/align.wast:432: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000023: error: OnStoreExpr callback failed
+out/test/spec/align.wast:436: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000023: error: OnStoreExpr callback failed
+out/test/spec/align.wast:440: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000023: error: OnStoreExpr callback failed
+out/test/spec/align.wast:444: assert_invalid passed:
   error: alignment must not be larger than natural alignment (8)
   0000023: error: OnStoreExpr callback failed
-6/6 tests passed.
+out/test/spec/align.wast:448: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000026: error: OnStoreExpr callback failed
+out/test/spec/align.wast:452: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000026: error: OnStoreExpr callback failed
+131/131 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -93,5 +93,7 @@ out/test/spec/binary.wast:292: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
 out/test/spec/binary.wast:312: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-46/46 tests passed.
+out/test/spec/binary.wast:331: assert_malformed passed:
+  000001c: error: local count must be < 0x10000000
+47/47 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -17,63 +17,369 @@ out/test/spec/block.wast:176: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:182: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i64]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/block.wast:188: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [f32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/block.wast:194: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [f64]
+  0000023: error: OnEndExpr callback failed
+out/test/spec/block.wast:201: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:188: assert_invalid passed:
+out/test/spec/block.wast:207: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/block.wast:213: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/block.wast:219: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/block.wast:226: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:194: assert_invalid passed:
+out/test/spec/block.wast:232: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/block.wast:238: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/block.wast:244: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/block.wast:251: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [i64]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:257: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:200: assert_invalid passed:
+out/test/spec/block.wast:263: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f64]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/block.wast:269: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got [i32]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:275: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got [f32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/block.wast:281: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got [f64]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/block.wast:287: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got [i32]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:293: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got [i64]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:299: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got [f64]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/block.wast:305: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got [i32]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:311: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got [i64]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:317: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got [f32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/block.wast:324: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:207: assert_invalid passed:
+out/test/spec/block.wast:330: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [f32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:336: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [f64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:342: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [i32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:348: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [f32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:354: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [f64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:360: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:366: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:372: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [f64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:378: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got [i32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:384: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:390: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got [f32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/block.wast:397: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:213: assert_invalid passed:
+out/test/spec/block.wast:403: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/block.wast:409: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/block.wast:415: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/block.wast:422: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:220: assert_invalid passed:
+out/test/spec/block.wast:428: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/block.wast:434: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/block.wast:440: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/block.wast:447: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:226: assert_invalid passed:
+out/test/spec/block.wast:453: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:459: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:465: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:472: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:232: assert_invalid passed:
+out/test/spec/block.wast:478: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:484: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/block.wast:490: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:496: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:502: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/block.wast:508: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:514: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:520: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/block.wast:526: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:532: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:538: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:545: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:238: assert_invalid passed:
+out/test/spec/block.wast:551: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:557: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:563: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:570: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:245: assert_invalid passed:
+out/test/spec/block.wast:576: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:582: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/block.wast:588: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:594: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:600: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/block.wast:606: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:612: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:618: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/block.wast:624: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:630: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:636: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:643: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
-out/test/spec/block.wast:251: assert_invalid passed:
+out/test/spec/block.wast:649: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i64]
+  0000024: error: EndFunctionBody callback failed
+out/test/spec/block.wast:655: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f32]
+  0000027: error: EndFunctionBody callback failed
+out/test/spec/block.wast:661: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f64]
+  000002b: error: EndFunctionBody callback failed
+out/test/spec/block.wast:668: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:258: assert_invalid passed:
+out/test/spec/block.wast:674: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:680: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:686: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:693: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:264: assert_invalid passed:
+out/test/spec/block.wast:699: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/block.wast:705: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/block.wast:711: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/block.wast:718: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:273: assert_invalid passed:
+out/test/spec/block.wast:726: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/block.wast:734: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f64]
+  0000027: error: OnBrExpr callback failed
+out/test/spec/block.wast:742: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/block.wast:750: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f32]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/block.wast:758: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f64]
+  0000027: error: OnBrExpr callback failed
+out/test/spec/block.wast:766: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i32]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/block.wast:774: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i64]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/block.wast:782: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [f64]
+  0000027: error: OnBrExpr callback failed
+out/test/spec/block.wast:790: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i32]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/block.wast:798: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i64]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/block.wast:806: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [f32]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/block.wast:815: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:279: assert_invalid passed:
+out/test/spec/block.wast:821: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:827: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:833: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:840: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:846: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:285: assert_invalid passed:
+out/test/spec/block.wast:852: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:858: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:865: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:293: assert_malformed passed:
-  out/test/spec/block/block.23.wat:1:17: error: unexpected label "$l"
+out/test/spec/block.wast:871: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  0000023: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:877: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  0000027: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:883: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:889: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  0000023: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:895: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  0000027: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:901: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:907: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:913: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  0000027: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:919: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:925: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:931: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  0000023: error: OnUnaryExpr callback failed
+out/test/spec/block.wast:938: assert_malformed passed:
+  out/test/spec/block/block.125.wat:1:17: error: unexpected label "$l"
   (func block end $l)
                   ^^
-out/test/spec/block.wast:297: assert_malformed passed:
-  out/test/spec/block/block.24.wat:1:20: error: mismatching label "$a" != "$l"
+out/test/spec/block.wast:942: assert_malformed passed:
+  out/test/spec/block/block.126.wat:1:20: error: mismatching label "$a" != "$l"
   (func block $a end $l)
                      ^^
-38/38 tests passed.
+140/140 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/float_literals.txt
+++ b/test/spec/float_literals.txt
@@ -1,309 +1,309 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/float_literals.wast
 (;; STDOUT ;;;
-out/test/spec/float_literals.wast:196: assert_malformed passed:
+out/test/spec/float_literals.wast:204: assert_malformed passed:
   out/test/spec/float_literals/float_literals.2.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _100))
                          ^^^^
-out/test/spec/float_literals.wast:200: assert_malformed passed:
+out/test/spec/float_literals.wast:208: assert_malformed passed:
   out/test/spec/float_literals/float_literals.3.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const +_100))
                          ^^^^^
-out/test/spec/float_literals.wast:204: assert_malformed passed:
+out/test/spec/float_literals.wast:212: assert_malformed passed:
   out/test/spec/float_literals/float_literals.4.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const -_100))
                          ^^^^^
-out/test/spec/float_literals.wast:208: assert_malformed passed:
+out/test/spec/float_literals.wast:216: assert_malformed passed:
   out/test/spec/float_literals/float_literals.5.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 99_))
                          ^^^
-out/test/spec/float_literals.wast:212: assert_malformed passed:
+out/test/spec/float_literals.wast:220: assert_malformed passed:
   out/test/spec/float_literals/float_literals.6.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1__000))
                          ^^^^^^
-out/test/spec/float_literals.wast:216: assert_malformed passed:
+out/test/spec/float_literals.wast:224: assert_malformed passed:
   out/test/spec/float_literals/float_literals.7.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _1.0))
                          ^^^^
-out/test/spec/float_literals.wast:220: assert_malformed passed:
+out/test/spec/float_literals.wast:228: assert_malformed passed:
   out/test/spec/float_literals/float_literals.8.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0_))
                          ^^^^
-out/test/spec/float_literals.wast:224: assert_malformed passed:
+out/test/spec/float_literals.wast:232: assert_malformed passed:
   out/test/spec/float_literals/float_literals.9.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1_.0))
                          ^^^^
-out/test/spec/float_literals.wast:228: assert_malformed passed:
+out/test/spec/float_literals.wast:236: assert_malformed passed:
   out/test/spec/float_literals/float_literals.10.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1._0))
                          ^^^^
-out/test/spec/float_literals.wast:232: assert_malformed passed:
+out/test/spec/float_literals.wast:240: assert_malformed passed:
   out/test/spec/float_literals/float_literals.11.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _1e1))
                          ^^^^
-out/test/spec/float_literals.wast:236: assert_malformed passed:
+out/test/spec/float_literals.wast:244: assert_malformed passed:
   out/test/spec/float_literals/float_literals.12.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1e1_))
                          ^^^^
-out/test/spec/float_literals.wast:240: assert_malformed passed:
+out/test/spec/float_literals.wast:248: assert_malformed passed:
   out/test/spec/float_literals/float_literals.13.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1_e1))
                          ^^^^
-out/test/spec/float_literals.wast:244: assert_malformed passed:
+out/test/spec/float_literals.wast:252: assert_malformed passed:
   out/test/spec/float_literals/float_literals.14.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1e_1))
                          ^^^^
-out/test/spec/float_literals.wast:248: assert_malformed passed:
+out/test/spec/float_literals.wast:256: assert_malformed passed:
   out/test/spec/float_literals/float_literals.15.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _1.0e1))
                          ^^^^^^
-out/test/spec/float_literals.wast:252: assert_malformed passed:
+out/test/spec/float_literals.wast:260: assert_malformed passed:
   out/test/spec/float_literals/float_literals.16.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e1_))
                          ^^^^^^
-out/test/spec/float_literals.wast:256: assert_malformed passed:
+out/test/spec/float_literals.wast:264: assert_malformed passed:
   out/test/spec/float_literals/float_literals.17.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0_e1))
                          ^^^^^^
-out/test/spec/float_literals.wast:260: assert_malformed passed:
+out/test/spec/float_literals.wast:268: assert_malformed passed:
   out/test/spec/float_literals/float_literals.18.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e_1))
                          ^^^^^^
-out/test/spec/float_literals.wast:264: assert_malformed passed:
+out/test/spec/float_literals.wast:272: assert_malformed passed:
   out/test/spec/float_literals/float_literals.19.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e+_1))
                          ^^^^^^^
-out/test/spec/float_literals.wast:268: assert_malformed passed:
+out/test/spec/float_literals.wast:276: assert_malformed passed:
   out/test/spec/float_literals/float_literals.20.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 1.0e_+1))
                          ^^^^^^^
-out/test/spec/float_literals.wast:272: assert_malformed passed:
+out/test/spec/float_literals.wast:280: assert_malformed passed:
   out/test/spec/float_literals/float_literals.21.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const _0x100))
                          ^^^^^^
-out/test/spec/float_literals.wast:276: assert_malformed passed:
+out/test/spec/float_literals.wast:284: assert_malformed passed:
   out/test/spec/float_literals/float_literals.22.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0_x100))
                          ^^^^^^
-out/test/spec/float_literals.wast:280: assert_malformed passed:
+out/test/spec/float_literals.wast:288: assert_malformed passed:
   out/test/spec/float_literals/float_literals.23.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_100))
                          ^^^^^^
-out/test/spec/float_literals.wast:284: assert_malformed passed:
+out/test/spec/float_literals.wast:292: assert_malformed passed:
   out/test/spec/float_literals/float_literals.24.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x00_))
                          ^^^^^
-out/test/spec/float_literals.wast:288: assert_malformed passed:
+out/test/spec/float_literals.wast:296: assert_malformed passed:
   out/test/spec/float_literals/float_literals.25.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0xff__ffff))
                          ^^^^^^^^^^
-out/test/spec/float_literals.wast:292: assert_malformed passed:
+out/test/spec/float_literals.wast:300: assert_malformed passed:
   out/test/spec/float_literals/float_literals.26.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_1.0))
                          ^^^^^^
-out/test/spec/float_literals.wast:296: assert_malformed passed:
+out/test/spec/float_literals.wast:304: assert_malformed passed:
   out/test/spec/float_literals/float_literals.27.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0_))
                          ^^^^^^
-out/test/spec/float_literals.wast:300: assert_malformed passed:
+out/test/spec/float_literals.wast:308: assert_malformed passed:
   out/test/spec/float_literals/float_literals.28.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1_.0))
                          ^^^^^^
-out/test/spec/float_literals.wast:304: assert_malformed passed:
+out/test/spec/float_literals.wast:312: assert_malformed passed:
   out/test/spec/float_literals/float_literals.29.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1._0))
                          ^^^^^^
-out/test/spec/float_literals.wast:308: assert_malformed passed:
+out/test/spec/float_literals.wast:316: assert_malformed passed:
   out/test/spec/float_literals/float_literals.30.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_1p1))
                          ^^^^^^
-out/test/spec/float_literals.wast:312: assert_malformed passed:
+out/test/spec/float_literals.wast:320: assert_malformed passed:
   out/test/spec/float_literals/float_literals.31.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1p1_))
                          ^^^^^^
-out/test/spec/float_literals.wast:316: assert_malformed passed:
+out/test/spec/float_literals.wast:324: assert_malformed passed:
   out/test/spec/float_literals/float_literals.32.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1_p1))
                          ^^^^^^
-out/test/spec/float_literals.wast:320: assert_malformed passed:
+out/test/spec/float_literals.wast:328: assert_malformed passed:
   out/test/spec/float_literals/float_literals.33.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1p_1))
                          ^^^^^^
-out/test/spec/float_literals.wast:324: assert_malformed passed:
+out/test/spec/float_literals.wast:332: assert_malformed passed:
   out/test/spec/float_literals/float_literals.34.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x_1.0p1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:328: assert_malformed passed:
+out/test/spec/float_literals.wast:336: assert_malformed passed:
   out/test/spec/float_literals/float_literals.35.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p1_))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:332: assert_malformed passed:
+out/test/spec/float_literals.wast:340: assert_malformed passed:
   out/test/spec/float_literals/float_literals.36.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0_p1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:336: assert_malformed passed:
+out/test/spec/float_literals.wast:344: assert_malformed passed:
   out/test/spec/float_literals/float_literals.37.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p_1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:340: assert_malformed passed:
+out/test/spec/float_literals.wast:348: assert_malformed passed:
   out/test/spec/float_literals/float_literals.38.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p+_1))
                          ^^^^^^^^^
-out/test/spec/float_literals.wast:344: assert_malformed passed:
+out/test/spec/float_literals.wast:352: assert_malformed passed:
   out/test/spec/float_literals/float_literals.39.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f32 (f32.const 0x1.0p_+1))
                          ^^^^^^^^^
-out/test/spec/float_literals.wast:349: assert_malformed passed:
+out/test/spec/float_literals.wast:357: assert_malformed passed:
   out/test/spec/float_literals/float_literals.40.wat:1:24: error: unexpected token "_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _100))
                          ^^^^
-out/test/spec/float_literals.wast:353: assert_malformed passed:
+out/test/spec/float_literals.wast:361: assert_malformed passed:
   out/test/spec/float_literals/float_literals.41.wat:1:24: error: unexpected token "+_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const +_100))
                          ^^^^^
-out/test/spec/float_literals.wast:357: assert_malformed passed:
+out/test/spec/float_literals.wast:365: assert_malformed passed:
   out/test/spec/float_literals/float_literals.42.wat:1:24: error: unexpected token "-_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const -_100))
                          ^^^^^
-out/test/spec/float_literals.wast:361: assert_malformed passed:
+out/test/spec/float_literals.wast:369: assert_malformed passed:
   out/test/spec/float_literals/float_literals.43.wat:1:24: error: unexpected token "99_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 99_))
                          ^^^
-out/test/spec/float_literals.wast:365: assert_malformed passed:
+out/test/spec/float_literals.wast:373: assert_malformed passed:
   out/test/spec/float_literals/float_literals.44.wat:1:24: error: unexpected token "1__000", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1__000))
                          ^^^^^^
-out/test/spec/float_literals.wast:369: assert_malformed passed:
+out/test/spec/float_literals.wast:377: assert_malformed passed:
   out/test/spec/float_literals/float_literals.45.wat:1:24: error: unexpected token "_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1.0))
                          ^^^^
-out/test/spec/float_literals.wast:373: assert_malformed passed:
+out/test/spec/float_literals.wast:381: assert_malformed passed:
   out/test/spec/float_literals/float_literals.46.wat:1:24: error: unexpected token "1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0_))
                          ^^^^
-out/test/spec/float_literals.wast:377: assert_malformed passed:
+out/test/spec/float_literals.wast:385: assert_malformed passed:
   out/test/spec/float_literals/float_literals.47.wat:1:24: error: unexpected token "1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1_.0))
                          ^^^^
-out/test/spec/float_literals.wast:381: assert_malformed passed:
+out/test/spec/float_literals.wast:389: assert_malformed passed:
   out/test/spec/float_literals/float_literals.48.wat:1:24: error: unexpected token "1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1._0))
                          ^^^^
-out/test/spec/float_literals.wast:385: assert_malformed passed:
+out/test/spec/float_literals.wast:393: assert_malformed passed:
   out/test/spec/float_literals/float_literals.49.wat:1:24: error: unexpected token "_1e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1e1))
                          ^^^^
-out/test/spec/float_literals.wast:389: assert_malformed passed:
+out/test/spec/float_literals.wast:397: assert_malformed passed:
   out/test/spec/float_literals/float_literals.50.wat:1:24: error: unexpected token "1e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1e1_))
                          ^^^^
-out/test/spec/float_literals.wast:393: assert_malformed passed:
+out/test/spec/float_literals.wast:401: assert_malformed passed:
   out/test/spec/float_literals/float_literals.51.wat:1:24: error: unexpected token "1_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1_e1))
                          ^^^^
-out/test/spec/float_literals.wast:397: assert_malformed passed:
+out/test/spec/float_literals.wast:405: assert_malformed passed:
   out/test/spec/float_literals/float_literals.52.wat:1:24: error: unexpected token "1e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1e_1))
                          ^^^^
-out/test/spec/float_literals.wast:401: assert_malformed passed:
+out/test/spec/float_literals.wast:409: assert_malformed passed:
   out/test/spec/float_literals/float_literals.53.wat:1:24: error: unexpected token "_1.0e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _1.0e1))
                          ^^^^^^
-out/test/spec/float_literals.wast:405: assert_malformed passed:
+out/test/spec/float_literals.wast:413: assert_malformed passed:
   out/test/spec/float_literals/float_literals.54.wat:1:24: error: unexpected token "1.0e1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e1_))
                          ^^^^^^
-out/test/spec/float_literals.wast:409: assert_malformed passed:
+out/test/spec/float_literals.wast:417: assert_malformed passed:
   out/test/spec/float_literals/float_literals.55.wat:1:24: error: unexpected token "1.0_e1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0_e1))
                          ^^^^^^
-out/test/spec/float_literals.wast:413: assert_malformed passed:
+out/test/spec/float_literals.wast:421: assert_malformed passed:
   out/test/spec/float_literals/float_literals.56.wat:1:24: error: unexpected token "1.0e_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e_1))
                          ^^^^^^
-out/test/spec/float_literals.wast:417: assert_malformed passed:
+out/test/spec/float_literals.wast:425: assert_malformed passed:
   out/test/spec/float_literals/float_literals.57.wat:1:24: error: unexpected token "1.0e+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e+_1))
                          ^^^^^^^
-out/test/spec/float_literals.wast:421: assert_malformed passed:
+out/test/spec/float_literals.wast:429: assert_malformed passed:
   out/test/spec/float_literals/float_literals.58.wat:1:24: error: unexpected token "1.0e_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 1.0e_+1))
                          ^^^^^^^
-out/test/spec/float_literals.wast:425: assert_malformed passed:
+out/test/spec/float_literals.wast:433: assert_malformed passed:
   out/test/spec/float_literals/float_literals.59.wat:1:24: error: unexpected token "_0x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const _0x100))
                          ^^^^^^
-out/test/spec/float_literals.wast:429: assert_malformed passed:
+out/test/spec/float_literals.wast:437: assert_malformed passed:
   out/test/spec/float_literals/float_literals.60.wat:1:24: error: unexpected token "0_x100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0_x100))
                          ^^^^^^
-out/test/spec/float_literals.wast:433: assert_malformed passed:
+out/test/spec/float_literals.wast:441: assert_malformed passed:
   out/test/spec/float_literals/float_literals.61.wat:1:24: error: unexpected token "0x_100", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_100))
                          ^^^^^^
-out/test/spec/float_literals.wast:437: assert_malformed passed:
+out/test/spec/float_literals.wast:445: assert_malformed passed:
   out/test/spec/float_literals/float_literals.62.wat:1:24: error: unexpected token "0x00_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x00_))
                          ^^^^^
-out/test/spec/float_literals.wast:441: assert_malformed passed:
+out/test/spec/float_literals.wast:449: assert_malformed passed:
   out/test/spec/float_literals/float_literals.63.wat:1:24: error: unexpected token "0xff__ffff", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0xff__ffff))
                          ^^^^^^^^^^
-out/test/spec/float_literals.wast:445: assert_malformed passed:
+out/test/spec/float_literals.wast:453: assert_malformed passed:
   out/test/spec/float_literals/float_literals.64.wat:1:24: error: unexpected token "0x_1.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1.0))
                          ^^^^^^
-out/test/spec/float_literals.wast:449: assert_malformed passed:
+out/test/spec/float_literals.wast:457: assert_malformed passed:
   out/test/spec/float_literals/float_literals.65.wat:1:24: error: unexpected token "0x1.0_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0_))
                          ^^^^^^
-out/test/spec/float_literals.wast:453: assert_malformed passed:
+out/test/spec/float_literals.wast:461: assert_malformed passed:
   out/test/spec/float_literals/float_literals.66.wat:1:24: error: unexpected token "0x1_.0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1_.0))
                          ^^^^^^
-out/test/spec/float_literals.wast:457: assert_malformed passed:
+out/test/spec/float_literals.wast:465: assert_malformed passed:
   out/test/spec/float_literals/float_literals.67.wat:1:24: error: unexpected token "0x1._0", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1._0))
                          ^^^^^^
-out/test/spec/float_literals.wast:461: assert_malformed passed:
+out/test/spec/float_literals.wast:469: assert_malformed passed:
   out/test/spec/float_literals/float_literals.68.wat:1:24: error: unexpected token "0x_1p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1p1))
                          ^^^^^^
-out/test/spec/float_literals.wast:465: assert_malformed passed:
+out/test/spec/float_literals.wast:473: assert_malformed passed:
   out/test/spec/float_literals/float_literals.69.wat:1:24: error: unexpected token "0x1p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1p1_))
                          ^^^^^^
-out/test/spec/float_literals.wast:469: assert_malformed passed:
+out/test/spec/float_literals.wast:477: assert_malformed passed:
   out/test/spec/float_literals/float_literals.70.wat:1:24: error: unexpected token "0x1_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1_p1))
                          ^^^^^^
-out/test/spec/float_literals.wast:473: assert_malformed passed:
+out/test/spec/float_literals.wast:481: assert_malformed passed:
   out/test/spec/float_literals/float_literals.71.wat:1:24: error: unexpected token "0x1p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1p_1))
                          ^^^^^^
-out/test/spec/float_literals.wast:477: assert_malformed passed:
+out/test/spec/float_literals.wast:485: assert_malformed passed:
   out/test/spec/float_literals/float_literals.72.wat:1:24: error: unexpected token "0x_1.0p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x_1.0p1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:481: assert_malformed passed:
+out/test/spec/float_literals.wast:489: assert_malformed passed:
   out/test/spec/float_literals/float_literals.73.wat:1:24: error: unexpected token "0x1.0p1_", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p1_))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:485: assert_malformed passed:
+out/test/spec/float_literals.wast:493: assert_malformed passed:
   out/test/spec/float_literals/float_literals.74.wat:1:24: error: unexpected token "0x1.0_p1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0_p1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:489: assert_malformed passed:
+out/test/spec/float_literals.wast:497: assert_malformed passed:
   out/test/spec/float_literals/float_literals.75.wat:1:24: error: unexpected token "0x1.0p_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p_1))
                          ^^^^^^^^
-out/test/spec/float_literals.wast:493: assert_malformed passed:
+out/test/spec/float_literals.wast:501: assert_malformed passed:
   out/test/spec/float_literals/float_literals.76.wat:1:24: error: unexpected token "0x1.0p+_1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p+_1))
                          ^^^^^^^^^
-out/test/spec/float_literals.wast:497: assert_malformed passed:
+out/test/spec/float_literals.wast:505: assert_malformed passed:
   out/test/spec/float_literals/float_literals.77.wat:1:24: error: unexpected token "0x1.0p_+1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (global f64 (f64.const 0x1.0p_+1))
                          ^^^^^^^^^
-157/157 tests passed.
+159/159 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -4,49 +4,37 @@
 out/test/spec/globals.wast:50: assert_invalid passed:
   error: can't set_global on immutable global at index 0.
   0000026: error: OnSetGlobalExpr callback failed
-out/test/spec/globals.wast:55: assert_invalid passed:
-  error: unknown import module "m"
-  0000012: error: OnImportGlobal callback failed
-out/test/spec/globals.wast:60: assert_invalid passed:
-  error: unknown import module "m"
-  0000012: error: OnImportGlobal callback failed
-out/test/spec/globals.wast:65: assert_invalid passed:
-  error: mutable globals cannot be exported
-  000001a: error: OnExport callback failed
-out/test/spec/globals.wast:70: assert_invalid passed:
-  error: mutable globals cannot be exported
-  000001a: error: OnExport callback failed
-out/test/spec/globals.wast:75: assert_invalid passed:
+out/test/spec/globals.wast:59: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:80: assert_invalid passed:
+out/test/spec/globals.wast:64: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 32 (0x20)
-out/test/spec/globals.wast:85: assert_invalid passed:
+out/test/spec/globals.wast:69: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:90: assert_invalid passed:
+out/test/spec/globals.wast:74: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:95: assert_invalid passed:
+out/test/spec/globals.wast:79: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 1 (0x1)
-out/test/spec/globals.wast:100: assert_invalid passed:
+out/test/spec/globals.wast:84: assert_invalid passed:
   error: type mismatch in global, expected i32 but got f32.
   0000013: error: EndGlobalInitExpr callback failed
-out/test/spec/globals.wast:105: assert_invalid passed:
+out/test/spec/globals.wast:89: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:110: assert_invalid passed:
+out/test/spec/globals.wast:94: assert_invalid passed:
   error: type mismatch in global, expected i32 but got void.
   000000e: error: EndGlobalInitExpr callback failed
-out/test/spec/globals.wast:115: assert_invalid passed:
+out/test/spec/globals.wast:99: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
-out/test/spec/globals.wast:120: assert_invalid passed:
+out/test/spec/globals.wast:104: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
-out/test/spec/globals.wast:128: assert_malformed passed:
+out/test/spec/globals.wast:112: assert_malformed passed:
   0000019: error: unable to read string: import field name
-out/test/spec/globals.wast:141: assert_malformed passed:
+out/test/spec/globals.wast:125: assert_malformed passed:
   0000019: error: unable to read string: import field name
-out/test/spec/globals.wast:158: assert_malformed passed:
+out/test/spec/globals.wast:142: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/test/spec/globals.wast:170: assert_malformed passed:
+out/test/spec/globals.wast:154: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-35/35 tests passed.
+31/31 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -7,29 +7,35 @@ out/test/spec/linking.wast:28: assert_unlinkable passed:
 out/test/spec/linking.wast:32: assert_unlinkable passed:
   error: import signature mismatch
   0000026: error: OnImportFunc callback failed
-out/test/spec/linking.wast:174: assert_unlinkable passed:
+out/test/spec/linking.wast:87: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected mutable but got immutable.
+  000001a: error: OnImportGlobal callback failed
+out/test/spec/linking.wast:91: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected immutable but got mutable.
+  0000016: error: OnImportGlobal callback failed
+out/test/spec/linking.wast:207: assert_unlinkable passed:
   error: elem segment is out of bounds: [10, 11) >= max value 10
   0000028: error: OnElemSegmentFunctionIndexCount callback failed
-out/test/spec/linking.wast:183: assert_unlinkable passed:
+out/test/spec/linking.wast:216: assert_unlinkable passed:
   error: unknown module field "mem"
   0000027: error: OnImportMemory callback failed
-out/test/spec/linking.wast:195: assert_unlinkable passed:
+out/test/spec/linking.wast:228: assert_unlinkable passed:
   error: elem segment is out of bounds: [12, 13) >= max value 10
   000002f: error: OnElemSegmentFunctionIndexCount callback failed
-out/test/spec/linking.wast:206: assert_unlinkable passed:
+out/test/spec/linking.wast:239: assert_unlinkable passed:
   error: data segment is out of bounds: [65536, 65537) >= max value 65536
   0000042: error: OnDataSegmentData callback failed
-out/test/spec/linking.wast:266: assert_unlinkable passed:
+out/test/spec/linking.wast:299: assert_unlinkable passed:
   error: data segment is out of bounds: [65536, 65537) >= max value 65536
   0000020: error: OnDataSegmentData callback failed
-out/test/spec/linking.wast:291: assert_unlinkable passed:
+out/test/spec/linking.wast:324: assert_unlinkable passed:
   error: unknown module field "tab"
   0000037: error: OnImportTable callback failed
-out/test/spec/linking.wast:302: assert_unlinkable passed:
+out/test/spec/linking.wast:335: assert_unlinkable passed:
   error: data segment is out of bounds: [327680, 327681) >= max value 327680
   0000028: error: OnDataSegmentData callback failed
-out/test/spec/linking.wast:312: assert_unlinkable passed:
+out/test/spec/linking.wast:345: assert_unlinkable passed:
   error: elem segment is out of bounds: [0, 1) >= max value 0
   000002d: error: OnElemSegmentFunctionIndexCount callback failed
-80/80 tests passed.
+91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -44,112 +44,85 @@ out/test/spec/memory.wast:69: assert_invalid passed:
   0000012: error: invalid memory max size
 out/test/spec/memory.wast:73: assert_invalid passed:
   0000012: error: invalid memory max size
-out/test/spec/memory.wast:84: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:88: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:92: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:96: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:100: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:104: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
-  0000023: error: OnStoreExpr callback failed
-out/test/spec/memory.wast:108: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:112: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
-  0000021: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:116: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
-  0000023: error: OnStoreExpr callback failed
-out/test/spec/memory.wast:308: assert_malformed passed:
-  out/test/spec/memory/memory.39.wat:1:43: error: unexpected token "i32.load32", expected an instr.
+out/test/spec/memory.wast:215: assert_malformed passed:
+  out/test/spec/memory/memory.26.wat:1:43: error: unexpected token "i32.load32", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load32 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:315: assert_malformed passed:
-  out/test/spec/memory/memory.40.wat:1:43: error: unexpected token "i32.load32_u", expected an instr.
+out/test/spec/memory.wast:222: assert_malformed passed:
+  out/test/spec/memory/memory.27.wat:1:43: error: unexpected token "i32.load32_u", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load32_u (get_local 0)))
                                             ^^^^^^^^^^^^
-out/test/spec/memory.wast:322: assert_malformed passed:
-  out/test/spec/memory/memory.41.wat:1:43: error: unexpected token "i32.load32_s", expected an instr.
+out/test/spec/memory.wast:229: assert_malformed passed:
+  out/test/spec/memory/memory.28.wat:1:43: error: unexpected token "i32.load32_s", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load32_s (get_local 0)))
                                             ^^^^^^^^^^^^
-out/test/spec/memory.wast:329: assert_malformed passed:
-  out/test/spec/memory/memory.42.wat:1:43: error: unexpected token "i32.load64", expected an instr.
+out/test/spec/memory.wast:236: assert_malformed passed:
+  out/test/spec/memory/memory.29.wat:1:43: error: unexpected token "i32.load64", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:336: assert_malformed passed:
-  out/test/spec/memory/memory.43.wat:1:43: error: unexpected token "i32.load64_u", expected an instr.
+out/test/spec/memory.wast:243: assert_malformed passed:
+  out/test/spec/memory/memory.30.wat:1:43: error: unexpected token "i32.load64_u", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load64_u (get_local 0)))
                                             ^^^^^^^^^^^^
-out/test/spec/memory.wast:343: assert_malformed passed:
-  out/test/spec/memory/memory.44.wat:1:43: error: unexpected token "i32.load64_s", expected an instr.
+out/test/spec/memory.wast:250: assert_malformed passed:
+  out/test/spec/memory/memory.31.wat:1:43: error: unexpected token "i32.load64_s", expected an instr.
   (memory 1)(func (param i32) (result i32) (i32.load64_s (get_local 0)))
                                             ^^^^^^^^^^^^
-out/test/spec/memory.wast:350: assert_malformed passed:
-  out/test/spec/memory/memory.45.wat:1:30: error: unexpected token "i32.store32", expected an instr.
+out/test/spec/memory.wast:257: assert_malformed passed:
+  out/test/spec/memory/memory.32.wat:1:30: error: unexpected token "i32.store32", expected an instr.
   (memory 1)(func (param i32) (i32.store32 (get_local 0) (i32.const 0)))
                                ^^^^^^^^^^^
-out/test/spec/memory.wast:357: assert_malformed passed:
-  out/test/spec/memory/memory.46.wat:1:30: error: unexpected token "i32.store64", expected an instr.
+out/test/spec/memory.wast:264: assert_malformed passed:
+  out/test/spec/memory/memory.33.wat:1:30: error: unexpected token "i32.store64", expected an instr.
   (memory 1)(func (param i32) (i32.store64 (get_local 0) (i64.const 0)))
                                ^^^^^^^^^^^
-out/test/spec/memory.wast:365: assert_malformed passed:
-  out/test/spec/memory/memory.47.wat:1:43: error: unexpected token "i64.load64", expected an instr.
+out/test/spec/memory.wast:272: assert_malformed passed:
+  out/test/spec/memory/memory.34.wat:1:43: error: unexpected token "i64.load64", expected an instr.
   (memory 1)(func (param i32) (result i64) (i64.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:372: assert_malformed passed:
-  out/test/spec/memory/memory.48.wat:1:43: error: unexpected token "i64.load64_u", expected an instr.
+out/test/spec/memory.wast:279: assert_malformed passed:
+  out/test/spec/memory/memory.35.wat:1:43: error: unexpected token "i64.load64_u", expected an instr.
   (memory 1)(func (param i32) (result i64) (i64.load64_u (get_local 0)))
                                             ^^^^^^^^^^^^
-out/test/spec/memory.wast:379: assert_malformed passed:
-  out/test/spec/memory/memory.49.wat:1:43: error: unexpected token "i64.load64_s", expected an instr.
+out/test/spec/memory.wast:286: assert_malformed passed:
+  out/test/spec/memory/memory.36.wat:1:43: error: unexpected token "i64.load64_s", expected an instr.
   (memory 1)(func (param i32) (result i64) (i64.load64_s (get_local 0)))
                                             ^^^^^^^^^^^^
-out/test/spec/memory.wast:386: assert_malformed passed:
-  out/test/spec/memory/memory.50.wat:1:30: error: unexpected token "i64.store64", expected an instr.
+out/test/spec/memory.wast:293: assert_malformed passed:
+  out/test/spec/memory/memory.37.wat:1:30: error: unexpected token "i64.store64", expected an instr.
   (memory 1)(func (param i32) (i64.store64 (get_local 0) (i64.const 0)))
                                ^^^^^^^^^^^
-out/test/spec/memory.wast:394: assert_malformed passed:
-  out/test/spec/memory/memory.51.wat:1:43: error: unexpected token "f32.load32", expected an instr.
+out/test/spec/memory.wast:301: assert_malformed passed:
+  out/test/spec/memory/memory.38.wat:1:43: error: unexpected token "f32.load32", expected an instr.
   (memory 1)(func (param i32) (result f32) (f32.load32 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:401: assert_malformed passed:
-  out/test/spec/memory/memory.52.wat:1:43: error: unexpected token "f32.load64", expected an instr.
+out/test/spec/memory.wast:308: assert_malformed passed:
+  out/test/spec/memory/memory.39.wat:1:43: error: unexpected token "f32.load64", expected an instr.
   (memory 1)(func (param i32) (result f32) (f32.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:408: assert_malformed passed:
-  out/test/spec/memory/memory.53.wat:1:30: error: unexpected token "f32.store32", expected an instr.
+out/test/spec/memory.wast:315: assert_malformed passed:
+  out/test/spec/memory/memory.40.wat:1:30: error: unexpected token "f32.store32", expected an instr.
   (memory 1)(func (param i32) (f32.store32 (get_local 0) (f32.const 0)))
                                ^^^^^^^^^^^
-out/test/spec/memory.wast:415: assert_malformed passed:
-  out/test/spec/memory/memory.54.wat:1:30: error: unexpected token "f32.store64", expected an instr.
+out/test/spec/memory.wast:322: assert_malformed passed:
+  out/test/spec/memory/memory.41.wat:1:30: error: unexpected token "f32.store64", expected an instr.
   (memory 1)(func (param i32) (f32.store64 (get_local 0) (f64.const 0)))
                                ^^^^^^^^^^^
-out/test/spec/memory.wast:423: assert_malformed passed:
-  out/test/spec/memory/memory.55.wat:1:43: error: unexpected token "f64.load32", expected an instr.
+out/test/spec/memory.wast:330: assert_malformed passed:
+  out/test/spec/memory/memory.42.wat:1:43: error: unexpected token "f64.load32", expected an instr.
   (memory 1)(func (param i32) (result f64) (f64.load32 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:430: assert_malformed passed:
-  out/test/spec/memory/memory.56.wat:1:43: error: unexpected token "f64.load64", expected an instr.
+out/test/spec/memory.wast:337: assert_malformed passed:
+  out/test/spec/memory/memory.43.wat:1:43: error: unexpected token "f64.load64", expected an instr.
   (memory 1)(func (param i32) (result f64) (f64.load64 (get_local 0)))
                                             ^^^^^^^^^^
-out/test/spec/memory.wast:437: assert_malformed passed:
-  out/test/spec/memory/memory.57.wat:1:30: error: unexpected token "f64.store32", expected an instr.
+out/test/spec/memory.wast:344: assert_malformed passed:
+  out/test/spec/memory/memory.44.wat:1:30: error: unexpected token "f64.store32", expected an instr.
   (memory 1)(func (param i32) (f64.store32 (get_local 0) (f32.const 0)))
                                ^^^^^^^^^^^
-out/test/spec/memory.wast:444: assert_malformed passed:
-  out/test/spec/memory/memory.58.wat:1:30: error: unexpected token "f64.store64", expected an instr.
+out/test/spec/memory.wast:351: assert_malformed passed:
+  out/test/spec/memory/memory.45.wat:1:30: error: unexpected token "f64.store64", expected an instr.
   (memory 1)(func (param i32) (f64.store64 (get_local 0) (f64.const 0)))
                                ^^^^^^^^^^^
-94/94 tests passed.
+83/83 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory_grow.txt
+++ b/test/spec/memory_grow.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/memory_grow.wast
+(;; STDOUT ;;;
+45/45 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/names.txt
+++ b/test/spec/names.txt
@@ -3,5 +3,5 @@
 (;; STDOUT ;;;
 called host spectest.print_i32(i32:42) =>
 called host spectest.print_i32(i32:123) =>
-475/475 tests passed.
+479/479 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/bad-enable-feature.txt
+++ b/test/wasm2c/bad-enable-feature.txt
@@ -2,5 +2,5 @@
 ;;; ARGS: --enable-simd %(in_file)s
 ;;; ERROR: 1
 (;; STDERR ;;;
-wasm2c doesn't currently support any --enable-* flags.
+wasm2c currently support only default feature flags.
 ;;; STDERR ;;)

--- a/test/wasm2c/spec/address.txt
+++ b/test/wasm2c/spec/address.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/address.wast
 (;; STDOUT ;;;
-41/41 tests passed.
+238/238 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/align.txt
+++ b/test/wasm2c/spec/align.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/align.wast
 (;; STDOUT ;;;
-0/0 tests passed.
+48/48 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/float_literals.txt
+++ b/test/wasm2c/spec/float_literals.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/float_literals.wast
 (;; STDOUT ;;;
-81/81 tests passed.
+83/83 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/linking.txt
+++ b/test/wasm2c/spec/linking.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/linking.wast
 (;; STDOUT ;;;
-70/70 tests passed.
+79/79 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/memory.txt
+++ b/test/wasm2c/spec/memory.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/memory.wast
 (;; STDOUT ;;;
-47/47 tests passed.
+45/45 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/names.txt
+++ b/test/wasm2c/spec/names.txt
@@ -3,5 +3,5 @@
 (;; STDOUT ;;;
 spectest.print_i32(42)
 spectest.print_i32(123)
-475/475 tests passed.
+479/479 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
The newest testsuite update enables mutable globals by default, which
matches the v1 WebAssembly spec.

This change changes the default for all wabt tools, and changes the flag
to `--disable-mutable-globals` in case you need the previous behavior.
This flag will likely be removed in the future.