### PR TITLE
Handle mismatch in function/code section

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2214,6 +2214,10 @@ Result BinaryReader::ReadModule() {
 
   CALLBACK(BeginModule, version);
   CHECK_RESULT(ReadSections());
+  // This is checked in ReadCodeSection, but it must be checked at the end too,
+  // in case the code section was omitted.
+  ERROR_UNLESS(num_function_signatures_ == num_function_bodies_,
+               "function signature count != function body count");
   CALLBACK0(EndModule);
 
   return Result::Ok;

--- a/test/binary/bad-function-count-missing-code-section.txt
+++ b/test/binary/bad-function-count-missing-code-section.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[2] func[0] func[0] }
+(;; STDERR ;;;
+0000013: error: function signature count != function body count
+0000013: error: function signature count != function body count
+;;; STDERR ;;)

--- a/test/binary/missing-code-section-empty-function-section.txt
+++ b/test/binary/missing-code-section-empty-function-section.txt
@@ -1,0 +1,7 @@
+;;; TOOL: run-gen-wasm
+magic
+version
+section(FUNCTION) { count[0] }
+(;; STDOUT ;;;
+(module)
+;;; STDOUT ;;)

--- a/test/binary/missing-function-section-empty-code-section.txt
+++ b/test/binary/missing-function-section-empty-code-section.txt
@@ -1,0 +1,7 @@
+;;; TOOL: run-gen-wasm
+magic
+version
+section(CODE) { count[0] }
+(;; STDOUT ;;;
+(module)
+;;; STDOUT ;;)

--- a/test/regress/regress-7.txt
+++ b/test/regress/regress-7.txt
@@ -28,6 +28,19 @@ section(FUNCTION) {
   type[0]
   type[0]
 }
+section(CODE) {
+  count[10]
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+  func { locals[0] }
+}
 (;; STDOUT ;;;
 (module
   (type (;0;) (func))


### PR DESCRIPTION
If the function section is present, and has a non-zero count, then if
the code section is absent the module should not validate.

If either section is missing, but the count is zero it is OK.