### PR TITLE
Add `--version` to wabt tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,6 +68,22 @@ include(CheckTypeSize)
 check_type_size(ssize_t SSIZE_T)
 check_type_size(size_t SIZEOF_SIZE_T)
 
+FIND_PACKAGE(Git QUIET REQUIRED)
+EXECUTE_PROCESS(COMMAND
+        "${GIT_EXECUTABLE}" --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git describe --tags
+        RESULT_VARIABLE
+            GIT_HASH_RESULT
+        OUTPUT_VARIABLE
+            GIT_HASH
+        OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+IF(${GIT_HASH_RESULT})
+    MESSAGE(WARNING "Error running git describe to determine version")
+    SET(WABT_VERSION_INFO "(unable to determine version)")
+ELSE()
+    SET(WABT_VERSION_INFO "${GIT_HASH}")
+ENDIF()
+
 configure_file(
   ${WABT_SOURCE_DIR}/src/config.h.in
   ${WABT_BINARY_DIR}/config.h

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,6 +20,8 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#cmakedefine WABT_VERSION_INFO "${WABT_VERSION_INFO}"
+
 /* TODO(binji): nice way to define these with WABT_ prefix? */
 
 /* Whether <alloca.h> is available */

--- a/src/option-parser.cc
+++ b/src/option-parser.cc
@@ -96,6 +96,13 @@ void OptionParser::AddHelpOption() {
   });
 }
 
+void OptionParser::AddVersionOption() {
+  AddOption("version", "Print version information", [this]() {
+    printf("%s\n", WABT_VERSION_INFO);
+    exit(0);
+  });
+}
+
 void OptionParser::SetErrorCallback(const Callback& callback) {
   on_error_ = callback;
 }

--- a/src/option-parser.cc
+++ b/src/option-parser.cc
@@ -50,6 +50,10 @@ OptionParser::OptionParser(const char* program_name, const char* description)
     : program_name_(program_name),
       description_(description),
       on_error_([this](const std::string& message) { DefaultError(message); }) {
+
+  // Add common options
+  AddHelpOption();
+  AddVersionOption();
 }
 
 void OptionParser::AddOption(const Option& option) {

--- a/src/option-parser.h
+++ b/src/option-parser.h
@@ -78,10 +78,10 @@ class OptionParser {
                  const char* metavar,
                  const char* help,
                  const Callback&);
-  void AddHelpOption();
-  void AddVersionOption();
 
  private:
+  void AddHelpOption();
+  void AddVersionOption();
   static int Match(const char* s, const std::string& full, bool has_argument);
   void WABT_PRINTF_FORMAT(2, 3) Errorf(const char* format, ...);
   void HandleArgument(size_t* arg_index, const char* arg_value);

--- a/src/option-parser.h
+++ b/src/option-parser.h
@@ -79,6 +79,7 @@ class OptionParser {
                  const char* help,
                  const Callback&);
   void AddHelpOption();
+  void AddVersionOption();
 
  private:
   static int Match(const char* s, const std::string& full, bool has_argument);

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -71,6 +71,7 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption('V', "value-stack-size", "SIZE",
                    "Size in elements of the value stack",

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -70,8 +70,6 @@ static void ParseOptions(int argc, char** argv) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption('V', "value-stack-size", "SIZE",
                    "Size in elements of the value stack",

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -52,8 +52,6 @@ int ProgramMain(int argc, char** argv) {
       "  # parse binary file test.wasm and write text file test.dcmp\n"
       "  $ wasm-decompile test.wasm -o test.dcmp\n";
     OptionParser parser("wasm-decompile", s_description);
-    parser.AddHelpOption();
-    parser.AddVersionOption();
     parser.AddOption(
         'o', "output", "FILENAME",
         "Output file for the decompiled file, by default use stdout",

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -53,6 +53,7 @@ int ProgramMain(int argc, char** argv) {
       "  $ wasm-decompile test.wasm -o test.dcmp\n";
     OptionParser parser("wasm-decompile", s_description);
     parser.AddHelpOption();
+    parser.AddVersionOption();
     parser.AddOption(
         'o', "output", "FILENAME",
         "Output file for the decompiled file, by default use stdout",

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -83,8 +83,6 @@ static void ParseOptions(int argc, char** argv) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption('V', "value-stack-size", "SIZE",
                    "Size in elements of the value stack",

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -84,6 +84,7 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption('V', "value-stack-size", "SIZE",
                    "Size in elements of the value stack",

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -61,6 +61,7 @@ static void ParseOptions(int argc, char** argv) {
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",
                    []() { s_objdump_options.relocs = true; });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddArgument(
       "filename", OptionParser::ArgumentCount::OneOrMore,
       [](const char* argument) { s_infiles.push_back(argument); });

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -60,8 +60,6 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_objdump_options.details = true; });
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",
                    []() { s_objdump_options.relocs = true; });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddArgument(
       "filename", OptionParser::ArgumentCount::OneOrMore,
       [](const char* argument) { s_infiles.push_back(argument); });

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -61,6 +61,7 @@ static void ParseOptions(int argc, char** argv) {
     s_read_binary_options.log_stream = s_log_stream.get();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption('o', "output", "FILENAME",
                    "Output file for the opcode counts, by default use stdout",

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -60,8 +60,6 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
     s_read_binary_options.log_stream = s_log_stream.get();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption('o', "output", "FILENAME",
                    "Output file for the opcode counts, by default use stdout",

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -37,8 +37,6 @@ examples:
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-strip", s_description);
 
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) {
                        s_filename = argument;

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -38,6 +38,7 @@ static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm-strip", s_description);
 
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) {
                        s_filename = argument;

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -53,6 +53,7 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -52,8 +52,6 @@ static void ParseOptions(int argc, char** argv) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   s_features.AddOptions(&parser);
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -62,8 +62,6 @@ static void ParseOptions(int argc, char** argv) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddOption(
       'o', "output", "FILENAME",
       "Output file for the generated C source file, by default use stdout",

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -63,6 +63,7 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddOption(
       'o', "output", "FILENAME",
       "Output file for the generated C source file, by default use stdout",

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -64,8 +64,6 @@ static void ParseOptions(int argc, char** argv) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddOption(
       'o', "output", "FILENAME",
       "Output file for the generated wast file, by default use stdout",

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -65,6 +65,7 @@ static void ParseOptions(int argc, char** argv) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddOption(
       'o', "output", "FILENAME",
       "Output file for the generated wast file, by default use stdout",

--- a/src/tools/wast2json.cc
+++ b/src/tools/wast2json.cc
@@ -65,8 +65,6 @@ static void ParseOptions(int argc, char* argv[]) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddOption("debug-parser", "Turn on debugging the parser of wast files",
                    []() { s_debug_parsing = true; });
   s_features.AddOptions(&parser);

--- a/src/tools/wast2json.cc
+++ b/src/tools/wast2json.cc
@@ -66,6 +66,7 @@ static void ParseOptions(int argc, char* argv[]) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddOption("debug-parser", "Turn on debugging the parser of wast files",
                    []() { s_debug_parsing = true; });
   s_features.AddOptions(&parser);

--- a/src/tools/wat-desugar.cc
+++ b/src/tools/wat-desugar.cc
@@ -59,8 +59,6 @@ examples:
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wat-desugar", s_description);
 
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddOption('o', "output", "FILE", "Output file for the formatted file",
                    [](const char* argument) { s_outfile = argument; });
   parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",

--- a/src/tools/wat-desugar.cc
+++ b/src/tools/wat-desugar.cc
@@ -60,6 +60,7 @@ static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wat-desugar", s_description);
 
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddOption('o', "output", "FILE", "Output file for the formatted file",
                    [](const char* argument) { s_outfile = argument; });
   parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -72,6 +72,7 @@ static void ParseOptions(int argc, char* argv[]) {
     s_log_stream = FileStream::CreateStdout();
   });
   parser.AddHelpOption();
+  parser.AddVersionOption();
   parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",
                    []() { s_debug_parsing = true; });
   parser.AddOption('d', "dump-module",

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -71,8 +71,6 @@ static void ParseOptions(int argc, char* argv[]) {
     s_verbose++;
     s_log_stream = FileStream::CreateStdout();
   });
-  parser.AddHelpOption();
-  parser.AddVersionOption();
   parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",
                    []() { s_debug_parsing = true; });
   parser.AddOption('d', "dump-module",

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -10,9 +10,9 @@ examples:
   $ spectest-interp test.json
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -12,6 +12,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -21,9 +21,9 @@ examples:
   $ wasm-interp test.wasm -V 100 --run-all-exports
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -23,6 +23,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -9,6 +9,8 @@ examples:
   $ wasm-objdump test.wasm
 
 options:
+      --help                   Print this help message
+      --version                Print version information
   -h, --headers                Print headers
   -j, --section=SECTION        Select just one section
   -s, --full-contents          Print raw section contents
@@ -16,6 +18,4 @@ options:
       --debug                  Print extra debug information
   -x, --details                Show section details
   -r, --reloc                  Show relocations inline with disassembly
-      --help                   Print this help message
-      --version                Print version information
 ;;; STDOUT ;;)

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -17,4 +17,5 @@ options:
   -x, --details                Show section details
   -r, --reloc                  Show relocations inline with disassembly
       --help                   Print this help message
+      --version                Print version information
 ;;; STDOUT ;;)

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -13,6 +13,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -11,9 +11,9 @@ examples:
   $ wasm-opcodecnt test.wasm -o test.dist
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -10,9 +10,9 @@ examples:
   $ wasm-validate test.wasm
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -12,6 +12,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals
       --enable-saturating-float-to-int        Enable Saturating float-to-int operators

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -16,6 +16,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
   -o, --output=FILENAME                       Output file for the generated wast file, by default use stdout
   -f, --fold-exprs                            Write folded expressions where possible
       --enable-exceptions                     Enable Experimental exception handling

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -14,9 +14,9 @@ examples:
   $ wasm2wat test.wasm --no-debug-names -o test.wat
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
   -o, --output=FILENAME                       Output file for the generated wast file, by default use stdout
   -f, --fold-exprs                            Write folded expressions where possible
       --enable-exceptions                     Enable Experimental exception handling

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -12,9 +12,9 @@ examples:
   $ wast2json spec-test.wast -o spec-test.json
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
       --debug-parser                          Turn on debugging the parser of wast files
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -14,6 +14,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
       --debug-parser                          Turn on debugging the parser of wast files
       --enable-exceptions                     Enable Experimental exception handling
       --disable-mutable-globals               Disable Import/export mutable globals

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -17,6 +17,7 @@ examples:
 
 options:
       --help                                  Print this help message
+      --version                               Print version information
   -o, --output=FILE                           Output file for the formatted file
       --debug-parser                          Turn on debugging the parser of wat files
   -f, --fold-exprs                            Write folded expressions where possible

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -20,6 +20,7 @@ examples:
 options:
   -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
+      --version                               Print version information
       --debug-parser                          Turn on debugging the parser of wat files
   -d, --dump-module                           Print a hexdump of the module to stdout
       --enable-exceptions                     Enable Experimental exception handling

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -18,9 +18,9 @@ examples:
   $ wat2wasm spec-test.wast -v
 
 options:
-  -v, --verbose                               Use multiple times for more info
       --help                                  Print this help message
       --version                               Print version information
+  -v, --verbose                               Use multiple times for more info
       --debug-parser                          Turn on debugging the parser of wat files
   -d, --dump-module                           Print a hexdump of the module to stdout
       --enable-exceptions                     Enable Experimental exception handling


### PR DESCRIPTION
Closes: #1106

Ported versioning system from [Binaryen CMakeLists.txt](https://github.com/WebAssembly/binaryen/blob/dc31b460fef47dfb3415b4ae6276fff4919a03e2/CMakeLists.txt#L10-L23)

```
bin/wasm2c --version
1.0.11-44-g71f883ad
```

Applied to (all) tools in `src/tools/`.