### PR TITLE
Initial custom annotation support

### DIFF
--- a/src/feature.def
+++ b/src/feature.def
@@ -32,3 +32,4 @@ WABT_FEATURE(multi_value,      "multi-value",             false,   "Multi-value"
 WABT_FEATURE(tail_call,        "tail-call",               false,   "Tail-call support")
 WABT_FEATURE(bulk_memory,      "bulk-memory",             false,   "Bulk-memory operations")
 WABT_FEATURE(reference_types,  "reference-types",         false,   "Reference types (anyref)")
+WABT_FEATURE(annotations,      "annotations",             false,   "Custom annotation syntax")

--- a/src/token.def
+++ b/src/token.def
@@ -137,6 +137,7 @@ WABT_TOKEN_LAST(Opcode, Unreachable)
 
 /* Tokens with string data. */
 WABT_TOKEN(AlignEqNat, "align=")
+WABT_TOKEN(LparAnn, "Annotation")
 WABT_TOKEN(OffsetEqNat, "offset=")
 WABT_TOKEN(Reserved, "Reserved")
 WABT_TOKEN(Text, "TEXT")

--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -64,6 +64,9 @@ Token WastLexer::GetToken(WastParser* parser) {
             continue;
           }
           return BareToken(TokenType::Eof);
+        } else if (MatchString("(@")) {
+          ReadReservedChars();
+          return TextToken(TokenType::LparAnn);
         } else {
           ReadChar();
           return BareToken(TokenType::Lpar);

--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -66,7 +66,8 @@ Token WastLexer::GetToken(WastParser* parser) {
           return BareToken(TokenType::Eof);
         } else if (MatchString("(@")) {
           ReadReservedChars();
-          return TextToken(TokenType::LparAnn);
+          // offset=2 to skip the "(@" prefix
+          return TextToken(TokenType::LparAnn, 2);
         } else {
           ReadChar();
           return BareToken(TokenType::Lpar);

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -22,6 +22,7 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
   -V, --value-stack-size=SIZE                 Size in elements of the value stack
   -C, --call-stack-size=SIZE                  Size in elements of the call stack
   -t, --trace                                 Trace execution

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -33,6 +33,7 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
   -V, --value-stack-size=SIZE                 Size in elements of the value stack
   -C, --call-stack-size=SIZE                  Size in elements of the call stack
   -t, --trace                                 Trace execution

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -22,6 +22,7 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
       --no-debug-names                        Ignore debug names in the binary file
       --ignore-custom-section-errors          Ignore errors in custom sections
 ;;; STDOUT ;;)

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -28,6 +28,7 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
       --inline-exports                        Write all exports inline
       --inline-imports                        Write all imports inline
       --no-debug-names                        Ignore debug names in the binary file

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -25,6 +25,7 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
   -o, --output=FILE                           output wasm binary file
   -r, --relocatable                           Create a relocatable wasm binary (suitable for linking with e.g. lld)
       --no-canonicalize-leb128s               Write all LEB128 sizes as 5-bytes instead of their minimal size

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -32,5 +32,6 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
       --generate-names                        Give auto-generated names to non-named functions, types, etc.
 ;;; STDOUT ;;)

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -32,6 +32,7 @@ options:
       --enable-tail-call                      Enable Tail-call support
       --enable-bulk-memory                    Enable Bulk-memory operations
       --enable-reference-types                Enable Reference types (anyref)
+      --enable-annotations                    Enable Custom annotation syntax
   -o, --output=FILE                           output wasm binary file
   -r, --relocatable                           Create a relocatable wasm binary (suitable for linking with e.g. lld)
       --no-canonicalize-leb128s               Write all LEB128 sizes as 5-bytes instead of their minimal size

--- a/test/parse/annotations.txt
+++ b/test/parse/annotations.txt
@@ -1,0 +1,9 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-annotations
+(module
+  (func (@name "some func") (result i32)
+    i32.const 42
+    return)
+  (@custom section)
+  (@custom (@nested section))
+  (@custom (section) (@with "other") nested-subsections))

--- a/test/parse/bad-annotations.txt
+++ b/test/parse/bad-annotations.txt
@@ -8,13 +8,13 @@
   (@custom (@nested section))
   (@custom (section) (@with "other") nested-subsections))
 (;; STDERR ;;;
-out/test/parse/bad-annotations.txt:4:9: error: annotations not enabled: (@name
+out/test/parse/bad-annotations.txt:4:9: error: annotations not enabled: name
   (func (@name "some func") (result i32)
         ^^^^^^
 out/test/parse/bad-annotations.txt:4:16: error: unexpected token "some func", expected ).
   (func (@name "some func") (result i32)
                ^^^^^^^^^^^
-out/test/parse/bad-annotations.txt:7:3: error: annotations not enabled: (@custom
+out/test/parse/bad-annotations.txt:7:3: error: annotations not enabled: custom
   (@custom section)
   ^^^^^^^^
 out/test/parse/bad-annotations.txt:7:12: error: unexpected token section.

--- a/test/parse/bad-annotations.txt
+++ b/test/parse/bad-annotations.txt
@@ -1,0 +1,23 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+  (func (@name "some func") (result i32)
+    i32.const 42
+    return)
+  (@custom section)
+  (@custom (@nested section))
+  (@custom (section) (@with "other") nested-subsections))
+(;; STDERR ;;;
+out/test/parse/bad-annotations.txt:4:9: error: annotations not enabled: (@name
+  (func (@name "some func") (result i32)
+        ^^^^^^
+out/test/parse/bad-annotations.txt:4:16: error: unexpected token "some func", expected ).
+  (func (@name "some func") (result i32)
+               ^^^^^^^^^^^
+out/test/parse/bad-annotations.txt:7:3: error: annotations not enabled: (@custom
+  (@custom section)
+  ^^^^^^^^
+out/test/parse/bad-annotations.txt:7:12: error: unexpected token section.
+  (@custom section)
+           ^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
Lex custom annotations, but discard them in the parser. In the future we
should be able to parse some of them, but this is simple and
spec-compliant for now.

(Annotations proposal: https://github.com/WebAssembly/annotations)