### PR TITLE
Fix value dropping bug in return_call

### DIFF
--- a/test/regress/regress-29.txt
+++ b/test/regress/regress-29.txt
@@ -1,0 +1,18 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-tail-call
+(table funcref (elem $f))
+(func $f (result i32) i32.const 65)
+
+(func (export "g") (result i32)
+  i32.const 7  ;; extra i32 on stack
+  return_call $f
+)
+(func (export "h") (result i32)
+  i32.const 7  ;; extra i32 on stack
+  i32.const 0
+  return_call_indirect (result i32)
+)
+(;; STDOUT ;;;
+g() => i32:65
+h() => i32:65
+;;; STDOUT ;;)


### PR DESCRIPTION
The previous implementation was not properly dropping values on the
stack when performing a return_call or return_call_indirect.

In particular, the "keep count" (i.e. the number of values to keep that
are on the top of the stack) was set properly, but the "drop count" (the
number of values to drop below the keep count), was not.

This fixes issue #1108.