### PR TITLE
Add `dummy_workaround_...` function to fix Travis

### DIFF
--- a/src/emscripten-helpers.cc
+++ b/src/emscripten-helpers.cc
@@ -404,6 +404,9 @@ void wabt_destroy_output_buffer(wabt::OutputBuffer* output_buffer) {
   delete output_buffer;
 }
 
+// See https://github.com/kripken/emscripten/issues/7073.
+void dummy_workaround_for_emscripten_issue_7073(void) {}
+
 }  // extern "C"
 
 #endif /* WABT_EMSCRIPTEN_HELPERS_H_ */


### PR DESCRIPTION
Newer versions of emscripten will error out if you attempt to export
functions that aren't defined.

We added a dummy function to the export list to work around emscripten
issue 7073. It's fixed now, but we may want to keep this workaround for
a bit to allow for non-HEAD emscripten versions.

Fixes #939.