### PR TITLE
Add option to wasm2wat for using names from custom linking section

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1126,11 +1126,11 @@ Result BinaryReaderIR::OnFunctionSymbol(Index index,
       return Result::Ok;
     }
 
+    std::string func_name = name.to_string();
     Func* func = module_->funcs[function_index];
-    std::string dollar_name =
-      GetUniqueName(&module_->func_bindings, MakeDollarName(name));
-    func->name = dollar_name;
-    module_->func_bindings.emplace(dollar_name, Binding(function_index));
+    GetUniqueName(&module_->func_bindings, func_name);
+    func->name = func_name;
+    module_->func_bindings.emplace(func_name, Binding(function_index));
   }
 
   return Result::Ok;

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1776,7 +1776,7 @@ Result ReadBinaryObjdump(const uint8_t* data,
   const bool kReadDebugNames = true;
   const bool kStopOnFirstError = false;
   const bool kFailOnCustomSectionError = false;
-  const bool kUseLinkingNames = true;
+  const LinkingNameStrategy kUseLinkingNames = LinkingNameStrategy::USE_PURE_LINKING_NAMES;
   ReadBinaryOptions read_options(features, options->log_stream, kReadDebugNames,
                                  kStopOnFirstError, kFailOnCustomSectionError, kUseLinkingNames);
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1776,8 +1776,9 @@ Result ReadBinaryObjdump(const uint8_t* data,
   const bool kReadDebugNames = true;
   const bool kStopOnFirstError = false;
   const bool kFailOnCustomSectionError = false;
+  const bool kUseLinkingNames = true;
   ReadBinaryOptions read_options(features, options->log_stream, kReadDebugNames,
-                                 kStopOnFirstError, kFailOnCustomSectionError);
+                                 kStopOnFirstError, kFailOnCustomSectionError, kUseLinkingNames);
 
   switch (options->mode) {
     case ObjdumpMode::Prepass: {

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -31,6 +31,7 @@
 #include "src/leb128.h"
 #include "src/stream.h"
 #include "src/utf8.h"
+#include "src/generate-names.h"
 
 #if HAVE_ALLOCA
 #include <alloca.h>
@@ -1712,8 +1713,16 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
                 CHECK_RESULT(ReadStr(&name, "symbol name"));
               switch (sym_type) {
                 case SymbolType::Function:
-                  if (options_.read_linking_names) {
-                    CALLBACK(OnFunctionSymbol, i, flags, name, index);
+                  if (options_.read_linking_names != LinkingNameStrategy::DONT_USE_LINKING_NAMES) {
+                    bool prepend_dollar = (options_.read_linking_names == LinkingNameStrategy::USE_LINKING_NAMES_WITH_DOLLAR);
+
+                    std::string function_name = name.to_string();
+
+                    if (prepend_dollar) {
+                      function_name = wabt::GenerateNameWithDollar(name.to_string(), index);
+                    }
+
+                    CALLBACK(OnFunctionSymbol, i, flags, function_name, index);
                   }
                   break;
                 case SymbolType::Global:

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1712,7 +1712,9 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
                 CHECK_RESULT(ReadStr(&name, "symbol name"));
               switch (sym_type) {
                 case SymbolType::Function:
-                  CALLBACK(OnFunctionSymbol, i, flags, name, index);
+                  if (options_.read_linking_names) {
+                    CALLBACK(OnFunctionSymbol, i, flags, name, index);
+                  }
                   break;
                 case SymbolType::Global:
                   CALLBACK(OnGlobalSymbol, i, flags, name, index);

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -37,18 +37,21 @@ struct ReadBinaryOptions {
                     Stream* log_stream,
                     bool read_debug_names,
                     bool stop_on_first_error,
-                    bool fail_on_custom_section_error)
+                    bool fail_on_custom_section_error,
+                    bool read_linking_names)
       : features(features),
         log_stream(log_stream),
         read_debug_names(read_debug_names),
         stop_on_first_error(stop_on_first_error),
-        fail_on_custom_section_error(fail_on_custom_section_error) {}
+        fail_on_custom_section_error(fail_on_custom_section_error),
+        read_linking_names(read_linking_names) {}
 
   Features features;
   Stream* log_stream = nullptr;
   bool read_debug_names = false;
   bool stop_on_first_error = true;
   bool fail_on_custom_section_error = true;
+  bool read_linking_names = true;
 };
 
 class BinaryReaderDelegate {

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -31,6 +31,10 @@ namespace wabt {
 
 class Stream;
 
+enum class LinkingNameStrategy {DONT_USE_LINKING_NAMES,
+                                USE_PURE_LINKING_NAMES,
+                                USE_LINKING_NAMES_WITH_DOLLAR};
+
 struct ReadBinaryOptions {
   ReadBinaryOptions() = default;
   ReadBinaryOptions(const Features& features,
@@ -38,7 +42,7 @@ struct ReadBinaryOptions {
                     bool read_debug_names,
                     bool stop_on_first_error,
                     bool fail_on_custom_section_error,
-                    bool read_linking_names)
+                    LinkingNameStrategy read_linking_names)
       : features(features),
         log_stream(log_stream),
         read_debug_names(read_debug_names),
@@ -51,7 +55,7 @@ struct ReadBinaryOptions {
   bool read_debug_names = false;
   bool stop_on_first_error = true;
   bool fail_on_custom_section_error = true;
-  bool read_linking_names = true;
+  LinkingNameStrategy read_linking_names = LinkingNameStrategy::USE_PURE_LINKING_NAMES;
 };
 
 class BinaryReaderDelegate {

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <string>
 #include <vector>
+#include <sstream>
 
 #include "src/cast.h"
 #include "src/expr-visitor.h"
@@ -427,6 +428,25 @@ Result NameGenerator::VisitModule(Module* module) {
 Result GenerateNames(Module* module, NameOpts opts) {
   NameGenerator generator(opts);
   return generator.VisitModule(module);
+}
+
+std::string GenerateNameWithDollar( const std::string& func_name, Index function_index) {
+
+  std::stringstream ss;
+
+  assert( !func_name.empty() || function_index != kInvalidIndex );
+
+  ss << "$";
+
+  if (func_name.empty() ) {
+    ss << function_index;
+  } else if (func_name[0] == '$') {
+    ss << func_name.substr(1);
+  } else {
+    ss << func_name;
+  }
+
+  return ss.str();
 }
 
 }  // namespace wabt

--- a/src/generate-names.h
+++ b/src/generate-names.h
@@ -42,6 +42,8 @@ inline std::string IndexToAlphaName(Index index) {
   return s;
 }
 
+  std::string GenerateNameWithDollar( const std::string& func_name, Index function_index);
+
 }  // namespace wabt
 
 #endif /* WABT_GENERATE_NAMES_H_ */

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1026,10 +1026,11 @@ static wabt::Result ReadModule(string_view module_filename,
   result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
     const bool kReadDebugNames = true;
+    const bool kReadLinkingNames = true;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
-                              kStopOnFirstError, kFailOnCustomSectionError);
+                              kStopOnFirstError, kFailOnCustomSectionError, kReadLinkingNames);
     result = ReadBinaryInterp(env, file_data.data(), file_data.size(), options,
                               errors, out_module);
 

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1026,7 +1026,7 @@ static wabt::Result ReadModule(string_view module_filename,
   result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
     const bool kReadDebugNames = true;
-    const bool kReadLinkingNames = true;
+    const LinkingNameStrategy kReadLinkingNames = LinkingNameStrategy::DONT_USE_LINKING_NAMES;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -42,6 +42,7 @@ int ProgramMain(int argc, char** argv) {
   Features features;
   DecompileOptions decompile_options;
   bool fail_on_custom_section_error = true;
+  bool use_custom_linking_names = false;
 
   {
     const char s_description[] =
@@ -63,6 +64,10 @@ int ProgramMain(int argc, char** argv) {
     parser.AddOption("ignore-custom-section-errors",
                      "Ignore errors in custom sections",
                      [&]() { fail_on_custom_section_error = false; });
+    parser.AddOption("use-linking-names",
+                     "Use custom linking section names, if available",
+                      [&]() { use_custom_linking_names = true; });
+
     parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                        [&](const char* argument) {
                          infile = argument;
@@ -82,7 +87,9 @@ int ProgramMain(int argc, char** argv) {
                               true,
                               kStopOnFirstError,
                               fail_on_custom_section_error,
-                              LinkingNameStrategy::DONT_USE_LINKING_NAMES);
+                              //prepending names with dollar doesn't make here
+                              use_custom_linking_names ? LinkingNameStrategy::USE_PURE_LINKING_NAMES :
+                                                         LinkingNameStrategy::DONT_USE_LINKING_NAMES);
 
     result = ReadBinaryIr(infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -77,9 +77,13 @@ int ProgramMain(int argc, char** argv) {
     Errors errors;
     Module module;
     const bool kStopOnFirstError = true;
-    ReadBinaryOptions options(features, nullptr,
-                              true, kStopOnFirstError,
-                              fail_on_custom_section_error);
+    ReadBinaryOptions options(features, 
+                              nullptr,
+                              true,
+                              kStopOnFirstError,
+                              fail_on_custom_section_error,
+                              LinkingNameStrategy::DONT_USE_LINKING_NAMES);
+
     result = ReadBinaryIr(infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -146,10 +146,11 @@ static wabt::Result ReadModule(const char* module_filename,
   result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
     const bool kReadDebugNames = true;
+    const bool kReadLinkingNames = true;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
-                              kStopOnFirstError, kFailOnCustomSectionError);
+                              kStopOnFirstError, kFailOnCustomSectionError, kReadLinkingNames);
     result = ReadBinaryInterp(env, file_data.data(), file_data.size(), options,
                               errors, out_module);
 

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -146,11 +146,15 @@ static wabt::Result ReadModule(const char* module_filename,
   result = ReadFile(module_filename, &file_data);
   if (Succeeded(result)) {
     const bool kReadDebugNames = true;
-    const bool kReadLinkingNames = true;
+    const LinkingNameStrategy kReadLinkingNames = LinkingNameStrategy::DONT_USE_LINKING_NAMES;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
-    ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
-                              kStopOnFirstError, kFailOnCustomSectionError, kReadLinkingNames);
+    ReadBinaryOptions options(s_features,
+                              s_log_stream.get(),
+                              kReadDebugNames,
+                              kStopOnFirstError,
+                              kFailOnCustomSectionError,
+                              kReadLinkingNames);
     result = ReadBinaryInterp(env, file_data.data(), file_data.size(), options,
                               errors, out_module);
 

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -91,10 +91,11 @@ int ProgramMain(int argc, char** argv) {
     Errors errors;
     Features features;
     const bool kReadDebugNames = false;
+    const bool kReadLinkingNames = true;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = false;
     ReadBinaryOptions options(features, nullptr, kReadDebugNames,
-                              kStopOnFirstError, kFailOnCustomSectionError);
+                              kStopOnFirstError, kFailOnCustomSectionError, kReadLinkingNames);
 
     BinaryReaderStrip reader(&errors);
     result = ReadBinary(file_data.data(), file_data.size(), &reader, options);

--- a/src/tools/wasm-strip.cc
+++ b/src/tools/wasm-strip.cc
@@ -91,7 +91,7 @@ int ProgramMain(int argc, char** argv) {
     Errors errors;
     Features features;
     const bool kReadDebugNames = false;
-    const bool kReadLinkingNames = true;
+    const LinkingNameStrategy kReadLinkingNames = LinkingNameStrategy::DONT_USE_LINKING_NAMES;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = false;
     ReadBinaryOptions options(features, nullptr, kReadDebugNames,

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -35,6 +35,7 @@ static std::string s_infile;
 static Features s_features;
 static bool s_read_debug_names = true;
 static bool s_fail_on_custom_section_error = true;
+static bool s_read_linking_names = false;
 static std::unique_ptr<FileStream> s_log_stream;
 
 static const char s_description[] =
@@ -80,7 +81,8 @@ int ProgramMain(int argc, char** argv) {
     const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
-                              s_fail_on_custom_section_error);
+                              s_fail_on_custom_section_error,
+                              s_read_linking_names);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -35,7 +35,6 @@ static std::string s_infile;
 static Features s_features;
 static bool s_read_debug_names = true;
 static bool s_fail_on_custom_section_error = true;
-static bool s_read_linking_names = false;
 static std::unique_ptr<FileStream> s_log_stream;
 
 static const char s_description[] =
@@ -82,7 +81,8 @@ int ProgramMain(int argc, char** argv) {
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
                               s_fail_on_custom_section_error,
-                              s_read_linking_names);
+                              LinkingNameStrategy::DONT_USE_LINKING_NAMES);
+
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -116,9 +116,10 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
+    const bool kReadLinkingNames = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
-                              kFailOnCustomSectionError);
+                              kFailOnCustomSectionError, kReadLinkingNames);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -116,7 +116,7 @@ int ProgramMain(int argc, char** argv) {
     Module module;
     const bool kStopOnFirstError = true;
     const bool kFailOnCustomSectionError = true;
-    const bool kReadLinkingNames = true;
+    const LinkingNameStrategy kReadLinkingNames = LinkingNameStrategy::USE_PURE_LINKING_NAMES;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
                               kFailOnCustomSectionError, kReadLinkingNames);

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -115,7 +115,10 @@ int ProgramMain(int argc, char** argv) {
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
                               s_fail_on_custom_section_error,
-                              s_read_linking_names);
+                              // "Prepend names with dollar" has to be true for valid WAT
+                              s_read_linking_names ?  LinkingNameStrategy::USE_LINKING_NAMES_WITH_DOLLAR :
+                                                      LinkingNameStrategy::DONT_USE_LINKING_NAMES
+                              );
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -41,6 +41,7 @@ static Features s_features;
 static WriteWatOptions s_write_wat_options;
 static bool s_generate_names;
 static bool s_read_debug_names = true;
+static bool s_read_linking_names = false;
 static bool s_fail_on_custom_section_error = true;
 static std::unique_ptr<FileStream> s_log_stream;
 static bool s_validate = true;
@@ -80,6 +81,8 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_write_wat_options.inline_import = true; });
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });
+  parser.AddOption("read-linking-names", "Use names in linking custom section of the binary file",
+                   []() { s_read_linking_names = true; });
   parser.AddOption("ignore-custom-section-errors",
                    "Ignore errors in custom sections",
                    []() { s_fail_on_custom_section_error = false; });
@@ -111,7 +114,8 @@ int ProgramMain(int argc, char** argv) {
     const bool kStopOnFirstError = true;
     ReadBinaryOptions options(s_features, s_log_stream.get(),
                               s_read_debug_names, kStopOnFirstError,
-                              s_fail_on_custom_section_error);
+                              s_fail_on_custom_section_error,
+                              s_read_linking_names);
     result = ReadBinaryIr(s_infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -34,6 +34,7 @@ options:
       --inline-exports                        Write all exports inline
       --inline-imports                        Write all imports inline
       --no-debug-names                        Ignore debug names in the binary file
+      --read-linking-names                    Use names in linking custom section of the binary file
       --ignore-custom-section-errors          Ignore errors in custom sections
       --generate-names                        Give auto-generated names to non-named functions, types, etc.
       --no-check                              Don't check for invalid modules


### PR DESCRIPTION
This change introduces an option in wasm2wat for using the linking custom section for providing names for the functions present in the module. This was inspired by observing what wasm-objdump does and replicating it.

You might notice I've duplicated the code in `BinaryReaderIR::OnFunctionSymbol` from `BinaryReaderIR::OnFunctionName` - thats because while, on the surface level, both do the same thing, I expect this to change, as the handling of the flags might be expanded.

I was just "scratching my own itch", but this seems like something useful for other people as well (it surely makes it easier to read the generated WAT).