### PR TITLE
Fix some bugs w/ wast2json and SIMD

### DIFF
--- a/src/test-wast-parser.cc
+++ b/src/test-wast-parser.cc
@@ -37,7 +37,9 @@ Errors ParseInvalidModule(std::string text) {
   auto lexer = WastLexer::CreateBufferLexer("test", text.c_str(), text.size());
   Errors errors;
   std::unique_ptr<Module> module;
-  Result result = ParseWatModule(lexer.get(), &module, &errors);
+  Features features;
+  WastParseOptions options(features);
+  Result result = ParseWatModule(lexer.get(), &module, &errors, &options);
   EXPECT_EQ(Result::Error, result);
 
   return errors;

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -996,7 +996,8 @@ wabt::Result CommandRunner::ReadInvalidTextModule(string_view module_filename,
   Errors errors;
   if (Succeeded(result)) {
     std::unique_ptr<::Script> script;
-    result = ParseWastScript(lexer.get(), &script, &errors);
+    WastParseOptions options(s_features);
+    result = ParseWastScript(lexer.get(), &script, &errors, &options);
     if (Succeeded(result)) {
       wabt::Module* module = script->GetFirstModule();
       result = ResolveNamesModule(module, &errors);

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1851,12 +1851,10 @@ Result WastParser::ParseSimdV128Const(Const* const_, TokenType token_type) {
     Location loc = GetLocation();
 
     // Check that the lane literal type matches the element type of the v128:
-    if (integer) {
-      if (!(PeekMatch(TokenType::Int) || PeekMatch(TokenType::Nat))) {
+    if (!PeekMatch(TokenType::Int) && !PeekMatch(TokenType::Nat)) {
+      if (integer) {
         return ErrorExpected({"a Nat or Integer literal"}, "123");
-      }
-    } else {
-      if (!PeekMatch(TokenType::Float)) {
+      } else if (!PeekMatch(TokenType::Float)) {
         return ErrorExpected({"a Float literal"}, "42.0");
       }
     }
@@ -2600,6 +2598,7 @@ Result ParseWatModule(WastLexer* lexer,
                       Errors* errors,
                       WastParseOptions* options) {
   assert(out_module != nullptr);
+  assert(options != nullptr);
   WastParser parser(lexer, errors, options);
   return parser.ParseModule(out_module);
 }
@@ -2609,6 +2608,7 @@ Result ParseWastScript(WastLexer* lexer,
                        Errors* errors,
                        WastParseOptions* options) {
   assert(out_script != nullptr);
+  assert(options != nullptr);
   WastParser parser(lexer, errors, options);
   return parser.ParseScript(out_script);
 }

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -220,12 +220,12 @@ class WastParser {
 Result ParseWatModule(WastLexer* lexer,
                       std::unique_ptr<Module>* out_module,
                       Errors*,
-                      WastParseOptions* options = nullptr);
+                      WastParseOptions* options);
 
 Result ParseWastScript(WastLexer* lexer,
                        std::unique_ptr<Script>* out_script,
                        Errors*,
-                       WastParseOptions* options = nullptr);
+                       WastParseOptions* options);
 
 }  // namespace wabt
 

--- a/test/regress/regress-34.txt
+++ b/test/regress/regress-34.txt
@@ -1,0 +1,15 @@
+;;; TOOL: run-interp-spec
+;;; ARGS*: --enable-simd
+(module (func (v128.const f32x4  340282356779733623858607532500980858880 340282356779733623858607532500980858880
+                                 340282356779733623858607532500980858880 340282356779733623858607532500980858880) drop))
+(assert_malformed
+  (module quote "(func (v128.const i8x16 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100) drop)")
+  "constant out of range"
+)
+(;; STDOUT ;;;
+out/test/regress/regress-34.txt:6: assert_malformed passed:
+  out/test/regress/regress-34/regress-34.1.wat:1:25: error: invalid literal "0x100"
+  (func (v128.const i8x16 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100...
+                          ^^^^^
+1/1 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
* Never allow a null options pointer to `ParseWatModule` or
  `ParseWastScript`
* Allow a token of type Int or Nat when parsing a simd float const