### PR TITLE
[interp] Simplify host module imports

### DIFF
--- a/src/binary-reader-interp.cc
+++ b/src/binary-reader-interp.cc
@@ -287,8 +287,6 @@ class BinaryReaderInterp : public BinaryReaderNop {
                                string_view field_name,
                                Export** out_export);
 
-  HostImportDelegate::ErrorCallback MakePrintErrorCallback();
-
   Features features_;
   ErrorHandler* error_handler_ = nullptr;
   Environment* env_ = nullptr;
@@ -659,11 +657,7 @@ wabt::Result BinaryReaderInterp::AppendExport(Module* module,
     return wabt::Result::Error;
   }
 
-  module->exports.emplace_back(name, kind, item_index);
-  Export* export_ = &module->exports.back();
-
-  module->export_bindings.emplace(export_->name,
-                                  Binding(module->exports.size() - 1));
+  module->AppendExport(kind, item_index, name);
   return wabt::Result::Ok;
 }
 
@@ -694,10 +688,6 @@ wabt::Result BinaryReaderInterp::GetModuleExport(Module* module,
   return wabt::Result::Ok;
 }
 
-HostImportDelegate::ErrorCallback BinaryReaderInterp::MakePrintErrorCallback() {
-  return [this](const char* msg) { PrintError("%s", msg); };
-}
-
 wabt::Result BinaryReaderInterp::OnImportFunc(Index import_index,
                                               string_view module_name,
                                               string_view field_name,
@@ -710,34 +700,24 @@ wabt::Result BinaryReaderInterp::OnImportFunc(Index import_index,
   Module* import_module;
   CHECK_RESULT(FindRegisteredModule(import->module_name, &import_module));
 
-  Index func_env_index;
-  if (auto* host_import_module = dyn_cast<HostModule>(import_module)) {
-    HostFunc* func = new HostFunc(import->module_name, import->field_name,
-                                  import->sig_index);
-    env_->EmplaceBackFunc(func);
-
-    FuncSignature* sig = env_->GetFuncSignature(func->sig_index);
-    CHECK_RESULT(host_import_module->import_delegate->ImportFunc(
-        import, func, sig, MakePrintErrorCallback()));
-    assert(func->callback);
-
-    func_env_index = env_->GetFuncCount() - 1;
-    AppendExport(host_import_module, ExternalKind::Func, func_env_index,
-                 import->field_name);
-  } else {
-    Export* export_;
+  Export* export_ =
+      import_module->GetFuncExport(env_, field_name, import->sig_index);
+  if (!export_) {
+    // If GetFuncExport fails then GetModuleExport will fail too. But it's
+    // useful to call here to share the same error handling code as other
+    // imports.
     CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
-    CHECK_RESULT(CheckImportKind(import, export_->kind));
-
-    Func* func = env_->GetFunc(export_->index);
-    if (!env_->FuncSignaturesAreEqual(import->sig_index, func->sig_index)) {
-      PrintError("import signature mismatch");
-      return wabt::Result::Error;
-    }
-
-    func_env_index = export_->index;
   }
-  func_index_mapping_.push_back(func_env_index);
+
+  CHECK_RESULT(CheckImportKind(import, export_->kind));
+
+  Func* func = env_->GetFunc(export_->index);
+  if (!env_->FuncSignaturesAreEqual(import->sig_index, func->sig_index)) {
+    PrintError("import signature mismatch");
+    return wabt::Result::Error;
+  }
+
+  func_index_mapping_.push_back(export_->index);
   num_func_imports_++;
   return wabt::Result::Ok;
 }
@@ -759,30 +739,15 @@ wabt::Result BinaryReaderInterp::OnImportTable(Index import_index,
   Module* import_module;
   CHECK_RESULT(FindRegisteredModule(import->module_name, &import_module));
 
-  if (auto* host_import_module = dyn_cast<HostModule>(import_module)) {
-    Table* table = env_->EmplaceBackTable(*elem_limits);
+  Export* export_;
+  CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
+  CHECK_RESULT(CheckImportKind(import, export_->kind));
 
-    CHECK_RESULT(host_import_module->import_delegate->ImportTable(
-        import, table, MakePrintErrorCallback()));
+  Table* table = env_->GetTable(export_->index);
+  CHECK_RESULT(CheckImportLimits(elem_limits, &table->limits));
 
-    CHECK_RESULT(CheckImportLimits(elem_limits, &table->limits));
-
-    table->func_indexes.resize(table->limits.initial);
-
-    module_->table_index = env_->GetTableCount() - 1;
-    AppendExport(host_import_module, ExternalKind::Table, module_->table_index,
-                 import->field_name);
-  } else {
-    Export* export_;
-    CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
-    CHECK_RESULT(CheckImportKind(import, export_->kind));
-
-    Table* table = env_->GetTable(export_->index);
-    CHECK_RESULT(CheckImportLimits(elem_limits, &table->limits));
-
-    import->limits = *elem_limits;
-    module_->table_index = export_->index;
-  }
+  import->limits = *elem_limits;
+  module_->table_index = export_->index;
   return wabt::Result::Ok;
 }
 
@@ -802,28 +767,15 @@ wabt::Result BinaryReaderInterp::OnImportMemory(Index import_index,
   Module* import_module;
   CHECK_RESULT(FindRegisteredModule(import->module_name, &import_module));
 
-  if (auto* host_import_module = dyn_cast<HostModule>(import_module)) {
-    Memory* memory = env_->EmplaceBackMemory();
+  Export* export_;
+  CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
+  CHECK_RESULT(CheckImportKind(import, export_->kind));
 
-    CHECK_RESULT(host_import_module->import_delegate->ImportMemory(
-        import, memory, MakePrintErrorCallback()));
+  Memory* memory = env_->GetMemory(export_->index);
+  CHECK_RESULT(CheckImportLimits(page_limits, &memory->page_limits));
 
-    CHECK_RESULT(CheckImportLimits(page_limits, &memory->page_limits));
-
-    module_->memory_index = env_->GetMemoryCount() - 1;
-    AppendExport(host_import_module, ExternalKind::Memory,
-                 module_->memory_index, import->field_name);
-  } else {
-    Export* export_;
-    CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
-    CHECK_RESULT(CheckImportKind(import, export_->kind));
-
-    Memory* memory = env_->GetMemory(export_->index);
-    CHECK_RESULT(CheckImportLimits(page_limits, &memory->page_limits));
-
-    import->limits = *page_limits;
-    module_->memory_index = export_->index;
-  }
+  import->limits = *page_limits;
+  module_->memory_index = export_->index;
   return wabt::Result::Ok;
 }
 
@@ -839,46 +791,29 @@ wabt::Result BinaryReaderInterp::OnImportGlobal(Index import_index,
   Module* import_module;
   CHECK_RESULT(FindRegisteredModule(import->module_name, &import_module));
 
-  Index global_env_index = env_->GetGlobalCount() - 1;
-  if (auto* host_import_module = dyn_cast<HostModule>(import_module)) {
-    Global* global = env_->EmplaceBackGlobal(TypedValue(type), mutable_);
+  Export* export_;
+  CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
+  CHECK_RESULT(CheckImportKind(import, export_->kind));
 
-    CHECK_RESULT(host_import_module->import_delegate->ImportGlobal(
-        import, global, MakePrintErrorCallback()));
-
-    // Make sure the ImportGlobal callback gave us a global that matches.
-    assert(global->typed_value.type == type);
-    assert(global->mutable_ == mutable_);
-
-    global_env_index = env_->GetGlobalCount() - 1;
-    AppendExport(host_import_module, ExternalKind::Global, global_env_index,
-                 import->field_name);
-  } else {
-    Export* export_;
-    CHECK_RESULT(GetModuleExport(import_module, import->field_name, &export_));
-    CHECK_RESULT(CheckImportKind(import, export_->kind));
-
-    Global* exported_global = env_->GetGlobal(export_->index);
-    if (exported_global->typed_value.type != type) {
-      PrintError("type mismatch in imported global, expected %s but got %s.",
-                 GetTypeName(exported_global->typed_value.type),
-                 GetTypeName(type));
-      return wabt::Result::Error;
-    }
-
-    if (exported_global->mutable_ != mutable_) {
-      const char* kMutableNames[] = {"immutable", "mutable"};
-      PrintError(
-          "mutability mismatch in imported global, expected %s but got %s.",
-          kMutableNames[exported_global->mutable_], kMutableNames[mutable_]);
-      return wabt::Result::Error;
-    }
-
-    global_env_index = export_->index;
+  Global* exported_global = env_->GetGlobal(export_->index);
+  if (exported_global->typed_value.type != type) {
+    PrintError("type mismatch in imported global, expected %s but got %s.",
+               GetTypeName(exported_global->typed_value.type),
+               GetTypeName(type));
+    return wabt::Result::Error;
   }
+
+  if (exported_global->mutable_ != mutable_) {
+    const char* kMutableNames[] = {"immutable", "mutable"};
+    PrintError(
+        "mutability mismatch in imported global, expected %s but got %s.",
+        kMutableNames[exported_global->mutable_], kMutableNames[mutable_]);
+    return wabt::Result::Error;
+  }
+
   import->type = type;
   import->mutable_ = mutable_;
-  global_index_mapping_.push_back(global_env_index);
+  global_index_mapping_.push_back(export_->index);
   num_global_imports_++;
   return wabt::Result::Ok;
 }

--- a/src/common.h
+++ b/src/common.h
@@ -289,6 +289,13 @@ enum class ExternalKind {
 static const int kExternalKindCount = WABT_ENUM_COUNT(ExternalKind);
 
 struct Limits {
+  Limits() = default;
+  explicit Limits(uint64_t initial) : initial(initial) {}
+  Limits(uint64_t initial, uint64_t max)
+      : initial(initial), max(max), has_max(true) {}
+  Limits(uint64_t initial, uint64_t max, bool is_shared)
+      : initial(initial), max(max), has_max(true), is_shared(is_shared) {}
+
   uint64_t initial = 0;
   uint64_t max = 0;
   bool has_max = false;

--- a/src/interp.cc
+++ b/src/interp.cc
@@ -54,21 +54,17 @@ namespace interp {
 std::string TypedValueToString(const TypedValue& tv) {
   switch (tv.type) {
     case Type::I32:
-      return StringPrintf("i32:%u", tv.value.i32);
+      return StringPrintf("i32:%u", tv.get_i32());
 
     case Type::I64:
-      return StringPrintf("i64:%" PRIu64, tv.value.i64);
+      return StringPrintf("i64:%" PRIu64, tv.get_i64());
 
     case Type::F32: {
-      float value;
-      memcpy(&value, &tv.value.f32_bits, sizeof(float));
-      return StringPrintf("f32:%f", value);
+      return StringPrintf("f32:%f", tv.get_f32());
     }
 
     case Type::F64: {
-      double value;
-      memcpy(&value, &tv.value.f64_bits, sizeof(double));
-      return StringPrintf("f64:%f", value);
+      return StringPrintf("f64:%f", tv.get_f64());
     }
 
     case Type::V128:
@@ -161,6 +157,10 @@ Thread::Thread(Environment* env, const Options& options)
       value_stack_(options.value_stack_size),
       call_stack_(options.call_stack_size) {}
 
+FuncSignature::FuncSignature(std::vector<Type> param_types,
+                             std::vector<Type> result_types)
+    : param_types(param_types), result_types(result_types) {}
+
 FuncSignature::FuncSignature(Index param_count,
                              Type* param_types,
                              Index result_count,
@@ -179,6 +179,35 @@ Module::Module(string_view name, bool is_host)
       table_index(kInvalidIndex),
       is_host(is_host) {}
 
+Export* Module::GetFuncExport(Environment* env,
+                              string_view name,
+                              Index sig_index) {
+  auto range = export_bindings.equal_range(name.to_string());
+  for (auto iter = range.first; iter != range.second; ++iter) {
+    const Binding& binding = iter->second;
+    Export* export_ = &exports[binding.index];
+    if (export_->kind == ExternalKind::Func) {
+      const Func* func = env->GetFunc(export_->index);
+      if (env->FuncSignaturesAreEqual(sig_index, func->sig_index)) {
+        return export_;
+      }
+    }
+  }
+
+  // No match; check whether the module wants to spontaneously create a
+  // function of this name and signature.
+  Index index = OnUnknownFuncExport(name, sig_index);
+  if (index != kInvalidIndex) {
+    Export* export_ = &exports[index];
+    assert(export_->kind == ExternalKind::Func);
+    const Func* func = env->GetFunc(export_->index);
+    assert(env->FuncSignaturesAreEqual(sig_index, func->sig_index));
+    return export_;
+  }
+
+  return nullptr;
+}
+
 Export* Module::GetExport(string_view name) {
   int field_index = export_bindings.FindIndex(name);
   if (field_index < 0) {
@@ -187,13 +216,114 @@ Export* Module::GetExport(string_view name) {
   return &exports[field_index];
 }
 
+Index Module::AppendExport(ExternalKind kind,
+                           Index item_index,
+                           string_view name) {
+  exports.emplace_back(name, kind, item_index);
+  Export* export_ = &exports.back();
+  export_bindings.emplace(export_->name, Binding(exports.size() - 1));
+  return exports.size() - 1;
+}
+
 DefinedModule::DefinedModule()
     : Module(false),
       start_func_index(kInvalidIndex),
       istream_start(kInvalidIstreamOffset),
       istream_end(kInvalidIstreamOffset) {}
 
-HostModule::HostModule(string_view name) : Module(name, true) {}
+HostModule::HostModule(Environment* env, string_view name)
+    : Module(name, true), env_(env) {}
+
+Index HostModule::OnUnknownFuncExport(string_view name, Index sig_index) {
+  if (on_unknown_func_export) {
+    return on_unknown_func_export(env_, this, name, sig_index);
+  }
+  return kInvalidIndex;
+}
+
+std::pair<HostFunc*, Index> HostModule::AppendFuncExport(
+    string_view name,
+    const FuncSignature& sig,
+    HostFunc::Callback callback) {
+  // TODO(binji): dedupe signature?
+  env_->EmplaceBackFuncSignature(sig);
+  Index sig_index = env_->GetFuncSignatureCount() - 1;
+  return AppendFuncExport(name, sig_index, callback);
+}
+
+std::pair<HostFunc*, Index> HostModule::AppendFuncExport(
+    string_view name,
+    Index sig_index,
+    HostFunc::Callback callback) {
+  auto* host_func = new HostFunc(this->name, name, sig_index, callback);
+  env_->EmplaceBackFunc(host_func);
+  Index func_env_index = env_->GetFuncCount() - 1;
+  Index export_index = AppendExport(ExternalKind::Func, func_env_index, name);
+  return {host_func, export_index};
+}
+
+std::pair<Table*, Index> HostModule::AppendTableExport(string_view name,
+                                                       const Limits& limits) {
+  Table* table = env_->EmplaceBackTable(limits);
+  Index table_env_index = env_->GetTableCount() - 1;
+  Index export_index = AppendExport(ExternalKind::Table, table_env_index, name);
+  return {table, export_index};
+}
+
+std::pair<Memory*, Index> HostModule::AppendMemoryExport(string_view name,
+                                                         const Limits& limits) {
+  Memory* memory = env_->EmplaceBackMemory(limits);
+  Index memory_env_index = env_->GetMemoryCount() - 1;
+  Index export_index =
+      AppendExport(ExternalKind::Memory, memory_env_index, name);
+  return {memory, export_index};
+}
+
+std::pair<Global*, Index> HostModule::AppendGlobalExport(string_view name,
+                                                         Type type,
+                                                         bool mutable_) {
+  Global* global = env_->EmplaceBackGlobal(TypedValue(type), mutable_);
+  Index global_env_index = env_->GetGlobalCount() - 1;
+  Index export_index =
+      AppendExport(ExternalKind::Global, global_env_index, name);
+  return {global, export_index};
+}
+
+std::pair<Global*, Index> HostModule::AppendGlobalExport(string_view name,
+                                             bool mutable_,
+                                             uint32_t value) {
+  std::pair<Global*, Index> pair =
+      AppendGlobalExport(name, Type::I32, mutable_);
+  pair.first->typed_value.set_i32(value);
+  return pair;
+}
+
+std::pair<Global*, Index> HostModule::AppendGlobalExport(string_view name,
+                                             bool mutable_,
+                                             uint64_t value) {
+  std::pair<Global*, Index> pair =
+      AppendGlobalExport(name, Type::I64, mutable_);
+  pair.first->typed_value.set_i64(value);
+  return pair;
+}
+
+std::pair<Global*, Index> HostModule::AppendGlobalExport(string_view name,
+                                             bool mutable_,
+                                             float value) {
+  std::pair<Global*, Index> pair =
+      AppendGlobalExport(name, Type::F32, mutable_);
+  pair.first->typed_value.set_f32(value);
+  return pair;
+}
+
+std::pair<Global*, Index> HostModule::AppendGlobalExport(string_view name,
+                                             bool mutable_,
+                                             double value) {
+  std::pair<Global*, Index> pair =
+      AppendGlobalExport(name, Type::F64, mutable_);
+  pair.first->typed_value.set_f64(value);
+  return pair;
+}
 
 Environment::MarkPoint Environment::Mark() {
   MarkPoint mark;
@@ -237,7 +367,7 @@ void Environment::ResetToMarkPoint(const MarkPoint& mark) {
 }
 
 HostModule* Environment::AppendHostModule(string_view name) {
-  HostModule* module = new HostModule(name);
+  HostModule* module = new HostModule(this, name);
   modules_.emplace_back(module);
   registered_module_bindings_.emplace(name.to_string(),
                                       Binding(modules_.size() - 1));
@@ -1412,21 +1542,23 @@ Result Thread::CallHost(HostFunc* func) {
 
   size_t num_params = sig->param_types.size();
   size_t num_results = sig->result_types.size();
-  // + 1 is a workaround for using data() below; UBSAN doesn't like calling
-  // data() with an empty vector.
-  TypedValues params(num_params + 1);
-  TypedValues results(num_results + 1);
+  TypedValues params(num_params);
+  TypedValues results(num_results);
 
   for (size_t i = num_params; i > 0; --i) {
     params[i - 1].value = Pop();
     params[i - 1].type = sig->param_types[i - 1];
   }
 
-  Result call_result =
-      func->callback(func, sig, num_params, params.data(), num_results,
-                     results.data(), func->user_data);
+  for (size_t i = 0; i < num_results; ++i) {
+    results[i].type = sig->result_types[i];
+    results[i].SetZero();
+  }
+
+  Result call_result = func->callback(func, sig, params, results);
   TRAP_IF(call_result != Result::Ok, HostTrapped);
 
+  TRAP_IF(results.size() != num_results, HostResultTypeMismatch);
   for (size_t i = 0; i < num_results; ++i) {
     TRAP_IF(results[i].type != sig->result_types[i], HostResultTypeMismatch);
     CHECK_TRAP(Push(results[i].value));

--- a/src/interp.cc
+++ b/src/interp.cc
@@ -201,6 +201,7 @@ Export* Module::GetFuncExport(Environment* env,
     Export* export_ = &exports[index];
     assert(export_->kind == ExternalKind::Func);
     const Func* func = env->GetFunc(export_->index);
+    WABT_USE(func);
     assert(env->FuncSignaturesAreEqual(sig_index, func->sig_index));
     return export_;
   }

--- a/src/interp.h
+++ b/src/interp.h
@@ -20,7 +20,9 @@
 #include <stdint.h>
 
 #include <functional>
+#include <map>
 #include <memory>
+#include <utility>
 #include <vector>
 
 #include "src/binding-hash.h"
@@ -95,6 +97,7 @@ static const IstreamOffset kInvalidIstreamOffset = ~0;
 
 struct FuncSignature {
   FuncSignature() = default;
+  FuncSignature(std::vector<Type> param_types, std::vector<Type> result_types);
   FuncSignature(Index param_count,
                 Type* param_types,
                 Index result_count,
@@ -149,6 +152,25 @@ struct TypedValue {
   TypedValue() {}
   explicit TypedValue(Type type) : type(type) {}
   TypedValue(Type type, const Value& value) : type(type), value(value) {}
+
+  void SetZero() { ZeroMemory(value); }
+  void set_i32(uint32_t x) { value.i32 = x; }
+  void set_i64(uint64_t x) { value.i64 = x; }
+  void set_f32(float x) { memcpy(&value.f32_bits, &x, sizeof(x)); }
+  void set_f64(double x) { memcpy(&value.f64_bits, &x, sizeof(x)); }
+
+  uint32_t get_i32() const { return value.i32; }
+  uint64_t get_i64() const { return value.i64; }
+  float get_f32() const {
+    float x;
+    memcpy(&x, &value.f32_bits, sizeof(x));
+    return x;
+  }
+  double get_f64() const {
+    double x;
+    memcpy(&x, &value.f64_bits, sizeof(x));
+    return x;
+  }
 
   Type type;
   Value value;
@@ -219,14 +241,6 @@ struct ExceptImport : Import {
 
 struct Func;
 
-typedef Result (*HostFuncCallback)(const struct HostFunc* func,
-                                   const FuncSignature* sig,
-                                   Index num_args,
-                                   TypedValue* args,
-                                   Index num_results,
-                                   TypedValue* out_results,
-                                   void* user_data);
-
 struct Func {
   WABT_DISALLOW_COPY_AND_ASSIGN(Func);
   Func(Index sig_index, bool is_host)
@@ -253,17 +267,25 @@ struct DefinedFunc : Func {
 };
 
 struct HostFunc : Func {
-  HostFunc(string_view module_name, string_view field_name, Index sig_index)
+  using Callback = std::function<Result(const HostFunc*,
+                                        const FuncSignature*,
+                                        const TypedValues& args,
+                                        TypedValues& results)>;
+
+  HostFunc(string_view module_name,
+           string_view field_name,
+           Index sig_index,
+           Callback callback)
       : Func(sig_index, true),
         module_name(module_name.to_string()),
-        field_name(field_name.to_string()) {}
+        field_name(field_name.to_string()),
+        callback(callback) {}
 
   static bool classof(const Func* func) { return func->is_host; }
 
   std::string module_name;
   std::string field_name;
-  HostFuncCallback callback;
-  void* user_data;
+  Callback callback;
 };
 
 struct Export {
@@ -275,25 +297,9 @@ struct Export {
   Index index;
 };
 
-class HostImportDelegate {
- public:
-  typedef std::function<void(const char* msg)> ErrorCallback;
-
-  virtual ~HostImportDelegate() {}
-  virtual wabt::Result ImportFunc(FuncImport*,
-                                  Func*,
-                                  FuncSignature*,
-                                  const ErrorCallback&) = 0;
-  virtual wabt::Result ImportTable(TableImport*,
-                                   Table*,
-                                   const ErrorCallback&) = 0;
-  virtual wabt::Result ImportMemory(MemoryImport*,
-                                    Memory*,
-                                    const ErrorCallback&) = 0;
-  virtual wabt::Result ImportGlobal(GlobalImport*,
-                                    Global*,
-                                    const ErrorCallback&) = 0;
-};
+class Environment;
+struct DefinedModule;
+struct HostModule;
 
 struct Module {
   WABT_DISALLOW_COPY_AND_ASSIGN(Module);
@@ -301,7 +307,14 @@ struct Module {
   Module(string_view name, bool is_host);
   virtual ~Module() = default;
 
+  // Function exports are special-cased to allow for overloading functions by
+  // name.
+  Export* GetFuncExport(Environment*, string_view name, Index sig_index);
   Export* GetExport(string_view name);
+  virtual Index OnUnknownFuncExport(string_view name, Index sig_index) = 0;
+
+  // Returns export index.
+  Index AppendExport(ExternalKind kind, Index item_index, string_view name);
 
   std::string name;
   std::vector<Export> exports;
@@ -315,6 +328,10 @@ struct DefinedModule : Module {
   DefinedModule();
   static bool classof(const Module* module) { return !module->is_host; }
 
+  Index OnUnknownFuncExport(string_view name, Index sig_index) override {
+    return kInvalidIndex;
+  }
+
   std::vector<FuncImport> func_imports;
   std::vector<TableImport> table_imports;
   std::vector<MemoryImport> memory_imports;
@@ -326,10 +343,45 @@ struct DefinedModule : Module {
 };
 
 struct HostModule : Module {
-  explicit HostModule(string_view name);
+  HostModule(Environment* env, string_view name);
   static bool classof(const Module* module) { return module->is_host; }
 
-  std::unique_ptr<HostImportDelegate> import_delegate;
+  Index OnUnknownFuncExport(string_view name, Index sig_index) override;
+
+  std::pair<HostFunc*, Index> AppendFuncExport(string_view name,
+                                               const FuncSignature&,
+                                               HostFunc::Callback);
+  std::pair<HostFunc*, Index> AppendFuncExport(string_view name,
+                                               Index sig_index,
+                                               HostFunc::Callback);
+  std::pair<Table*, Index> AppendTableExport(string_view name, const Limits&);
+  std::pair<Memory*, Index> AppendMemoryExport(string_view name, const Limits&);
+  std::pair<Global*, Index> AppendGlobalExport(string_view name,
+                                               Type,
+                                               bool mutable_);
+
+  // Convenience functions.
+  std::pair<Global*, Index> AppendGlobalExport(string_view name,
+                                               bool mutable_,
+                                               uint32_t);
+  std::pair<Global*, Index> AppendGlobalExport(string_view name,
+                                               bool mutable_,
+                                               uint64_t);
+  std::pair<Global*, Index> AppendGlobalExport(string_view name,
+                                               bool mutable_,
+                                               float);
+  std::pair<Global*, Index> AppendGlobalExport(string_view name,
+                                               bool mutable_,
+                                               double);
+
+  // Should return an Export index if a new function was created via
+  // AppendFuncExport, or kInvalidIndex if no function was created.
+  std::function<
+      Index(Environment*, HostModule*, string_view name, Index sig_index)>
+      on_unknown_func_export;
+
+ private:
+  Environment* env_;
 };
 
 class Environment {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -154,77 +154,30 @@ static wabt::Result ReadModule(const char* module_filename,
   return result;
 }
 
-#define PRIimport "\"" PRIstringview "." PRIstringview "\""
-#define PRINTF_IMPORT_ARG(x)                   \
-  WABT_PRINTF_STRING_VIEW_ARG((x).module_name) \
-  , WABT_PRINTF_STRING_VIEW_ARG((x).field_name)
-
-class WasmInterpHostImportDelegate : public HostImportDelegate {
- public:
-  wabt::Result ImportFunc(interp::FuncImport* import,
-                          interp::Func* func,
-                          interp::FuncSignature* func_sig,
-                          const ErrorCallback& callback) override {
-    if (import->field_name == "print") {
-      cast<HostFunc>(func)->callback = PrintCallback;
-      return wabt::Result::Ok;
-    } else {
-      PrintError(callback, "unknown host function import " PRIimport,
-                 PRINTF_IMPORT_ARG(*import));
-      return wabt::Result::Error;
-    }
-  }
-
-  wabt::Result ImportTable(interp::TableImport* import,
-                           interp::Table* table,
-                           const ErrorCallback& callback) override {
-    return wabt::Result::Error;
-  }
-
-  wabt::Result ImportMemory(interp::MemoryImport* import,
-                            interp::Memory* memory,
-                            const ErrorCallback& callback) override {
-    return wabt::Result::Error;
-  }
-
-  wabt::Result ImportGlobal(interp::GlobalImport* import,
-                            interp::Global* global,
-                            const ErrorCallback& callback) override {
-    return wabt::Result::Error;
-  }
-
- private:
-  static interp::Result PrintCallback(const HostFunc* func,
-                                      const interp::FuncSignature* sig,
-                                      Index num_args,
-                                      TypedValue* args,
-                                      Index num_results,
-                                      TypedValue* out_results,
-                                      void* user_data) {
-    memset(static_cast<void*>(out_results), 0,
-                              sizeof(TypedValue) * num_results);
-    for (Index i = 0; i < num_results; ++i)
-      out_results[i].type = sig->result_types[i];
-
-    TypedValues vec_args(args, args + num_args);
-    TypedValues vec_results(out_results, out_results + num_results);
-
-    printf("called host ");
-    WriteCall(s_stdout_stream.get(), func->module_name, func->field_name,
-              vec_args, vec_results, interp::Result::Ok);
-    return interp::Result::Ok;
-  }
-
-  void PrintError(const ErrorCallback& callback, const char* format, ...) {
-    WABT_SNPRINTF_ALLOCA(buffer, length, format);
-    callback(buffer);
-  }
-};
+static interp::Result PrintCallback(const HostFunc* func,
+                                    const interp::FuncSignature* sig,
+                                    const TypedValues& args,
+                                    TypedValues& results) {
+  printf("called host ");
+  WriteCall(s_stdout_stream.get(), func->module_name, func->field_name, args,
+            results, interp::Result::Ok);
+  return interp::Result::Ok;
+}
 
 static void InitEnvironment(Environment* env) {
   if (s_host_print) {
     HostModule* host_module = env->AppendHostModule("host");
-    host_module->import_delegate.reset(new WasmInterpHostImportDelegate());
+    host_module->on_unknown_func_export =
+        [](Environment* env, HostModule* host_module, string_view name,
+           Index sig_index) -> Index {
+      if (name != "print") {
+        return kInvalidIndex;
+      }
+
+      std::pair<HostFunc*, Index> pair =
+          host_module->AppendFuncExport(name, sig_index, PrintCallback);
+      return pair.second;
+    };
   }
 }
 

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -17,7 +17,7 @@ out/test/spec/imports.wast:107: assert_unlinkable passed:
   error: unknown module field "unknown"
   0000020: error: OnImportFunc callback failed
 out/test/spec/imports.wast:111: assert_unlinkable passed:
-  error: unknown host function import "spectest.unknown"
+  error: unknown module field "unknown"
   0000024: error: OnImportFunc callback failed
 out/test/spec/imports.wast:116: assert_unlinkable passed:
   error: import signature mismatch
@@ -77,19 +77,19 @@ out/test/spec/imports.wast:189: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind func, not memory
   0000025: error: OnImportFunc callback failed
 out/test/spec/imports.wast:193: assert_unlinkable passed:
-  error: unknown host function import "spectest.global_i32"
+  error: expected import "spectest.global_i32" to have kind func, not global
   0000027: error: OnImportFunc callback failed
 out/test/spec/imports.wast:197: assert_unlinkable passed:
-  error: unknown host function import "spectest.table"
+  error: expected import "spectest.table" to have kind func, not table
   0000022: error: OnImportFunc callback failed
 out/test/spec/imports.wast:201: assert_unlinkable passed:
-  error: unknown host function import "spectest.memory"
+  error: expected import "spectest.memory" to have kind func, not memory
   0000023: error: OnImportFunc callback failed
 out/test/spec/imports.wast:235: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001b: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:239: assert_unlinkable passed:
-  error: unknown host global import "spectest.unknown"
+  error: unknown module field "unknown"
   000001f: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:244: assert_unlinkable passed:
   error: expected import "test.func" to have kind global, not func
@@ -101,13 +101,13 @@ out/test/spec/imports.wast:252: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind global, not memory
   0000020: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:256: assert_unlinkable passed:
-  error: unknown host global import "spectest.print_i32"
+  error: expected import "spectest.print_i32" to have kind global, not func
   0000021: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:260: assert_unlinkable passed:
-  error: unknown host global import "spectest.table"
+  error: expected import "spectest.table" to have kind global, not table
   000001d: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:264: assert_unlinkable passed:
-  error: unknown host global import "spectest.memory"
+  error: expected import "spectest.memory" to have kind global, not memory
   000001e: error: OnImportGlobal callback failed
 out/test/spec/imports.wast:310: assert_invalid passed:
   error: unknown import module ""
@@ -121,7 +121,7 @@ out/test/spec/imports.wast:335: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001c: error: OnImportTable callback failed
 out/test/spec/imports.wast:339: assert_unlinkable passed:
-  error: unknown host table import "spectest.unknown"
+  error: unknown module field "unknown"
   0000020: error: OnImportTable callback failed
 out/test/spec/imports.wast:344: assert_unlinkable passed:
   error: actual size (10) smaller than declared (12)
@@ -145,7 +145,7 @@ out/test/spec/imports.wast:369: assert_unlinkable passed:
   error: expected import "test.memory-2-inf" to have kind table, not memory
   0000021: error: OnImportTable callback failed
 out/test/spec/imports.wast:373: assert_unlinkable passed:
-  error: unknown host table import "spectest.print_i32"
+  error: expected import "spectest.print_i32" to have kind table, not func
   0000022: error: OnImportTable callback failed
 out/test/spec/imports.wast:405: assert_invalid passed:
   error: unknown import module ""
@@ -159,7 +159,7 @@ out/test/spec/imports.wast:428: assert_unlinkable passed:
   error: unknown module field "unknown"
   000001b: error: OnImportMemory callback failed
 out/test/spec/imports.wast:432: assert_unlinkable passed:
-  error: unknown host memory import "spectest.unknown"
+  error: unknown module field "unknown"
   000001f: error: OnImportMemory callback failed
 out/test/spec/imports.wast:437: assert_unlinkable passed:
   error: actual size (2) smaller than declared (3)
@@ -183,13 +183,13 @@ out/test/spec/imports.wast:462: assert_unlinkable passed:
   error: expected import "test.table-10-inf" to have kind memory, not table
   0000020: error: OnImportMemory callback failed
 out/test/spec/imports.wast:466: assert_unlinkable passed:
-  error: unknown host memory import "spectest.print_i32"
+  error: expected import "spectest.print_i32" to have kind memory, not func
   0000021: error: OnImportMemory callback failed
 out/test/spec/imports.wast:470: assert_unlinkable passed:
-  error: unknown host memory import "spectest.global_i32"
+  error: expected import "spectest.global_i32" to have kind memory, not global
   0000022: error: OnImportMemory callback failed
 out/test/spec/imports.wast:474: assert_unlinkable passed:
-  error: unknown host memory import "spectest.table"
+  error: expected import "spectest.table" to have kind memory, not table
   000001d: error: OnImportMemory callback failed
 out/test/spec/imports.wast:479: assert_unlinkable passed:
   error: actual size (1) smaller than declared (2)


### PR DESCRIPTION
Importing from host modules used to be handled by a delegate, which is a
powerful enough solution to allow for all host import behaviors, but
makes the common case difficult and clunky.

It also assumed that every imported function/global/etc. needed to be
newly created and added to the environment, which is OK (though
wasteful) for functions, but is incorrect for mutable values like
memories and globals.

This change simplifies the common case by providing a set of functions
on `HostModule` that can be used to add exports, e.g.

    AppendFuncExport("add", {{Type::I32, Type::I32}, {Type::I32}},
                     AddFunc);

A generic interface for functions is provided as well, to allow for
automatically generating functions as needed. This is currently used for
functions like "host.print" in `wasm-interp`.