### PR TITLE
[interp] Add flag to provide dummy import funcs

### DIFF
--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -537,6 +537,11 @@ class Environment {
   void Disassemble(Stream* stream, IstreamOffset from, IstreamOffset to);
   void DisassembleModule(Stream* stream, Module*);
 
+  // Called when a module name isn't found in registered_module_bindings_. If
+  // you want to provide a module with this name, call AppendHostModule() with
+  // this name and return true.
+  std::function<bool(Environment*, string_view name)> on_unknown_module;
+
  private:
   friend class Thread;
 

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -39,4 +39,5 @@ options:
   -t, --trace                                 Trace execution
       --run-all-exports                       Run all the exported functions, in order. Useful for testing
       --host-print                            Include an importable function named "host.print" for printing to stdout
+      --dummy-import-func                     Provide a dummy implementation of all imported functions. The function will log the call and return an appropriate zero value.
 ;;; STDOUT ;;)

--- a/test/interp/call-dummy-import.txt
+++ b/test/interp/call-dummy-import.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-interp
+;;; ARGS: --dummy-import-func
+(module
+  (import "foo" "bar" (func $bar (param i32 f32) (result i32)))
+  (import "baz" "quux" (func $quux (param f64) (result i64)))
+
+  (func (export "f1") (result i32)
+    i32.const 1
+    f32.const 2
+    call $bar)
+
+  (func (export "f2") (result i64)
+    f64.const 3
+    call $quux))
+(;; STDOUT ;;;
+called host foo.bar(i32:1, f32:2.000000) => i32:0
+f1() => i32:0
+called host baz.quux(f64:3.000000) => i64:0
+f2() => i64:0
+;;; STDOUT ;;)


### PR DESCRIPTION
You can now pass `--dummy-import-func` to `wasm-interp`, which will
provide a function that logs the call and returns zero.