### PR TITLE
Attempt to locate Emscripten if EMSCRIPTEN_DIR is not set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ FUZZ_BIN_DIR ?= ${ROOT_DIR}/afl-fuzz
 GCC_FUZZ_CC := ${FUZZ_BIN_DIR}/afl-gcc
 GCC_FUZZ_CXX := ${FUZZ_BIN_DIR}/afl-g++
 EMSCRIPTEN_DIR ?= $(dir $(shell which emcc))
-EMSCRIPTEN_DIR ?= ${ROOT_DIR}/emscripten
 CMAKE_CMD ?= cmake
 
 DEFAULT_SUFFIX = clang-debug

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ USE_NINJA ?= 0
 FUZZ_BIN_DIR ?= ${ROOT_DIR}/afl-fuzz
 GCC_FUZZ_CC := ${FUZZ_BIN_DIR}/afl-gcc
 GCC_FUZZ_CXX := ${FUZZ_BIN_DIR}/afl-g++
+EMSCRIPTEN_DIR ?= $(dir $(shell which emcc))
 EMSCRIPTEN_DIR ?= ${ROOT_DIR}/emscripten
 CMAKE_CMD ?= cmake
 


### PR DESCRIPTION
This PR is an attempt to locate Emscripten automatically if it is in path, like when using emsdk, instead of having to set `EMSCRIPTEN_DIR` manually in order to run `make emscripten-release`. Not super important, just stumbled over this while trying to compile libwabt.js in a docker container.