### PR TITLE
Add wabt-unittests as dependency of run-tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -438,6 +438,7 @@ if (NOT EMSCRIPTEN)
       WORKING_DIRECTORY ${WABT_SOURCE_DIR}
       ${USES_TERMINAL}
     )
+    add_dependencies(run-tests wabt-unittests)
   endif ()
 
   # install


### PR DESCRIPTION
Without this, running `make test` will fail.

Fixes issue #1149.