### PR TITLE
Update typechecking for `table.grow`

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -641,7 +641,7 @@ Result TypeChecker::OnTableSet(Index segment) {
 }
 
 Result TypeChecker::OnTableGrow(Index segment) {
-  Result result = PopAndCheck2Types(Type::I32, Type::Anyref, "table.grow");
+  Result result = PopAndCheck2Types(Type::Anyref, Type::I32, "table.grow");
   PushType(Type::I32);
   return result;
 }

--- a/test/dump/reference-types.txt
+++ b/test/dump/reference-types.txt
@@ -27,13 +27,13 @@
   )
 
   (func (result i32)
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow $foo
   )
   (func (result i32)
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow $bar
   )
 
@@ -79,13 +79,13 @@ Code Disassembly:
  000055: 26 01                      | table.set 1
  000057: 0b                         | end
 000059 func[4]:
- 00005a: 41 00                      | i32.const 0
- 00005c: d0                         | ref.null
+ 00005a: d0                         | ref.null
+ 00005b: 41 00                      | i32.const 0
  00005d: fc 0f 00                   | table.grow 0
  000060: 0b                         | end
 000062 func[5]:
- 000063: 41 00                      | i32.const 0
- 000065: d0                         | ref.null
+ 000063: d0                         | ref.null
+ 000064: 41 00                      | i32.const 0
  000066: fc 0f 01                   | table.grow 1
  000069: 0b                         | end
 00006b func[6]:

--- a/test/parse/expr/reference-types-named.txt
+++ b/test/parse/expr/reference-types-named.txt
@@ -13,8 +13,8 @@
     table.set $foo
   )
   (func (result i32)
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow $foo
   )
 )

--- a/test/parse/expr/reference-types.txt
+++ b/test/parse/expr/reference-types.txt
@@ -27,13 +27,13 @@
   )
 
   (func (result i32)
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow $foo
   )
   (func (result i32)
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow $bar
   )
 

--- a/test/parse/expr/table-grow.txt
+++ b/test/parse/expr/table-grow.txt
@@ -2,8 +2,8 @@
 ;;; ARGS: --enable-reference-types
 (module
   (func (result i32)
-    i32.const 0
     ref.null
+    i32.const 0
     table.grow 0)
 
   (table 1 anyref))


### PR DESCRIPTION
I think the previous order was implemented in Firefox at some point but
it looks like it's since been updated so reversing the order of
operands in `table.grow` matches what the proposed spec text currently
says.