### PR TITLE
Fix warning in test-hexfloat.cc

### DIFF
--- a/src/test-hexfloat.cc
+++ b/src/test-hexfloat.cc
@@ -35,15 +35,15 @@
   for (; bits >= last_bits;  \
        last_bits = bits, bits += num_threads_ * FOREACH_UINT32_MULTIPLIER)
 
-#define LOG_COMPLETION(bits)                                                 \
-  if (shard == 0) {                                                          \
-    int top_byte = bits >> 24;                                               \
-    if (top_byte != last_top_byte) {                                         \
-      printf("value: 0x%08x (%d%%)\r", bits,                                 \
-             static_cast<int>(static_cast<float>(bits) * 100 / UINT32_MAX)); \
-      fflush(stdout);                                                        \
-      last_top_byte = top_byte;                                              \
-    }                                                                        \
+#define LOG_COMPLETION(bits)                                                  \
+  if (shard == 0) {                                                           \
+    int top_byte = bits >> 24;                                                \
+    if (top_byte != last_top_byte) {                                          \
+      printf("value: 0x%08x (%d%%)\r", bits,                                  \
+             static_cast<int>(static_cast<double>(bits) * 100 / UINT32_MAX)); \
+      fflush(stdout);                                                         \
+      last_top_byte = top_byte;                                               \
+    }                                                                         \
   }
 
 #define LOG_DONE()     \


### PR DESCRIPTION
A `float` cant fit all the values of a `uint32_t` with full precision, since they are the same size. But a `double` has a 52-bit mantissa so it can represent a `uint32_t` with full precision. This fixes the compiler warning in test-hexfloat.cc.

Fixes #1200.