### PR TITLE
Don't install wabt-unittests; refactor CMakeLists

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -41,7 +41,6 @@ build_script:
   - cmake --build . --config %CONFIG% --target install -- %JOBS_FLAG%%JOBS%
 
 test_script:
-  - "%APPVEYOR_BUILD_FOLDER%\\bin\\wabt-unittests"
   - python test\run-tests.py -v --bindir %APPVEYOR_BUILD_FOLDER%\bin
 
 # Must happen before artifacts step.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,7 +212,7 @@ endif ()
 
 add_custom_target(everything)
 
-add_library(libwabt STATIC
+add_library(wabt STATIC
   src/token.cc
   src/opcode.cc
   src/opcode-code-table.c
@@ -254,7 +254,7 @@ add_library(libwabt STATIC
   src/tracing.cc
   src/utf8.cc
 )
-set_target_properties(libwabt PROPERTIES OUTPUT_NAME wabt)
+
 
 if (NOT EMSCRIPTEN)
   if (CODE_COVERAGE)
@@ -266,68 +266,114 @@ if (NOT EMSCRIPTEN)
     endif ()
   endif ()
 
-  function(wabt_executable name)
-    # ARGV contains all arguments; remove the first one, ${name}, so it's just
-    # a list of sources.
-    list(REMOVE_AT ARGV 0)
+  function(wabt_executable)
+    cmake_parse_arguments(EXE "WITH_LIBM;INSTALL" "NAME" "SOURCES;LIBS" ${ARGN})
 
-    add_executable(${name} ${ARGV})
-    add_dependencies(everything ${name})
-    target_link_libraries(${name} libwabt)
-    set_property(TARGET ${name} PROPERTY CXX_STANDARD 11)
-    set_property(TARGET ${name} PROPERTY CXX_STANDARD_REQUIRED ON)
-    list(APPEND WABT_EXECUTABLES ${name})
-    set(WABT_EXECUTABLES ${WABT_EXECUTABLES} PARENT_SCOPE)
+    # Always link libwabt.
+    set(EXE_LIBS "${EXE_LIBS};wabt")
 
-    add_custom_target(${name}-copy-to-bin ALL
-      COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
-      COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${name}> ${WABT_SOURCE_DIR}/bin
-      DEPENDS ${name}
-    )
+    # Optionally link libm.
+    if (EXE_WITH_LIBM AND (COMPILER_IS_CLANG OR COMPILER_IS_GNU))
+      set(EXE_LIBS "${EXE_LIBS};m")
+    endif ()
+
+    add_executable(${EXE_NAME} ${EXE_SOURCES})
+    add_dependencies(everything ${EXE_NAME})
+    target_link_libraries(${EXE_NAME} ${EXE_LIBS})
+    set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD 11)
+    set_property(TARGET ${EXE_NAME} PROPERTY CXX_STANDARD_REQUIRED ON)
+
+    if (EXE_INSTALL)
+      list(APPEND WABT_EXECUTABLES ${EXE_NAME})
+      set(WABT_EXECUTABLES ${WABT_EXECUTABLES} PARENT_SCOPE)
+
+      add_custom_target(${EXE_NAME}-copy-to-bin ALL
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${EXE_NAME}> ${WABT_SOURCE_DIR}/bin
+        DEPENDS ${EXE_NAME}
+      )
+    endif ()
   endfunction()
 
   if (BUILD_TOOLS)
     # wat2wasm
-    wabt_executable(wat2wasm src/tools/wat2wasm.cc)
+    wabt_executable(
+      NAME wat2wasm
+      SOURCES src/tools/wat2wasm.cc
+      INSTALL
+    )
 
     # wast2json
-    wabt_executable(wast2json src/tools/wast2json.cc)
+    wabt_executable(
+      NAME wast2json
+      SOURCES src/tools/wast2json.cc
+      INSTALL
+    )
 
     # wasm2wat
-    wabt_executable(wasm2wat src/tools/wasm2wat.cc)
+    wabt_executable(
+      NAME wasm2wat
+      SOURCES src/tools/wasm2wat.cc
+      INSTALL
+    )
 
     # wasm2c
-    wabt_executable(wasm2c
-      src/tools/wasm2c.cc src/c-writer.cc)
+    wabt_executable(
+      NAME wasm2c
+      SOURCES src/tools/wasm2c.cc src/c-writer.cc
+      INSTALL
+    )
 
     # wasm-opcodecnt
-    wabt_executable(wasm-opcodecnt
-      src/tools/wasm-opcodecnt.cc src/binary-reader-opcnt.cc)
+    wabt_executable(
+      NAME wasm-opcodecnt
+      SOURCES src/tools/wasm-opcodecnt.cc src/binary-reader-opcnt.cc
+      INSTALL
+    )
 
     # wasm-objdump
-    wabt_executable(wasm-objdump
-      src/tools/wasm-objdump.cc src/binary-reader-objdump.cc)
+    wabt_executable(
+      NAME wasm-objdump
+      SOURCES src/tools/wasm-objdump.cc src/binary-reader-objdump.cc
+      INSTALL
+    )
 
     # wasm-interp
-    wabt_executable(wasm-interp src/tools/wasm-interp.cc)
-    if (COMPILER_IS_CLANG OR COMPILER_IS_GNU)
-      target_link_libraries(wasm-interp m)
-    endif ()
+    wabt_executable(
+      NAME wasm-interp
+      SOURCES src/tools/wasm-interp.cc
+      WITH_LIBM
+      INSTALL
+    )
 
     # spectest-interp
-    wabt_executable(spectest-interp src/tools/spectest-interp.cc)
-    if (COMPILER_IS_CLANG OR COMPILER_IS_GNU)
-      target_link_libraries(spectest-interp m)
-    endif ()
+    wabt_executable(
+      NAME spectest-interp
+      SOURCES src/tools/spectest-interp.cc
+      WITH_LIBM
+      INSTALL
+    )
 
     # wat-desugar
-    wabt_executable(wat-desugar src/tools/wat-desugar.cc)
+    wabt_executable(
+      NAME wat-desugar
+      SOURCES src/tools/wat-desugar.cc
+      INSTALL
+    )
 
     # wasm-validate
-    wabt_executable(wasm-validate src/tools/wasm-validate.cc)
+    wabt_executable(
+      NAME wasm-validate
+      SOURCES src/tools/wasm-validate.cc
+      INSTALL
+    )
 
     # wasm-strip
-    wabt_executable(wasm-strip src/tools/wasm-strip.cc)
+    wabt_executable(
+      NAME wasm-strip
+      SOURCES src/tools/wasm-strip.cc
+      INSTALL
+    )
   endif ()
 
   find_package(Threads)
@@ -352,11 +398,11 @@ if (NOT EMSCRIPTEN)
       src/test-hexfloat.cc
       third_party/gtest/googletest/src/gtest_main.cc
     )
-    add_executable(hexfloat_test ${HEXFLOAT_TEST_SRCS})
-    add_dependencies(everything hexfloat_test)
-    target_link_libraries(hexfloat_test libgtest ${CMAKE_THREAD_LIBS_INIT})
-    set_property(TARGET hexfloat_test PROPERTY CXX_STANDARD 11)
-    set_property(TARGET hexfloat_test PROPERTY CXX_STANDARD_REQUIRED ON)
+    wabt_executable(
+      NAME hexfloat_test
+      SOURCES ${HEXFLOAT_TEST_SRCS}
+      LIBS libgtest ${CMAKE_THREAD_LIBS_INIT}
+    )
 
     # wabt-unittests
     set(UNITTESTS_SRCS
@@ -370,8 +416,11 @@ if (NOT EMSCRIPTEN)
       src/test-wast-parser.cc
       third_party/gtest/googletest/src/gtest_main.cc
     )
-    wabt_executable(wabt-unittests ${UNITTESTS_SRCS})
-    target_link_libraries(wabt-unittests libgtest ${CMAKE_THREAD_LIBS_INIT})
+    wabt_executable(
+      NAME wabt-unittests
+      SOURCES ${UNITTESTS_SRCS}
+      LIBS libgtest ${CMAKE_THREAD_LIBS_INIT}
+    )
   endif ()
 
   if (NOT CMAKE_VERSION VERSION_LESS "3.2")
@@ -410,7 +459,7 @@ else ()
   add_definitions(-Wno-warn-absolute-paths)
   add_executable(libwabtjs src/emscripten-helpers.cc)
   add_dependencies(everything libwabtjs)
-  target_link_libraries(libwabtjs libwabt)
+  target_link_libraries(libwabtjs wabt)
   set_target_properties(libwabtjs PROPERTIES OUTPUT_NAME libwabt)
 
   set(WABT_POST_JS ${WABT_SOURCE_DIR}/src/wabt.post.js)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -431,6 +431,7 @@ if (NOT EMSCRIPTEN)
   find_package(PythonInterp 2.7 REQUIRED)
   set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
   add_custom_target(run-tests
+    COMMAND ${CMAKE_BINARY_DIR}/wabt-unittests
     COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir ${CMAKE_BINARY_DIR}
     DEPENDS ${WABT_EXECUTABLES}
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}


### PR DESCRIPTION
`wabt-unittests` used to be installed, but it really shouldn't be.

Also use `cmake_parse_arguments` to make the `wabt_executable` function
a little more powerful.