### PR TITLE
Fix INSTALL_PREFIX in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,12 @@ $ make gcc-debug-no-tests
 ## Building (Windows)
 
 You'll need [CMake](https://cmake.org). You'll also need
-[Visual Studio](https://www.visualstudio.com/) (2015 or newer) or 
+[Visual Studio](https://www.visualstudio.com/) (2015 or newer) or
 [MinGW](http://www.mingw.org/).
+
+_Note: Visual Studio 2017 and later come with CMake (and the Ninja build system)
+out of the box, and should be on your PATH if you open a Developer Command prompt.
+See <https://aka.ms/cmake> for more details._
 
 You can run CMake from the command prompt, or use the CMake GUI tool. See
 [Running CMake](https://cmake.org/runningcmake/) for more information.
@@ -133,7 +137,7 @@ So, for example, if you want to build the debug configuration on Visual Studio 2
 ```console
 > mkdir build
 > cd build
-> cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=..\bin -G "Visual Studio 14 2015"
+> cmake .. -DCMAKE_BUILD_TYPE=DEBUG -DCMAKE_INSTALL_PREFIX=..\ -G "Visual Studio 14 2015"
 > cmake --build . --config DEBUG --target install
 ```
 


### PR DESCRIPTION
The `install` command in the `CMakeLists.txt` file already includes a `bin` destination (see https://github.com/WebAssembly/wabt/blob/master/CMakeLists.txt#L439), so the current readme instructions left me with the binaries in a `.\bin\bin` directory. Updating the README here to remove the unnecessary `bin`.

Also updated the readme to note that CMake (and Ninja) are in the box now with VS (and thus don't need to be installed as a separate dependencies).

Note: VS 2015 is a couple releases old now, so happy to update those instructions to 2019 too if you like :wink: