### PR TITLE
Reset Executor’s Thread at start of RunFunction

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -4571,6 +4571,7 @@ ExecResult Executor::RunFunction(Index func_index, const TypedValues& args) {
   Func* func = env_->GetFunc(func_index);
   FuncSignature* sig = env_->GetFuncSignature(func->sig_index);
 
+  thread_.Reset();
   exec_result.result = PushArgs(sig, args);
   if (exec_result.result == Result::Ok) {
     exec_result.result =
@@ -4581,7 +4582,6 @@ ExecResult Executor::RunFunction(Index func_index, const TypedValues& args) {
     }
   }
 
-  thread_.Reset();
   return exec_result;
 }
 


### PR DESCRIPTION
At the end of Executor::RunFunction(), the Thread is Reset() so that
the Executor can be reused for subsequent RunFunction()s. However in
some cases the execution won’t make it that far in RunFunction() —
for example, if a HostModule’s callback throws an exception. Move the
call to the Thread’s Reset() to the start of RunFunction() so that
the Thread’s state is always as expected when Executor starts a function.