### PR TITLE
Decompiler: Recurse into block exprs

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -290,6 +290,15 @@ struct Decompiler : ModuleContext {
           return;
         }
       }
+      case ExprType::Block: {
+        auto le = cast<BlockExpr>(&e);
+        DecompileExprs(le->block.exprs);
+        auto &val = stack.back();
+        IndentValue(val, indent_amount, {});
+        val.v.insert(val.v.begin(), "block {");
+        val.v.push_back("}");
+        return;
+      }
       case ExprType::Loop: {
         auto le = cast<LoopExpr>(&e);
         DecompileExprs(le->block.exprs);


### PR DESCRIPTION
Basically copy-pasted from loops, but this is simplest at the moment. I imagine we can extract a "bracketed expression list" pattern, and use that for ifs/loops/etc.