### PR TITLE
handle traps in host functions

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -1557,7 +1557,7 @@ Result Thread::Run(int num_instructions) {
         TRAP_UNLESS(env_->FuncSignaturesAreEqual(func->sig_index, sig_index),
                     IndirectCallSignatureMismatch);
         if (func->is_host) {
-          CallHost(cast<HostFunc>(func));
+          CHECK_TRAP(CallHost(cast<HostFunc>(func)));
         } else {
           CHECK_TRAP(PushCall(pc));
           GOTO(cast<DefinedFunc>(func)->offset);
@@ -1567,7 +1567,7 @@ Result Thread::Run(int num_instructions) {
 
       case Opcode::InterpCallHost: {
         Index func_index = ReadU32(&pc);
-        CallHost(cast<HostFunc>(env_->funcs_[func_index].get()));
+        CHECK_TRAP(CallHost(cast<HostFunc>(env_->funcs_[func_index].get())));
         break;
       }
 


### PR DESCRIPTION
With these changes, when my host function returns `interp::Result::TrapHostTrapped`, execution traps as desired.

By the way, great work on wabt! Useful tools!