### PR TITLE
Rename v128_bits to simply vec128 since this is stored natively

### DIFF
--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -217,7 +217,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteSeparator();
       WriteKey("value");
       char buffer[128];
-      WriteUint128(buffer, 128, const_.v128_bits);
+      WriteUint128(buffer, 128, const_.vec128);
       json_stream_->Writef("\"%s\"", buffer);
       break;
     }

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -498,7 +498,7 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
           break;
         case Type::V128:
           WriteOpcode(stream_, Opcode::V128Const);
-          stream_->WriteU128(const_.v128_bits, "v128 literal");
+          stream_->WriteU128(const_.vec128, "v128 literal");
           break;
         default:
           assert(0);

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -979,7 +979,7 @@ wabt::Result BinaryReaderInterp::OnInitExprF64ConstExpr(Index index,
 wabt::Result BinaryReaderInterp::OnInitExprV128ConstExpr(Index index,
                                                          v128 value_bits) {
   init_expr_value_.type = Type::V128;
-  init_expr_value_.value.v128_bits = value_bits;
+  init_expr_value_.value.vec128 = value_bits;
   return wabt::Result::Ok;
 }
 

--- a/src/interp/interp-trace.cc
+++ b/src/interp/interp-trace.cc
@@ -268,8 +268,8 @@ void Thread::Trace(Stream* stream) {
       const Index memory_index = ReadU32(&pc);
       stream->Writef("%s $%" PRIindex ":%u+$%u, $0x%08x 0x%08x 0x%08x 0x%08x\n",
                      opcode.GetName(), memory_index, Pick(2).i32, ReadU32At(pc),
-                     Pick(1).v128_bits.v[0], Pick(1).v128_bits.v[1],
-                     Pick(1).v128_bits.v[2], Pick(1).v128_bits.v[3]);
+                     Pick(1).vec128.v[0], Pick(1).vec128.v[1],
+                     Pick(1).vec128.v[2], Pick(1).vec128.v[3]);
       break;
     }
 
@@ -511,8 +511,8 @@ void Thread::Trace(Stream* stream) {
     case Opcode::I64X2TruncSatF64X2S:
     case Opcode::I64X2TruncSatF64X2U: {
       stream->Writef("%s $0x%08x 0x%08x 0x%08x 0x%08x\n", opcode.GetName(),
-                     Top().v128_bits.v[0], Top().v128_bits.v[1],
-                     Top().v128_bits.v[2], Top().v128_bits.v[3]);
+                     Top().vec128.v[0], Top().vec128.v[1],
+                     Top().vec128.v[2], Top().vec128.v[3]);
       break;
     }
 
@@ -520,12 +520,12 @@ void Thread::Trace(Stream* stream) {
       stream->Writef(
           "%s $0x%08x %08x %08x %08x $0x%08x %08x %08x %08x $0x%08x %08x %08x "
           "%08x\n",
-          opcode.GetName(), Pick(3).v128_bits.v[0], Pick(3).v128_bits.v[1],
-          Pick(3).v128_bits.v[2], Pick(3).v128_bits.v[3],
-          Pick(2).v128_bits.v[0], Pick(2).v128_bits.v[1],
-          Pick(2).v128_bits.v[2], Pick(2).v128_bits.v[3],
-          Pick(1).v128_bits.v[0], Pick(1).v128_bits.v[1],
-          Pick(1).v128_bits.v[2], Pick(1).v128_bits.v[3]);
+          opcode.GetName(), Pick(3).vec128.v[0], Pick(3).vec128.v[1],
+          Pick(3).vec128.v[2], Pick(3).vec128.v[3],
+          Pick(2).vec128.v[0], Pick(2).vec128.v[1],
+          Pick(2).vec128.v[2], Pick(2).vec128.v[3],
+          Pick(1).vec128.v[0], Pick(1).vec128.v[1],
+          Pick(1).vec128.v[2], Pick(1).vec128.v[3]);
       break;
 
     case Opcode::I8X16ExtractLaneS:
@@ -537,9 +537,9 @@ void Thread::Trace(Stream* stream) {
     case Opcode::F32X4ExtractLane:
     case Opcode::F64X2ExtractLane: {
       stream->Writef("%s : LaneIdx %d From $0x%08x 0x%08x 0x%08x 0x%08x\n",
-                     opcode.GetName(), ReadU8At(pc), Top().v128_bits.v[0],
-                     Top().v128_bits.v[1], Top().v128_bits.v[2],
-                     Top().v128_bits.v[3]);
+                     opcode.GetName(), ReadU8At(pc), Top().vec128.v[0],
+                     Top().vec128.v[1], Top().vec128.v[2],
+                     Top().vec128.v[3]);
       break;
     }
 
@@ -548,25 +548,25 @@ void Thread::Trace(Stream* stream) {
     case Opcode::I32X4ReplaceLane: {
       stream->Writef(
           "%s : Set %u to LaneIdx %d In $0x%08x 0x%08x 0x%08x 0x%08x\n",
-          opcode.GetName(), Pick(1).i32, ReadU8At(pc), Pick(2).v128_bits.v[0],
-          Pick(2).v128_bits.v[1], Pick(2).v128_bits.v[2],
-          Pick(2).v128_bits.v[3]);
+          opcode.GetName(), Pick(1).i32, ReadU8At(pc), Pick(2).vec128.v[0],
+          Pick(2).vec128.v[1], Pick(2).vec128.v[2],
+          Pick(2).vec128.v[3]);
       break;
     }
     case Opcode::I64X2ReplaceLane: {
       stream->Writef("%s : Set %" PRIu64
                      " to LaneIdx %d In $0x%08x 0x%08x 0x%08x 0x%08x\n",
                      opcode.GetName(), Pick(1).i64, ReadU8At(pc),
-                     Pick(2).v128_bits.v[0], Pick(2).v128_bits.v[1],
-                     Pick(2).v128_bits.v[2], Pick(2).v128_bits.v[3]);
+                     Pick(2).vec128.v[0], Pick(2).vec128.v[1],
+                     Pick(2).vec128.v[2], Pick(2).vec128.v[3]);
       break;
     }
     case Opcode::F32X4ReplaceLane: {
       stream->Writef(
           "%s : Set %g to LaneIdx %d In $0x%08x 0x%08x 0x%08x 0x%08x\n",
           opcode.GetName(), Bitcast<float>(Pick(1).f32_bits), ReadU8At(pc),
-          Pick(2).v128_bits.v[0], Pick(2).v128_bits.v[1],
-          Pick(2).v128_bits.v[2], Pick(2).v128_bits.v[3]);
+          Pick(2).vec128.v[0], Pick(2).vec128.v[1],
+          Pick(2).vec128.v[2], Pick(2).vec128.v[3]);
 
       break;
     }
@@ -574,8 +574,8 @@ void Thread::Trace(Stream* stream) {
       stream->Writef(
           "%s : Set %g to LaneIdx %d In $0x%08x 0x%08x 0x%08x 0x%08x\n",
           opcode.GetName(), Bitcast<double>(Pick(1).f64_bits), ReadU8At(pc),
-          Pick(2).v128_bits.v[0], Pick(2).v128_bits.v[1],
-          Pick(2).v128_bits.v[2], Pick(2).v128_bits.v[3]);
+          Pick(2).vec128.v[0], Pick(2).vec128.v[1],
+          Pick(2).vec128.v[2], Pick(2).vec128.v[3]);
       break;
     }
 
@@ -583,10 +583,10 @@ void Thread::Trace(Stream* stream) {
       stream->Writef(
           "%s $0x%08x %08x %08x %08x $0x%08x %08x %08x %08x : with lane imm: "
           "$0x%08x %08x %08x %08x\n",
-          opcode.GetName(), Pick(2).v128_bits.v[0], Pick(2).v128_bits.v[1],
-          Pick(2).v128_bits.v[2], Pick(2).v128_bits.v[3],
-          Pick(1).v128_bits.v[0], Pick(1).v128_bits.v[1],
-          Pick(1).v128_bits.v[2], Pick(1).v128_bits.v[3], ReadU32At(pc),
+          opcode.GetName(), Pick(2).vec128.v[0], Pick(2).vec128.v[1],
+          Pick(2).vec128.v[2], Pick(2).vec128.v[3],
+          Pick(1).vec128.v[0], Pick(1).vec128.v[1],
+          Pick(1).vec128.v[2], Pick(1).vec128.v[3], ReadU32At(pc),
           ReadU32At(pc + 4), ReadU32At(pc + 8), ReadU32At(pc + 12));
       break;
 
@@ -668,11 +668,11 @@ void Thread::Trace(Stream* stream) {
     case Opcode::F64X2Mul:
     case Opcode::V8X16Swizzle: {
       stream->Writef("%s $0x%08x %08x %08x %08x  $0x%08x %08x %08x %08x\n",
-                     opcode.GetName(), Pick(2).v128_bits.v[0],
-                     Pick(2).v128_bits.v[1], Pick(2).v128_bits.v[2],
-                     Pick(2).v128_bits.v[3], Pick(1).v128_bits.v[0],
-                     Pick(1).v128_bits.v[1], Pick(1).v128_bits.v[2],
-                     Pick(1).v128_bits.v[3]);
+                     opcode.GetName(), Pick(2).vec128.v[0],
+                     Pick(2).vec128.v[1], Pick(2).vec128.v[2],
+                     Pick(2).vec128.v[3], Pick(1).vec128.v[0],
+                     Pick(1).vec128.v[1], Pick(1).vec128.v[2],
+                     Pick(1).vec128.v[3]);
       break;
     }
 
@@ -689,8 +689,8 @@ void Thread::Trace(Stream* stream) {
     case Opcode::I64X2ShrS:
     case Opcode::I64X2ShrU: {
       stream->Writef("%s $0x%08x %08x %08x %08x  $0x%08x\n", opcode.GetName(),
-                     Pick(2).v128_bits.v[0], Pick(2).v128_bits.v[1],
-                     Pick(2).v128_bits.v[2], Pick(2).v128_bits.v[3],
+                     Pick(2).vec128.v[0], Pick(2).vec128.v[1],
+                     Pick(2).vec128.v[2], Pick(2).vec128.v[3],
                      Pick(1).i32);
       break;
     }

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -69,8 +69,8 @@ std::string TypedValueToString(const TypedValue& tv) {
 
     case Type::V128:
       return StringPrintf("v128 i32x4:0x%08x 0x%08x 0x%08x 0x%08x",
-                          tv.value.v128_bits.v[0], tv.value.v128_bits.v[1],
-                          tv.value.v128_bits.v[2], tv.value.v128_bits.v[3]);
+                          tv.value.vec128.v[0], tv.value.vec128.v[1],
+                          tv.value.vec128.v[2], tv.value.vec128.v[3]);
 
     case Type::Nullref:
       return StringPrintf("nullref");
@@ -420,7 +420,7 @@ uint32_t ToRep(int32_t x) { return Bitcast<uint32_t>(x); }
 uint64_t ToRep(int64_t x) { return Bitcast<uint64_t>(x); }
 uint32_t ToRep(float x) { return Bitcast<uint32_t>(x); }
 uint64_t ToRep(double x) { return Bitcast<uint64_t>(x); }
-v128     ToRep(v128 x) { return Bitcast<v128>(x); }
+v128     ToRep(v128 x) { return x; }
 Ref      ToRep(Ref x) { return x; }
 
 template <typename Dst, typename Src>
@@ -439,7 +439,7 @@ float FromRep<float>(uint32_t x) { return Bitcast<float>(x); }
 template <>
 double FromRep<double>(uint64_t x) { return Bitcast<double>(x); }
 template <>
-v128 FromRep<v128>(v128 x) { return Bitcast<v128>(x); }
+v128 FromRep<v128>(v128 x) { return x; }
 template <>
 Ref FromRep<Ref>(Ref x) { return x; }
 
@@ -729,7 +729,7 @@ Value MakeValue<double>(uint64_t v) {
 template <>
 Value MakeValue<v128>(v128 v) {
   Value result;
-  result.v128_bits = v;
+  result.vec128 = v;
   return result;
 }
 
@@ -747,7 +747,7 @@ template<> uint64_t GetValue<int64_t>(Value v) { return v.i64; }
 template<> uint64_t GetValue<uint64_t>(Value v) { return v.i64; }
 template<> uint32_t GetValue<float>(Value v) { return v.f32_bits; }
 template<> uint64_t GetValue<double>(Value v) { return v.f64_bits; }
-template<> v128 GetValue<v128>(Value v) { return v.v128_bits; }
+template<> v128 GetValue<v128>(Value v) { return v.vec128; }
 template<> Ref GetValue<Ref>(Value v) { return v.ref; }
 
 template <typename T>

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -168,7 +168,7 @@ union Value {
   uint64_t i64;
   ValueTypeRep<float> f32_bits;
   ValueTypeRep<double> f64_bits;
-  ValueTypeRep<v128> v128_bits;
+  ValueTypeRep<v128> vec128;
   Ref ref;
 };
 

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -648,6 +648,6 @@ Const::Const(F64Tag, uint64_t value, const Location& loc_)
     : loc(loc_), type(Type::F64), f64_bits(value) {}
 
 Const::Const(V128Tag, v128 value, const Location& loc_)
-    : loc(loc_), type(Type::V128), v128_bits(value) {}
+    : loc(loc_), type(Type::V128), vec128(value) {}
 
 }  // namespace wabt

--- a/src/ir.h
+++ b/src/ir.h
@@ -102,7 +102,7 @@ struct Const {
     uint32_t f32_bits;
     uint64_t f64_bits;
     uintptr_t ref_bits;
-    v128 v128_bits;
+    v128 vec128;
   };
 
  private:

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -513,7 +513,7 @@ wabt::Result JSONParser::ParseConst(TypedValue* out_value) {
     v128 value_bits;
     CHECK_RESULT(ParseUint128(value_start, value_end, &value_bits));
     out_value->type = Type::V128;
-    out_value->value.v128_bits = value_bits;
+    out_value->value.vec128 = value_bits;
     return wabt::Result::Ok;
   } else {
     PrintError("unknown type: \"%s\"", type_str.c_str());
@@ -1220,7 +1220,7 @@ static bool TypedValuesAreEqual(const TypedValue& tv1, const TypedValue& tv2) {
     case Type::F64:
       return tv1.value.f64_bits == tv2.value.f64_bits;
     case Type::V128:
-      return tv1.value.v128_bits == tv2.value.v128_bits;
+      return tv1.value.vec128 == tv2.value.vec128;
     default:
       WABT_UNREACHABLE;
   }

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1924,7 +1924,7 @@ Result WastParser::ParseSimdV128Const(Const* const_, TokenType token_type) {
     }
   }
 
-  memcpy(&const_->v128_bits.v, v128_bytes.data(), 16);
+  memcpy(&const_->vec128.v, v128_bytes.data(), 16);
 
   return Result::Ok;
 }

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -465,9 +465,9 @@ void WatWriter::WriteConst(const Const& const_) {
 
     case Type::V128: {
       WritePutsSpace(Opcode::V128Const_Opcode.GetName());
-      Writef("i32x4 0x%08x 0x%08x 0x%08x 0x%08x", const_.v128_bits.v[0],
-             const_.v128_bits.v[1], const_.v128_bits.v[2],
-             const_.v128_bits.v[3]);
+      Writef("i32x4 0x%08x 0x%08x 0x%08x 0x%08x", const_.vec128.v[0],
+             const_.vec128.v[1], const_.vec128.v[2],
+             const_.vec128.v[3]);
       WriteNewline(NO_FORCE_NEWLINE);
       break;
     }


### PR DESCRIPTION
The _bits suffix is used the floating point types where we use types
that differ from the native C types.  For v128 we have a native struct
type that we store and manipulate directly.

Also remove the unneeded bitcast operations.