### PR TITLE
Combine param_binding and local_binding in IR

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1144,20 +1144,8 @@ Result BinaryReaderIR::OnLocalName(Index func_index,
   }
 
   Func* func = module_->funcs[func_index];
-  Index num_params = func->GetNumParams();
-  BindingHash* bindings;
-  Index index;
-  if (local_index < num_params) {
-    // param name
-    bindings = &func->param_bindings;
-    index = local_index;
-  } else {
-    // local name
-    bindings = &func->local_bindings;
-    index = local_index - num_params;
-  }
-  bindings->emplace(GetUniqueName(bindings, MakeDollarName(name)),
-                    Binding(index));
+  func->bindings.emplace(GetUniqueName(&func->bindings, MakeDollarName(name)),
+                         Binding(local_index));
   return Result::Ok;
 }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1075,28 +1075,17 @@ Result BinaryWriter::WriteModule() {
     WriteU32Leb128(stream_, module_->funcs.size(), "num functions");
     for (size_t i = 0; i < module_->funcs.size(); ++i) {
       const Func* func = module_->funcs[i];
-      Index num_params = func->GetNumParams();
-      Index num_locals = func->local_types.size();
       Index num_params_and_locals = func->GetNumParamsAndLocals();
 
       WriteU32Leb128(stream_, i, "function index");
       WriteU32Leb128(stream_, num_params_and_locals, "num locals");
 
-      MakeTypeBindingReverseMapping(func->decl.sig.param_types.size(),
-                                    func->param_bindings, &index_to_name);
-      for (size_t j = 0; j < num_params; ++j) {
+      MakeTypeBindingReverseMapping(num_params_and_locals, func->bindings,
+                                    &index_to_name);
+      for (size_t j = 0; j < num_params_and_locals; ++j) {
         const std::string& name = index_to_name[j];
         wabt_snprintf(desc, sizeof(desc), "local name %" PRIzd, j);
         WriteU32Leb128(stream_, j, "local index");
-        WriteDebugName(stream_, name, desc);
-      }
-
-      MakeTypeBindingReverseMapping(func->local_types.size(),
-                                    func->local_bindings, &index_to_name);
-      for (size_t j = 0; j < num_locals; ++j) {
-        const std::string& name = index_to_name[j];
-        wabt_snprintf(desc, sizeof(desc), "local name %" PRIzd, num_params + j);
-        WriteU32Leb128(stream_, num_params + j, "local index");
         WriteDebugName(stream_, name, desc);
       }
     }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -240,8 +240,9 @@ class CWriter {
   void WriteInit();
   void WriteFuncs();
   void Write(const Func&);
-  void WriteParams();
-  void WriteLocals();
+  void WriteParamsAndLocals();
+  void WriteParams(const std::vector<std::string>& index_to_name);
+  void WriteLocals(const std::vector<std::string>& index_to_name);
   void WriteStackVarDeclarations();
   void Write(const ExprList&);
 
@@ -1281,8 +1282,7 @@ void CWriter::Write(const Func& func) {
 
   Write("static ", ResultType(func.decl.sig.result_types), " ",
         GlobalName(func.name), "(");
-  WriteParams();
-  WriteLocals();
+  WriteParamsAndLocals();
   Write("FUNC_PROLOGUE;", Newline());
 
   stream_ = &func_stream_;
@@ -1316,13 +1316,18 @@ void CWriter::Write(const Func& func) {
   func_ = nullptr;
 }
 
-void CWriter::WriteParams() {
-  if (func_->decl.sig.param_types.empty()) {
+void CWriter::WriteParamsAndLocals() {
+  std::vector<std::string> index_to_name;
+  MakeTypeBindingReverseMapping(func_->GetNumParamsAndLocals(), func_->bindings,
+                                &index_to_name);
+  WriteParams(index_to_name);
+  WriteLocals(index_to_name);
+}
+
+void CWriter::WriteParams(const std::vector<std::string>& index_to_name) {
+  if (func_->GetNumParams() == 0) {
     Write("void");
   } else {
-    std::vector<std::string> index_to_name;
-    MakeTypeBindingReverseMapping(func_->decl.sig.param_types.size(),
-                                  func_->param_bindings, &index_to_name);
     Indent(4);
     for (Index i = 0; i < func_->GetNumParams(); ++i) {
       if (i != 0) {
@@ -1338,10 +1343,8 @@ void CWriter::WriteParams() {
   Write(") ", OpenBrace());
 }
 
-void CWriter::WriteLocals() {
-  std::vector<std::string> index_to_name;
-  MakeTypeBindingReverseMapping(func_->local_types.size(),
-                                func_->local_bindings, &index_to_name);
+void CWriter::WriteLocals(const std::vector<std::string>& index_to_name) {
+  Index num_params = func_->GetNumParams();
   for (Type type : {Type::I32, Type::I64, Type::F32, Type::F64}) {
     Index local_index = 0;
     size_t count = 0;
@@ -1356,7 +1359,8 @@ void CWriter::WriteLocals() {
             Write(Newline());
         }
 
-        Write(DefineLocalScopeName(index_to_name[local_index]), " = 0");
+        Write(DefineLocalScopeName(index_to_name[num_params + local_index]),
+              " = 0");
         ++count;
       }
       ++local_index;

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -213,19 +213,7 @@ Index Func::GetLocalIndex(const Var& var) const {
   if (var.is_index()) {
     return var.index();
   }
-
-  Index result = param_bindings.FindIndex(var);
-  if (result != kInvalidIndex) {
-    return result;
-  }
-
-  result = local_bindings.FindIndex(var);
-  if (result == kInvalidIndex) {
-    return result;
-  }
-
-  // The locals start after all the params.
-  return decl.GetNumParams() + result;
+  return bindings.FindIndex(var);
 }
 
 const Func* Module::GetFunc(const Var& var) const {

--- a/src/ir.h
+++ b/src/ir.h
@@ -510,8 +510,7 @@ struct Func {
   std::string name;
   FuncDeclaration decl;
   LocalTypes local_types;
-  BindingHash param_bindings;
-  BindingHash local_bindings;
+  BindingHash bindings;
   ExprList exprs;
 };
 

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -149,7 +149,10 @@ class WastParser {
   Result ParseTypeUseOpt(FuncDeclaration*);
   Result ParseFuncSignature(FuncSignature*, BindingHash* param_bindings);
   Result ParseUnboundFuncSignature(FuncSignature*);
-  Result ParseBoundValueTypeList(TokenType, TypeVector*, BindingHash*);
+  Result ParseBoundValueTypeList(TokenType,
+                                 TypeVector*,
+                                 BindingHash*,
+                                 Index binding_index_offset = 0);
   Result ParseUnboundValueTypeList(TokenType, TypeVector*);
   Result ParseResultList(TypeVector*);
   Result ParseInstrList(ExprList*);

--- a/test/parse/func/bad-local-redefinition.txt
+++ b/test/parse/func/bad-local-redefinition.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func (param $n i32) (local $n f32)))
+(;; STDERR ;;;
+out/test/parse/func/bad-local-redefinition.txt:3:37: error: redefinition of parameter "$n"
+(module (func (param $n i32) (local $n f32)))
+                                    ^^
+;;; STDERR ;;)

--- a/test/roundtrip/generate-local-names.txt
+++ b/test/roundtrip/generate-local-names.txt
@@ -24,21 +24,21 @@
 (module
   (type $t0 (func (param i32 f32)))
   (func $f0 (type $t0) (param $p0 i32) (param $p1 f32)
-    (local $l0 f64) (local $l1 i64)
+    (local $l2 f64) (local $l3 i64)
     get_local $p0
     drop
     get_local $p1
     drop
-    get_local $l0
+    get_local $l2
     drop
-    get_local $l1
+    get_local $l3
     drop
     i32.const 1
     set_local $p0
     f32.const 0x1p+0 (;=1;)
     set_local $p1
     f64.const 0x1p+0 (;=1;)
-    set_local $l0
+    set_local $l2
     i64.const 1
-    set_local $l1))
+    set_local $l3))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-some-names.txt
+++ b/test/roundtrip/generate-some-names.txt
@@ -37,7 +37,7 @@
   (func $func0 (type $t0) (param $p0 i32) (result f32)
     f32.const 0x1p+0 (;=1;))
   (func $f2 (type $t2) (param $p0 i32) (param $param1 i64)
-    (local $l0 f32) (local $local1 f64)
+    (local $l2 f32) (local $local1 f64)
     call $import
     drop
     i32.const 0
@@ -50,7 +50,7 @@
     get_local $param1
     drop
     f32.const 0x0p+0 (;=0;)
-    set_local $l0)
+    set_local $l2)
   (table $T0 1 1 anyfunc)
   (export "baz" (func $import))
   (export "quux" (func $func0))


### PR DESCRIPTION
The `BindingHash` object is used to map from a name to an Index, and to
detect multiply-defined names. Since the locals and params use the same
Index space and namespace, they should always have been using the same
`BindingHash`.