### PR TITLE
wasm-objdump: Fix type signature for multi-value result types

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1029,10 +1029,23 @@ Result BinaryReaderObjdump::OnType(Index index,
     printf("%s", GetTypeName(param_types[i]));
   }
   printf(") -> ");
-  if (result_count) {
-    printf("%s", GetTypeName(result_types[0]));
-  } else {
-    printf("nil");
+  switch (result_count) {
+    case 0:
+      printf("nil");
+      break;
+    case 1:
+      printf("%s", GetTypeName(result_types[0]));
+      break;
+    default:
+      printf("(");
+      for (Index i = 0; i < result_count; i++) {
+        if (i != 0) {
+          printf(", ");
+        }
+        printf("%s", GetTypeName(result_types[i]));
+      }
+      printf(")");
+      break;
   }
   printf("\n");
   return Result::Ok;

--- a/test/dump/func-result-multi.txt
+++ b/test/dump/func-result-multi.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-objdump
 ;;; ARGS0: -v --enable-multi-value
+;;; ARGS1: -x
 (module
   (func (result i32 i64)
     i32.const 0
@@ -40,6 +41,15 @@
 0000015: 08                                        ; FIXUP section size
 
 func-result-multi.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type[1]:
+ - type[0] () -> (i32, i64)
+Function[1]:
+ - func[0] sig=0
+Code[1]:
+ - func[0] size=6
 
 Code Disassembly:
 


### PR DESCRIPTION
Previously only the first result type was printed, even for multiple results.

This change prints multiple result types in parenthesized form whereas single result types are printed as before.

The `func-result-multi.txt` test case is modified to cover the Type section as well.