### PR TITLE
Add CMAKE_EXPORT_COMPILE_COMMANDS to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@
 cmake_minimum_required(VERSION 2.6)
 project(WABT)
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
 option(BUILD_TESTS "Build GTest-based tests" ON)
 option(USE_SYSTEM_GTEST "Use system GTest, instead of building" OFF)
 option(BUILD_TOOLS "Build wabt commandline tools" ON)


### PR DESCRIPTION
This allows code completion tools such as clangd to work.  I'm not sure
if there is any downside to enabling this in all cases?