### PR TITLE
wasm-objdump: Consistent output of table types

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1129,10 +1129,11 @@ Result BinaryReaderObjdump::OnImportTable(Index import_index,
                                           Index table_index,
                                           Type elem_type,
                                           const Limits* elem_limits) {
-  PrintDetails(" - table[%" PRIindex "] elem_type=%s init=%" PRId64
-               " max=%" PRId64,
-               table_index, GetTypeName(elem_type), elem_limits->initial,
-               elem_limits->max);
+  PrintDetails(" - table[%" PRIindex "] type=%s initial=%" PRId64, table_index,
+               GetTypeName(elem_type), elem_limits->initial);
+  if (elem_limits->has_max) {
+    PrintDetails(" max=%" PRId64, elem_limits->max);
+  }
   PrintDetails(" <- " PRIstringview "." PRIstringview "\n",
                WABT_PRINTF_STRING_VIEW_ARG(module_name),
                WABT_PRINTF_STRING_VIEW_ARG(field_name));

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -92,7 +92,7 @@ Import[5]:
  - func[0] sig=0 <ignored.test> <- ignored.test
  - func[1] sig=1 <ignored.test2> <- ignored.test2
  - memory[0] pages: initial=0 <- ignored.testmem
- - table[0] elem_type=funcref init=0 max=0 <- ignored.testtable
+ - table[0] type=funcref initial=0 <- ignored.testtable
  - event[0] sig=2 <ignored.testevent> <- ignored.testevent
 
 Code Disassembly:


### PR DESCRIPTION
Adjusts the output of table imports to the output of table declarations and other elements:

  - `type` instead of `elem_type`
  - limits: `initial` instead of `init`, check `has_max`