### PR TITLE
Fix: set_global on immutable global is invalid

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -728,7 +728,18 @@ Result Validator::OnSelectExpr(SelectExpr* expr) {
 
 Result Validator::OnSetGlobalExpr(SetGlobalExpr* expr) {
   expr_loc_ = &expr->loc;
-  typechecker_.OnSetGlobal(GetGlobalVarTypeOrAny(&expr->var));
+  Type type = Type::Any;
+  const Global* global;
+  Index global_index;
+  if (Succeeded(CheckGlobalVar(&expr->var, &global, &global_index))) {
+    if (!global->mutable_) {
+      PrintError(&expr->loc,
+                 "can't set_global on immutable global at index %" PRIindex ".",
+                 global_index);
+    }
+    type = global->type;
+  }
+  typechecker_.OnSetGlobal(type);
   return Result::Ok;
 }
 

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-objdump
 ;;; ARGS0: -v
 (module
-  (global f32 (f32.const 1))
+  (global (mut f32) (f32.const 1))
   (func
     f32.const 2
     set_global 0))
@@ -28,7 +28,7 @@
 0000013: 00                                        ; section size (guess)
 0000014: 01                                        ; num globals
 0000015: 7d                                        ; f32
-0000016: 00                                        ; global mutability
+0000016: 01                                        ; global mutability
 0000017: 43                                        ; f32.const
 0000018: 0000 803f                                 ; f32 literal
 000001c: 0b                                        ; end

--- a/test/parse/expr/setglobal-named.txt
+++ b/test/parse/expr/setglobal-named.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: wat2wasm
 (module
-  (global $g f32 (f32.const 1))
+  (global $g (mut f32) (f32.const 1))
   (func
     f32.const 2
     set_global $g))

--- a/test/parse/expr/setglobal.txt
+++ b/test/parse/expr/setglobal.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: wat2wasm
 (module
-  (global f32 (f32.const 1))
+  (global (mut f32) (f32.const 1))
   (func
     f32.const 2
     set_global 0))

--- a/test/regress/regress-21.txt
+++ b/test/regress/regress-21.txt
@@ -1,0 +1,15 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+  (type $foo.ty       (func))
+  (global $g i32 (i32.const -1))
+  (func $foo (type $foo.ty)
+     (set_global $g (i32.const 1))
+  )
+  (export "foo" (func $foo))
+)
+(;; STDERR ;;;
+out/test/regress/regress-21.txt:7:7: error: can't set_global on immutable global at index 0.
+     (set_global $g (i32.const 1))
+      ^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/roundtrip/fold-getset-global.txt
+++ b/test/roundtrip/fold-getset-global.txt
@@ -1,8 +1,8 @@
 ;;; TOOL: run-roundtrip
 ;;; ARGS: --stdout --fold-exprs
 (module
-  (global i32 (i32.const 1))
-  (global f32 (f32.const 1.5))
+  (global (mut i32) (i32.const 1))
+  (global (mut f32) (f32.const 1.5))
 
   (func $fold-get-global (result i32)
     get_global 1
@@ -36,6 +36,6 @@
         (i32.const 1)))
     (set_global 1
       (f32.const 0x1p+1 (;=2;))))
-  (global (;0;) i32 (i32.const 1))
-  (global (;1;) f32 (f32.const 0x1.8p+0 (;=1.5;))))
+  (global (;0;) (mut i32) (i32.const 1))
+  (global (;1;) (mut f32) (f32.const 0x1.8p+0 (;=1.5;))))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-global-names.txt
+++ b/test/roundtrip/generate-global-names.txt
@@ -2,7 +2,7 @@
 ;;; ARGS: --stdout --generate-names
 (module
   (global i32 (i32.const 42))
-  (global f32 (f32.const -1.5))
+  (global (mut f32) (f32.const -1.5))
   (func (result i32)
     f32.const 3.0
     set_global 1
@@ -15,5 +15,5 @@
     set_global $g1
     get_global $g0)
   (global $g0 i32 (i32.const 42))
-  (global $g1 f32 (f32.const -0x1.8p+0 (;=-1.5;))))
+  (global $g1 (mut f32) (f32.const -0x1.8p+0 (;=-1.5;))))
 ;;; STDOUT ;;)


### PR DESCRIPTION
There is a spec test for this, but spectest-interp only runs the
validator in `binary-reader-interp.cc`, which is different than the
validator in `validator.cc`. This is necessarily so, since some
checks only make sense when the module is linked or instantiated.

This fixes issue #894.