### PR TITLE
Add test for disabled opcodes in binary reader

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -408,6 +408,7 @@ if (NOT EMSCRIPTEN)
 
     # wabt-unittests
     set(UNITTESTS_SRCS
+      src/test-binary-reader.cc
       src/test-circular-array.cc
       src/test-interp.cc
       src/test-intrusive-list.cc

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -202,19 +202,23 @@ void WABT_PRINTF_FORMAT(2, 3) BinaryReader::PrintError(const char* format,
 }
 
 Result BinaryReader::ReportUnexpectedOpcode(Opcode opcode,
-                                            const char* message) {
-  const char* maybe_space = " ";
-  if (!message) {
-    message = maybe_space = "";
+                                            const char* where) {
+  std::string message = "unexpected opcode";
+  if (where) {
+    message += ' ';
+    message += where;
   }
-  if (opcode.HasPrefix()) {
-    PrintError("unexpected opcode%s%s: %d %d (0x%x 0x%x)", maybe_space, message,
-               opcode.GetPrefix(), opcode.GetCode(), opcode.GetPrefix(),
-               opcode.GetCode());
-  } else {
-    PrintError("unexpected opcode%s%s: %d (0x%x)", maybe_space, message,
-               opcode.GetCode(), opcode.GetCode());
+
+  message += ":";
+
+  std::vector<uint8_t> bytes = opcode.GetBytes();
+  assert(bytes.size() > 0);
+
+  for (uint8_t byte: bytes) {
+    message += StringPrintf(" 0x%x", byte);
   }
+
+  PrintError("%s", message.c_str());
   return Result::Error;
 }
 
@@ -806,6 +810,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::F32Load:
       case Opcode::F64Load:
       case Opcode::V128Load: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -826,6 +831,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::F32Store:
       case Opcode::F64Store:
       case Opcode::V128Store: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "store alignment"));
         Address offset;
@@ -1225,6 +1231,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         break;
 
       case Opcode::AtomicWake: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -1237,6 +1244,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::I32AtomicWait:
       case Opcode::I64AtomicWait: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -1254,6 +1262,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicLoad32U:
       case Opcode::I32AtomicLoad:
       case Opcode::I64AtomicLoad: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -1271,6 +1280,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicStore32:
       case Opcode::I32AtomicStore:
       case Opcode::I64AtomicStore: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "store alignment"));
         Address offset;
@@ -1323,6 +1333,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicRmw8UXchg:
       case Opcode::I64AtomicRmw16UXchg:
       case Opcode::I64AtomicRmw32UXchg: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "memory alignment"));
         Address offset;
@@ -1340,6 +1351,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicRmw8UCmpxchg:
       case Opcode::I64AtomicRmw16UCmpxchg:
       case Opcode::I64AtomicRmw32UCmpxchg: {
+        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "memory alignment"));
         Address offset;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -420,6 +420,7 @@ Result BinaryReader::ReadI32InitExpr(Index index) {
 Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
   Opcode opcode;
   CHECK_RESULT(ReadOpcode(&opcode, "opcode"));
+  ERROR_UNLESS_OPCODE_ENABLED(opcode);
 
   switch (opcode) {
     case Opcode::I32Const: {
@@ -451,7 +452,6 @@ Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
     }
 
     case Opcode::V128Const: {
-      ERROR_UNLESS_OPCODE_ENABLED(opcode);
       v128 value_bits;
       ZeroMemory(value_bits);
       CHECK_RESULT(ReadV128(&value_bits, "init_expr v128.const value"));
@@ -695,7 +695,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::V128Const: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         v128 value_bits;
         ZeroMemory(value_bits);
         CHECK_RESULT(ReadV128(&value_bits, "v128.const value"));
@@ -760,7 +759,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::ReturnCall: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         Index func_index;
         CHECK_RESULT(ReadIndex(&func_index, "return_call"));
         ERROR_UNLESS(func_index < NumTotalFuncs(),
@@ -772,7 +770,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::ReturnCallIndirect: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
 
         Index sig_index;
         CHECK_RESULT(ReadIndex(&sig_index, "return_call_indirect"));
@@ -810,7 +807,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::F32Load:
       case Opcode::F64Load:
       case Opcode::V128Load: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -831,7 +827,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::F32Store:
       case Opcode::F64Store:
       case Opcode::V128Store: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "store alignment"));
         Address offset;
@@ -950,7 +945,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::F64X2Div:
       case Opcode::F32X4Mul:
       case Opcode::F64X2Mul:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnBinaryExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
@@ -1029,7 +1023,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I32X4GeU:
       case Opcode::F32X4Ge:
       case Opcode::F64X2Ge:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnCompareExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
@@ -1079,13 +1072,11 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::F64X2Abs:
       case Opcode::F32X4Sqrt:
       case Opcode::F64X2Sqrt:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnUnaryExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::V128BitSelect:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnTernaryExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
@@ -1104,7 +1095,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64X2ReplaceLane:
       case Opcode::F32X4ReplaceLane:
       case Opcode::F64X2ReplaceLane: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint8_t lane_val;
         CHECK_RESULT(ReadU8(&lane_val, "Lane idx"));
         CALLBACK(OnSimdLaneOpExpr, opcode, lane_val);
@@ -1113,7 +1103,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::V8X16Shuffle: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         v128 value;
         CHECK_RESULT(ReadV128(&value, "Lane idx [16]"));
         CALLBACK(OnSimdShuffleOpExpr, opcode, value);
@@ -1156,13 +1145,11 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I32X4TruncUF32X4Sat:
       case Opcode::I64X2TruncSF64X2Sat:
       case Opcode::I64X2TruncUF64X2Sat:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnConvertExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::Try: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         Type sig_type;
         CHECK_RESULT(ReadType(&sig_type, "try signature type"));
         ERROR_UNLESS(IsBlockType(sig_type),
@@ -1173,21 +1160,18 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::Catch: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK0(OnCatchExpr);
         CALLBACK0(OnOpcodeBare);
         break;
       }
 
       case Opcode::Rethrow: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK0(OnRethrowExpr);
         CALLBACK0(OnOpcodeBare);
         break;
       }
 
       case Opcode::Throw: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         Index index;
         CHECK_RESULT(ReadIndex(&index, "exception index"));
         CALLBACK(OnThrowExpr, index);
@@ -1196,7 +1180,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::IfExcept: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         Type sig_type;
         CHECK_RESULT(ReadType(&sig_type, "if signature type"));
         ERROR_UNLESS(IsBlockType(sig_type),
@@ -1212,7 +1195,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64Extend8S:
       case Opcode::I64Extend16S:
       case Opcode::I64Extend32S:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnUnaryExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
@@ -1225,13 +1207,11 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64TruncUSatF32:
       case Opcode::I64TruncSSatF64:
       case Opcode::I64TruncUSatF64:
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         CALLBACK(OnConvertExpr, opcode);
         CALLBACK0(OnOpcodeBare);
         break;
 
       case Opcode::AtomicWake: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -1244,7 +1224,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::I32AtomicWait:
       case Opcode::I64AtomicWait: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -1262,7 +1241,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicLoad32U:
       case Opcode::I32AtomicLoad:
       case Opcode::I64AtomicLoad: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "load alignment"));
         Address offset;
@@ -1280,7 +1258,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicStore32:
       case Opcode::I32AtomicStore:
       case Opcode::I64AtomicStore: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "store alignment"));
         Address offset;
@@ -1333,7 +1310,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicRmw8UXchg:
       case Opcode::I64AtomicRmw16UXchg:
       case Opcode::I64AtomicRmw32UXchg: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "memory alignment"));
         Address offset;
@@ -1351,7 +1327,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       case Opcode::I64AtomicRmw8UCmpxchg:
       case Opcode::I64AtomicRmw16UCmpxchg:
       case Opcode::I64AtomicRmw32UCmpxchg: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint32_t alignment_log2;
         CHECK_RESULT(ReadU32Leb128(&alignment_log2, "memory alignment"));
         Address offset;
@@ -1363,7 +1338,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::TableInit: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint8_t reserved;
         CHECK_RESULT(ReadU8(&reserved, "reserved table index"));
         ERROR_UNLESS(reserved == 0, "reserved value must be 0");
@@ -1375,7 +1349,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::MemoryInit: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint8_t reserved;
         CHECK_RESULT(ReadU8(&reserved, "reserved memory index"));
         ERROR_UNLESS(reserved == 0, "reserved value must be 0");
@@ -1388,7 +1361,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::MemoryDrop:
       case Opcode::TableDrop: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         Index segment;
         CHECK_RESULT(ReadIndex(&segment, "segment index"));
         if (opcode == Opcode::MemoryDrop) {
@@ -1402,7 +1374,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::MemoryCopy:
       case Opcode::MemoryFill: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint8_t reserved;
         CHECK_RESULT(ReadU8(&reserved, "reserved memory index"));
         ERROR_UNLESS(reserved == 0, "reserved value must be 0");
@@ -1416,7 +1387,6 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::TableCopy: {
-        ERROR_UNLESS_OPCODE_ENABLED(opcode);
         uint8_t reserved;
         CHECK_RESULT(ReadU8(&reserved, "reserved table index"));
         ERROR_UNLESS(reserved == 0, "reserved value must be 0");

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -554,6 +554,8 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
     Opcode opcode;
     CHECK_RESULT(ReadOpcode(&opcode, "opcode"));
     CALLBACK(OnOpcode, opcode);
+    ERROR_UNLESS_OPCODE_ENABLED(opcode);
+
     switch (opcode) {
       case Opcode::Unreachable:
         CALLBACK0(OnUnreachableExpr);

--- a/src/error.h
+++ b/src/error.h
@@ -42,6 +42,7 @@ static WABT_INLINE const char* GetErrorLevelName(ErrorLevel error_level) {
 
 class Error {
  public:
+  Error() : error_level(ErrorLevel::Error) {}
   Error(ErrorLevel error_level, Location loc, string_view message)
       : error_level(error_level), loc(loc), message(message.to_string()) {}
 

--- a/src/leb128.cc
+++ b/src/leb128.cc
@@ -83,6 +83,17 @@ Offset WriteU32Leb128At(Stream* stream,
   return length;
 }
 
+Offset WriteU32Leb128Raw(uint8_t* dest, uint8_t* dest_end, uint32_t value) {
+  uint8_t data[MAX_U32_LEB128_BYTES];
+  Offset length = 0;
+  LEB128_LOOP_UNTIL(value == 0);
+  if (static_cast<Offset>(dest_end - dest) < length) {
+    return 0;
+  }
+  memcpy(dest, data, length);
+  return length;
+}
+
 Offset WriteFixedU32Leb128Raw(uint8_t* data, uint8_t* end, uint32_t value) {
   if (end - data < MAX_U32_LEB128_BYTES) {
     return 0;

--- a/src/leb128.h
+++ b/src/leb128.h
@@ -43,6 +43,7 @@ Offset WriteFixedU32Leb128At(Stream* stream,
                              uint32_t value,
                              const char* desc);
 
+Offset WriteU32Leb128Raw(uint8_t* data, uint8_t* end, uint32_t value);
 Offset WriteFixedU32Leb128Raw(uint8_t* data, uint8_t* end, uint32_t value);
 
 // Convenience functions for writing enums as LEB128s.

--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -353,4 +353,20 @@ uint32_t Opcode::GetSimdLaneCount() const {
   }
 }
 
+// Get the byte sequence for this opcode, including prefix.
+std::vector<uint8_t> Opcode::GetBytes() const {
+  std::vector<uint8_t> result;
+  if (HasPrefix()) {
+    result.push_back(GetPrefix());
+    uint8_t buffer[5];
+    Offset length =
+        WriteU32Leb128Raw(buffer, buffer + sizeof(buffer), GetCode());
+    assert(length != 0);
+    result.insert(result.end(), buffer, buffer + length);
+  } else {
+    result.push_back(GetCode());
+  }
+  return result;
+}
+
 }  // namespace wabt

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -58,7 +58,7 @@ struct Opcode {
   uint8_t GetPrefix() const { return GetInfo().prefix; }
   uint32_t GetCode() const { return GetInfo().code; }
   size_t GetLength() const {
-    return HasPrefix() ? 1 + U32Leb128Length(GetCode()) : 1;
+    return GetBytes().size();
   }
   const char* GetName() const { return GetInfo().name; }
   Type GetResultType() const { return GetInfo().result_type; }

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -57,9 +57,7 @@ struct Opcode {
   bool HasPrefix() const { return GetInfo().prefix != 0; }
   uint8_t GetPrefix() const { return GetInfo().prefix; }
   uint32_t GetCode() const { return GetInfo().code; }
-  size_t GetLength() const {
-    return GetBytes().size();
-  }
+  size_t GetLength() const { return GetBytes().size(); }
   const char* GetName() const { return GetInfo().name; }
   Type GetResultType() const { return GetInfo().result_type; }
   Type GetParamType1() const { return GetInfo().param1_type; }

--- a/src/opcode.h
+++ b/src/opcode.h
@@ -17,8 +17,11 @@
 #ifndef WABT_OPCODE_H_
 #define WABT_OPCODE_H_
 
+#include <vector>
+
 #include "src/common.h"
 #include "src/opcode-code-table.h"
+#include "src/leb128.h"
 
 namespace wabt {
 
@@ -54,13 +57,18 @@ struct Opcode {
   bool HasPrefix() const { return GetInfo().prefix != 0; }
   uint8_t GetPrefix() const { return GetInfo().prefix; }
   uint32_t GetCode() const { return GetInfo().code; }
-  size_t GetLength() const { return HasPrefix() ? 2 : 1; }
+  size_t GetLength() const {
+    return HasPrefix() ? 1 + U32Leb128Length(GetCode()) : 1;
+  }
   const char* GetName() const { return GetInfo().name; }
   Type GetResultType() const { return GetInfo().result_type; }
   Type GetParamType1() const { return GetInfo().param1_type; }
   Type GetParamType2() const { return GetInfo().param2_type; }
   Type GetParamType3() const { return GetInfo().param3_type; }
   Address GetMemorySize() const { return GetInfo().memory_size; }
+
+  // Get the byte sequence for this opcode, including prefix.
+  std::vector<uint8_t> GetBytes() const;
 
   // Get the lane count of an extract/replace simd op.
   uint32_t GetSimdLaneCount() const;

--- a/src/test-binary-reader.cc
+++ b/src/test-binary-reader.cc
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2018 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/binary-reader.h"
+#include "src/binary-reader-nop.h"
+#include "src/leb128.h"
+#include "src/opcode.h"
+
+using namespace wabt;
+
+namespace {
+
+struct BinaryReaderError : BinaryReaderNop {
+  bool OnError(const Error& error) override {
+    first_error = error;
+    return true;  // Error handled.
+  }
+
+  Error first_error;
+};
+
+}  // End of anonymous namespace
+
+TEST(BinaryReader, DisabledOpcodes) {
+  // Use the default features.
+  ReadBinaryOptions options;
+
+  // Loop through all opcodes.
+  for (uint32_t i = 0; i < static_cast<uint32_t>(Opcode::Invalid); ++i) {
+    Opcode opcode(static_cast<Opcode::Enum>(i));
+    if (opcode.IsEnabled(options.features)) {
+      continue;
+    }
+
+    // Use a shorter name to make the clang-formatted table below look nicer.
+    std::vector<uint8_t> b = opcode.GetBytes();
+    assert(b.size() <= 3);
+    b.resize(3);
+
+    uint8_t data[] = {
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,  // magic + version
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,  // type section: 1 type, (func)
+        0x03, 0x02, 0x01, 0x00,              // func section: 1 func, type 0
+        0x0a, 0x07, 0x01, 0x05, 0x00,        // code section: 1 func, 0 locals
+        b[0], b[1], b[2],  // The instruction, padded with zeroes
+        0x0b,              // end
+    };
+    const size_t size = sizeof(data);
+
+    BinaryReaderError reader;
+    Result result = ReadBinary(data, size, &reader, options);
+    EXPECT_EQ(Result::Error, result);
+
+    // This relies on the binary reader checking whether the opcode is allowed
+    // before reading any further data needed by the instruction.
+    const std::string& message = reader.first_error.message;
+    EXPECT_EQ(0u, message.find("unexpected opcode"))
+        << "Got error message: " << message;
+  }
+}

--- a/test/binary/bad-opcode-prefix.txt
+++ b/test/binary/bad-opcode-prefix.txt
@@ -12,7 +12,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-000001a: error: unexpected opcode: 254 127 (0xfe 0x7f)
+000001a: error: unexpected opcode: 0xfe 0x7f
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -13,7 +13,7 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-0000019: error: unexpected opcode: 255 (0xff)
+0000019: error: unexpected opcode: 0xff
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -50,9 +50,9 @@ out/test/spec/data.wast:292: assert_invalid passed:
 out/test/spec/data.wast:300: assert_invalid passed:
   0000014: error: expected END opcode after initializer expression
 out/test/spec/data.wast:308: assert_invalid passed:
-  0000012: error: unexpected opcode in initializer expression: 1 (0x1)
+  0000012: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/data.wast:316: assert_invalid passed:
-  0000012: error: unexpected opcode in initializer expression: 1 (0x1)
+  0000012: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/data.wast:324: assert_invalid passed:
   0000014: error: expected END opcode after initializer expression
 20/20 tests passed.

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -44,9 +44,9 @@ out/test/spec/elem.wast:258: assert_invalid passed:
 out/test/spec/elem.wast:266: assert_invalid passed:
   0000015: error: expected END opcode after initializer expression
 out/test/spec/elem.wast:274: assert_invalid passed:
-  0000013: error: unexpected opcode in initializer expression: 1 (0x1)
+  0000013: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/elem.wast:282: assert_invalid passed:
-  0000013: error: unexpected opcode in initializer expression: 1 (0x1)
+  0000013: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/elem.wast:290: assert_invalid passed:
   0000015: error: expected END opcode after initializer expression
 31/31 tests passed.

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -12,7 +12,7 @@ out/test/spec/func_ptrs.wast:36: assert_invalid passed:
 out/test/spec/func_ptrs.wast:40: assert_invalid passed:
   0000015: error: expected END opcode after initializer expression
 out/test/spec/func_ptrs.wast:44: assert_invalid passed:
-  0000013: error: unexpected opcode in initializer expression: 1 (0x1)
+  0000013: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/func_ptrs.wast:48: assert_invalid passed:
   000000c: error: invalid function signature index: 42
 out/test/spec/func_ptrs.wast:49: assert_invalid passed:

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -7,13 +7,13 @@ out/test/spec/globals.wast:50: assert_invalid passed:
 out/test/spec/globals.wast:59: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
 out/test/spec/globals.wast:64: assert_invalid passed:
-  000000e: error: unexpected opcode in initializer expression: 32 (0x20)
+  000000e: error: unexpected opcode in initializer expression: 0x20
 out/test/spec/globals.wast:69: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
 out/test/spec/globals.wast:74: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
 out/test/spec/globals.wast:79: assert_invalid passed:
-  000000e: error: unexpected opcode in initializer expression: 1 (0x1)
+  000000e: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/globals.wast:84: assert_invalid passed:
   error: type mismatch in global, expected i32 but got f32.
   0000013: error: EndGlobalInitExpr callback failed


### PR DESCRIPTION
It's easy to forget to add a check for unexpected opcodes, and it's
tedious to have to write additional tests in `test/binary/*`.

This way we can test all potentially disabled instructions at once.