### PR TITLE
Fix some multi-value bugs; run spec tests

### DIFF
--- a/src/interp.cc
+++ b/src/interp.cc
@@ -860,8 +860,9 @@ ValueTypeRep<T> Thread::PopRep() {
 }
 
 void Thread::DropKeep(uint32_t drop_count, uint32_t keep_count) {
-  for (uint32_t i = 0; i < keep_count; ++i) {
-    Pick(drop_count + i + 1) = Pick(i + 1);
+  // Copy backward to avoid clobbering when the regions overlap.
+  for (uint32_t i = keep_count; i > 0; --i) {
+    Pick(drop_count + i) = Pick(i);
   }
   value_stack_top_ -= drop_count;
 }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -473,10 +473,10 @@ Result TypeChecker::OnEnd() {
   assert(static_cast<int>(label->label_type) < kLabelTypeCount);
   if (label->label_type == LabelType::If ||
       label->label_type == LabelType::IfExcept) {
-    if (label->result_types.size() != 0) {
-      PrintError("if without else cannot have results.");
-      result = Result::Error;
-    }
+    // An if without an else will just pass the params through, so the result
+    // types must be the same as the param types. It has the same behavior as
+    // an empty else block.
+    CHECK_RESULT(OnElse());
   }
   const char* desc = s_label_type_name[static_cast<int>(label->label_type)];
   result |= OnEnd(label, desc, desc);

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -1398,8 +1398,38 @@ class Validator::CheckFuncSignatureExprVisitorDelegate
   explicit CheckFuncSignatureExprVisitorDelegate(Validator* validator)
       : validator_(validator) {}
 
+  Result BeginBlockExpr(BlockExpr* expr) override {
+    validator_->CheckBlockDeclaration(&expr->loc, Opcode::Block,
+                                      &expr->block.decl);
+    return Result::Ok;
+  }
+
   Result OnCallIndirectExpr(CallIndirectExpr* expr) override {
     validator_->CheckFuncSignature(&expr->loc, expr->decl);
+    return Result::Ok;
+  }
+
+  Result BeginIfExpr(IfExpr* expr) override {
+    validator_->CheckBlockDeclaration(&expr->loc, Opcode::If,
+                                      &expr->true_.decl);
+    return Result::Ok;
+  }
+
+  Result BeginIfExceptExpr(IfExceptExpr* expr) override {
+    validator_->CheckBlockDeclaration(&expr->loc, Opcode::IfExcept,
+                                      &expr->true_.decl);
+    return Result::Ok;
+  }
+
+  Result BeginLoopExpr(LoopExpr* expr) override {
+    validator_->CheckBlockDeclaration(&expr->loc, Opcode::Loop,
+                                      &expr->block.decl);
+    return Result::Ok;
+  }
+
+  Result BeginTryExpr(TryExpr* expr) override {
+    validator_->CheckBlockDeclaration(&expr->loc, Opcode::Try,
+                                      &expr->block.decl);
     return Result::Ok;
   }
 

--- a/test/parse/expr/block-multi-named.txt
+++ b/test/parse/expr/block-multi-named.txt
@@ -1,0 +1,34 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-multi-value
+(type $v_v (func))
+(type $v_ii (func (param i32 i32)))
+(type $ii_v (func (result i32 i32)))
+(type $ff_ff (func (param f32 f32) (result f32 f32)))
+
+(func
+  block (type $v_v)
+  end)
+
+(func
+  i32.const 1
+  i32.const 2
+  block (type $v_ii)
+    drop
+    drop
+  end)
+
+(func
+  block (type $ii_v)
+    i32.const 1
+    i32.const 2
+  end
+  drop
+  drop)
+
+(func
+  f32.const 1
+  f32.const 2
+  block (type $ff_ff)
+  end
+  drop
+  drop)

--- a/test/parse/expr/if-multi-named.txt
+++ b/test/parse/expr/if-multi-named.txt
@@ -1,0 +1,44 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-multi-value
+(type $v_v (func))
+(type $v_ii (func (param i32 i32)))
+(type $ii_v (func (result i32 i32)))
+(type $ff_ff (func (param f32 f32) (result f32 f32)))
+
+(func
+  i32.const 0
+  if (type $v_v)
+  end)
+
+(func
+  i32.const 0
+  i32.const 1
+  i32.const 2
+  if (type $v_ii)
+    drop
+    drop
+  else
+    drop
+    drop
+  end)
+
+(func
+  i32.const 0
+  if (type $ii_v)
+    i32.const 1
+    i32.const 2
+  else
+    i32.const 3
+    i32.const 4
+  end
+  drop
+  drop)
+
+(func
+  f32.const 1
+  f32.const 2
+  i32.const 0
+  if (type $ff_ff)
+  end
+  drop
+  drop)

--- a/test/parse/expr/loop-multi-named.txt
+++ b/test/parse/expr/loop-multi-named.txt
@@ -1,0 +1,34 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-multi-value
+(type $v_v (func))
+(type $v_ii (func (param i32 i32)))
+(type $ii_v (func (result i32 i32)))
+(type $ff_ff (func (param f32 f32) (result f32 f32)))
+
+(func
+  loop (type $v_v)
+  end)
+
+(func
+  i32.const 1
+  i32.const 2
+  loop (type $v_ii)
+    drop
+    drop
+  end)
+
+(func
+  loop (type $ii_v)
+    i32.const 1
+    i32.const 2
+  end
+  drop
+  drop)
+
+(func
+  f32.const 1
+  f32.const 2
+  loop (type $ff_ff)
+  end
+  drop
+  drop)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -26,10 +26,10 @@ out/test/spec/if.wast:505: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:510: assert_invalid passed:
-  error: type mismatch in if, expected [] but got [i32]
+  error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:516: assert_invalid passed:
-  error: type mismatch in if, expected [] but got [i32]
+  error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:522: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32]
@@ -41,14 +41,13 @@ out/test/spec/if.wast:535: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
 out/test/spec/if.wast:541: assert_invalid passed:
-  error: if without else cannot have results.
+  error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:547: assert_invalid passed:
-  error: if without else cannot have results.
-  error: type mismatch in if, expected [i32] but got []
+  error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
 out/test/spec/if.wast:553: assert_invalid passed:
-  error: if without else cannot have results.
+  error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:560: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []

--- a/test/spec/multi-value/block.txt
+++ b/test/spec/multi-value/block.txt
@@ -1,0 +1,222 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/block.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/block.wast:275: assert_malformed passed:
+  out/test/spec/multi-value/block/block.1.wat:1:96: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (type $sig) (result i32) (param i32)))
+                                                                     ^
+out/test/spec/multi-value/block.wast:282: assert_malformed passed:
+  out/test/spec/multi-value/block/block.2.wat:1:83: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (param i32) (type $sig) (result i32)))
+                                                        ^
+out/test/spec/multi-value/block.wast:289: assert_malformed passed:
+  out/test/spec/multi-value/block/block.3.wat:1:96: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (param i32) (result i32) (type $sig)))
+                                                                     ^
+out/test/spec/multi-value/block.wast:296: assert_malformed passed:
+  out/test/spec/multi-value/block/block.4.wat:1:84: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (result i32) (type $sig) (param i32)))
+                                                         ^
+out/test/spec/multi-value/block.wast:303: assert_malformed passed:
+  out/test/spec/multi-value/block/block.5.wat:1:84: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (result i32) (param i32) (type $sig)))
+                                                         ^
+out/test/spec/multi-value/block.wast:310: assert_malformed passed:
+  out/test/spec/multi-value/block/block.6.wat:1:41: error: unexpected token (, expected ).
+  (func (i32.const 0) (block (result i32) (param i32)))
+                                          ^
+out/test/spec/multi-value/block.wast:317: assert_malformed passed:
+  out/test/spec/multi-value/block/block.7.wat:1:35: error: unexpected token $x, expected ).
+  (func (i32.const 0) (block (param $x i32) (drop)))
+                                    ^^
+  out/test/spec/multi-value/block/block.7.wat:1:50: error: unexpected token ), expected EOF.
+  (func (i32.const 0) (block (param $x i32) (drop)))
+                                                   ^
+out/test/spec/multi-value/block.wast:321: assert_malformed passed:
+  out/test/spec/multi-value/block/block.8.wat:1:25: error: expected 0 results, got 1
+  (type $sig (func))(func (block (type $sig) (result i32) (i32.const 0)) (unrea...
+                          ^
+out/test/spec/multi-value/block.wast:328: assert_malformed passed:
+  out/test/spec/multi-value/block/block.9.wat:1:50: error: expected 1 arguments, got 0
+  ...func (param i32) (result i32)))(func (block (type $sig) (result i32) (i32....
+                                          ^
+out/test/spec/multi-value/block.wast:335: assert_malformed passed:
+  out/test/spec/multi-value/block/block.10.wat:1:64: error: expected 1 results, got 0
+  ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (drop)...
+                                          ^
+out/test/spec/multi-value/block.wast:342: assert_malformed passed:
+  out/test/spec/multi-value/block/block.11.wat:1:68: error: expected 2 arguments, got 1
+  ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (resul...
+                                          ^
+out/test/spec/multi-value/block.wast:350: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:358: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:362: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:366: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:370: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:375: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:381: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32, i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:387: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:393: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:399: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:405: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got []
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:411: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:417: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:423: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:429: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:435: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:442: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:448: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:454: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:460: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:467: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:473: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:479: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:485: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:491: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:497: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:503: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:509: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:515: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:522: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  0000024: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:528: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32, i32]
+  000002b: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:534: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:540: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:546: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:553: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:559: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:565: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:574: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:580: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/multi-value/block.wast:586: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:592: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/multi-value/block.wast:598: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:604: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/multi-value/block.wast:611: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001d: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:617: assert_invalid passed:
+  error: type mismatch in block, expected [i32, f64] but got []
+  000001e: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:623: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000022: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:629: assert_invalid passed:
+  error: type mismatch in block, expected [f32, i32] but got [f32]
+  0000023: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:635: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001f: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:641: assert_invalid passed:
+  error: type mismatch in block, expected [i32, f64] but got []
+  0000020: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:647: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000024: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:653: assert_invalid passed:
+  error: type mismatch in block, expected [f32, i32] but got [f32]
+  0000025: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:660: assert_malformed passed:
+  out/test/spec/multi-value/block/block.63.wat:1:45: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) block (param $x i32) end)
+                                              ^^
+out/test/spec/multi-value/block.wast:664: assert_malformed passed:
+  out/test/spec/multi-value/block/block.64.wat:1:46: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) (block (param $x i32)))
+                                               ^^
+out/test/spec/multi-value/block.wast:669: assert_malformed passed:
+  out/test/spec/multi-value/block/block.65.wat:1:17: error: unexpected label "$l"
+  (func block end $l)
+                  ^^
+out/test/spec/multi-value/block.wast:673: assert_malformed passed:
+  out/test/spec/multi-value/block/block.66.wat:1:20: error: mismatching label "$a" != "$l"
+  (func block $a end $l)
+                     ^^
+91/91 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/br.txt
+++ b/test/spec/multi-value/br.txt
@@ -1,0 +1,27 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/br.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/br.wast:462: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:469: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:475: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:481: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:488: assert_invalid passed:
+  error: invalid depth: 1 (max 0)
+  0000019: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:492: assert_invalid passed:
+  error: invalid depth: 5 (max 2)
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:496: assert_invalid passed:
+  error: invalid depth: 268435457 (max 0)
+  000001d: error: OnBrExpr callback failed
+81/81 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/call.txt
+++ b/test/spec/multi-value/call.txt
@@ -1,0 +1,40 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/call.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/call.wast:215: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got []
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/multi-value/call.wast:222: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got [i64]
+  000001f: error: OnConvertExpr callback failed
+out/test/spec/multi-value/call.wast:230: assert_invalid passed:
+  error: type mismatch in call, expected [i32] but got []
+  000001e: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:237: assert_invalid passed:
+  error: type mismatch in call, expected [f64, i32] but got []
+  000001f: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:244: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  000001d: error: EndFunctionBody callback failed
+out/test/spec/multi-value/call.wast:251: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f64, i32]
+  0000026: error: EndFunctionBody callback failed
+out/test/spec/multi-value/call.wast:259: assert_invalid passed:
+  error: type mismatch in call, expected [i32, i32] but got [i32]
+  0000022: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:266: assert_invalid passed:
+  error: type mismatch in call, expected [i32, i32] but got [i32]
+  0000022: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:273: assert_invalid passed:
+  error: type mismatch in call, expected [i32, f64] but got [f64, i32]
+  000002a: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:280: assert_invalid passed:
+  error: type mismatch in call, expected [f64, i32] but got [i32, f64]
+  000002a: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:291: assert_invalid passed:
+  0000019: error: invalid call function index: 1
+out/test/spec/multi-value/call.wast:295: assert_invalid passed:
+  000001d: error: invalid call function index: 1012321300
+55/55 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/call_indirect.txt
+++ b/test/spec/multi-value/call_indirect.txt
@@ -1,0 +1,117 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/call_indirect.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/call_indirect.wast:302: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.1.wat:1:122: error: unexpected token "param", expected an expr.
+  ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
+                                        ^^^^^
+  out/test/spec/multi-value/call_indirect/call_indirect.1.wat:1:166: error: unexpected token ), expected EOF.
+  ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:314: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.2.wat:1:109: error: unexpected token "type", expected an expr.
+  ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
+                                        ^^^^
+  out/test/spec/multi-value/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
+  ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:326: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.3.wat:1:122: error: unexpected token "type", expected an expr.
+  ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
+                                        ^^^^
+  out/test/spec/multi-value/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
+  ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:338: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.4.wat:1:110: error: unexpected token "type", expected an expr.
+  ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
+                                        ^^^^
+  out/test/spec/multi-value/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
+  ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:350: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "param", expected an expr.
+  ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
+                                        ^^^^^
+  out/test/spec/multi-value/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
+  ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:362: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.6.wat:1:67: error: unexpected token "param", expected an expr.
+  ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
+                                          ^^^^^
+  out/test/spec/multi-value/call_indirect/call_indirect.6.wat:1:106: error: unexpected token ), expected EOF.
+  ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:372: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.7.wat:1:46: error: unexpected token $x, expected ).
+  ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
+                                             ^^
+  out/test/spec/multi-value/call_indirect/call_indirect.7.wat:1:82: error: unexpected token ), expected EOF.
+  ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
+                                                                                 ^
+out/test/spec/multi-value/call_indirect.wast:379: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.8.wat:1:57: error: expected 0 results, got 1
+  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
+                                    ^^^^^^^^^^^^^
+out/test/spec/multi-value/call_indirect.wast:389: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.9.wat:1:82: error: expected 1 arguments, got 0
+  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
+                                    ^^^^^^^^^^^^^
+out/test/spec/multi-value/call_indirect.wast:399: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.10.wat:1:69: error: expected 1 results, got 0
+  ...i32)))(table 0 anyfunc)(func  (call_indirect (type $sig) (param i32) (i32....
+                                    ^^^^^^^^^^^^^
+out/test/spec/multi-value/call_indirect.wast:409: assert_malformed passed:
+  out/test/spec/multi-value/call_indirect/call_indirect.11.wat:1:86: error: expected 2 arguments, got 1
+  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
+                                    ^^^^^^^^^^^^^
+out/test/spec/multi-value/call_indirect.wast:424: assert_invalid passed:
+  error: found call_indirect operator, but no table
+  000001c: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:432: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got []
+  0000023: error: OnConvertExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:440: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got [i64]
+  0000027: error: OnConvertExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:449: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got []
+  0000026: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:457: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [f64, i32] but got []
+  0000027: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:465: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  0000025: error: EndFunctionBody callback failed
+out/test/spec/multi-value/call_indirect.wast:473: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f64, i32]
+  000002e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/call_indirect.wast:484: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got []
+  0000027: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:492: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got [... i64]
+  0000028: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:501: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  000002a: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:511: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  000002a: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:521: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
+  0000032: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:531: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
+  0000032: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:545: assert_invalid passed:
+  0000021: error: invalid call_indirect signature index
+out/test/spec/multi-value/call_indirect.wast:552: assert_invalid passed:
+  0000025: error: invalid call_indirect signature index
+out/test/spec/multi-value/call_indirect.wast:563: assert_invalid passed:
+  error: invalid func_index: 0 (max 0)
+  0000018: error: OnElemSegmentFunctionIndex callback failed
+79/79 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/fac.txt
+++ b/test/spec/multi-value/fac.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/fac.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+7/7 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/func.txt
+++ b/test/spec/multi-value/func.txt
@@ -1,0 +1,219 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/func.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/func.wast:436: assert_invalid passed:
+  000001a: error: invalid function signature index: 2
+out/test/spec/multi-value/func.wast:520: assert_malformed passed:
+  out/test/spec/multi-value/func/func.4.wat:1:76: error: unexpected token "param", expected an instr.
+  ... i32) (result i32)))(func (type $sig) (result i32) (param i32) (i32.const 0))
+                                                         ^^^^^
+out/test/spec/multi-value/func.wast:527: assert_malformed passed:
+  out/test/spec/multi-value/func/func.5.wat:1:63: error: unexpected token "type", expected an instr.
+  ... i32) (result i32)))(func (param i32) (type $sig) (result i32) (i32.const 0))
+                                            ^^^^
+out/test/spec/multi-value/func.wast:534: assert_malformed passed:
+  out/test/spec/multi-value/func/func.6.wat:1:76: error: unexpected token "type", expected an instr.
+  ... i32) (result i32)))(func (param i32) (result i32) (type $sig) (i32.const 0))
+                                                         ^^^^
+out/test/spec/multi-value/func.wast:541: assert_malformed passed:
+  out/test/spec/multi-value/func/func.7.wat:1:64: error: unexpected token "type", expected an instr.
+  ... i32) (result i32)))(func (result i32) (type $sig) (param i32) (i32.const 0))
+                                             ^^^^
+out/test/spec/multi-value/func.wast:548: assert_malformed passed:
+  out/test/spec/multi-value/func/func.8.wat:1:64: error: unexpected token "param", expected an instr.
+  ... i32) (result i32)))(func (result i32) (param i32) (type $sig) (i32.const 0))
+                                             ^^^^^
+  out/test/spec/multi-value/func/func.8.wat:1:85: error: unexpected token ), expected (.
+  ... i32) (result i32)))(func (result i32) (param i32) (type $sig) (i32.const 0))
+                                                                  ^
+out/test/spec/multi-value/func.wast:555: assert_malformed passed:
+  out/test/spec/multi-value/func/func.9.wat:1:21: error: unexpected token "param", expected an instr.
+  (func (result i32) (param i32) (i32.const 0))
+                      ^^^^^
+out/test/spec/multi-value/func.wast:562: assert_malformed passed:
+  out/test/spec/multi-value/func/func.10.wat:1:20: error: expected 0 results, got 1
+  (type $sig (func))(func (type $sig) (result i32) (i32.const 0))
+                     ^^^^
+out/test/spec/multi-value/func.wast:569: assert_malformed passed:
+  out/test/spec/multi-value/func/func.11.wat:1:45: error: expected 1 arguments, got 0
+  ...g (func (param i32) (result i32)))(func (type $sig) (result i32) (i32.cons...
+                                        ^^^^
+out/test/spec/multi-value/func.wast:576: assert_malformed passed:
+  out/test/spec/multi-value/func/func.12.wat:1:45: error: expected 1 results, got 0
+  ...g (func (param i32) (result i32)))(func (type $sig) (param i32) (i32.const...
+                                        ^^^^
+out/test/spec/multi-value/func.wast:583: assert_malformed passed:
+  out/test/spec/multi-value/func/func.13.wat:1:49: error: expected 2 arguments, got 1
+  ...unc (param i32 i32) (result i32)))(func (type $sig) (param i32) (result i3...
+                                        ^^^^
+out/test/spec/multi-value/func.wast:594: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [i32]
+  000001d: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:598: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  000001c: error: OnConvertExpr callback failed
+out/test/spec/multi-value/func.wast:602: assert_invalid passed:
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/func.wast:610: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [i32]
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:614: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/multi-value/func.wast:618: assert_invalid passed:
+  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/func.wast:626: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  0000019: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:630: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  0000019: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:634: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  0000019: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:638: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  0000019: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:642: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64, i32] but got []
+  000001a: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:647: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001a: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:653: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32, i32] but got []
+  000001b: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:659: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  000001a: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:665: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32, i64]
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:671: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [f32]
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:677: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32, f32] but got [f32]
+  000001f: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:683: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f32]
+  0000023: error: EndFunctionBody callback failed
+out/test/spec/multi-value/func.wast:690: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got []
+  0000019: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:696: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got []
+  000001a: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:702: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got []
+  000001a: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:708: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i64] but got []
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:714: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got [i64]
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:720: assert_invalid passed:
+  error: type mismatch in return, expected [i64, i64] but got [i64]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:727: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got []
+  0000019: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:733: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got []
+  000001a: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:739: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got [i32]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:745: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got []
+  000001a: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:751: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got []
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:757: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got [i64]
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:763: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got [i64]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:769: assert_invalid passed:
+  error: type mismatch in return, expected [i32] but got [i64]
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:775: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got [i32]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/multi-value/func.wast:782: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001a: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:788: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:794: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:800: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:806: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001a: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:812: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:818: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:824: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:830: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:837: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:843: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:849: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:855: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:861: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:867: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/func.wast:877: assert_malformed passed:
+  out/test/spec/multi-value/func/func.62.wat:1:14: error: unexpected token "local", expected an instr.
+  (func (nop) (local i32))
+               ^^^^^
+out/test/spec/multi-value/func.wast:881: assert_malformed passed:
+  out/test/spec/multi-value/func/func.63.wat:1:14: error: unexpected token "param", expected an instr.
+  (func (nop) (param i32))
+               ^^^^^
+out/test/spec/multi-value/func.wast:885: assert_malformed passed:
+  out/test/spec/multi-value/func/func.64.wat:1:14: error: unexpected token "result", expected an instr.
+  (func (nop) (result i32))
+               ^^^^^^
+out/test/spec/multi-value/func.wast:889: assert_malformed passed:
+  out/test/spec/multi-value/func/func.65.wat:1:20: error: unexpected token "param", expected an instr.
+  (func (local i32) (param i32))
+                     ^^^^^
+out/test/spec/multi-value/func.wast:893: assert_malformed passed:
+  out/test/spec/multi-value/func/func.66.wat:1:20: error: unexpected token "result", expected an instr.
+  (func (local i32) (result i32) (get_local 0))
+                     ^^^^^^
+out/test/spec/multi-value/func.wast:897: assert_malformed passed:
+  out/test/spec/multi-value/func/func.67.wat:1:21: error: unexpected token "param", expected an instr.
+  (func (result i32) (param i32) (get_local 0))
+                      ^^^^^
+158/158 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/if.txt
+++ b/test/spec/multi-value/if.txt
@@ -1,0 +1,350 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/if.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/if.wast:410: assert_malformed passed:
+  out/test/spec/multi-value/if/if.1.wat:1:95: error: unexpected token "param", expected then block (e.g. (then ...)).
+  ...i32.const 0)  (if (type $sig) (result i32) (param i32) (i32.const 1) (then)))
+                                                 ^^^^^
+  out/test/spec/multi-value/if/if.1.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (type $sig) (result i32) (param i32) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/multi-value/if.wast:419: assert_malformed passed:
+  out/test/spec/multi-value/if/if.2.wat:1:82: error: unexpected token "type", expected then block (e.g. (then ...)).
+  ...nc (i32.const 0)  (if (param i32) (type $sig) (result i32) (i32.const 1) (...
+                                        ^^^^
+  out/test/spec/multi-value/if/if.2.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (param i32) (type $sig) (result i32) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/multi-value/if.wast:428: assert_malformed passed:
+  out/test/spec/multi-value/if/if.3.wat:1:95: error: unexpected token "type", expected then block (e.g. (then ...)).
+  ...i32.const 0)  (if (param i32) (result i32) (type $sig) (i32.const 1) (then)))
+                                                 ^^^^
+  out/test/spec/multi-value/if/if.3.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (param i32) (result i32) (type $sig) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/multi-value/if.wast:437: assert_malformed passed:
+  out/test/spec/multi-value/if/if.4.wat:1:83: error: unexpected token "type", expected then block (e.g. (then ...)).
+  ...c (i32.const 0)  (if (result i32) (type $sig) (param i32) (i32.const 1) (t...
+                                        ^^^^
+  out/test/spec/multi-value/if/if.4.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (result i32) (type $sig) (param i32) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/multi-value/if.wast:446: assert_malformed passed:
+  out/test/spec/multi-value/if/if.5.wat:1:83: error: unexpected token "param", expected then block (e.g. (then ...)).
+  ...c (i32.const 0)  (if (result i32) (param i32) (type $sig) (i32.const 1) (t...
+                                        ^^^^^
+  out/test/spec/multi-value/if/if.5.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (result i32) (param i32) (type $sig) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/multi-value/if.wast:455: assert_malformed passed:
+  out/test/spec/multi-value/if/if.6.wat:1:39: error: unexpected token "param", expected then block (e.g. (then ...)).
+  (func (i32.const 0) (if (result i32) (param i32) (i32.const 1) (then)))
+                                        ^^^^^
+  out/test/spec/multi-value/if/if.6.wat:1:65: error: unexpected token "then", expected an instr.
+  (func (i32.const 0) (if (result i32) (param i32) (i32.const 1) (then)))
+                                                                  ^^^^
+out/test/spec/multi-value/if.wast:462: assert_malformed passed:
+  out/test/spec/multi-value/if/if.7.wat:1:47: error: unexpected token $x, expected ).
+  ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
+                                             ^^
+  out/test/spec/multi-value/if/if.7.wat:1:69: error: unexpected token (, expected EOF.
+  ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
+                                                                   ^
+out/test/spec/multi-value/if.wast:470: assert_malformed passed:
+  out/test/spec/multi-value/if/if.8.wat:1:40: error: expected 0 results, got 1
+  (type $sig (func))(func (i32.const 1)  (if (type $sig) (result i32) (then (i3...
+                                         ^
+out/test/spec/multi-value/if.wast:480: assert_malformed passed:
+  out/test/spec/multi-value/if/if.9.wat:1:65: error: expected 1 arguments, got 0
+  ...) (result i32)))(func (i32.const 1)  (if (type $sig) (result i32) (then (i...
+                                          ^
+out/test/spec/multi-value/if.wast:490: assert_malformed passed:
+  out/test/spec/multi-value/if/if.10.wat:1:79: error: expected 1 results, got 0
+  ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (then (dr...
+                                          ^
+out/test/spec/multi-value/if.wast:500: assert_malformed passed:
+  out/test/spec/multi-value/if/if.11.wat:1:83: error: expected 2 arguments, got 1
+  ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (result i...
+                                          ^
+out/test/spec/multi-value/if.wast:510: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  000001f: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:518: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:522: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:526: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:530: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:535: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:539: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:543: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:547: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:552: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:558: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:564: assert_invalid passed:
+  error: type mismatch in if false branch, expected [] but got [i32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:570: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  000001e: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:577: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:583: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:589: assert_invalid passed:
+  error: type mismatch in if false branch, expected [] but got [i32, i32]
+  0000021: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:595: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  0000020: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:602: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got []
+  000001d: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:608: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32] but got []
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:614: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got []
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:621: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001e: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:627: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got []
+  0000022: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:633: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:640: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32] but got []
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:646: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got []
+  0000022: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:653: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got []
+  000001e: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:659: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32] but got []
+  0000021: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:665: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got []
+  000001e: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:672: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001f: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:678: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got []
+  0000024: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:684: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001f: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:691: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got [i64]
+  000001f: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:697: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32] but got [i64]
+  0000022: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:703: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got [i64]
+  000001f: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:710: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000020: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:716: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  0000025: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:722: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000020: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:729: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000022: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:736: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  0000027: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:743: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000022: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:751: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  0000021: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:757: assert_invalid passed:
+  error: type mismatch in if false branch, expected [] but got [i32]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/multi-value/if.wast:763: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  0000021: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:770: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got [i64]
+  000001f: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:776: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  0000024: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:783: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000025: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:793: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000025: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:803: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000027: error: EndFunctionBody callback failed
+out/test/spec/multi-value/if.wast:814: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:820: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:826: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:832: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000024: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:839: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:848: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:857: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:866: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000024: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:876: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:885: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000022: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:894: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:903: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:913: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:922: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:931: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i64]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:940: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i64]
+  0000026: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:949: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i64]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/multi-value/if.wast:959: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000022: error: OnElseExpr callback failed
+out/test/spec/multi-value/if.wast:970: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001f: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:976: assert_invalid passed:
+  error: type mismatch in if, expected [i32, f64] but got []
+  0000020: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:982: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got [f32]
+  0000024: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:988: assert_invalid passed:
+  error: type mismatch in if, expected [f32, i32] but got [f32]
+  0000025: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:994: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000021: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1000: assert_invalid passed:
+  error: type mismatch in if, expected [i32, f64] but got []
+  0000022: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1006: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got [f32]
+  0000026: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1012: assert_invalid passed:
+  error: type mismatch in if, expected [f32, i32] but got [f32]
+  0000027: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1019: assert_malformed passed:
+  out/test/spec/multi-value/if/if.86.wat:1:42: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) if (param $x i32) end)
+                                           ^^
+out/test/spec/multi-value/if.wast:1023: assert_malformed passed:
+  out/test/spec/multi-value/if/if.87.wat:1:43: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) (if (param $x i32) (then)))
+                                            ^^
+out/test/spec/multi-value/if.wast:1028: assert_malformed passed:
+  out/test/spec/multi-value/if/if.88.wat:1:14: error: unexpected label "$l"
+  (func if end $l)
+               ^^
+out/test/spec/multi-value/if.wast:1032: assert_malformed passed:
+  out/test/spec/multi-value/if/if.89.wat:1:17: error: mismatching label "$a" != "$l"
+  (func if $a end $l)
+                  ^^
+out/test/spec/multi-value/if.wast:1036: assert_malformed passed:
+  out/test/spec/multi-value/if/if.90.wat:1:15: error: unexpected label "$l"
+  (func if else $l end)
+                ^^
+out/test/spec/multi-value/if.wast:1040: assert_malformed passed:
+  out/test/spec/multi-value/if/if.91.wat:1:18: error: mismatching label "$a" != "$l"
+  (func if $a else $l end)
+                   ^^
+out/test/spec/multi-value/if.wast:1044: assert_malformed passed:
+  out/test/spec/multi-value/if/if.92.wat:1:19: error: unexpected label "$l"
+  (func if else end $l)
+                    ^^
+out/test/spec/multi-value/if.wast:1048: assert_malformed passed:
+  out/test/spec/multi-value/if/if.93.wat:1:15: error: unexpected label "$l"
+  (func if else $l end $l)
+                ^^
+  out/test/spec/multi-value/if/if.93.wat:1:22: error: unexpected label "$l"
+  (func if else $l end $l)
+                       ^^
+out/test/spec/multi-value/if.wast:1052: assert_malformed passed:
+  out/test/spec/multi-value/if/if.94.wat:1:15: error: unexpected label "$l1"
+  (func if else $l1 end $l2)
+                ^^^
+  out/test/spec/multi-value/if/if.94.wat:1:23: error: unexpected label "$l2"
+  (func if else $l1 end $l2)
+                        ^^^
+out/test/spec/multi-value/if.wast:1056: assert_malformed passed:
+  out/test/spec/multi-value/if/if.95.wat:1:22: error: mismatching label "$a" != "$l"
+  (func if $a else end $l)
+                       ^^
+out/test/spec/multi-value/if.wast:1060: assert_malformed passed:
+  out/test/spec/multi-value/if/if.96.wat:1:25: error: mismatching label "$a" != "$l"
+  (func if $a else $a end $l)
+                          ^^
+out/test/spec/multi-value/if.wast:1064: assert_malformed passed:
+  out/test/spec/multi-value/if/if.97.wat:1:18: error: mismatching label "$a" != "$l"
+  (func if $a else $l end $l)
+                   ^^
+  out/test/spec/multi-value/if/if.97.wat:1:25: error: mismatching label "$a" != "$l"
+  (func if $a else $l end $l)
+                          ^^
+170/170 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/loop.txt
+++ b/test/spec/multi-value/loop.txt
@@ -1,0 +1,141 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/loop.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/loop.wast:394: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.1.wat:1:95: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (type $sig) (result i32) (param i32)))
+                                                                     ^
+out/test/spec/multi-value/loop.wast:401: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.2.wat:1:82: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (param i32) (type $sig) (result i32)))
+                                                        ^
+out/test/spec/multi-value/loop.wast:408: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.3.wat:1:95: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (param i32) (result i32) (type $sig)))
+                                                                     ^
+out/test/spec/multi-value/loop.wast:415: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.4.wat:1:83: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (result i32) (type $sig) (param i32)))
+                                                         ^
+out/test/spec/multi-value/loop.wast:422: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.5.wat:1:83: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (result i32) (param i32) (type $sig)))
+                                                         ^
+out/test/spec/multi-value/loop.wast:429: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.6.wat:1:40: error: unexpected token (, expected ).
+  (func (i32.const 0) (loop (result i32) (param i32)))
+                                         ^
+out/test/spec/multi-value/loop.wast:436: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.7.wat:1:34: error: unexpected token $x, expected ).
+  (func (i32.const 0) (loop (param $x i32) (drop)))
+                                   ^^
+  out/test/spec/multi-value/loop/loop.7.wat:1:49: error: unexpected token ), expected EOF.
+  (func (i32.const 0) (loop (param $x i32) (drop)))
+                                                  ^
+out/test/spec/multi-value/loop.wast:440: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.8.wat:1:25: error: expected 0 results, got 1
+  (type $sig (func))(func (loop (type $sig) (result i32) (i32.const 0)) (unreac...
+                          ^
+out/test/spec/multi-value/loop.wast:447: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.9.wat:1:50: error: expected 1 arguments, got 0
+  ...func (param i32) (result i32)))(func (loop (type $sig) (result i32) (i32.c...
+                                          ^
+out/test/spec/multi-value/loop.wast:454: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.10.wat:1:64: error: expected 1 results, got 0
+  ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (drop))...
+                                          ^
+out/test/spec/multi-value/loop.wast:461: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.11.wat:1:68: error: expected 2 arguments, got 1
+  ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (result...
+                                          ^
+out/test/spec/multi-value/loop.wast:469: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:477: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/loop.wast:481: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/loop.wast:485: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/loop.wast:489: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/multi-value/loop.wast:494: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:500: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32, i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:506: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:512: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:518: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:524: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got []
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:530: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got [f32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:536: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:542: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:548: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:554: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/loop.wast:561: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001d: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:567: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, f64] but got []
+  000001e: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:573: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got [f32]
+  0000022: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:579: assert_invalid passed:
+  error: type mismatch in loop, expected [f32, i32] but got [f32]
+  0000023: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:585: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001f: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:591: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, f64] but got []
+  0000020: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:597: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got [f32]
+  0000024: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:603: assert_invalid passed:
+  error: type mismatch in loop, expected [f32, i32] but got [f32]
+  0000025: error: OnLoopExpr callback failed
+out/test/spec/multi-value/loop.wast:610: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.36.wat:1:44: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) loop (param $x i32) end)
+                                             ^^
+out/test/spec/multi-value/loop.wast:614: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.37.wat:1:45: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) (loop (param $x i32)))
+                                              ^^
+out/test/spec/multi-value/loop.wast:619: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.38.wat:1:16: error: unexpected label "$l"
+  (func loop end $l)
+                 ^^
+out/test/spec/multi-value/loop.wast:623: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.39.wat:1:19: error: mismatching label "$a" != "$l"
+  (func loop $a end $l)
+                    ^^
+92/92 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/type.txt
+++ b/test/spec/multi-value/type.txt
@@ -1,0 +1,14 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/type.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/type.wast:44: assert_malformed passed:
+  out/test/spec/multi-value/type/type.1.wat:1:27: error: unexpected token "param", expected param or result.
+  (type (func (result i32) (param i32)))
+                            ^^^^^
+out/test/spec/multi-value/type.wast:48: assert_malformed passed:
+  out/test/spec/multi-value/type/type.2.wat:1:21: error: unexpected token $x, expected ).
+  (type (func (result $x i32)))
+                      ^^
+2/2 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -219,11 +219,10 @@ out/test/spec/unreached-invalid.wast:427: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:433: assert_invalid passed:
-  error: type mismatch in if, expected [] but got [i32]
+  error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:439: assert_invalid passed:
-  error: if without else cannot have results.
-  error: type mismatch in if, expected [i32] but got [f32]
+  error: type mismatch in if true branch, expected [i32] but got [f32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:445: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]


### PR DESCRIPTION
Running the multi-value spec tests found a few bugs:

* DropKeep needs to copy the kept values backward when the regions
  overlap.

* Type names need to be resolved to indexes in block declarations
  (e.g. `block (type $foo)`)

* `if` without an `else` is valid, it just behaves as though the `else`
  is empty, which will pass the params through as results.

* When validating function signatures, we need to also check block
  declaration signatures.

* Split `ResolveFuncType` into two functions:
  `ResolveFuncTypeWithEmptySignature` and
  `ResolveImplicitlyDefinedFunctionType`.

* When resolving implicitly defined function types, we only create an
  implicit function type when the type is not inlinable; i.e. only for
  block/loop/if with 0 or 1 result values and no params.

* Change `update-spec-tests` to include the `multi-value` proposal repo
  from the testsuite.