### PR TITLE
Add more bulk memory tests; use vars for segments  

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -816,7 +816,7 @@ Result BinaryReaderIR::OnMemoryCopyExpr() {
 }
 
 Result BinaryReaderIR::OnMemoryDropExpr(Index segment) {
-  return AppendExpr(MakeUnique<MemoryDropExpr>(segment));
+  return AppendExpr(MakeUnique<MemoryDropExpr>(Var(segment)));
 }
 
 Result BinaryReaderIR::OnMemoryFillExpr() {
@@ -828,7 +828,7 @@ Result BinaryReaderIR::OnMemoryGrowExpr() {
 }
 
 Result BinaryReaderIR::OnMemoryInitExpr(Index segment) {
-  return AppendExpr(MakeUnique<MemoryInitExpr>(segment));
+  return AppendExpr(MakeUnique<MemoryInitExpr>(Var(segment)));
 }
 
 Result BinaryReaderIR::OnMemorySizeExpr() {
@@ -840,11 +840,11 @@ Result BinaryReaderIR::OnTableCopyExpr() {
 }
 
 Result BinaryReaderIR::OnTableDropExpr(Index segment) {
-  return AppendExpr(MakeUnique<TableDropExpr>(segment));
+  return AppendExpr(MakeUnique<TableDropExpr>(Var(segment)));
 }
 
 Result BinaryReaderIR::OnTableInitExpr(Index segment) {
-  return AppendExpr(MakeUnique<TableInitExpr>(segment));
+  return AppendExpr(MakeUnique<TableInitExpr>(Var(segment)));
 }
 
 Result BinaryReaderIR::OnNopExpr() {

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1356,6 +1356,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         Index segment;
         CHECK_RESULT(ReadIndex(&segment, "elem segment index"));
         CALLBACK(OnTableInitExpr, segment);
+        CALLBACK(OnOpcodeUint32Uint32, segment, reserved);
         break;
       }
 
@@ -1367,6 +1368,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         Index segment;
         CHECK_RESULT(ReadIndex(&segment, "elem segment index"));
         CALLBACK(OnMemoryInitExpr, segment);
+        CALLBACK(OnOpcodeUint32Uint32, segment, reserved);
         break;
       }
 
@@ -1380,6 +1382,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         } else {
           CALLBACK(OnTableDropExpr, segment);
         }
+        CALLBACK(OnOpcodeUint32, segment);
         break;
       }
 
@@ -1394,6 +1397,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         } else {
           CALLBACK(OnMemoryFillExpr);
         }
+        CALLBACK(OnOpcodeUint32, reserved);
         break;
       }
 
@@ -1403,6 +1407,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         CHECK_RESULT(ReadU8(&reserved, "reserved table index"));
         ERROR_UNLESS(reserved == 0, "reserved value must be 0");
         CALLBACK(OnTableCopyExpr);
+        CALLBACK(OnOpcodeUint32, reserved);
         break;
       }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -550,9 +550,10 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       WriteU32Leb128(stream_, 0, "memory.copy reserved");
       break;
     case ExprType::MemoryDrop: {
-      auto* drop_expr = cast<MemoryDropExpr>(expr);
+      Index index =
+          module_->GetDataSegmentIndex(cast<MemoryDropExpr>(expr)->var);
       WriteOpcode(stream_, Opcode::MemoryDrop);
-      WriteU32Leb128(stream_, drop_expr->segment, "memory.drop segment");
+      WriteU32Leb128(stream_, index, "memory.drop segment");
       break;
     }
     case ExprType::MemoryFill:
@@ -564,10 +565,11 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       WriteU32Leb128(stream_, 0, "memory.grow reserved");
       break;
     case ExprType::MemoryInit: {
-      auto* init_expr = cast<MemoryInitExpr>(expr);
+      Index index =
+          module_->GetDataSegmentIndex(cast<MemoryInitExpr>(expr)->var);
       WriteOpcode(stream_, Opcode::MemoryInit);
       WriteU32Leb128(stream_, 0, "memory.init reserved");
-      WriteU32Leb128(stream_, init_expr->segment, "memory.init segment");
+      WriteU32Leb128(stream_, index, "memory.init segment");
       break;
     }
     case ExprType::MemorySize:
@@ -579,16 +581,18 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       WriteU32Leb128(stream_, 0, "table.copy reserved");
       break;
     case ExprType::TableDrop: {
-      auto* drop_expr = cast<TableDropExpr>(expr);
+      Index index =
+          module_->GetElemSegmentIndex(cast<TableDropExpr>(expr)->var);
       WriteOpcode(stream_, Opcode::TableDrop);
-      WriteU32Leb128(stream_, drop_expr->segment, "table.drop segment");
+      WriteU32Leb128(stream_, index, "table.drop segment");
       break;
     }
     case ExprType::TableInit: {
-      auto* init_expr = cast<TableInitExpr>(expr);
+      Index index =
+          module_->GetElemSegmentIndex(cast<TableInitExpr>(expr)->var);
       WriteOpcode(stream_, Opcode::TableInit);
       WriteU32Leb128(stream_, 0, "table.init reserved");
-      WriteU32Leb128(stream_, init_expr->segment, "table.init segment");
+      WriteU32Leb128(stream_, index, "table.init segment");
       break;
     }
     case ExprType::Nop:

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -126,6 +126,14 @@ Index Module::GetExceptIndex(const Var& var) const {
   return except_bindings.FindIndex(var);
 }
 
+Index Module::GetDataSegmentIndex(const Var& var) const {
+  return data_segment_bindings.FindIndex(var);
+}
+
+Index Module::GetElemSegmentIndex(const Var& var) const {
+  return elem_segment_bindings.FindIndex(var);
+}
+
 bool Module::IsImport(ExternalKind kind, const Var& var) const {
   switch (kind) {
     case ExternalKind::Func:
@@ -276,6 +284,30 @@ Exception* Module::GetExcept(const Var& var) const {
   return excepts[index];
 }
 
+const DataSegment* Module::GetDataSegment(const Var& var) const {
+  return const_cast<Module*>(this)->GetDataSegment(var);
+}
+
+DataSegment* Module::GetDataSegment(const Var& var) {
+  Index index = data_segment_bindings.FindIndex(var);
+  if (index >= data_segments.size()) {
+    return nullptr;
+  }
+  return data_segments[index];
+}
+
+const ElemSegment* Module::GetElemSegment(const Var& var) const {
+  return const_cast<Module*>(this)->GetElemSegment(var);
+}
+
+ElemSegment* Module::GetElemSegment(const Var& var) {
+  Index index = elem_segment_bindings.FindIndex(var);
+  if (index >= elem_segments.size()) {
+    return nullptr;
+  }
+  return elem_segments[index];
+}
+
 const FuncType* Module::GetFuncType(const Var& var) const {
   return const_cast<Module*>(this)->GetFuncType(var);
 }
@@ -306,12 +338,22 @@ Index Module::GetFuncTypeIndex(const FuncDeclaration& decl) const {
 }
 
 void Module::AppendField(std::unique_ptr<DataSegmentModuleField> field) {
-  data_segments.push_back(&field->data_segment);
+  DataSegment& data_segment = field->data_segment;
+  if (!data_segment.name.empty()) {
+    data_segment_bindings.emplace(data_segment.name,
+                                  Binding(field->loc, data_segments.size()));
+  }
+  data_segments.push_back(&data_segment);
   fields.push_back(std::move(field));
 }
 
 void Module::AppendField(std::unique_ptr<ElemSegmentModuleField> field) {
-  elem_segments.push_back(&field->elem_segment);
+  ElemSegment& elem_segment = field->elem_segment;
+  if (!elem_segment.name.empty()) {
+    elem_segment_bindings.emplace(elem_segment.name,
+                                  Binding(field->loc, elem_segments.size()));
+  }
+  elem_segments.push_back(&elem_segment);
   fields.push_back(std::move(field));
 }
 

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -53,8 +53,12 @@ class NameResolver : public ExprVisitor::DelegateNop {
   Result EndIfExceptExpr(IfExceptExpr*) override;
   Result BeginLoopExpr(LoopExpr*) override;
   Result EndLoopExpr(LoopExpr*) override;
+  Result OnMemoryDropExpr(MemoryDropExpr*) override;
+  Result OnMemoryInitExpr(MemoryInitExpr*) override;
   Result OnSetGlobalExpr(SetGlobalExpr*) override;
   Result OnSetLocalExpr(SetLocalExpr*) override;
+  Result OnTableDropExpr(TableDropExpr*) override;
+  Result OnTableInitExpr(TableInitExpr*) override;
   Result OnTeeLocalExpr(TeeLocalExpr*) override;
   Result BeginTryExpr(TryExpr*) override;
   Result EndTryExpr(TryExpr*) override;
@@ -73,6 +77,8 @@ class NameResolver : public ExprVisitor::DelegateNop {
   void ResolveTableVar(Var* var);
   void ResolveMemoryVar(Var* var);
   void ResolveExceptionVar(Var* var);
+  void ResolveDataSegmentVar(Var* var);
+  void ResolveElemSegmentVar(Var* var);
   void ResolveLocalVar(Var* var);
   void ResolveBlockDeclarationVar(BlockDeclaration* decl);
   void VisitFunc(Func* func);
@@ -178,6 +184,14 @@ void NameResolver::ResolveMemoryVar(Var* var) {
 
 void NameResolver::ResolveExceptionVar(Var* var) {
   ResolveVar(&current_module_->except_bindings, var, "exception");
+}
+
+void NameResolver::ResolveDataSegmentVar(Var* var) {
+  ResolveVar(&current_module_->data_segment_bindings, var, "data segment");
+}
+
+void NameResolver::ResolveElemSegmentVar(Var* var) {
+  ResolveVar(&current_module_->elem_segment_bindings, var, "elem segment");
 }
 
 void NameResolver::ResolveLocalVar(Var* var) {
@@ -299,6 +313,16 @@ Result NameResolver::EndIfExceptExpr(IfExceptExpr* expr) {
   return Result::Ok;
 }
 
+Result NameResolver::OnMemoryDropExpr(MemoryDropExpr* expr) {
+  ResolveDataSegmentVar(&expr->var);
+  return Result::Ok;
+}
+
+Result NameResolver::OnMemoryInitExpr(MemoryInitExpr* expr) {
+  ResolveDataSegmentVar(&expr->var);
+  return Result::Ok;
+}
+
 Result NameResolver::OnSetGlobalExpr(SetGlobalExpr* expr) {
   ResolveGlobalVar(&expr->var);
   return Result::Ok;
@@ -306,6 +330,16 @@ Result NameResolver::OnSetGlobalExpr(SetGlobalExpr* expr) {
 
 Result NameResolver::OnSetLocalExpr(SetLocalExpr* expr) {
   ResolveLocalVar(&expr->var);
+  return Result::Ok;
+}
+
+Result NameResolver::OnTableDropExpr(TableDropExpr* expr) {
+  ResolveElemSegmentVar(&expr->var);
+  return Result::Ok;
+}
+
+Result NameResolver::OnTableInitExpr(TableInitExpr* expr) {
+  ResolveElemSegmentVar(&expr->var);
   return Result::Ok;
 }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -216,6 +216,8 @@ class WatWriter {
   Index memory_index_ = 0;
   Index func_type_index_ = 0;
   Index except_index_ = 0;
+  Index data_segment_index_ = 0;
+  Index elem_segment_index_ = 0;
 };
 
 void WatWriter::Indent() {
@@ -757,8 +759,7 @@ Result WatWriter::ExprVisitorDelegate::OnMemoryCopyExpr(MemoryCopyExpr* expr) {
 
 Result WatWriter::ExprVisitorDelegate::OnMemoryDropExpr(MemoryDropExpr* expr) {
   writer_->WritePutsSpace(Opcode::MemoryDrop_Opcode.GetName());
-  writer_->Writef("%d", expr->segment);
-  writer_->WriteNewline(FORCE_NEWLINE);
+  writer_->WriteVar(expr->var, NextChar::Newline);
   return Result::Ok;
 }
 
@@ -774,8 +775,7 @@ Result WatWriter::ExprVisitorDelegate::OnMemoryGrowExpr(MemoryGrowExpr* expr) {
 
 Result WatWriter::ExprVisitorDelegate::OnMemoryInitExpr(MemoryInitExpr* expr) {
   writer_->WritePutsSpace(Opcode::MemoryInit_Opcode.GetName());
-  writer_->Writef("%d", expr->segment);
-  writer_->WriteNewline(FORCE_NEWLINE);
+  writer_->WriteVar(expr->var, NextChar::Newline);
   return Result::Ok;
 }
 
@@ -791,15 +791,13 @@ Result WatWriter::ExprVisitorDelegate::OnTableCopyExpr(TableCopyExpr* expr) {
 
 Result WatWriter::ExprVisitorDelegate::OnTableDropExpr(TableDropExpr* expr) {
   writer_->WritePutsSpace(Opcode::TableDrop_Opcode.GetName());
-  writer_->Writef("%d", expr->segment);
-  writer_->WriteNewline(FORCE_NEWLINE);
+  writer_->WriteVar(expr->var, NextChar::Newline);
   return Result::Ok;
 }
 
 Result WatWriter::ExprVisitorDelegate::OnTableInitExpr(TableInitExpr* expr) {
   writer_->WritePutsSpace(Opcode::TableInit_Opcode.GetName());
-  writer_->Writef("%d", expr->segment);
-  writer_->WriteNewline(FORCE_NEWLINE);
+  writer_->WriteVar(expr->var, NextChar::Newline);
   return Result::Ok;
 }
 
@@ -1459,6 +1457,7 @@ void WatWriter::WriteTable(const Table& table) {
 
 void WatWriter::WriteElemSegment(const ElemSegment& segment) {
   WriteOpenSpace("elem");
+  WriteNameOrIndex(segment.name, elem_segment_index_, NextChar::Space);
   if (segment.passive) {
     WritePutsSpace("passive");
   } else {
@@ -1468,6 +1467,7 @@ void WatWriter::WriteElemSegment(const ElemSegment& segment) {
     WriteVar(var, NextChar::Space);
   }
   WriteCloseNewline();
+  elem_segment_index_++;
 }
 
 void WatWriter::WriteMemory(const Memory& memory) {
@@ -1482,6 +1482,7 @@ void WatWriter::WriteMemory(const Memory& memory) {
 
 void WatWriter::WriteDataSegment(const DataSegment& segment) {
   WriteOpenSpace("data");
+  WriteNameOrIndex(segment.name, data_segment_index_, NextChar::Space);
   if (segment.passive) {
     WritePutsSpace("passive");
   } else {
@@ -1489,6 +1490,7 @@ void WatWriter::WriteDataSegment(const DataSegment& segment) {
   }
   WriteQuotedData(segment.data.data(), segment.data.size());
   WriteCloseNewline();
+  data_segment_index_++;
 }
 
 void WatWriter::WriteImport(const Import& import) {

--- a/test/desugar/basic.txt
+++ b/test/desugar/basic.txt
@@ -15,9 +15,9 @@
   (import "foo" "bar" (func (;0;) (result i32)))
   (global (;0;) i32 (i32.const 1))
   (table (;0;) 1 1 anyfunc)
-  (elem (i32.const 0) 0)
+  (elem (;0;) (i32.const 0) 0)
   (memory (;0;) 1 1)
-  (data (i32.const 0) "hello")
+  (data (;0;) (i32.const 0) "hello")
   (func (;1;) (result i32)
     call 0
     i32.const 1

--- a/test/dump/bulk-memory.txt
+++ b/test/dump/bulk-memory.txt
@@ -1,0 +1,54 @@
+;;; TOOL: run-objdump
+;;; ARGS0: --enable-bulk-memory
+
+(module
+  (memory 1)
+  (data passive "a")
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+    memory.drop 0
+    i32.const 0 i32.const 0 i32.const 0 memory.copy
+    i32.const 0 i32.const 0 i32.const 0 memory.fill
+  )
+
+  (table 1 anyfunc)
+  (elem passive 0)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+    table.drop 0
+    i32.const 0 i32.const 0 i32.const 0 table.copy
+  )
+)
+(;; STDOUT ;;;
+
+bulk-memory.wasm:	file format wasm 0x1
+
+Code Disassembly:
+
+000027 func[0]:
+ 000029: 41 00                      | i32.const 0
+ 00002b: 41 00                      | i32.const 0
+ 00002d: 41 00                      | i32.const 0
+ 000030: fc 08 00 00                | memory.init 0 0
+ 000034: fc 09 00                   | memory.drop 0
+ 000036: 41 00                      | i32.const 0
+ 000038: 41 00                      | i32.const 0
+ 00003a: 41 00                      | i32.const 0
+ 00003d: fc 0a 00                   | memory.copy 0
+ 00003f: 41 00                      | i32.const 0
+ 000041: 41 00                      | i32.const 0
+ 000043: 41 00                      | i32.const 0
+ 000046: fc 0b 00                   | memory.fill 0
+ 000048: 0b                         | end
+000049 func[1]:
+ 00004b: 41 00                      | i32.const 0
+ 00004d: 41 00                      | i32.const 0
+ 00004f: 41 00                      | i32.const 0
+ 000052: fc 0c 00 00                | table.init 0 0
+ 000056: fc 0d 00                   | table.drop 0
+ 000058: 41 00                      | i32.const 0
+ 00005a: 41 00                      | i32.const 0
+ 00005c: 41 00                      | i32.const 0
+ 00005f: fc 0e 00                   | table.copy 0
+ 000061: 0b                         | end
+;;; STDOUT ;;)

--- a/test/parse/expr/bulk-memory-disabled.txt
+++ b/test/parse/expr/bulk-memory-disabled.txt
@@ -1,0 +1,44 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+
+(module
+  (memory 1)
+  (data $data passive "a")
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+    memory.drop 0
+    i32.const 0 i32.const 0 i32.const 0 memory.copy
+    i32.const 0 i32.const 0 i32.const 0 memory.fill
+  )
+
+  (table 1 anyfunc)
+  (elem $elem passive 0)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+    table.drop 0
+    i32.const 0 i32.const 0 i32.const 0 table.copy
+  )
+)
+(;; STDERR ;;;
+out/test/parse/expr/bulk-memory-disabled.txt:8:41: error: opcode not allowed: memory.init
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+                                        ^^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:9:5: error: opcode not allowed: memory.drop
+    memory.drop 0
+    ^^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:10:41: error: opcode not allowed: memory.copy
+    i32.const 0 i32.const 0 i32.const 0 memory.copy
+                                        ^^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:11:41: error: opcode not allowed: memory.fill
+    i32.const 0 i32.const 0 i32.const 0 memory.fill
+                                        ^^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:17:41: error: opcode not allowed: table.init
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+                                        ^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:18:5: error: opcode not allowed: table.drop
+    table.drop 0
+    ^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:19:41: error: opcode not allowed: table.copy
+    i32.const 0 i32.const 0 i32.const 0 table.copy
+                                        ^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/parse/expr/bulk-memory-named.txt
+++ b/test/parse/expr/bulk-memory-named.txt
@@ -1,0 +1,18 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-bulk-memory
+
+(module
+  (memory 1)
+  (data $data passive "a")
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init $data
+    memory.drop $data
+  )
+
+  (table 1 anyfunc)
+  (elem $elem passive 0)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init $elem
+    table.drop $elem
+  )
+)

--- a/test/roundtrip/apply-global-names.txt
+++ b/test/roundtrip/apply-global-names.txt
@@ -18,6 +18,6 @@
   (table $T0 1 anyfunc)
   (memory $M0 1)
   (global $g1 i32 (get_global $m.g))
-  (elem (get_global $m.g) $f0)
-  (data (get_global $m.g) "hi"))
+  (elem $e0 (get_global $m.g) $f0)
+  (data $d0 (get_global $m.g) "hi"))
 ;;; STDOUT ;;)

--- a/test/roundtrip/bulk-memory.txt
+++ b/test/roundtrip/bulk-memory.txt
@@ -70,6 +70,6 @@
   (func (;1;) (type 0))
   (table (;0;) 0 anyfunc)
   (memory (;0;) 0)
-  (elem passive 1)
-  (data passive "hi"))
+  (elem (;0;) passive 1)
+  (data (;0;) passive "hi"))
 ;;; STDOUT ;;)

--- a/test/roundtrip/fold-bulk-memory.txt
+++ b/test/roundtrip/fold-bulk-memory.txt
@@ -1,0 +1,53 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --fold-exprs --enable-bulk-memory
+
+(module
+  (memory 1)
+  (data passive "a")
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+    memory.drop 0
+    i32.const 0 i32.const 0 i32.const 0 memory.copy
+    i32.const 0 i32.const 0 i32.const 0 memory.fill
+  )
+
+  (table 1 anyfunc)
+  (elem passive 0)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+    table.drop 0
+    i32.const 0 i32.const 0 i32.const 0 table.copy
+  )
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (memory.init 0
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0))
+    (memory.drop 0)
+    (memory.copy
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0))
+    (memory.fill
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0)))
+  (func (;1;) (type 0)
+    (table.init 0
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0))
+    (table.drop 0)
+    (table.copy
+      (i32.const 0)
+      (i32.const 0)
+      (i32.const 0)))
+  (table (;0;) 1 anyfunc)
+  (memory (;0;) 1)
+  (elem (;0;) passive 0)
+  (data (;0;) passive "a"))
+;;; STDOUT ;;)

--- a/test/roundtrip/fold-call.txt
+++ b/test/roundtrip/fold-call.txt
@@ -65,5 +65,5 @@
       (i32.const 1)
       (i32.const 2)))
   (table (;0;) 2 2 anyfunc)
-  (elem (i32.const 0) 0 1))
+  (elem (;0;) (i32.const 0) 0 1))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-bulk-memory-names.txt
+++ b/test/roundtrip/generate-bulk-memory-names.txt
@@ -1,0 +1,38 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --generate-names --enable-bulk-memory
+
+(module
+  (memory 1)
+  (data passive "a")
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+    memory.drop 0
+  )
+
+  (table 1 anyfunc)
+  (elem passive 0)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+    table.drop 0
+  )
+)
+(;; STDOUT ;;;
+(module
+  (type $t0 (func))
+  (func $f0 (type $t0)
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    memory.init $d0
+    memory.drop $d0)
+  (func $f1 (type $t0)
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.init $e0
+    table.drop $e0)
+  (table $T0 1 anyfunc)
+  (memory $M0 1)
+  (elem $e0 passive $f0)
+  (data $d0 passive "a"))
+;;; STDOUT ;;)

--- a/test/roundtrip/generate-func-names.txt
+++ b/test/roundtrip/generate-func-names.txt
@@ -18,5 +18,5 @@
   (table $T0 3 3 anyfunc)
   (export "zero" (func $zero))
   (export "one" (func $one))
-  (elem (i32.const 0) $zero $one $zero))
+  (elem $e0 (i32.const 0) $zero $one $zero))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-func-type-names.txt
+++ b/test/roundtrip/generate-func-type-names.txt
@@ -21,5 +21,5 @@
     call_indirect (type $t0)
     i32.const 1)
   (table $T0 1 1 anyfunc)
-  (elem (i32.const 0) $foo.bar))
+  (elem $e0 (i32.const 0) $foo.bar))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-some-names.txt
+++ b/test/roundtrip/generate-some-names.txt
@@ -54,5 +54,5 @@
   (table $T0 1 1 anyfunc)
   (export "baz" (func $import))
   (export "quux" (func $func0))
-  (elem (i32.const 0) $import))
+  (elem $e0 (i32.const 0) $import))
 ;;; STDOUT ;;)

--- a/test/roundtrip/inline-export-table.txt
+++ b/test/roundtrip/inline-export-table.txt
@@ -11,5 +11,5 @@
   (func (;0;) (type 0))
   (func (;1;) (type 0))
   (table (;0;) (export "foo") 2 2 anyfunc)
-  (elem (i32.const 0) 0 1))
+  (elem (;0;) (i32.const 0) 0 1))
 ;;; STDOUT ;;)

--- a/test/typecheck/bad-bulk-memory-invalid-segment.txt
+++ b/test/typecheck/bad-bulk-memory-invalid-segment.txt
@@ -1,0 +1,31 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-bulk-memory
+;;; ERROR: 1
+
+(module
+  (memory 1)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+    memory.drop 0
+  )
+
+  (table 1 anyfunc)
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+    table.drop 0
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:8:53: error: data_segment variable out of range (max 0)
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+                                                    ^
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:9:17: error: data_segment variable out of range (max 0)
+    memory.drop 0
+                ^
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:14:52: error: elem_segment variable out of range (max 0)
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+                                                   ^
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:15:16: error: elem_segment variable out of range (max 0)
+    table.drop 0
+               ^
+;;; STDERR ;;)

--- a/test/typecheck/bad-bulk-memory-no-memory.txt
+++ b/test/typecheck/bad-bulk-memory-no-memory.txt
@@ -1,0 +1,32 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-bulk-memory
+;;; ERROR: 1
+
+(module
+  (func
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+    memory.drop 0
+    i32.const 0 i32.const 0 i32.const 0 memory.copy
+    i32.const 0 i32.const 0 i32.const 0 memory.fill
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/bad-bulk-memory-no-memory.txt:7:41: error: memory.init requires an imported or defined memory.
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-no-memory.txt:7:53: error: data_segment variable out of range (max 0)
+    i32.const 0 i32.const 0 i32.const 0 memory.init 0
+                                                    ^
+out/test/typecheck/bad-bulk-memory-no-memory.txt:8:5: error: memory.drop requires an imported or defined memory.
+    memory.drop 0
+    ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-no-memory.txt:8:17: error: data_segment variable out of range (max 0)
+    memory.drop 0
+                ^
+out/test/typecheck/bad-bulk-memory-no-memory.txt:9:41: error: memory.copy requires an imported or defined memory.
+    i32.const 0 i32.const 0 i32.const 0 memory.copy
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-no-memory.txt:10:41: error: memory.fill requires an imported or defined memory.
+    i32.const 0 i32.const 0 i32.const 0 memory.fill
+                                        ^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/typecheck/bad-bulk-memory-no-table.txt
+++ b/test/typecheck/bad-bulk-memory-no-table.txt
@@ -1,0 +1,28 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-bulk-memory
+;;; ERROR: 1
+
+(module
+  (func
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+    table.drop 0
+    i32.const 0 i32.const 0 i32.const 0 table.copy
+  )
+)
+(;; STDERR ;;;
+out/test/typecheck/bad-bulk-memory-no-table.txt:7:41: error: table.init requires an imported or defined table.
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-no-table.txt:7:52: error: elem_segment variable out of range (max 0)
+    i32.const 0 i32.const 0 i32.const 0 table.init 0
+                                                   ^
+out/test/typecheck/bad-bulk-memory-no-table.txt:8:5: error: table.drop requires an imported or defined table.
+    table.drop 0
+    ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-no-table.txt:8:16: error: elem_segment variable out of range (max 0)
+    table.drop 0
+               ^
+out/test/typecheck/bad-bulk-memory-no-table.txt:9:41: error: table.copy requires an imported or defined table.
+    i32.const 0 i32.const 0 i32.const 0 table.copy
+                                        ^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/typecheck/bad-bulk-memory-type-mismatch.txt
+++ b/test/typecheck/bad-bulk-memory-type-mismatch.txt
@@ -1,0 +1,82 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-bulk-memory
+;;; ERROR: 1
+
+(module
+  (memory 1)
+  (data passive "a")
+  (table 1 anyfunc)
+  (elem passive 0)
+
+  (func
+    ;; Mismatch first operand.
+    f32.const 0 i32.const 0 i32.const 0 memory.init 0
+    f32.const 0 i32.const 0 i32.const 0 memory.copy
+    f32.const 0 i32.const 0 i32.const 0 memory.fill
+    f32.const 0 i32.const 0 i32.const 0 table.init 0
+    f32.const 0 i32.const 0 i32.const 0 table.copy
+
+    ;; Mismatch second operand.
+    i32.const 0 f32.const 0 i32.const 0 memory.init 0
+    i32.const 0 f32.const 0 i32.const 0 memory.copy
+    i32.const 0 f32.const 0 i32.const 0 memory.fill
+    i32.const 0 f32.const 0 i32.const 0 table.init 0
+    i32.const 0 f32.const 0 i32.const 0 table.copy
+
+    ;; Mismatch third operand.
+    i32.const 0 i32.const 0 i64.const 0 memory.init 0
+    i32.const 0 i32.const 0 i64.const 0 memory.copy
+    i32.const 0 i32.const 0 i64.const 0 memory.fill
+    i32.const 0 i32.const 0 i64.const 0 table.init 0
+    i32.const 0 i32.const 0 i64.const 0 table.copy
+  )
+)
+
+
+(;; STDERR ;;;
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:13:41: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, i32]
+    f32.const 0 i32.const 0 i32.const 0 memory.init 0
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:14:41: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
+    f32.const 0 i32.const 0 i32.const 0 memory.copy
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:15:41: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i32]
+    f32.const 0 i32.const 0 i32.const 0 memory.fill
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:16:41: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i32]
+    f32.const 0 i32.const 0 i32.const 0 table.init 0
+                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:17:41: error: type mismatch in table.copy, expected [i32, i32, i32] but got [f32, i32, i32]
+    f32.const 0 i32.const 0 i32.const 0 table.copy
+                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:20:41: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, i32]
+    i32.const 0 f32.const 0 i32.const 0 memory.init 0
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:21:41: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
+    i32.const 0 f32.const 0 i32.const 0 memory.copy
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:22:41: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i32]
+    i32.const 0 f32.const 0 i32.const 0 memory.fill
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:23:41: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i32]
+    i32.const 0 f32.const 0 i32.const 0 table.init 0
+                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:24:41: error: type mismatch in table.copy, expected [i32, i32, i32] but got [i32, f32, i32]
+    i32.const 0 f32.const 0 i32.const 0 table.copy
+                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:27:41: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, i64]
+    i32.const 0 i32.const 0 i64.const 0 memory.init 0
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:28:41: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
+    i32.const 0 i32.const 0 i64.const 0 memory.copy
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:29:41: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, i64]
+    i32.const 0 i32.const 0 i64.const 0 memory.fill
+                                        ^^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:30:41: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, i64]
+    i32.const 0 i32.const 0 i64.const 0 table.init 0
+                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:31:41: error: type mismatch in table.copy, expected [i32, i32, i32] but got [i32, i32, i64]
+    i32.const 0 i32.const 0 i64.const 0 table.copy
+                                        ^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
* Allow for names in data/elem segments:
```
(data $foo (i32.const 0) "abcdef")
```

* These names can be referenced by the memory/table instructions that
operate on segments:
```
memory.drop $foo
```

* Fix running wasm-objdump with bulk-memory instructions

* Check for valid data/elem segments in validation

* Check that bulk-memory is enabled when parsing text

Partial fix for #928; still needs interpreter checks too.