### PR TITLE
Write assert_exhaustion text to JSON file

### DIFF
--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -490,6 +490,9 @@ void BinaryWriterSpec::WriteCommands() {
         WriteSeparator();
         WriteAction(*assert_exhaustion_command->action);
         WriteSeparator();
+        WriteKey("text");
+        WriteEscapedString(assert_exhaustion_command->text);
+        WriteSeparator();
         WriteKey("expected");
         WriteActionResultType(*assert_exhaustion_command->action);
         break;

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -738,6 +738,8 @@ wabt::Result JSONParser::ParseCommand(CommandPtr* out_command) {
     EXPECT(",");
     CHECK_RESULT(ParseAction(&command->action));
     EXPECT(",");
+    PARSE_KEY_STRING_VALUE("text", &command->text);
+    EXPECT(",");
     CHECK_RESULT(ParseActionResult());
     *out_command = std::move(command);
   } else {


### PR DESCRIPTION
The wast file definition for assert_exhaustion looks like:

```wasm
(assert_exhaustion
  (invoke "function" (i32.const 132))
  "error message")
```

This commit adds the "error message" part to the output.