### PR TITLE
Update testsuite

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1963,9 +1963,11 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
   ERROR_UNLESS(num_elem_segments == 0 || NumTotalTables() > 0,
                "elem section without table section");
   for (Index i = 0; i < num_elem_segments; ++i) {
-    uint8_t flags_byte;
-    CHECK_RESULT(ReadU8(&flags_byte, "elem segment flags"));
-    SegmentFlags flags = static_cast<SegmentFlags>(flags_byte);
+    uint32_t flags_u32;
+    CHECK_RESULT(ReadU32Leb128(&flags_u32, "elem segment flags"));
+    ERROR_UNLESS(flags_u32 <= static_cast<uint32_t>(SegmentFlags::IndexOther),
+                 "invalid elem segment flags");
+    SegmentFlags flags = static_cast<SegmentFlags>(flags_u32);
     Index table_index(0);
     if (flags == SegmentFlags::IndexOther) {
       CHECK_RESULT(ReadIndex(&table_index, "elem segment table index"));
@@ -2041,9 +2043,11 @@ Result BinaryReader::ReadDataSection(Offset section_size) {
   ERROR_UNLESS(num_data_segments == 0 || NumTotalMemories() > 0,
                "data section without memory section");
   for (Index i = 0; i < num_data_segments; ++i) {
-    uint8_t flags_byte;
-    CHECK_RESULT(ReadU8(&flags_byte, "data segment flags"));
-    SegmentFlags flags = static_cast<SegmentFlags>(flags_byte);
+    uint32_t flags_u32;
+    CHECK_RESULT(ReadU32Leb128(&flags_u32, "data segment flags"));
+    ERROR_UNLESS(flags_u32 <= static_cast<uint32_t>(SegmentFlags::IndexOther),
+                 "invalid data segment flags");
+    SegmentFlags flags = static_cast<SegmentFlags>(flags_u32);
     Index memory_index(0);
     if (flags == SegmentFlags::IndexOther) {
       CHECK_RESULT(ReadIndex(&memory_index, "data segment memory index"));

--- a/src/binary.h
+++ b/src/binary.h
@@ -64,7 +64,7 @@ enum class NameSectionSubsection {
   Local = 2,
 };
 
-enum class SegmentFlags: uint8_t {
+enum class SegmentFlags : uint8_t {
   IndexZero = 0,
   Passive = 1,
   IndexOther = 2,

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -57,43 +57,67 @@ out/test/spec/binary.wast:43: assert_malformed passed:
   0000008: error: bad wasm file version: 0x10000 (expected 0x1)
 out/test/spec/binary.wast:44: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
-out/test/spec/binary.wast:119: assert_malformed passed:
-  000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:129: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
 out/test/spec/binary.wast:139: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
-out/test/spec/binary.wast:150: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
-out/test/spec/binary.wast:160: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
-out/test/spec/binary.wast:172: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/binary.wast:149: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary.wast:159: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary.wast:170: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
 out/test/spec/binary.wast:180: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary.wast:192: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
-out/test/spec/binary.wast:190: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
 out/test/spec/binary.wast:200: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000c: error: unable to read u32 leb128: memory initial page count
 out/test/spec/binary.wast:210: assert_malformed passed:
   000000e: error: unable to read i32 leb128: init_expr i32.const value
 out/test/spec/binary.wast:220: assert_malformed passed:
   000000e: error: unable to read i32 leb128: init_expr i32.const value
-out/test/spec/binary.wast:231: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
-out/test/spec/binary.wast:241: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary.wast:230: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary.wast:240: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
 out/test/spec/binary.wast:251: assert_malformed passed:
   000000e: error: unable to read i64 leb128: init_expr i64.const value
 out/test/spec/binary.wast:261: assert_malformed passed:
   000000e: error: unable to read i64 leb128: init_expr i64.const value
-out/test/spec/binary.wast:273: assert_malformed passed:
+out/test/spec/binary.wast:271: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary.wast:281: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary.wast:293: assert_malformed passed:
   0000022: error: call_indirect reserved value must be 0
-out/test/spec/binary.wast:292: assert_malformed passed:
-  0000020: error: memory.grow reserved value must be 0
 out/test/spec/binary.wast:312: assert_malformed passed:
-  000001e: error: memory.size reserved value must be 0
+  0000022: error: call_indirect reserved value must be 0
 out/test/spec/binary.wast:331: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/binary.wast:349: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/binary.wast:367: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/binary.wast:386: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/binary.wast:406: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/binary.wast:426: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/binary.wast:445: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/binary.wast:464: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/binary.wast:484: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/binary.wast:503: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/binary.wast:522: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/binary.wast:540: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/binary.wast:558: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/binary.wast:577: assert_malformed passed:
   000001c: error: local count must be < 0x10000000
-47/47 tests passed.
+59/59 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -1,385 +1,385 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/block.wast
 (;; STDOUT ;;;
-out/test/spec/block.wast:295: assert_invalid passed:
+out/test/spec/block.wast:306: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:299: assert_invalid passed:
+out/test/spec/block.wast:310: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:303: assert_invalid passed:
+out/test/spec/block.wast:314: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:307: assert_invalid passed:
+out/test/spec/block.wast:318: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:312: assert_invalid passed:
+out/test/spec/block.wast:323: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:318: assert_invalid passed:
+out/test/spec/block.wast:329: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i64]
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:324: assert_invalid passed:
+out/test/spec/block.wast:335: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f32]
   000001f: error: OnEndExpr callback failed
-out/test/spec/block.wast:330: assert_invalid passed:
+out/test/spec/block.wast:341: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f64]
   0000023: error: OnEndExpr callback failed
-out/test/spec/block.wast:337: assert_invalid passed:
+out/test/spec/block.wast:348: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:343: assert_invalid passed:
+out/test/spec/block.wast:354: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:349: assert_invalid passed:
+out/test/spec/block.wast:360: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:355: assert_invalid passed:
+out/test/spec/block.wast:366: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:362: assert_invalid passed:
+out/test/spec/block.wast:373: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:368: assert_invalid passed:
+out/test/spec/block.wast:379: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:374: assert_invalid passed:
+out/test/spec/block.wast:385: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:380: assert_invalid passed:
+out/test/spec/block.wast:391: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:387: assert_invalid passed:
+out/test/spec/block.wast:398: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:393: assert_invalid passed:
+out/test/spec/block.wast:404: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:399: assert_invalid passed:
+out/test/spec/block.wast:410: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f64]
   0000024: error: OnEndExpr callback failed
-out/test/spec/block.wast:405: assert_invalid passed:
+out/test/spec/block.wast:416: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:411: assert_invalid passed:
+out/test/spec/block.wast:422: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:417: assert_invalid passed:
+out/test/spec/block.wast:428: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got [f64]
   0000024: error: OnEndExpr callback failed
-out/test/spec/block.wast:423: assert_invalid passed:
+out/test/spec/block.wast:434: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:429: assert_invalid passed:
+out/test/spec/block.wast:440: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:435: assert_invalid passed:
+out/test/spec/block.wast:446: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [f64]
   0000024: error: OnEndExpr callback failed
-out/test/spec/block.wast:441: assert_invalid passed:
+out/test/spec/block.wast:452: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:447: assert_invalid passed:
+out/test/spec/block.wast:458: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:453: assert_invalid passed:
+out/test/spec/block.wast:464: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:460: assert_invalid passed:
+out/test/spec/block.wast:471: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:466: assert_invalid passed:
+out/test/spec/block.wast:477: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:472: assert_invalid passed:
+out/test/spec/block.wast:483: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:478: assert_invalid passed:
+out/test/spec/block.wast:489: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:484: assert_invalid passed:
+out/test/spec/block.wast:495: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [f32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:490: assert_invalid passed:
+out/test/spec/block.wast:501: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [f64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:496: assert_invalid passed:
+out/test/spec/block.wast:507: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:502: assert_invalid passed:
+out/test/spec/block.wast:513: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:508: assert_invalid passed:
+out/test/spec/block.wast:519: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [f64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:514: assert_invalid passed:
+out/test/spec/block.wast:525: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got [i32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:520: assert_invalid passed:
+out/test/spec/block.wast:531: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:526: assert_invalid passed:
+out/test/spec/block.wast:537: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got [f32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:533: assert_invalid passed:
+out/test/spec/block.wast:544: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:539: assert_invalid passed:
+out/test/spec/block.wast:550: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:545: assert_invalid passed:
+out/test/spec/block.wast:556: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:551: assert_invalid passed:
+out/test/spec/block.wast:562: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:558: assert_invalid passed:
+out/test/spec/block.wast:569: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:564: assert_invalid passed:
+out/test/spec/block.wast:575: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:570: assert_invalid passed:
+out/test/spec/block.wast:581: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:576: assert_invalid passed:
+out/test/spec/block.wast:587: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:583: assert_invalid passed:
+out/test/spec/block.wast:594: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:589: assert_invalid passed:
+out/test/spec/block.wast:600: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:595: assert_invalid passed:
+out/test/spec/block.wast:606: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:601: assert_invalid passed:
+out/test/spec/block.wast:612: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:608: assert_invalid passed:
+out/test/spec/block.wast:619: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:614: assert_invalid passed:
+out/test/spec/block.wast:625: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:620: assert_invalid passed:
+out/test/spec/block.wast:631: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:626: assert_invalid passed:
+out/test/spec/block.wast:637: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:632: assert_invalid passed:
+out/test/spec/block.wast:643: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:638: assert_invalid passed:
+out/test/spec/block.wast:649: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:644: assert_invalid passed:
+out/test/spec/block.wast:655: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:650: assert_invalid passed:
+out/test/spec/block.wast:661: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:656: assert_invalid passed:
+out/test/spec/block.wast:667: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:662: assert_invalid passed:
+out/test/spec/block.wast:673: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:668: assert_invalid passed:
+out/test/spec/block.wast:679: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:674: assert_invalid passed:
+out/test/spec/block.wast:685: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:681: assert_invalid passed:
+out/test/spec/block.wast:692: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:687: assert_invalid passed:
+out/test/spec/block.wast:698: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:693: assert_invalid passed:
+out/test/spec/block.wast:704: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:699: assert_invalid passed:
+out/test/spec/block.wast:710: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:706: assert_invalid passed:
+out/test/spec/block.wast:717: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:712: assert_invalid passed:
+out/test/spec/block.wast:723: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:718: assert_invalid passed:
+out/test/spec/block.wast:729: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:724: assert_invalid passed:
+out/test/spec/block.wast:735: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:730: assert_invalid passed:
+out/test/spec/block.wast:741: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:736: assert_invalid passed:
+out/test/spec/block.wast:747: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:742: assert_invalid passed:
+out/test/spec/block.wast:753: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:748: assert_invalid passed:
+out/test/spec/block.wast:759: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:754: assert_invalid passed:
+out/test/spec/block.wast:765: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:760: assert_invalid passed:
+out/test/spec/block.wast:771: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:766: assert_invalid passed:
+out/test/spec/block.wast:777: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:772: assert_invalid passed:
+out/test/spec/block.wast:783: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:779: assert_invalid passed:
+out/test/spec/block.wast:790: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
-out/test/spec/block.wast:785: assert_invalid passed:
+out/test/spec/block.wast:796: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i64]
   0000024: error: EndFunctionBody callback failed
-out/test/spec/block.wast:791: assert_invalid passed:
+out/test/spec/block.wast:802: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f32]
   0000027: error: EndFunctionBody callback failed
-out/test/spec/block.wast:797: assert_invalid passed:
+out/test/spec/block.wast:808: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64]
   000002b: error: EndFunctionBody callback failed
-out/test/spec/block.wast:804: assert_invalid passed:
+out/test/spec/block.wast:815: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:810: assert_invalid passed:
+out/test/spec/block.wast:821: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:816: assert_invalid passed:
+out/test/spec/block.wast:827: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:822: assert_invalid passed:
+out/test/spec/block.wast:833: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:829: assert_invalid passed:
+out/test/spec/block.wast:840: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:835: assert_invalid passed:
+out/test/spec/block.wast:846: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:841: assert_invalid passed:
+out/test/spec/block.wast:852: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:847: assert_invalid passed:
+out/test/spec/block.wast:858: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:854: assert_invalid passed:
+out/test/spec/block.wast:865: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:862: assert_invalid passed:
+out/test/spec/block.wast:873: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   0000023: error: OnBrExpr callback failed
-out/test/spec/block.wast:870: assert_invalid passed:
+out/test/spec/block.wast:881: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000027: error: OnBrExpr callback failed
-out/test/spec/block.wast:878: assert_invalid passed:
+out/test/spec/block.wast:889: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:886: assert_invalid passed:
+out/test/spec/block.wast:897: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f32]
   0000023: error: OnBrExpr callback failed
-out/test/spec/block.wast:894: assert_invalid passed:
+out/test/spec/block.wast:905: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f64]
   0000027: error: OnBrExpr callback failed
-out/test/spec/block.wast:902: assert_invalid passed:
+out/test/spec/block.wast:913: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i32]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:910: assert_invalid passed:
+out/test/spec/block.wast:921: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:918: assert_invalid passed:
+out/test/spec/block.wast:929: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [f64]
   0000027: error: OnBrExpr callback failed
-out/test/spec/block.wast:926: assert_invalid passed:
+out/test/spec/block.wast:937: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i32]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:934: assert_invalid passed:
+out/test/spec/block.wast:945: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:942: assert_invalid passed:
+out/test/spec/block.wast:953: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [f32]
   0000023: error: OnBrExpr callback failed
-out/test/spec/block.wast:951: assert_invalid passed:
+out/test/spec/block.wast:962: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:957: assert_invalid passed:
+out/test/spec/block.wast:968: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:963: assert_invalid passed:
+out/test/spec/block.wast:974: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:969: assert_invalid passed:
+out/test/spec/block.wast:980: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:976: assert_invalid passed:
+out/test/spec/block.wast:987: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:982: assert_invalid passed:
+out/test/spec/block.wast:993: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:988: assert_invalid passed:
+out/test/spec/block.wast:999: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:994: assert_invalid passed:
+out/test/spec/block.wast:1005: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1001: assert_invalid passed:
+out/test/spec/block.wast:1012: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1007: assert_invalid passed:
+out/test/spec/block.wast:1018: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1013: assert_invalid passed:
+out/test/spec/block.wast:1024: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1019: assert_invalid passed:
+out/test/spec/block.wast:1030: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1025: assert_invalid passed:
+out/test/spec/block.wast:1036: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1031: assert_invalid passed:
+out/test/spec/block.wast:1042: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1037: assert_invalid passed:
+out/test/spec/block.wast:1048: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1043: assert_invalid passed:
+out/test/spec/block.wast:1054: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1049: assert_invalid passed:
+out/test/spec/block.wast:1060: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1055: assert_invalid passed:
+out/test/spec/block.wast:1066: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1061: assert_invalid passed:
+out/test/spec/block.wast:1072: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1067: assert_invalid passed:
+out/test/spec/block.wast:1078: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1074: assert_malformed passed:
+out/test/spec/block.wast:1085: assert_malformed passed:
   out/test/spec/block/block.125.wat:1:17: error: unexpected label "$l"
   (func block end $l)
                   ^^
-out/test/spec/block.wast:1078: assert_malformed passed:
+out/test/spec/block.wast:1089: assert_malformed passed:
   out/test/spec/block/block.126.wat:1:20: error: mismatching label "$a" != "$l"
   (func block $a end $l)
                      ^^
-165/165 tests passed.
+167/167 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -1,26 +1,26 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
-out/test/spec/br.wast:411: assert_invalid passed:
+out/test/spec/br.wast:420: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/br.wast:418: assert_invalid passed:
+out/test/spec/br.wast:427: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:424: assert_invalid passed:
+out/test/spec/br.wast:433: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
-out/test/spec/br.wast:430: assert_invalid passed:
+out/test/spec/br.wast:439: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/br.wast:437: assert_invalid passed:
+out/test/spec/br.wast:446: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   0000019: error: OnBrExpr callback failed
-out/test/spec/br.wast:441: assert_invalid passed:
+out/test/spec/br.wast:450: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:445: assert_invalid passed:
+out/test/spec/br.wast:454: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
   000001d: error: OnBrExpr callback failed
-68/68 tests passed.
+70/70 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_if.txt
+++ b/test/spec/br_if.txt
@@ -1,77 +1,77 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br_if.wast
 (;; STDOUT ;;;
-out/test/spec/br_if.wast:413: assert_invalid passed:
+out/test/spec/br_if.wast:432: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/br_if.wast:417: assert_invalid passed:
+out/test/spec/br_if.wast:436: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/br_if.wast:421: assert_invalid passed:
+out/test/spec/br_if.wast:440: assert_invalid passed:
   error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/br_if.wast:425: assert_invalid passed:
+out/test/spec/br_if.wast:444: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/br_if.wast:430: assert_invalid passed:
+out/test/spec/br_if.wast:449: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/br_if.wast:434: assert_invalid passed:
+out/test/spec/br_if.wast:453: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:438: assert_invalid passed:
+out/test/spec/br_if.wast:457: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [f32]
   0000020: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:442: assert_invalid passed:
+out/test/spec/br_if.wast:461: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:447: assert_invalid passed:
+out/test/spec/br_if.wast:466: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:453: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
-  000001e: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:459: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
-  0000020: error: OnEndExpr callback failed
-out/test/spec/br_if.wast:465: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
-  0000020: error: OnEndExpr callback failed
 out/test/spec/br_if.wast:472: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
-  000001f: error: OnBrIfExpr callback failed
+  000001e: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:478: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/br_if.wast:484: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/br_if.wast:491: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:484: assert_invalid passed:
+out/test/spec/br_if.wast:497: assert_invalid passed:
+  error: type mismatch in br_if, expected [i32] but got []
+  000001f: error: OnBrIfExpr callback failed
+out/test/spec/br_if.wast:503: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:492: assert_invalid passed:
+out/test/spec/br_if.wast:511: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:501: assert_invalid passed:
+out/test/spec/br_if.wast:520: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001c: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:507: assert_invalid passed:
+out/test/spec/br_if.wast:526: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:513: assert_invalid passed:
+out/test/spec/br_if.wast:532: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:519: assert_invalid passed:
+out/test/spec/br_if.wast:538: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got []
   0000022: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:525: assert_invalid passed:
+out/test/spec/br_if.wast:544: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [... i64]
   0000020: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:532: assert_invalid passed:
+out/test/spec/br_if.wast:551: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   000001b: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:536: assert_invalid passed:
+out/test/spec/br_if.wast:555: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   000001f: error: OnBrIfExpr callback failed
-out/test/spec/br_if.wast:540: assert_invalid passed:
+out/test/spec/br_if.wast:559: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
   000001f: error: OnBrIfExpr callback failed
-99/99 tests passed.
+103/103 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -1,50 +1,50 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
-out/test/spec/br_table.wast:1413: assert_invalid passed:
+out/test/spec/br_table.wast:1429: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
-out/test/spec/br_table.wast:1420: assert_invalid passed:
+out/test/spec/br_table.wast:1436: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   0000020: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1426: assert_invalid passed:
+out/test/spec/br_table.wast:1442: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1434: assert_invalid passed:
+out/test/spec/br_table.wast:1450: assert_invalid passed:
   error: br_table labels have inconsistent types: expected [f32], got []
   0000026: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1446: assert_invalid passed:
+out/test/spec/br_table.wast:1462: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   000001f: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1452: assert_invalid passed:
+out/test/spec/br_table.wast:1468: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
   000001e: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1458: assert_invalid passed:
+out/test/spec/br_table.wast:1474: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   0000021: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1464: assert_invalid passed:
+out/test/spec/br_table.wast:1480: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
   0000023: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1470: assert_invalid passed:
+out/test/spec/br_table.wast:1486: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [... i64]
   0000022: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1479: assert_invalid passed:
+out/test/spec/br_table.wast:1495: assert_invalid passed:
   error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1485: assert_invalid passed:
+out/test/spec/br_table.wast:1501: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1491: assert_invalid passed:
+out/test/spec/br_table.wast:1507: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1498: assert_invalid passed:
+out/test/spec/br_table.wast:1514: assert_invalid passed:
   error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1504: assert_invalid passed:
+out/test/spec/br_table.wast:1520: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
-out/test/spec/br_table.wast:1510: assert_invalid passed:
+out/test/spec/br_table.wast:1526: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
-159/159 tests passed.
+161/161 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -1,39 +1,39 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call.wast
 (;; STDOUT ;;;
-out/test/spec/call.wast:160: assert_invalid passed:
+out/test/spec/call.wast:278: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001b: error: OnConvertExpr callback failed
-out/test/spec/call.wast:167: assert_invalid passed:
+out/test/spec/call.wast:285: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001f: error: OnConvertExpr callback failed
-out/test/spec/call.wast:175: assert_invalid passed:
+out/test/spec/call.wast:293: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   000001e: error: OnCallExpr callback failed
-out/test/spec/call.wast:182: assert_invalid passed:
+out/test/spec/call.wast:300: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
-out/test/spec/call.wast:189: assert_invalid passed:
+out/test/spec/call.wast:307: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/test/spec/call.wast:196: assert_invalid passed:
+out/test/spec/call.wast:314: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
-out/test/spec/call.wast:204: assert_invalid passed:
+out/test/spec/call.wast:322: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/test/spec/call.wast:211: assert_invalid passed:
+out/test/spec/call.wast:329: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/test/spec/call.wast:218: assert_invalid passed:
+out/test/spec/call.wast:336: assert_invalid passed:
   error: type mismatch in call, expected [i32, f64] but got [f64, i32]
   000002a: error: OnCallExpr callback failed
-out/test/spec/call.wast:225: assert_invalid passed:
+out/test/spec/call.wast:343: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got [i32, f64]
   000002a: error: OnCallExpr callback failed
-out/test/spec/call.wast:236: assert_invalid passed:
+out/test/spec/call.wast:354: assert_invalid passed:
   0000019: error: invalid call function index: 1
-out/test/spec/call.wast:240: assert_invalid passed:
+out/test/spec/call.wast:358: assert_invalid passed:
   000001d: error: invalid call function index: 1012321300
-47/47 tests passed.
+68/68 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -1,116 +1,116 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call_indirect.wast
 (;; STDOUT ;;;
-out/test/spec/call_indirect.wast:273: assert_malformed passed:
+out/test/spec/call_indirect.wast:527: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.1.wat:1:122: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
   out/test/spec/call_indirect/call_indirect.1.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:285: assert_malformed passed:
+out/test/spec/call_indirect.wast:539: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.2.wat:1:109: error: unexpected token "type", expected an expr.
   ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
   out/test/spec/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:297: assert_malformed passed:
+out/test/spec/call_indirect.wast:551: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.3.wat:1:122: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
   out/test/spec/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:309: assert_malformed passed:
+out/test/spec/call_indirect.wast:563: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.4.wat:1:110: error: unexpected token "type", expected an expr.
   ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
   out/test/spec/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:321: assert_malformed passed:
+out/test/spec/call_indirect.wast:575: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "param", expected an expr.
   ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
   out/test/spec/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:333: assert_malformed passed:
+out/test/spec/call_indirect.wast:587: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.6.wat:1:67: error: unexpected token "param", expected an expr.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                           ^^^^^
   out/test/spec/call_indirect/call_indirect.6.wat:1:106: error: unexpected token ), expected EOF.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/test/spec/call_indirect.wast:343: assert_malformed passed:
+out/test/spec/call_indirect.wast:597: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.7.wat:1:46: error: unexpected token $x, expected ).
   ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
   out/test/spec/call_indirect/call_indirect.7.wat:1:82: error: unexpected token ), expected EOF.
   ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/test/spec/call_indirect.wast:350: assert_malformed passed:
+out/test/spec/call_indirect.wast:604: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.8.wat:1:57: error: expected 0 results, got 1
   ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:360: assert_malformed passed:
+out/test/spec/call_indirect.wast:614: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.9.wat:1:82: error: expected 1 arguments, got 0
   ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:370: assert_malformed passed:
+out/test/spec/call_indirect.wast:624: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.10.wat:1:69: error: expected 1 results, got 0
   ...i32)))(table 0 anyfunc)(func  (call_indirect (type $sig) (param i32) (i32....
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:380: assert_malformed passed:
+out/test/spec/call_indirect.wast:634: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.11.wat:1:86: error: expected 2 arguments, got 1
   ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:395: assert_invalid passed:
+out/test/spec/call_indirect.wast:649: assert_invalid passed:
   error: found call_indirect operator, but no table
   000001c: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:403: assert_invalid passed:
+out/test/spec/call_indirect.wast:657: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
-out/test/spec/call_indirect.wast:411: assert_invalid passed:
+out/test/spec/call_indirect.wast:665: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
-out/test/spec/call_indirect.wast:420: assert_invalid passed:
+out/test/spec/call_indirect.wast:674: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:428: assert_invalid passed:
+out/test/spec/call_indirect.wast:682: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:436: assert_invalid passed:
+out/test/spec/call_indirect.wast:690: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/call_indirect.wast:444: assert_invalid passed:
+out/test/spec/call_indirect.wast:698: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
-out/test/spec/call_indirect.wast:455: assert_invalid passed:
+out/test/spec/call_indirect.wast:709: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:463: assert_invalid passed:
+out/test/spec/call_indirect.wast:717: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:472: assert_invalid passed:
+out/test/spec/call_indirect.wast:726: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:482: assert_invalid passed:
+out/test/spec/call_indirect.wast:736: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:492: assert_invalid passed:
+out/test/spec/call_indirect.wast:746: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:502: assert_invalid passed:
+out/test/spec/call_indirect.wast:756: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:516: assert_invalid passed:
+out/test/spec/call_indirect.wast:770: assert_invalid passed:
   0000021: error: invalid call_indirect signature index
-out/test/spec/call_indirect.wast:523: assert_invalid passed:
+out/test/spec/call_indirect.wast:777: assert_invalid passed:
   0000025: error: invalid call_indirect signature index
-out/test/spec/call_indirect.wast:534: assert_invalid passed:
+out/test/spec/call_indirect.wast:788: assert_invalid passed:
   error: invalid func_index: 0 (max 0)
   0000018: error: OnElemSegmentFunctionIndex callback failed
-75/75 tests passed.
+138/138 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -1,40 +1,40 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/globals.wast
 (;; STDOUT ;;;
-out/test/spec/globals.wast:50: assert_invalid passed:
+out/test/spec/globals.wast:243: assert_invalid passed:
   error: can't set_global on immutable global at index 0.
   0000026: error: OnSetGlobalExpr callback failed
-out/test/spec/globals.wast:59: assert_invalid passed:
+out/test/spec/globals.wast:252: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:64: assert_invalid passed:
+out/test/spec/globals.wast:257: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 0x20
-out/test/spec/globals.wast:69: assert_invalid passed:
+out/test/spec/globals.wast:262: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:74: assert_invalid passed:
+out/test/spec/globals.wast:267: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:79: assert_invalid passed:
+out/test/spec/globals.wast:272: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 0x1
-out/test/spec/globals.wast:84: assert_invalid passed:
+out/test/spec/globals.wast:277: assert_invalid passed:
   error: type mismatch in global, expected i32 but got f32.
   0000013: error: EndGlobalInitExpr callback failed
-out/test/spec/globals.wast:89: assert_invalid passed:
+out/test/spec/globals.wast:282: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
-out/test/spec/globals.wast:94: assert_invalid passed:
+out/test/spec/globals.wast:287: assert_invalid passed:
   error: type mismatch in global, expected i32 but got void.
   000000e: error: EndGlobalInitExpr callback failed
-out/test/spec/globals.wast:99: assert_invalid passed:
+out/test/spec/globals.wast:292: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
-out/test/spec/globals.wast:104: assert_invalid passed:
+out/test/spec/globals.wast:297: assert_invalid passed:
   error: initializer expression can only reference an imported global
   000000f: error: OnInitExprGetGlobalExpr callback failed
-out/test/spec/globals.wast:112: assert_malformed passed:
+out/test/spec/globals.wast:305: assert_malformed passed:
   0000019: error: unable to read string: import field name
-out/test/spec/globals.wast:125: assert_malformed passed:
+out/test/spec/globals.wast:318: assert_malformed passed:
   0000019: error: unable to read string: import field name
-out/test/spec/globals.wast:142: assert_malformed passed:
+out/test/spec/globals.wast:335: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-out/test/spec/globals.wast:154: assert_malformed passed:
+out/test/spec/globals.wast:347: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
-31/31 tests passed.
+61/61 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -1,156 +1,156 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/if.wast
 (;; STDOUT ;;;
-out/test/spec/if.wast:476: assert_invalid passed:
+out/test/spec/if.wast:499: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:480: assert_invalid passed:
+out/test/spec/if.wast:503: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:484: assert_invalid passed:
+out/test/spec/if.wast:507: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:488: assert_invalid passed:
+out/test/spec/if.wast:511: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:493: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
-  000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:497: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
-  000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:501: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
-  000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:505: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
-  000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:510: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
-  000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:516: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/if.wast:520: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/if.wast:524: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/if.wast:528: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001e: error: EndFunctionBody callback failed
+out/test/spec/if.wast:533: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/if.wast:522: assert_invalid passed:
+out/test/spec/if.wast:539: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/if.wast:545: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/test/spec/if.wast:528: assert_invalid passed:
+out/test/spec/if.wast:551: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
-out/test/spec/if.wast:535: assert_invalid passed:
+out/test/spec/if.wast:558: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
-out/test/spec/if.wast:541: assert_invalid passed:
+out/test/spec/if.wast:564: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
-out/test/spec/if.wast:547: assert_invalid passed:
+out/test/spec/if.wast:570: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
-out/test/spec/if.wast:553: assert_invalid passed:
+out/test/spec/if.wast:576: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
-out/test/spec/if.wast:560: assert_invalid passed:
+out/test/spec/if.wast:583: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/if.wast:566: assert_invalid passed:
+out/test/spec/if.wast:589: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
-out/test/spec/if.wast:572: assert_invalid passed:
+out/test/spec/if.wast:595: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/if.wast:579: assert_invalid passed:
+out/test/spec/if.wast:602: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/if.wast:585: assert_invalid passed:
+out/test/spec/if.wast:608: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
-out/test/spec/if.wast:591: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got [i64]
-  000001f: error: OnElseExpr callback failed
-out/test/spec/if.wast:597: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got [i64]
-  000001f: error: OnElseExpr callback failed
-out/test/spec/if.wast:604: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
-  0000025: error: EndFunctionBody callback failed
 out/test/spec/if.wast:614: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got [i64]
+  000001f: error: OnElseExpr callback failed
+out/test/spec/if.wast:620: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32] but got [i64]
+  000001f: error: OnElseExpr callback failed
+out/test/spec/if.wast:627: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/if.wast:624: assert_invalid passed:
+out/test/spec/if.wast:637: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000025: error: EndFunctionBody callback failed
+out/test/spec/if.wast:647: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
-out/test/spec/if.wast:635: assert_invalid passed:
+out/test/spec/if.wast:658: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/if.wast:641: assert_invalid passed:
+out/test/spec/if.wast:664: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/test/spec/if.wast:647: assert_invalid passed:
+out/test/spec/if.wast:670: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/if.wast:656: assert_invalid passed:
+out/test/spec/if.wast:679: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/test/spec/if.wast:665: assert_invalid passed:
+out/test/spec/if.wast:688: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/if.wast:674: assert_invalid passed:
+out/test/spec/if.wast:697: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
-out/test/spec/if.wast:684: assert_invalid passed:
+out/test/spec/if.wast:707: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/if.wast:693: assert_invalid passed:
+out/test/spec/if.wast:716: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
-out/test/spec/if.wast:704: assert_malformed passed:
+out/test/spec/if.wast:727: assert_malformed passed:
   out/test/spec/if/if.35.wat:1:14: error: unexpected label "$l"
   (func if end $l)
                ^^
-out/test/spec/if.wast:708: assert_malformed passed:
+out/test/spec/if.wast:731: assert_malformed passed:
   out/test/spec/if/if.36.wat:1:17: error: mismatching label "$a" != "$l"
   (func if $a end $l)
                   ^^
-out/test/spec/if.wast:712: assert_malformed passed:
+out/test/spec/if.wast:735: assert_malformed passed:
   out/test/spec/if/if.37.wat:1:15: error: unexpected label "$l"
   (func if else $l end)
                 ^^
-out/test/spec/if.wast:716: assert_malformed passed:
+out/test/spec/if.wast:739: assert_malformed passed:
   out/test/spec/if/if.38.wat:1:18: error: mismatching label "$a" != "$l"
   (func if $a else $l end)
                    ^^
-out/test/spec/if.wast:720: assert_malformed passed:
+out/test/spec/if.wast:743: assert_malformed passed:
   out/test/spec/if/if.39.wat:1:19: error: unexpected label "$l"
   (func if else end $l)
                     ^^
-out/test/spec/if.wast:724: assert_malformed passed:
+out/test/spec/if.wast:747: assert_malformed passed:
   out/test/spec/if/if.40.wat:1:15: error: unexpected label "$l"
   (func if else $l end $l)
                 ^^
   out/test/spec/if/if.40.wat:1:22: error: unexpected label "$l"
   (func if else $l end $l)
                        ^^
-out/test/spec/if.wast:728: assert_malformed passed:
+out/test/spec/if.wast:751: assert_malformed passed:
   out/test/spec/if/if.41.wat:1:15: error: unexpected label "$l1"
   (func if else $l1 end $l2)
                 ^^^
   out/test/spec/if/if.41.wat:1:23: error: unexpected label "$l2"
   (func if else $l1 end $l2)
                         ^^^
-out/test/spec/if.wast:732: assert_malformed passed:
+out/test/spec/if.wast:755: assert_malformed passed:
   out/test/spec/if/if.42.wat:1:22: error: mismatching label "$a" != "$l"
   (func if $a else end $l)
                        ^^
-out/test/spec/if.wast:736: assert_malformed passed:
+out/test/spec/if.wast:759: assert_malformed passed:
   out/test/spec/if/if.43.wat:1:25: error: mismatching label "$a" != "$l"
   (func if $a else $a end $l)
                           ^^
-out/test/spec/if.wast:740: assert_malformed passed:
+out/test/spec/if.wast:763: assert_malformed passed:
   out/test/spec/if/if.44.wat:1:18: error: mismatching label "$a" != "$l"
   (func if $a else $l end $l)
                    ^^
   out/test/spec/if/if.44.wat:1:25: error: mismatching label "$a" != "$l"
   (func if $a else $l end $l)
                           ^^
-128/128 tests passed.
+132/132 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -1,40 +1,40 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/loop.wast
 (;; STDOUT ;;;
-out/test/spec/loop.wast:376: assert_invalid passed:
+out/test/spec/loop.wast:386: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:380: assert_invalid passed:
+out/test/spec/loop.wast:390: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:384: assert_invalid passed:
+out/test/spec/loop.wast:394: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:388: assert_invalid passed:
+out/test/spec/loop.wast:398: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:393: assert_invalid passed:
+out/test/spec/loop.wast:403: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/loop.wast:399: assert_invalid passed:
+out/test/spec/loop.wast:409: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/loop.wast:405: assert_invalid passed:
+out/test/spec/loop.wast:415: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/loop.wast:411: assert_invalid passed:
+out/test/spec/loop.wast:421: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/loop.wast:417: assert_invalid passed:
+out/test/spec/loop.wast:427: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:425: assert_malformed passed:
+out/test/spec/loop.wast:435: assert_malformed passed:
   out/test/spec/loop/loop.10.wat:1:16: error: unexpected label "$l"
   (func loop end $l)
                  ^^
-out/test/spec/loop.wast:429: assert_malformed passed:
+out/test/spec/loop.wast:439: assert_malformed passed:
   out/test/spec/loop/loop.11.wat:1:19: error: mismatching label "$a" != "$l"
   (func loop $a end $l)
                     ^^
-75/75 tests passed.
+77/77 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/nop.txt
+++ b/test/spec/nop.txt
@@ -1,17 +1,17 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/nop.wast
 (;; STDOUT ;;;
-out/test/spec/nop.wast:382: assert_invalid passed:
+out/test/spec/nop.wast:412: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
-out/test/spec/nop.wast:386: assert_invalid passed:
+out/test/spec/nop.wast:416: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001a: error: EndFunctionBody callback failed
-out/test/spec/nop.wast:390: assert_invalid passed:
+out/test/spec/nop.wast:420: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001a: error: EndFunctionBody callback failed
-out/test/spec/nop.wast:394: assert_invalid passed:
+out/test/spec/nop.wast:424: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001a: error: EndFunctionBody callback failed
-81/81 tests passed.
+87/87 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/return.txt
+++ b/test/spec/return.txt
@@ -1,14 +1,14 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/return.wast
 (;; STDOUT ;;;
-out/test/spec/return.wast:302: assert_invalid passed:
+out/test/spec/return.wast:311: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got []
   0000019: error: OnReturnExpr callback failed
-out/test/spec/return.wast:306: assert_invalid passed:
+out/test/spec/return.wast:315: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got []
   000001a: error: OnReturnExpr callback failed
-out/test/spec/return.wast:310: assert_invalid passed:
+out/test/spec/return.wast:319: assert_invalid passed:
   error: type mismatch in return, expected [f64] but got [i64]
   000001b: error: OnReturnExpr callback failed
-64/64 tests passed.
+66/66 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -1,8 +1,17 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/select.wast
 (;; STDOUT ;;;
-out/test/spec/select.wast:65: assert_invalid passed:
+out/test/spec/select.wast:259: assert_invalid passed:
   error: type mismatch in select, expected [i32, any, any] but got [i32]
   000001c: error: OnSelectExpr callback failed
-29/29 tests passed.
+out/test/spec/select.wast:266: assert_invalid passed:
+  error: type mismatch in select, expected [i32, i64, i64] but got [i32, i64, i32]
+  000001e: error: OnSelectExpr callback failed
+out/test/spec/select.wast:270: assert_invalid passed:
+  error: type mismatch in select, expected [i32, f32, f32] but got [i32, f32, i32]
+  0000021: error: OnSelectExpr callback failed
+out/test/spec/select.wast:274: assert_invalid passed:
+  error: type mismatch in select, expected [i32, f64, f64] but got [i32, f64, i32]
+  0000025: error: OnSelectExpr callback failed
+90/90 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreachable.txt
+++ b/test/spec/unreachable.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/unreachable.wast
 (;; STDOUT ;;;
-59/59 tests passed.
+61/61 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/block.txt
+++ b/test/wasm2c/spec/block.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/block.wast
 (;; STDOUT ;;;
-39/39 tests passed.
+41/41 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/br.txt
+++ b/test/wasm2c/spec/br.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
-61/61 tests passed.
+63/63 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/br_if.txt
+++ b/test/wasm2c/spec/br_if.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/br_if.wast
 (;; STDOUT ;;;
-75/75 tests passed.
+79/79 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/br_table.txt
+++ b/test/wasm2c/spec/br_table.txt
@@ -2,5 +2,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
-144/144 tests passed.
+146/146 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/call.txt
+++ b/test/wasm2c/spec/call.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/call.wast
 (;; STDOUT ;;;
-35/35 tests passed.
+56/56 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/call_indirect.txt
+++ b/test/wasm2c/spec/call_indirect.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/call_indirect.wast
 (;; STDOUT ;;;
-48/48 tests passed.
+111/111 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/globals.txt
+++ b/test/wasm2c/spec/globals.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/globals.wast
 (;; STDOUT ;;;
-16/16 tests passed.
+46/46 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/if.txt
+++ b/test/wasm2c/spec/if.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/if.wast
 (;; STDOUT ;;;
-84/84 tests passed.
+88/88 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/loop.txt
+++ b/test/wasm2c/spec/loop.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/loop.wast
 (;; STDOUT ;;;
-64/64 tests passed.
+66/66 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/nop.txt
+++ b/test/wasm2c/spec/nop.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/nop.wast
 (;; STDOUT ;;;
-77/77 tests passed.
+83/83 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/return.txt
+++ b/test/wasm2c/spec/return.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/return.wast
 (;; STDOUT ;;;
-61/61 tests passed.
+63/63 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/select.txt
+++ b/test/wasm2c/spec/select.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/select.wast
 (;; STDOUT ;;;
-28/28 tests passed.
+86/86 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/unreachable.txt
+++ b/test/wasm2c/spec/unreachable.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/unreachable.wast
 (;; STDOUT ;;;
-59/59 tests passed.
+61/61 tests passed.
 ;;; STDOUT ;;)

--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -32,6 +32,7 @@ typedef struct FuncType {
 } FuncType;
 
 uint32_t wasm_rt_call_stack_depth;
+uint32_t g_saved_call_stack_depth;
 
 jmp_buf g_jmp_buf;
 FuncType* g_func_types;
@@ -39,6 +40,7 @@ uint32_t g_func_type_count;
 
 void wasm_rt_trap(wasm_rt_trap_t code) {
   assert(code != WASM_RT_TRAP_NONE);
+  wasm_rt_call_stack_depth = g_saved_call_stack_depth;
   longjmp(g_jmp_buf, code);
 }
 

--- a/wasm2c/wasm-rt-impl.h
+++ b/wasm2c/wasm-rt-impl.h
@@ -28,6 +28,9 @@ extern "C" {
 /** A setjmp buffer used for handling traps. */
 extern jmp_buf g_jmp_buf;
 
+/** Saved call stack depth that will be restored in case a trap occurs. */
+extern uint32_t g_saved_call_stack_depth;
+
 /** Convenience macro to use before calling a wasm function. On first execution
  * it will return `WASM_RT_TRAP_NONE` (i.e. 0). If the function traps, it will
  * jump back and return the trap that occurred.
@@ -43,7 +46,8 @@ extern jmp_buf g_jmp_buf;
  *   my_wasm_func();
  * ```
  */
-#define wasm_rt_impl_try() setjmp(g_jmp_buf)
+#define wasm_rt_impl_try() \
+  (g_saved_call_stack_depth = wasm_rt_call_stack_depth, setjmp(g_jmp_buf))
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Also fix bug when parsing elem/data segment; the table/memory index is
stored as an LEB128, not a U8.