### PR TITLE
Set `end_loc` in folded `if` expressions

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2006,6 +2006,7 @@ Result WastParser::ParseExpr(ExprList* exprs) {
 
         if (MatchLpar(TokenType::Then)) {
           CHECK_RESULT(ParseTerminatingInstrList(&expr->true_.exprs));
+          expr->true_.end_loc = GetLocation();
           EXPECT(Rpar);
 
           if (MatchLpar(TokenType::Else)) {
@@ -2014,10 +2015,13 @@ Result WastParser::ParseExpr(ExprList* exprs) {
           } else if (PeekMatchExpr()) {
             CHECK_RESULT(ParseExpr(&expr->false_));
           }
+          expr->false_end_loc = GetLocation();
         } else if (PeekMatchExpr()) {
           CHECK_RESULT(ParseExpr(&expr->true_.exprs));
+          expr->true_.end_loc = GetLocation();
           if (PeekMatchExpr()) {
             CHECK_RESULT(ParseExpr(&expr->false_));
+            expr->false_end_loc = GetLocation();
           }
         } else {
           ConsumeIfLpar();
@@ -2043,6 +2047,7 @@ Result WastParser::ParseExpr(ExprList* exprs) {
 
         if (MatchLpar(TokenType::Then)) {
           CHECK_RESULT(ParseTerminatingInstrList(&expr->true_.exprs));
+          expr->true_.end_loc = GetLocation();
           EXPECT(Rpar);
 
           if (MatchLpar(TokenType::Else)) {
@@ -2051,10 +2056,13 @@ Result WastParser::ParseExpr(ExprList* exprs) {
           } else if (PeekMatchExpr()) {
             CHECK_RESULT(ParseExpr(&expr->false_));
           }
+          expr->false_end_loc = GetLocation();
         } else if (PeekMatchExpr()) {
           CHECK_RESULT(ParseExpr(&expr->true_.exprs));
+          expr->true_.end_loc = GetLocation();
           if (PeekMatchExpr()) {
             CHECK_RESULT(ParseExpr(&expr->false_));
+            expr->false_end_loc = GetLocation();
           }
         } else {
           ConsumeIfLpar();

--- a/test/regress/regress-23.txt
+++ b/test/regress/regress-23.txt
@@ -1,0 +1,71 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+
+;; This regression test makes sure that the end_loc of `if` blocks is properly
+;; set when using the folded format.
+
+;; if/else shorthand format, error in true branch.
+(func (result i32)
+  (if (result i32)
+    (i32.const 0)
+    (block
+      (unreachable)
+    )
+    (i32.const 0)
+  )
+)
+
+;; if/else with `then`/`else` keywords, error in true branch.
+(func (result i32)
+  (if (result i32)
+    (i32.const 0)
+    (then
+      (block
+        (unreachable)
+      )
+    )
+    (else
+      (i32.const 0)
+    )
+  )
+)
+
+;; if/else shorthand format, error in false branch.
+(func (result i32)
+  (if (result i32)
+    (i32.const 0)
+    (i32.const 0)
+    (block
+      (unreachable)
+    )
+  )
+)
+
+;; if/else with `then`/`else` keywords, error in false branch.
+(func (result i32)
+  (if (result i32)
+    (i32.const 0)
+    (then
+      (i32.const 0)
+    )
+    (else
+      (block
+        (unreachable)
+      )
+    )
+  )
+)
+(;; STDERR ;;;
+out/test/regress/regress-23.txt:13:5: error: type mismatch in if true branch, expected [i32] but got []
+    )
+    ^
+out/test/regress/regress-23.txt:25:7: error: type mismatch in if true branch, expected [i32] but got []
+      )
+      ^
+out/test/regress/regress-23.txt:41:3: error: type mismatch in if false branch, expected [i32] but got []
+  )
+  ^
+out/test/regress/regress-23.txt:56:3: error: type mismatch in if false branch, expected [i32] but got []
+  )
+  ^
+;;; STDERR ;;)


### PR DESCRIPTION
Without this fix, some validation errors will not display the location
properly.