### PR TITLE
Fix floating point conversions on MSVC 32-bit

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -18,15 +18,12 @@ environment:
     JOBS_FLAG: -j
     EXE_DIR: .
     DEPLOY: false
-# TODO(binji): re-enable. This is disabled because of a test failure in the
-# spec testsuite, and because it's unlikely that most users need a 32-bit
-# build. See https://github.com/WebAssembly/wabt/issues/1113
-#  - GENERATOR: Visual Studio 14 2015
-#    CONFIG: Release
-#    JOBS_FLAG: "/m:"
-#    EXE_DIR: '%CONFIG%'
-#    DEPLOY: true
-#    DEPLOY_NAME: wabt-%APPVEYOR_REPO_TAG_NAME%-win32.zip
+  - GENERATOR: Visual Studio 14 2015
+    CONFIG: Release
+    JOBS_FLAG: "/m:"
+    EXE_DIR: '%CONFIG%'
+    DEPLOY: true
+    DEPLOY_NAME: wabt-%APPVEYOR_REPO_TAG_NAME%-win32.zip
   - GENERATOR: Visual Studio 14 2015 Win64
     CONFIG: Debug
     JOBS_FLAG: "/m:"


### PR DESCRIPTION
MSVC uses 53-bit precision for the x87 registers by default. In this
mode, it's not possible to properly round a large unsigned 64-bit
integer to a 32-bit float.

As a work-around, we can change the x87 floating-point precision, just
for these functions, and then reset it to the original precision.

A better solution may be to change the floating-point precision for the
entire program, though it's not clear what other effects that may have
on the generated code.

This change also re-enables the Appveyor 32-bit MSVC build.

Fixes issue #1113.