### PR TITLE
Visit catch even when its body is empty

### DIFF
--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -95,12 +95,11 @@ Result ExprVisitor::VisitExpr(Expr* root_expr) {
         if (iter != try_expr->block.exprs.end()) {
           PushDefault(&*iter++);
         } else {
+          CHECK_RESULT(delegate_->OnCatchExpr(try_expr));
+          PopExprlist();
           if (try_expr->catch_.empty()) {
             CHECK_RESULT(delegate_->EndTryExpr(try_expr));
-            PopExprlist();
           } else {
-            CHECK_RESULT(delegate_->OnCatchExpr(try_expr));
-            PopExprlist();
             PushExprlist(State::Catch, expr, try_expr->catch_);
           }
         }

--- a/test/typecheck/bad-empty-catch.txt
+++ b/test/typecheck/bad-empty-catch.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-exceptions
+;;; ERROR: 1
+(module
+  (func
+    try
+    catch
+    end
+  ))
+(;; STDERR ;;;
+out/test/typecheck/bad-empty-catch.txt:7:5: error: type mismatch in try catch, expected [] but got [except_ref]
+    catch
+    ^^^^^
+;;; STDERR ;;)

--- a/test/typecheck/bad-empty-catch.txt
+++ b/test/typecheck/bad-empty-catch.txt
@@ -8,7 +8,7 @@
     end
   ))
 (;; STDERR ;;;
-out/test/typecheck/bad-empty-catch.txt:7:5: error: type mismatch in try catch, expected [] but got [except_ref]
+out/test/typecheck/bad-empty-catch.txt:7:5: error: type mismatch in try catch, expected [] but got [exnref]
     catch
     ^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
The current visitor does not visit `catch` itself when its body is
empty. So even if the attached test with an empty `catch` body is
supposed to be a validation failure (because an `exnref` value is left
on the stack in the `catch` body), it passed the validator.

In more detail, in the current code,
Input: (should be a validation failure)
```
try
catch   ;; this pushes an exnref value onto the stack
end
```

Output: (wrong, `catch` is missing)
```
try
end
```

Now we correctly visit `catch` even when its body is empty, this test
correctly causes a validation failure.