### PR TITLE
wasm-decompile: Refactored code to first build an AST.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,7 @@ add_library(wabt STATIC
   src/config.h
   src/config.cc
   src/decompiler.h
+  src/decompiler-ast.inl
   src/decompiler.cc
   src/error-formatter.h
   src/error-formatter.cc

--- a/src/decompiler-ast.inl
+++ b/src/decompiler-ast.inl
@@ -1,0 +1,258 @@
+/*
+ * Copyright 2016 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cinttypes>
+#include <cstdarg>
+#include <cstdio>
+#include <iterator>
+#include <map>
+#include <numeric>
+#include <set>
+#include <string>
+#include <vector>
+#include <sstream>
+
+#include "src/cast.h"
+#include "src/common.h"
+#include "src/expr-visitor.h"
+#include "src/ir.h"
+#include "src/ir-util.h"
+#include "src/literal.h"
+#include "src/generate-names.h"
+#include "src/stream.h"
+
+namespace wabt {
+
+enum class NodeType {
+  PushAll,
+  Pop,
+  Statements,
+  EndReturn,
+  Decl,
+  DeclInit,
+  Expr
+};
+
+// The AST we're going to convert the standard IR into.
+struct Node {
+  NodeType ntype;
+  ExprType etype;  // Only if ntype == Expr.
+  const Expr* e;
+  std::vector<Node> children;
+  // Node specific annotations.
+  union {
+    LabelType lt;  // br/br_if target.
+  };
+
+  Node()
+    : ntype(NodeType::Expr), etype(ExprType::Nop), e(nullptr),
+      lt(LabelType::First) {}
+  Node(NodeType ntype, ExprType etype, const Expr* e)
+    : ntype(ntype), etype(etype), e(e), lt(LabelType::First) {}
+
+  // This value should really never be copied, only moved.
+  Node(Node&& rhs) = default;
+  Node(const Node& rhs) = delete;
+  Node& operator=(Node&& rhs) = default;
+  Node& operator=(const Node& rhs) = delete;
+};
+
+struct AST {
+  AST(ModuleContext& mc, const Func *f) : mc(mc), f(f) {
+    if (f) {
+      mc.BeginFunc(*f);
+      for (Index i = 0; i < f->GetNumParams(); i++) {
+        auto name = IndexToAlphaName(i);
+        vars_defined.insert(name);
+      }
+    }
+  }
+
+  ~AST() {
+    if (f) mc.EndFunc();
+  }
+
+  void NewNode(NodeType ntype, ExprType etype, const Expr* e, Index nargs) {
+    assert(stack.size() >= nargs);
+    Node n { ntype, etype, e };
+    n.children.reserve(nargs);
+    std::move(stack.end() - nargs, stack.end(),
+              std::back_inserter(n.children));
+    stack.resize(stack.size() - nargs);
+    stack.push_back(std::move(n));
+  }
+
+  template<ExprType T> void PreDecl(const VarExpr<T>& ve) {
+    stack.emplace(stack.begin() + pre_decl_insertion_point++,
+                  NodeType::Decl, ExprType::Nop, &ve);
+  }
+
+  template<ExprType T> void Get(const VarExpr<T>& ve, bool local) {
+    if (local && vars_defined.insert(ve.var.name()).second) {
+      // Use before def, may happen since locals are guaranteed 0.
+      PreDecl(ve);
+    }
+    NewNode(NodeType::Expr, T, &ve, 0);
+  }
+
+  template<ExprType T> void Set(const VarExpr<T>& ve, bool local) {
+    // Seen this var before?
+    if (local && vars_defined.insert(ve.var.name()).second) {
+      if (stack_depth == 1) {
+        // Top level, declare it here.
+        NewNode(NodeType::DeclInit, ExprType::Nop, &ve, 1);
+        return;
+      } else {
+        // Inside exp, better leave it as assignment exp and lift the decl out.
+        PreDecl(ve);
+      }
+    }
+    NewNode(NodeType::Expr, T, &ve, 1);
+  }
+
+  template<ExprType T> void Block(const BlockExprBase<T>& be, LabelType label) {
+    mc.BeginBlock(label, be.block);
+    Construct(be.block.exprs, be.block.decl.GetNumResults(), false);
+    mc.EndBlock();
+    NewNode(NodeType::Expr, T, &be, 1);
+  }
+
+  void Construct(const Expr& e) {
+    auto arity = mc.GetExprArity(e);
+    switch (e.type()) {
+      case ExprType::LocalGet: {
+        Get(*cast<LocalGetExpr>(&e), true);
+        return;
+      }
+      case ExprType::GlobalGet: {
+        Get(*cast<GlobalGetExpr>(&e), false);
+        return;
+      }
+      case ExprType::LocalSet: {
+        Set(*cast<LocalSetExpr>(&e), true);
+        return;
+      }
+      case ExprType::GlobalSet: {
+        Set(*cast<GlobalSetExpr>(&e), false);
+        return;
+      }
+      case ExprType::LocalTee: {
+        auto& lt = *cast<LocalTeeExpr>(&e);
+        Set(lt, true);
+        if (stack_depth == 1) {  // Tee is the only thing on there.
+          Get(lt, true);  // Now Set + Get instead.
+        } else {
+          // Things are above us on the stack so the Tee can't be eliminated.
+          // The Set makes this work as a Tee when consumed by a parent.
+        }
+        return;
+      }
+      case ExprType::If: {
+        auto ife = cast<IfExpr>(&e);
+        stack_depth--;  // Condition.
+        mc.BeginBlock(LabelType::Block, ife->true_);
+        Construct(ife->true_.exprs, ife->true_.decl.GetNumResults(), false);
+        if (!ife->false_.empty()) {
+          Construct(ife->false_, ife->true_.decl.GetNumResults(), false);
+        }
+        mc.EndBlock();
+        stack_depth++;  // Put Condition back.
+        NewNode(NodeType::Expr, ExprType::If, &e, ife->false_.empty() ? 2 : 3);
+        return;
+      }
+      case ExprType::Block: {
+        Block(*cast<BlockExpr>(&e), LabelType::Block);
+        return;
+      }
+      case ExprType::Loop: {
+        Block(*cast<LoopExpr>(&e), LabelType::Loop);
+        return;
+      }
+      case ExprType::Br: {
+        NewNode(NodeType::Expr, ExprType::Br, &e, 0);
+        stack.back().lt = mc.GetLabel(cast<BrExpr>(&e)->var)->label_type;
+        return;
+      }
+      case ExprType::BrIf: {
+        NewNode(NodeType::Expr, ExprType::BrIf, &e, 1);
+        stack.back().lt = mc.GetLabel(cast<BrIfExpr>(&e)->var)->label_type;
+        return;
+      }
+      default: {
+        NewNode(NodeType::Expr, e.type(), &e, mc.GetExprArity(e).nargs);
+        return;
+      }
+    }
+    NewNode(NodeType::Expr, e.type(), &e, arity.nargs);
+  }
+
+  void Construct(const ExprList& es, Index nresults, bool return_results) {
+    auto start = stack.size();
+    auto stack_depth_start = stack_depth;
+    bool unreachable = false;
+    for (auto& e : es) {
+      Construct(e);
+      auto arity = mc.GetExprArity(e);
+      stack_depth -= arity.nargs;
+      stack_depth += arity.nreturns;
+      unreachable = unreachable || arity.unreachable;
+      assert(unreachable || stack_depth >= 0);
+      if (arity.nreturns > 1) {
+        // Multivalue: we "push" everything on to the stack.
+        NewNode(NodeType::PushAll, ExprType::Nop, nullptr, 1);
+        // All values become pops.
+        for (Index i = 0; i < arity.nreturns; i++)
+          NewNode(NodeType::Pop, ExprType::Nop, nullptr, 0);
+        // TODO: can also implement a push_all_but_one that returns the top,
+        // then insert N-1 pops below it. Or have a function that returns N
+        // values direcly to N arguments for when structs are passed on,
+        // etc.
+      }
+    }
+    assert(unreachable ||
+           stack_depth - stack_depth_start == static_cast<int>(nresults));
+    // Undo any changes to stack_depth, since parent takes care of arity
+    // changes.
+    stack_depth = stack_depth_start;
+    auto end = stack.size();
+    assert(end >= start);
+    if (return_results && nresults) {
+      // Combine nresults into a return statement, for when this is used as
+      // a function body.
+      // TODO: if this is some other kind of block and >1 value is being
+      // returned, probably need some kind of syntax to make that clearer.
+      NewNode(NodeType::EndReturn, ExprType::Nop, nullptr, nresults);
+    }
+    end = stack.size();
+    assert(end >= start);
+    auto size = end - start;
+    if (size != 1) {
+      NewNode(NodeType::Statements, ExprType::Nop, nullptr, size);
+    }
+  }
+
+  ModuleContext& mc;
+  std::vector<Node> stack;
+  const Func *f;
+  size_t pre_decl_insertion_point = 0;
+  int stack_depth = 0;
+  std::set<std::string> vars_defined;
+};
+
+}  // namespace wabt

--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -40,23 +40,23 @@
 
 using namespace wabt;
 
-Label* ModuleContext::GetLabel(const Var& var) {
+const Label* ModuleContext::GetLabel(const Var& var) const {
   if (var.is_name()) {
     for (Index i = GetLabelStackSize(); i > 0; --i) {
-      Label* label = &label_stack_[i - 1];
+      auto label = &label_stack_[i - 1];
       if (label->name == var.name()) {
         return label;
       }
     }
   } else if (var.index() < GetLabelStackSize()) {
-    Label* label = &label_stack_[GetLabelStackSize() - var.index() - 1];
+    auto label = &label_stack_[GetLabelStackSize() - var.index() - 1];
     return label;
   }
   return nullptr;
 }
 
-Index ModuleContext::GetLabelArity(const Var& var) {
-  Label* label = GetLabel(var);
+Index ModuleContext::GetLabelArity(const Var& var) const {
+  auto label = GetLabel(var);
   if (!label) {
     return 0;
   }
@@ -65,12 +65,12 @@ Index ModuleContext::GetLabelArity(const Var& var) {
                                               : label->result_types.size();
 }
 
-Index ModuleContext::GetFuncParamCount(const Var& var) {
+Index ModuleContext::GetFuncParamCount(const Var& var) const {
   const Func* func = module.GetFunc(var);
   return func ? func->GetNumParams() : 0;
 }
 
-Index ModuleContext::GetFuncResultCount(const Var& var) {
+Index ModuleContext::GetFuncResultCount(const Var& var) const {
   const Func* func = module.GetFunc(var);
   return func ? func->GetNumResults() : 0;
 }
@@ -95,7 +95,7 @@ void ModuleContext::EndFunc() {
   current_func_ = nullptr;
 }
 
-ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) {
+ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
   switch (expr.type()) {
     case ExprType::AtomicNotify:
     case ExprType::AtomicRmw:

--- a/src/ir-util.h
+++ b/src/ir-util.h
@@ -41,15 +41,15 @@ struct Label {
 struct ModuleContext {
   ModuleContext(const Module &module) : module(module) {}
 
-  Index GetLabelStackSize() { return label_stack_.size(); }
-  Label* GetLabel(const Var& var);
-  Index GetLabelArity(const Var& var);
+  Index GetLabelStackSize() const { return label_stack_.size(); }
+  const Label* GetLabel(const Var& var) const;
+  Index GetLabelArity(const Var& var) const;
   void SetTopLabelType(LabelType label_type) {
     label_stack_.back().label_type = label_type;
   }
 
-  Index GetFuncParamCount(const Var& var);
-  Index GetFuncResultCount(const Var& var);
+  Index GetFuncParamCount(const Var& var) const;
+  Index GetFuncResultCount(const Var& var) const;
 
   void BeginBlock(LabelType label_type, const Block& block);
   void EndBlock();
@@ -63,7 +63,7 @@ struct ModuleContext {
     Arities(Index na, Index nr, bool ur = false)
       : nargs(na), nreturns(nr), unreachable(ur) {}
   };
-  Arities GetExprArity(const Expr& expr);
+  Arities GetExprArity(const Expr& expr) const;
 
   const Module &module;
  private:


### PR DESCRIPTION
This will pave the way for a better multi-pass analysis that
can collect information for the final output pass.