### PR TITLE
Change WABT_UNREACHABLE to call abort()

### DIFF
--- a/src/config.h.in
+++ b/src/config.h.in
@@ -18,6 +18,7 @@
 #define WABT_CONFIG_H_
 
 #include <stdint.h>
+#include <stdlib.h>
 
 /* TODO(binji): nice way to define these with WABT_ prefix? */
 
@@ -57,8 +58,6 @@
 #define alloca _alloca
 #elif defined(__MINGW32__)
 #include <malloc.h>
-#else
-#include <stdlib.h>
 #endif
 
 #if COMPILER_IS_CLANG || COMPILER_IS_GNU
@@ -93,8 +92,6 @@
 #define WABT_STATIC_ASSERT(x) _Static_assert((x), #x)
 #endif
 
-#define WABT_UNREACHABLE __builtin_unreachable()
-
 #elif COMPILER_IS_MSVC
 
 #include <intrin.h>
@@ -108,13 +105,13 @@
 #define WABT_LIKELY(x) (x)
 #define WABT_PRINTF_FORMAT(format_arg, first_arg)
 
-#define WABT_UNREACHABLE __assume(0)
-
 #else
 
 #error unknown compiler
 
 #endif
+
+#define WABT_UNREACHABLE abort()
 
 #ifdef __cplusplus
 


### PR DESCRIPTION
Using __builtin_unreachable instead will basically produce undefined
behavior if it is ever reached, which makes it very difficult to debug.
This is perhaps desired for an optimized build, but certainly not for a
debug build.

For now, we'll always convert these to abort().