### PR TITLE
Typo fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ So, for example, if you want to build the debug configuration on Visual Studio 2
 > mkdir build
 > cd build
 > cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=..\bin -G "Visual Studio 14 2015"
-> cmake --build .. --config DEBUG --target install
+> cmake --build . --config DEBUG --target install
 ```
 
 ## Changing the lexer


### PR DESCRIPTION
The Windows build example has a typo, and causes some confusion.