### PR TITLE
Run wasm-interp on specific (exported) functions

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -149,7 +149,7 @@ static void ParseOptions(int argc, char** argv) {
                       func.name = argument;
                       s_run_exports.push_back(func);
                     });
-  parser.AddOption('a', "argument", "ARGUMENT", "Add argument to a function execution.",
+  parser.AddOption('a', "argument", "ARGUMENT", "Add argument to a function execution",
                    [](const std::string& argument){
                       TypedValue tval;
                       ERROR_EXIT_UNLESS(!s_run_exports.empty(),

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -38,6 +38,8 @@ options:
   -V, --value-stack-size=SIZE                 Size in elements of the value stack
   -C, --call-stack-size=SIZE                  Size in elements of the call stack
   -t, --trace                                 Trace execution
+  -r, --run-export=FUNCTION                   Run exported function by name
+  -a, --argument=ARGUMENT                     Add argument to a function execution
       --run-all-exports                       Run all the exported functions, in order. Useful for testing
       --host-print                            Include an importable function named "host.print" for printing to stdout
       --dummy-import-func                     Provide a dummy implementation of all imported functions. The function will log the call and return an appropriate zero value.


### PR DESCRIPTION
Closes: #198 

Minor changes allowing 'wasm-interp' to be executed for specific exported
wasm functions. Example syntax:

```
./wasm-interp                              \
-r "my_func" -a "i32:1" -a "i32:2", etc... \
file.wasm

./wasm-interp          \
-r "func_A" -a "f32:1" \
-r "func_A" -a "f32:2" \
-r "func_B" -a "i64:1" \
file.wasm
```

Currently supported types: i32, i64, f32, f64