### PR TITLE
Fix assertion in WastLexer::IsCharClass()

### DIFF
--- a/src/wast-lexer.cc
+++ b/src/wast-lexer.cc
@@ -196,11 +196,11 @@ Token WastLexer::TextToken(TokenType token_type, size_t offset) {
 }
 
 int WastLexer::PeekChar() {
-  return cursor_ < buffer_end_ ? *cursor_ : kEof;
+  return cursor_ < buffer_end_ ? static_cast<uint8_t>(*cursor_) : kEof;
 }
 
 int WastLexer::ReadChar() {
-  return cursor_ < buffer_end_ ? *cursor_++ : kEof;
+  return cursor_ < buffer_end_ ? static_cast<uint8_t>(*cursor_++) : kEof;
 }
 
 bool WastLexer::MatchChar(char c) {

--- a/test/regress/regress-30.txt
+++ b/test/regress/regress-30.txt
@@ -1,0 +1,14 @@
+;;; TOOL: run-interp-spec
+(assert_malformed
+  (module quote "\80")
+  "")
+(;; STDOUT ;;;
+out/test/regress/regress-30.txt:3: assert_malformed passed:
+  out/test/regress/regress-30/regress-30.0.wat:1:1: error: unexpected char
+  €
+  ^
+  out/test/regress/regress-30/regress-30.0.wat:1:2: error: unexpected token "EOF", expected a module field or a command.
+  €
+   ^
+1/1 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
If `char` is signed, then conversion to `int` will keep the sign.
`IsCharClass()` uses this value as an index, so the value must be
unsigned.

Fixes issue #1117.