### PR TITLE
Optimize interpreter and `Opcode::FromCode`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -94,7 +94,7 @@ else ()
     -Wuninitialized
   )
 
-  set(CMAKE_CXX_FLAGS "-std=c++11 -Wold-style-cast")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wold-style-cast")
 
   if (NOT WITH_EXCEPTIONS)
     add_definitions(-fno-exceptions)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,9 +90,11 @@ else ()
   #   interfaces, etc.
   # disable -Wpointer-arith: this is a GCC extension, and doesn't work in MSVC.
   add_definitions(
-    -Wall -Wextra -Werror -Wno-unused-parameter -Wpointer-arith -g -std=c++11
-    -Wold-style-cast -Wuninitialized
+    -Wall -Wextra -Werror -Wno-unused-parameter -Wpointer-arith -g
+    -Wuninitialized
   )
+
+  set(CMAKE_CXX_FLAGS "-std=c++11 -Wold-style-cast")
 
   if (NOT WITH_EXCEPTIONS)
     add_definitions(-fno-exceptions)
@@ -213,6 +215,7 @@ add_custom_target(everything)
 add_library(libwabt STATIC
   src/token.cc
   src/opcode.cc
+  src/opcode-code-table.c
   src/error-formatter.cc
   src/hash-util.cc
   src/filenames.cc

--- a/src/binary-reader-interp.cc
+++ b/src/binary-reader-interp.cc
@@ -422,14 +422,7 @@ wabt::Result BinaryReaderInterp::EmitData(const void* data,
 }
 
 wabt::Result BinaryReaderInterp::EmitOpcode(Opcode opcode) {
-  if (opcode.HasPrefix()) {
-    CHECK_RESULT(EmitI8(opcode.GetPrefix()));
-  }
-
-  // Assume opcode codes are all 1 byte for now (excluding the prefix).
-  uint32_t code = opcode.GetCode();
-  assert(code < 256);
-  return EmitI8(code);
+  return EmitI32(static_cast<uint32_t>(opcode));
 }
 
 wabt::Result BinaryReaderInterp::EmitI8(uint8_t value) {

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -89,6 +89,8 @@
 #define WABT_STATIC_ASSERT_(x, c) WABT_STATIC_ASSERT__(x, c)
 #define WABT_STATIC_ASSERT(x) WABT_STATIC_ASSERT_(x, __COUNTER__)
 #endif
+#elif COMPILER_IS_MSVC
+#define WABT_STATIC_ASSERT(x) _STATIC_ASSERT((x))
 #else
 #define WABT_STATIC_ASSERT(x) _Static_assert((x), #x)
 #endif
@@ -115,6 +117,8 @@
 #error unknown compiler
 
 #endif
+
+#ifdef __cplusplus
 
 namespace wabt {
 
@@ -325,5 +329,7 @@ __inline float wabt_convert_uint64_to_float(uint64_t x) {
   return static_cast<float>(x);
 }
 #endif
+
+#endif  // __cplusplus
 
 #endif /* WABT_CONFIG_H_ */

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -89,8 +89,6 @@
 #define WABT_STATIC_ASSERT_(x, c) WABT_STATIC_ASSERT__(x, c)
 #define WABT_STATIC_ASSERT(x) WABT_STATIC_ASSERT_(x, __COUNTER__)
 #endif
-#elif COMPILER_IS_MSVC
-#define WABT_STATIC_ASSERT(x) _STATIC_ASSERT((x))
 #else
 #define WABT_STATIC_ASSERT(x) _Static_assert((x), #x)
 #endif
@@ -100,7 +98,7 @@
 #elif COMPILER_IS_MSVC
 
 #include <intrin.h>
-#include <cstring>
+#include <string.h>
 
 #define WABT_UNUSED
 #define WABT_WARN_UNUSED

--- a/src/interp.cc
+++ b/src/interp.cc
@@ -762,17 +762,8 @@ inline v128 ReadV128(const uint8_t** pc) {
 }
 
 inline Opcode ReadOpcode(const uint8_t** pc) {
-  uint8_t value = ReadU8(pc);
-  if (Opcode::IsPrefixByte(value)) {
-    // For now, assume all instructions are encoded with just one extra byte
-    // so we don't have to decode LEB128 here.
-    uint32_t code = ReadU8(pc);
-    return Opcode::FromCode(value, code);
-  } else {
-    // TODO(binji): Optimize if needed; Opcode::FromCode does a log2(n) lookup
-    // from the encoding.
-    return Opcode::FromCode(value);
-  }
+  uint32_t value = ReadU32(pc);
+  return Opcode(static_cast<Opcode::Enum>(value));
 }
 
 inline void read_table_entry_at(const uint8_t* pc,

--- a/src/opcode-code-table.c
+++ b/src/opcode-code-table.c
@@ -32,10 +32,10 @@ typedef enum WabtOpcodeEnum {
 _Static_assert(Invalid <= 65536, "Too many opcodes");
 
 /* The array index calculated below must match the one in Opcode::FromCode. */
-uint32_t WabtOpcodeCodeTable[] = {
+uint32_t WabtOpcodeCodeTable[65536] = {
 #define WABT_OPCODE(rtype, type1, type2, type3, mem_size, prefix, code, Name, \
                     text)                                                     \
-  [prefix * 256 + code] = Name,
+  [(prefix << 8) + code] = Name,
 #include "opcode.def"
 #undef WABT_OPCODE
 };

--- a/src/opcode-code-table.c
+++ b/src/opcode-code-table.c
@@ -14,9 +14,7 @@
  * limitations under the License.
  */
 
-/* This structure is defined in C because C++ doesn't (yet) allow you to use
- * designated array initializers, i.e. [10] = {foo}.
- */
+#include "src/opcode-code-table.h"
 
 #include <stdint.h>
 
@@ -29,10 +27,10 @@ typedef enum WabtOpcodeEnum {
   Invalid,
 } WabtOpcodeEnum;
 
-_Static_assert(Invalid <= 65536, "Too many opcodes");
+_Static_assert(Invalid <= WABT_OPCODE_CODE_TABLE_SIZE, "Too many opcodes");
 
 /* The array index calculated below must match the one in Opcode::FromCode. */
-uint32_t WabtOpcodeCodeTable[65536] = {
+uint32_t WabtOpcodeCodeTable[WABT_OPCODE_CODE_TABLE_SIZE] = {
 #define WABT_OPCODE(rtype, type1, type2, type3, mem_size, prefix, code, Name, \
                     text)                                                     \
   [(prefix << 8) + code] = Name,

--- a/src/opcode-code-table.c
+++ b/src/opcode-code-table.c
@@ -16,6 +16,8 @@
 
 #include "src/opcode-code-table.h"
 
+#include "config.h"
+
 #include <stdint.h>
 
 typedef enum WabtOpcodeEnum {
@@ -27,7 +29,7 @@ typedef enum WabtOpcodeEnum {
   Invalid,
 } WabtOpcodeEnum;
 
-_Static_assert(Invalid <= WABT_OPCODE_CODE_TABLE_SIZE, "Too many opcodes");
+WABT_STATIC_ASSERT(Invalid <= WABT_OPCODE_CODE_TABLE_SIZE);
 
 /* The array index calculated below must match the one in Opcode::FromCode. */
 uint32_t WabtOpcodeCodeTable[WABT_OPCODE_CODE_TABLE_SIZE] = {

--- a/src/opcode-code-table.c
+++ b/src/opcode-code-table.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* This structure is defined in C because C++ doesn't (yet) allow you to use
+ * designated array initializers, i.e. [10] = {foo}.
+ */
+
+#include <stdint.h>
+
+typedef enum WabtOpcodeEnum {
+#define WABT_OPCODE(rtype, type1, type2, type3, mem_size, prefix, code, Name, \
+                    text)                                                     \
+  Name,
+#include "opcode.def"
+#undef WABT_OPCODE
+  Invalid,
+} WabtOpcodeEnum;
+
+_Static_assert(Invalid <= 65536, "Too many opcodes");
+
+/* The array index calculated below must match the one in Opcode::FromCode. */
+uint32_t WabtOpcodeCodeTable[] = {
+#define WABT_OPCODE(rtype, type1, type2, type3, mem_size, prefix, code, Name, \
+                    text)                                                     \
+  [prefix * 256 + code] = Name,
+#include "opcode.def"
+#undef WABT_OPCODE
+};

--- a/src/opcode-code-table.h
+++ b/src/opcode-code-table.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_OPCODE_CODE_TABLE_H_
+#define WABT_OPCODE_CODE_TABLE_H_
+
+#include <stdlib.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define WABT_OPCODE_CODE_TABLE_SIZE 65536
+
+/* This structure is defined in C because C++ doesn't (yet) allow you to use
+ * designated array initializers, i.e. [10] = {foo}.
+ */
+extern uint32_t WabtOpcodeCodeTable[WABT_OPCODE_CODE_TABLE_SIZE];
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* WABT_OPCODE_CODE_TABLE_H_ */

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -18,6 +18,7 @@
 #define WABT_OPCODE_H_
 
 #include "src/common.h"
+#include "src/opcode-code-table.h"
 
 namespace wabt {
 
@@ -133,8 +134,6 @@ struct Opcode {
 
   Enum enum_;
 };
-
-extern "C" uint32_t WabtOpcodeCodeTable[65536];
 
 // static
 inline Opcode Opcode::FromCode(uint32_t code) {

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -134,6 +134,26 @@ struct Opcode {
   Enum enum_;
 };
 
+extern "C" uint32_t WabtOpcodeCodeTable[];
+
+// static
+inline Opcode Opcode::FromCode(uint32_t code) {
+  return FromCode(0, code);
+}
+
+// static
+inline Opcode Opcode::FromCode(uint8_t prefix, uint32_t code) {
+  uint32_t value = WabtOpcodeCodeTable[prefix * 256 + code];
+  // The default value in the table is 0. That's a valid value, but only if the
+  // code is 0 (for nop).
+  if (WABT_UNLIKELY(value == 0 && code != 0)) {
+    return Opcode(EncodeInvalidOpcode(PrefixCode(prefix, code)));
+  }
+
+  return Opcode(static_cast<Enum>(value));
+}
+
+
 }  // namespace wabt
 
 #endif  // WABT_OPCODE_H_

--- a/test/interp/basic-logging.txt
+++ b/test/interp/basic-logging.txt
@@ -68,7 +68,7 @@ BeginModule(version: 1)
   EndCodeSection
 EndModule
    0| i32.const $42
-   5| return
-   6| return
+   8| return
+  12| return
 main() => i32:42
 ;;; STDOUT ;;)

--- a/test/interp/basic-tracing.txt
+++ b/test/interp/basic-tracing.txt
@@ -21,40 +21,40 @@
     call $fib))
 (;; STDOUT ;;;
 >>> running export "main":
-#0.   58: V:0  | i32.const $3
-#0.   63: V:1  | call @0
+#0.  100: V:0  | i32.const $3
+#0.  108: V:1  | call @0
 #1.    0: V:1  | get_local $1
-#1.    5: V:2  | i32.const $1
-#1.   10: V:3  | i32.le_s 3, 1
-#1.   11: V:2  | br_unless @26, 0
-#1.   26: V:1  | get_local $1
-#1.   31: V:2  | i32.const $1
-#1.   36: V:3  | i32.sub 3, 1
-#1.   37: V:2  | call @0
+#1.    8: V:2  | i32.const $1
+#1.   16: V:3  | i32.le_s 3, 1
+#1.   20: V:2  | br_unless @44, 0
+#1.   44: V:1  | get_local $1
+#1.   52: V:2  | i32.const $1
+#1.   60: V:3  | i32.sub 3, 1
+#1.   64: V:2  | call @0
 #2.    0: V:2  | get_local $1
-#2.    5: V:3  | i32.const $1
-#2.   10: V:4  | i32.le_s 2, 1
-#2.   11: V:3  | br_unless @26, 0
-#2.   26: V:2  | get_local $1
-#2.   31: V:3  | i32.const $1
-#2.   36: V:4  | i32.sub 2, 1
-#2.   37: V:3  | call @0
+#2.    8: V:3  | i32.const $1
+#2.   16: V:4  | i32.le_s 2, 1
+#2.   20: V:3  | br_unless @44, 0
+#2.   44: V:2  | get_local $1
+#2.   52: V:3  | i32.const $1
+#2.   60: V:4  | i32.sub 2, 1
+#2.   64: V:3  | call @0
 #3.    0: V:3  | get_local $1
-#3.    5: V:4  | i32.const $1
-#3.   10: V:5  | i32.le_s 1, 1
-#3.   11: V:4  | br_unless @26, 1
-#3.   16: V:3  | i32.const $1
-#3.   21: V:4  | br @48
-#3.   48: V:4  | drop_keep $1 $1
-#3.   57: V:3  | return
-#2.   42: V:3  | get_local $2
-#2.   47: V:4  | i32.mul 1, 2
-#2.   48: V:3  | drop_keep $1 $1
-#2.   57: V:2  | return
-#1.   42: V:2  | get_local $2
-#1.   47: V:3  | i32.mul 2, 3
-#1.   48: V:2  | drop_keep $1 $1
-#1.   57: V:1  | return
-#0.   68: V:1  | return
+#3.    8: V:4  | i32.const $1
+#3.   16: V:5  | i32.le_s 1, 1
+#3.   20: V:4  | br_unless @44, 1
+#3.   28: V:3  | i32.const $1
+#3.   36: V:4  | br @84
+#3.   84: V:4  | drop_keep $1 $1
+#3.   96: V:3  | return
+#2.   72: V:3  | get_local $2
+#2.   80: V:4  | i32.mul 1, 2
+#2.   84: V:3  | drop_keep $1 $1
+#2.   96: V:2  | return
+#1.   72: V:2  | get_local $2
+#1.   80: V:3  | i32.mul 2, 3
+#1.   84: V:2  | drop_keep $1 $1
+#1.   96: V:1  | return
+#0.  116: V:1  | return
 main() => i32:6
 ;;; STDOUT ;;)

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -10563,1786 +10563,1786 @@ BeginModule(version: 1)
   EndCodeSection
 EndModule
    0| return
-   1| unreachable
-   2| return
-   3| br @8
+   4| unreachable
    8| return
-   9| i32.const $1
-  14| br_table %[-1], $#0, table:$28
-  23| data $12
-  28|   entry 0: offset: 40 drop: 0 keep: 0
-  40| return
-  41| return
-  42| return
-  43| call @0
-  48| return
-  49| i32.const $1
-  54| call_indirect $0:0, %[-1]
-  63| return
-  64| i32.const $1
-  69| drop
-  70| return
-  71| i32.const $1
-  76| i32.const $2
-  81| i32.const $3
-  86| select %[-3], %[-2], %[-1]
-  87| drop
-  88| return
-  89| alloca $1
-  94| get_local $1
-  99| drop
- 100| drop
- 101| return
- 102| alloca $1
- 107| i32.const $1
- 112| set_local $1, %[-1]
- 117| drop
- 118| return
- 119| alloca $1
- 124| i32.const $1
- 129| tee_local $2, %[-1]
- 134| drop
- 135| drop
- 136| return
- 137| get_global $0
- 142| drop
- 143| return
- 144| i32.const $1
- 149| set_global $0, %[-1]
- 154| return
- 155| i32.const $1
- 160| i32.load $0:%[-1]+$2
- 169| drop
- 170| return
- 171| i32.const $1
- 176| i64.load $0:%[-1]+$2
- 185| drop
- 186| return
- 187| i32.const $1
- 192| f32.load $0:%[-1]+$2
- 201| drop
- 202| return
- 203| i32.const $1
- 208| f64.load $0:%[-1]+$2
- 217| drop
- 218| return
- 219| i32.const $1
- 224| i32.load8_s $0:%[-1]+$2
- 233| drop
- 234| return
- 235| i32.const $1
- 240| i32.load8_u $0:%[-1]+$2
- 249| drop
- 250| return
- 251| i32.const $1
- 256| i32.load16_s $0:%[-1]+$2
- 265| drop
- 266| return
- 267| i32.const $1
- 272| i32.load16_u $0:%[-1]+$2
- 281| drop
- 282| return
- 283| i32.const $1
- 288| i64.load8_s $0:%[-1]+$2
- 297| drop
- 298| return
- 299| i32.const $1
- 304| i64.load8_u $0:%[-1]+$2
- 313| drop
- 314| return
- 315| i32.const $1
- 320| i64.load16_s $0:%[-1]+$2
- 329| drop
- 330| return
- 331| i32.const $1
- 336| i64.load16_u $0:%[-1]+$2
- 345| drop
- 346| return
- 347| i32.const $1
- 352| i64.load32_s $0:%[-1]+$2
- 361| drop
- 362| return
- 363| i32.const $1
- 368| i64.load32_u $0:%[-1]+$2
- 377| drop
- 378| return
- 379| i32.const $1
- 384| i32.const $2
- 389| i32.store $0:%[-2]+$2, %[-1]
- 398| return
- 399| i32.const $1
- 404| i64.const $2
- 413| i64.store $0:%[-2]+$2, %[-1]
- 422| return
- 423| i32.const $1
- 428| f32.const $2
- 433| f32.store $0:%[-2]+$2, %[-1]
- 442| return
- 443| i32.const $1
- 448| f64.const $2
- 457| f64.store $0:%[-2]+$2, %[-1]
- 466| return
- 467| i32.const $1
- 472| i32.const $2
- 477| i32.store8 $0:%[-2]+$2, %[-1]
- 486| return
- 487| i32.const $1
- 492| i32.const $2
- 497| i32.store16 $0:%[-2]+$2, %[-1]
- 506| return
- 507| i32.const $1
- 512| i64.const $2
- 521| i64.store8 $0:%[-2]+$2, %[-1]
- 530| return
- 531| i32.const $1
- 536| i64.const $2
- 545| i64.store16 $0:%[-2]+$2, %[-1]
- 554| return
- 555| i32.const $1
- 560| i64.const $2
- 569| i64.store32 $0:%[-2]+$2, %[-1]
- 578| return
- 579| memory.size $0
- 584| drop
- 585| return
- 586| i32.const $1
- 591| memory.grow $0:%[-1]
+  12| br @20
+  20| return
+  24| i32.const $1
+  32| br_table %[-1], $#0, table:$52
+  44| data $12
+  52|   entry 0: offset: 64 drop: 0 keep: 0
+  64| return
+  68| return
+  72| return
+  76| call @0
+  84| return
+  88| i32.const $1
+  96| call_indirect $0:0, %[-1]
+ 108| return
+ 112| i32.const $1
+ 120| drop
+ 124| return
+ 128| i32.const $1
+ 136| i32.const $2
+ 144| i32.const $3
+ 152| select %[-3], %[-2], %[-1]
+ 156| drop
+ 160| return
+ 164| alloca $1
+ 172| get_local $1
+ 180| drop
+ 184| drop
+ 188| return
+ 192| alloca $1
+ 200| i32.const $1
+ 208| set_local $1, %[-1]
+ 216| drop
+ 220| return
+ 224| alloca $1
+ 232| i32.const $1
+ 240| tee_local $2, %[-1]
+ 248| drop
+ 252| drop
+ 256| return
+ 260| get_global $0
+ 268| drop
+ 272| return
+ 276| i32.const $1
+ 284| set_global $0, %[-1]
+ 292| return
+ 296| i32.const $1
+ 304| i32.load $0:%[-1]+$2
+ 316| drop
+ 320| return
+ 324| i32.const $1
+ 332| i64.load $0:%[-1]+$2
+ 344| drop
+ 348| return
+ 352| i32.const $1
+ 360| f32.load $0:%[-1]+$2
+ 372| drop
+ 376| return
+ 380| i32.const $1
+ 388| f64.load $0:%[-1]+$2
+ 400| drop
+ 404| return
+ 408| i32.const $1
+ 416| i32.load8_s $0:%[-1]+$2
+ 428| drop
+ 432| return
+ 436| i32.const $1
+ 444| i32.load8_u $0:%[-1]+$2
+ 456| drop
+ 460| return
+ 464| i32.const $1
+ 472| i32.load16_s $0:%[-1]+$2
+ 484| drop
+ 488| return
+ 492| i32.const $1
+ 500| i32.load16_u $0:%[-1]+$2
+ 512| drop
+ 516| return
+ 520| i32.const $1
+ 528| i64.load8_s $0:%[-1]+$2
+ 540| drop
+ 544| return
+ 548| i32.const $1
+ 556| i64.load8_u $0:%[-1]+$2
+ 568| drop
+ 572| return
+ 576| i32.const $1
+ 584| i64.load16_s $0:%[-1]+$2
  596| drop
- 597| return
- 598| i32.const $1
- 603| drop
- 604| return
- 605| i64.const $1
- 614| drop
- 615| return
- 616| f32.const $1
- 621| drop
- 622| return
- 623| f64.const $1
- 632| drop
- 633| return
- 634| i32.const $1
- 639| i32.eqz %[-1]
- 640| drop
- 641| return
- 642| i32.const $1
- 647| i32.const $2
- 652| i32.eq %[-2], %[-1]
- 653| drop
- 654| return
- 655| i32.const $1
- 660| i32.const $2
- 665| i32.ne %[-2], %[-1]
- 666| drop
- 667| return
- 668| i32.const $1
- 673| i32.const $2
- 678| i32.lt_s %[-2], %[-1]
- 679| drop
- 680| return
- 681| i32.const $1
- 686| i32.const $2
- 691| i32.lt_u %[-2], %[-1]
- 692| drop
- 693| return
- 694| i32.const $1
- 699| i32.const $2
- 704| i32.gt_s %[-2], %[-1]
- 705| drop
- 706| return
- 707| i32.const $1
- 712| i32.const $2
- 717| i32.gt_u %[-2], %[-1]
- 718| drop
- 719| return
+ 600| return
+ 604| i32.const $1
+ 612| i64.load16_u $0:%[-1]+$2
+ 624| drop
+ 628| return
+ 632| i32.const $1
+ 640| i64.load32_s $0:%[-1]+$2
+ 652| drop
+ 656| return
+ 660| i32.const $1
+ 668| i64.load32_u $0:%[-1]+$2
+ 680| drop
+ 684| return
+ 688| i32.const $1
+ 696| i32.const $2
+ 704| i32.store $0:%[-2]+$2, %[-1]
+ 716| return
  720| i32.const $1
- 725| i32.const $2
- 730| i32.le_s %[-2], %[-1]
- 731| drop
- 732| return
- 733| i32.const $1
- 738| i32.const $2
- 743| i32.le_u %[-2], %[-1]
- 744| drop
- 745| return
- 746| i32.const $1
- 751| i32.const $2
- 756| i32.ge_s %[-2], %[-1]
- 757| drop
- 758| return
- 759| i32.const $1
- 764| i32.const $2
- 769| i32.ge_u %[-2], %[-1]
- 770| drop
- 771| return
- 772| i64.const $1
- 781| i64.eqz %[-1]
- 782| drop
- 783| return
- 784| i64.const $1
- 793| i64.const $2
- 802| i64.eq %[-2], %[-1]
- 803| drop
- 804| return
- 805| i64.const $1
- 814| i64.const $2
- 823| i64.ne %[-2], %[-1]
- 824| drop
- 825| return
- 826| i64.const $1
- 835| i64.const $2
- 844| i64.lt_s %[-2], %[-1]
- 845| drop
- 846| return
- 847| i64.const $1
- 856| i64.const $2
- 865| i64.lt_u %[-2], %[-1]
- 866| drop
- 867| return
- 868| i64.const $1
- 877| i64.const $2
- 886| i64.gt_s %[-2], %[-1]
- 887| drop
- 888| return
- 889| i64.const $1
- 898| i64.const $2
- 907| i64.gt_u %[-2], %[-1]
- 908| drop
- 909| return
- 910| i64.const $1
- 919| i64.const $2
- 928| i64.le_s %[-2], %[-1]
- 929| drop
- 930| return
- 931| i64.const $1
- 940| i64.const $2
- 949| i64.le_u %[-2], %[-1]
- 950| drop
- 951| return
- 952| i64.const $1
- 961| i64.const $2
- 970| i64.ge_s %[-2], %[-1]
- 971| drop
- 972| return
- 973| i64.const $1
- 982| i64.const $2
- 991| i64.ge_u %[-2], %[-1]
- 992| drop
- 993| return
- 994| f32.const $1
- 999| f32.const $2
-1004| f32.eq %[-2], %[-1]
-1005| drop
-1006| return
-1007| f32.const $1
-1012| f32.const $2
-1017| f32.ne %[-2], %[-1]
-1018| drop
-1019| return
-1020| f32.const $1
-1025| f32.const $2
-1030| f32.lt %[-2], %[-1]
-1031| drop
+ 728| i64.const $2
+ 740| i64.store $0:%[-2]+$2, %[-1]
+ 752| return
+ 756| i32.const $1
+ 764| f32.const $2
+ 772| f32.store $0:%[-2]+$2, %[-1]
+ 784| return
+ 788| i32.const $1
+ 796| f64.const $2
+ 808| f64.store $0:%[-2]+$2, %[-1]
+ 820| return
+ 824| i32.const $1
+ 832| i32.const $2
+ 840| i32.store8 $0:%[-2]+$2, %[-1]
+ 852| return
+ 856| i32.const $1
+ 864| i32.const $2
+ 872| i32.store16 $0:%[-2]+$2, %[-1]
+ 884| return
+ 888| i32.const $1
+ 896| i64.const $2
+ 908| i64.store8 $0:%[-2]+$2, %[-1]
+ 920| return
+ 924| i32.const $1
+ 932| i64.const $2
+ 944| i64.store16 $0:%[-2]+$2, %[-1]
+ 956| return
+ 960| i32.const $1
+ 968| i64.const $2
+ 980| i64.store32 $0:%[-2]+$2, %[-1]
+ 992| return
+ 996| memory.size $0
+1004| drop
+1008| return
+1012| i32.const $1
+1020| memory.grow $0:%[-1]
+1028| drop
 1032| return
-1033| f32.const $1
-1038| f32.const $2
-1043| f32.gt %[-2], %[-1]
+1036| i32.const $1
 1044| drop
-1045| return
-1046| f32.const $1
-1051| f32.const $2
-1056| f32.le %[-2], %[-1]
-1057| drop
-1058| return
-1059| f32.const $1
-1064| f32.const $2
-1069| f32.ge %[-2], %[-1]
-1070| drop
-1071| return
-1072| f64.const $1
-1081| f64.const $2
-1090| f64.eq %[-2], %[-1]
-1091| drop
-1092| return
-1093| f64.const $1
-1102| f64.const $2
-1111| f64.ne %[-2], %[-1]
-1112| drop
-1113| return
-1114| f64.const $1
-1123| f64.const $2
-1132| f64.lt %[-2], %[-1]
-1133| drop
-1134| return
-1135| f64.const $1
-1144| f64.const $2
-1153| f64.gt %[-2], %[-1]
-1154| drop
-1155| return
-1156| f64.const $1
-1165| f64.const $2
-1174| f64.le %[-2], %[-1]
-1175| drop
-1176| return
-1177| f64.const $1
-1186| f64.const $2
-1195| f64.ge %[-2], %[-1]
-1196| drop
-1197| return
-1198| i32.const $1
-1203| i32.clz %[-1]
+1048| return
+1052| i64.const $1
+1064| drop
+1068| return
+1072| f32.const $1
+1080| drop
+1084| return
+1088| f64.const $1
+1100| drop
+1104| return
+1108| i32.const $1
+1116| i32.eqz %[-1]
+1120| drop
+1124| return
+1128| i32.const $1
+1136| i32.const $2
+1144| i32.eq %[-2], %[-1]
+1148| drop
+1152| return
+1156| i32.const $1
+1164| i32.const $2
+1172| i32.ne %[-2], %[-1]
+1176| drop
+1180| return
+1184| i32.const $1
+1192| i32.const $2
+1200| i32.lt_s %[-2], %[-1]
 1204| drop
-1205| return
-1206| i32.const $1
-1211| i32.ctz %[-1]
-1212| drop
-1213| return
-1214| i32.const $1
-1219| i32.popcnt %[-1]
-1220| drop
-1221| return
-1222| i32.const $1
-1227| i32.const $2
-1232| i32.add %[-2], %[-1]
-1233| drop
-1234| return
-1235| i32.const $1
-1240| i32.const $2
-1245| i32.sub %[-2], %[-1]
-1246| drop
-1247| return
-1248| i32.const $1
-1253| i32.const $2
-1258| i32.mul %[-2], %[-1]
-1259| drop
-1260| return
-1261| i32.const $1
-1266| i32.const $2
-1271| i32.div_s %[-2], %[-1]
-1272| drop
-1273| return
-1274| i32.const $1
-1279| i32.const $2
-1284| i32.div_u %[-2], %[-1]
-1285| drop
-1286| return
-1287| i32.const $1
-1292| i32.const $2
-1297| i32.rem_s %[-2], %[-1]
-1298| drop
-1299| return
-1300| i32.const $1
-1305| i32.const $2
-1310| i32.rem_u %[-2], %[-1]
-1311| drop
-1312| return
-1313| i32.const $1
-1318| i32.const $2
-1323| i32.and %[-2], %[-1]
-1324| drop
-1325| return
-1326| i32.const $1
-1331| i32.const $2
-1336| i32.or %[-2], %[-1]
-1337| drop
-1338| return
-1339| i32.const $1
-1344| i32.const $2
-1349| i32.xor %[-2], %[-1]
-1350| drop
-1351| return
+1208| return
+1212| i32.const $1
+1220| i32.const $2
+1228| i32.lt_u %[-2], %[-1]
+1232| drop
+1236| return
+1240| i32.const $1
+1248| i32.const $2
+1256| i32.gt_s %[-2], %[-1]
+1260| drop
+1264| return
+1268| i32.const $1
+1276| i32.const $2
+1284| i32.gt_u %[-2], %[-1]
+1288| drop
+1292| return
+1296| i32.const $1
+1304| i32.const $2
+1312| i32.le_s %[-2], %[-1]
+1316| drop
+1320| return
+1324| i32.const $1
+1332| i32.const $2
+1340| i32.le_u %[-2], %[-1]
+1344| drop
+1348| return
 1352| i32.const $1
-1357| i32.const $2
-1362| i32.shl %[-2], %[-1]
-1363| drop
-1364| return
-1365| i32.const $1
-1370| i32.const $2
-1375| i32.shr_s %[-2], %[-1]
-1376| drop
-1377| return
-1378| i32.const $1
-1383| i32.const $2
-1388| i32.shr_u %[-2], %[-1]
-1389| drop
-1390| return
-1391| i32.const $1
-1396| i32.const $2
-1401| i32.rotl %[-2], %[-1]
-1402| drop
-1403| return
-1404| i32.const $1
-1409| i32.const $2
-1414| i32.rotr %[-2], %[-1]
-1415| drop
-1416| return
-1417| i64.const $1
-1426| i64.clz %[-1]
-1427| drop
+1360| i32.const $2
+1368| i32.ge_s %[-2], %[-1]
+1372| drop
+1376| return
+1380| i32.const $1
+1388| i32.const $2
+1396| i32.ge_u %[-2], %[-1]
+1400| drop
+1404| return
+1408| i64.const $1
+1420| i64.eqz %[-1]
+1424| drop
 1428| return
-1429| i64.const $1
-1438| i64.ctz %[-1]
-1439| drop
-1440| return
-1441| i64.const $1
-1450| i64.popcnt %[-1]
-1451| drop
-1452| return
-1453| i64.const $1
-1462| i64.const $2
-1471| i64.add %[-2], %[-1]
-1472| drop
-1473| return
-1474| i64.const $1
-1483| i64.const $2
-1492| i64.sub %[-2], %[-1]
-1493| drop
-1494| return
-1495| i64.const $1
-1504| i64.const $2
-1513| i64.mul %[-2], %[-1]
-1514| drop
-1515| return
-1516| i64.const $1
-1525| i64.const $2
-1534| i64.div_s %[-2], %[-1]
-1535| drop
+1432| i64.const $1
+1444| i64.const $2
+1456| i64.eq %[-2], %[-1]
+1460| drop
+1464| return
+1468| i64.const $1
+1480| i64.const $2
+1492| i64.ne %[-2], %[-1]
+1496| drop
+1500| return
+1504| i64.const $1
+1516| i64.const $2
+1528| i64.lt_s %[-2], %[-1]
+1532| drop
 1536| return
-1537| i64.const $1
-1546| i64.const $2
-1555| i64.div_u %[-2], %[-1]
-1556| drop
-1557| return
-1558| i64.const $1
-1567| i64.const $2
-1576| i64.rem_s %[-2], %[-1]
-1577| drop
-1578| return
-1579| i64.const $1
+1540| i64.const $1
+1552| i64.const $2
+1564| i64.lt_u %[-2], %[-1]
+1568| drop
+1572| return
+1576| i64.const $1
 1588| i64.const $2
-1597| i64.rem_u %[-2], %[-1]
-1598| drop
-1599| return
-1600| i64.const $1
-1609| i64.const $2
-1618| i64.and %[-2], %[-1]
-1619| drop
-1620| return
-1621| i64.const $1
-1630| i64.const $2
-1639| i64.or %[-2], %[-1]
+1600| i64.gt_s %[-2], %[-1]
+1604| drop
+1608| return
+1612| i64.const $1
+1624| i64.const $2
+1636| i64.gt_u %[-2], %[-1]
 1640| drop
-1641| return
-1642| i64.const $1
-1651| i64.const $2
-1660| i64.xor %[-2], %[-1]
-1661| drop
-1662| return
-1663| i64.const $1
-1672| i64.const $2
-1681| i64.shl %[-2], %[-1]
-1682| drop
-1683| return
+1644| return
+1648| i64.const $1
+1660| i64.const $2
+1672| i64.le_s %[-2], %[-1]
+1676| drop
+1680| return
 1684| i64.const $1
-1693| i64.const $2
-1702| i64.shr_s %[-2], %[-1]
-1703| drop
-1704| return
-1705| i64.const $1
-1714| i64.const $2
-1723| i64.shr_u %[-2], %[-1]
-1724| drop
-1725| return
-1726| i64.const $1
-1735| i64.const $2
-1744| i64.rotl %[-2], %[-1]
-1745| drop
-1746| return
-1747| i64.const $1
-1756| i64.const $2
-1765| i64.rotr %[-2], %[-1]
-1766| drop
-1767| return
-1768| f32.const $1
-1773| f32.abs %[-1]
-1774| drop
-1775| return
-1776| f32.const $1
-1781| f32.neg %[-1]
-1782| drop
-1783| return
-1784| f32.const $1
-1789| f32.ceil %[-1]
-1790| drop
-1791| return
+1696| i64.const $2
+1708| i64.le_u %[-2], %[-1]
+1712| drop
+1716| return
+1720| i64.const $1
+1732| i64.const $2
+1744| i64.ge_s %[-2], %[-1]
+1748| drop
+1752| return
+1756| i64.const $1
+1768| i64.const $2
+1780| i64.ge_u %[-2], %[-1]
+1784| drop
+1788| return
 1792| f32.const $1
-1797| f32.floor %[-1]
-1798| drop
-1799| return
-1800| f32.const $1
-1805| f32.trunc %[-1]
-1806| drop
-1807| return
-1808| f32.const $1
-1813| f32.nearest %[-1]
-1814| drop
-1815| return
-1816| f32.const $1
-1821| f32.sqrt %[-1]
-1822| drop
-1823| return
-1824| f32.const $1
-1829| f32.const $2
-1834| f32.add %[-2], %[-1]
-1835| drop
-1836| return
-1837| f32.const $1
-1842| f32.const $2
-1847| f32.sub %[-2], %[-1]
-1848| drop
-1849| return
-1850| f32.const $1
-1855| f32.const $2
-1860| f32.mul %[-2], %[-1]
-1861| drop
-1862| return
-1863| f32.const $1
-1868| f32.const $2
-1873| f32.div %[-2], %[-1]
-1874| drop
-1875| return
+1800| f32.const $2
+1808| f32.eq %[-2], %[-1]
+1812| drop
+1816| return
+1820| f32.const $1
+1828| f32.const $2
+1836| f32.ne %[-2], %[-1]
+1840| drop
+1844| return
+1848| f32.const $1
+1856| f32.const $2
+1864| f32.lt %[-2], %[-1]
+1868| drop
+1872| return
 1876| f32.const $1
-1881| f32.const $2
-1886| f32.min %[-2], %[-1]
-1887| drop
-1888| return
-1889| f32.const $1
-1894| f32.const $2
-1899| f32.max %[-2], %[-1]
-1900| drop
-1901| return
-1902| f32.const $1
-1907| f32.const $2
-1912| f32.copysign %[-2], %[-1]
-1913| drop
-1914| return
-1915| f64.const $1
-1924| f64.abs %[-1]
-1925| drop
-1926| return
-1927| f64.const $1
-1936| f64.neg %[-1]
-1937| drop
-1938| return
-1939| f64.const $1
-1948| f64.ceil %[-1]
-1949| drop
-1950| return
-1951| f64.const $1
-1960| f64.floor %[-1]
-1961| drop
-1962| return
-1963| f64.const $1
-1972| f64.trunc %[-1]
-1973| drop
-1974| return
-1975| f64.const $1
-1984| f64.nearest %[-1]
-1985| drop
-1986| return
-1987| f64.const $1
-1996| f64.sqrt %[-1]
-1997| drop
-1998| return
-1999| f64.const $1
+1884| f32.const $2
+1892| f32.gt %[-2], %[-1]
+1896| drop
+1900| return
+1904| f32.const $1
+1912| f32.const $2
+1920| f32.le %[-2], %[-1]
+1924| drop
+1928| return
+1932| f32.const $1
+1940| f32.const $2
+1948| f32.ge %[-2], %[-1]
+1952| drop
+1956| return
+1960| f64.const $1
+1972| f64.const $2
+1984| f64.eq %[-2], %[-1]
+1988| drop
+1992| return
+1996| f64.const $1
 2008| f64.const $2
-2017| f64.add %[-2], %[-1]
-2018| drop
-2019| return
-2020| f64.const $1
-2029| f64.const $2
-2038| f64.sub %[-2], %[-1]
-2039| drop
-2040| return
-2041| f64.const $1
-2050| f64.const $2
-2059| f64.mul %[-2], %[-1]
+2020| f64.ne %[-2], %[-1]
+2024| drop
+2028| return
+2032| f64.const $1
+2044| f64.const $2
+2056| f64.lt %[-2], %[-1]
 2060| drop
-2061| return
-2062| f64.const $1
-2071| f64.const $2
-2080| f64.div %[-2], %[-1]
-2081| drop
-2082| return
-2083| f64.const $1
-2092| f64.const $2
-2101| f64.min %[-2], %[-1]
-2102| drop
-2103| return
+2064| return
+2068| f64.const $1
+2080| f64.const $2
+2092| f64.gt %[-2], %[-1]
+2096| drop
+2100| return
 2104| f64.const $1
-2113| f64.const $2
-2122| f64.max %[-2], %[-1]
-2123| drop
-2124| return
-2125| f64.const $1
-2134| f64.const $2
-2143| f64.copysign %[-2], %[-1]
-2144| drop
-2145| return
-2146| i64.const $1
-2155| i32.wrap/i64 %[-1]
-2156| drop
-2157| return
-2158| f32.const $1
-2163| i32.trunc_s/f32 %[-1]
-2164| drop
-2165| return
-2166| f32.const $1
-2171| i32.trunc_u/f32 %[-1]
-2172| drop
-2173| return
-2174| f64.const $1
-2183| i32.trunc_s/f64 %[-1]
-2184| drop
-2185| return
-2186| f64.const $1
-2195| i32.trunc_u/f64 %[-1]
-2196| drop
-2197| return
-2198| i32.const $1
-2203| i64.extend_s/i32 %[-1]
-2204| drop
-2205| return
-2206| i32.const $1
-2211| i64.extend_u/i32 %[-1]
-2212| drop
-2213| return
-2214| f32.const $1
-2219| i64.trunc_s/f32 %[-1]
-2220| drop
-2221| return
-2222| f32.const $1
-2227| i64.trunc_u/f32 %[-1]
+2116| f64.const $2
+2128| f64.le %[-2], %[-1]
+2132| drop
+2136| return
+2140| f64.const $1
+2152| f64.const $2
+2164| f64.ge %[-2], %[-1]
+2168| drop
+2172| return
+2176| i32.const $1
+2184| i32.clz %[-1]
+2188| drop
+2192| return
+2196| i32.const $1
+2204| i32.ctz %[-1]
+2208| drop
+2212| return
+2216| i32.const $1
+2224| i32.popcnt %[-1]
 2228| drop
-2229| return
-2230| f64.const $1
-2239| i64.trunc_s/f64 %[-1]
-2240| drop
-2241| return
-2242| f64.const $1
-2251| i64.trunc_u/f64 %[-1]
-2252| drop
-2253| return
-2254| i32.const $1
-2259| f32.convert_s/i32 %[-1]
-2260| drop
-2261| return
-2262| i32.const $1
-2267| f32.convert_u/i32 %[-1]
-2268| drop
-2269| return
-2270| i64.const $1
-2279| f32.convert_s/i64 %[-1]
-2280| drop
-2281| return
-2282| i64.const $1
-2291| f32.convert_u/i64 %[-1]
-2292| drop
-2293| return
-2294| f64.const $1
-2303| f32.demote/f64 %[-1]
-2304| drop
-2305| return
-2306| i32.const $1
-2311| f64.convert_s/i32 %[-1]
+2232| return
+2236| i32.const $1
+2244| i32.const $2
+2252| i32.add %[-2], %[-1]
+2256| drop
+2260| return
+2264| i32.const $1
+2272| i32.const $2
+2280| i32.sub %[-2], %[-1]
+2284| drop
+2288| return
+2292| i32.const $1
+2300| i32.const $2
+2308| i32.mul %[-2], %[-1]
 2312| drop
-2313| return
-2314| i32.const $1
-2319| f64.convert_u/i32 %[-1]
-2320| drop
-2321| return
-2322| i64.const $1
-2331| f64.convert_s/i64 %[-1]
-2332| drop
-2333| return
-2334| i64.const $1
-2343| f64.convert_u/i64 %[-1]
-2344| drop
-2345| return
-2346| f32.const $1
-2351| f64.promote/f32 %[-1]
-2352| drop
-2353| return
-2354| i32.const $1
-2359| f32.reinterpret/i32 %[-1]
-2360| drop
-2361| return
-2362| f32.const $1
-2367| i32.reinterpret/f32 %[-1]
+2316| return
+2320| i32.const $1
+2328| i32.const $2
+2336| i32.div_s %[-2], %[-1]
+2340| drop
+2344| return
+2348| i32.const $1
+2356| i32.const $2
+2364| i32.div_u %[-2], %[-1]
 2368| drop
-2369| return
-2370| i64.const $1
-2379| f64.reinterpret/i64 %[-1]
-2380| drop
-2381| return
-2382| f64.const $1
-2391| i64.reinterpret/f64 %[-1]
-2392| drop
-2393| return
-2394| i32.const $1
-2399| i32.extend8_s %[-1]
-2400| drop
-2401| return
-2402| i32.const $1
-2407| i32.extend16_s %[-1]
-2408| drop
-2409| return
-2410| i64.const $1
-2419| i64.extend8_s %[-1]
-2420| drop
-2421| return
-2422| i64.const $1
-2431| i64.extend16_s %[-1]
-2432| drop
-2433| return
-2434| i64.const $1
-2443| i64.extend32_s %[-1]
-2444| drop
-2445| return
-2446| alloca $1
-2451| drop
-2452| return
-2453| i32.const $1
-2458| br_unless @2468, %[-1]
-2463| br @2468
-2468| return
-2469| i32.const $1
-2474| call_host $0
-2479| return
-2480| i32.const $1
-2485| br_table %[-1], $#0, table:$2499
-2494| data $12
-2499|   entry 0: offset: 2511 drop: 0 keep: 0
-2511| return
-2512| i32.const $1
-2517| i32.const $2
-2522| drop_keep $1 $1
-2531| br @2536
+2372| return
+2376| i32.const $1
+2384| i32.const $2
+2392| i32.rem_s %[-2], %[-1]
+2396| drop
+2400| return
+2404| i32.const $1
+2412| i32.const $2
+2420| i32.rem_u %[-2], %[-1]
+2424| drop
+2428| return
+2432| i32.const $1
+2440| i32.const $2
+2448| i32.and %[-2], %[-1]
+2452| drop
+2456| return
+2460| i32.const $1
+2468| i32.const $2
+2476| i32.or %[-2], %[-1]
+2480| drop
+2484| return
+2488| i32.const $1
+2496| i32.const $2
+2504| i32.xor %[-2], %[-1]
+2508| drop
+2512| return
+2516| i32.const $1
+2524| i32.const $2
+2532| i32.shl %[-2], %[-1]
 2536| drop
-2537| return
-2538| f32.const $1
-2543| i32.trunc_s:sat/f32 %[-1]
-2545| drop
-2546| return
-2547| f32.const $1
-2552| i32.trunc_u:sat/f32 %[-1]
-2554| drop
-2555| return
-2556| f64.const $1
-2565| i32.trunc_s:sat/f64 %[-1]
-2567| drop
+2540| return
+2544| i32.const $1
+2552| i32.const $2
+2560| i32.shr_s %[-2], %[-1]
+2564| drop
 2568| return
-2569| f64.const $1
-2578| i32.trunc_u:sat/f64 %[-1]
-2580| drop
-2581| return
-2582| f32.const $1
-2587| i64.trunc_s:sat/f32 %[-1]
-2589| drop
-2590| return
-2591| f32.const $1
-2596| i64.trunc_u:sat/f32 %[-1]
-2598| drop
-2599| return
-2600| f64.const $1
-2609| i64.trunc_s:sat/f64 %[-1]
-2611| drop
-2612| return
-2613| f64.const $1
-2622| i64.trunc_u:sat/f64 %[-1]
-2624| drop
-2625| return
-2626| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2644| drop
-2645| return
-2646| i32.const $1
-2651| v128.load $0:%[-1]+$3
-2661| drop
-2662| return
-2663| i32.const $1
-2668| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2686| v128.store $0:%[-2]+$3, %[-1]
-2696| return
-2697| i32.const $1
-2702| i8x16.splat %[-1]
-2704| drop
-2705| return
-2706| i32.const $1
-2711| i16x8.splat %[-1]
-2713| drop
-2714| return
-2715| i32.const $1
-2720| i32x4.splat %[-1]
-2722| drop
-2723| return
-2724| i64.const $1
-2733| i64x2.splat %[-1]
-2735| drop
-2736| return
-2737| f32.const $1
-2742| f32x4.splat %[-1]
-2744| drop
-2745| return
-2746| f64.const $1
-2755| f64x2.splat %[-1]
-2757| drop
-2758| return
-2759| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2777| i8x16.extract_lane_s %[-1] : (Lane imm: 15)
-2780| drop
-2781| return
-2782| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2800| i8x16.extract_lane_u %[-1] : (Lane imm: 15)
-2803| drop
-2804| return
-2805| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2823| i16x8.extract_lane_s %[-1] : (Lane imm: 7)
-2826| drop
-2827| return
-2828| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2846| i16x8.extract_lane_u %[-1] : (Lane imm: 7)
-2849| drop
-2850| return
-2851| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2869| i32x4.extract_lane %[-1] : (Lane imm: 3)
-2872| drop
-2873| return
-2874| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2892| i64x2.extract_lane %[-1] : (Lane imm: 1)
-2895| drop
-2896| return
-2897| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2915| f32x4.extract_lane %[-1] : (Lane imm: 3)
-2918| drop
-2919| return
-2920| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2938| f64x2.extract_lane %[-1] : (Lane imm: 1)
-2941| drop
-2942| return
-2943| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2961| i32.const $0
-2966| i8x16.replace_lane %[-1], %[-2] : (Lane imm: 15)
-2969| drop
-2970| return
-2971| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-2989| i32.const $0
-2994| i16x8.replace_lane %[-1], %[-2] : (Lane imm: 7)
-2997| drop
-2998| return
-2999| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3017| i32.const $0
-3022| i32x4.replace_lane %[-1], %[-2] : (Lane imm: 3)
-3025| drop
-3026| return
-3027| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3045| i64.const $0
-3054| i64x2.replace_lane %[-1], %[-2] : (Lane imm: 1)
-3057| drop
-3058| return
-3059| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3077| f32.const $0
-3082| f32x4.replace_lane %[-1], %[-2] : (Lane imm: 3)
-3085| drop
-3086| return
-3087| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3105| f64.const $0
-3114| f64x2.replace_lane %[-1], %[-2] : (Lane imm: 1)
-3117| drop
-3118| return
-3119| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3137| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3155| v8x16.shuffle %[-2], %[-1] : (Lane imm: $0x00000001 0x00000001 0x00000001 0x00000001 )
-3173| drop
-3174| return
-3175| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3193| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3211| i8x16.add %[-2], %[-1]
-3213| drop
-3214| return
-3215| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3233| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3251| i16x8.add %[-2], %[-1]
-3253| drop
-3254| return
-3255| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3273| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3291| i32x4.add %[-2], %[-1]
-3293| drop
-3294| return
-3295| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3313| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3331| i64x2.add %[-2], %[-1]
-3333| drop
-3334| return
-3335| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3353| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3371| i8x16.sub %[-2], %[-1]
-3373| drop
-3374| return
-3375| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3393| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3411| i16x8.sub %[-2], %[-1]
-3413| drop
-3414| return
-3415| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3433| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3451| i32x4.sub %[-2], %[-1]
-3453| drop
-3454| return
-3455| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3473| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3491| i64x2.sub %[-2], %[-1]
-3493| drop
-3494| return
-3495| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3513| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3531| i8x16.mul %[-2], %[-1]
-3533| drop
-3534| return
-3535| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3553| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3571| i16x8.mul %[-2], %[-1]
-3573| drop
-3574| return
-3575| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3593| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3611| i32x4.mul %[-2], %[-1]
-3613| drop
-3614| return
-3615| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3633| i8x16.neg %[-1]
-3635| drop
-3636| return
-3637| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3655| i16x8.neg %[-1]
-3657| drop
-3658| return
-3659| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3677| i32x4.neg %[-1]
-3679| drop
-3680| return
-3681| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3699| i64x2.neg %[-1]
-3701| drop
-3702| return
-3703| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3721| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3739| i8x16.add_saturate_s %[-2], %[-1]
-3741| drop
-3742| return
-3743| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3761| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3779| i8x16.add_saturate_u %[-2], %[-1]
-3781| drop
-3782| return
-3783| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3801| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3819| i16x8.add_saturate_s %[-2], %[-1]
-3821| drop
-3822| return
-3823| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3841| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3859| i16x8.add_saturate_u %[-2], %[-1]
-3861| drop
-3862| return
-3863| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3881| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3899| i8x16.sub_saturate_s %[-2], %[-1]
-3901| drop
-3902| return
-3903| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3921| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3939| i8x16.sub_saturate_u %[-2], %[-1]
-3941| drop
-3942| return
-3943| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-3961| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-3979| i16x8.sub_saturate_s %[-2], %[-1]
-3981| drop
-3982| return
-3983| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4001| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4019| i16x8.sub_saturate_u %[-2], %[-1]
-4021| drop
-4022| return
-4023| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4041| i32.const $0
-4046| i8x16.shl %[-2], %[-1]
-4048| drop
-4049| return
-4050| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4068| i32.const $0
-4073| i16x8.shl %[-2], %[-1]
-4075| drop
-4076| return
-4077| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4095| i32.const $0
-4100| i32x4.shl %[-2], %[-1]
-4102| drop
-4103| return
-4104| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4122| i32.const $0
-4127| i64x2.shl %[-2], %[-1]
-4129| drop
-4130| return
-4131| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4149| i32.const $0
-4154| i8x16.shr_s %[-2], %[-1]
-4156| drop
-4157| return
-4158| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4176| i32.const $0
-4181| i8x16.shr_u %[-2], %[-1]
-4183| drop
-4184| return
-4185| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4203| i32.const $0
-4208| i16x8.shr_s %[-2], %[-1]
-4210| drop
-4211| return
-4212| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4230| i32.const $0
-4235| i16x8.shr_u %[-2], %[-1]
-4237| drop
-4238| return
-4239| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4257| i32.const $0
-4262| i32x4.shr_s %[-2], %[-1]
-4264| drop
-4265| return
-4266| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4284| i32.const $0
-4289| i32x4.shr_u %[-2], %[-1]
-4291| drop
-4292| return
-4293| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4311| i32.const $0
-4316| i64x2.shr_s %[-2], %[-1]
-4318| drop
-4319| return
-4320| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4338| i32.const $0
-4343| i64x2.shr_u %[-2], %[-1]
-4345| drop
-4346| return
-4347| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4365| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4383| v128.and %[-2], %[-1]
-4385| drop
-4386| return
-4387| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4405| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4423| v128.or %[-2], %[-1]
-4425| drop
-4426| return
-4427| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4445| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4463| v128.xor %[-2], %[-1]
-4465| drop
-4466| return
-4467| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4485| v128.not %[-1]
-4487| drop
-4488| return
-4489| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4507| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4525| v128.const $0x00000003 0x00000003 0x00000003 0x00000003
-4543| v128.bitselect %[-3], %[-2], %[-1]
-4545| drop
-4546| return
-4547| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4565| i8x16.any_true %[-1]
-4567| drop
+2572| i32.const $1
+2580| i32.const $2
+2588| i32.shr_u %[-2], %[-1]
+2592| drop
+2596| return
+2600| i32.const $1
+2608| i32.const $2
+2616| i32.rotl %[-2], %[-1]
+2620| drop
+2624| return
+2628| i32.const $1
+2636| i32.const $2
+2644| i32.rotr %[-2], %[-1]
+2648| drop
+2652| return
+2656| i64.const $1
+2668| i64.clz %[-1]
+2672| drop
+2676| return
+2680| i64.const $1
+2692| i64.ctz %[-1]
+2696| drop
+2700| return
+2704| i64.const $1
+2716| i64.popcnt %[-1]
+2720| drop
+2724| return
+2728| i64.const $1
+2740| i64.const $2
+2752| i64.add %[-2], %[-1]
+2756| drop
+2760| return
+2764| i64.const $1
+2776| i64.const $2
+2788| i64.sub %[-2], %[-1]
+2792| drop
+2796| return
+2800| i64.const $1
+2812| i64.const $2
+2824| i64.mul %[-2], %[-1]
+2828| drop
+2832| return
+2836| i64.const $1
+2848| i64.const $2
+2860| i64.div_s %[-2], %[-1]
+2864| drop
+2868| return
+2872| i64.const $1
+2884| i64.const $2
+2896| i64.div_u %[-2], %[-1]
+2900| drop
+2904| return
+2908| i64.const $1
+2920| i64.const $2
+2932| i64.rem_s %[-2], %[-1]
+2936| drop
+2940| return
+2944| i64.const $1
+2956| i64.const $2
+2968| i64.rem_u %[-2], %[-1]
+2972| drop
+2976| return
+2980| i64.const $1
+2992| i64.const $2
+3004| i64.and %[-2], %[-1]
+3008| drop
+3012| return
+3016| i64.const $1
+3028| i64.const $2
+3040| i64.or %[-2], %[-1]
+3044| drop
+3048| return
+3052| i64.const $1
+3064| i64.const $2
+3076| i64.xor %[-2], %[-1]
+3080| drop
+3084| return
+3088| i64.const $1
+3100| i64.const $2
+3112| i64.shl %[-2], %[-1]
+3116| drop
+3120| return
+3124| i64.const $1
+3136| i64.const $2
+3148| i64.shr_s %[-2], %[-1]
+3152| drop
+3156| return
+3160| i64.const $1
+3172| i64.const $2
+3184| i64.shr_u %[-2], %[-1]
+3188| drop
+3192| return
+3196| i64.const $1
+3208| i64.const $2
+3220| i64.rotl %[-2], %[-1]
+3224| drop
+3228| return
+3232| i64.const $1
+3244| i64.const $2
+3256| i64.rotr %[-2], %[-1]
+3260| drop
+3264| return
+3268| f32.const $1
+3276| f32.abs %[-1]
+3280| drop
+3284| return
+3288| f32.const $1
+3296| f32.neg %[-1]
+3300| drop
+3304| return
+3308| f32.const $1
+3316| f32.ceil %[-1]
+3320| drop
+3324| return
+3328| f32.const $1
+3336| f32.floor %[-1]
+3340| drop
+3344| return
+3348| f32.const $1
+3356| f32.trunc %[-1]
+3360| drop
+3364| return
+3368| f32.const $1
+3376| f32.nearest %[-1]
+3380| drop
+3384| return
+3388| f32.const $1
+3396| f32.sqrt %[-1]
+3400| drop
+3404| return
+3408| f32.const $1
+3416| f32.const $2
+3424| f32.add %[-2], %[-1]
+3428| drop
+3432| return
+3436| f32.const $1
+3444| f32.const $2
+3452| f32.sub %[-2], %[-1]
+3456| drop
+3460| return
+3464| f32.const $1
+3472| f32.const $2
+3480| f32.mul %[-2], %[-1]
+3484| drop
+3488| return
+3492| f32.const $1
+3500| f32.const $2
+3508| f32.div %[-2], %[-1]
+3512| drop
+3516| return
+3520| f32.const $1
+3528| f32.const $2
+3536| f32.min %[-2], %[-1]
+3540| drop
+3544| return
+3548| f32.const $1
+3556| f32.const $2
+3564| f32.max %[-2], %[-1]
+3568| drop
+3572| return
+3576| f32.const $1
+3584| f32.const $2
+3592| f32.copysign %[-2], %[-1]
+3596| drop
+3600| return
+3604| f64.const $1
+3616| f64.abs %[-1]
+3620| drop
+3624| return
+3628| f64.const $1
+3640| f64.neg %[-1]
+3644| drop
+3648| return
+3652| f64.const $1
+3664| f64.ceil %[-1]
+3668| drop
+3672| return
+3676| f64.const $1
+3688| f64.floor %[-1]
+3692| drop
+3696| return
+3700| f64.const $1
+3712| f64.trunc %[-1]
+3716| drop
+3720| return
+3724| f64.const $1
+3736| f64.nearest %[-1]
+3740| drop
+3744| return
+3748| f64.const $1
+3760| f64.sqrt %[-1]
+3764| drop
+3768| return
+3772| f64.const $1
+3784| f64.const $2
+3796| f64.add %[-2], %[-1]
+3800| drop
+3804| return
+3808| f64.const $1
+3820| f64.const $2
+3832| f64.sub %[-2], %[-1]
+3836| drop
+3840| return
+3844| f64.const $1
+3856| f64.const $2
+3868| f64.mul %[-2], %[-1]
+3872| drop
+3876| return
+3880| f64.const $1
+3892| f64.const $2
+3904| f64.div %[-2], %[-1]
+3908| drop
+3912| return
+3916| f64.const $1
+3928| f64.const $2
+3940| f64.min %[-2], %[-1]
+3944| drop
+3948| return
+3952| f64.const $1
+3964| f64.const $2
+3976| f64.max %[-2], %[-1]
+3980| drop
+3984| return
+3988| f64.const $1
+4000| f64.const $2
+4012| f64.copysign %[-2], %[-1]
+4016| drop
+4020| return
+4024| i64.const $1
+4036| i32.wrap/i64 %[-1]
+4040| drop
+4044| return
+4048| f32.const $1
+4056| i32.trunc_s/f32 %[-1]
+4060| drop
+4064| return
+4068| f32.const $1
+4076| i32.trunc_u/f32 %[-1]
+4080| drop
+4084| return
+4088| f64.const $1
+4100| i32.trunc_s/f64 %[-1]
+4104| drop
+4108| return
+4112| f64.const $1
+4124| i32.trunc_u/f64 %[-1]
+4128| drop
+4132| return
+4136| i32.const $1
+4144| i64.extend_s/i32 %[-1]
+4148| drop
+4152| return
+4156| i32.const $1
+4164| i64.extend_u/i32 %[-1]
+4168| drop
+4172| return
+4176| f32.const $1
+4184| i64.trunc_s/f32 %[-1]
+4188| drop
+4192| return
+4196| f32.const $1
+4204| i64.trunc_u/f32 %[-1]
+4208| drop
+4212| return
+4216| f64.const $1
+4228| i64.trunc_s/f64 %[-1]
+4232| drop
+4236| return
+4240| f64.const $1
+4252| i64.trunc_u/f64 %[-1]
+4256| drop
+4260| return
+4264| i32.const $1
+4272| f32.convert_s/i32 %[-1]
+4276| drop
+4280| return
+4284| i32.const $1
+4292| f32.convert_u/i32 %[-1]
+4296| drop
+4300| return
+4304| i64.const $1
+4316| f32.convert_s/i64 %[-1]
+4320| drop
+4324| return
+4328| i64.const $1
+4340| f32.convert_u/i64 %[-1]
+4344| drop
+4348| return
+4352| f64.const $1
+4364| f32.demote/f64 %[-1]
+4368| drop
+4372| return
+4376| i32.const $1
+4384| f64.convert_s/i32 %[-1]
+4388| drop
+4392| return
+4396| i32.const $1
+4404| f64.convert_u/i32 %[-1]
+4408| drop
+4412| return
+4416| i64.const $1
+4428| f64.convert_s/i64 %[-1]
+4432| drop
+4436| return
+4440| i64.const $1
+4452| f64.convert_u/i64 %[-1]
+4456| drop
+4460| return
+4464| f32.const $1
+4472| f64.promote/f32 %[-1]
+4476| drop
+4480| return
+4484| i32.const $1
+4492| f32.reinterpret/i32 %[-1]
+4496| drop
+4500| return
+4504| f32.const $1
+4512| i32.reinterpret/f32 %[-1]
+4516| drop
+4520| return
+4524| i64.const $1
+4536| f64.reinterpret/i64 %[-1]
+4540| drop
+4544| return
+4548| f64.const $1
+4560| i64.reinterpret/f64 %[-1]
+4564| drop
 4568| return
-4569| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4587| i16x8.any_true %[-1]
-4589| drop
-4590| return
-4591| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4609| i32x4.any_true %[-1]
-4611| drop
-4612| return
-4613| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4631| i64x2.any_true %[-1]
-4633| drop
-4634| return
-4635| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4653| i8x16.all_true %[-1]
-4655| drop
+4572| i32.const $1
+4580| i32.extend8_s %[-1]
+4584| drop
+4588| return
+4592| i32.const $1
+4600| i32.extend16_s %[-1]
+4604| drop
+4608| return
+4612| i64.const $1
+4624| i64.extend8_s %[-1]
+4628| drop
+4632| return
+4636| i64.const $1
+4648| i64.extend16_s %[-1]
+4652| drop
 4656| return
-4657| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4675| i16x8.all_true %[-1]
-4677| drop
-4678| return
-4679| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4697| i32x4.all_true %[-1]
-4699| drop
-4700| return
-4701| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4719| i64x2.all_true %[-1]
-4721| drop
-4722| return
-4723| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4741| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4759| i8x16.eq %[-2], %[-1]
-4761| drop
-4762| return
-4763| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4781| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4799| i16x8.eq %[-2], %[-1]
-4801| drop
-4802| return
-4803| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4821| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4839| i32x4.eq %[-2], %[-1]
-4841| drop
-4842| return
-4843| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4861| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4879| f32x4.eq %[-2], %[-1]
-4881| drop
-4882| return
-4883| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4901| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4919| f64x2.eq %[-2], %[-1]
-4921| drop
-4922| return
-4923| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4941| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4959| i8x16.ne %[-2], %[-1]
-4961| drop
-4962| return
-4963| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-4981| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-4999| i16x8.ne %[-2], %[-1]
-5001| drop
-5002| return
-5003| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5021| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5039| i32x4.ne %[-2], %[-1]
-5041| drop
-5042| return
-5043| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5061| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5079| f32x4.ne %[-2], %[-1]
-5081| drop
-5082| return
-5083| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5101| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5119| f64x2.ne %[-2], %[-1]
-5121| drop
-5122| return
-5123| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5141| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5159| i8x16.lt_s %[-2], %[-1]
-5161| drop
-5162| return
-5163| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5181| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5199| i8x16.lt_u %[-2], %[-1]
-5201| drop
-5202| return
-5203| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5221| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5239| i16x8.lt_s %[-2], %[-1]
-5241| drop
-5242| return
-5243| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5261| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5279| i16x8.lt_u %[-2], %[-1]
-5281| drop
-5282| return
-5283| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5301| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5319| i32x4.lt_s %[-2], %[-1]
-5321| drop
-5322| return
-5323| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5341| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5359| i32x4.lt_u %[-2], %[-1]
-5361| drop
-5362| return
-5363| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5381| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5399| f32x4.lt %[-2], %[-1]
-5401| drop
-5402| return
-5403| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5421| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5439| f64x2.lt %[-2], %[-1]
-5441| drop
-5442| return
-5443| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5461| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5479| i8x16.le_s %[-2], %[-1]
-5481| drop
-5482| return
-5483| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5501| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5519| i8x16.le_u %[-2], %[-1]
-5521| drop
-5522| return
-5523| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5541| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5559| i16x8.le_s %[-2], %[-1]
-5561| drop
-5562| return
-5563| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5581| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5599| i16x8.le_u %[-2], %[-1]
-5601| drop
-5602| return
-5603| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5621| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5639| i32x4.le_s %[-2], %[-1]
-5641| drop
-5642| return
-5643| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5661| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5679| i32x4.le_u %[-2], %[-1]
-5681| drop
-5682| return
-5683| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5701| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5719| f32x4.le %[-2], %[-1]
-5721| drop
-5722| return
-5723| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5741| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5759| f64x2.le %[-2], %[-1]
-5761| drop
-5762| return
-5763| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5781| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5799| i8x16.gt_s %[-2], %[-1]
-5801| drop
-5802| return
-5803| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5821| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5839| i8x16.gt_u %[-2], %[-1]
-5841| drop
-5842| return
-5843| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5861| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5879| i16x8.gt_s %[-2], %[-1]
-5881| drop
-5882| return
-5883| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5901| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5919| i16x8.gt_u %[-2], %[-1]
-5921| drop
-5922| return
-5923| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5941| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5959| i32x4.gt_s %[-2], %[-1]
-5961| drop
-5962| return
-5963| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-5981| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-5999| i32x4.gt_u %[-2], %[-1]
-6001| drop
-6002| return
-6003| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6021| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6039| f32x4.gt %[-2], %[-1]
-6041| drop
-6042| return
-6043| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6061| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6079| f64x2.gt %[-2], %[-1]
-6081| drop
+4660| i64.const $1
+4672| i64.extend32_s %[-1]
+4676| drop
+4680| return
+4684| alloca $1
+4692| drop
+4696| return
+4700| i32.const $1
+4708| br_unless @4724, %[-1]
+4716| br @4724
+4724| return
+4728| i32.const $1
+4736| call_host $0
+4744| return
+4748| i32.const $1
+4756| br_table %[-1], $#0, table:$4776
+4768| data $12
+4776|   entry 0: offset: 4788 drop: 0 keep: 0
+4788| return
+4792| i32.const $1
+4800| i32.const $2
+4808| drop_keep $1 $1
+4820| br @4828
+4828| drop
+4832| return
+4836| f32.const $1
+4844| i32.trunc_s:sat/f32 %[-1]
+4848| drop
+4852| return
+4856| f32.const $1
+4864| i32.trunc_u:sat/f32 %[-1]
+4868| drop
+4872| return
+4876| f64.const $1
+4888| i32.trunc_s:sat/f64 %[-1]
+4892| drop
+4896| return
+4900| f64.const $1
+4912| i32.trunc_u:sat/f64 %[-1]
+4916| drop
+4920| return
+4924| f32.const $1
+4932| i64.trunc_s:sat/f32 %[-1]
+4936| drop
+4940| return
+4944| f32.const $1
+4952| i64.trunc_u:sat/f32 %[-1]
+4956| drop
+4960| return
+4964| f64.const $1
+4976| i64.trunc_s:sat/f64 %[-1]
+4980| drop
+4984| return
+4988| f64.const $1
+5000| i64.trunc_u:sat/f64 %[-1]
+5004| drop
+5008| return
+5012| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5032| drop
+5036| return
+5040| i32.const $1
+5048| v128.load $0:%[-1]+$3
+5060| drop
+5064| return
+5068| i32.const $1
+5076| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5096| v128.store $0:%[-2]+$3, %[-1]
+5108| return
+5112| i32.const $1
+5120| i8x16.splat %[-1]
+5124| drop
+5128| return
+5132| i32.const $1
+5140| i16x8.splat %[-1]
+5144| drop
+5148| return
+5152| i32.const $1
+5160| i32x4.splat %[-1]
+5164| drop
+5168| return
+5172| i64.const $1
+5184| i64x2.splat %[-1]
+5188| drop
+5192| return
+5196| f32.const $1
+5204| f32x4.splat %[-1]
+5208| drop
+5212| return
+5216| f64.const $1
+5228| f64x2.splat %[-1]
+5232| drop
+5236| return
+5240| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5260| i8x16.extract_lane_s %[-1] : (Lane imm: 15)
+5265| drop
+5269| return
+5273| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5293| i8x16.extract_lane_u %[-1] : (Lane imm: 15)
+5298| drop
+5302| return
+5306| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5326| i16x8.extract_lane_s %[-1] : (Lane imm: 7)
+5331| drop
+5335| return
+5339| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5359| i16x8.extract_lane_u %[-1] : (Lane imm: 7)
+5364| drop
+5368| return
+5372| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5392| i32x4.extract_lane %[-1] : (Lane imm: 3)
+5397| drop
+5401| return
+5405| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5425| i64x2.extract_lane %[-1] : (Lane imm: 1)
+5430| drop
+5434| return
+5438| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5458| f32x4.extract_lane %[-1] : (Lane imm: 3)
+5463| drop
+5467| return
+5471| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5491| f64x2.extract_lane %[-1] : (Lane imm: 1)
+5496| drop
+5500| return
+5504| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5524| i32.const $0
+5532| i8x16.replace_lane %[-1], %[-2] : (Lane imm: 15)
+5537| drop
+5541| return
+5545| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5565| i32.const $0
+5573| i16x8.replace_lane %[-1], %[-2] : (Lane imm: 7)
+5578| drop
+5582| return
+5586| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5606| i32.const $0
+5614| i32x4.replace_lane %[-1], %[-2] : (Lane imm: 3)
+5619| drop
+5623| return
+5627| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5647| i64.const $0
+5659| i64x2.replace_lane %[-1], %[-2] : (Lane imm: 1)
+5664| drop
+5668| return
+5672| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5692| f32.const $0
+5700| f32x4.replace_lane %[-1], %[-2] : (Lane imm: 3)
+5705| drop
+5709| return
+5713| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5733| f64.const $0
+5745| f64x2.replace_lane %[-1], %[-2] : (Lane imm: 1)
+5750| drop
+5754| return
+5758| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5778| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+5798| v8x16.shuffle %[-2], %[-1] : (Lane imm: $0x00000001 0x00000001 0x00000001 0x00000001 )
+5818| drop
+5822| return
+5826| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5846| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+5866| i8x16.add %[-2], %[-1]
+5870| drop
+5874| return
+5878| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5898| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+5918| i16x8.add %[-2], %[-1]
+5922| drop
+5926| return
+5930| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+5950| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+5970| i32x4.add %[-2], %[-1]
+5974| drop
+5978| return
+5982| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6002| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6022| i64x2.add %[-2], %[-1]
+6026| drop
+6030| return
+6034| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6054| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6074| i8x16.sub %[-2], %[-1]
+6078| drop
 6082| return
-6083| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6101| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6119| i8x16.ge_s %[-2], %[-1]
-6121| drop
-6122| return
-6123| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6141| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6159| i8x16.ge_u %[-2], %[-1]
-6161| drop
-6162| return
-6163| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6181| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6199| i16x8.ge_s %[-2], %[-1]
-6201| drop
-6202| return
-6203| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6221| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6239| i16x8.ge_u %[-2], %[-1]
-6241| drop
-6242| return
-6243| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6261| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6279| i32x4.ge_s %[-2], %[-1]
-6281| drop
-6282| return
-6283| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6301| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6319| i32x4.ge_u %[-2], %[-1]
-6321| drop
-6322| return
-6323| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6341| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6359| f32x4.ge %[-2], %[-1]
-6361| drop
-6362| return
-6363| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6381| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6399| f64x2.ge %[-2], %[-1]
-6401| drop
-6402| return
-6403| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6421| f32x4.neg %[-1]
-6423| drop
-6424| return
-6425| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6443| f64x2.neg %[-1]
-6445| drop
-6446| return
-6447| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6465| f32x4.abs %[-1]
-6467| drop
-6468| return
-6469| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6487| f64x2.abs %[-1]
-6489| drop
+6086| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6106| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6126| i16x8.sub %[-2], %[-1]
+6130| drop
+6134| return
+6138| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6158| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6178| i32x4.sub %[-2], %[-1]
+6182| drop
+6186| return
+6190| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6210| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6230| i64x2.sub %[-2], %[-1]
+6234| drop
+6238| return
+6242| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6262| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6282| i8x16.mul %[-2], %[-1]
+6286| drop
+6290| return
+6294| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6314| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6334| i16x8.mul %[-2], %[-1]
+6338| drop
+6342| return
+6346| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6366| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6386| i32x4.mul %[-2], %[-1]
+6390| drop
+6394| return
+6398| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6418| i8x16.neg %[-1]
+6422| drop
+6426| return
+6430| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6450| i16x8.neg %[-1]
+6454| drop
+6458| return
+6462| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6482| i32x4.neg %[-1]
+6486| drop
 6490| return
-6491| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6509| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6527| f32x4.min %[-2], %[-1]
-6529| drop
-6530| return
-6531| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6549| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6567| f64x2.min %[-2], %[-1]
-6569| drop
-6570| return
-6571| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6589| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6607| f32x4.max %[-2], %[-1]
-6609| drop
-6610| return
-6611| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6629| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6647| f64x2.max %[-2], %[-1]
-6649| drop
-6650| return
-6651| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6669| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6687| f32x4.add %[-2], %[-1]
-6689| drop
-6690| return
-6691| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6709| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6727| f64x2.add %[-2], %[-1]
-6729| drop
+6494| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6514| i64x2.neg %[-1]
+6518| drop
+6522| return
+6526| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6546| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6566| i8x16.add_saturate_s %[-2], %[-1]
+6570| drop
+6574| return
+6578| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6598| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6618| i8x16.add_saturate_u %[-2], %[-1]
+6622| drop
+6626| return
+6630| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6650| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6670| i16x8.add_saturate_s %[-2], %[-1]
+6674| drop
+6678| return
+6682| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6702| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6722| i16x8.add_saturate_u %[-2], %[-1]
+6726| drop
 6730| return
-6731| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6749| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6767| f32x4.sub %[-2], %[-1]
-6769| drop
-6770| return
-6771| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6789| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6807| f64x2.sub %[-2], %[-1]
-6809| drop
-6810| return
-6811| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6829| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6847| f32x4.div %[-2], %[-1]
-6849| drop
-6850| return
-6851| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6869| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6887| f64x2.div %[-2], %[-1]
-6889| drop
-6890| return
-6891| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6909| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6927| f32x4.mul %[-2], %[-1]
-6929| drop
-6930| return
-6931| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6949| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-6967| f64x2.mul %[-2], %[-1]
-6969| drop
-6970| return
-6971| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-6989| f32x4.sqrt %[-1]
-6991| drop
-6992| return
-6993| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7011| f64x2.sqrt %[-1]
-7013| drop
-7014| return
-7015| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7033| f32x4.convert_s/i32x4 %[-1]
-7035| drop
-7036| return
-7037| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7055| f32x4.convert_u/i32x4 %[-1]
-7057| drop
+6734| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6754| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6774| i8x16.sub_saturate_s %[-2], %[-1]
+6778| drop
+6782| return
+6786| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6806| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6826| i8x16.sub_saturate_u %[-2], %[-1]
+6830| drop
+6834| return
+6838| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6858| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6878| i16x8.sub_saturate_s %[-2], %[-1]
+6882| drop
+6886| return
+6890| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6910| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+6930| i16x8.sub_saturate_u %[-2], %[-1]
+6934| drop
+6938| return
+6942| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+6962| i32.const $0
+6970| i8x16.shl %[-2], %[-1]
+6974| drop
+6978| return
+6982| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7002| i32.const $0
+7010| i16x8.shl %[-2], %[-1]
+7014| drop
+7018| return
+7022| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7042| i32.const $0
+7050| i32x4.shl %[-2], %[-1]
+7054| drop
 7058| return
-7059| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7077| f64x2.convert_s/i64x2 %[-1]
-7079| drop
-7080| return
-7081| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7099| f64x2.convert_u/i64x2 %[-1]
-7101| drop
-7102| return
-7103| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7121| i32x4.trunc_s/f32x4:sat %[-1]
-7123| drop
-7124| return
-7125| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7143| i32x4.trunc_u/f32x4:sat %[-1]
-7145| drop
-7146| return
-7147| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7165| i64x2.trunc_s/f64x2:sat %[-1]
-7167| drop
-7168| return
-7169| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-7187| i64x2.trunc_u/f64x2:sat %[-1]
-7189| drop
-7190| return
-7191| i32.const $1
-7196| i32.const $2
-7201| atomic.wake $0:%[-2]+$3, %[-1]
-7211| drop
-7212| return
-7213| i32.const $1
-7218| i32.const $2
-7223| i64.const $3
-7232| i32.atomic.wait $0:%[-3]+$3, %[-2], %[-1]
-7242| drop
-7243| return
-7244| i32.const $1
-7249| i64.const $2
-7258| i64.const $3
-7267| i64.atomic.wait $0:%[-3]+$3, %[-2], %[-1]
-7277| drop
-7278| return
-7279| i32.const $1
-7284| i32.atomic.load $0:%[-1]+$3
+7062| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7082| i32.const $0
+7090| i64x2.shl %[-2], %[-1]
+7094| drop
+7098| return
+7102| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7122| i32.const $0
+7130| i8x16.shr_s %[-2], %[-1]
+7134| drop
+7138| return
+7142| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7162| i32.const $0
+7170| i8x16.shr_u %[-2], %[-1]
+7174| drop
+7178| return
+7182| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7202| i32.const $0
+7210| i16x8.shr_s %[-2], %[-1]
+7214| drop
+7218| return
+7222| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7242| i32.const $0
+7250| i16x8.shr_u %[-2], %[-1]
+7254| drop
+7258| return
+7262| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7282| i32.const $0
+7290| i32x4.shr_s %[-2], %[-1]
 7294| drop
-7295| return
-7296| i32.const $1
-7301| i64.atomic.load $0:%[-1]+$7
-7311| drop
-7312| return
-7313| i32.const $1
-7318| i32.atomic.load8_u $0:%[-1]+$3
-7328| drop
-7329| return
-7330| i32.const $1
-7335| i32.atomic.load16_u $0:%[-1]+$3
-7345| drop
-7346| return
-7347| i32.const $1
-7352| i64.atomic.load8_u $0:%[-1]+$3
-7362| drop
-7363| return
-7364| i32.const $1
-7369| i64.atomic.load16_u $0:%[-1]+$3
-7379| drop
-7380| return
-7381| i32.const $1
-7386| i64.atomic.load32_u $0:%[-1]+$3
-7396| drop
-7397| return
-7398| i32.const $1
-7403| i32.const $2
-7408| i32.atomic.store $0:%[-2]+$3, %[-1]
+7298| return
+7302| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7322| i32.const $0
+7330| i32x4.shr_u %[-2], %[-1]
+7334| drop
+7338| return
+7342| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7362| i32.const $0
+7370| i64x2.shr_s %[-2], %[-1]
+7374| drop
+7378| return
+7382| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7402| i32.const $0
+7410| i64x2.shr_u %[-2], %[-1]
+7414| drop
 7418| return
-7419| i32.const $1
-7424| i64.const $2
-7433| i64.atomic.store $0:%[-2]+$7, %[-1]
-7443| return
-7444| i32.const $1
-7449| i32.const $2
-7454| i32.atomic.store8 $0:%[-2]+$3, %[-1]
-7464| return
-7465| i32.const $1
-7470| i32.const $2
-7475| i32.atomic.store16 $0:%[-2]+$3, %[-1]
-7485| return
-7486| i32.const $1
-7491| i64.const $2
-7500| i64.atomic.store8 $0:%[-2]+$3, %[-1]
-7510| return
-7511| i32.const $1
-7516| i64.const $2
-7525| i64.atomic.store16 $0:%[-2]+$3, %[-1]
-7535| return
-7536| i32.const $1
-7541| i64.const $2
-7550| i64.atomic.store32 $0:%[-2]+$3, %[-1]
-7560| return
-7561| i32.const $1
-7566| i32.const $2
-7571| i32.atomic.rmw.add $0:%[-2]+$3, %[-1]
-7581| drop
-7582| return
-7583| i32.const $1
-7588| i64.const $2
-7597| i64.atomic.rmw.add $0:%[-2]+$7, %[-1]
-7607| drop
-7608| return
-7609| i32.const $1
-7614| i32.const $2
-7619| i32.atomic.rmw8_u.add $0:%[-2]+$3, %[-1]
-7629| drop
-7630| return
-7631| i32.const $1
-7636| i32.const $2
-7641| i32.atomic.rmw16_u.add $0:%[-2]+$3, %[-1]
-7651| drop
-7652| return
-7653| i32.const $1
-7658| i64.const $2
-7667| i64.atomic.rmw8_u.add $0:%[-2]+$3, %[-1]
-7677| drop
+7422| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7442| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+7462| v128.and %[-2], %[-1]
+7466| drop
+7470| return
+7474| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7494| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+7514| v128.or %[-2], %[-1]
+7518| drop
+7522| return
+7526| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7546| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+7566| v128.xor %[-2], %[-1]
+7570| drop
+7574| return
+7578| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7598| v128.not %[-1]
+7602| drop
+7606| return
+7610| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7630| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+7650| v128.const $0x00000003 0x00000003 0x00000003 0x00000003
+7670| v128.bitselect %[-3], %[-2], %[-1]
+7674| drop
 7678| return
-7679| i32.const $1
-7684| i64.const $2
-7693| i64.atomic.rmw16_u.add $0:%[-2]+$3, %[-1]
-7703| drop
-7704| return
-7705| i32.const $1
-7710| i64.const $2
-7719| i64.atomic.rmw32_u.add $0:%[-2]+$3, %[-1]
-7729| drop
-7730| return
-7731| i32.const $1
-7736| i32.const $2
-7741| i32.atomic.rmw.sub $0:%[-2]+$3, %[-1]
-7751| drop
-7752| return
-7753| i32.const $1
-7758| i64.const $2
-7767| i64.atomic.rmw.sub $0:%[-2]+$7, %[-1]
-7777| drop
-7778| return
-7779| i32.const $1
-7784| i32.const $2
-7789| i32.atomic.rmw8_u.sub $0:%[-2]+$3, %[-1]
-7799| drop
-7800| return
-7801| i32.const $1
-7806| i32.const $2
-7811| i32.atomic.rmw16_u.sub $0:%[-2]+$3, %[-1]
-7821| drop
-7822| return
-7823| i32.const $1
-7828| i64.const $2
-7837| i64.atomic.rmw8_u.sub $0:%[-2]+$3, %[-1]
-7847| drop
-7848| return
-7849| i32.const $1
-7854| i64.const $2
-7863| i64.atomic.rmw16_u.sub $0:%[-2]+$3, %[-1]
-7873| drop
-7874| return
-7875| i32.const $1
-7880| i64.const $2
-7889| i64.atomic.rmw32_u.sub $0:%[-2]+$3, %[-1]
-7899| drop
-7900| return
-7901| i32.const $1
-7906| i32.const $2
-7911| i32.atomic.rmw.and $0:%[-2]+$3, %[-1]
-7921| drop
-7922| return
-7923| i32.const $1
-7928| i64.const $2
-7937| i64.atomic.rmw.and $0:%[-2]+$7, %[-1]
-7947| drop
-7948| return
-7949| i32.const $1
-7954| i32.const $2
-7959| i32.atomic.rmw8_u.and $0:%[-2]+$3, %[-1]
-7969| drop
-7970| return
-7971| i32.const $1
-7976| i32.const $2
-7981| i32.atomic.rmw16_u.and $0:%[-2]+$3, %[-1]
-7991| drop
-7992| return
-7993| i32.const $1
-7998| i64.const $2
-8007| i64.atomic.rmw8_u.and $0:%[-2]+$3, %[-1]
-8017| drop
-8018| return
-8019| i32.const $1
-8024| i64.const $2
-8033| i64.atomic.rmw16_u.and $0:%[-2]+$3, %[-1]
-8043| drop
-8044| return
-8045| i32.const $1
-8050| i64.const $2
-8059| i64.atomic.rmw32_u.and $0:%[-2]+$3, %[-1]
-8069| drop
-8070| return
-8071| i32.const $1
-8076| i32.const $2
-8081| i32.atomic.rmw.or $0:%[-2]+$3, %[-1]
-8091| drop
-8092| return
-8093| i32.const $1
-8098| i64.const $2
-8107| i64.atomic.rmw.or $0:%[-2]+$7, %[-1]
-8117| drop
-8118| return
-8119| i32.const $1
-8124| i32.const $2
-8129| i32.atomic.rmw8_u.or $0:%[-2]+$3, %[-1]
-8139| drop
-8140| return
-8141| i32.const $1
-8146| i32.const $2
-8151| i32.atomic.rmw16_u.or $0:%[-2]+$3, %[-1]
-8161| drop
-8162| return
-8163| i32.const $1
-8168| i64.const $2
-8177| i64.atomic.rmw8_u.or $0:%[-2]+$3, %[-1]
-8187| drop
-8188| return
-8189| i32.const $1
-8194| i64.const $2
-8203| i64.atomic.rmw16_u.or $0:%[-2]+$3, %[-1]
-8213| drop
-8214| return
-8215| i32.const $1
-8220| i64.const $2
-8229| i64.atomic.rmw32_u.or $0:%[-2]+$3, %[-1]
-8239| drop
-8240| return
-8241| i32.const $1
-8246| i32.const $2
-8251| i32.atomic.rmw.xor $0:%[-2]+$3, %[-1]
-8261| drop
-8262| return
-8263| i32.const $1
-8268| i64.const $2
-8277| i64.atomic.rmw.xor $0:%[-2]+$7, %[-1]
-8287| drop
-8288| return
-8289| i32.const $1
-8294| i32.const $2
-8299| i32.atomic.rmw8_u.xor $0:%[-2]+$3, %[-1]
-8309| drop
-8310| return
-8311| i32.const $1
-8316| i32.const $2
-8321| i32.atomic.rmw16_u.xor $0:%[-2]+$3, %[-1]
-8331| drop
-8332| return
-8333| i32.const $1
-8338| i64.const $2
-8347| i64.atomic.rmw8_u.xor $0:%[-2]+$3, %[-1]
-8357| drop
-8358| return
-8359| i32.const $1
-8364| i64.const $2
-8373| i64.atomic.rmw16_u.xor $0:%[-2]+$3, %[-1]
-8383| drop
-8384| return
-8385| i32.const $1
-8390| i64.const $2
-8399| i64.atomic.rmw32_u.xor $0:%[-2]+$3, %[-1]
-8409| drop
-8410| return
-8411| i32.const $1
-8416| i32.const $2
-8421| i32.atomic.rmw.xchg $0:%[-2]+$3, %[-1]
-8431| drop
-8432| return
-8433| i32.const $1
-8438| i64.const $2
-8447| i64.atomic.rmw.xchg $0:%[-2]+$7, %[-1]
-8457| drop
-8458| return
-8459| i32.const $1
-8464| i32.const $2
-8469| i32.atomic.rmw8_u.xchg $0:%[-2]+$3, %[-1]
-8479| drop
-8480| return
-8481| i32.const $1
-8486| i32.const $2
-8491| i32.atomic.rmw16_u.xchg $0:%[-2]+$3, %[-1]
-8501| drop
-8502| return
-8503| i32.const $1
-8508| i64.const $2
-8517| i64.atomic.rmw8_u.xchg $0:%[-2]+$3, %[-1]
-8527| drop
-8528| return
-8529| i32.const $1
-8534| i64.const $2
-8543| i64.atomic.rmw16_u.xchg $0:%[-2]+$3, %[-1]
-8553| drop
-8554| return
-8555| i32.const $1
-8560| i64.const $2
-8569| i64.atomic.rmw32_u.xchg $0:%[-2]+$3, %[-1]
-8579| drop
-8580| return
-8581| i32.const $1
-8586| i32.const $2
-8591| i32.const $3
-8596| i32.atomic.rmw.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+7682| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7702| i8x16.any_true %[-1]
+7706| drop
+7710| return
+7714| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7734| i16x8.any_true %[-1]
+7738| drop
+7742| return
+7746| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7766| i32x4.any_true %[-1]
+7770| drop
+7774| return
+7778| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7798| i64x2.any_true %[-1]
+7802| drop
+7806| return
+7810| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7830| i8x16.all_true %[-1]
+7834| drop
+7838| return
+7842| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7862| i16x8.all_true %[-1]
+7866| drop
+7870| return
+7874| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7894| i32x4.all_true %[-1]
+7898| drop
+7902| return
+7906| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7926| i64x2.all_true %[-1]
+7930| drop
+7934| return
+7938| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+7958| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+7978| i8x16.eq %[-2], %[-1]
+7982| drop
+7986| return
+7990| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8010| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8030| i16x8.eq %[-2], %[-1]
+8034| drop
+8038| return
+8042| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8062| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8082| i32x4.eq %[-2], %[-1]
+8086| drop
+8090| return
+8094| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8114| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8134| f32x4.eq %[-2], %[-1]
+8138| drop
+8142| return
+8146| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8166| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8186| f64x2.eq %[-2], %[-1]
+8190| drop
+8194| return
+8198| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8218| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8238| i8x16.ne %[-2], %[-1]
+8242| drop
+8246| return
+8250| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8270| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8290| i16x8.ne %[-2], %[-1]
+8294| drop
+8298| return
+8302| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8322| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8342| i32x4.ne %[-2], %[-1]
+8346| drop
+8350| return
+8354| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8374| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8394| f32x4.ne %[-2], %[-1]
+8398| drop
+8402| return
+8406| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8426| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8446| f64x2.ne %[-2], %[-1]
+8450| drop
+8454| return
+8458| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8478| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8498| i8x16.lt_s %[-2], %[-1]
+8502| drop
+8506| return
+8510| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8530| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8550| i8x16.lt_u %[-2], %[-1]
+8554| drop
+8558| return
+8562| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8582| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8602| i16x8.lt_s %[-2], %[-1]
 8606| drop
-8607| return
-8608| i32.const $1
-8613| i64.const $2
-8622| i64.const $3
-8631| i64.atomic.rmw.cmpxchg $0:%[-3]+$7, %[-2], %[-1]
-8641| drop
-8642| return
-8643| i32.const $1
-8648| i32.const $2
-8653| i32.const $3
-8658| i32.atomic.rmw8_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
-8668| drop
-8669| return
-8670| i32.const $1
-8675| i32.const $2
-8680| i32.const $3
-8685| i32.atomic.rmw16_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
-8695| drop
-8696| return
-8697| i32.const $1
-8702| i64.const $2
-8711| i64.const $3
-8720| i64.atomic.rmw8_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
-8730| drop
-8731| return
-8732| i32.const $1
-8737| i64.const $2
-8746| i64.const $3
-8755| i64.atomic.rmw16_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
-8765| drop
+8610| return
+8614| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8634| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8654| i16x8.lt_u %[-2], %[-1]
+8658| drop
+8662| return
+8666| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8686| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8706| i32x4.lt_s %[-2], %[-1]
+8710| drop
+8714| return
+8718| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8738| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8758| i32x4.lt_u %[-2], %[-1]
+8762| drop
 8766| return
-8767| i32.const $1
-8772| i64.const $2
-8781| i64.const $3
-8790| i64.atomic.rmw32_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
-8800| drop
-8801| return
+8770| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8790| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8810| f32x4.lt %[-2], %[-1]
+8814| drop
+8818| return
+8822| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8842| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8862| f64x2.lt %[-2], %[-1]
+8866| drop
+8870| return
+8874| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8894| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8914| i8x16.le_s %[-2], %[-1]
+8918| drop
+8922| return
+8926| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8946| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+8966| i8x16.le_u %[-2], %[-1]
+8970| drop
+8974| return
+8978| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+8998| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9018| i16x8.le_s %[-2], %[-1]
+9022| drop
+9026| return
+9030| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9050| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9070| i16x8.le_u %[-2], %[-1]
+9074| drop
+9078| return
+9082| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9102| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9122| i32x4.le_s %[-2], %[-1]
+9126| drop
+9130| return
+9134| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9154| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9174| i32x4.le_u %[-2], %[-1]
+9178| drop
+9182| return
+9186| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9206| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9226| f32x4.le %[-2], %[-1]
+9230| drop
+9234| return
+9238| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9258| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9278| f64x2.le %[-2], %[-1]
+9282| drop
+9286| return
+9290| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9310| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9330| i8x16.gt_s %[-2], %[-1]
+9334| drop
+9338| return
+9342| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9362| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9382| i8x16.gt_u %[-2], %[-1]
+9386| drop
+9390| return
+9394| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9414| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9434| i16x8.gt_s %[-2], %[-1]
+9438| drop
+9442| return
+9446| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9466| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9486| i16x8.gt_u %[-2], %[-1]
+9490| drop
+9494| return
+9498| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9518| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9538| i32x4.gt_s %[-2], %[-1]
+9542| drop
+9546| return
+9550| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9570| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9590| i32x4.gt_u %[-2], %[-1]
+9594| drop
+9598| return
+9602| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9622| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9642| f32x4.gt %[-2], %[-1]
+9646| drop
+9650| return
+9654| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9674| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9694| f64x2.gt %[-2], %[-1]
+9698| drop
+9702| return
+9706| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9726| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9746| i8x16.ge_s %[-2], %[-1]
+9750| drop
+9754| return
+9758| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9778| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9798| i8x16.ge_u %[-2], %[-1]
+9802| drop
+9806| return
+9810| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9830| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9850| i16x8.ge_s %[-2], %[-1]
+9854| drop
+9858| return
+9862| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9882| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9902| i16x8.ge_u %[-2], %[-1]
+9906| drop
+9910| return
+9914| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9934| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+9954| i32x4.ge_s %[-2], %[-1]
+9958| drop
+9962| return
+9966| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+9986| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10006| i32x4.ge_u %[-2], %[-1]
+10010| drop
+10014| return
+10018| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10038| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10058| f32x4.ge %[-2], %[-1]
+10062| drop
+10066| return
+10070| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10090| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10110| f64x2.ge %[-2], %[-1]
+10114| drop
+10118| return
+10122| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10142| f32x4.neg %[-1]
+10146| drop
+10150| return
+10154| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10174| f64x2.neg %[-1]
+10178| drop
+10182| return
+10186| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10206| f32x4.abs %[-1]
+10210| drop
+10214| return
+10218| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10238| f64x2.abs %[-1]
+10242| drop
+10246| return
+10250| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10270| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10290| f32x4.min %[-2], %[-1]
+10294| drop
+10298| return
+10302| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10322| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10342| f64x2.min %[-2], %[-1]
+10346| drop
+10350| return
+10354| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10374| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10394| f32x4.max %[-2], %[-1]
+10398| drop
+10402| return
+10406| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10426| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10446| f64x2.max %[-2], %[-1]
+10450| drop
+10454| return
+10458| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10478| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10498| f32x4.add %[-2], %[-1]
+10502| drop
+10506| return
+10510| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10530| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10550| f64x2.add %[-2], %[-1]
+10554| drop
+10558| return
+10562| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10582| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10602| f32x4.sub %[-2], %[-1]
+10606| drop
+10610| return
+10614| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10634| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10654| f64x2.sub %[-2], %[-1]
+10658| drop
+10662| return
+10666| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10686| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10706| f32x4.div %[-2], %[-1]
+10710| drop
+10714| return
+10718| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10738| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10758| f64x2.div %[-2], %[-1]
+10762| drop
+10766| return
+10770| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10790| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10810| f32x4.mul %[-2], %[-1]
+10814| drop
+10818| return
+10822| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10842| v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+10862| f64x2.mul %[-2], %[-1]
+10866| drop
+10870| return
+10874| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10894| f32x4.sqrt %[-1]
+10898| drop
+10902| return
+10906| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10926| f64x2.sqrt %[-1]
+10930| drop
+10934| return
+10938| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10958| f32x4.convert_s/i32x4 %[-1]
+10962| drop
+10966| return
+10970| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+10990| f32x4.convert_u/i32x4 %[-1]
+10994| drop
+10998| return
+11002| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+11022| f64x2.convert_s/i64x2 %[-1]
+11026| drop
+11030| return
+11034| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+11054| f64x2.convert_u/i64x2 %[-1]
+11058| drop
+11062| return
+11066| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+11086| i32x4.trunc_s/f32x4:sat %[-1]
+11090| drop
+11094| return
+11098| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+11118| i32x4.trunc_u/f32x4:sat %[-1]
+11122| drop
+11126| return
+11130| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+11150| i64x2.trunc_s/f64x2:sat %[-1]
+11154| drop
+11158| return
+11162| v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+11182| i64x2.trunc_u/f64x2:sat %[-1]
+11186| drop
+11190| return
+11194| i32.const $1
+11202| i32.const $2
+11210| atomic.wake $0:%[-2]+$3, %[-1]
+11222| drop
+11226| return
+11230| i32.const $1
+11238| i32.const $2
+11246| i64.const $3
+11258| i32.atomic.wait $0:%[-3]+$3, %[-2], %[-1]
+11270| drop
+11274| return
+11278| i32.const $1
+11286| i64.const $2
+11298| i64.const $3
+11310| i64.atomic.wait $0:%[-3]+$3, %[-2], %[-1]
+11322| drop
+11326| return
+11330| i32.const $1
+11338| i32.atomic.load $0:%[-1]+$3
+11350| drop
+11354| return
+11358| i32.const $1
+11366| i64.atomic.load $0:%[-1]+$7
+11378| drop
+11382| return
+11386| i32.const $1
+11394| i32.atomic.load8_u $0:%[-1]+$3
+11406| drop
+11410| return
+11414| i32.const $1
+11422| i32.atomic.load16_u $0:%[-1]+$3
+11434| drop
+11438| return
+11442| i32.const $1
+11450| i64.atomic.load8_u $0:%[-1]+$3
+11462| drop
+11466| return
+11470| i32.const $1
+11478| i64.atomic.load16_u $0:%[-1]+$3
+11490| drop
+11494| return
+11498| i32.const $1
+11506| i64.atomic.load32_u $0:%[-1]+$3
+11518| drop
+11522| return
+11526| i32.const $1
+11534| i32.const $2
+11542| i32.atomic.store $0:%[-2]+$3, %[-1]
+11554| return
+11558| i32.const $1
+11566| i64.const $2
+11578| i64.atomic.store $0:%[-2]+$7, %[-1]
+11590| return
+11594| i32.const $1
+11602| i32.const $2
+11610| i32.atomic.store8 $0:%[-2]+$3, %[-1]
+11622| return
+11626| i32.const $1
+11634| i32.const $2
+11642| i32.atomic.store16 $0:%[-2]+$3, %[-1]
+11654| return
+11658| i32.const $1
+11666| i64.const $2
+11678| i64.atomic.store8 $0:%[-2]+$3, %[-1]
+11690| return
+11694| i32.const $1
+11702| i64.const $2
+11714| i64.atomic.store16 $0:%[-2]+$3, %[-1]
+11726| return
+11730| i32.const $1
+11738| i64.const $2
+11750| i64.atomic.store32 $0:%[-2]+$3, %[-1]
+11762| return
+11766| i32.const $1
+11774| i32.const $2
+11782| i32.atomic.rmw.add $0:%[-2]+$3, %[-1]
+11794| drop
+11798| return
+11802| i32.const $1
+11810| i64.const $2
+11822| i64.atomic.rmw.add $0:%[-2]+$7, %[-1]
+11834| drop
+11838| return
+11842| i32.const $1
+11850| i32.const $2
+11858| i32.atomic.rmw8_u.add $0:%[-2]+$3, %[-1]
+11870| drop
+11874| return
+11878| i32.const $1
+11886| i32.const $2
+11894| i32.atomic.rmw16_u.add $0:%[-2]+$3, %[-1]
+11906| drop
+11910| return
+11914| i32.const $1
+11922| i64.const $2
+11934| i64.atomic.rmw8_u.add $0:%[-2]+$3, %[-1]
+11946| drop
+11950| return
+11954| i32.const $1
+11962| i64.const $2
+11974| i64.atomic.rmw16_u.add $0:%[-2]+$3, %[-1]
+11986| drop
+11990| return
+11994| i32.const $1
+12002| i64.const $2
+12014| i64.atomic.rmw32_u.add $0:%[-2]+$3, %[-1]
+12026| drop
+12030| return
+12034| i32.const $1
+12042| i32.const $2
+12050| i32.atomic.rmw.sub $0:%[-2]+$3, %[-1]
+12062| drop
+12066| return
+12070| i32.const $1
+12078| i64.const $2
+12090| i64.atomic.rmw.sub $0:%[-2]+$7, %[-1]
+12102| drop
+12106| return
+12110| i32.const $1
+12118| i32.const $2
+12126| i32.atomic.rmw8_u.sub $0:%[-2]+$3, %[-1]
+12138| drop
+12142| return
+12146| i32.const $1
+12154| i32.const $2
+12162| i32.atomic.rmw16_u.sub $0:%[-2]+$3, %[-1]
+12174| drop
+12178| return
+12182| i32.const $1
+12190| i64.const $2
+12202| i64.atomic.rmw8_u.sub $0:%[-2]+$3, %[-1]
+12214| drop
+12218| return
+12222| i32.const $1
+12230| i64.const $2
+12242| i64.atomic.rmw16_u.sub $0:%[-2]+$3, %[-1]
+12254| drop
+12258| return
+12262| i32.const $1
+12270| i64.const $2
+12282| i64.atomic.rmw32_u.sub $0:%[-2]+$3, %[-1]
+12294| drop
+12298| return
+12302| i32.const $1
+12310| i32.const $2
+12318| i32.atomic.rmw.and $0:%[-2]+$3, %[-1]
+12330| drop
+12334| return
+12338| i32.const $1
+12346| i64.const $2
+12358| i64.atomic.rmw.and $0:%[-2]+$7, %[-1]
+12370| drop
+12374| return
+12378| i32.const $1
+12386| i32.const $2
+12394| i32.atomic.rmw8_u.and $0:%[-2]+$3, %[-1]
+12406| drop
+12410| return
+12414| i32.const $1
+12422| i32.const $2
+12430| i32.atomic.rmw16_u.and $0:%[-2]+$3, %[-1]
+12442| drop
+12446| return
+12450| i32.const $1
+12458| i64.const $2
+12470| i64.atomic.rmw8_u.and $0:%[-2]+$3, %[-1]
+12482| drop
+12486| return
+12490| i32.const $1
+12498| i64.const $2
+12510| i64.atomic.rmw16_u.and $0:%[-2]+$3, %[-1]
+12522| drop
+12526| return
+12530| i32.const $1
+12538| i64.const $2
+12550| i64.atomic.rmw32_u.and $0:%[-2]+$3, %[-1]
+12562| drop
+12566| return
+12570| i32.const $1
+12578| i32.const $2
+12586| i32.atomic.rmw.or $0:%[-2]+$3, %[-1]
+12598| drop
+12602| return
+12606| i32.const $1
+12614| i64.const $2
+12626| i64.atomic.rmw.or $0:%[-2]+$7, %[-1]
+12638| drop
+12642| return
+12646| i32.const $1
+12654| i32.const $2
+12662| i32.atomic.rmw8_u.or $0:%[-2]+$3, %[-1]
+12674| drop
+12678| return
+12682| i32.const $1
+12690| i32.const $2
+12698| i32.atomic.rmw16_u.or $0:%[-2]+$3, %[-1]
+12710| drop
+12714| return
+12718| i32.const $1
+12726| i64.const $2
+12738| i64.atomic.rmw8_u.or $0:%[-2]+$3, %[-1]
+12750| drop
+12754| return
+12758| i32.const $1
+12766| i64.const $2
+12778| i64.atomic.rmw16_u.or $0:%[-2]+$3, %[-1]
+12790| drop
+12794| return
+12798| i32.const $1
+12806| i64.const $2
+12818| i64.atomic.rmw32_u.or $0:%[-2]+$3, %[-1]
+12830| drop
+12834| return
+12838| i32.const $1
+12846| i32.const $2
+12854| i32.atomic.rmw.xor $0:%[-2]+$3, %[-1]
+12866| drop
+12870| return
+12874| i32.const $1
+12882| i64.const $2
+12894| i64.atomic.rmw.xor $0:%[-2]+$7, %[-1]
+12906| drop
+12910| return
+12914| i32.const $1
+12922| i32.const $2
+12930| i32.atomic.rmw8_u.xor $0:%[-2]+$3, %[-1]
+12942| drop
+12946| return
+12950| i32.const $1
+12958| i32.const $2
+12966| i32.atomic.rmw16_u.xor $0:%[-2]+$3, %[-1]
+12978| drop
+12982| return
+12986| i32.const $1
+12994| i64.const $2
+13006| i64.atomic.rmw8_u.xor $0:%[-2]+$3, %[-1]
+13018| drop
+13022| return
+13026| i32.const $1
+13034| i64.const $2
+13046| i64.atomic.rmw16_u.xor $0:%[-2]+$3, %[-1]
+13058| drop
+13062| return
+13066| i32.const $1
+13074| i64.const $2
+13086| i64.atomic.rmw32_u.xor $0:%[-2]+$3, %[-1]
+13098| drop
+13102| return
+13106| i32.const $1
+13114| i32.const $2
+13122| i32.atomic.rmw.xchg $0:%[-2]+$3, %[-1]
+13134| drop
+13138| return
+13142| i32.const $1
+13150| i64.const $2
+13162| i64.atomic.rmw.xchg $0:%[-2]+$7, %[-1]
+13174| drop
+13178| return
+13182| i32.const $1
+13190| i32.const $2
+13198| i32.atomic.rmw8_u.xchg $0:%[-2]+$3, %[-1]
+13210| drop
+13214| return
+13218| i32.const $1
+13226| i32.const $2
+13234| i32.atomic.rmw16_u.xchg $0:%[-2]+$3, %[-1]
+13246| drop
+13250| return
+13254| i32.const $1
+13262| i64.const $2
+13274| i64.atomic.rmw8_u.xchg $0:%[-2]+$3, %[-1]
+13286| drop
+13290| return
+13294| i32.const $1
+13302| i64.const $2
+13314| i64.atomic.rmw16_u.xchg $0:%[-2]+$3, %[-1]
+13326| drop
+13330| return
+13334| i32.const $1
+13342| i64.const $2
+13354| i64.atomic.rmw32_u.xchg $0:%[-2]+$3, %[-1]
+13366| drop
+13370| return
+13374| i32.const $1
+13382| i32.const $2
+13390| i32.const $3
+13398| i32.atomic.rmw.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+13410| drop
+13414| return
+13418| i32.const $1
+13426| i64.const $2
+13438| i64.const $3
+13450| i64.atomic.rmw.cmpxchg $0:%[-3]+$7, %[-2], %[-1]
+13462| drop
+13466| return
+13470| i32.const $1
+13478| i32.const $2
+13486| i32.const $3
+13494| i32.atomic.rmw8_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+13506| drop
+13510| return
+13514| i32.const $1
+13522| i32.const $2
+13530| i32.const $3
+13538| i32.atomic.rmw16_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+13550| drop
+13554| return
+13558| i32.const $1
+13566| i64.const $2
+13578| i64.const $3
+13590| i64.atomic.rmw8_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+13602| drop
+13606| return
+13610| i32.const $1
+13618| i64.const $2
+13630| i64.const $3
+13642| i64.atomic.rmw16_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+13654| drop
+13658| return
+13662| i32.const $1
+13670| i64.const $2
+13682| i64.const $3
+13694| i64.atomic.rmw32_u.cmpxchg $0:%[-3]+$3, %[-2], %[-1]
+13706| drop
+13710| return
 unreachable() => error: unreachable executed
 br() =>
 br_table() =>

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -426,2547 +426,2547 @@
 )
 (;; STDOUT ;;;
 >>> running export "unreachable":
-#0.    1: V:0  | unreachable
+#0.    4: V:0  | unreachable
 unreachable() => error: unreachable executed
 >>> running export "br":
-#0.    3: V:0  | br @8
-#0.    8: V:0  | return
+#0.   12: V:0  | br @20
+#0.   20: V:0  | return
 br() =>
 >>> running export "br_table":
-#0.    9: V:0  | i32.const $1
-#0.   14: V:1  | br_table 1, $#0, table:$28
-#0.   40: V:0  | return
+#0.   24: V:0  | i32.const $1
+#0.   32: V:1  | br_table 1, $#0, table:$52
+#0.   64: V:0  | return
 br_table() =>
 >>> running export "return":
-#0.   41: V:0  | return
+#0.   68: V:0  | return
 return() =>
 >>> running export "call":
-#0.   43: V:0  | call @0
+#0.   76: V:0  | call @0
 #1.    0: V:0  | return
-#0.   48: V:0  | return
+#0.   84: V:0  | return
 call() =>
 >>> running export "call_indirect":
-#0.   49: V:0  | i32.const $1
-#0.   54: V:1  | call_indirect $0, 1
+#0.   88: V:0  | i32.const $1
+#0.   96: V:1  | call_indirect $0, 1
 #1.    0: V:0  | return
-#0.   63: V:0  | return
+#0.  108: V:0  | return
 call_indirect() =>
 >>> running export "drop":
-#0.   64: V:0  | i32.const $1
-#0.   69: V:1  | drop
-#0.   70: V:0  | return
+#0.  112: V:0  | i32.const $1
+#0.  120: V:1  | drop
+#0.  124: V:0  | return
 drop() =>
 >>> running export "select":
-#0.   71: V:0  | i32.const $1
-#0.   76: V:1  | i32.const $2
-#0.   81: V:2  | i32.const $3
-#0.   86: V:3  | select 1, %[-2], %[-1]
-#0.   87: V:1  | drop
-#0.   88: V:0  | return
+#0.  128: V:0  | i32.const $1
+#0.  136: V:1  | i32.const $2
+#0.  144: V:2  | i32.const $3
+#0.  152: V:3  | select 1, %[-2], %[-1]
+#0.  156: V:1  | drop
+#0.  160: V:0  | return
 select() =>
 >>> running export "get_local":
-#0.   89: V:0  | alloca $1
-#0.   94: V:1  | get_local $1
-#0.   99: V:2  | drop
-#0.  100: V:1  | drop
-#0.  101: V:0  | return
+#0.  164: V:0  | alloca $1
+#0.  172: V:1  | get_local $1
+#0.  180: V:2  | drop
+#0.  184: V:1  | drop
+#0.  188: V:0  | return
 get_local() =>
 >>> running export "set_local":
-#0.  102: V:0  | alloca $1
-#0.  107: V:1  | i32.const $1
-#0.  112: V:2  | set_local $1, 1
-#0.  117: V:1  | drop
-#0.  118: V:0  | return
+#0.  192: V:0  | alloca $1
+#0.  200: V:1  | i32.const $1
+#0.  208: V:2  | set_local $1, 1
+#0.  216: V:1  | drop
+#0.  220: V:0  | return
 set_local() =>
 >>> running export "tee_local":
-#0.  119: V:0  | alloca $1
-#0.  124: V:1  | i32.const $1
-#0.  129: V:2  | tee_local $2, 1
-#0.  134: V:2  | drop
-#0.  135: V:1  | drop
-#0.  136: V:0  | return
+#0.  224: V:0  | alloca $1
+#0.  232: V:1  | i32.const $1
+#0.  240: V:2  | tee_local $2, 1
+#0.  248: V:2  | drop
+#0.  252: V:1  | drop
+#0.  256: V:0  | return
 tee_local() =>
 >>> running export "get_global":
-#0.  137: V:0  | get_global $0
-#0.  142: V:1  | drop
-#0.  143: V:0  | return
+#0.  260: V:0  | get_global $0
+#0.  268: V:1  | drop
+#0.  272: V:0  | return
 get_global() =>
 >>> running export "set_global":
-#0.  144: V:0  | i32.const $1
-#0.  149: V:1  | set_global $0, 1
-#0.  154: V:0  | return
+#0.  276: V:0  | i32.const $1
+#0.  284: V:1  | set_global $0, 1
+#0.  292: V:0  | return
 set_global() =>
 >>> running export "i32.load":
-#0.  155: V:0  | i32.const $1
-#0.  160: V:1  | i32.load $0:1+$2
-#0.  169: V:1  | drop
-#0.  170: V:0  | return
+#0.  296: V:0  | i32.const $1
+#0.  304: V:1  | i32.load $0:1+$2
+#0.  316: V:1  | drop
+#0.  320: V:0  | return
 i32.load() =>
 >>> running export "i64.load":
-#0.  171: V:0  | i32.const $1
-#0.  176: V:1  | i64.load $0:1+$2
-#0.  185: V:1  | drop
-#0.  186: V:0  | return
+#0.  324: V:0  | i32.const $1
+#0.  332: V:1  | i64.load $0:1+$2
+#0.  344: V:1  | drop
+#0.  348: V:0  | return
 i64.load() =>
 >>> running export "f32.load":
-#0.  187: V:0  | i32.const $1
-#0.  192: V:1  | f32.load $0:1+$2
-#0.  201: V:1  | drop
-#0.  202: V:0  | return
+#0.  352: V:0  | i32.const $1
+#0.  360: V:1  | f32.load $0:1+$2
+#0.  372: V:1  | drop
+#0.  376: V:0  | return
 f32.load() =>
 >>> running export "f64.load":
-#0.  203: V:0  | i32.const $1
-#0.  208: V:1  | f64.load $0:1+$2
-#0.  217: V:1  | drop
-#0.  218: V:0  | return
+#0.  380: V:0  | i32.const $1
+#0.  388: V:1  | f64.load $0:1+$2
+#0.  400: V:1  | drop
+#0.  404: V:0  | return
 f64.load() =>
 >>> running export "i32.load8_s":
-#0.  219: V:0  | i32.const $1
-#0.  224: V:1  | i32.load8_s $0:1+$2
-#0.  233: V:1  | drop
-#0.  234: V:0  | return
+#0.  408: V:0  | i32.const $1
+#0.  416: V:1  | i32.load8_s $0:1+$2
+#0.  428: V:1  | drop
+#0.  432: V:0  | return
 i32.load8_s() =>
 >>> running export "i32.load8_u":
-#0.  235: V:0  | i32.const $1
-#0.  240: V:1  | i32.load8_u $0:1+$2
-#0.  249: V:1  | drop
-#0.  250: V:0  | return
+#0.  436: V:0  | i32.const $1
+#0.  444: V:1  | i32.load8_u $0:1+$2
+#0.  456: V:1  | drop
+#0.  460: V:0  | return
 i32.load8_u() =>
 >>> running export "i32.load16_s":
-#0.  251: V:0  | i32.const $1
-#0.  256: V:1  | i32.load16_s $0:1+$2
-#0.  265: V:1  | drop
-#0.  266: V:0  | return
+#0.  464: V:0  | i32.const $1
+#0.  472: V:1  | i32.load16_s $0:1+$2
+#0.  484: V:1  | drop
+#0.  488: V:0  | return
 i32.load16_s() =>
 >>> running export "i32.load16_u":
-#0.  267: V:0  | i32.const $1
-#0.  272: V:1  | i32.load16_u $0:1+$2
-#0.  281: V:1  | drop
-#0.  282: V:0  | return
+#0.  492: V:0  | i32.const $1
+#0.  500: V:1  | i32.load16_u $0:1+$2
+#0.  512: V:1  | drop
+#0.  516: V:0  | return
 i32.load16_u() =>
 >>> running export "i64.load8_s":
-#0.  283: V:0  | i32.const $1
-#0.  288: V:1  | i64.load8_s $0:1+$2
-#0.  297: V:1  | drop
-#0.  298: V:0  | return
+#0.  520: V:0  | i32.const $1
+#0.  528: V:1  | i64.load8_s $0:1+$2
+#0.  540: V:1  | drop
+#0.  544: V:0  | return
 i64.load8_s() =>
 >>> running export "i64.load8_u":
-#0.  299: V:0  | i32.const $1
-#0.  304: V:1  | i64.load8_u $0:1+$2
-#0.  313: V:1  | drop
-#0.  314: V:0  | return
+#0.  548: V:0  | i32.const $1
+#0.  556: V:1  | i64.load8_u $0:1+$2
+#0.  568: V:1  | drop
+#0.  572: V:0  | return
 i64.load8_u() =>
 >>> running export "i64.load16_s":
-#0.  315: V:0  | i32.const $1
-#0.  320: V:1  | i64.load16_s $0:1+$2
-#0.  329: V:1  | drop
-#0.  330: V:0  | return
+#0.  576: V:0  | i32.const $1
+#0.  584: V:1  | i64.load16_s $0:1+$2
+#0.  596: V:1  | drop
+#0.  600: V:0  | return
 i64.load16_s() =>
 >>> running export "i64.load16_u":
-#0.  331: V:0  | i32.const $1
-#0.  336: V:1  | i64.load16_u $0:1+$2
-#0.  345: V:1  | drop
-#0.  346: V:0  | return
+#0.  604: V:0  | i32.const $1
+#0.  612: V:1  | i64.load16_u $0:1+$2
+#0.  624: V:1  | drop
+#0.  628: V:0  | return
 i64.load16_u() =>
 >>> running export "i64.load32_s":
-#0.  347: V:0  | i32.const $1
-#0.  352: V:1  | i64.load32_s $0:1+$2
-#0.  361: V:1  | drop
-#0.  362: V:0  | return
+#0.  632: V:0  | i32.const $1
+#0.  640: V:1  | i64.load32_s $0:1+$2
+#0.  652: V:1  | drop
+#0.  656: V:0  | return
 i64.load32_s() =>
 >>> running export "i64.load32_u":
-#0.  363: V:0  | i32.const $1
-#0.  368: V:1  | i64.load32_u $0:1+$2
-#0.  377: V:1  | drop
-#0.  378: V:0  | return
+#0.  660: V:0  | i32.const $1
+#0.  668: V:1  | i64.load32_u $0:1+$2
+#0.  680: V:1  | drop
+#0.  684: V:0  | return
 i64.load32_u() =>
 >>> running export "i32.store":
-#0.  379: V:0  | i32.const $1
-#0.  384: V:1  | i32.const $2
-#0.  389: V:2  | i32.store $0:1+$2, 2
-#0.  398: V:0  | return
+#0.  688: V:0  | i32.const $1
+#0.  696: V:1  | i32.const $2
+#0.  704: V:2  | i32.store $0:1+$2, 2
+#0.  716: V:0  | return
 i32.store() =>
 >>> running export "i64.store":
-#0.  399: V:0  | i32.const $1
-#0.  404: V:1  | i64.const $2
-#0.  413: V:2  | i64.store $0:1+$2, 2
-#0.  422: V:0  | return
+#0.  720: V:0  | i32.const $1
+#0.  728: V:1  | i64.const $2
+#0.  740: V:2  | i64.store $0:1+$2, 2
+#0.  752: V:0  | return
 i64.store() =>
 >>> running export "f32.store":
-#0.  423: V:0  | i32.const $1
-#0.  428: V:1  | f32.const $2
-#0.  433: V:2  | f32.store $0:1+$2, 2
-#0.  442: V:0  | return
+#0.  756: V:0  | i32.const $1
+#0.  764: V:1  | f32.const $2
+#0.  772: V:2  | f32.store $0:1+$2, 2
+#0.  784: V:0  | return
 f32.store() =>
 >>> running export "f64.store":
-#0.  443: V:0  | i32.const $1
-#0.  448: V:1  | f64.const $2
-#0.  457: V:2  | f64.store $0:1+$2, 2
-#0.  466: V:0  | return
+#0.  788: V:0  | i32.const $1
+#0.  796: V:1  | f64.const $2
+#0.  808: V:2  | f64.store $0:1+$2, 2
+#0.  820: V:0  | return
 f64.store() =>
 >>> running export "i32.store8":
-#0.  467: V:0  | i32.const $1
-#0.  472: V:1  | i32.const $2
-#0.  477: V:2  | i32.store8 $0:1+$2, 2
-#0.  486: V:0  | return
+#0.  824: V:0  | i32.const $1
+#0.  832: V:1  | i32.const $2
+#0.  840: V:2  | i32.store8 $0:1+$2, 2
+#0.  852: V:0  | return
 i32.store8() =>
 >>> running export "i32.store16":
-#0.  487: V:0  | i32.const $1
-#0.  492: V:1  | i32.const $2
-#0.  497: V:2  | i32.store16 $0:1+$2, 2
-#0.  506: V:0  | return
+#0.  856: V:0  | i32.const $1
+#0.  864: V:1  | i32.const $2
+#0.  872: V:2  | i32.store16 $0:1+$2, 2
+#0.  884: V:0  | return
 i32.store16() =>
 >>> running export "i64.store8":
-#0.  507: V:0  | i32.const $1
-#0.  512: V:1  | i64.const $2
-#0.  521: V:2  | i64.store8 $0:1+$2, 2
-#0.  530: V:0  | return
+#0.  888: V:0  | i32.const $1
+#0.  896: V:1  | i64.const $2
+#0.  908: V:2  | i64.store8 $0:1+$2, 2
+#0.  920: V:0  | return
 i64.store8() =>
 >>> running export "i64.store16":
-#0.  531: V:0  | i32.const $1
-#0.  536: V:1  | i64.const $2
-#0.  545: V:2  | i64.store16 $0:1+$2, 2
-#0.  554: V:0  | return
+#0.  924: V:0  | i32.const $1
+#0.  932: V:1  | i64.const $2
+#0.  944: V:2  | i64.store16 $0:1+$2, 2
+#0.  956: V:0  | return
 i64.store16() =>
 >>> running export "i64.store32":
-#0.  555: V:0  | i32.const $1
-#0.  560: V:1  | i64.const $2
-#0.  569: V:2  | i64.store32 $0:1+$2, 2
-#0.  578: V:0  | return
+#0.  960: V:0  | i32.const $1
+#0.  968: V:1  | i64.const $2
+#0.  980: V:2  | i64.store32 $0:1+$2, 2
+#0.  992: V:0  | return
 i64.store32() =>
 >>> running export "current_memory":
-#0.  579: V:0  | memory.size $0
-#0.  584: V:1  | drop
-#0.  585: V:0  | return
+#0.  996: V:0  | memory.size $0
+#0. 1004: V:1  | drop
+#0. 1008: V:0  | return
 current_memory() =>
 >>> running export "grow_memory":
-#0.  586: V:0  | i32.const $1
-#0.  591: V:1  | memory.grow $0:1
-#0.  596: V:1  | drop
-#0.  597: V:0  | return
+#0. 1012: V:0  | i32.const $1
+#0. 1020: V:1  | memory.grow $0:1
+#0. 1028: V:1  | drop
+#0. 1032: V:0  | return
 grow_memory() =>
 >>> running export "i32.const":
-#0.  598: V:0  | i32.const $1
-#0.  603: V:1  | drop
-#0.  604: V:0  | return
+#0. 1036: V:0  | i32.const $1
+#0. 1044: V:1  | drop
+#0. 1048: V:0  | return
 i32.const() =>
 >>> running export "i64.const":
-#0.  605: V:0  | i64.const $1
-#0.  614: V:1  | drop
-#0.  615: V:0  | return
+#0. 1052: V:0  | i64.const $1
+#0. 1064: V:1  | drop
+#0. 1068: V:0  | return
 i64.const() =>
 >>> running export "f32.const":
-#0.  616: V:0  | f32.const $1
-#0.  621: V:1  | drop
-#0.  622: V:0  | return
+#0. 1072: V:0  | f32.const $1
+#0. 1080: V:1  | drop
+#0. 1084: V:0  | return
 f32.const() =>
 >>> running export "f64.const":
-#0.  623: V:0  | f64.const $1
-#0.  632: V:1  | drop
-#0.  633: V:0  | return
+#0. 1088: V:0  | f64.const $1
+#0. 1100: V:1  | drop
+#0. 1104: V:0  | return
 f64.const() =>
 >>> running export "i32.eqz":
-#0.  634: V:0  | i32.const $1
-#0.  639: V:1  | i32.eqz 1
-#0.  640: V:1  | drop
-#0.  641: V:0  | return
+#0. 1108: V:0  | i32.const $1
+#0. 1116: V:1  | i32.eqz 1
+#0. 1120: V:1  | drop
+#0. 1124: V:0  | return
 i32.eqz() =>
 >>> running export "i32.eq":
-#0.  642: V:0  | i32.const $1
-#0.  647: V:1  | i32.const $2
-#0.  652: V:2  | i32.eq 1, 2
-#0.  653: V:1  | drop
-#0.  654: V:0  | return
+#0. 1128: V:0  | i32.const $1
+#0. 1136: V:1  | i32.const $2
+#0. 1144: V:2  | i32.eq 1, 2
+#0. 1148: V:1  | drop
+#0. 1152: V:0  | return
 i32.eq() =>
 >>> running export "i32.ne":
-#0.  655: V:0  | i32.const $1
-#0.  660: V:1  | i32.const $2
-#0.  665: V:2  | i32.ne 1, 2
-#0.  666: V:1  | drop
-#0.  667: V:0  | return
+#0. 1156: V:0  | i32.const $1
+#0. 1164: V:1  | i32.const $2
+#0. 1172: V:2  | i32.ne 1, 2
+#0. 1176: V:1  | drop
+#0. 1180: V:0  | return
 i32.ne() =>
 >>> running export "i32.lt_s":
-#0.  668: V:0  | i32.const $1
-#0.  673: V:1  | i32.const $2
-#0.  678: V:2  | i32.lt_s 1, 2
-#0.  679: V:1  | drop
-#0.  680: V:0  | return
+#0. 1184: V:0  | i32.const $1
+#0. 1192: V:1  | i32.const $2
+#0. 1200: V:2  | i32.lt_s 1, 2
+#0. 1204: V:1  | drop
+#0. 1208: V:0  | return
 i32.lt_s() =>
 >>> running export "i32.lt_u":
-#0.  681: V:0  | i32.const $1
-#0.  686: V:1  | i32.const $2
-#0.  691: V:2  | i32.lt_u 1, 2
-#0.  692: V:1  | drop
-#0.  693: V:0  | return
+#0. 1212: V:0  | i32.const $1
+#0. 1220: V:1  | i32.const $2
+#0. 1228: V:2  | i32.lt_u 1, 2
+#0. 1232: V:1  | drop
+#0. 1236: V:0  | return
 i32.lt_u() =>
 >>> running export "i32.gt_s":
-#0.  694: V:0  | i32.const $1
-#0.  699: V:1  | i32.const $2
-#0.  704: V:2  | i32.gt_s 1, 2
-#0.  705: V:1  | drop
-#0.  706: V:0  | return
+#0. 1240: V:0  | i32.const $1
+#0. 1248: V:1  | i32.const $2
+#0. 1256: V:2  | i32.gt_s 1, 2
+#0. 1260: V:1  | drop
+#0. 1264: V:0  | return
 i32.gt_s() =>
 >>> running export "i32.gt_u":
-#0.  707: V:0  | i32.const $1
-#0.  712: V:1  | i32.const $2
-#0.  717: V:2  | i32.gt_u 1, 2
-#0.  718: V:1  | drop
-#0.  719: V:0  | return
+#0. 1268: V:0  | i32.const $1
+#0. 1276: V:1  | i32.const $2
+#0. 1284: V:2  | i32.gt_u 1, 2
+#0. 1288: V:1  | drop
+#0. 1292: V:0  | return
 i32.gt_u() =>
 >>> running export "i32.le_s":
-#0.  720: V:0  | i32.const $1
-#0.  725: V:1  | i32.const $2
-#0.  730: V:2  | i32.le_s 1, 2
-#0.  731: V:1  | drop
-#0.  732: V:0  | return
+#0. 1296: V:0  | i32.const $1
+#0. 1304: V:1  | i32.const $2
+#0. 1312: V:2  | i32.le_s 1, 2
+#0. 1316: V:1  | drop
+#0. 1320: V:0  | return
 i32.le_s() =>
 >>> running export "i32.le_u":
-#0.  733: V:0  | i32.const $1
-#0.  738: V:1  | i32.const $2
-#0.  743: V:2  | i32.le_u 1, 2
-#0.  744: V:1  | drop
-#0.  745: V:0  | return
+#0. 1324: V:0  | i32.const $1
+#0. 1332: V:1  | i32.const $2
+#0. 1340: V:2  | i32.le_u 1, 2
+#0. 1344: V:1  | drop
+#0. 1348: V:0  | return
 i32.le_u() =>
 >>> running export "i32.ge_s":
-#0.  746: V:0  | i32.const $1
-#0.  751: V:1  | i32.const $2
-#0.  756: V:2  | i32.ge_s 1, 2
-#0.  757: V:1  | drop
-#0.  758: V:0  | return
+#0. 1352: V:0  | i32.const $1
+#0. 1360: V:1  | i32.const $2
+#0. 1368: V:2  | i32.ge_s 1, 2
+#0. 1372: V:1  | drop
+#0. 1376: V:0  | return
 i32.ge_s() =>
 >>> running export "i32.ge_u":
-#0.  759: V:0  | i32.const $1
-#0.  764: V:1  | i32.const $2
-#0.  769: V:2  | i32.ge_u 1, 2
-#0.  770: V:1  | drop
-#0.  771: V:0  | return
+#0. 1380: V:0  | i32.const $1
+#0. 1388: V:1  | i32.const $2
+#0. 1396: V:2  | i32.ge_u 1, 2
+#0. 1400: V:1  | drop
+#0. 1404: V:0  | return
 i32.ge_u() =>
 >>> running export "i64.eqz":
-#0.  772: V:0  | i64.const $1
-#0.  781: V:1  | i64.eqz 1
-#0.  782: V:1  | drop
-#0.  783: V:0  | return
+#0. 1408: V:0  | i64.const $1
+#0. 1420: V:1  | i64.eqz 1
+#0. 1424: V:1  | drop
+#0. 1428: V:0  | return
 i64.eqz() =>
 >>> running export "i64.eq":
-#0.  784: V:0  | i64.const $1
-#0.  793: V:1  | i64.const $2
-#0.  802: V:2  | i64.eq 1, 2
-#0.  803: V:1  | drop
-#0.  804: V:0  | return
+#0. 1432: V:0  | i64.const $1
+#0. 1444: V:1  | i64.const $2
+#0. 1456: V:2  | i64.eq 1, 2
+#0. 1460: V:1  | drop
+#0. 1464: V:0  | return
 i64.eq() =>
 >>> running export "i64.ne":
-#0.  805: V:0  | i64.const $1
-#0.  814: V:1  | i64.const $2
-#0.  823: V:2  | i64.ne 1, 2
-#0.  824: V:1  | drop
-#0.  825: V:0  | return
+#0. 1468: V:0  | i64.const $1
+#0. 1480: V:1  | i64.const $2
+#0. 1492: V:2  | i64.ne 1, 2
+#0. 1496: V:1  | drop
+#0. 1500: V:0  | return
 i64.ne() =>
 >>> running export "i64.lt_s":
-#0.  826: V:0  | i64.const $1
-#0.  835: V:1  | i64.const $2
-#0.  844: V:2  | i64.lt_s 1, 2
-#0.  845: V:1  | drop
-#0.  846: V:0  | return
+#0. 1504: V:0  | i64.const $1
+#0. 1516: V:1  | i64.const $2
+#0. 1528: V:2  | i64.lt_s 1, 2
+#0. 1532: V:1  | drop
+#0. 1536: V:0  | return
 i64.lt_s() =>
 >>> running export "i64.lt_u":
-#0.  847: V:0  | i64.const $1
-#0.  856: V:1  | i64.const $2
-#0.  865: V:2  | i64.lt_u 1, 2
-#0.  866: V:1  | drop
-#0.  867: V:0  | return
+#0. 1540: V:0  | i64.const $1
+#0. 1552: V:1  | i64.const $2
+#0. 1564: V:2  | i64.lt_u 1, 2
+#0. 1568: V:1  | drop
+#0. 1572: V:0  | return
 i64.lt_u() =>
 >>> running export "i64.gt_s":
-#0.  868: V:0  | i64.const $1
-#0.  877: V:1  | i64.const $2
-#0.  886: V:2  | i64.gt_s 1, 2
-#0.  887: V:1  | drop
-#0.  888: V:0  | return
+#0. 1576: V:0  | i64.const $1
+#0. 1588: V:1  | i64.const $2
+#0. 1600: V:2  | i64.gt_s 1, 2
+#0. 1604: V:1  | drop
+#0. 1608: V:0  | return
 i64.gt_s() =>
 >>> running export "i64.gt_u":
-#0.  889: V:0  | i64.const $1
-#0.  898: V:1  | i64.const $2
-#0.  907: V:2  | i64.gt_u 1, 2
-#0.  908: V:1  | drop
-#0.  909: V:0  | return
+#0. 1612: V:0  | i64.const $1
+#0. 1624: V:1  | i64.const $2
+#0. 1636: V:2  | i64.gt_u 1, 2
+#0. 1640: V:1  | drop
+#0. 1644: V:0  | return
 i64.gt_u() =>
 >>> running export "i64.le_s":
-#0.  910: V:0  | i64.const $1
-#0.  919: V:1  | i64.const $2
-#0.  928: V:2  | i64.le_s 1, 2
-#0.  929: V:1  | drop
-#0.  930: V:0  | return
+#0. 1648: V:0  | i64.const $1
+#0. 1660: V:1  | i64.const $2
+#0. 1672: V:2  | i64.le_s 1, 2
+#0. 1676: V:1  | drop
+#0. 1680: V:0  | return
 i64.le_s() =>
 >>> running export "i64.le_u":
-#0.  931: V:0  | i64.const $1
-#0.  940: V:1  | i64.const $2
-#0.  949: V:2  | i64.le_u 1, 2
-#0.  950: V:1  | drop
-#0.  951: V:0  | return
+#0. 1684: V:0  | i64.const $1
+#0. 1696: V:1  | i64.const $2
+#0. 1708: V:2  | i64.le_u 1, 2
+#0. 1712: V:1  | drop
+#0. 1716: V:0  | return
 i64.le_u() =>
 >>> running export "i64.ge_s":
-#0.  952: V:0  | i64.const $1
-#0.  961: V:1  | i64.const $2
-#0.  970: V:2  | i64.ge_s 1, 2
-#0.  971: V:1  | drop
-#0.  972: V:0  | return
+#0. 1720: V:0  | i64.const $1
+#0. 1732: V:1  | i64.const $2
+#0. 1744: V:2  | i64.ge_s 1, 2
+#0. 1748: V:1  | drop
+#0. 1752: V:0  | return
 i64.ge_s() =>
 >>> running export "i64.ge_u":
-#0.  973: V:0  | i64.const $1
-#0.  982: V:1  | i64.const $2
-#0.  991: V:2  | i64.ge_u 1, 2
-#0.  992: V:1  | drop
-#0.  993: V:0  | return
+#0. 1756: V:0  | i64.const $1
+#0. 1768: V:1  | i64.const $2
+#0. 1780: V:2  | i64.ge_u 1, 2
+#0. 1784: V:1  | drop
+#0. 1788: V:0  | return
 i64.ge_u() =>
 >>> running export "f32.eq":
-#0.  994: V:0  | f32.const $1
-#0.  999: V:1  | f32.const $2
-#0. 1004: V:2  | f32.eq 1, 2
-#0. 1005: V:1  | drop
-#0. 1006: V:0  | return
+#0. 1792: V:0  | f32.const $1
+#0. 1800: V:1  | f32.const $2
+#0. 1808: V:2  | f32.eq 1, 2
+#0. 1812: V:1  | drop
+#0. 1816: V:0  | return
 f32.eq() =>
 >>> running export "f32.ne":
-#0. 1007: V:0  | f32.const $1
-#0. 1012: V:1  | f32.const $2
-#0. 1017: V:2  | f32.ne 1, 2
-#0. 1018: V:1  | drop
-#0. 1019: V:0  | return
+#0. 1820: V:0  | f32.const $1
+#0. 1828: V:1  | f32.const $2
+#0. 1836: V:2  | f32.ne 1, 2
+#0. 1840: V:1  | drop
+#0. 1844: V:0  | return
 f32.ne() =>
 >>> running export "f32.lt":
-#0. 1020: V:0  | f32.const $1
-#0. 1025: V:1  | f32.const $2
-#0. 1030: V:2  | f32.lt 1, 2
-#0. 1031: V:1  | drop
-#0. 1032: V:0  | return
+#0. 1848: V:0  | f32.const $1
+#0. 1856: V:1  | f32.const $2
+#0. 1864: V:2  | f32.lt 1, 2
+#0. 1868: V:1  | drop
+#0. 1872: V:0  | return
 f32.lt() =>
 >>> running export "f32.gt":
-#0. 1033: V:0  | f32.const $1
-#0. 1038: V:1  | f32.const $2
-#0. 1043: V:2  | f32.gt 1, 2
-#0. 1044: V:1  | drop
-#0. 1045: V:0  | return
+#0. 1876: V:0  | f32.const $1
+#0. 1884: V:1  | f32.const $2
+#0. 1892: V:2  | f32.gt 1, 2
+#0. 1896: V:1  | drop
+#0. 1900: V:0  | return
 f32.gt() =>
 >>> running export "f32.le":
-#0. 1046: V:0  | f32.const $1
-#0. 1051: V:1  | f32.const $2
-#0. 1056: V:2  | f32.le 1, 2
-#0. 1057: V:1  | drop
-#0. 1058: V:0  | return
+#0. 1904: V:0  | f32.const $1
+#0. 1912: V:1  | f32.const $2
+#0. 1920: V:2  | f32.le 1, 2
+#0. 1924: V:1  | drop
+#0. 1928: V:0  | return
 f32.le() =>
 >>> running export "f32.ge":
-#0. 1059: V:0  | f32.const $1
-#0. 1064: V:1  | f32.const $2
-#0. 1069: V:2  | f32.ge 1, 2
-#0. 1070: V:1  | drop
-#0. 1071: V:0  | return
+#0. 1932: V:0  | f32.const $1
+#0. 1940: V:1  | f32.const $2
+#0. 1948: V:2  | f32.ge 1, 2
+#0. 1952: V:1  | drop
+#0. 1956: V:0  | return
 f32.ge() =>
 >>> running export "f64.eq":
-#0. 1072: V:0  | f64.const $1
-#0. 1081: V:1  | f64.const $2
-#0. 1090: V:2  | f64.eq 1, 2
-#0. 1091: V:1  | drop
-#0. 1092: V:0  | return
+#0. 1960: V:0  | f64.const $1
+#0. 1972: V:1  | f64.const $2
+#0. 1984: V:2  | f64.eq 1, 2
+#0. 1988: V:1  | drop
+#0. 1992: V:0  | return
 f64.eq() =>
 >>> running export "f64.ne":
-#0. 1093: V:0  | f64.const $1
-#0. 1102: V:1  | f64.const $2
-#0. 1111: V:2  | f64.ne 1, 2
-#0. 1112: V:1  | drop
-#0. 1113: V:0  | return
+#0. 1996: V:0  | f64.const $1
+#0. 2008: V:1  | f64.const $2
+#0. 2020: V:2  | f64.ne 1, 2
+#0. 2024: V:1  | drop
+#0. 2028: V:0  | return
 f64.ne() =>
 >>> running export "f64.lt":
-#0. 1114: V:0  | f64.const $1
-#0. 1123: V:1  | f64.const $2
-#0. 1132: V:2  | f64.lt 1, 2
-#0. 1133: V:1  | drop
-#0. 1134: V:0  | return
+#0. 2032: V:0  | f64.const $1
+#0. 2044: V:1  | f64.const $2
+#0. 2056: V:2  | f64.lt 1, 2
+#0. 2060: V:1  | drop
+#0. 2064: V:0  | return
 f64.lt() =>
 >>> running export "f64.gt":
-#0. 1135: V:0  | f64.const $1
-#0. 1144: V:1  | f64.const $2
-#0. 1153: V:2  | f64.gt 1, 2
-#0. 1154: V:1  | drop
-#0. 1155: V:0  | return
+#0. 2068: V:0  | f64.const $1
+#0. 2080: V:1  | f64.const $2
+#0. 2092: V:2  | f64.gt 1, 2
+#0. 2096: V:1  | drop
+#0. 2100: V:0  | return
 f64.gt() =>
 >>> running export "f64.le":
-#0. 1156: V:0  | f64.const $1
-#0. 1165: V:1  | f64.const $2
-#0. 1174: V:2  | f64.le 1, 2
-#0. 1175: V:1  | drop
-#0. 1176: V:0  | return
+#0. 2104: V:0  | f64.const $1
+#0. 2116: V:1  | f64.const $2
+#0. 2128: V:2  | f64.le 1, 2
+#0. 2132: V:1  | drop
+#0. 2136: V:0  | return
 f64.le() =>
 >>> running export "f64.ge":
-#0. 1177: V:0  | f64.const $1
-#0. 1186: V:1  | f64.const $2
-#0. 1195: V:2  | f64.ge 1, 2
-#0. 1196: V:1  | drop
-#0. 1197: V:0  | return
+#0. 2140: V:0  | f64.const $1
+#0. 2152: V:1  | f64.const $2
+#0. 2164: V:2  | f64.ge 1, 2
+#0. 2168: V:1  | drop
+#0. 2172: V:0  | return
 f64.ge() =>
 >>> running export "i32.clz":
-#0. 1198: V:0  | i32.const $1
-#0. 1203: V:1  | i32.clz 1
-#0. 1204: V:1  | drop
-#0. 1205: V:0  | return
+#0. 2176: V:0  | i32.const $1
+#0. 2184: V:1  | i32.clz 1
+#0. 2188: V:1  | drop
+#0. 2192: V:0  | return
 i32.clz() =>
 >>> running export "i32.ctz":
-#0. 1206: V:0  | i32.const $1
-#0. 1211: V:1  | i32.ctz 1
-#0. 1212: V:1  | drop
-#0. 1213: V:0  | return
+#0. 2196: V:0  | i32.const $1
+#0. 2204: V:1  | i32.ctz 1
+#0. 2208: V:1  | drop
+#0. 2212: V:0  | return
 i32.ctz() =>
 >>> running export "i32.popcnt":
-#0. 1214: V:0  | i32.const $1
-#0. 1219: V:1  | i32.popcnt 1
-#0. 1220: V:1  | drop
-#0. 1221: V:0  | return
+#0. 2216: V:0  | i32.const $1
+#0. 2224: V:1  | i32.popcnt 1
+#0. 2228: V:1  | drop
+#0. 2232: V:0  | return
 i32.popcnt() =>
 >>> running export "i32.add":
-#0. 1222: V:0  | i32.const $1
-#0. 1227: V:1  | i32.const $2
-#0. 1232: V:2  | i32.add 1, 2
-#0. 1233: V:1  | drop
-#0. 1234: V:0  | return
+#0. 2236: V:0  | i32.const $1
+#0. 2244: V:1  | i32.const $2
+#0. 2252: V:2  | i32.add 1, 2
+#0. 2256: V:1  | drop
+#0. 2260: V:0  | return
 i32.add() =>
 >>> running export "i32.sub":
-#0. 1235: V:0  | i32.const $1
-#0. 1240: V:1  | i32.const $2
-#0. 1245: V:2  | i32.sub 1, 2
-#0. 1246: V:1  | drop
-#0. 1247: V:0  | return
+#0. 2264: V:0  | i32.const $1
+#0. 2272: V:1  | i32.const $2
+#0. 2280: V:2  | i32.sub 1, 2
+#0. 2284: V:1  | drop
+#0. 2288: V:0  | return
 i32.sub() =>
 >>> running export "i32.mul":
-#0. 1248: V:0  | i32.const $1
-#0. 1253: V:1  | i32.const $2
-#0. 1258: V:2  | i32.mul 1, 2
-#0. 1259: V:1  | drop
-#0. 1260: V:0  | return
+#0. 2292: V:0  | i32.const $1
+#0. 2300: V:1  | i32.const $2
+#0. 2308: V:2  | i32.mul 1, 2
+#0. 2312: V:1  | drop
+#0. 2316: V:0  | return
 i32.mul() =>
 >>> running export "i32.div_s":
-#0. 1261: V:0  | i32.const $1
-#0. 1266: V:1  | i32.const $2
-#0. 1271: V:2  | i32.div_s 1, 2
-#0. 1272: V:1  | drop
-#0. 1273: V:0  | return
+#0. 2320: V:0  | i32.const $1
+#0. 2328: V:1  | i32.const $2
+#0. 2336: V:2  | i32.div_s 1, 2
+#0. 2340: V:1  | drop
+#0. 2344: V:0  | return
 i32.div_s() =>
 >>> running export "i32.div_u":
-#0. 1274: V:0  | i32.const $1
-#0. 1279: V:1  | i32.const $2
-#0. 1284: V:2  | i32.div_u 1, 2
-#0. 1285: V:1  | drop
-#0. 1286: V:0  | return
+#0. 2348: V:0  | i32.const $1
+#0. 2356: V:1  | i32.const $2
+#0. 2364: V:2  | i32.div_u 1, 2
+#0. 2368: V:1  | drop
+#0. 2372: V:0  | return
 i32.div_u() =>
 >>> running export "i32.rem_s":
-#0. 1287: V:0  | i32.const $1
-#0. 1292: V:1  | i32.const $2
-#0. 1297: V:2  | i32.rem_s 1, 2
-#0. 1298: V:1  | drop
-#0. 1299: V:0  | return
+#0. 2376: V:0  | i32.const $1
+#0. 2384: V:1  | i32.const $2
+#0. 2392: V:2  | i32.rem_s 1, 2
+#0. 2396: V:1  | drop
+#0. 2400: V:0  | return
 i32.rem_s() =>
 >>> running export "i32.rem_u":
-#0. 1300: V:0  | i32.const $1
-#0. 1305: V:1  | i32.const $2
-#0. 1310: V:2  | i32.rem_u 1, 2
-#0. 1311: V:1  | drop
-#0. 1312: V:0  | return
+#0. 2404: V:0  | i32.const $1
+#0. 2412: V:1  | i32.const $2
+#0. 2420: V:2  | i32.rem_u 1, 2
+#0. 2424: V:1  | drop
+#0. 2428: V:0  | return
 i32.rem_u() =>
 >>> running export "i32.and":
-#0. 1313: V:0  | i32.const $1
-#0. 1318: V:1  | i32.const $2
-#0. 1323: V:2  | i32.and 1, 2
-#0. 1324: V:1  | drop
-#0. 1325: V:0  | return
+#0. 2432: V:0  | i32.const $1
+#0. 2440: V:1  | i32.const $2
+#0. 2448: V:2  | i32.and 1, 2
+#0. 2452: V:1  | drop
+#0. 2456: V:0  | return
 i32.and() =>
 >>> running export "i32.or":
-#0. 1326: V:0  | i32.const $1
-#0. 1331: V:1  | i32.const $2
-#0. 1336: V:2  | i32.or 1, 2
-#0. 1337: V:1  | drop
-#0. 1338: V:0  | return
+#0. 2460: V:0  | i32.const $1
+#0. 2468: V:1  | i32.const $2
+#0. 2476: V:2  | i32.or 1, 2
+#0. 2480: V:1  | drop
+#0. 2484: V:0  | return
 i32.or() =>
 >>> running export "i32.xor":
-#0. 1339: V:0  | i32.const $1
-#0. 1344: V:1  | i32.const $2
-#0. 1349: V:2  | i32.xor 1, 2
-#0. 1350: V:1  | drop
-#0. 1351: V:0  | return
+#0. 2488: V:0  | i32.const $1
+#0. 2496: V:1  | i32.const $2
+#0. 2504: V:2  | i32.xor 1, 2
+#0. 2508: V:1  | drop
+#0. 2512: V:0  | return
 i32.xor() =>
 >>> running export "i32.shl":
-#0. 1352: V:0  | i32.const $1
-#0. 1357: V:1  | i32.const $2
-#0. 1362: V:2  | i32.shl 1, 2
-#0. 1363: V:1  | drop
-#0. 1364: V:0  | return
+#0. 2516: V:0  | i32.const $1
+#0. 2524: V:1  | i32.const $2
+#0. 2532: V:2  | i32.shl 1, 2
+#0. 2536: V:1  | drop
+#0. 2540: V:0  | return
 i32.shl() =>
 >>> running export "i32.shr_s":
-#0. 1365: V:0  | i32.const $1
-#0. 1370: V:1  | i32.const $2
-#0. 1375: V:2  | i32.shr_s 1, 2
-#0. 1376: V:1  | drop
-#0. 1377: V:0  | return
+#0. 2544: V:0  | i32.const $1
+#0. 2552: V:1  | i32.const $2
+#0. 2560: V:2  | i32.shr_s 1, 2
+#0. 2564: V:1  | drop
+#0. 2568: V:0  | return
 i32.shr_s() =>
 >>> running export "i32.shr_u":
-#0. 1378: V:0  | i32.const $1
-#0. 1383: V:1  | i32.const $2
-#0. 1388: V:2  | i32.shr_u 1, 2
-#0. 1389: V:1  | drop
-#0. 1390: V:0  | return
+#0. 2572: V:0  | i32.const $1
+#0. 2580: V:1  | i32.const $2
+#0. 2588: V:2  | i32.shr_u 1, 2
+#0. 2592: V:1  | drop
+#0. 2596: V:0  | return
 i32.shr_u() =>
 >>> running export "i32.rotl":
-#0. 1391: V:0  | i32.const $1
-#0. 1396: V:1  | i32.const $2
-#0. 1401: V:2  | i32.rotl 1, 2
-#0. 1402: V:1  | drop
-#0. 1403: V:0  | return
+#0. 2600: V:0  | i32.const $1
+#0. 2608: V:1  | i32.const $2
+#0. 2616: V:2  | i32.rotl 1, 2
+#0. 2620: V:1  | drop
+#0. 2624: V:0  | return
 i32.rotl() =>
 >>> running export "i32.rotr":
-#0. 1404: V:0  | i32.const $1
-#0. 1409: V:1  | i32.const $2
-#0. 1414: V:2  | i32.rotr 1, 2
-#0. 1415: V:1  | drop
-#0. 1416: V:0  | return
+#0. 2628: V:0  | i32.const $1
+#0. 2636: V:1  | i32.const $2
+#0. 2644: V:2  | i32.rotr 1, 2
+#0. 2648: V:1  | drop
+#0. 2652: V:0  | return
 i32.rotr() =>
 >>> running export "i64.clz":
-#0. 1417: V:0  | i64.const $1
-#0. 1426: V:1  | i64.clz 1
-#0. 1427: V:1  | drop
-#0. 1428: V:0  | return
+#0. 2656: V:0  | i64.const $1
+#0. 2668: V:1  | i64.clz 1
+#0. 2672: V:1  | drop
+#0. 2676: V:0  | return
 i64.clz() =>
 >>> running export "i64.ctz":
-#0. 1429: V:0  | i64.const $1
-#0. 1438: V:1  | i64.ctz 1
-#0. 1439: V:1  | drop
-#0. 1440: V:0  | return
+#0. 2680: V:0  | i64.const $1
+#0. 2692: V:1  | i64.ctz 1
+#0. 2696: V:1  | drop
+#0. 2700: V:0  | return
 i64.ctz() =>
 >>> running export "i64.popcnt":
-#0. 1441: V:0  | i64.const $1
-#0. 1450: V:1  | i64.popcnt 1
-#0. 1451: V:1  | drop
-#0. 1452: V:0  | return
+#0. 2704: V:0  | i64.const $1
+#0. 2716: V:1  | i64.popcnt 1
+#0. 2720: V:1  | drop
+#0. 2724: V:0  | return
 i64.popcnt() =>
 >>> running export "i64.add":
-#0. 1453: V:0  | i64.const $1
-#0. 1462: V:1  | i64.const $2
-#0. 1471: V:2  | i64.add 1, 2
-#0. 1472: V:1  | drop
-#0. 1473: V:0  | return
+#0. 2728: V:0  | i64.const $1
+#0. 2740: V:1  | i64.const $2
+#0. 2752: V:2  | i64.add 1, 2
+#0. 2756: V:1  | drop
+#0. 2760: V:0  | return
 i64.add() =>
 >>> running export "i64.sub":
-#0. 1474: V:0  | i64.const $1
-#0. 1483: V:1  | i64.const $2
-#0. 1492: V:2  | i64.sub 1, 2
-#0. 1493: V:1  | drop
-#0. 1494: V:0  | return
+#0. 2764: V:0  | i64.const $1
+#0. 2776: V:1  | i64.const $2
+#0. 2788: V:2  | i64.sub 1, 2
+#0. 2792: V:1  | drop
+#0. 2796: V:0  | return
 i64.sub() =>
 >>> running export "i64.mul":
-#0. 1495: V:0  | i64.const $1
-#0. 1504: V:1  | i64.const $2
-#0. 1513: V:2  | i64.mul 1, 2
-#0. 1514: V:1  | drop
-#0. 1515: V:0  | return
+#0. 2800: V:0  | i64.const $1
+#0. 2812: V:1  | i64.const $2
+#0. 2824: V:2  | i64.mul 1, 2
+#0. 2828: V:1  | drop
+#0. 2832: V:0  | return
 i64.mul() =>
 >>> running export "i64.div_s":
-#0. 1516: V:0  | i64.const $1
-#0. 1525: V:1  | i64.const $2
-#0. 1534: V:2  | i64.div_s 1, 2
-#0. 1535: V:1  | drop
-#0. 1536: V:0  | return
+#0. 2836: V:0  | i64.const $1
+#0. 2848: V:1  | i64.const $2
+#0. 2860: V:2  | i64.div_s 1, 2
+#0. 2864: V:1  | drop
+#0. 2868: V:0  | return
 i64.div_s() =>
 >>> running export "i64.div_u":
-#0. 1537: V:0  | i64.const $1
-#0. 1546: V:1  | i64.const $2
-#0. 1555: V:2  | i64.div_u 1, 2
-#0. 1556: V:1  | drop
-#0. 1557: V:0  | return
+#0. 2872: V:0  | i64.const $1
+#0. 2884: V:1  | i64.const $2
+#0. 2896: V:2  | i64.div_u 1, 2
+#0. 2900: V:1  | drop
+#0. 2904: V:0  | return
 i64.div_u() =>
 >>> running export "i64.rem_s":
-#0. 1558: V:0  | i64.const $1
-#0. 1567: V:1  | i64.const $2
-#0. 1576: V:2  | i64.rem_s 1, 2
-#0. 1577: V:1  | drop
-#0. 1578: V:0  | return
+#0. 2908: V:0  | i64.const $1
+#0. 2920: V:1  | i64.const $2
+#0. 2932: V:2  | i64.rem_s 1, 2
+#0. 2936: V:1  | drop
+#0. 2940: V:0  | return
 i64.rem_s() =>
 >>> running export "i64.rem_u":
-#0. 1579: V:0  | i64.const $1
-#0. 1588: V:1  | i64.const $2
-#0. 1597: V:2  | i64.rem_u 1, 2
-#0. 1598: V:1  | drop
-#0. 1599: V:0  | return
+#0. 2944: V:0  | i64.const $1
+#0. 2956: V:1  | i64.const $2
+#0. 2968: V:2  | i64.rem_u 1, 2
+#0. 2972: V:1  | drop
+#0. 2976: V:0  | return
 i64.rem_u() =>
 >>> running export "i64.and":
-#0. 1600: V:0  | i64.const $1
-#0. 1609: V:1  | i64.const $2
-#0. 1618: V:2  | i64.and 1, 2
-#0. 1619: V:1  | drop
-#0. 1620: V:0  | return
+#0. 2980: V:0  | i64.const $1
+#0. 2992: V:1  | i64.const $2
+#0. 3004: V:2  | i64.and 1, 2
+#0. 3008: V:1  | drop
+#0. 3012: V:0  | return
 i64.and() =>
 >>> running export "i64.or":
-#0. 1621: V:0  | i64.const $1
-#0. 1630: V:1  | i64.const $2
-#0. 1639: V:2  | i64.or 1, 2
-#0. 1640: V:1  | drop
-#0. 1641: V:0  | return
+#0. 3016: V:0  | i64.const $1
+#0. 3028: V:1  | i64.const $2
+#0. 3040: V:2  | i64.or 1, 2
+#0. 3044: V:1  | drop
+#0. 3048: V:0  | return
 i64.or() =>
 >>> running export "i64.xor":
-#0. 1642: V:0  | i64.const $1
-#0. 1651: V:1  | i64.const $2
-#0. 1660: V:2  | i64.xor 1, 2
-#0. 1661: V:1  | drop
-#0. 1662: V:0  | return
+#0. 3052: V:0  | i64.const $1
+#0. 3064: V:1  | i64.const $2
+#0. 3076: V:2  | i64.xor 1, 2
+#0. 3080: V:1  | drop
+#0. 3084: V:0  | return
 i64.xor() =>
 >>> running export "i64.shl":
-#0. 1663: V:0  | i64.const $1
-#0. 1672: V:1  | i64.const $2
-#0. 1681: V:2  | i64.shl 1, 2
-#0. 1682: V:1  | drop
-#0. 1683: V:0  | return
+#0. 3088: V:0  | i64.const $1
+#0. 3100: V:1  | i64.const $2
+#0. 3112: V:2  | i64.shl 1, 2
+#0. 3116: V:1  | drop
+#0. 3120: V:0  | return
 i64.shl() =>
 >>> running export "i64.shr_s":
-#0. 1684: V:0  | i64.const $1
-#0. 1693: V:1  | i64.const $2
-#0. 1702: V:2  | i64.shr_s 1, 2
-#0. 1703: V:1  | drop
-#0. 1704: V:0  | return
+#0. 3124: V:0  | i64.const $1
+#0. 3136: V:1  | i64.const $2
+#0. 3148: V:2  | i64.shr_s 1, 2
+#0. 3152: V:1  | drop
+#0. 3156: V:0  | return
 i64.shr_s() =>
 >>> running export "i64.shr_u":
-#0. 1705: V:0  | i64.const $1
-#0. 1714: V:1  | i64.const $2
-#0. 1723: V:2  | i64.shr_u 1, 2
-#0. 1724: V:1  | drop
-#0. 1725: V:0  | return
+#0. 3160: V:0  | i64.const $1
+#0. 3172: V:1  | i64.const $2
+#0. 3184: V:2  | i64.shr_u 1, 2
+#0. 3188: V:1  | drop
+#0. 3192: V:0  | return
 i64.shr_u() =>
 >>> running export "i64.rotl":
-#0. 1726: V:0  | i64.const $1
-#0. 1735: V:1  | i64.const $2
-#0. 1744: V:2  | i64.rotl 1, 2
-#0. 1745: V:1  | drop
-#0. 1746: V:0  | return
+#0. 3196: V:0  | i64.const $1
+#0. 3208: V:1  | i64.const $2
+#0. 3220: V:2  | i64.rotl 1, 2
+#0. 3224: V:1  | drop
+#0. 3228: V:0  | return
 i64.rotl() =>
 >>> running export "i64.rotr":
-#0. 1747: V:0  | i64.const $1
-#0. 1756: V:1  | i64.const $2
-#0. 1765: V:2  | i64.rotr 1, 2
-#0. 1766: V:1  | drop
-#0. 1767: V:0  | return
+#0. 3232: V:0  | i64.const $1
+#0. 3244: V:1  | i64.const $2
+#0. 3256: V:2  | i64.rotr 1, 2
+#0. 3260: V:1  | drop
+#0. 3264: V:0  | return
 i64.rotr() =>
 >>> running export "f32.abs":
-#0. 1768: V:0  | f32.const $1
-#0. 1773: V:1  | f32.abs 1
-#0. 1774: V:1  | drop
-#0. 1775: V:0  | return
+#0. 3268: V:0  | f32.const $1
+#0. 3276: V:1  | f32.abs 1
+#0. 3280: V:1  | drop
+#0. 3284: V:0  | return
 f32.abs() =>
 >>> running export "f32.neg":
-#0. 1776: V:0  | f32.const $1
-#0. 1781: V:1  | f32.neg 1
-#0. 1782: V:1  | drop
-#0. 1783: V:0  | return
+#0. 3288: V:0  | f32.const $1
+#0. 3296: V:1  | f32.neg 1
+#0. 3300: V:1  | drop
+#0. 3304: V:0  | return
 f32.neg() =>
 >>> running export "f32.ceil":
-#0. 1784: V:0  | f32.const $1
-#0. 1789: V:1  | f32.ceil 1
-#0. 1790: V:1  | drop
-#0. 1791: V:0  | return
+#0. 3308: V:0  | f32.const $1
+#0. 3316: V:1  | f32.ceil 1
+#0. 3320: V:1  | drop
+#0. 3324: V:0  | return
 f32.ceil() =>
 >>> running export "f32.floor":
-#0. 1792: V:0  | f32.const $1
-#0. 1797: V:1  | f32.floor 1
-#0. 1798: V:1  | drop
-#0. 1799: V:0  | return
+#0. 3328: V:0  | f32.const $1
+#0. 3336: V:1  | f32.floor 1
+#0. 3340: V:1  | drop
+#0. 3344: V:0  | return
 f32.floor() =>
 >>> running export "f32.trunc":
-#0. 1800: V:0  | f32.const $1
-#0. 1805: V:1  | f32.trunc 1
-#0. 1806: V:1  | drop
-#0. 1807: V:0  | return
+#0. 3348: V:0  | f32.const $1
+#0. 3356: V:1  | f32.trunc 1
+#0. 3360: V:1  | drop
+#0. 3364: V:0  | return
 f32.trunc() =>
 >>> running export "f32.nearest":
-#0. 1808: V:0  | f32.const $1
-#0. 1813: V:1  | f32.nearest 1
-#0. 1814: V:1  | drop
-#0. 1815: V:0  | return
+#0. 3368: V:0  | f32.const $1
+#0. 3376: V:1  | f32.nearest 1
+#0. 3380: V:1  | drop
+#0. 3384: V:0  | return
 f32.nearest() =>
 >>> running export "f32.sqrt":
-#0. 1816: V:0  | f32.const $1
-#0. 1821: V:1  | f32.sqrt 1
-#0. 1822: V:1  | drop
-#0. 1823: V:0  | return
+#0. 3388: V:0  | f32.const $1
+#0. 3396: V:1  | f32.sqrt 1
+#0. 3400: V:1  | drop
+#0. 3404: V:0  | return
 f32.sqrt() =>
 >>> running export "f32.add":
-#0. 1824: V:0  | f32.const $1
-#0. 1829: V:1  | f32.const $2
-#0. 1834: V:2  | f32.add 1, 2
-#0. 1835: V:1  | drop
-#0. 1836: V:0  | return
+#0. 3408: V:0  | f32.const $1
+#0. 3416: V:1  | f32.const $2
+#0. 3424: V:2  | f32.add 1, 2
+#0. 3428: V:1  | drop
+#0. 3432: V:0  | return
 f32.add() =>
 >>> running export "f32.sub":
-#0. 1837: V:0  | f32.const $1
-#0. 1842: V:1  | f32.const $2
-#0. 1847: V:2  | f32.sub 1, 2
-#0. 1848: V:1  | drop
-#0. 1849: V:0  | return
+#0. 3436: V:0  | f32.const $1
+#0. 3444: V:1  | f32.const $2
+#0. 3452: V:2  | f32.sub 1, 2
+#0. 3456: V:1  | drop
+#0. 3460: V:0  | return
 f32.sub() =>
 >>> running export "f32.mul":
-#0. 1850: V:0  | f32.const $1
-#0. 1855: V:1  | f32.const $2
-#0. 1860: V:2  | f32.mul 1, 2
-#0. 1861: V:1  | drop
-#0. 1862: V:0  | return
+#0. 3464: V:0  | f32.const $1
+#0. 3472: V:1  | f32.const $2
+#0. 3480: V:2  | f32.mul 1, 2
+#0. 3484: V:1  | drop
+#0. 3488: V:0  | return
 f32.mul() =>
 >>> running export "f32.div":
-#0. 1863: V:0  | f32.const $1
-#0. 1868: V:1  | f32.const $2
-#0. 1873: V:2  | f32.div 1, 2
-#0. 1874: V:1  | drop
-#0. 1875: V:0  | return
+#0. 3492: V:0  | f32.const $1
+#0. 3500: V:1  | f32.const $2
+#0. 3508: V:2  | f32.div 1, 2
+#0. 3512: V:1  | drop
+#0. 3516: V:0  | return
 f32.div() =>
 >>> running export "f32.min":
-#0. 1876: V:0  | f32.const $1
-#0. 1881: V:1  | f32.const $2
-#0. 1886: V:2  | f32.min 1, 2
-#0. 1887: V:1  | drop
-#0. 1888: V:0  | return
+#0. 3520: V:0  | f32.const $1
+#0. 3528: V:1  | f32.const $2
+#0. 3536: V:2  | f32.min 1, 2
+#0. 3540: V:1  | drop
+#0. 3544: V:0  | return
 f32.min() =>
 >>> running export "f32.max":
-#0. 1889: V:0  | f32.const $1
-#0. 1894: V:1  | f32.const $2
-#0. 1899: V:2  | f32.max 1, 2
-#0. 1900: V:1  | drop
-#0. 1901: V:0  | return
+#0. 3548: V:0  | f32.const $1
+#0. 3556: V:1  | f32.const $2
+#0. 3564: V:2  | f32.max 1, 2
+#0. 3568: V:1  | drop
+#0. 3572: V:0  | return
 f32.max() =>
 >>> running export "f32.copysign":
-#0. 1902: V:0  | f32.const $1
-#0. 1907: V:1  | f32.const $2
-#0. 1912: V:2  | f32.copysign 1, 2
-#0. 1913: V:1  | drop
-#0. 1914: V:0  | return
+#0. 3576: V:0  | f32.const $1
+#0. 3584: V:1  | f32.const $2
+#0. 3592: V:2  | f32.copysign 1, 2
+#0. 3596: V:1  | drop
+#0. 3600: V:0  | return
 f32.copysign() =>
 >>> running export "f64.abs":
-#0. 1915: V:0  | f64.const $1
-#0. 1924: V:1  | f64.abs 1
-#0. 1925: V:1  | drop
-#0. 1926: V:0  | return
+#0. 3604: V:0  | f64.const $1
+#0. 3616: V:1  | f64.abs 1
+#0. 3620: V:1  | drop
+#0. 3624: V:0  | return
 f64.abs() =>
 >>> running export "f64.neg":
-#0. 1927: V:0  | f64.const $1
-#0. 1936: V:1  | f64.neg 1
-#0. 1937: V:1  | drop
-#0. 1938: V:0  | return
+#0. 3628: V:0  | f64.const $1
+#0. 3640: V:1  | f64.neg 1
+#0. 3644: V:1  | drop
+#0. 3648: V:0  | return
 f64.neg() =>
 >>> running export "f64.ceil":
-#0. 1939: V:0  | f64.const $1
-#0. 1948: V:1  | f64.ceil 1
-#0. 1949: V:1  | drop
-#0. 1950: V:0  | return
+#0. 3652: V:0  | f64.const $1
+#0. 3664: V:1  | f64.ceil 1
+#0. 3668: V:1  | drop
+#0. 3672: V:0  | return
 f64.ceil() =>
 >>> running export "f64.floor":
-#0. 1951: V:0  | f64.const $1
-#0. 1960: V:1  | f64.floor 1
-#0. 1961: V:1  | drop
-#0. 1962: V:0  | return
+#0. 3676: V:0  | f64.const $1
+#0. 3688: V:1  | f64.floor 1
+#0. 3692: V:1  | drop
+#0. 3696: V:0  | return
 f64.floor() =>
 >>> running export "f64.trunc":
-#0. 1963: V:0  | f64.const $1
-#0. 1972: V:1  | f64.trunc 1
-#0. 1973: V:1  | drop
-#0. 1974: V:0  | return
+#0. 3700: V:0  | f64.const $1
+#0. 3712: V:1  | f64.trunc 1
+#0. 3716: V:1  | drop
+#0. 3720: V:0  | return
 f64.trunc() =>
 >>> running export "f64.nearest":
-#0. 1975: V:0  | f64.const $1
-#0. 1984: V:1  | f64.nearest 1
-#0. 1985: V:1  | drop
-#0. 1986: V:0  | return
+#0. 3724: V:0  | f64.const $1
+#0. 3736: V:1  | f64.nearest 1
+#0. 3740: V:1  | drop
+#0. 3744: V:0  | return
 f64.nearest() =>
 >>> running export "f64.sqrt":
-#0. 1987: V:0  | f64.const $1
-#0. 1996: V:1  | f64.sqrt 1
-#0. 1997: V:1  | drop
-#0. 1998: V:0  | return
+#0. 3748: V:0  | f64.const $1
+#0. 3760: V:1  | f64.sqrt 1
+#0. 3764: V:1  | drop
+#0. 3768: V:0  | return
 f64.sqrt() =>
 >>> running export "f64.add":
-#0. 1999: V:0  | f64.const $1
-#0. 2008: V:1  | f64.const $2
-#0. 2017: V:2  | f64.add 1, 2
-#0. 2018: V:1  | drop
-#0. 2019: V:0  | return
+#0. 3772: V:0  | f64.const $1
+#0. 3784: V:1  | f64.const $2
+#0. 3796: V:2  | f64.add 1, 2
+#0. 3800: V:1  | drop
+#0. 3804: V:0  | return
 f64.add() =>
 >>> running export "f64.sub":
-#0. 2020: V:0  | f64.const $1
-#0. 2029: V:1  | f64.const $2
-#0. 2038: V:2  | f64.sub 1, 2
-#0. 2039: V:1  | drop
-#0. 2040: V:0  | return
+#0. 3808: V:0  | f64.const $1
+#0. 3820: V:1  | f64.const $2
+#0. 3832: V:2  | f64.sub 1, 2
+#0. 3836: V:1  | drop
+#0. 3840: V:0  | return
 f64.sub() =>
 >>> running export "f64.mul":
-#0. 2041: V:0  | f64.const $1
-#0. 2050: V:1  | f64.const $2
-#0. 2059: V:2  | f64.mul 1, 2
-#0. 2060: V:1  | drop
-#0. 2061: V:0  | return
+#0. 3844: V:0  | f64.const $1
+#0. 3856: V:1  | f64.const $2
+#0. 3868: V:2  | f64.mul 1, 2
+#0. 3872: V:1  | drop
+#0. 3876: V:0  | return
 f64.mul() =>
 >>> running export "f64.div":
-#0. 2062: V:0  | f64.const $1
-#0. 2071: V:1  | f64.const $2
-#0. 2080: V:2  | f64.div 1, 2
-#0. 2081: V:1  | drop
-#0. 2082: V:0  | return
+#0. 3880: V:0  | f64.const $1
+#0. 3892: V:1  | f64.const $2
+#0. 3904: V:2  | f64.div 1, 2
+#0. 3908: V:1  | drop
+#0. 3912: V:0  | return
 f64.div() =>
 >>> running export "f64.min":
-#0. 2083: V:0  | f64.const $1
-#0. 2092: V:1  | f64.const $2
-#0. 2101: V:2  | f64.min 1, 2
-#0. 2102: V:1  | drop
-#0. 2103: V:0  | return
+#0. 3916: V:0  | f64.const $1
+#0. 3928: V:1  | f64.const $2
+#0. 3940: V:2  | f64.min 1, 2
+#0. 3944: V:1  | drop
+#0. 3948: V:0  | return
 f64.min() =>
 >>> running export "f64.max":
-#0. 2104: V:0  | f64.const $1
-#0. 2113: V:1  | f64.const $2
-#0. 2122: V:2  | f64.max 1, 2
-#0. 2123: V:1  | drop
-#0. 2124: V:0  | return
+#0. 3952: V:0  | f64.const $1
+#0. 3964: V:1  | f64.const $2
+#0. 3976: V:2  | f64.max 1, 2
+#0. 3980: V:1  | drop
+#0. 3984: V:0  | return
 f64.max() =>
 >>> running export "f64.copysign":
-#0. 2125: V:0  | f64.const $1
-#0. 2134: V:1  | f64.const $2
-#0. 2143: V:2  | f64.copysign 1, 2
-#0. 2144: V:1  | drop
-#0. 2145: V:0  | return
+#0. 3988: V:0  | f64.const $1
+#0. 4000: V:1  | f64.const $2
+#0. 4012: V:2  | f64.copysign 1, 2
+#0. 4016: V:1  | drop
+#0. 4020: V:0  | return
 f64.copysign() =>
 >>> running export "i32.wrap/i64":
-#0. 2146: V:0  | i64.const $1
-#0. 2155: V:1  | i32.wrap/i64 1
-#0. 2156: V:1  | drop
-#0. 2157: V:0  | return
+#0. 4024: V:0  | i64.const $1
+#0. 4036: V:1  | i32.wrap/i64 1
+#0. 4040: V:1  | drop
+#0. 4044: V:0  | return
 i32.wrap/i64() =>
 >>> running export "i32.trunc_s/f32":
-#0. 2158: V:0  | f32.const $1
-#0. 2163: V:1  | i32.trunc_s/f32 1
-#0. 2164: V:1  | drop
-#0. 2165: V:0  | return
+#0. 4048: V:0  | f32.const $1
+#0. 4056: V:1  | i32.trunc_s/f32 1
+#0. 4060: V:1  | drop
+#0. 4064: V:0  | return
 i32.trunc_s/f32() =>
 >>> running export "i32.trunc_u/f32":
-#0. 2166: V:0  | f32.const $1
-#0. 2171: V:1  | i32.trunc_u/f32 1
-#0. 2172: V:1  | drop
-#0. 2173: V:0  | return
+#0. 4068: V:0  | f32.const $1
+#0. 4076: V:1  | i32.trunc_u/f32 1
+#0. 4080: V:1  | drop
+#0. 4084: V:0  | return
 i32.trunc_u/f32() =>
 >>> running export "i32.trunc_s/f64":
-#0. 2174: V:0  | f64.const $1
-#0. 2183: V:1  | i32.trunc_s/f64 1
-#0. 2184: V:1  | drop
-#0. 2185: V:0  | return
+#0. 4088: V:0  | f64.const $1
+#0. 4100: V:1  | i32.trunc_s/f64 1
+#0. 4104: V:1  | drop
+#0. 4108: V:0  | return
 i32.trunc_s/f64() =>
 >>> running export "i32.trunc_u/f64":
-#0. 2186: V:0  | f64.const $1
-#0. 2195: V:1  | i32.trunc_u/f64 1
-#0. 2196: V:1  | drop
-#0. 2197: V:0  | return
+#0. 4112: V:0  | f64.const $1
+#0. 4124: V:1  | i32.trunc_u/f64 1
+#0. 4128: V:1  | drop
+#0. 4132: V:0  | return
 i32.trunc_u/f64() =>
 >>> running export "i64.extend_s/i32":
-#0. 2198: V:0  | i32.const $1
-#0. 2203: V:1  | i64.extend_s/i32 1
-#0. 2204: V:1  | drop
-#0. 2205: V:0  | return
+#0. 4136: V:0  | i32.const $1
+#0. 4144: V:1  | i64.extend_s/i32 1
+#0. 4148: V:1  | drop
+#0. 4152: V:0  | return
 i64.extend_s/i32() =>
 >>> running export "i64.extend_u/i32":
-#0. 2206: V:0  | i32.const $1
-#0. 2211: V:1  | i64.extend_u/i32 1
-#0. 2212: V:1  | drop
-#0. 2213: V:0  | return
+#0. 4156: V:0  | i32.const $1
+#0. 4164: V:1  | i64.extend_u/i32 1
+#0. 4168: V:1  | drop
+#0. 4172: V:0  | return
 i64.extend_u/i32() =>
 >>> running export "i64.trunc_s/f32":
-#0. 2214: V:0  | f32.const $1
-#0. 2219: V:1  | i64.trunc_s/f32 1
-#0. 2220: V:1  | drop
-#0. 2221: V:0  | return
+#0. 4176: V:0  | f32.const $1
+#0. 4184: V:1  | i64.trunc_s/f32 1
+#0. 4188: V:1  | drop
+#0. 4192: V:0  | return
 i64.trunc_s/f32() =>
 >>> running export "i64.trunc_u/f32":
-#0. 2222: V:0  | f32.const $1
-#0. 2227: V:1  | i64.trunc_u/f32 1
-#0. 2228: V:1  | drop
-#0. 2229: V:0  | return
+#0. 4196: V:0  | f32.const $1
+#0. 4204: V:1  | i64.trunc_u/f32 1
+#0. 4208: V:1  | drop
+#0. 4212: V:0  | return
 i64.trunc_u/f32() =>
 >>> running export "i64.trunc_s/f64":
-#0. 2230: V:0  | f64.const $1
-#0. 2239: V:1  | i64.trunc_s/f64 1
-#0. 2240: V:1  | drop
-#0. 2241: V:0  | return
+#0. 4216: V:0  | f64.const $1
+#0. 4228: V:1  | i64.trunc_s/f64 1
+#0. 4232: V:1  | drop
+#0. 4236: V:0  | return
 i64.trunc_s/f64() =>
 >>> running export "i64.trunc_u/f64":
-#0. 2242: V:0  | f64.const $1
-#0. 2251: V:1  | i64.trunc_u/f64 1
-#0. 2252: V:1  | drop
-#0. 2253: V:0  | return
+#0. 4240: V:0  | f64.const $1
+#0. 4252: V:1  | i64.trunc_u/f64 1
+#0. 4256: V:1  | drop
+#0. 4260: V:0  | return
 i64.trunc_u/f64() =>
 >>> running export "f32.convert_s/i32":
-#0. 2254: V:0  | i32.const $1
-#0. 2259: V:1  | f32.convert_s/i32 1
-#0. 2260: V:1  | drop
-#0. 2261: V:0  | return
+#0. 4264: V:0  | i32.const $1
+#0. 4272: V:1  | f32.convert_s/i32 1
+#0. 4276: V:1  | drop
+#0. 4280: V:0  | return
 f32.convert_s/i32() =>
 >>> running export "f32.convert_u/i32":
-#0. 2262: V:0  | i32.const $1
-#0. 2267: V:1  | f32.convert_u/i32 1
-#0. 2268: V:1  | drop
-#0. 2269: V:0  | return
+#0. 4284: V:0  | i32.const $1
+#0. 4292: V:1  | f32.convert_u/i32 1
+#0. 4296: V:1  | drop
+#0. 4300: V:0  | return
 f32.convert_u/i32() =>
 >>> running export "f32.convert_s/i64":
-#0. 2270: V:0  | i64.const $1
-#0. 2279: V:1  | f32.convert_s/i64 1
-#0. 2280: V:1  | drop
-#0. 2281: V:0  | return
+#0. 4304: V:0  | i64.const $1
+#0. 4316: V:1  | f32.convert_s/i64 1
+#0. 4320: V:1  | drop
+#0. 4324: V:0  | return
 f32.convert_s/i64() =>
 >>> running export "f32.convert_u/i64":
-#0. 2282: V:0  | i64.const $1
-#0. 2291: V:1  | f32.convert_u/i64 1
-#0. 2292: V:1  | drop
-#0. 2293: V:0  | return
+#0. 4328: V:0  | i64.const $1
+#0. 4340: V:1  | f32.convert_u/i64 1
+#0. 4344: V:1  | drop
+#0. 4348: V:0  | return
 f32.convert_u/i64() =>
 >>> running export "f32.demote/f64":
-#0. 2294: V:0  | f64.const $1
-#0. 2303: V:1  | f32.demote/f64 1
-#0. 2304: V:1  | drop
-#0. 2305: V:0  | return
+#0. 4352: V:0  | f64.const $1
+#0. 4364: V:1  | f32.demote/f64 1
+#0. 4368: V:1  | drop
+#0. 4372: V:0  | return
 f32.demote/f64() =>
 >>> running export "f64.convert_s/i32":
-#0. 2306: V:0  | i32.const $1
-#0. 2311: V:1  | f64.convert_s/i32 1
-#0. 2312: V:1  | drop
-#0. 2313: V:0  | return
+#0. 4376: V:0  | i32.const $1
+#0. 4384: V:1  | f64.convert_s/i32 1
+#0. 4388: V:1  | drop
+#0. 4392: V:0  | return
 f64.convert_s/i32() =>
 >>> running export "f64.convert_u/i32":
-#0. 2314: V:0  | i32.const $1
-#0. 2319: V:1  | f64.convert_u/i32 1
-#0. 2320: V:1  | drop
-#0. 2321: V:0  | return
+#0. 4396: V:0  | i32.const $1
+#0. 4404: V:1  | f64.convert_u/i32 1
+#0. 4408: V:1  | drop
+#0. 4412: V:0  | return
 f64.convert_u/i32() =>
 >>> running export "f64.convert_s/i64":
-#0. 2322: V:0  | i64.const $1
-#0. 2331: V:1  | f64.convert_s/i64 1
-#0. 2332: V:1  | drop
-#0. 2333: V:0  | return
+#0. 4416: V:0  | i64.const $1
+#0. 4428: V:1  | f64.convert_s/i64 1
+#0. 4432: V:1  | drop
+#0. 4436: V:0  | return
 f64.convert_s/i64() =>
 >>> running export "f64.convert_u/i64":
-#0. 2334: V:0  | i64.const $1
-#0. 2343: V:1  | f64.convert_u/i64 1
-#0. 2344: V:1  | drop
-#0. 2345: V:0  | return
+#0. 4440: V:0  | i64.const $1
+#0. 4452: V:1  | f64.convert_u/i64 1
+#0. 4456: V:1  | drop
+#0. 4460: V:0  | return
 f64.convert_u/i64() =>
 >>> running export "f64.promote/f32":
-#0. 2346: V:0  | f32.const $1
-#0. 2351: V:1  | f64.promote/f32 1
-#0. 2352: V:1  | drop
-#0. 2353: V:0  | return
+#0. 4464: V:0  | f32.const $1
+#0. 4472: V:1  | f64.promote/f32 1
+#0. 4476: V:1  | drop
+#0. 4480: V:0  | return
 f64.promote/f32() =>
 >>> running export "i32.reinterpret/f32":
-#0. 2354: V:0  | i32.const $1
-#0. 2359: V:1  | f32.reinterpret/i32 1
-#0. 2360: V:1  | drop
-#0. 2361: V:0  | return
+#0. 4484: V:0  | i32.const $1
+#0. 4492: V:1  | f32.reinterpret/i32 1
+#0. 4496: V:1  | drop
+#0. 4500: V:0  | return
 i32.reinterpret/f32() =>
 >>> running export "f32.reinterpret/i32":
-#0. 2362: V:0  | f32.const $1
-#0. 2367: V:1  | i32.reinterpret/f32 1
-#0. 2368: V:1  | drop
-#0. 2369: V:0  | return
+#0. 4504: V:0  | f32.const $1
+#0. 4512: V:1  | i32.reinterpret/f32 1
+#0. 4516: V:1  | drop
+#0. 4520: V:0  | return
 f32.reinterpret/i32() =>
 >>> running export "i64.reinterpret/f64":
-#0. 2370: V:0  | i64.const $1
-#0. 2379: V:1  | f64.reinterpret/i64 1
-#0. 2380: V:1  | drop
-#0. 2381: V:0  | return
+#0. 4524: V:0  | i64.const $1
+#0. 4536: V:1  | f64.reinterpret/i64 1
+#0. 4540: V:1  | drop
+#0. 4544: V:0  | return
 i64.reinterpret/f64() =>
 >>> running export "f64.reinterpret/i64":
-#0. 2382: V:0  | f64.const $1
-#0. 2391: V:1  | i64.reinterpret/f64 1
-#0. 2392: V:1  | drop
-#0. 2393: V:0  | return
+#0. 4548: V:0  | f64.const $1
+#0. 4560: V:1  | i64.reinterpret/f64 1
+#0. 4564: V:1  | drop
+#0. 4568: V:0  | return
 f64.reinterpret/i64() =>
 >>> running export "i32.extend8_s":
-#0. 2394: V:0  | i32.const $1
-#0. 2399: V:1  | i32.extend8_s 1
-#0. 2400: V:1  | drop
-#0. 2401: V:0  | return
+#0. 4572: V:0  | i32.const $1
+#0. 4580: V:1  | i32.extend8_s 1
+#0. 4584: V:1  | drop
+#0. 4588: V:0  | return
 i32.extend8_s() =>
 >>> running export "i32.extend16_s":
-#0. 2402: V:0  | i32.const $1
-#0. 2407: V:1  | i32.extend16_s 1
-#0. 2408: V:1  | drop
-#0. 2409: V:0  | return
+#0. 4592: V:0  | i32.const $1
+#0. 4600: V:1  | i32.extend16_s 1
+#0. 4604: V:1  | drop
+#0. 4608: V:0  | return
 i32.extend16_s() =>
 >>> running export "i64.extend8_s":
-#0. 2410: V:0  | i64.const $1
-#0. 2419: V:1  | i64.extend8_s 1
-#0. 2420: V:1  | drop
-#0. 2421: V:0  | return
+#0. 4612: V:0  | i64.const $1
+#0. 4624: V:1  | i64.extend8_s 1
+#0. 4628: V:1  | drop
+#0. 4632: V:0  | return
 i64.extend8_s() =>
 >>> running export "i64.extend16_s":
-#0. 2422: V:0  | i64.const $1
-#0. 2431: V:1  | i64.extend16_s 1
-#0. 2432: V:1  | drop
-#0. 2433: V:0  | return
+#0. 4636: V:0  | i64.const $1
+#0. 4648: V:1  | i64.extend16_s 1
+#0. 4652: V:1  | drop
+#0. 4656: V:0  | return
 i64.extend16_s() =>
 >>> running export "i64.extend32_s":
-#0. 2434: V:0  | i64.const $1
-#0. 2443: V:1  | i64.extend32_s 1
-#0. 2444: V:1  | drop
-#0. 2445: V:0  | return
+#0. 4660: V:0  | i64.const $1
+#0. 4672: V:1  | i64.extend32_s 1
+#0. 4676: V:1  | drop
+#0. 4680: V:0  | return
 i64.extend32_s() =>
 >>> running export "alloca":
-#0. 2446: V:0  | alloca $1
-#0. 2451: V:1  | drop
-#0. 2452: V:0  | return
+#0. 4684: V:0  | alloca $1
+#0. 4692: V:1  | drop
+#0. 4696: V:0  | return
 alloca() =>
 >>> running export "br_unless":
-#0. 2453: V:0  | i32.const $1
-#0. 2458: V:1  | br_unless @2468, 1
-#0. 2463: V:0  | br @2468
-#0. 2468: V:0  | return
+#0. 4700: V:0  | i32.const $1
+#0. 4708: V:1  | br_unless @4724, 1
+#0. 4716: V:0  | br @4724
+#0. 4724: V:0  | return
 br_unless() =>
 >>> running export "call_host":
-#0. 2469: V:0  | i32.const $1
-#0. 2474: V:1  | call_host $0
+#0. 4728: V:0  | i32.const $1
+#0. 4736: V:1  | call_host $0
 called host host.print(i32:1) =>
-#0. 2479: V:0  | return
+#0. 4744: V:0  | return
 call_host() =>
 >>> running export "drop_keep":
-#0. 2480: V:0  | i32.const $1
-#0. 2485: V:1  | i32.const $2
-#0. 2490: V:2  | drop_keep $1 $1
-#0. 2499: V:1  | br @2504
-#0. 2504: V:1  | drop
-#0. 2505: V:0  | return
+#0. 4748: V:0  | i32.const $1
+#0. 4756: V:1  | i32.const $2
+#0. 4764: V:2  | drop_keep $1 $1
+#0. 4776: V:1  | br @4784
+#0. 4784: V:1  | drop
+#0. 4788: V:0  | return
 drop_keep() =>
 >>> running export "i32.trunc_s:sat/f32":
-#0. 2506: V:0  | f32.const $1
-#0. 2511: V:1  | i32.trunc_s:sat/f32 1
-#0. 2513: V:1  | drop
-#0. 2514: V:0  | return
+#0. 4792: V:0  | f32.const $1
+#0. 4800: V:1  | i32.trunc_s:sat/f32 1
+#0. 4804: V:1  | drop
+#0. 4808: V:0  | return
 i32.trunc_s:sat/f32() =>
 >>> running export "i32.trunc_u:sat/f32":
-#0. 2515: V:0  | f32.const $1
-#0. 2520: V:1  | i32.trunc_u:sat/f32 1
-#0. 2522: V:1  | drop
-#0. 2523: V:0  | return
+#0. 4812: V:0  | f32.const $1
+#0. 4820: V:1  | i32.trunc_u:sat/f32 1
+#0. 4824: V:1  | drop
+#0. 4828: V:0  | return
 i32.trunc_u:sat/f32() =>
 >>> running export "i32.trunc_s:sat/f64":
-#0. 2524: V:0  | f64.const $1
-#0. 2533: V:1  | i32.trunc_s:sat/f64 1
-#0. 2535: V:1  | drop
-#0. 2536: V:0  | return
+#0. 4832: V:0  | f64.const $1
+#0. 4844: V:1  | i32.trunc_s:sat/f64 1
+#0. 4848: V:1  | drop
+#0. 4852: V:0  | return
 i32.trunc_s:sat/f64() =>
 >>> running export "i32.trunc_u:sat/f64":
-#0. 2537: V:0  | f64.const $1
-#0. 2546: V:1  | i32.trunc_u:sat/f64 1
-#0. 2548: V:1  | drop
-#0. 2549: V:0  | return
+#0. 4856: V:0  | f64.const $1
+#0. 4868: V:1  | i32.trunc_u:sat/f64 1
+#0. 4872: V:1  | drop
+#0. 4876: V:0  | return
 i32.trunc_u:sat/f64() =>
 >>> running export "i64.trunc_s:sat/f32":
-#0. 2550: V:0  | f32.const $1
-#0. 2555: V:1  | i64.trunc_s:sat/f32 1
-#0. 2557: V:1  | drop
-#0. 2558: V:0  | return
+#0. 4880: V:0  | f32.const $1
+#0. 4888: V:1  | i64.trunc_s:sat/f32 1
+#0. 4892: V:1  | drop
+#0. 4896: V:0  | return
 i64.trunc_s:sat/f32() =>
 >>> running export "i64.trunc_u:sat/f32":
-#0. 2559: V:0  | f32.const $1
-#0. 2564: V:1  | i64.trunc_u:sat/f32 1
-#0. 2566: V:1  | drop
-#0. 2567: V:0  | return
+#0. 4900: V:0  | f32.const $1
+#0. 4908: V:1  | i64.trunc_u:sat/f32 1
+#0. 4912: V:1  | drop
+#0. 4916: V:0  | return
 i64.trunc_u:sat/f32() =>
 >>> running export "i64.trunc_s:sat/f64":
-#0. 2568: V:0  | f64.const $1
-#0. 2577: V:1  | i64.trunc_s:sat/f64 1
-#0. 2579: V:1  | drop
-#0. 2580: V:0  | return
+#0. 4920: V:0  | f64.const $1
+#0. 4932: V:1  | i64.trunc_s:sat/f64 1
+#0. 4936: V:1  | drop
+#0. 4940: V:0  | return
 i64.trunc_s:sat/f64() =>
 >>> running export "i64.trunc_u:sat/f64":
-#0. 2581: V:0  | f64.const $1
-#0. 2590: V:1  | i64.trunc_u:sat/f64 1
-#0. 2592: V:1  | drop
-#0. 2593: V:0  | return
+#0. 4944: V:0  | f64.const $1
+#0. 4956: V:1  | i64.trunc_u:sat/f64 1
+#0. 4960: V:1  | drop
+#0. 4964: V:0  | return
 i64.trunc_u:sat/f64() =>
 >>> running export "v128.const":
-#0. 2594: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2612: V:1  | drop
-#0. 2613: V:0  | return
+#0. 4968: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 4988: V:1  | drop
+#0. 4992: V:0  | return
 v128.const() =>
 >>> running export "v128.load":
-#0. 2614: V:0  | i32.const $1
-#0. 2619: V:1  | v128.load $0:1+$3
-#0. 2629: V:1  | drop
-#0. 2630: V:0  | return
+#0. 4996: V:0  | i32.const $1
+#0. 5004: V:1  | v128.load $0:1+$3
+#0. 5016: V:1  | drop
+#0. 5020: V:0  | return
 v128.load() =>
 >>> running export "v128.store":
-#0. 2631: V:0  | i32.const $1
-#0. 2636: V:1  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2654: V:2  | v128.store $0:1+$3, $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2664: V:0  | return
+#0. 5024: V:0  | i32.const $1
+#0. 5032: V:1  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5052: V:2  | v128.store $0:1+$3, $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5064: V:0  | return
 v128.store() =>
 >>> running export "i8x16.splat":
-#0. 2665: V:0  | i32.const $1
-#0. 2670: V:1  | i8x16.splat 1
-#0. 2672: V:1  | drop
-#0. 2673: V:0  | return
+#0. 5068: V:0  | i32.const $1
+#0. 5076: V:1  | i8x16.splat 1
+#0. 5080: V:1  | drop
+#0. 5084: V:0  | return
 i8x16.splat() =>
 >>> running export "i16x8.splat":
-#0. 2674: V:0  | i32.const $1
-#0. 2679: V:1  | i16x8.splat 1
-#0. 2681: V:1  | drop
-#0. 2682: V:0  | return
+#0. 5088: V:0  | i32.const $1
+#0. 5096: V:1  | i16x8.splat 1
+#0. 5100: V:1  | drop
+#0. 5104: V:0  | return
 i16x8.splat() =>
 >>> running export "i32x4.splat":
-#0. 2683: V:0  | i32.const $1
-#0. 2688: V:1  | i32x4.splat 1
-#0. 2690: V:1  | drop
-#0. 2691: V:0  | return
+#0. 5108: V:0  | i32.const $1
+#0. 5116: V:1  | i32x4.splat 1
+#0. 5120: V:1  | drop
+#0. 5124: V:0  | return
 i32x4.splat() =>
 >>> running export "i64x2.splat":
-#0. 2692: V:0  | i64.const $1
-#0. 2701: V:1  | i64x2.splat 1
-#0. 2703: V:1  | drop
-#0. 2704: V:0  | return
+#0. 5128: V:0  | i64.const $1
+#0. 5140: V:1  | i64x2.splat 1
+#0. 5144: V:1  | drop
+#0. 5148: V:0  | return
 i64x2.splat() =>
 >>> running export "f32x4.splat":
-#0. 2705: V:0  | f32.const $1
-#0. 2710: V:1  | f32x4.splat 1
-#0. 2712: V:1  | drop
-#0. 2713: V:0  | return
+#0. 5152: V:0  | f32.const $1
+#0. 5160: V:1  | f32x4.splat 1
+#0. 5164: V:1  | drop
+#0. 5168: V:0  | return
 f32x4.splat() =>
 >>> running export "f64x2.splat":
-#0. 2714: V:0  | f64.const $1
-#0. 2723: V:1  | f64x2.splat 1
-#0. 2725: V:1  | drop
-#0. 2726: V:0  | return
+#0. 5172: V:0  | f64.const $1
+#0. 5184: V:1  | f64x2.splat 1
+#0. 5188: V:1  | drop
+#0. 5192: V:0  | return
 f64x2.splat() =>
 >>> running export "i8x16.extract_lane_s":
-#0. 2727: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2745: V:1  | i8x16.extract_lane_s : LaneIdx 15 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2748: V:1  | drop
-#0. 2749: V:0  | return
+#0. 5196: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5216: V:1  | i8x16.extract_lane_s : LaneIdx 15 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5221: V:1  | drop
+#0. 5225: V:0  | return
 i8x16.extract_lane_s() =>
 >>> running export "i8x16.extract_lane_u":
-#0. 2750: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2768: V:1  | i8x16.extract_lane_u : LaneIdx 15 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2771: V:1  | drop
-#0. 2772: V:0  | return
+#0. 5229: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5249: V:1  | i8x16.extract_lane_u : LaneIdx 15 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5254: V:1  | drop
+#0. 5258: V:0  | return
 i8x16.extract_lane_u() =>
 >>> running export "i16x8.extract_lane_s":
-#0. 2773: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2791: V:1  | i16x8.extract_lane_s : LaneIdx 7 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2794: V:1  | drop
-#0. 2795: V:0  | return
+#0. 5262: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5282: V:1  | i16x8.extract_lane_s : LaneIdx 7 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5287: V:1  | drop
+#0. 5291: V:0  | return
 i16x8.extract_lane_s() =>
 >>> running export "i16x8.extract_lane_u":
-#0. 2796: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2814: V:1  | i16x8.extract_lane_u : LaneIdx 7 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2817: V:1  | drop
-#0. 2818: V:0  | return
+#0. 5295: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5315: V:1  | i16x8.extract_lane_u : LaneIdx 7 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5320: V:1  | drop
+#0. 5324: V:0  | return
 i16x8.extract_lane_u() =>
 >>> running export "i32x4.extract_lane":
-#0. 2819: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2837: V:1  | i32x4.extract_lane : LaneIdx 3 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2840: V:1  | drop
-#0. 2841: V:0  | return
+#0. 5328: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5348: V:1  | i32x4.extract_lane : LaneIdx 3 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5353: V:1  | drop
+#0. 5357: V:0  | return
 i32x4.extract_lane() =>
 >>> running export "i64x2.extract_lane":
-#0. 2842: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2860: V:1  | i64x2.extract_lane : LaneIdx 1 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2863: V:1  | drop
-#0. 2864: V:0  | return
+#0. 5361: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5381: V:1  | i64x2.extract_lane : LaneIdx 1 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5386: V:1  | drop
+#0. 5390: V:0  | return
 i64x2.extract_lane() =>
 >>> running export "f32x4.extract_lane":
-#0. 2865: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2883: V:1  | f32x4.extract_lane : LaneIdx 3 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2886: V:1  | drop
-#0. 2887: V:0  | return
+#0. 5394: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5414: V:1  | f32x4.extract_lane : LaneIdx 3 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5419: V:1  | drop
+#0. 5423: V:0  | return
 f32x4.extract_lane() =>
 >>> running export "f64x2.extract_lane":
-#0. 2888: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2906: V:1  | f64x2.extract_lane : LaneIdx 1 From $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2909: V:1  | drop
-#0. 2910: V:0  | return
+#0. 5427: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5447: V:1  | f64x2.extract_lane : LaneIdx 1 From $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5452: V:1  | drop
+#0. 5456: V:0  | return
 f64x2.extract_lane() =>
 >>> running export "i8x16.replace_lane":
-#0. 2911: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2929: V:1  | i32.const $0
-#0. 2934: V:2  | i8x16.replace_lane : Set 0 to LaneIdx 15 In $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2937: V:1  | drop
-#0. 2938: V:0  | return
+#0. 5460: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5480: V:1  | i32.const $0
+#0. 5488: V:2  | i8x16.replace_lane : Set 0 to LaneIdx 15 In $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5493: V:1  | drop
+#0. 5497: V:0  | return
 i8x16.replace_lane() =>
 >>> running export "i16x8.replace_lane":
-#0. 2939: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2957: V:1  | i32.const $0
-#0. 2962: V:2  | i16x8.replace_lane : Set 0 to LaneIdx 7 In $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2965: V:1  | drop
-#0. 2966: V:0  | return
+#0. 5501: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5521: V:1  | i32.const $0
+#0. 5529: V:2  | i16x8.replace_lane : Set 0 to LaneIdx 7 In $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5534: V:1  | drop
+#0. 5538: V:0  | return
 i16x8.replace_lane() =>
 >>> running export "i32x4.replace_lane":
-#0. 2967: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2985: V:1  | i32.const $0
-#0. 2990: V:2  | i32x4.replace_lane : Set 0 to LaneIdx 3 In $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 2993: V:1  | drop
-#0. 2994: V:0  | return
+#0. 5542: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5562: V:1  | i32.const $0
+#0. 5570: V:2  | i32x4.replace_lane : Set 0 to LaneIdx 3 In $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5575: V:1  | drop
+#0. 5579: V:0  | return
 i32x4.replace_lane() =>
 >>> running export "i64x2.replace_lane":
-#0. 2995: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3013: V:1  | i64.const $0
-#0. 3022: V:2  | i64x2.replace_lane : Set 0 to LaneIdx 1 In $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3025: V:1  | drop
-#0. 3026: V:0  | return
+#0. 5583: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5603: V:1  | i64.const $0
+#0. 5615: V:2  | i64x2.replace_lane : Set 0 to LaneIdx 1 In $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5620: V:1  | drop
+#0. 5624: V:0  | return
 i64x2.replace_lane() =>
 >>> running export "f32x4.replace_lane":
-#0. 3027: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3045: V:1  | f32.const $0
-#0. 3050: V:2  | f32x4.replace_lane : Set 0 to LaneIdx 3 In $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3053: V:1  | drop
-#0. 3054: V:0  | return
+#0. 5628: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5648: V:1  | f32.const $0
+#0. 5656: V:2  | f32x4.replace_lane : Set 0 to LaneIdx 3 In $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5661: V:1  | drop
+#0. 5665: V:0  | return
 f32x4.replace_lane() =>
 >>> running export "f64x2.replace_lane":
-#0. 3055: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3073: V:1  | f64.const $0
-#0. 3082: V:2  | f64x2.replace_lane : Set 0 to LaneIdx 1 In $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3085: V:1  | drop
-#0. 3086: V:0  | return
+#0. 5669: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5689: V:1  | f64.const $0
+#0. 5701: V:2  | f64x2.replace_lane : Set 0 to LaneIdx 1 In $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5706: V:1  | drop
+#0. 5710: V:0  | return
 f64x2.replace_lane() =>
 >>> running export "v8x16.shuffle":
-#0. 3087: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3105: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3123: V:2  | v8x16.shuffle $0x00000001 00000001 00000001 00000001 $0x00000002 00000002 00000002 00000002 : with lane imm: $0x00000001 00000001 00000001 00000001
-#0. 3141: V:1  | drop
-#0. 3142: V:0  | return
+#0. 5714: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5734: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 5754: V:2  | v8x16.shuffle $0x00000001 00000001 00000001 00000001 $0x00000002 00000002 00000002 00000002 : with lane imm: $0x00000001 00000001 00000001 00000001
+#0. 5774: V:1  | drop
+#0. 5778: V:0  | return
 v8x16.shuffle() =>
 >>> running export "i8x16.add":
-#0. 3143: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3161: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3179: V:2  | i8x16.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3181: V:1  | drop
-#0. 3182: V:0  | return
+#0. 5782: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5802: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 5822: V:2  | i8x16.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 5826: V:1  | drop
+#0. 5830: V:0  | return
 i8x16.add() =>
 >>> running export "i16x8.add":
-#0. 3183: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3201: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3219: V:2  | i16x8.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3221: V:1  | drop
-#0. 3222: V:0  | return
+#0. 5834: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5854: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 5874: V:2  | i16x8.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 5878: V:1  | drop
+#0. 5882: V:0  | return
 i16x8.add() =>
 >>> running export "i32x4.add":
-#0. 3223: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3241: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3259: V:2  | i32x4.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3261: V:1  | drop
-#0. 3262: V:0  | return
+#0. 5886: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5906: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 5926: V:2  | i32x4.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 5930: V:1  | drop
+#0. 5934: V:0  | return
 i32x4.add() =>
 >>> running export "i64x2.add":
-#0. 3263: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3281: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3299: V:2  | i64x2.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3301: V:1  | drop
-#0. 3302: V:0  | return
+#0. 5938: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 5958: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 5978: V:2  | i64x2.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 5982: V:1  | drop
+#0. 5986: V:0  | return
 i64x2.add() =>
 >>> running export "i8x16.sub":
-#0. 3303: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3321: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3339: V:2  | i8x16.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3341: V:1  | drop
-#0. 3342: V:0  | return
+#0. 5990: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6010: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6030: V:2  | i8x16.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6034: V:1  | drop
+#0. 6038: V:0  | return
 i8x16.sub() =>
 >>> running export "i16x8.sub":
-#0. 3343: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3361: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3379: V:2  | i16x8.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3381: V:1  | drop
-#0. 3382: V:0  | return
+#0. 6042: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6062: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6082: V:2  | i16x8.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6086: V:1  | drop
+#0. 6090: V:0  | return
 i16x8.sub() =>
 >>> running export "i32x4.sub":
-#0. 3383: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3401: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3419: V:2  | i32x4.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3421: V:1  | drop
-#0. 3422: V:0  | return
+#0. 6094: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6114: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6134: V:2  | i32x4.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6138: V:1  | drop
+#0. 6142: V:0  | return
 i32x4.sub() =>
 >>> running export "i64x2.sub":
-#0. 3423: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3441: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3459: V:2  | i64x2.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3461: V:1  | drop
-#0. 3462: V:0  | return
+#0. 6146: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6166: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6186: V:2  | i64x2.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6190: V:1  | drop
+#0. 6194: V:0  | return
 i64x2.sub() =>
 >>> running export "i8x16.mul":
-#0. 3463: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3481: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3499: V:2  | i8x16.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3501: V:1  | drop
-#0. 3502: V:0  | return
+#0. 6198: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6218: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6238: V:2  | i8x16.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6242: V:1  | drop
+#0. 6246: V:0  | return
 i8x16.mul() =>
 >>> running export "i16x8.mul":
-#0. 3503: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3521: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3539: V:2  | i16x8.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3541: V:1  | drop
-#0. 3542: V:0  | return
+#0. 6250: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6270: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6290: V:2  | i16x8.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6294: V:1  | drop
+#0. 6298: V:0  | return
 i16x8.mul() =>
 >>> running export "i32x4.mul":
-#0. 3543: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3561: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3579: V:2  | i32x4.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3581: V:1  | drop
-#0. 3582: V:0  | return
+#0. 6302: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6322: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6342: V:2  | i32x4.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6346: V:1  | drop
+#0. 6350: V:0  | return
 i32x4.mul() =>
 >>> running export "i8x16.neg":
-#0. 3583: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3601: V:1  | i8x16.neg $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3603: V:1  | drop
-#0. 3604: V:0  | return
+#0. 6354: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6374: V:1  | i8x16.neg $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6378: V:1  | drop
+#0. 6382: V:0  | return
 i8x16.neg() =>
 >>> running export "i16x8.neg":
-#0. 3605: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3623: V:1  | i16x8.neg $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3625: V:1  | drop
-#0. 3626: V:0  | return
+#0. 6386: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6406: V:1  | i16x8.neg $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6410: V:1  | drop
+#0. 6414: V:0  | return
 i16x8.neg() =>
 >>> running export "i32x4.neg":
-#0. 3627: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3645: V:1  | i32x4.neg $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3647: V:1  | drop
-#0. 3648: V:0  | return
+#0. 6418: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6438: V:1  | i32x4.neg $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6442: V:1  | drop
+#0. 6446: V:0  | return
 i32x4.neg() =>
 >>> running export "i64x2.neg":
-#0. 3649: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3667: V:1  | i64x2.neg $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3669: V:1  | drop
-#0. 3670: V:0  | return
+#0. 6450: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6470: V:1  | i64x2.neg $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6474: V:1  | drop
+#0. 6478: V:0  | return
 i64x2.neg() =>
 >>> running export "i8x16.add_saturate_s":
-#0. 3671: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3689: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3707: V:2  | i8x16.add_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3709: V:1  | drop
-#0. 3710: V:0  | return
+#0. 6482: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6502: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6522: V:2  | i8x16.add_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6526: V:1  | drop
+#0. 6530: V:0  | return
 i8x16.add_saturate_s() =>
 >>> running export "i8x16.add_saturate_u":
-#0. 3711: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3729: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3747: V:2  | i8x16.add_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3749: V:1  | drop
-#0. 3750: V:0  | return
+#0. 6534: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6554: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6574: V:2  | i8x16.add_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6578: V:1  | drop
+#0. 6582: V:0  | return
 i8x16.add_saturate_u() =>
 >>> running export "i16x8.add_saturate_s":
-#0. 3751: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3769: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3787: V:2  | i16x8.add_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3789: V:1  | drop
-#0. 3790: V:0  | return
+#0. 6586: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6606: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6626: V:2  | i16x8.add_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6630: V:1  | drop
+#0. 6634: V:0  | return
 i16x8.add_saturate_s() =>
 >>> running export "i16x8.add_saturate_u":
-#0. 3791: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3809: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3827: V:2  | i16x8.add_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3829: V:1  | drop
-#0. 3830: V:0  | return
+#0. 6638: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6658: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6678: V:2  | i16x8.add_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6682: V:1  | drop
+#0. 6686: V:0  | return
 i16x8.add_saturate_u() =>
 >>> running export "i8x16.sub_saturate_s":
-#0. 3831: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3849: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3867: V:2  | i8x16.sub_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3869: V:1  | drop
-#0. 3870: V:0  | return
+#0. 6690: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6710: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6730: V:2  | i8x16.sub_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6734: V:1  | drop
+#0. 6738: V:0  | return
 i8x16.sub_saturate_s() =>
 >>> running export "i8x16.sub_saturate_u":
-#0. 3871: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3889: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3907: V:2  | i8x16.sub_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3909: V:1  | drop
-#0. 3910: V:0  | return
+#0. 6742: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6762: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6782: V:2  | i8x16.sub_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6786: V:1  | drop
+#0. 6790: V:0  | return
 i8x16.sub_saturate_u() =>
 >>> running export "i16x8.sub_saturate_s":
-#0. 3911: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3929: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3947: V:2  | i16x8.sub_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3949: V:1  | drop
-#0. 3950: V:0  | return
+#0. 6794: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6814: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6834: V:2  | i16x8.sub_saturate_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6838: V:1  | drop
+#0. 6842: V:0  | return
 i16x8.sub_saturate_s() =>
 >>> running export "i16x8.sub_saturate_u":
-#0. 3951: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 3969: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 3987: V:2  | i16x8.sub_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 3989: V:1  | drop
-#0. 3990: V:0  | return
+#0. 6846: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6866: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 6886: V:2  | i16x8.sub_saturate_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 6890: V:1  | drop
+#0. 6894: V:0  | return
 i16x8.sub_saturate_u() =>
 >>> running export "i8x16.shl":
-#0. 3991: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4009: V:1  | i32.const $0
-#0. 4014: V:2  | i8x16.shl $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4016: V:1  | drop
-#0. 4017: V:0  | return
+#0. 6898: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6918: V:1  | i32.const $0
+#0. 6926: V:2  | i8x16.shl $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 6930: V:1  | drop
+#0. 6934: V:0  | return
 i8x16.shl() =>
 >>> running export "i16x8.shl":
-#0. 4018: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4036: V:1  | i32.const $0
-#0. 4041: V:2  | i16x8.shl $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4043: V:1  | drop
-#0. 4044: V:0  | return
+#0. 6938: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6958: V:1  | i32.const $0
+#0. 6966: V:2  | i16x8.shl $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 6970: V:1  | drop
+#0. 6974: V:0  | return
 i16x8.shl() =>
 >>> running export "i32x4.shl":
-#0. 4045: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4063: V:1  | i32.const $0
-#0. 4068: V:2  | i32x4.shl $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4070: V:1  | drop
-#0. 4071: V:0  | return
+#0. 6978: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 6998: V:1  | i32.const $0
+#0. 7006: V:2  | i32x4.shl $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7010: V:1  | drop
+#0. 7014: V:0  | return
 i32x4.shl() =>
 >>> running export "i64x2.shl":
-#0. 4072: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4090: V:1  | i32.const $0
-#0. 4095: V:2  | i64x2.shl $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4097: V:1  | drop
-#0. 4098: V:0  | return
+#0. 7018: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7038: V:1  | i32.const $0
+#0. 7046: V:2  | i64x2.shl $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7050: V:1  | drop
+#0. 7054: V:0  | return
 i64x2.shl() =>
 >>> running export "i8x16.shr_s":
-#0. 4099: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4117: V:1  | i32.const $0
-#0. 4122: V:2  | i8x16.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4124: V:1  | drop
-#0. 4125: V:0  | return
+#0. 7058: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7078: V:1  | i32.const $0
+#0. 7086: V:2  | i8x16.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7090: V:1  | drop
+#0. 7094: V:0  | return
 i8x16.shr_s() =>
 >>> running export "i8x16.shr_u":
-#0. 4126: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4144: V:1  | i32.const $0
-#0. 4149: V:2  | i8x16.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4151: V:1  | drop
-#0. 4152: V:0  | return
+#0. 7098: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7118: V:1  | i32.const $0
+#0. 7126: V:2  | i8x16.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7130: V:1  | drop
+#0. 7134: V:0  | return
 i8x16.shr_u() =>
 >>> running export "i16x8.shr_s":
-#0. 4153: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4171: V:1  | i32.const $0
-#0. 4176: V:2  | i16x8.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4178: V:1  | drop
-#0. 4179: V:0  | return
+#0. 7138: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7158: V:1  | i32.const $0
+#0. 7166: V:2  | i16x8.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7170: V:1  | drop
+#0. 7174: V:0  | return
 i16x8.shr_s() =>
 >>> running export "i16x8.shr_u":
-#0. 4180: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4198: V:1  | i32.const $0
-#0. 4203: V:2  | i16x8.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4205: V:1  | drop
-#0. 4206: V:0  | return
+#0. 7178: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7198: V:1  | i32.const $0
+#0. 7206: V:2  | i16x8.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7210: V:1  | drop
+#0. 7214: V:0  | return
 i16x8.shr_u() =>
 >>> running export "i32x4.shr_s":
-#0. 4207: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4225: V:1  | i32.const $0
-#0. 4230: V:2  | i32x4.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4232: V:1  | drop
-#0. 4233: V:0  | return
+#0. 7218: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7238: V:1  | i32.const $0
+#0. 7246: V:2  | i32x4.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7250: V:1  | drop
+#0. 7254: V:0  | return
 i32x4.shr_s() =>
 >>> running export "i32x4.shr_u":
-#0. 4234: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4252: V:1  | i32.const $0
-#0. 4257: V:2  | i32x4.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4259: V:1  | drop
-#0. 4260: V:0  | return
+#0. 7258: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7278: V:1  | i32.const $0
+#0. 7286: V:2  | i32x4.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7290: V:1  | drop
+#0. 7294: V:0  | return
 i32x4.shr_u() =>
 >>> running export "i64x2.shr_s":
-#0. 4261: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4279: V:1  | i32.const $0
-#0. 4284: V:2  | i64x2.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4286: V:1  | drop
-#0. 4287: V:0  | return
+#0. 7298: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7318: V:1  | i32.const $0
+#0. 7326: V:2  | i64x2.shr_s $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7330: V:1  | drop
+#0. 7334: V:0  | return
 i64x2.shr_s() =>
 >>> running export "i64x2.shr_u":
-#0. 4288: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4306: V:1  | i32.const $0
-#0. 4311: V:2  | i64x2.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
-#0. 4313: V:1  | drop
-#0. 4314: V:0  | return
+#0. 7338: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7358: V:1  | i32.const $0
+#0. 7366: V:2  | i64x2.shr_u $0x00000001 00000001 00000001 00000001  $0x00000000
+#0. 7370: V:1  | drop
+#0. 7374: V:0  | return
 i64x2.shr_u() =>
 >>> running export "v128.and":
-#0. 4315: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4333: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4351: V:2  | v128.and $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4353: V:1  | drop
-#0. 4354: V:0  | return
+#0. 7378: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7398: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 7418: V:2  | v128.and $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 7422: V:1  | drop
+#0. 7426: V:0  | return
 v128.and() =>
 >>> running export "v128.or":
-#0. 4355: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4373: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4391: V:2  | v128.or $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4393: V:1  | drop
-#0. 4394: V:0  | return
+#0. 7430: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7450: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 7470: V:2  | v128.or $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 7474: V:1  | drop
+#0. 7478: V:0  | return
 v128.or() =>
 >>> running export "v128.xor":
-#0. 4395: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4413: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4431: V:2  | v128.xor $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4433: V:1  | drop
-#0. 4434: V:0  | return
+#0. 7482: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7502: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 7522: V:2  | v128.xor $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 7526: V:1  | drop
+#0. 7530: V:0  | return
 v128.xor() =>
 >>> running export "v128.not":
-#0. 4435: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4453: V:1  | v128.not $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4455: V:1  | drop
-#0. 4456: V:0  | return
+#0. 7534: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7554: V:1  | v128.not $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7558: V:1  | drop
+#0. 7562: V:0  | return
 v128.not() =>
 >>> running export "v128.bitselect":
-#0. 4457: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4475: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4493: V:2  | v128.const $0x00000003 0x00000003 0x00000003 0x00000003
-#0. 4511: V:3  | v128.bitselect $0x00000001 00000001 00000001 00000001 $0x00000002 00000002 00000002 00000002 $0x00000003 00000003 00000003 00000003
-#0. 4513: V:1  | drop
-#0. 4514: V:0  | return
+#0. 7566: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7586: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 7606: V:2  | v128.const $0x00000003 0x00000003 0x00000003 0x00000003
+#0. 7626: V:3  | v128.bitselect $0x00000001 00000001 00000001 00000001 $0x00000002 00000002 00000002 00000002 $0x00000003 00000003 00000003 00000003
+#0. 7630: V:1  | drop
+#0. 7634: V:0  | return
 v128.bitselect() =>
 >>> running export "i8x16.any_true":
-#0. 4515: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4533: V:1  | i8x16.any_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4535: V:1  | drop
-#0. 4536: V:0  | return
+#0. 7638: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7658: V:1  | i8x16.any_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7662: V:1  | drop
+#0. 7666: V:0  | return
 i8x16.any_true() =>
 >>> running export "i16x8.any_true":
-#0. 4537: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4555: V:1  | i16x8.any_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4557: V:1  | drop
-#0. 4558: V:0  | return
+#0. 7670: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7690: V:1  | i16x8.any_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7694: V:1  | drop
+#0. 7698: V:0  | return
 i16x8.any_true() =>
 >>> running export "i32x4.any_true":
-#0. 4559: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4577: V:1  | i32x4.any_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4579: V:1  | drop
-#0. 4580: V:0  | return
+#0. 7702: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7722: V:1  | i32x4.any_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7726: V:1  | drop
+#0. 7730: V:0  | return
 i32x4.any_true() =>
 >>> running export "i64x2.any_true":
-#0. 4581: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4599: V:1  | i64x2.any_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4601: V:1  | drop
-#0. 4602: V:0  | return
+#0. 7734: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7754: V:1  | i64x2.any_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7758: V:1  | drop
+#0. 7762: V:0  | return
 i64x2.any_true() =>
 >>> running export "i8x16.all_true":
-#0. 4603: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4621: V:1  | i8x16.all_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4623: V:1  | drop
-#0. 4624: V:0  | return
+#0. 7766: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7786: V:1  | i8x16.all_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7790: V:1  | drop
+#0. 7794: V:0  | return
 i8x16.all_true() =>
 >>> running export "i16x8.all_true":
-#0. 4625: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4643: V:1  | i16x8.all_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4645: V:1  | drop
-#0. 4646: V:0  | return
+#0. 7798: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7818: V:1  | i16x8.all_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7822: V:1  | drop
+#0. 7826: V:0  | return
 i16x8.all_true() =>
 >>> running export "i32x4.all_true":
-#0. 4647: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4665: V:1  | i32x4.all_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4667: V:1  | drop
-#0. 4668: V:0  | return
+#0. 7830: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7850: V:1  | i32x4.all_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7854: V:1  | drop
+#0. 7858: V:0  | return
 i32x4.all_true() =>
 >>> running export "i64x2.all_true":
-#0. 4669: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4687: V:1  | i64x2.all_true $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4689: V:1  | drop
-#0. 4690: V:0  | return
+#0. 7862: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7882: V:1  | i64x2.all_true $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7886: V:1  | drop
+#0. 7890: V:0  | return
 i64x2.all_true() =>
 >>> running export "i8x16.eq":
-#0. 4691: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4709: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4727: V:2  | i8x16.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4729: V:1  | drop
-#0. 4730: V:0  | return
+#0. 7894: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7914: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 7934: V:2  | i8x16.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 7938: V:1  | drop
+#0. 7942: V:0  | return
 i8x16.eq() =>
 >>> running export "i16x8.eq":
-#0. 4731: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4749: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4767: V:2  | i16x8.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4769: V:1  | drop
-#0. 4770: V:0  | return
+#0. 7946: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 7966: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 7986: V:2  | i16x8.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 7990: V:1  | drop
+#0. 7994: V:0  | return
 i16x8.eq() =>
 >>> running export "i32x4.eq":
-#0. 4771: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4789: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4807: V:2  | i32x4.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4809: V:1  | drop
-#0. 4810: V:0  | return
+#0. 7998: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8018: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8038: V:2  | i32x4.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8042: V:1  | drop
+#0. 8046: V:0  | return
 i32x4.eq() =>
 >>> running export "f32x4.eq":
-#0. 4811: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4829: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4847: V:2  | f32x4.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4849: V:1  | drop
-#0. 4850: V:0  | return
+#0. 8050: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8070: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8090: V:2  | f32x4.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8094: V:1  | drop
+#0. 8098: V:0  | return
 f32x4.eq() =>
 >>> running export "f64x2.eq":
-#0. 4851: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4869: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4887: V:2  | f64x2.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4889: V:1  | drop
-#0. 4890: V:0  | return
+#0. 8102: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8122: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8142: V:2  | f64x2.eq $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8146: V:1  | drop
+#0. 8150: V:0  | return
 f64x2.eq() =>
 >>> running export "i8x16.ne":
-#0. 4891: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4909: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4927: V:2  | i8x16.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4929: V:1  | drop
-#0. 4930: V:0  | return
+#0. 8154: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8174: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8194: V:2  | i8x16.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8198: V:1  | drop
+#0. 8202: V:0  | return
 i8x16.ne() =>
 >>> running export "i16x8.ne":
-#0. 4931: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4949: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 4967: V:2  | i16x8.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 4969: V:1  | drop
-#0. 4970: V:0  | return
+#0. 8206: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8226: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8246: V:2  | i16x8.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8250: V:1  | drop
+#0. 8254: V:0  | return
 i16x8.ne() =>
 >>> running export "i32x4.ne":
-#0. 4971: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 4989: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5007: V:2  | i32x4.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5009: V:1  | drop
-#0. 5010: V:0  | return
+#0. 8258: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8278: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8298: V:2  | i32x4.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8302: V:1  | drop
+#0. 8306: V:0  | return
 i32x4.ne() =>
 >>> running export "f32x4.ne":
-#0. 5011: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5029: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5047: V:2  | f32x4.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5049: V:1  | drop
-#0. 5050: V:0  | return
+#0. 8310: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8330: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8350: V:2  | f32x4.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8354: V:1  | drop
+#0. 8358: V:0  | return
 f32x4.ne() =>
 >>> running export "f64x2.ne":
-#0. 5051: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5069: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5087: V:2  | f64x2.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5089: V:1  | drop
-#0. 5090: V:0  | return
+#0. 8362: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8382: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8402: V:2  | f64x2.ne $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8406: V:1  | drop
+#0. 8410: V:0  | return
 f64x2.ne() =>
 >>> running export "i8x16.lt_s":
-#0. 5091: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5109: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5127: V:2  | i8x16.lt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5129: V:1  | drop
-#0. 5130: V:0  | return
+#0. 8414: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8434: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8454: V:2  | i8x16.lt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8458: V:1  | drop
+#0. 8462: V:0  | return
 i8x16.lt_s() =>
 >>> running export "i8x16.lt_u":
-#0. 5131: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5149: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5167: V:2  | i8x16.lt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5169: V:1  | drop
-#0. 5170: V:0  | return
+#0. 8466: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8486: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8506: V:2  | i8x16.lt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8510: V:1  | drop
+#0. 8514: V:0  | return
 i8x16.lt_u() =>
 >>> running export "i16x8.lt_s":
-#0. 5171: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5189: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5207: V:2  | i16x8.lt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5209: V:1  | drop
-#0. 5210: V:0  | return
+#0. 8518: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8538: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8558: V:2  | i16x8.lt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8562: V:1  | drop
+#0. 8566: V:0  | return
 i16x8.lt_s() =>
 >>> running export "i16x8.lt_u":
-#0. 5211: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5229: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5247: V:2  | i16x8.lt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5249: V:1  | drop
-#0. 5250: V:0  | return
+#0. 8570: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8590: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8610: V:2  | i16x8.lt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8614: V:1  | drop
+#0. 8618: V:0  | return
 i16x8.lt_u() =>
 >>> running export "i32x4.lt_s":
-#0. 5251: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5269: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5287: V:2  | i32x4.lt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5289: V:1  | drop
-#0. 5290: V:0  | return
+#0. 8622: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8642: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8662: V:2  | i32x4.lt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8666: V:1  | drop
+#0. 8670: V:0  | return
 i32x4.lt_s() =>
 >>> running export "i32x4.lt_u":
-#0. 5291: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5309: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5327: V:2  | i32x4.lt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5329: V:1  | drop
-#0. 5330: V:0  | return
+#0. 8674: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8694: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8714: V:2  | i32x4.lt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8718: V:1  | drop
+#0. 8722: V:0  | return
 i32x4.lt_u() =>
 >>> running export "f32x4.lt":
-#0. 5331: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5349: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5367: V:2  | f32x4.lt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5369: V:1  | drop
-#0. 5370: V:0  | return
+#0. 8726: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8746: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8766: V:2  | f32x4.lt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8770: V:1  | drop
+#0. 8774: V:0  | return
 f32x4.lt() =>
 >>> running export "f64x2.lt":
-#0. 5371: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5389: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5407: V:2  | f64x2.lt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5409: V:1  | drop
-#0. 5410: V:0  | return
+#0. 8778: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8798: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8818: V:2  | f64x2.lt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8822: V:1  | drop
+#0. 8826: V:0  | return
 f64x2.lt() =>
 >>> running export "i8x16.le_s":
-#0. 5411: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5429: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5447: V:2  | i8x16.le_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5449: V:1  | drop
-#0. 5450: V:0  | return
+#0. 8830: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8850: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8870: V:2  | i8x16.le_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8874: V:1  | drop
+#0. 8878: V:0  | return
 i8x16.le_s() =>
 >>> running export "i8x16.le_u":
-#0. 5451: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5469: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5487: V:2  | i8x16.le_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5489: V:1  | drop
-#0. 5490: V:0  | return
+#0. 8882: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8902: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8922: V:2  | i8x16.le_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8926: V:1  | drop
+#0. 8930: V:0  | return
 i8x16.le_u() =>
 >>> running export "i16x8.le_s":
-#0. 5491: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5509: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5527: V:2  | i16x8.le_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5529: V:1  | drop
-#0. 5530: V:0  | return
+#0. 8934: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 8954: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 8974: V:2  | i16x8.le_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 8978: V:1  | drop
+#0. 8982: V:0  | return
 i16x8.le_s() =>
 >>> running export "i16x8.le_u":
-#0. 5531: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5549: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5567: V:2  | i16x8.le_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5569: V:1  | drop
-#0. 5570: V:0  | return
+#0. 8986: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9006: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9026: V:2  | i16x8.le_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9030: V:1  | drop
+#0. 9034: V:0  | return
 i16x8.le_u() =>
 >>> running export "i32x4.le_s":
-#0. 5571: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5589: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5607: V:2  | i32x4.le_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5609: V:1  | drop
-#0. 5610: V:0  | return
+#0. 9038: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9058: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9078: V:2  | i32x4.le_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9082: V:1  | drop
+#0. 9086: V:0  | return
 i32x4.le_s() =>
 >>> running export "i32x4.le_u":
-#0. 5611: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5629: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5647: V:2  | i32x4.le_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5649: V:1  | drop
-#0. 5650: V:0  | return
+#0. 9090: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9110: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9130: V:2  | i32x4.le_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9134: V:1  | drop
+#0. 9138: V:0  | return
 i32x4.le_u() =>
 >>> running export "f32x4.le":
-#0. 5651: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5669: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5687: V:2  | f32x4.le $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5689: V:1  | drop
-#0. 5690: V:0  | return
+#0. 9142: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9162: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9182: V:2  | f32x4.le $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9186: V:1  | drop
+#0. 9190: V:0  | return
 f32x4.le() =>
 >>> running export "f64x2.le":
-#0. 5691: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5709: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5727: V:2  | f64x2.le $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5729: V:1  | drop
-#0. 5730: V:0  | return
+#0. 9194: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9214: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9234: V:2  | f64x2.le $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9238: V:1  | drop
+#0. 9242: V:0  | return
 f64x2.le() =>
 >>> running export "i8x16.gt_s":
-#0. 5731: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5749: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5767: V:2  | i8x16.gt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5769: V:1  | drop
-#0. 5770: V:0  | return
+#0. 9246: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9266: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9286: V:2  | i8x16.gt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9290: V:1  | drop
+#0. 9294: V:0  | return
 i8x16.gt_s() =>
 >>> running export "i8x16.gt_u":
-#0. 5771: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5789: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5807: V:2  | i8x16.gt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5809: V:1  | drop
-#0. 5810: V:0  | return
+#0. 9298: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9318: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9338: V:2  | i8x16.gt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9342: V:1  | drop
+#0. 9346: V:0  | return
 i8x16.gt_u() =>
 >>> running export "i16x8.gt_s":
-#0. 5811: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5829: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5847: V:2  | i16x8.gt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5849: V:1  | drop
-#0. 5850: V:0  | return
+#0. 9350: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9370: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9390: V:2  | i16x8.gt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9394: V:1  | drop
+#0. 9398: V:0  | return
 i16x8.gt_s() =>
 >>> running export "i16x8.gt_u":
-#0. 5851: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5869: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5887: V:2  | i16x8.gt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5889: V:1  | drop
-#0. 5890: V:0  | return
+#0. 9402: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9422: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9442: V:2  | i16x8.gt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9446: V:1  | drop
+#0. 9450: V:0  | return
 i16x8.gt_u() =>
 >>> running export "i32x4.gt_s":
-#0. 5891: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5909: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5927: V:2  | i32x4.gt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5929: V:1  | drop
-#0. 5930: V:0  | return
+#0. 9454: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9474: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9494: V:2  | i32x4.gt_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9498: V:1  | drop
+#0. 9502: V:0  | return
 i32x4.gt_s() =>
 >>> running export "i32x4.gt_u":
-#0. 5931: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5949: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5967: V:2  | i32x4.gt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 5969: V:1  | drop
-#0. 5970: V:0  | return
+#0. 9506: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9526: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9546: V:2  | i32x4.gt_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9550: V:1  | drop
+#0. 9554: V:0  | return
 i32x4.gt_u() =>
 >>> running export "f32x4.gt":
-#0. 5971: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 5989: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6007: V:2  | f32x4.gt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6009: V:1  | drop
-#0. 6010: V:0  | return
+#0. 9558: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9578: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9598: V:2  | f32x4.gt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9602: V:1  | drop
+#0. 9606: V:0  | return
 f32x4.gt() =>
 >>> running export "f64x2.gt":
-#0. 6011: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6029: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6047: V:2  | f64x2.gt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6049: V:1  | drop
-#0. 6050: V:0  | return
+#0. 9610: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9630: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9650: V:2  | f64x2.gt $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9654: V:1  | drop
+#0. 9658: V:0  | return
 f64x2.gt() =>
 >>> running export "i8x16.ge_s":
-#0. 6051: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6069: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6087: V:2  | i8x16.ge_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6089: V:1  | drop
-#0. 6090: V:0  | return
+#0. 9662: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9682: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9702: V:2  | i8x16.ge_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9706: V:1  | drop
+#0. 9710: V:0  | return
 i8x16.ge_s() =>
 >>> running export "i8x16.ge_u":
-#0. 6091: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6109: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6127: V:2  | i8x16.ge_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6129: V:1  | drop
-#0. 6130: V:0  | return
+#0. 9714: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9734: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9754: V:2  | i8x16.ge_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9758: V:1  | drop
+#0. 9762: V:0  | return
 i8x16.ge_u() =>
 >>> running export "i16x8.ge_s":
-#0. 6131: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6149: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6167: V:2  | i16x8.ge_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6169: V:1  | drop
-#0. 6170: V:0  | return
+#0. 9766: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9786: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9806: V:2  | i16x8.ge_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9810: V:1  | drop
+#0. 9814: V:0  | return
 i16x8.ge_s() =>
 >>> running export "i16x8.ge_u":
-#0. 6171: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6189: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6207: V:2  | i16x8.ge_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6209: V:1  | drop
-#0. 6210: V:0  | return
+#0. 9818: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9838: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9858: V:2  | i16x8.ge_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9862: V:1  | drop
+#0. 9866: V:0  | return
 i16x8.ge_u() =>
 >>> running export "i32x4.ge_s":
-#0. 6211: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6229: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6247: V:2  | i32x4.ge_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6249: V:1  | drop
-#0. 6250: V:0  | return
+#0. 9870: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9890: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9910: V:2  | i32x4.ge_s $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9914: V:1  | drop
+#0. 9918: V:0  | return
 i32x4.ge_s() =>
 >>> running export "i32x4.ge_u":
-#0. 6251: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6269: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6287: V:2  | i32x4.ge_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6289: V:1  | drop
-#0. 6290: V:0  | return
+#0. 9922: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9942: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 9962: V:2  | i32x4.ge_u $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 9966: V:1  | drop
+#0. 9970: V:0  | return
 i32x4.ge_u() =>
 >>> running export "f32x4.ge":
-#0. 6291: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6309: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6327: V:2  | f32x4.ge $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6329: V:1  | drop
-#0. 6330: V:0  | return
+#0. 9974: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 9994: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10014: V:2  | f32x4.ge $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10018: V:1  | drop
+#0. 10022: V:0  | return
 f32x4.ge() =>
 >>> running export "f64x2.ge":
-#0. 6331: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6349: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6367: V:2  | f64x2.ge $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6369: V:1  | drop
-#0. 6370: V:0  | return
+#0. 10026: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10046: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10066: V:2  | f64x2.ge $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10070: V:1  | drop
+#0. 10074: V:0  | return
 f64x2.ge() =>
 >>> running export "f32x4.neg":
-#0. 6371: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6389: V:1  | f32x4.neg $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6391: V:1  | drop
-#0. 6392: V:0  | return
+#0. 10078: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10098: V:1  | f32x4.neg $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10102: V:1  | drop
+#0. 10106: V:0  | return
 f32x4.neg() =>
 >>> running export "f64x2.neg":
-#0. 6393: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6411: V:1  | f64x2.neg $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6413: V:1  | drop
-#0. 6414: V:0  | return
+#0. 10110: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10130: V:1  | f64x2.neg $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10134: V:1  | drop
+#0. 10138: V:0  | return
 f64x2.neg() =>
 >>> running export "f32x4.abs":
-#0. 6415: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6433: V:1  | f32x4.abs $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6435: V:1  | drop
-#0. 6436: V:0  | return
+#0. 10142: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10162: V:1  | f32x4.abs $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10166: V:1  | drop
+#0. 10170: V:0  | return
 f32x4.abs() =>
 >>> running export "f64x2.abs":
-#0. 6437: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6455: V:1  | f64x2.abs $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6457: V:1  | drop
-#0. 6458: V:0  | return
+#0. 10174: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10194: V:1  | f64x2.abs $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10198: V:1  | drop
+#0. 10202: V:0  | return
 f64x2.abs() =>
 >>> running export "f32x4.min":
-#0. 6459: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6477: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6495: V:2  | f32x4.min $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6497: V:1  | drop
-#0. 6498: V:0  | return
+#0. 10206: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10226: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10246: V:2  | f32x4.min $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10250: V:1  | drop
+#0. 10254: V:0  | return
 f32x4.min() =>
 >>> running export "f64x2.min":
-#0. 6499: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6517: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6535: V:2  | f64x2.min $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6537: V:1  | drop
-#0. 6538: V:0  | return
+#0. 10258: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10278: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10298: V:2  | f64x2.min $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10302: V:1  | drop
+#0. 10306: V:0  | return
 f64x2.min() =>
 >>> running export "f32x4.max":
-#0. 6539: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6557: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6575: V:2  | f32x4.max $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6577: V:1  | drop
-#0. 6578: V:0  | return
+#0. 10310: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10330: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10350: V:2  | f32x4.max $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10354: V:1  | drop
+#0. 10358: V:0  | return
 f32x4.max() =>
 >>> running export "f64x2.max":
-#0. 6579: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6597: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6615: V:2  | f64x2.max $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6617: V:1  | drop
-#0. 6618: V:0  | return
+#0. 10362: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10382: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10402: V:2  | f64x2.max $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10406: V:1  | drop
+#0. 10410: V:0  | return
 f64x2.max() =>
 >>> running export "f32x4.add":
-#0. 6619: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6637: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6655: V:2  | f32x4.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6657: V:1  | drop
-#0. 6658: V:0  | return
+#0. 10414: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10434: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10454: V:2  | f32x4.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10458: V:1  | drop
+#0. 10462: V:0  | return
 f32x4.add() =>
 >>> running export "f64x2.add":
-#0. 6659: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6677: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6695: V:2  | f64x2.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6697: V:1  | drop
-#0. 6698: V:0  | return
+#0. 10466: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10486: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10506: V:2  | f64x2.add $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10510: V:1  | drop
+#0. 10514: V:0  | return
 f64x2.add() =>
 >>> running export "f32x4.sub":
-#0. 6699: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6717: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6735: V:2  | f32x4.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6737: V:1  | drop
-#0. 6738: V:0  | return
+#0. 10518: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10538: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10558: V:2  | f32x4.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10562: V:1  | drop
+#0. 10566: V:0  | return
 f32x4.sub() =>
 >>> running export "f64x2.sub":
-#0. 6739: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6757: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6775: V:2  | f64x2.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6777: V:1  | drop
-#0. 6778: V:0  | return
+#0. 10570: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10590: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10610: V:2  | f64x2.sub $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10614: V:1  | drop
+#0. 10618: V:0  | return
 f64x2.sub() =>
 >>> running export "f32x4.div":
-#0. 6779: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6797: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6815: V:2  | f32x4.div $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6817: V:1  | drop
-#0. 6818: V:0  | return
+#0. 10622: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10642: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10662: V:2  | f32x4.div $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10666: V:1  | drop
+#0. 10670: V:0  | return
 f32x4.div() =>
 >>> running export "f64x2.div":
-#0. 6819: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6837: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6855: V:2  | f64x2.div $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6857: V:1  | drop
-#0. 6858: V:0  | return
+#0. 10674: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10694: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10714: V:2  | f64x2.div $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10718: V:1  | drop
+#0. 10722: V:0  | return
 f64x2.div() =>
 >>> running export "f32x4.mul":
-#0. 6859: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6877: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6895: V:2  | f32x4.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6897: V:1  | drop
-#0. 6898: V:0  | return
+#0. 10726: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10746: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10766: V:2  | f32x4.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10770: V:1  | drop
+#0. 10774: V:0  | return
 f32x4.mul() =>
 >>> running export "f64x2.mul":
-#0. 6899: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6917: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
-#0. 6935: V:2  | f64x2.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
-#0. 6937: V:1  | drop
-#0. 6938: V:0  | return
+#0. 10778: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10798: V:1  | v128.const $0x00000002 0x00000002 0x00000002 0x00000002
+#0. 10818: V:2  | f64x2.mul $0x00000001 00000001 00000001 00000001  $0x00000002 00000002 00000002 00000002
+#0. 10822: V:1  | drop
+#0. 10826: V:0  | return
 f64x2.mul() =>
 >>> running export "f32x4.sqrt":
-#0. 6939: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6957: V:1  | f32x4.sqrt $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6959: V:1  | drop
-#0. 6960: V:0  | return
+#0. 10830: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10850: V:1  | f32x4.sqrt $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10854: V:1  | drop
+#0. 10858: V:0  | return
 f32x4.sqrt() =>
 >>> running export "f64x2.sqrt":
-#0. 6961: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6979: V:1  | f64x2.sqrt $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 6981: V:1  | drop
-#0. 6982: V:0  | return
+#0. 10862: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10882: V:1  | f64x2.sqrt $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10886: V:1  | drop
+#0. 10890: V:0  | return
 f64x2.sqrt() =>
 >>> running export "f32x4.convert_s/i32x4":
-#0. 6983: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7001: V:1  | f32x4.convert_s/i32x4 $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7003: V:1  | drop
-#0. 7004: V:0  | return
+#0. 10894: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10914: V:1  | f32x4.convert_s/i32x4 $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10918: V:1  | drop
+#0. 10922: V:0  | return
 f32x4.convert_s/i32x4() =>
 >>> running export "f32x4.convert_u/i32x4":
-#0. 7005: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7023: V:1  | f32x4.convert_u/i32x4 $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7025: V:1  | drop
-#0. 7026: V:0  | return
+#0. 10926: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10946: V:1  | f32x4.convert_u/i32x4 $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10950: V:1  | drop
+#0. 10954: V:0  | return
 f32x4.convert_u/i32x4() =>
 >>> running export "f64x2.convert_s/i64x2":
-#0. 7027: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7045: V:1  | f64x2.convert_s/i64x2 $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7047: V:1  | drop
-#0. 7048: V:0  | return
+#0. 10958: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10978: V:1  | f64x2.convert_s/i64x2 $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 10982: V:1  | drop
+#0. 10986: V:0  | return
 f64x2.convert_s/i64x2() =>
 >>> running export "f64x2.convert_u/i64x2":
-#0. 7049: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7067: V:1  | f64x2.convert_u/i64x2 $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7069: V:1  | drop
-#0. 7070: V:0  | return
+#0. 10990: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11010: V:1  | f64x2.convert_u/i64x2 $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11014: V:1  | drop
+#0. 11018: V:0  | return
 f64x2.convert_u/i64x2() =>
 >>> running export "i32x4.trunc_s/f32x4:sat":
-#0. 7071: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7089: V:1  | i32x4.trunc_s/f32x4:sat $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7091: V:1  | drop
-#0. 7092: V:0  | return
+#0. 11022: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11042: V:1  | i32x4.trunc_s/f32x4:sat $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11046: V:1  | drop
+#0. 11050: V:0  | return
 i32x4.trunc_s/f32x4:sat() =>
 >>> running export "i32x4.trunc_u/f32x4:sat":
-#0. 7093: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7111: V:1  | i32x4.trunc_u/f32x4:sat $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7113: V:1  | drop
-#0. 7114: V:0  | return
+#0. 11054: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11074: V:1  | i32x4.trunc_u/f32x4:sat $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11078: V:1  | drop
+#0. 11082: V:0  | return
 i32x4.trunc_u/f32x4:sat() =>
 >>> running export "i64x2.trunc_s/f64x2:sat":
-#0. 7115: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7133: V:1  | i64x2.trunc_s/f64x2:sat $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7135: V:1  | drop
-#0. 7136: V:0  | return
+#0. 11086: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11106: V:1  | i64x2.trunc_s/f64x2:sat $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11110: V:1  | drop
+#0. 11114: V:0  | return
 i64x2.trunc_s/f64x2:sat() =>
 >>> running export "i64x2.trunc_u/f64x2:sat":
-#0. 7137: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7155: V:1  | i64x2.trunc_u/f64x2:sat $0x00000001 0x00000001 0x00000001 0x00000001
-#0. 7157: V:1  | drop
-#0. 7158: V:0  | return
+#0. 11118: V:0  | v128.const $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11138: V:1  | i64x2.trunc_u/f64x2:sat $0x00000001 0x00000001 0x00000001 0x00000001
+#0. 11142: V:1  | drop
+#0. 11146: V:0  | return
 i64x2.trunc_u/f64x2:sat() =>
 >>> running export "atomic.wake":
-#0. 7159: V:0  | i32.const $1
-#0. 7164: V:1  | i32.const $2
-#0. 7169: V:2  | atomic.wake $0:1+$3, 2
+#0. 11150: V:0  | i32.const $1
+#0. 11158: V:1  | i32.const $2
+#0. 11166: V:2  | atomic.wake $0:1+$3, 2
 atomic.wake() => error: unreachable executed
 >>> running export "i32.atomic.wait":
-#0. 7181: V:0  | i32.const $1
-#0. 7186: V:1  | i32.const $2
-#0. 7191: V:2  | i64.const $3
-#0. 7200: V:3  | i32.atomic.wait $0:1+$3, 2, 3
+#0. 11186: V:0  | i32.const $1
+#0. 11194: V:1  | i32.const $2
+#0. 11202: V:2  | i64.const $3
+#0. 11214: V:3  | i32.atomic.wait $0:1+$3, 2, 3
 i32.atomic.wait() => error: unreachable executed
 >>> running export "i64.atomic.wait":
-#0. 7212: V:0  | i32.const $1
-#0. 7217: V:1  | i64.const $2
-#0. 7226: V:2  | i64.const $3
-#0. 7235: V:3  | i64.atomic.wait $0:1+$3, 2, 3
+#0. 11234: V:0  | i32.const $1
+#0. 11242: V:1  | i64.const $2
+#0. 11254: V:2  | i64.const $3
+#0. 11266: V:3  | i64.atomic.wait $0:1+$3, 2, 3
 i64.atomic.wait() => error: unreachable executed
 >>> running export "i32.atomic.load":
-#0. 7247: V:0  | i32.const $1
-#0. 7252: V:1  | i32.atomic.load $0:1+$3
-#0. 7262: V:1  | drop
-#0. 7263: V:0  | return
+#0. 11286: V:0  | i32.const $1
+#0. 11294: V:1  | i32.atomic.load $0:1+$3
+#0. 11306: V:1  | drop
+#0. 11310: V:0  | return
 i32.atomic.load() =>
 >>> running export "i64.atomic.load":
-#0. 7264: V:0  | i32.const $1
-#0. 7269: V:1  | i64.atomic.load $0:1+$7
-#0. 7279: V:1  | drop
-#0. 7280: V:0  | return
+#0. 11314: V:0  | i32.const $1
+#0. 11322: V:1  | i64.atomic.load $0:1+$7
+#0. 11334: V:1  | drop
+#0. 11338: V:0  | return
 i64.atomic.load() =>
 >>> running export "i32.atomic.load8_u":
-#0. 7281: V:0  | i32.const $1
-#0. 7286: V:1  | i32.atomic.load8_u $0:1+$3
-#0. 7296: V:1  | drop
-#0. 7297: V:0  | return
+#0. 11342: V:0  | i32.const $1
+#0. 11350: V:1  | i32.atomic.load8_u $0:1+$3
+#0. 11362: V:1  | drop
+#0. 11366: V:0  | return
 i32.atomic.load8_u() =>
 >>> running export "i32.atomic.load16_u":
-#0. 7298: V:0  | i32.const $1
-#0. 7303: V:1  | i32.atomic.load16_u $0:1+$3
-#0. 7313: V:1  | drop
-#0. 7314: V:0  | return
+#0. 11370: V:0  | i32.const $1
+#0. 11378: V:1  | i32.atomic.load16_u $0:1+$3
+#0. 11390: V:1  | drop
+#0. 11394: V:0  | return
 i32.atomic.load16_u() =>
 >>> running export "i64.atomic.load8_u":
-#0. 7315: V:0  | i32.const $1
-#0. 7320: V:1  | i64.atomic.load8_u $0:1+$3
-#0. 7330: V:1  | drop
-#0. 7331: V:0  | return
+#0. 11398: V:0  | i32.const $1
+#0. 11406: V:1  | i64.atomic.load8_u $0:1+$3
+#0. 11418: V:1  | drop
+#0. 11422: V:0  | return
 i64.atomic.load8_u() =>
 >>> running export "i64.atomic.load16_u":
-#0. 7332: V:0  | i32.const $1
-#0. 7337: V:1  | i64.atomic.load16_u $0:1+$3
-#0. 7347: V:1  | drop
-#0. 7348: V:0  | return
+#0. 11426: V:0  | i32.const $1
+#0. 11434: V:1  | i64.atomic.load16_u $0:1+$3
+#0. 11446: V:1  | drop
+#0. 11450: V:0  | return
 i64.atomic.load16_u() =>
 >>> running export "i64.atomic.load32_u":
-#0. 7349: V:0  | i32.const $1
-#0. 7354: V:1  | i64.atomic.load32_u $0:1+$3
-#0. 7364: V:1  | drop
-#0. 7365: V:0  | return
+#0. 11454: V:0  | i32.const $1
+#0. 11462: V:1  | i64.atomic.load32_u $0:1+$3
+#0. 11474: V:1  | drop
+#0. 11478: V:0  | return
 i64.atomic.load32_u() =>
 >>> running export "i32.atomic.store":
-#0. 7366: V:0  | i32.const $1
-#0. 7371: V:1  | i32.const $2
-#0. 7376: V:2  | i32.atomic.store $0:1+$3, 2
-#0. 7386: V:0  | return
+#0. 11482: V:0  | i32.const $1
+#0. 11490: V:1  | i32.const $2
+#0. 11498: V:2  | i32.atomic.store $0:1+$3, 2
+#0. 11510: V:0  | return
 i32.atomic.store() =>
 >>> running export "i64.atomic.store":
-#0. 7387: V:0  | i32.const $1
-#0. 7392: V:1  | i64.const $2
-#0. 7401: V:2  | i64.atomic.store $0:1+$7, 2
-#0. 7411: V:0  | return
+#0. 11514: V:0  | i32.const $1
+#0. 11522: V:1  | i64.const $2
+#0. 11534: V:2  | i64.atomic.store $0:1+$7, 2
+#0. 11546: V:0  | return
 i64.atomic.store() =>
 >>> running export "i32.atomic.store8":
-#0. 7412: V:0  | i32.const $1
-#0. 7417: V:1  | i32.const $2
-#0. 7422: V:2  | i32.atomic.store8 $0:1+$3, 2
-#0. 7432: V:0  | return
+#0. 11550: V:0  | i32.const $1
+#0. 11558: V:1  | i32.const $2
+#0. 11566: V:2  | i32.atomic.store8 $0:1+$3, 2
+#0. 11578: V:0  | return
 i32.atomic.store8() =>
 >>> running export "i32.atomic.store16":
-#0. 7433: V:0  | i32.const $1
-#0. 7438: V:1  | i32.const $2
-#0. 7443: V:2  | i32.atomic.store16 $0:1+$3, 2
-#0. 7453: V:0  | return
+#0. 11582: V:0  | i32.const $1
+#0. 11590: V:1  | i32.const $2
+#0. 11598: V:2  | i32.atomic.store16 $0:1+$3, 2
+#0. 11610: V:0  | return
 i32.atomic.store16() =>
 >>> running export "i64.atomic.store8":
-#0. 7454: V:0  | i32.const $1
-#0. 7459: V:1  | i64.const $2
-#0. 7468: V:2  | i64.atomic.store8 $0:1+$3, 2
-#0. 7478: V:0  | return
+#0. 11614: V:0  | i32.const $1
+#0. 11622: V:1  | i64.const $2
+#0. 11634: V:2  | i64.atomic.store8 $0:1+$3, 2
+#0. 11646: V:0  | return
 i64.atomic.store8() =>
 >>> running export "i64.atomic.store16":
-#0. 7479: V:0  | i32.const $1
-#0. 7484: V:1  | i64.const $2
-#0. 7493: V:2  | i64.atomic.store16 $0:1+$3, 2
-#0. 7503: V:0  | return
+#0. 11650: V:0  | i32.const $1
+#0. 11658: V:1  | i64.const $2
+#0. 11670: V:2  | i64.atomic.store16 $0:1+$3, 2
+#0. 11682: V:0  | return
 i64.atomic.store16() =>
 >>> running export "i64.atomic.store32":
-#0. 7504: V:0  | i32.const $1
-#0. 7509: V:1  | i64.const $2
-#0. 7518: V:2  | i64.atomic.store32 $0:1+$3, 2
-#0. 7528: V:0  | return
+#0. 11686: V:0  | i32.const $1
+#0. 11694: V:1  | i64.const $2
+#0. 11706: V:2  | i64.atomic.store32 $0:1+$3, 2
+#0. 11718: V:0  | return
 i64.atomic.store32() =>
 >>> running export "i32.atomic.rmw.add":
-#0. 7529: V:0  | i32.const $1
-#0. 7534: V:1  | i32.const $2
-#0. 7539: V:2  | i32.atomic.rmw.add $0:1+$3, 2
-#0. 7549: V:1  | drop
-#0. 7550: V:0  | return
+#0. 11722: V:0  | i32.const $1
+#0. 11730: V:1  | i32.const $2
+#0. 11738: V:2  | i32.atomic.rmw.add $0:1+$3, 2
+#0. 11750: V:1  | drop
+#0. 11754: V:0  | return
 i32.atomic.rmw.add() =>
 >>> running export "i64.atomic.rmw.add":
-#0. 7551: V:0  | i32.const $1
-#0. 7556: V:1  | i64.const $2
-#0. 7565: V:2  | i64.atomic.rmw.add $0:1+$7, 2
-#0. 7575: V:1  | drop
-#0. 7576: V:0  | return
+#0. 11758: V:0  | i32.const $1
+#0. 11766: V:1  | i64.const $2
+#0. 11778: V:2  | i64.atomic.rmw.add $0:1+$7, 2
+#0. 11790: V:1  | drop
+#0. 11794: V:0  | return
 i64.atomic.rmw.add() =>
 >>> running export "i32.atomic.rmw8_u.add":
-#0. 7577: V:0  | i32.const $1
-#0. 7582: V:1  | i32.const $2
-#0. 7587: V:2  | i32.atomic.rmw8_u.add $0:1+$3, 2
-#0. 7597: V:1  | drop
-#0. 7598: V:0  | return
+#0. 11798: V:0  | i32.const $1
+#0. 11806: V:1  | i32.const $2
+#0. 11814: V:2  | i32.atomic.rmw8_u.add $0:1+$3, 2
+#0. 11826: V:1  | drop
+#0. 11830: V:0  | return
 i32.atomic.rmw8_u.add() =>
 >>> running export "i32.atomic.rmw16_u.add":
-#0. 7599: V:0  | i32.const $1
-#0. 7604: V:1  | i32.const $2
-#0. 7609: V:2  | i32.atomic.rmw16_u.add $0:1+$3, 2
-#0. 7619: V:1  | drop
-#0. 7620: V:0  | return
+#0. 11834: V:0  | i32.const $1
+#0. 11842: V:1  | i32.const $2
+#0. 11850: V:2  | i32.atomic.rmw16_u.add $0:1+$3, 2
+#0. 11862: V:1  | drop
+#0. 11866: V:0  | return
 i32.atomic.rmw16_u.add() =>
 >>> running export "i64.atomic.rmw8_u.add":
-#0. 7621: V:0  | i32.const $1
-#0. 7626: V:1  | i64.const $2
-#0. 7635: V:2  | i64.atomic.rmw8_u.add $0:1+$3, 2
-#0. 7645: V:1  | drop
-#0. 7646: V:0  | return
+#0. 11870: V:0  | i32.const $1
+#0. 11878: V:1  | i64.const $2
+#0. 11890: V:2  | i64.atomic.rmw8_u.add $0:1+$3, 2
+#0. 11902: V:1  | drop
+#0. 11906: V:0  | return
 i64.atomic.rmw8_u.add() =>
 >>> running export "i64.atomic.rmw16_u.add":
-#0. 7647: V:0  | i32.const $1
-#0. 7652: V:1  | i64.const $2
-#0. 7661: V:2  | i64.atomic.rmw16_u.add $0:1+$3, 2
-#0. 7671: V:1  | drop
-#0. 7672: V:0  | return
+#0. 11910: V:0  | i32.const $1
+#0. 11918: V:1  | i64.const $2
+#0. 11930: V:2  | i64.atomic.rmw16_u.add $0:1+$3, 2
+#0. 11942: V:1  | drop
+#0. 11946: V:0  | return
 i64.atomic.rmw16_u.add() =>
 >>> running export "i64.atomic.rmw32_u.add":
-#0. 7673: V:0  | i32.const $1
-#0. 7678: V:1  | i64.const $2
-#0. 7687: V:2  | i64.atomic.rmw32_u.add $0:1+$3, 2
-#0. 7697: V:1  | drop
-#0. 7698: V:0  | return
+#0. 11950: V:0  | i32.const $1
+#0. 11958: V:1  | i64.const $2
+#0. 11970: V:2  | i64.atomic.rmw32_u.add $0:1+$3, 2
+#0. 11982: V:1  | drop
+#0. 11986: V:0  | return
 i64.atomic.rmw32_u.add() =>
 >>> running export "i32.atomic.rmw.sub":
-#0. 7699: V:0  | i32.const $1
-#0. 7704: V:1  | i32.const $2
-#0. 7709: V:2  | i32.atomic.rmw.sub $0:1+$3, 2
-#0. 7719: V:1  | drop
-#0. 7720: V:0  | return
+#0. 11990: V:0  | i32.const $1
+#0. 11998: V:1  | i32.const $2
+#0. 12006: V:2  | i32.atomic.rmw.sub $0:1+$3, 2
+#0. 12018: V:1  | drop
+#0. 12022: V:0  | return
 i32.atomic.rmw.sub() =>
 >>> running export "i64.atomic.rmw.sub":
-#0. 7721: V:0  | i32.const $1
-#0. 7726: V:1  | i64.const $2
-#0. 7735: V:2  | i64.atomic.rmw.sub $0:1+$7, 2
-#0. 7745: V:1  | drop
-#0. 7746: V:0  | return
+#0. 12026: V:0  | i32.const $1
+#0. 12034: V:1  | i64.const $2
+#0. 12046: V:2  | i64.atomic.rmw.sub $0:1+$7, 2
+#0. 12058: V:1  | drop
+#0. 12062: V:0  | return
 i64.atomic.rmw.sub() =>
 >>> running export "i32.atomic.rmw8_u.sub":
-#0. 7747: V:0  | i32.const $1
-#0. 7752: V:1  | i32.const $2
-#0. 7757: V:2  | i32.atomic.rmw8_u.sub $0:1+$3, 2
-#0. 7767: V:1  | drop
-#0. 7768: V:0  | return
+#0. 12066: V:0  | i32.const $1
+#0. 12074: V:1  | i32.const $2
+#0. 12082: V:2  | i32.atomic.rmw8_u.sub $0:1+$3, 2
+#0. 12094: V:1  | drop
+#0. 12098: V:0  | return
 i32.atomic.rmw8_u.sub() =>
 >>> running export "i32.atomic.rmw16_u.sub":
-#0. 7769: V:0  | i32.const $1
-#0. 7774: V:1  | i32.const $2
-#0. 7779: V:2  | i32.atomic.rmw16_u.sub $0:1+$3, 2
-#0. 7789: V:1  | drop
-#0. 7790: V:0  | return
+#0. 12102: V:0  | i32.const $1
+#0. 12110: V:1  | i32.const $2
+#0. 12118: V:2  | i32.atomic.rmw16_u.sub $0:1+$3, 2
+#0. 12130: V:1  | drop
+#0. 12134: V:0  | return
 i32.atomic.rmw16_u.sub() =>
 >>> running export "i64.atomic.rmw8_u.sub":
-#0. 7791: V:0  | i32.const $1
-#0. 7796: V:1  | i64.const $2
-#0. 7805: V:2  | i64.atomic.rmw8_u.sub $0:1+$3, 2
-#0. 7815: V:1  | drop
-#0. 7816: V:0  | return
+#0. 12138: V:0  | i32.const $1
+#0. 12146: V:1  | i64.const $2
+#0. 12158: V:2  | i64.atomic.rmw8_u.sub $0:1+$3, 2
+#0. 12170: V:1  | drop
+#0. 12174: V:0  | return
 i64.atomic.rmw8_u.sub() =>
 >>> running export "i64.atomic.rmw16_u.sub":
-#0. 7817: V:0  | i32.const $1
-#0. 7822: V:1  | i64.const $2
-#0. 7831: V:2  | i64.atomic.rmw16_u.sub $0:1+$3, 2
-#0. 7841: V:1  | drop
-#0. 7842: V:0  | return
+#0. 12178: V:0  | i32.const $1
+#0. 12186: V:1  | i64.const $2
+#0. 12198: V:2  | i64.atomic.rmw16_u.sub $0:1+$3, 2
+#0. 12210: V:1  | drop
+#0. 12214: V:0  | return
 i64.atomic.rmw16_u.sub() =>
 >>> running export "i64.atomic.rmw32_u.sub":
-#0. 7843: V:0  | i32.const $1
-#0. 7848: V:1  | i64.const $2
-#0. 7857: V:2  | i64.atomic.rmw32_u.sub $0:1+$3, 2
-#0. 7867: V:1  | drop
-#0. 7868: V:0  | return
+#0. 12218: V:0  | i32.const $1
+#0. 12226: V:1  | i64.const $2
+#0. 12238: V:2  | i64.atomic.rmw32_u.sub $0:1+$3, 2
+#0. 12250: V:1  | drop
+#0. 12254: V:0  | return
 i64.atomic.rmw32_u.sub() =>
 >>> running export "i32.atomic.rmw.and":
-#0. 7869: V:0  | i32.const $1
-#0. 7874: V:1  | i32.const $2
-#0. 7879: V:2  | i32.atomic.rmw.and $0:1+$3, 2
-#0. 7889: V:1  | drop
-#0. 7890: V:0  | return
+#0. 12258: V:0  | i32.const $1
+#0. 12266: V:1  | i32.const $2
+#0. 12274: V:2  | i32.atomic.rmw.and $0:1+$3, 2
+#0. 12286: V:1  | drop
+#0. 12290: V:0  | return
 i32.atomic.rmw.and() =>
 >>> running export "i64.atomic.rmw.and":
-#0. 7891: V:0  | i32.const $1
-#0. 7896: V:1  | i64.const $2
-#0. 7905: V:2  | i64.atomic.rmw.and $0:1+$7, 2
-#0. 7915: V:1  | drop
-#0. 7916: V:0  | return
+#0. 12294: V:0  | i32.const $1
+#0. 12302: V:1  | i64.const $2
+#0. 12314: V:2  | i64.atomic.rmw.and $0:1+$7, 2
+#0. 12326: V:1  | drop
+#0. 12330: V:0  | return
 i64.atomic.rmw.and() =>
 >>> running export "i32.atomic.rmw8_u.and":
-#0. 7917: V:0  | i32.const $1
-#0. 7922: V:1  | i32.const $2
-#0. 7927: V:2  | i32.atomic.rmw8_u.and $0:1+$3, 2
-#0. 7937: V:1  | drop
-#0. 7938: V:0  | return
+#0. 12334: V:0  | i32.const $1
+#0. 12342: V:1  | i32.const $2
+#0. 12350: V:2  | i32.atomic.rmw8_u.and $0:1+$3, 2
+#0. 12362: V:1  | drop
+#0. 12366: V:0  | return
 i32.atomic.rmw8_u.and() =>
 >>> running export "i32.atomic.rmw16_u.and":
-#0. 7939: V:0  | i32.const $1
-#0. 7944: V:1  | i32.const $2
-#0. 7949: V:2  | i32.atomic.rmw16_u.and $0:1+$3, 2
-#0. 7959: V:1  | drop
-#0. 7960: V:0  | return
+#0. 12370: V:0  | i32.const $1
+#0. 12378: V:1  | i32.const $2
+#0. 12386: V:2  | i32.atomic.rmw16_u.and $0:1+$3, 2
+#0. 12398: V:1  | drop
+#0. 12402: V:0  | return
 i32.atomic.rmw16_u.and() =>
 >>> running export "i64.atomic.rmw8_u.and":
-#0. 7961: V:0  | i32.const $1
-#0. 7966: V:1  | i64.const $2
-#0. 7975: V:2  | i64.atomic.rmw8_u.and $0:1+$3, 2
-#0. 7985: V:1  | drop
-#0. 7986: V:0  | return
+#0. 12406: V:0  | i32.const $1
+#0. 12414: V:1  | i64.const $2
+#0. 12426: V:2  | i64.atomic.rmw8_u.and $0:1+$3, 2
+#0. 12438: V:1  | drop
+#0. 12442: V:0  | return
 i64.atomic.rmw8_u.and() =>
 >>> running export "i64.atomic.rmw16_u.and":
-#0. 7987: V:0  | i32.const $1
-#0. 7992: V:1  | i64.const $2
-#0. 8001: V:2  | i64.atomic.rmw16_u.and $0:1+$3, 2
-#0. 8011: V:1  | drop
-#0. 8012: V:0  | return
+#0. 12446: V:0  | i32.const $1
+#0. 12454: V:1  | i64.const $2
+#0. 12466: V:2  | i64.atomic.rmw16_u.and $0:1+$3, 2
+#0. 12478: V:1  | drop
+#0. 12482: V:0  | return
 i64.atomic.rmw16_u.and() =>
 >>> running export "i64.atomic.rmw32_u.and":
-#0. 8013: V:0  | i32.const $1
-#0. 8018: V:1  | i64.const $2
-#0. 8027: V:2  | i64.atomic.rmw32_u.and $0:1+$3, 2
-#0. 8037: V:1  | drop
-#0. 8038: V:0  | return
+#0. 12486: V:0  | i32.const $1
+#0. 12494: V:1  | i64.const $2
+#0. 12506: V:2  | i64.atomic.rmw32_u.and $0:1+$3, 2
+#0. 12518: V:1  | drop
+#0. 12522: V:0  | return
 i64.atomic.rmw32_u.and() =>
 >>> running export "i32.atomic.rmw.or":
-#0. 8039: V:0  | i32.const $1
-#0. 8044: V:1  | i32.const $2
-#0. 8049: V:2  | i32.atomic.rmw.or $0:1+$3, 2
-#0. 8059: V:1  | drop
-#0. 8060: V:0  | return
+#0. 12526: V:0  | i32.const $1
+#0. 12534: V:1  | i32.const $2
+#0. 12542: V:2  | i32.atomic.rmw.or $0:1+$3, 2
+#0. 12554: V:1  | drop
+#0. 12558: V:0  | return
 i32.atomic.rmw.or() =>
 >>> running export "i64.atomic.rmw.or":
-#0. 8061: V:0  | i32.const $1
-#0. 8066: V:1  | i64.const $2
-#0. 8075: V:2  | i64.atomic.rmw.or $0:1+$7, 2
-#0. 8085: V:1  | drop
-#0. 8086: V:0  | return
+#0. 12562: V:0  | i32.const $1
+#0. 12570: V:1  | i64.const $2
+#0. 12582: V:2  | i64.atomic.rmw.or $0:1+$7, 2
+#0. 12594: V:1  | drop
+#0. 12598: V:0  | return
 i64.atomic.rmw.or() =>
 >>> running export "i32.atomic.rmw8_u.or":
-#0. 8087: V:0  | i32.const $1
-#0. 8092: V:1  | i32.const $2
-#0. 8097: V:2  | i32.atomic.rmw8_u.or $0:1+$3, 2
-#0. 8107: V:1  | drop
-#0. 8108: V:0  | return
+#0. 12602: V:0  | i32.const $1
+#0. 12610: V:1  | i32.const $2
+#0. 12618: V:2  | i32.atomic.rmw8_u.or $0:1+$3, 2
+#0. 12630: V:1  | drop
+#0. 12634: V:0  | return
 i32.atomic.rmw8_u.or() =>
 >>> running export "i32.atomic.rmw16_u.or":
-#0. 8109: V:0  | i32.const $1
-#0. 8114: V:1  | i32.const $2
-#0. 8119: V:2  | i32.atomic.rmw16_u.or $0:1+$3, 2
-#0. 8129: V:1  | drop
-#0. 8130: V:0  | return
+#0. 12638: V:0  | i32.const $1
+#0. 12646: V:1  | i32.const $2
+#0. 12654: V:2  | i32.atomic.rmw16_u.or $0:1+$3, 2
+#0. 12666: V:1  | drop
+#0. 12670: V:0  | return
 i32.atomic.rmw16_u.or() =>
 >>> running export "i64.atomic.rmw8_u.or":
-#0. 8131: V:0  | i32.const $1
-#0. 8136: V:1  | i64.const $2
-#0. 8145: V:2  | i64.atomic.rmw8_u.or $0:1+$3, 2
-#0. 8155: V:1  | drop
-#0. 8156: V:0  | return
+#0. 12674: V:0  | i32.const $1
+#0. 12682: V:1  | i64.const $2
+#0. 12694: V:2  | i64.atomic.rmw8_u.or $0:1+$3, 2
+#0. 12706: V:1  | drop
+#0. 12710: V:0  | return
 i64.atomic.rmw8_u.or() =>
 >>> running export "i64.atomic.rmw16_u.or":
-#0. 8157: V:0  | i32.const $1
-#0. 8162: V:1  | i64.const $2
-#0. 8171: V:2  | i64.atomic.rmw16_u.or $0:1+$3, 2
-#0. 8181: V:1  | drop
-#0. 8182: V:0  | return
+#0. 12714: V:0  | i32.const $1
+#0. 12722: V:1  | i64.const $2
+#0. 12734: V:2  | i64.atomic.rmw16_u.or $0:1+$3, 2
+#0. 12746: V:1  | drop
+#0. 12750: V:0  | return
 i64.atomic.rmw16_u.or() =>
 >>> running export "i64.atomic.rmw32_u.or":
-#0. 8183: V:0  | i32.const $1
-#0. 8188: V:1  | i64.const $2
-#0. 8197: V:2  | i64.atomic.rmw32_u.or $0:1+$3, 2
-#0. 8207: V:1  | drop
-#0. 8208: V:0  | return
+#0. 12754: V:0  | i32.const $1
+#0. 12762: V:1  | i64.const $2
+#0. 12774: V:2  | i64.atomic.rmw32_u.or $0:1+$3, 2
+#0. 12786: V:1  | drop
+#0. 12790: V:0  | return
 i64.atomic.rmw32_u.or() =>
 >>> running export "i32.atomic.rmw.xor":
-#0. 8209: V:0  | i32.const $1
-#0. 8214: V:1  | i32.const $2
-#0. 8219: V:2  | i32.atomic.rmw.xor $0:1+$3, 2
-#0. 8229: V:1  | drop
-#0. 8230: V:0  | return
+#0. 12794: V:0  | i32.const $1
+#0. 12802: V:1  | i32.const $2
+#0. 12810: V:2  | i32.atomic.rmw.xor $0:1+$3, 2
+#0. 12822: V:1  | drop
+#0. 12826: V:0  | return
 i32.atomic.rmw.xor() =>
 >>> running export "i64.atomic.rmw.xor":
-#0. 8231: V:0  | i32.const $1
-#0. 8236: V:1  | i64.const $2
-#0. 8245: V:2  | i64.atomic.rmw.xor $0:1+$7, 2
-#0. 8255: V:1  | drop
-#0. 8256: V:0  | return
+#0. 12830: V:0  | i32.const $1
+#0. 12838: V:1  | i64.const $2
+#0. 12850: V:2  | i64.atomic.rmw.xor $0:1+$7, 2
+#0. 12862: V:1  | drop
+#0. 12866: V:0  | return
 i64.atomic.rmw.xor() =>
 >>> running export "i32.atomic.rmw8_u.xor":
-#0. 8257: V:0  | i32.const $1
-#0. 8262: V:1  | i32.const $2
-#0. 8267: V:2  | i32.atomic.rmw8_u.xor $0:1+$3, 2
-#0. 8277: V:1  | drop
-#0. 8278: V:0  | return
+#0. 12870: V:0  | i32.const $1
+#0. 12878: V:1  | i32.const $2
+#0. 12886: V:2  | i32.atomic.rmw8_u.xor $0:1+$3, 2
+#0. 12898: V:1  | drop
+#0. 12902: V:0  | return
 i32.atomic.rmw8_u.xor() =>
 >>> running export "i32.atomic.rmw16_u.xor":
-#0. 8279: V:0  | i32.const $1
-#0. 8284: V:1  | i32.const $2
-#0. 8289: V:2  | i32.atomic.rmw16_u.xor $0:1+$3, 2
-#0. 8299: V:1  | drop
-#0. 8300: V:0  | return
+#0. 12906: V:0  | i32.const $1
+#0. 12914: V:1  | i32.const $2
+#0. 12922: V:2  | i32.atomic.rmw16_u.xor $0:1+$3, 2
+#0. 12934: V:1  | drop
+#0. 12938: V:0  | return
 i32.atomic.rmw16_u.xor() =>
 >>> running export "i64.atomic.rmw8_u.xor":
-#0. 8301: V:0  | i32.const $1
-#0. 8306: V:1  | i64.const $2
-#0. 8315: V:2  | i64.atomic.rmw8_u.xor $0:1+$3, 2
-#0. 8325: V:1  | drop
-#0. 8326: V:0  | return
+#0. 12942: V:0  | i32.const $1
+#0. 12950: V:1  | i64.const $2
+#0. 12962: V:2  | i64.atomic.rmw8_u.xor $0:1+$3, 2
+#0. 12974: V:1  | drop
+#0. 12978: V:0  | return
 i64.atomic.rmw8_u.xor() =>
 >>> running export "i64.atomic.rmw16_u.xor":
-#0. 8327: V:0  | i32.const $1
-#0. 8332: V:1  | i64.const $2
-#0. 8341: V:2  | i64.atomic.rmw16_u.xor $0:1+$3, 2
-#0. 8351: V:1  | drop
-#0. 8352: V:0  | return
+#0. 12982: V:0  | i32.const $1
+#0. 12990: V:1  | i64.const $2
+#0. 13002: V:2  | i64.atomic.rmw16_u.xor $0:1+$3, 2
+#0. 13014: V:1  | drop
+#0. 13018: V:0  | return
 i64.atomic.rmw16_u.xor() =>
 >>> running export "i64.atomic.rmw32_u.xor":
-#0. 8353: V:0  | i32.const $1
-#0. 8358: V:1  | i64.const $2
-#0. 8367: V:2  | i64.atomic.rmw32_u.xor $0:1+$3, 2
-#0. 8377: V:1  | drop
-#0. 8378: V:0  | return
+#0. 13022: V:0  | i32.const $1
+#0. 13030: V:1  | i64.const $2
+#0. 13042: V:2  | i64.atomic.rmw32_u.xor $0:1+$3, 2
+#0. 13054: V:1  | drop
+#0. 13058: V:0  | return
 i64.atomic.rmw32_u.xor() =>
 >>> running export "i32.atomic.rmw.xchg":
-#0. 8379: V:0  | i32.const $1
-#0. 8384: V:1  | i32.const $2
-#0. 8389: V:2  | i32.atomic.rmw.xchg $0:1+$3, 2
-#0. 8399: V:1  | drop
-#0. 8400: V:0  | return
+#0. 13062: V:0  | i32.const $1
+#0. 13070: V:1  | i32.const $2
+#0. 13078: V:2  | i32.atomic.rmw.xchg $0:1+$3, 2
+#0. 13090: V:1  | drop
+#0. 13094: V:0  | return
 i32.atomic.rmw.xchg() =>
 >>> running export "i64.atomic.rmw.xchg":
-#0. 8401: V:0  | i32.const $1
-#0. 8406: V:1  | i64.const $2
-#0. 8415: V:2  | i64.atomic.rmw.xchg $0:1+$7, 2
-#0. 8425: V:1  | drop
-#0. 8426: V:0  | return
+#0. 13098: V:0  | i32.const $1
+#0. 13106: V:1  | i64.const $2
+#0. 13118: V:2  | i64.atomic.rmw.xchg $0:1+$7, 2
+#0. 13130: V:1  | drop
+#0. 13134: V:0  | return
 i64.atomic.rmw.xchg() =>
 >>> running export "i32.atomic.rmw8_u.xchg":
-#0. 8427: V:0  | i32.const $1
-#0. 8432: V:1  | i32.const $2
-#0. 8437: V:2  | i32.atomic.rmw8_u.xchg $0:1+$3, 2
-#0. 8447: V:1  | drop
-#0. 8448: V:0  | return
+#0. 13138: V:0  | i32.const $1
+#0. 13146: V:1  | i32.const $2
+#0. 13154: V:2  | i32.atomic.rmw8_u.xchg $0:1+$3, 2
+#0. 13166: V:1  | drop
+#0. 13170: V:0  | return
 i32.atomic.rmw8_u.xchg() =>
 >>> running export "i32.atomic.rmw16_u.xchg":
-#0. 8449: V:0  | i32.const $1
-#0. 8454: V:1  | i32.const $2
-#0. 8459: V:2  | i32.atomic.rmw16_u.xchg $0:1+$3, 2
-#0. 8469: V:1  | drop
-#0. 8470: V:0  | return
+#0. 13174: V:0  | i32.const $1
+#0. 13182: V:1  | i32.const $2
+#0. 13190: V:2  | i32.atomic.rmw16_u.xchg $0:1+$3, 2
+#0. 13202: V:1  | drop
+#0. 13206: V:0  | return
 i32.atomic.rmw16_u.xchg() =>
 >>> running export "i64.atomic.rmw8_u.xchg":
-#0. 8471: V:0  | i32.const $1
-#0. 8476: V:1  | i64.const $2
-#0. 8485: V:2  | i64.atomic.rmw8_u.xchg $0:1+$3, 2
-#0. 8495: V:1  | drop
-#0. 8496: V:0  | return
+#0. 13210: V:0  | i32.const $1
+#0. 13218: V:1  | i64.const $2
+#0. 13230: V:2  | i64.atomic.rmw8_u.xchg $0:1+$3, 2
+#0. 13242: V:1  | drop
+#0. 13246: V:0  | return
 i64.atomic.rmw8_u.xchg() =>
 >>> running export "i64.atomic.rmw16_u.xchg":
-#0. 8497: V:0  | i32.const $1
-#0. 8502: V:1  | i64.const $2
-#0. 8511: V:2  | i64.atomic.rmw16_u.xchg $0:1+$3, 2
-#0. 8521: V:1  | drop
-#0. 8522: V:0  | return
+#0. 13250: V:0  | i32.const $1
+#0. 13258: V:1  | i64.const $2
+#0. 13270: V:2  | i64.atomic.rmw16_u.xchg $0:1+$3, 2
+#0. 13282: V:1  | drop
+#0. 13286: V:0  | return
 i64.atomic.rmw16_u.xchg() =>
 >>> running export "i64.atomic.rmw32_u.xchg":
-#0. 8523: V:0  | i32.const $1
-#0. 8528: V:1  | i64.const $2
-#0. 8537: V:2  | i64.atomic.rmw32_u.xchg $0:1+$3, 2
-#0. 8547: V:1  | drop
-#0. 8548: V:0  | return
+#0. 13290: V:0  | i32.const $1
+#0. 13298: V:1  | i64.const $2
+#0. 13310: V:2  | i64.atomic.rmw32_u.xchg $0:1+$3, 2
+#0. 13322: V:1  | drop
+#0. 13326: V:0  | return
 i64.atomic.rmw32_u.xchg() =>
 >>> running export "i32.atomic.rmw.cmpxchg":
-#0. 8549: V:0  | i32.const $1
-#0. 8554: V:1  | i32.const $2
-#0. 8559: V:2  | i32.const $3
-#0. 8564: V:3  | i32.atomic.rmw.cmpxchg $0:1+$3, 2, 3
-#0. 8574: V:1  | drop
-#0. 8575: V:0  | return
+#0. 13330: V:0  | i32.const $1
+#0. 13338: V:1  | i32.const $2
+#0. 13346: V:2  | i32.const $3
+#0. 13354: V:3  | i32.atomic.rmw.cmpxchg $0:1+$3, 2, 3
+#0. 13366: V:1  | drop
+#0. 13370: V:0  | return
 i32.atomic.rmw.cmpxchg() =>
 >>> running export "i64.atomic.rmw.cmpxchg":
-#0. 8576: V:0  | i32.const $1
-#0. 8581: V:1  | i64.const $2
-#0. 8590: V:2  | i64.const $3
-#0. 8599: V:3  | i64.atomic.rmw.cmpxchg $0:1+$7, 2, 3
-#0. 8609: V:1  | drop
-#0. 8610: V:0  | return
+#0. 13374: V:0  | i32.const $1
+#0. 13382: V:1  | i64.const $2
+#0. 13394: V:2  | i64.const $3
+#0. 13406: V:3  | i64.atomic.rmw.cmpxchg $0:1+$7, 2, 3
+#0. 13418: V:1  | drop
+#0. 13422: V:0  | return
 i64.atomic.rmw.cmpxchg() =>
 >>> running export "i32.atomic.rmw8_u.cmpxchg":
-#0. 8611: V:0  | i32.const $1
-#0. 8616: V:1  | i32.const $2
-#0. 8621: V:2  | i32.const $3
-#0. 8626: V:3  | i32.atomic.rmw8_u.cmpxchg $0:1+$3, 2, 3
-#0. 8636: V:1  | drop
-#0. 8637: V:0  | return
+#0. 13426: V:0  | i32.const $1
+#0. 13434: V:1  | i32.const $2
+#0. 13442: V:2  | i32.const $3
+#0. 13450: V:3  | i32.atomic.rmw8_u.cmpxchg $0:1+$3, 2, 3
+#0. 13462: V:1  | drop
+#0. 13466: V:0  | return
 i32.atomic.rmw8_u.cmpxchg() =>
 >>> running export "i32.atomic.rmw16_u.cmpxchg":
-#0. 8638: V:0  | i32.const $1
-#0. 8643: V:1  | i32.const $2
-#0. 8648: V:2  | i32.const $3
-#0. 8653: V:3  | i32.atomic.rmw16_u.cmpxchg $0:1+$3, 2, 3
-#0. 8663: V:1  | drop
-#0. 8664: V:0  | return
+#0. 13470: V:0  | i32.const $1
+#0. 13478: V:1  | i32.const $2
+#0. 13486: V:2  | i32.const $3
+#0. 13494: V:3  | i32.atomic.rmw16_u.cmpxchg $0:1+$3, 2, 3
+#0. 13506: V:1  | drop
+#0. 13510: V:0  | return
 i32.atomic.rmw16_u.cmpxchg() =>
 >>> running export "i64.atomic.rmw8_u.cmpxchg":
-#0. 8665: V:0  | i32.const $1
-#0. 8670: V:1  | i64.const $2
-#0. 8679: V:2  | i64.const $3
-#0. 8688: V:3  | i64.atomic.rmw8_u.cmpxchg $0:1+$3, 2, 3
-#0. 8698: V:1  | drop
-#0. 8699: V:0  | return
+#0. 13514: V:0  | i32.const $1
+#0. 13522: V:1  | i64.const $2
+#0. 13534: V:2  | i64.const $3
+#0. 13546: V:3  | i64.atomic.rmw8_u.cmpxchg $0:1+$3, 2, 3
+#0. 13558: V:1  | drop
+#0. 13562: V:0  | return
 i64.atomic.rmw8_u.cmpxchg() =>
 >>> running export "i64.atomic.rmw16_u.cmpxchg":
-#0. 8700: V:0  | i32.const $1
-#0. 8705: V:1  | i64.const $2
-#0. 8714: V:2  | i64.const $3
-#0. 8723: V:3  | i64.atomic.rmw16_u.cmpxchg $0:1+$3, 2, 3
-#0. 8733: V:1  | drop
-#0. 8734: V:0  | return
+#0. 13566: V:0  | i32.const $1
+#0. 13574: V:1  | i64.const $2
+#0. 13586: V:2  | i64.const $3
+#0. 13598: V:3  | i64.atomic.rmw16_u.cmpxchg $0:1+$3, 2, 3
+#0. 13610: V:1  | drop
+#0. 13614: V:0  | return
 i64.atomic.rmw16_u.cmpxchg() =>
 >>> running export "i64.atomic.rmw32_u.cmpxchg":
-#0. 8735: V:0  | i32.const $1
-#0. 8740: V:1  | i64.const $2
-#0. 8749: V:2  | i64.const $3
-#0. 8758: V:3  | i64.atomic.rmw32_u.cmpxchg $0:1+$3, 2, 3
-#0. 8768: V:1  | drop
-#0. 8769: V:0  | return
+#0. 13618: V:0  | i32.const $1
+#0. 13626: V:1  | i64.const $2
+#0. 13638: V:2  | i64.const $3
+#0. 13650: V:3  | i64.atomic.rmw32_u.cmpxchg $0:1+$3, 2, 3
+#0. 13662: V:1  | drop
+#0. 13666: V:0  | return
 i64.atomic.rmw32_u.cmpxchg() =>
 ;;; STDOUT ;;)


### PR DESCRIPTION
`Opcode::FromCode` calculated the opcode given a prefix/code pair by
using lower_bound over the list of all `OpcodeInfo`s. This was happening
for every instruction, which is incredibly slow.

Since the interpreter's format is internal only, we can use any encoding
we want, so it's simpler and faster to use the `Opcode::Enum` directly
without calling `Opcode::FromCode`.

`Opcode::FromCode` is also used when reading a binary file, so it should
be optimized anyway. Instead of using the `infos_` table, which is
indexed by the opcode's `enum_` value, we create a new
statically-defined table that maps from prefix-code pair to its enum
value.

Unfortunately, this can't be done easily in C++ because it does not
currently support designated array initializers, so this table is
created in a C file instead, `opcode-code-table.c`.