### PR TITLE
wasm-decompile: Output Tee as Set+Get instead if possible.

### DIFF
--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -113,7 +113,7 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
       return { 0, cast<BlockExpr>(&expr)->block.decl.sig.GetNumResults() };
 
     case ExprType::Br:
-      return { GetLabelArity(cast<BrExpr>(&expr)->var), 1 };
+      return { GetLabelArity(cast<BrExpr>(&expr)->var), 1, true };
 
     case ExprType::BrIf: {
       Index arity = GetLabelArity(cast<BrIfExpr>(&expr)->var);
@@ -124,7 +124,8 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
       return { 1, 1 };
 
     case ExprType::BrTable:
-      return { GetLabelArity(cast<BrTableExpr>(&expr)->default_target) + 1, 1 };
+      return { GetLabelArity(cast<BrTableExpr>(&expr)->default_target) + 1, 1,
+               true };
 
     case ExprType::Call: {
       const Var& var = cast<CallExpr>(&expr)->var;
@@ -133,7 +134,7 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
 
     case ExprType::ReturnCall: {
       const Var& var = cast<ReturnCallExpr>(&expr)->var;
-      return { GetFuncParamCount(var), GetFuncResultCount(var) };
+      return { GetFuncParamCount(var), GetFuncResultCount(var), true };
     }
 
     case ExprType::CallIndirect: {
@@ -145,7 +146,7 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
     case ExprType::ReturnCallIndirect: {
       const auto* rci_expr = cast<ReturnCallIndirectExpr>(&expr);
       return { rci_expr->decl.GetNumParams() + 1,
-               rci_expr->decl.GetNumResults() };
+               rci_expr->decl.GetNumResults(), true };
     }
 
     case ExprType::Const:
@@ -153,9 +154,11 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
     case ExprType::LocalGet:
     case ExprType::MemorySize:
     case ExprType::TableSize:
-    case ExprType::Unreachable:
     case ExprType::RefNull:
       return { 0, 1 };
+
+    case ExprType::Unreachable:
+      return { 0, 1, true };
 
     case ExprType::DataDrop:
     case ExprType::ElemDrop:
@@ -194,10 +197,11 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
 
     case ExprType::Return:
       return
-        { static_cast<Index>(current_func_->decl.sig.result_types.size()), 1 };
+        { static_cast<Index>(current_func_->decl.sig.result_types.size()), 1,
+          true };
 
     case ExprType::Rethrow:
-      return { 0, 0 };
+      return { 0, 0, true };
 
     case ExprType::AtomicRmwCmpxchg:
     case ExprType::AtomicWait:
@@ -210,7 +214,7 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
       if (Event* event = module.GetEvent(throw_->var)) {
         operand_count = event->decl.sig.param_types.size();
       }
-      return { operand_count, 0 };
+      return { operand_count, 0, true };
     }
 
     case ExprType::Try:

--- a/src/ir-util.h
+++ b/src/ir-util.h
@@ -56,7 +56,13 @@ struct ModuleContext {
   void BeginFunc(const Func& func);
   void EndFunc();
 
-  struct Arities { Index nargs; Index nreturns; };
+  struct Arities {
+    Index nargs;
+    Index nreturns;
+    bool unreachable;
+    Arities(Index na, Index nr, bool ur = false)
+      : nargs(na), nreturns(nr), unreachable(ur) {}
+  };
   Arities GetExprArity(const Expr& expr);
 
   const Module &module;

--- a/src/stream.cc
+++ b/src/stream.cc
@@ -232,6 +232,10 @@ FileStream::~FileStream() {
   }
 }
 
+void FileStream::Flush() {
+  if (file_) fflush(file_);
+}
+
 Result FileStream::WriteDataImpl(size_t at, const void* data, size_t size) {
   if (!file_) {
     return Result::Error;

--- a/src/stream.h
+++ b/src/stream.h
@@ -125,6 +125,8 @@ class Stream {
     WriteU8(static_cast<uint32_t>(value), desc, print_chars);
   }
 
+  virtual void Flush() {}
+
  protected:
   virtual Result WriteDataImpl(size_t offset,
                                const void* data,
@@ -193,6 +195,8 @@ class FileStream : public Stream {
   static std::unique_ptr<FileStream> CreateStderr();
 
   bool is_open() const { return file_ != nullptr; }
+
+  void Flush() override;
 
  protected:
   Result WriteDataImpl(size_t offset, const void* data, size_t size) override;


### PR DESCRIPTION
This really de-tangles the code, as in-line assignments are
hard to read.

To make this possible, I had to track the current stack depth, take
into account unreachable paths and a few other support features.

Also added debug output upon assert.