### PR TITLE
Update testsuite; fix linking spec test

### DIFF
--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1167,7 +1167,6 @@ wabt::Result CommandRunner::OnAssertUninstantiableCommand(
     const AssertUninstantiableCommand* command) {
   Errors errors;
   DefinedModule* module;
-  Environment::MarkPoint mark = env_.Mark();
   wabt::Result result = ReadModule(command->filename, &env_, &errors, &module);
   FormatErrorsToFile(errors, Location::Type::Binary);
 
@@ -1186,7 +1185,9 @@ wabt::Result CommandRunner::OnAssertUninstantiableCommand(
     result = wabt::Result::Error;
   }
 
-  env_.ResetToMarkPoint(mark);
+  // Don't reset env_ here; if the start function fails, the environment is
+  // still modified. For example, a table may have been populated with a
+  // function from this module.
   return result;
 }
 

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -37,5 +37,5 @@ out/test/spec/linking.wast:335: assert_unlinkable passed:
 out/test/spec/linking.wast:345: assert_unlinkable passed:
   error: elem segment is out of bounds: [0, 1) >= max value 0
   000002d: error: OnElemSegmentFunctionIndexCount callback failed
-91/91 tests passed.
+94/94 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/linking.txt
+++ b/test/wasm2c/spec/linking.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/linking.wast
 (;; STDOUT ;;;
-79/79 tests passed.
+82/82 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/start.txt
+++ b/test/wasm2c/spec/start.txt
@@ -4,5 +4,5 @@
 spectest.print_i32(1)
 spectest.print_i32(2)
 spectest.print()
-6/6 tests passed.
+7/7 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
When a module is instantiated, and the start function traps, the
contents of the memory and the table may have been modified. This case
is handled by the `assert_uninstantiable` check in a wast test.

In spectest-interp, assert_uninstantiable would instantiate the module,
but was incorrectly resetting the environment. In run-spec-wasm2c, the
`assert_uninstantiable` tests weren't being run at all. Now the module's
`init` function is run, and it is expected to trap.