### PR TITLE
Update linking metadata version

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -766,9 +766,9 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
 
   Result OnDylinkInfo(uint32_t mem_size,
-                      uint32_t mem_align,
+                      uint32_t mem_align_log2,
                       uint32_t table_size,
-                      uint32_t table_align) override;
+                      uint32_t table_align_log2) override;
   Result OnDylinkNeededCount(Index count) override;
   Result OnDylinkNeeded(string_view so_name) override;
 
@@ -799,7 +799,7 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnSegmentInfoCount(Index count) override;
   Result OnSegmentInfo(Index index,
                        string_view name,
-                       uint32_t alignment,
+                       uint32_t alignment_log2,
                        uint32_t flags) override;
   Result OnInitFunctionCount(Index count) override;
   Result OnInitFunction(uint32_t priority, Index function_index) override;
@@ -1353,13 +1353,13 @@ Result BinaryReaderObjdump::OnDataSegmentData(Index index,
 }
 
 Result BinaryReaderObjdump::OnDylinkInfo(uint32_t mem_size,
-                                         uint32_t mem_align,
+                                         uint32_t mem_align_log2,
                                          uint32_t table_size,
-                                         uint32_t table_align) {
-  PrintDetails(" - mem_size   : %u\n", mem_size);
-  PrintDetails(" - mem_align  : %u\n", mem_align);
-  PrintDetails(" - table_size : %u\n", table_size);
-  PrintDetails(" - table_align: %u\n", table_align);
+                                         uint32_t table_align_log2) {
+  PrintDetails(" - mem_size     : %u\n", mem_size);
+  PrintDetails(" - mem_p2align  : %u\n", mem_align_log2);
+  PrintDetails(" - table_size   : %u\n", table_size);
+  PrintDetails(" - table_p2align: %u\n", table_align_log2);
   return Result::Ok;
 }
 
@@ -1512,10 +1512,10 @@ Result BinaryReaderObjdump::OnSegmentInfoCount(Index count) {
 
 Result BinaryReaderObjdump::OnSegmentInfo(Index index,
                                           string_view name,
-                                          uint32_t alignment,
+                                          uint32_t alignment_log2,
                                           uint32_t flags) {
-  PrintDetails("   - %d: " PRIstringview " align=%d flags=%#x\n", index,
-               WABT_PRINTF_STRING_VIEW_ARG(name), alignment, flags);
+  PrintDetails("   - %d: " PRIstringview " p2align=%d flags=%#x\n", index,
+               WABT_PRINTF_STRING_VIEW_ARG(name), alignment_log2, flags);
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1579,7 +1579,7 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
   CALLBACK(BeginLinkingSection, section_size);
   uint32_t version;
   CHECK_RESULT(ReadU32Leb128(&version, "version"));
-  ERROR_UNLESS(version == 1, "invalid linking metadata version: %u", version);
+  ERROR_UNLESS(version == 2, "invalid linking metadata version: %u", version);
   while (state_.offset < read_end_) {
     uint32_t linking_type;
     Offset subsection_size;
@@ -1645,12 +1645,12 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
         CALLBACK(OnSegmentInfoCount, count);
         for (Index i = 0; i < count; i++) {
           string_view name;
-          uint32_t alignment;
+          uint32_t alignment_log2;
           uint32_t flags;
           CHECK_RESULT(ReadStr(&name, "segment name"));
-          CHECK_RESULT(ReadU32Leb128(&alignment, "segment alignment"));
+          CHECK_RESULT(ReadU32Leb128(&alignment_log2, "segment alignment"));
           CHECK_RESULT(ReadU32Leb128(&flags, "segment flags"));
-          CALLBACK(OnSegmentInfo, i, name, alignment, flags);
+          CALLBACK(OnSegmentInfo, i, name, alignment_log2, flags);
         }
         break;
       case LinkingEntryType::InitFunctions:

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -329,9 +329,9 @@ class BinaryReaderDelegate {
   /* Dylink section */
   virtual Result BeginDylinkSection(Offset size) = 0;
   virtual Result OnDylinkInfo(uint32_t mem_size,
-                              uint32_t mem_align,
+                              uint32_t mem_align_log2,
                               uint32_t table_size,
-                              uint32_t table_align) = 0;
+                              uint32_t table_align_log2) = 0;
   virtual Result OnDylinkNeededCount(Index count) = 0;
   virtual Result OnDylinkNeeded(string_view so_name) = 0;
   virtual Result EndDylinkSection() = 0;
@@ -360,7 +360,7 @@ class BinaryReaderDelegate {
   virtual Result OnSegmentInfoCount(Index count) = 0;
   virtual Result OnSegmentInfo(Index index,
                                string_view name,
-                               uint32_t alignment,
+                               uint32_t alignment_log2,
                                uint32_t flags) = 0;
   virtual Result OnInitFunctionCount(Index count) = 0;
   virtual Result OnInitFunction(uint32_t priority, Index function_index) = 0;

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -751,7 +751,7 @@ void BinaryWriter::WriteRelocSection(const RelocSection* reloc_section) {
 
 void BinaryWriter::WriteLinkingSection() {
   BeginCustomSection(WABT_BINARY_SECTION_LINKING);
-  WriteU32Leb128(stream_, 1, "metadata version");
+  WriteU32Leb128(stream_, 2, "metadata version");
   if (symbols_.size()) {
     stream_->WriteU8Enum(LinkingEntryType::SymbolTable, "symbol table");
     BeginSubsection("symbol table");

--- a/test/binary/dylink-section.txt
+++ b/test/binary/dylink-section.txt
@@ -19,10 +19,10 @@ Section Details:
 
 Custom:
  - name: "dylink"
- - mem_size   : 5
- - mem_align  : 1
- - table_size : 3
- - table_align: 2
+ - mem_size     : 5
+ - mem_p2align  : 1
+ - table_size   : 3
+ - table_p2align: 2
  - needed_dynlibs[2]:
   - libfoo.so
   - libbar.so

--- a/test/binary/ignore-custom-section-error-objdump.txt
+++ b/test/binary/ignore-custom-section-error-objdump.txt
@@ -3,7 +3,8 @@
 magic
 version
 section("linking") {
-  1 2 3 4 5 6 7
+  metadata_version[2]
+  2 3 4 5 6 7
 }
 
 ;; Some dummy data to make sure the module is still parsed after the invalid

--- a/test/binary/ignore-custom-section-error-wasm2wat.txt
+++ b/test/binary/ignore-custom-section-error-wasm2wat.txt
@@ -4,7 +4,8 @@
 magic
 version
 section("linking") {
-  1 2 3 4 5 6 7
+  metadata_version[2]
+  2 3 4 5 6 7
 }
 
 ;; Some dummy data to make sure the module is still parsed after the invalid

--- a/test/binary/linking-section.txt
+++ b/test/binary/linking-section.txt
@@ -3,15 +3,15 @@
 magic
 version
 section("linking") {
-  metadata_version[1]
+  metadata_version[2]
 
   section(LINKING_SEGMENT_INFO) {
     count[2]
     str("data1")
-    align[4]
+    p2align[2]
     flags[0]
     str("data2")
-    align[8]
+    p2align[3]
     flags[0]
   }
 
@@ -57,8 +57,8 @@ Section Details:
 Custom:
  - name: "linking"
   - segment info [count=2]
-   - 0: data1 align=4 flags=0
-   - 1: data2 align=8 flags=0
+   - 0: data1 p2align=2 flags=0
+   - 1: data2 p2align=3 flags=0
   - init functions [count=2]
    - 1: priority=5
    - 0: priority=6

--- a/test/binary/relocs.txt
+++ b/test/binary/relocs.txt
@@ -5,7 +5,7 @@ version
 section(TYPE) { count[1] function params[0] results[1] i32 }
 section("mysection") {}
 section("linking") {
-  metadata_version[1]
+  metadata_version[2]
 
   section(LINKING_SYMBOL_TABLE) {
     num_symbols[1]


### PR DESCRIPTION
Also make explicit when are showing log2 alignment.

We could instead display actual byte alignment (1 << p2align)?