### PR TITLE
Add missing string.h include to wasm-rt-impl.c

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -21,6 +21,7 @@
 #include <stdbool.h>
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #define PAGE_SIZE 65536
 


### PR DESCRIPTION
Addresses:

gcc -I/tmp/wabt/wasm2c -O3 /tmp/wabt/wasm2c/wasm-rt-impl.c -o wasm-rt-impl.o
/tmp/wabt/wasm2c/wasm-rt-impl.c: In function ‘wasm_rt_grow_memory’:
/tmp/wabt/wasm2c/wasm-rt-impl.c:111:3: warning: implicit declaration of function ‘memset’ [-Wimplicit-function-declaration]
   memset(memory->data + old_pages * PAGE_SIZE, 0, delta * PAGE_SIZE);
   ^~~~~~
/tmp/wabt/wasm2c/wasm-rt-impl.c:111:3: warning: incompatible implicit declaration of built-in function ‘memset’
/tmp/wabt/wasm2c/wasm-rt-impl.c:111:3: note: include ‘<string.h>’ or provide a declaration of ‘memset’
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
(.text+0x20): undefined reference to `main'

with gcc (Debian 6.3.0-18+deb9u1).