### PR TITLE
Add `Event` known section; remove `exception`

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1722,9 +1722,6 @@ Result BinaryReader::ReadCustomSection(Offset section_size) {
     CHECK_RESULT(ReadRelocSection(section_size));
   } else if (section_name == WABT_BINARY_SECTION_LINKING) {
     CHECK_RESULT(ReadLinkingSection(section_size));
-  } else if (options_.features.exceptions_enabled() &&
-             section_name == WABT_BINARY_SECTION_EXCEPTION) {
-    CHECK_RESULT(ReadExceptionSection(section_size));
   } else {
     // This is an unknown custom section, skip it.
     state_.offset = read_end_;
@@ -2194,6 +2191,12 @@ Result BinaryReader::ReadSections() {
         break;
       case BinarySection::Data:
         section_result = ReadDataSection(section_size);
+        result |= section_result;
+        break;
+      case BinarySection::Event:
+        ERROR_UNLESS(options_.features.exceptions_enabled(),
+                     "invalid section code: %u", section);
+        section_result = ReadExceptionSection(section_size);
         result |= section_result;
         break;
       case BinarySection::DataCount:

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -900,6 +900,17 @@ Result BinaryWriter::WriteModule() {
     EndSection();
   }
 
+  assert(module_->excepts.size() >= module_->num_except_imports);
+  Index num_exceptions = module_->excepts.size() - module_->num_except_imports;
+  if (num_exceptions) {
+    BeginKnownSection(BinarySection::Event);
+    WriteU32Leb128(stream_, num_exceptions, "exception count");
+    for (Index i = module_->num_except_imports; i < num_exceptions; ++i) {
+      WriteExceptType(&module_->excepts[i]->sig);
+    }
+    EndSection();
+  }
+
   if (module_->exports.size()) {
     BeginKnownSection(BinarySection::Export);
     WriteU32Leb128(stream_, module_->exports.size(), "num exports");
@@ -966,17 +977,6 @@ Result BinaryWriter::WriteModule() {
         WriteU32Leb128WithReloc(index, "function index",
                                 RelocType::FuncIndexLEB);
       }
-    }
-    EndSection();
-  }
-
-  assert(module_->excepts.size() >= module_->num_except_imports);
-  Index num_exceptions = module_->excepts.size() - module_->num_except_imports;
-  if (num_exceptions) {
-    BeginCustomSection("exception");
-    WriteU32Leb128(stream_, num_exceptions, "exception count");
-    for (Index i = module_->num_except_imports; i < num_exceptions; ++i) {
-      WriteExceptType(&module_->excepts[i]->sig);
     }
     EndSection();
   }

--- a/src/binary.h
+++ b/src/binary.h
@@ -27,7 +27,6 @@
 #define WABT_BINARY_SECTION_NAME "name"
 #define WABT_BINARY_SECTION_RELOC "reloc"
 #define WABT_BINARY_SECTION_LINKING "linking"
-#define WABT_BINARY_SECTION_EXCEPTION "exception"
 #define WABT_BINARY_SECTION_DYLINK "dylink"
 
 #define WABT_FOREACH_BINARY_SECTION(V) \
@@ -38,6 +37,7 @@
   V(Table, table, 4)                   \
   V(Memory, memory, 5)                 \
   V(Global, global, 6)                 \
+  V(Event, event, 13)                  \
   V(Export, export, 7)                 \
   V(Start, start, 8)                   \
   V(Elem, elem, 9)                     \
@@ -55,7 +55,7 @@ enum class BinarySection {
   Invalid = ~0,
 
   First = Custom,
-  Last = DataCount,
+  Last = Event,
 };
 /* clang-format on */
 static const int kBinarySectionCount = WABT_ENUM_COUNT(BinarySection);

--- a/test/binary/bad-event-after-export.txt
+++ b/test/binary/bad-event-after-export.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-exceptions
+;;; ARGS2: --enable-exceptions
+magic
+version
+section(EXPORT) { count[0] }
+section(EVENT) { count[0] }
+(;; STDERR ;;;
+000000d: error: section Event out of order
+000000d: error: section Event out of order
+;;; STDERR ;;)

--- a/test/binary/bad-event-before-global.txt
+++ b/test/binary/bad-event-before-global.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-exceptions
+;;; ARGS2: --enable-exceptions
+magic
+version
+section(EVENT) { count[0] }
+section(GLOBAL) { count[0] }
+(;; STDERR ;;;
+000000d: error: section Global out of order
+000000d: error: section Global out of order
+;;; STDERR ;;)

--- a/test/dump/except.txt
+++ b/test/dump/except.txt
@@ -8,27 +8,23 @@
 (;; STDOUT ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
-; section "exception"
-0000008: 00                                        ; section code
+; section "Event" (13)
+0000008: 0d                                        ; section code
 0000009: 00                                        ; section size (guess)
-000000a: 09                                        ; string length
-000000b: 6578 6365 7074 696f 6e                   exception  ; custom section name
-0000014: 03                                        ; exception count
-0000015: 00                                        ; exception type count
-0000016: 01                                        ; exception type count
-0000017: 7f                                        ; i32
-0000018: 02                                        ; exception type count
-0000019: 7d                                        ; f32
-000001a: 7c                                        ; f64
-0000009: 11                                        ; FIXUP section size
+000000a: 03                                        ; exception count
+000000b: 00                                        ; exception type count
+000000c: 01                                        ; exception type count
+000000d: 7f                                        ; i32
+000000e: 02                                        ; exception type count
+000000f: 7d                                        ; f32
+0000010: 7c                                        ; f64
+0000009: 07                                        ; FIXUP section size
 
 except.wasm:	file format wasm 0x1
 
 Section Details:
 
-Custom:
- - name: "exception"
-[3]:
+Event[3]:
  - except[0] ()
  - except[1] (i32)
  - except[2] (f32, f64)

--- a/test/dump/rethrow.txt
+++ b/test/dump/rethrow.txt
@@ -25,38 +25,36 @@
 0000010: 01                                        ; num functions
 0000011: 00                                        ; function 0 signature index
 000000f: 02                                        ; FIXUP section size
-; section "exception"
-0000012: 00                                        ; section code
+; section "Event" (13)
+0000012: 0d                                        ; section code
 0000013: 00                                        ; section size (guess)
-0000014: 09                                        ; string length
-0000015: 6578 6365 7074 696f 6e                   exception  ; custom section name
-000001e: 01                                        ; exception count
-000001f: 00                                        ; exception type count
-0000013: 0c                                        ; FIXUP section size
+0000014: 01                                        ; exception count
+0000015: 00                                        ; exception type count
+0000013: 02                                        ; FIXUP section size
 ; section "Code" (10)
-0000020: 0a                                        ; section code
-0000021: 00                                        ; section size (guess)
-0000022: 01                                        ; num functions
+0000016: 0a                                        ; section code
+0000017: 00                                        ; section size (guess)
+0000018: 01                                        ; num functions
 ; function body 0
-0000023: 00                                        ; func body size (guess)
-0000024: 00                                        ; local decl count
-0000025: 06                                        ; try
-0000026: 40                                        ; void
-0000027: 07                                        ; catch
-0000028: 09                                        ; rethrow
-0000029: 0b                                        ; end
-000002a: 0b                                        ; end
-0000023: 07                                        ; FIXUP func body size
-0000021: 09                                        ; FIXUP section size
+0000019: 00                                        ; func body size (guess)
+000001a: 00                                        ; local decl count
+000001b: 06                                        ; try
+000001c: 40                                        ; void
+000001d: 07                                        ; catch
+000001e: 09                                        ; rethrow
+000001f: 0b                                        ; end
+0000020: 0b                                        ; end
+0000019: 07                                        ; FIXUP func body size
+0000017: 09                                        ; FIXUP section size
 
 rethrow.wasm:	file format wasm 0x1
 
 Code Disassembly:
 
-000024 func[0]:
- 000025: 06 40                      | try
- 000027: 07                         | catch
- 000028: 09                         |   rethrow
- 000029: 0b                         | end
- 00002a: 0b                         | end
+00001a func[0]:
+ 00001b: 06 40                      | try
+ 00001d: 07                         | catch
+ 00001e: 09                         |   rethrow
+ 00001f: 0b                         | end
+ 000020: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/throw.txt
+++ b/test/dump/throw.txt
@@ -23,36 +23,34 @@
 0000010: 01                                        ; num functions
 0000011: 00                                        ; function 0 signature index
 000000f: 02                                        ; FIXUP section size
-; section "exception"
-0000012: 00                                        ; section code
+; section "Event" (13)
+0000012: 0d                                        ; section code
 0000013: 00                                        ; section size (guess)
-0000014: 09                                        ; string length
-0000015: 6578 6365 7074 696f 6e                   exception  ; custom section name
-000001e: 01                                        ; exception count
-000001f: 01                                        ; exception type count
-0000020: 7f                                        ; i32
-0000013: 0d                                        ; FIXUP section size
+0000014: 01                                        ; exception count
+0000015: 01                                        ; exception type count
+0000016: 7f                                        ; i32
+0000013: 03                                        ; FIXUP section size
 ; section "Code" (10)
-0000021: 0a                                        ; section code
-0000022: 00                                        ; section size (guess)
-0000023: 01                                        ; num functions
+0000017: 0a                                        ; section code
+0000018: 00                                        ; section size (guess)
+0000019: 01                                        ; num functions
 ; function body 0
-0000024: 00                                        ; func body size (guess)
-0000025: 00                                        ; local decl count
-0000026: 41                                        ; i32.const
-0000027: 01                                        ; i32 literal
-0000028: 08                                        ; throw
-0000029: 00                                        ; throw exception
-000002a: 0b                                        ; end
-0000024: 06                                        ; FIXUP func body size
-0000022: 08                                        ; FIXUP section size
+000001a: 00                                        ; func body size (guess)
+000001b: 00                                        ; local decl count
+000001c: 41                                        ; i32.const
+000001d: 01                                        ; i32 literal
+000001e: 08                                        ; throw
+000001f: 00                                        ; throw exception
+0000020: 0b                                        ; end
+000001a: 06                                        ; FIXUP func body size
+0000018: 08                                        ; FIXUP section size
 
 throw.wasm:	file format wasm 0x1
 
 Code Disassembly:
 
-000025 func[0]:
- 000026: 41 01                      | i32.const 1
- 000028: 08 00                      | throw 0
- 00002a: 0b                         | end
+00001b func[0]:
+ 00001c: 41 01                      | i32.const 1
+ 00001e: 08 00                      | throw 0
+ 000020: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -63,6 +63,7 @@ NAMED_VALUES = {
     'CODE': 10,
     'DATA': 11,
     'DATACOUNT': 12,
+    'EVENT': 13,
 
     # name subsection codes
     'NAME_MODULE': 0,


### PR DESCRIPTION
The exception section is now a known section with code 13, and is known
as the "Event" section.

The structure of the section has changed too, but I'll fix that in
another PR.