### PR TITLE
Add support for ref.null in global initializers

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -240,6 +240,7 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnInitExprGlobalGetExpr(Index index, Index global_index) override;
   Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
+  Result OnInitExprRefNull(Index index) override;
 
  private:
   Location GetLocation() const;
@@ -1175,6 +1176,12 @@ Result BinaryReaderIR::OnInitExprI64ConstExpr(Index index, uint64_t value) {
   Location loc = GetLocation();
   current_init_expr_->push_back(
       MakeUnique<ConstExpr>(Const::I64(value, loc), loc));
+  return Result::Ok;
+}
+
+Result BinaryReaderIR::OnInitExprRefNull(Index index) {
+  Location loc = GetLocation();
+  current_init_expr_->push_back(MakeUnique<RefNullExpr>(loc));
   return Result::Ok;
 }
 

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -777,7 +777,9 @@ DEFINE_END(EndNamesSection)
 
 DEFINE_BEGIN(BeginRelocSection)
 DEFINE_END(EndRelocSection)
+
 DEFINE_INDEX_INDEX(OnInitExprGlobalGetExpr, "index", "global_index")
+DEFINE_INDEX(OnInitExprRefNull)
 
 DEFINE_BEGIN(BeginDylinkSection)
 DEFINE_INDEX(OnDylinkNeededCount)

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -339,6 +339,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnInitExprGlobalGetExpr(Index index, Index global_index) override;
   Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
+  Result OnInitExprRefNull(Index index) override;
 
  private:
   void Indent();

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -486,6 +486,9 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override {
     return Result::Ok;
   }
+  Result OnInitExprRefNull(Index index) override {
+    return Result::Ok;
+  }
 };
 
 }  // namespace wabt

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -683,6 +683,7 @@ enum class InitExprType {
   F64,
   V128,
   Global,
+  NullRef,
 };
 
 struct InitExpr {
@@ -821,6 +822,7 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnInitExprGlobalGetExpr(Index index, Index global_index) override;
   Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
+  Result OnInitExprRefNull(Index index) override;
 
   Result OnDylinkInfo(uint32_t mem_size,
                       uint32_t mem_align_log2,
@@ -1303,6 +1305,10 @@ void BinaryReaderObjdump::PrintInitExpr(const InitExpr& expr) {
       PrintDetails("\n");
       break;
     }
+    case InitExprType::NullRef: {
+      PrintDetails(" - init nullref\n");
+      break;
+    }
   }
 }
 
@@ -1319,6 +1325,7 @@ static Result InitExprToConstOffset(const InitExpr& expr,
     case InitExprType::F32:
     case InitExprType::F64:
     case InitExprType::V128:
+    case InitExprType::NullRef:
       fprintf(stderr, "Segment/Elem offset must be an i32 init expr");
       return Result::Error;
       break;
@@ -1388,6 +1395,13 @@ Result BinaryReaderObjdump::OnInitExprI64ConstExpr(Index index,
   InitExpr expr;
   expr.type = InitExprType::I64;
   expr.value.i64 = value;
+  HandleInitExpr(expr);
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdump::OnInitExprRefNull(Index index) {
+  InitExpr expr;
+  expr.type = InitExprType::NullRef;
   HandleInitExpr(expr);
   return Result::Ok;
 }

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -480,6 +480,10 @@ Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
       break;
     }
 
+    case Opcode::RefNull:
+      CALLBACK(OnInitExprRefNull, index);
+      break;
+
     case Opcode::End:
       return Result::Ok;
 

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -410,6 +410,7 @@ class BinaryReaderDelegate {
   virtual Result OnInitExprGlobalGetExpr(Index index, Index global_index) = 0;
   virtual Result OnInitExprI32ConstExpr(Index index, uint32_t value) = 0;
   virtual Result OnInitExprI64ConstExpr(Index index, uint64_t value) = 0;
+  virtual Result OnInitExprRefNull(Index index) = 0;
 
   const State* state = nullptr;
 };

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -245,6 +245,7 @@ class BinaryReaderInterp : public BinaryReaderNop {
                                        Index global_index) override;
   wabt::Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
   wabt::Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
+  wabt::Result OnInitExprRefNull(Index index) override;
 
  private:
   Label* GetLabel(Index depth);
@@ -1014,6 +1015,11 @@ wabt::Result BinaryReaderInterp::OnInitExprI64ConstExpr(Index index,
   init_expr_value_.type = Type::I64;
   init_expr_value_.value.i64 = value;
   return wabt::Result::Ok;
+}
+
+wabt::Result BinaryReaderInterp::OnInitExprRefNull(Index index) {
+  PrintError("ref.null global init expressions unimplemented by interpreter");
+  return wabt::Result::Error;
 }
 
 wabt::Result BinaryReaderInterp::OnExport(Index index,

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -1069,6 +1069,10 @@ void Validator::CheckConstInitExpr(const Location* loc,
         break;
       }
 
+      case ExprType::RefNull:
+        type = Type::Anyref;
+        break;
+      
       default:
         PrintConstExprError(loc, desc);
         return;

--- a/test/parse/module/global.txt
+++ b/test/parse/module/global.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --enable-reference-types
 (module
   (import "foo" "i32_global" (global i32))
   (import "foo" "i64_global" (global i64))
@@ -13,4 +14,6 @@
   (global i32 (get_global 0))
   (global i64 (get_global 1))
   (global f32 (get_global 2))
-  (global f64 (get_global 3)))
+  (global f64 (get_global 3))
+
+  (global anyref (ref.null)))


### PR DESCRIPTION
As per the reference-types spec, ref.null is a constant expression.

I did try to add support for ref.func at the same time, but I didn't really understand the strategy of wabt and reference types; there seems to be strong intertwingliness between func.ref and the element section, whereas it does seem possible for a func.ref to be global.  Oh well, I didn't need it :)