### PR TITLE
Add names to locally declared globals.

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1225,6 +1225,10 @@ Result BinaryReaderObjdump::OnGlobalCount(Index count) {
 Result BinaryReaderObjdump::BeginGlobal(Index index, Type type, bool mutable_) {
   PrintDetails(" - global[%" PRIindex "] %s mutable=%d", index,
                GetTypeName(type), mutable_);
+  string_view name = GetGlobalName(index);
+  if (!name.empty()) {
+    PrintDetails(" <" PRIstringview ">", WABT_PRINTF_STRING_VIEW_ARG(name));
+  }
   return Result::Ok;
 }
 

--- a/test/dump/mutable-global.txt
+++ b/test/dump/mutable-global.txt
@@ -47,7 +47,7 @@ Section Details:
 Import[1]:
  - global[0] i32 mutable=1 <- foo.imported
 Global[1]:
- - global[1] i32 mutable=1 - init i32=1
+ - global[1] i32 mutable=1 <exported> - init i32=1
 Export[1]:
  - global[1] -> "exported"
 


### PR DESCRIPTION
These currently can only come from the export of a global.