### PR TITLE
Check type use vs. explicit sig. in call_indirect

### DIFF
--- a/src/validator.cc
+++ b/src/validator.cc
@@ -602,10 +602,7 @@ Result Validator::OnCallIndirectExpr(CallIndirectExpr* expr) {
   if (current_module_->tables.size() == 0) {
     PrintError(&expr->loc, "found call_indirect operator, but no table");
   }
-  if (expr->decl.has_func_type) {
-    const FuncType* func_type;
-    CheckFuncTypeVar(&expr->decl.type_var, &func_type);
-  }
+  CheckFuncSignature(&expr->loc, expr->decl);
   typechecker_.OnCallIndirect(expr->decl.sig.param_types,
                               expr->decl.sig.result_types);
   return Result::Ok;
@@ -812,10 +809,7 @@ Result Validator::OnReturnCallIndirectExpr(ReturnCallIndirectExpr* expr) {
   if (current_module_->tables.empty()) {
     PrintError(&expr->loc, "found return_call_indirect operator, but no table");
   }
-  if (expr->decl.has_func_type) {
-    const FuncType* func_type;
-    CheckFuncTypeVar(&expr->decl.type_var, &func_type);
-  }
+  CheckFuncSignature(&expr->loc, expr->decl);
   typechecker_.OnReturnCallIndirect(expr->decl.sig.param_types,
                               expr->decl.sig.result_types);
   return Result::Ok;

--- a/test/regress/regress-22.txt
+++ b/test/regress/regress-22.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+    (type $sig (func (param i32) (result i32)))
+    (table 0 anyfunc)
+    (func (result i32)
+      (call_indirect (type $sig) (result i32) (i32.const 0))
+    )
+)
+(;; STDERR ;;;
+out/test/regress/regress-22.txt:7:8: error: expected 1 arguments, got 0
+      (call_indirect (type $sig) (result i32) (i32.const 0))
+       ^^^^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
The `call_indirect` instruction can take a type use, but can also take
an explicit signature:

```
call_indirect (type $foo)               ;; type use
call_indirect (param i32)               ;; explicit signature
call_indirect (type $bar) (result f32)  ;; both
```

These type signatures must match, or the wat file is considered
malformed. This was properly checked in the spec tests, because it
was performed in a separate function `wabt::ValidateFuncSignatures`.
This wasn't validated in `wat2wasm`, because it performs the full module
validation via `wabt::ValidateModule`, which doesn't share code with
`ValidateFuncSignatures`.

It might be a good idea to share the code between these two, but for now
it's enough to fix this bug by performing the same check in the module
validation path.

Fixes issue #936.