### PR TITLE
wasm-objdump: fix f64 init expressions

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1218,7 +1218,7 @@ void BinaryReaderObjdump::PrintInitExpr(const InitExpr& expr) {
       break;
     case InitExprType::F64: {
       char buffer[WABT_MAX_DOUBLE_HEX];
-      WriteFloatHex(buffer, sizeof(buffer), expr.value.f64);
+      WriteDoubleHex(buffer, sizeof(buffer), expr.value.f64);
       PrintDetails(" - init f64=%s\n", buffer);
       break;
     }

--- a/test/dump/global.txt
+++ b/test/dump/global.txt
@@ -115,7 +115,7 @@ Global[8]:
  - global[4] i32 mutable=0 - init i32=1
  - global[5] i64 mutable=0 - init i64=2
  - global[6] f32 mutable=0 - init f32=0x1.8p+1
- - global[7] f64 mutable=0 - init f64=0x0p+0
+ - global[7] f64 mutable=0 - init f64=0x1p+2
  - global[8] i32 mutable=0 - init global=0
  - global[9] i64 mutable=0 - init global=1
  - global[10] f32 mutable=0 - init global=2


### PR DESCRIPTION
The `PrintInitExpr` function falsely treated f64 as a float instead of a double.

The test case `global.txt` also contained the wrong output, namely `0x0p+0` instead of `0x1p+2` for `(f64.const 4)`.