### PR TITLE
Build against system gtest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "third_party/testsuite"]
 	path = third_party/testsuite
 	url = https://github.com/WebAssembly/testsuite
-[submodule "third_party/gtest"]
-	path = third_party/gtest
-	url = https://github.com/google/googletest
 [submodule "third_party/ply"]
 	path = third_party/ply
 	url = https://github.com/dabeaz/ply

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -373,30 +373,15 @@ if (NOT EMSCRIPTEN)
 
   find_package(Threads)
   if (BUILD_TESTS)
-    if (NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/third_party/gtest/googletest)
-      message(FATAL_ERROR "Can't find third_party/gtest. Run git submodule update --init, or disable with CMake -DBUILD_TESTS=OFF.")
-    endif ()
-
-    include_directories(
-      third_party/gtest/googletest
-      third_party/gtest/googletest/include
-    )
-
-    # gtest
-    add_library(libgtest STATIC
-      third_party/gtest/googletest/src/gtest-all.cc
-    )
-
     # hexfloat-test
     set(HEXFLOAT_TEST_SRCS
       src/literal.cc
       src/test-hexfloat.cc
-      third_party/gtest/googletest/src/gtest_main.cc
     )
     wabt_executable(
       NAME hexfloat_test
       SOURCES ${HEXFLOAT_TEST_SRCS}
-      LIBS libgtest ${CMAKE_THREAD_LIBS_INIT}
+      LIBS gtest_main gtest ${CMAKE_THREAD_LIBS_INIT}
     )
 
     # wabt-unittests
@@ -411,12 +396,11 @@ if (NOT EMSCRIPTEN)
       src/test-filenames.cc
       src/test-utf8.cc
       src/test-wast-parser.cc
-      third_party/gtest/googletest/src/gtest_main.cc
     )
     wabt_executable(
       NAME wabt-unittests
       SOURCES ${UNITTESTS_SRCS}
-      LIBS libgtest ${CMAKE_THREAD_LIBS_INIT}
+      LIBS gtest_main gtest ${CMAKE_THREAD_LIBS_INIT}
     )
 
     if (NOT CMAKE_VERSION VERSION_LESS "3.2")


### PR DESCRIPTION
Meant to address #1103.

`gtest` seems to be packaged on Arch Linux, Alpine Linux, Ubuntu, etc. It is generally preferable to use the system copy of a library instead of vendoring a copy.

Alternately, it be desirable to retain an option to build gtest, which could make things easier for some (for example, on Windows). But in my experience, building dependencies is generally left to the user.

I'm not particularly experience with `cmake`, so I don't necessarily know the preferred way to do things.