### PR TITLE
Rename except_ref type to exnref

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -384,7 +384,7 @@ bool BinaryReader::IsConcreteType(Type type) {
     case Type::V128:
       return options_.features.simd_enabled();
 
-    case Type::ExceptRef:
+    case Type::Exnref:
       return options_.features.exceptions_enabled();
 
     case Type::Anyref:

--- a/src/common.h
+++ b/src/common.h
@@ -207,18 +207,18 @@ struct Location {
 
 // Matches binary format, do not change.
 enum class Type : int32_t {
-  I32 = -0x01,        // 0x7f
-  I64 = -0x02,        // 0x7e
-  F32 = -0x03,        // 0x7d
-  F64 = -0x04,        // 0x7c
-  V128 = -0x05,       // 0x7b
-  Funcref = -0x10,    // 0x70
-  Anyref = -0x11,     // 0x6f
-  ExceptRef = -0x18,  // 0x68
-  Func = -0x20,       // 0x60
-  Void = -0x40,       // 0x40
-  ___ = Void,         // Convenient for the opcode table in opcode.h
-  Any = 0,            // Not actually specified, but useful for type-checking
+  I32 = -0x01,      // 0x7f
+  I64 = -0x02,      // 0x7e
+  F32 = -0x03,      // 0x7d
+  F64 = -0x04,      // 0x7c
+  V128 = -0x05,     // 0x7b
+  Funcref = -0x10,  // 0x70
+  Anyref = -0x11,   // 0x6f
+  Exnref = -0x18,   // 0x68
+  Func = -0x20,     // 0x60
+  Void = -0x40,     // 0x40
+  ___ = Void,       // Convenient for the opcode table in opcode.h
+  Any = 0,          // Not actually specified, but useful for type-checking
 };
 typedef std::vector<Type> TypeVector;
 
@@ -377,8 +377,8 @@ static WABT_INLINE const char* GetTypeName(Type type) {
       return "funcref";
     case Type::Func:
       return "func";
-    case Type::ExceptRef:
-      return "except_ref";
+    case Type::Exnref:
+      return "exnref";
     case Type::Void:
       return "void";
     case Type::Any:
@@ -412,7 +412,7 @@ static WABT_INLINE TypeVector GetInlineTypeVector(Type type) {
     case Type::V128:
     case Type::Funcref:
     case Type::Anyref:
-    case Type::ExceptRef:
+    case Type::Exnref:
       return TypeVector(&type, &type + 1);
 
     default:

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -385,7 +385,7 @@ Result TypeChecker::OnBrIf(Index depth) {
 }
 
 Result TypeChecker::OnBrOnExn(Index depth, const TypeVector& types) {
-  Result result = PopAndCheck1Type(Type::ExceptRef, "br_on_exn");
+  Result result = PopAndCheck1Type(Type::Exnref, "br_on_exn");
   Label* label;
   CHECK_RESULT(GetLabel(depth, &label));
   if (Failed(CheckTypes(types, label->br_types()))) {
@@ -394,7 +394,7 @@ Result TypeChecker::OnBrOnExn(Index depth, const TypeVector& types) {
                TypesToString(types).c_str());
     result = Result::Error;
   }
-  PushType(Type::ExceptRef);
+  PushType(Type::Exnref);
   return result;
 }
 
@@ -481,7 +481,7 @@ Result TypeChecker::OnCatch() {
   ResetTypeStackToLabel(label);
   label->label_type = LabelType::Catch;
   label->unreachable = false;
-  PushType(Type::ExceptRef);
+  PushType(Type::Exnref);
   return result;
 }
 
@@ -663,7 +663,7 @@ Result TypeChecker::OnRefIsNullExpr() {
 }
 
 Result TypeChecker::OnRethrow() {
-  Result result = PopAndCheck1Type(Type::ExceptRef, "rethrow");
+  Result result = PopAndCheck1Type(Type::Exnref, "rethrow");
   CHECK_RESULT(SetUnreachable());
   return result;
 }

--- a/test/parse/expr/bad-try-sig-multi.txt
+++ b/test/parse/expr/bad-try-sig-multi.txt
@@ -7,7 +7,7 @@
       i32.const 1
       i32.const 2
     catch
-      drop  ;; drop except_ref
+      drop  ;; drop exnref
       i32.const 3
       i32.const 4
     end
@@ -18,7 +18,7 @@
     try (param i32)
       drop
     catch
-      drop  ;; drop except_ref
+      drop  ;; drop exnref
     end
     return))
 (;; STDERR ;;;

--- a/test/parse/expr/try-multi.txt
+++ b/test/parse/expr/try-multi.txt
@@ -19,7 +19,7 @@
     try (param i32) (result i32)
       i32.eqz
     catch
-      drop  ;; no i32 param, just except_ref
+      drop  ;; no i32 param, just exnref
       i32.const 0
     end
     return)

--- a/test/typecheck/bad-br_on_exn-mismatch.txt
+++ b/test/typecheck/bad-br_on_exn-mismatch.txt
@@ -8,7 +8,7 @@
     br_on_exn 0 $e
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-br_on_exn-mismatch.txt:8:5: error: type mismatch in br_on_exn, expected [except_ref] but got [i32]
+out/test/typecheck/bad-br_on_exn-mismatch.txt:8:5: error: type mismatch in br_on_exn, expected [exnref] but got [i32]
     br_on_exn 0 $e
     ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-br_on_exn-result-mismatch.txt
+++ b/test/typecheck/bad-br_on_exn-result-mismatch.txt
@@ -9,7 +9,7 @@
       br_on_exn 0 $e
     end))
 (;; STDERR ;;;
-out/test/typecheck/bad-br_on_exn-result-mismatch.txt:8:5: error: type mismatch in try catch, expected [] but got [except_ref]
+out/test/typecheck/bad-br_on_exn-result-mismatch.txt:8:5: error: type mismatch in try catch, expected [] but got [exnref]
     catch
     ^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
In WebAssembly/exception-handling#79 we agreed to rename except_ref
type to exnref.