### PR TITLE
wasm-objdump: Print `br_table` immediates

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -634,8 +634,14 @@ Result BinaryReaderObjdumpDisassemble::OnBrTableExpr(
     Index* target_depths,
     Index default_target_depth) {
   Offset immediate_len = state->offset - current_opcode_offset;
-  /* TODO(sbc): Print targets */
-  LogOpcode(immediate_len, nullptr);
+
+  std::string buffer = std::string();
+  for (Index i = 0; i < num_targets; i++) {
+    buffer.append(std::to_string(target_depths[i])).append(" ");
+  }
+  buffer.append(std::to_string(default_target_depth));
+
+  LogOpcode(immediate_len, "%s", buffer.c_str());
   return Result::Ok;
 }
 

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -50,7 +50,7 @@ Code Disassembly:
 000016 func[0]:
  000017: 02 40                      | block
  000019: 41 00                      |   i32.const 0
- 00001b: 0e 00 00                   |   br_table
+ 00001b: 0e 00 00                   |   br_table 0
  00001e: 0b                         | end
  00001f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -85,7 +85,7 @@ Code Disassembly:
  000019: 02 40                      |   block
  00001b: 02 40                      |     block
  00001d: 41 00                      |       i32.const 0
- 00001f: 0e 02 00 01 00             |       br_table
+ 00001f: 0e 02 00 01 00             |       br_table 0 1 0
  000024: 0b                         |     end
  000025: 41 01                      |     i32.const 1
  000027: 1a                         |     drop


### PR DESCRIPTION
Print missing `br_table` immediates