### PR TITLE
Fix wasm-interp assertions

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -219,6 +219,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
                                 Index table_index,
                                 bool passive,
                                 Type elem_type) override;
+  wabt::Result BeginElemSegmentInitExpr(Index index) override;
   wabt::Result EndElemSegmentInitExpr(Index index) override;
   wabt::Result OnElemSegmentElemExprCount(Index index, Index count) override;
   wabt::Result OnElemSegmentElemExpr_RefNull(Index segment_index) override;
@@ -229,6 +230,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
   wabt::Result BeginDataSegment(Index index,
                                 Index memory_index,
                                 bool passive) override;
+  wabt::Result BeginDataSegmentInitExpr(Index index) override;
   wabt::Result OnDataSegmentData(Index index,
                                  const void* data,
                                  Address size) override;
@@ -1049,6 +1051,11 @@ wabt::Result BinaryReaderInterp::BeginElemSegment(Index index,
   return wabt::Result::Ok;
 }
 
+wabt::Result BinaryReaderInterp::BeginElemSegmentInitExpr(Index index) {
+  init_expr_value_.type = Type::Void;
+  return wabt::Result::Ok;
+}
+
 wabt::Result BinaryReaderInterp::EndElemSegmentInitExpr(Index index) {
   assert(segment_is_passive_ == false);
 
@@ -1121,6 +1128,11 @@ wabt::Result BinaryReaderInterp::BeginDataSegment(Index index,
                                                   Index memory_index,
                                                   bool passive) {
   segment_is_passive_ = passive;
+  return wabt::Result::Ok;
+}
+
+wabt::Result BinaryReaderInterp::BeginDataSegmentInitExpr(Index index) {
+  init_expr_value_.type = Type::Void;
   return wabt::Result::Ok;
 }
 

--- a/test/regress/regress-26.txt
+++ b/test/regress/regress-26.txt
@@ -1,0 +1,19 @@
+;;; TOOL: run-gen-wasm-interp
+;;; ERROR: 1
+magic
+version
+section(TABLE) {
+  count[1]
+  anyfunc
+  has_max[0]
+  initial[0]
+}
+section(ELEM) {
+  count[1]
+  flags[0]
+  addr[end]
+}
+(;; STDERR ;;;
+error: type mismatch in elem segment initializer expression, expected i32 but got <type_index>
+0000013: error: EndElemSegmentInitExpr callback failed
+;;; STDERR ;;)

--- a/test/regress/regress-26.txt
+++ b/test/regress/regress-26.txt
@@ -14,6 +14,6 @@ section(ELEM) {
   addr[end]
 }
 (;; STDERR ;;;
-error: type mismatch in elem segment initializer expression, expected i32 but got <type_index>
+error: type mismatch in elem segment initializer expression, expected i32 but got void
 0000013: error: EndElemSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-27.txt
+++ b/test/regress/regress-27.txt
@@ -1,0 +1,19 @@
+;;; TOOL: run-gen-wasm-interp
+;;; ERROR: 1
+magic
+version
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section(DATA) {
+  count[1]
+  flags[0]
+  addr[end]
+  data[str("test")]
+}
+(;; STDERR ;;;
+error: type mismatch in data segment initializer expression, expected i32 but got <type_index>
+0000017: error: OnDataSegmentData callback failed
+;;; STDERR ;;)

--- a/test/regress/regress-27.txt
+++ b/test/regress/regress-27.txt
@@ -14,6 +14,6 @@ section(DATA) {
   data[str("test")]
 }
 (;; STDERR ;;;
-error: type mismatch in data segment initializer expression, expected i32 but got <type_index>
+error: type mismatch in data segment initializer expression, expected i32 but got void
 0000017: error: OnDataSegmentData callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-28.txt
+++ b/test/regress/regress-28.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-gen-wasm-interp
+;;; ERROR: 1
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    unreachable
+    end
+    i32.div_s
+    select
+  }
+}
+(;; STDERR ;;;
+error: Unexpected instruction after end of function
+000001a: error: OnOpcode callback failed
+;;; STDERR ;;)


### PR DESCRIPTION
* i32 init expression in data/elem segments
* Instructions after the last "end" instruction of the function (the
  function label has been popped)

Fixes #1089, #1090, #1091