### PR TITLE
[wasm-interp] Fix assert with non-func exports

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -118,6 +118,9 @@ static void RunAllExports(interp::Module* module,
   TypedValues args;
   TypedValues results;
   for (const interp::Export& export_ : module->exports) {
+    if (export_.kind != ExternalKind::Func) {
+      continue;
+    }
     ExecResult exec_result = executor->RunExport(&export_, args);
     if (verbose == RunVerbosity::Verbose) {
       WriteCall(s_stdout_stream.get(), string_view(), export_.name, args,

--- a/test/interp/run-non-func-export.txt
+++ b/test/interp/run-non-func-export.txt
@@ -1,0 +1,7 @@
+;;; TOOL: run-interp
+(module
+  (memory (export "mem") 1 1)
+  (func (export "dummy") (result i32) i32.const 0x25))
+(;; STDOUT ;;;
+dummy() => i32:37
+;;; STDOUT ;;)


### PR DESCRIPTION
The `--run-all-exports` flag assumed that all exports are functions.