### PR TITLE
Fix SYNOPSIS in manpages

### DIFF
--- a/man/wasm-interp.1
+++ b/man/wasm-interp.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Nm wasm-interp
 .Op options
-.Ar filename
+.Ar file
 .Sh DESCRIPTION
 .Nm
 decodes and runs a WebAssembly binary file using a stack-based interpreter.

--- a/man/wasm-objdump.1
+++ b/man/wasm-objdump.1
@@ -7,14 +7,14 @@
 .Sh SYNOPSIS
 .Nm wasm-objdump
 .Op options
-.Ar filename
+.Ar
 .Sh DESCRIPTION
 .Nm
 prints information about a wasm binary, similiar to objdump.
 .Pp
 The options are as follows:
 .Bl -tag -width Ds
-.It Fl Fl headers
+.It Fl h , Fl Fl headers
 Print headers
 .It Fl j , Fl Fl section=SECTION
 Select just one section

--- a/man/wasm2c.1
+++ b/man/wasm2c.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Nm wasm2c
 .Op options
-.Ar filename
+.Ar file
 .Sh DESCRIPTION
 .Nm
 takes a WebAssembly module and produces an equivalent C source and header.

--- a/man/wasm2wat.1
+++ b/man/wasm2wat.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Nm wasm2wat
 .Op options
-.Ar filename
+.Ar file
 .Sh DESCRIPTION
 .Nm
 does the inverse of wat2wasm, translate from the binary format back to the text format (also known as a .wat).

--- a/man/wat-desugar.1
+++ b/man/wat-desugar.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Nm wat-desugar
 .Op options
-.Ar filename
+.Ar file
 .Sh DESCRIPTION
 .Nm
 parses .wat text form as supported by the spec interpreter (s-expressions, flat syntax, or mixed) and prints "canonical" flat format.

--- a/man/wat2wasm.1
+++ b/man/wat2wasm.1
@@ -7,7 +7,7 @@
 .Sh SYNOPSIS
 .Nm wat2wasm
 .Op options
-.Ar filename
+.Ar file
 .Sh DESCRIPTION
 .Nm
 translates from WebAssembly text format to the WebAssembly binary format.


### PR DESCRIPTION
Before: wasm-objdump [options] filename
After: wasm-objdump [options] file ...

Also document '-h' in wasm-objdump.1