### PR TITLE
Match custom section names in wasm-objdump

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -114,9 +114,10 @@ Result BinaryReaderLogging::BeginModule(uint32_t version) {
   return reader_->BeginModule(version);
 }
 
-Result BinaryReaderLogging::BeginSection(BinarySection section_type,
+Result BinaryReaderLogging::BeginSection(Index section_index,
+                                         BinarySection section_type,
                                          Offset size) {
-  return reader_->BeginSection(section_type, size);
+  return reader_->BeginSection(section_index, section_type, size);
 }
 
 Result BinaryReaderLogging::BeginCustomSection(Offset size,

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -33,7 +33,9 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result BeginModule(uint32_t version) override;
   Result EndModule() override;
 
-  Result BeginSection(BinarySection section_type, Offset size) override;
+  Result BeginSection(Index section_index,
+                      BinarySection section_type,
+                      Offset size) override;
 
   Result BeginCustomSection(Offset size, string_view section_name) override;
   Result EndCustomSection() override;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -29,7 +29,9 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result BeginModule(uint32_t version) override { return Result::Ok; }
   Result EndModule() override { return Result::Ok; }
 
-  Result BeginSection(BinarySection section_type, Offset size) override {
+  Result BeginSection(Index section_index,
+                      BinarySection section_type,
+                      Offset size) override {
     return Result::Ok;
   }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2238,8 +2238,9 @@ Result BinaryReader::ReadDataCountSection(Offset section_size) {
 
 Result BinaryReader::ReadSections() {
   Result result = Result::Ok;
+  Index section_index = 0;
 
-  while (state_.offset < state_.size) {
+  for (; state_.offset < state_.size; ++section_index) {
     uint32_t section_code;
     Offset section_size;
     CHECK_RESULT(ReadU32Leb128(&section_code, "section code"));
@@ -2266,7 +2267,7 @@ Result BinaryReader::ReadSections() {
                  "%s section can not occur after Name section",
                  GetSectionName(section));
 
-    CALLBACK(BeginSection, section, section_size);
+    CALLBACK(BeginSection, section_index, section, section_size);
 
     bool stop_on_first_error = options_.stop_on_first_error;
     Result section_result = Result::Error;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -71,7 +71,9 @@ class BinaryReaderDelegate {
   virtual Result BeginModule(uint32_t version) = 0;
   virtual Result EndModule() = 0;
 
-  virtual Result BeginSection(BinarySection section_type, Offset size) = 0;
+  virtual Result BeginSection(Index section_index,
+                              BinarySection section_type,
+                              Offset size) = 0;
 
   /* Custom section */
   virtual Result BeginCustomSection(Offset size, string_view section_name) = 0;

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -59,7 +59,9 @@ class BinaryReaderStrip : public BinaryReaderNop {
     return true;
   }
 
-  Result BeginSection(BinarySection section_type, Offset size) override {
+  Result BeginSection(Index section_index,
+                      BinarySection section_type,
+                      Offset size) override {
     if (section_type == BinarySection::Custom) {
       return Result::Ok;
     }


### PR DESCRIPTION
This way you can see the contents of just one custom section by using:

```
wasm-objdump -j section_name -x
```

Where `section_name` is the name of the custom section.