### PR TITLE
Update textual encoding of SIMD vector shuffle to conform to the latest SIMD draft

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1688,11 +1688,12 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       ErrorUnlessOpcodeEnabled(token);
       v128 value;
       char* value_ptr = reinterpret_cast<char*>(&value);
-      for (int32_t lane = 0; lane < 16; ++lane) {
+      for (int lane = 0; lane < 16; ++lane) {
         Location loc = GetLocation();
 
-        if (!PeekMatch(TokenType::Nat))
-          return ErrorExpected({"an natural number in range [0, 32)"});
+        if (!PeekMatch(TokenType::Nat)) {
+          return ErrorExpected({"a natural number in range [0, 32)"});
+        }
 
         Literal literal = Consume().literal();
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1686,8 +1686,7 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
     case TokenType::SimdShuffleOp: {
       Token token = Consume();
       ErrorUnlessOpcodeEnabled(token);
-      v128 value;
-      char* value_ptr = reinterpret_cast<char*>(&value);
+      uint8_t values[16];
       for (int lane = 0; lane < 16; ++lane) {
         Location loc = GetLocation();
 
@@ -1703,7 +1702,6 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
         Result result;
 
         uint32_t value = 0;
-
         result = ParseInt32(s, end, &value, ParseIntType::UnsignedOnly);
 
         if (Failed(result)) {
@@ -1716,8 +1714,10 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
           return Result::Error;
         }
 
-        *(value_ptr + lane) = static_cast<uint8_t>(value);
+        values[lane] = static_cast<uint8_t>(value);
       }
+      v128 value = Bitcast<v128>(values);
+
       out_expr->reset(
           new SimdShuffleOpExpr(token.opcode(), value, loc));
       break;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -17,6 +17,7 @@
 #include "src/wat-writer.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cinttypes>
 #include <cstdarg>
@@ -943,9 +944,9 @@ Result WatWriter::ExprVisitorDelegate::OnSimdLaneOpExpr(SimdLaneOpExpr* expr) {
 Result WatWriter::ExprVisitorDelegate::OnSimdShuffleOpExpr(
     SimdShuffleOpExpr* expr) {
   writer_->WritePutsSpace(expr->opcode.GetName());
-  uint8_t* value_ptr = reinterpret_cast<uint8_t*>(&expr->val);
+  std::array<uint8_t, 16> values = Bitcast<std::array<uint8_t, 16>>(expr->val);
   for (int32_t lane = 0; lane < 16; ++lane) {
-    writer_->Writef(" %u", value_ptr[lane]);
+    writer_->Writef(" %u", values[lane]);
   }
   writer_->WritePutsNewline("");
   return Result::Ok;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -943,8 +943,10 @@ Result WatWriter::ExprVisitorDelegate::OnSimdLaneOpExpr(SimdLaneOpExpr* expr) {
 Result WatWriter::ExprVisitorDelegate::OnSimdShuffleOpExpr(
     SimdShuffleOpExpr* expr) {
   writer_->WritePutsSpace(expr->opcode.GetName());
-  writer_->Writef(" 0x%08x 0x%08x 0x%08x 0x%08x", (expr->val.v[0]), (expr->val.v[1]),
-                  (expr->val.v[2]), (expr->val.v[3]));
+  uint8_t* value_ptr = reinterpret_cast<uint8_t*>(&expr->val);
+  for (int32_t lane = 0; lane < 16; ++lane) {
+    writer_->Writef(" %u", value_ptr[lane]);
+  }
   writer_->WritePutsNewline("");
   return Result::Ok;
 }

--- a/test/dump/simd-lane.txt
+++ b/test/dump/simd-lane.txt
@@ -82,7 +82,7 @@
   (func (export  "func_v8x16_shuffle_0") (result v128)
     v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
     v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
-    v8x16.shuffle 0x03120110 0x07160514 0x0b1a0918 0x0f1e0d1c)
+    v8x16.shuffle 16 1 18 3 20 5 22 7 24 9 26 11 28 13 30 15)
 )
 (;; STDOUT ;;;
 

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -222,7 +222,7 @@
   (; 0xfd 0x00 ;) (func (export "v128.load") i32.const 1 v128.load offset=3 drop)
   (; 0xfd 0x01 ;) (func (export "v128.store") i32.const 1 v128.const i32 1 1 1 1 v128.store offset=3)
   (; 0xfd 0x02 ;) (func (export "v128.const") v128.const i32 1 1 1 1 drop)
-  (; 0xfd 0x03 ;) (func (export "v8x16.shuffle") v128.const i32 1 1 1 1 v128.const i32 2 2 2 2 v8x16.shuffle 1 1 1 1 drop)
+  (; 0xfd 0x03 ;) (func (export "v8x16.shuffle") v128.const i32 1 1 1 1 v128.const i32 2 2 2 2 v8x16.shuffle 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 drop)
   (; 0xfd 0x04 ;) (func (export "i8x16.splat") i32.const 1 i8x16.splat drop)
   (; 0xfd 0x05 ;) (func (export "i8x16.extract_lane_s") v128.const i32 1 1 1 1 i8x16.extract_lane_s 15 drop)
   (; 0xfd 0x06 ;) (func (export "i8x16.extract_lane_u") v128.const i32 1 1 1 1 i8x16.extract_lane_u 15 drop)
@@ -4514,7 +4514,7 @@
 000224f: 0200 0000 0200 0000 0200 0000 0200 0000   ; v128 literal
 000225f: fd                                        ; prefix
 0002260: 03                                        ; v8x16.shuffle
-0002261: 0100 0000 0100 0000 0100 0000 0100 0000   ; Simd Lane[16] literal
+0002261: 0101 0101 0101 0101 0101 0101 0101 0101   ; Simd Lane[16] literal
 0002271: 1a                                        ; drop
 0002272: 0b                                        ; end
 0002239: 39                                        ; FIXUP func body size
@@ -9234,7 +9234,7 @@ BeginModule(version: 1)
     OnLocalDeclCount(0)
     OnV128ConstExpr(0x00000001 0x00000001 0x00000001 0x00000001)
     OnV128ConstExpr(0x00000002 0x00000002 0x00000002 0x00000002)
-    OnSimdShuffleOpExpr (lane: 0x00000001 00000001 00000001 00000001)
+    OnSimdShuffleOpExpr (lane: 0x01010101 01010101 01010101 01010101)
     OnDropExpr
     EndFunctionBody(190)
     BeginFunctionBody(191, size:7)
@@ -11426,7 +11426,7 @@ EndModule
 5144| return
 5148| v128.const 0x00000001 0x00000001 0x00000001 0x00000001
 5168| v128.const 0x00000002 0x00000002 0x00000002 0x00000002
-5188| v8x16.shuffle %[-2], %[-1] : (Lane imm: $0x00000001 0x00000001 0x00000001 0x00000001 )
+5188| v8x16.shuffle %[-2], %[-1] : (Lane imm: $0x01010101 0x01010101 0x01010101 0x01010101 )
 5208| drop
 5212| return
 5216| i32.const 1

--- a/test/interp/simd-lane.txt
+++ b/test/interp/simd-lane.txt
@@ -85,7 +85,7 @@
   (func (export  "func_v8x16_shuffle_0") (result v128)
     v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
     v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
-    v8x16.shuffle 0x03120110 0x07160514 0x0b1a0918 0x0f1e0d1c)
+    v8x16.shuffle  16 1 18 3 20 5 22 7 24 9 26 11 28 13 30 15)
 )
 (;; STDOUT ;;;
 func_i8x16_extract_lane_s_0() => i32:4294967295

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -222,7 +222,7 @@
   (; 0xfd 0x00 ;) (func (export "v128.load") i32.const 1 v128.load offset=3 drop)
   (; 0xfd 0x01 ;) (func (export "v128.store") i32.const 1 v128.const i32 1 1 1 1 v128.store offset=3)
   (; 0xfd 0x02 ;) (func (export "v128.const") v128.const i32 1 1 1 1 drop)
-  (; 0xfd 0x03 ;) (func (export "v8x16.shuffle") v128.const i32 1 1 1 1 v128.const i32 2 2 2 2 v8x16.shuffle 1 1 1 1 drop)
+  (; 0xfd 0x03 ;) (func (export "v8x16.shuffle") v128.const i32 1 1 1 1 v128.const i32 2 2 2 2 v8x16.shuffle 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 1 drop)
   (; 0xfd 0x04 ;) (func (export "i8x16.splat") i32.const 1 i8x16.splat drop)
   (; 0xfd 0x05 ;) (func (export "i8x16.extract_lane_s") v128.const i32 1 1 1 1 i8x16.extract_lane_s 15 drop)
   (; 0xfd 0x06 ;) (func (export "i8x16.extract_lane_u") v128.const i32 1 1 1 1 i8x16.extract_lane_u 15 drop)
@@ -1616,7 +1616,7 @@ v128.const() =>
 >>> running export "v8x16.shuffle":
 #0. 5104: V:0  | v128.const 0x00000001 0x00000001 0x00000001 0x00000001
 #0. 5124: V:1  | v128.const 0x00000002 0x00000002 0x00000002 0x00000002
-#0. 5144: V:2  | v8x16.shuffle $0x00000001 00000001 00000001 00000001 $0x00000002 00000002 00000002 00000002 : with lane imm: $0x00000001 00000001 00000001 00000001
+#0. 5144: V:2  | v8x16.shuffle $0x00000001 00000001 00000001 00000001 $0x00000002 00000002 00000002 00000002 : with lane imm: $0x01010101 01010101 01010101 01010101
 #0. 5164: V:1  | drop
 #0. 5168: V:0  | return
 v8x16.shuffle() =>

--- a/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt
+++ b/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt
@@ -9,16 +9,7 @@
     ))
 
 (;; STDERR ;;;
-out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: lane index must be less than 32 (got 100)
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:19: error: shuffle index "0x01020304" out-of-range [0, 32)
     v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
-    ^^^^^^^^^^^^^
-out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: lane index must be less than 32 (got 56)
-    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
-    ^^^^^^^^^^^^^
-out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: lane index must be less than 32 (got 77)
-    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
-    ^^^^^^^^^^^^^
-out/test/parse/expr/bad-simd-shuffle-lane-index-overflow.txt:8:5: error: type mismatch in function, expected [] but got [v128]
-    v8x16.shuffle 0x01020304 05060708 0x090a0b0c 0x00000000
-    ^^^^^^^^^^^^^
+                  ^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt
+++ b/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt
@@ -1,0 +1,15 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-simd
+;;; ERROR: 1
+(module
+  (func
+    v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
+    v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
+    v8x16.shuffle 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 33
+    ))
+
+(;; STDERR ;;;
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt:8:55: error: shuffle index "33" out-of-range [0, 32)
+    v8x16.shuffle 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 33
+                                                      ^^
+;;; STDERR ;;)

--- a/test/parse/expr/bad-simd-shuffle-nat-expected.txt
+++ b/test/parse/expr/bad-simd-shuffle-nat-expected.txt
@@ -9,7 +9,7 @@
     ))
 
 (;; STDERR ;;;
-out/test/parse/expr/bad-simd-shuffle-nat-expected.txt:8:19: error: unexpected token "$0x01020304", expected an Nat literal (e.g. 123).
+out/test/parse/expr/bad-simd-shuffle-nat-expected.txt:8:19: error: unexpected token "$0x01020304", expected an natural number in range [0, 32).
     v8x16.shuffle $0x01020304 0x05060708 0x090a0b0c 0x00000000
                   ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-simd-shuffle-nat-expected.txt
+++ b/test/parse/expr/bad-simd-shuffle-nat-expected.txt
@@ -9,7 +9,7 @@
     ))
 
 (;; STDERR ;;;
-out/test/parse/expr/bad-simd-shuffle-nat-expected.txt:8:19: error: unexpected token "$0x01020304", expected an natural number in range [0, 32).
+out/test/parse/expr/bad-simd-shuffle-nat-expected.txt:8:19: error: unexpected token "$0x01020304", expected a natural number in range [0, 32).
     v8x16.shuffle $0x01020304 0x05060708 0x090a0b0c 0x00000000
                   ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt
+++ b/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt
@@ -9,7 +9,7 @@
     ))
 
 (;; STDERR ;;;
-out/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt:9:5: error: unexpected token ")", expected an natural number in range [0, 32).
+out/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt:9:5: error: unexpected token ")", expected a natural number in range [0, 32).
     ))
     ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt
+++ b/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt
@@ -1,0 +1,15 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-simd
+;;; ERROR: 1
+(module
+  (func
+    v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
+    v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
+    v8x16.shuffle 1 1 1 1
+    ))
+
+(;; STDERR ;;;
+out/test/parse/expr/bad-simd-shuffle-not-enough-indices.txt:9:5: error: unexpected token ")", expected an natural number in range [0, 32).
+    ))
+    ^
+;;; STDERR ;;)

--- a/test/parse/expr/simd.txt
+++ b/test/parse/expr/simd.txt
@@ -4,6 +4,6 @@
   (func
     v128.const i32 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
     v128.const i32 0x00550055 0x00550055 0x00550055 0x00550155
-    v8x16.shuffle 0x01020304 0x05060708 0x090a0b0c 0x00000000
+    v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15
     drop
     ))


### PR DESCRIPTION
The textual (WAT) representation of the vector shuffle immediate argument was
underspecified. Recently, WebAssembly/simd#67 specified
it to be i8x16.shuffle i5 i5 ... i5 (16 times i5), which is what all other
implementations were doing. WABT was reading the shuffle argument as 4 32-bit
hex integers that specified a v128, that is, i8x16.shuffle 0x0 0x0 0x0 0x0.

This PR updates WABT to conform to the updated draft of the SIMD extension.