### PR TITLE
[wat2wasm] Don't crash on unsupported reloc type

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -317,7 +317,10 @@ Index BinaryWriter::GetSymbolIndex(RelocType reloc_type, Index index) {
       name = module_->globals[index]->name;
       break;
     default:
-      WABT_UNREACHABLE;
+      // TODO: Add support for TypeIndexLEB.
+      fprintf(stderr, "warning: unsupported relocation type: %s\n",
+              GetRelocTypeName(reloc_type));
+      return kInvalidIndex;
   }
   auto iter = symtab_.find(name);
   if (iter != symtab_.end()) {

--- a/test/regress/regress-35.txt
+++ b/test/regress/regress-35.txt
@@ -21,5 +21,5 @@
   (export "run" (func $run))
 )
 (;; STDERR ;;;
-warning: Unsupported relocation type: R_WASM_TYPE_INDEX_LEB
+warning: unsupported relocation type: R_WASM_TYPE_INDEX_LEB
 ;;; STDERR ;;)

--- a/test/regress/regress-35.txt
+++ b/test/regress/regress-35.txt
@@ -1,0 +1,25 @@
+;;; TOOL: wat2wasm
+;;; ARGS: -r
+(module 
+  ;; (type (func (param i32)(param i32)(result i32))) ;; fails, even if present
+  (func $add (param i32)(param i32)(result i32)
+    get_local 0
+    get_local 1
+    i32.add
+    return
+  )
+  (table 1 anyfunc)
+  (elem (i32.const 0) $add)
+  (func $run
+    i32.const 4444
+    i32.const 5555
+    i32.const 0
+    ;;call_indirect (type 0) ;; fails
+    call_indirect (param i32)(param i32)(result i32) ;; fails
+    drop
+  )
+  (export "run" (func $run))
+)
+(;; STDERR ;;;
+warning: Unsupported relocation type: R_WASM_TYPE_INDEX_LEB
+;;; STDERR ;;)


### PR DESCRIPTION
TypeIndexLEB relocations (used by call_indirect) doesn't seem to be
supported.