### PR TITLE
avoid Mac OS X ranlib error

### DIFF
--- a/src/config.cc
+++ b/src/config.cc
@@ -43,4 +43,7 @@ int wabt_snprintf(char* str, size_t size, const char* format, ...) {
   return result;
 }
 #endif
+
+#elif COMPILER_IS_CLANG
+void wabt_config_cc_dummy(void) {}
 #endif


### PR DESCRIPTION
#992 
[ 49%] Linking CXX static library libwabt.a
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libwabt.a(config.cc.o) has no symbols
/Library/Developer/CommandLineTools/usr/bin/ranlib: file: libwabt.a(config.cc.o) has no symbols

There's some environmental issues which is not clear with Mac OS X ranlib and empty symbol sources.
If we add a dummy function to config.cc for clang, the ranlib error can be avoided easily with no harm.