### PR TITLE
wasm-objdump: Fix output for passive data elem segments

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -897,6 +897,7 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   InitExpr data_init_expr_;
   InitExpr elem_init_expr_;
   bool data_is_passive_ = false;
+  bool elem_is_passive_ = false;
   Index data_mem_index_ = 0;
   uint32_t data_offset_ = 0;
   uint32_t elem_offset_ = 0;
@@ -1239,7 +1240,7 @@ Result BinaryReaderObjdump::OnExport(Index index,
 }
 
 Result BinaryReaderObjdump::OnElemSegmentElemExpr_RefNull(Index segment_index) {
-  PrintDetails("  - elem[%" PRIindex "] = null", elem_offset_ + elem_index_);
+  PrintDetails("  - elem[%" PRIindex "] = nullref\n", elem_offset_ + elem_index_);
   elem_index_++;
   return Result::Ok;
 }
@@ -1267,6 +1268,7 @@ Result BinaryReaderObjdump::BeginElemSegment(Index index,
                                              Type elem_type) {
   table_index_ = table_index;
   elem_index_ = 0;
+  elem_is_passive_ = passive;
   return Result::Ok;
 }
 
@@ -1274,7 +1276,11 @@ Result BinaryReaderObjdump::OnElemSegmentElemExprCount(Index index,
                                                        Index count) {
   PrintDetails(" - segment[%" PRIindex "] table=%" PRIindex " count=%" PRIindex,
                index, table_index_, count);
-  PrintInitExpr(elem_init_expr_);
+  if (elem_is_passive_) {
+    PrintDetails(" passive\n");
+  } else {
+    PrintInitExpr(elem_init_expr_);
+  }
   return Result::Ok;
 }
 

--- a/test/dump/reference-types.txt
+++ b/test/dump/reference-types.txt
@@ -1,10 +1,12 @@
 ;;; TOOL: run-objdump
 ;;; ARGS0: --enable-reference-types
+;;; ARGS1: -x
 
 (module
   (table $foo 1 anyref)
   (table $bar 1 anyref)
   (table $baz 1 anyfunc)
+  (elem funcref (ref.null))
 
   (func (result anyref)
     i32.const 0
@@ -58,47 +60,84 @@
 
 reference-types.wasm:	file format wasm 0x1
 
+Section Details:
+
+Type[4]:
+ - type[0] () -> anyref
+ - type[1] (anyref) -> nil
+ - type[2] () -> i32
+ - type[3] (anyref) -> i32
+Function[10]:
+ - func[0] sig=0
+ - func[1] sig=0
+ - func[2] sig=1
+ - func[3] sig=1
+ - func[4] sig=2
+ - func[5] sig=2
+ - func[6] sig=3
+ - func[7] sig=2
+ - func[8] sig=2
+ - func[9] sig=2
+Table[3]:
+ - table[0] type=anyref initial=1
+ - table[1] type=anyref initial=1
+ - table[2] type=funcref initial=1
+Elem[1]:
+ - segment[0] table=0 count=1 passive
+  - elem[0] = nullref
+Code[10]:
+ - func[0] size=6
+ - func[1] size=6
+ - func[2] size=8
+ - func[3] size=8
+ - func[4] size=8
+ - func[5] size=8
+ - func[6] size=5
+ - func[7] size=5
+ - func[8] size=5
+ - func[9] size=5
+
 Code Disassembly:
 
-000039 func[0]:
- 00003a: 41 00                      | i32.const 0
- 00003c: 25 00                      | table.get 0
- 00003e: 0b                         | end
-000040 func[1]:
- 000041: 41 00                      | i32.const 0
- 000043: 25 01                      | table.get 1
- 000045: 0b                         | end
-000047 func[2]:
- 000048: 41 00                      | i32.const 0
- 00004a: 20 00                      | local.get 0
- 00004c: 26 00                      | table.set 0
- 00004e: 0b                         | end
-000050 func[3]:
- 000051: 41 00                      | i32.const 0
- 000053: 20 00                      | local.get 0
- 000055: 26 01                      | table.set 1
- 000057: 0b                         | end
-000059 func[4]:
- 00005a: d0                         | ref.null
- 00005b: 41 00                      | i32.const 0
- 00005d: fc 0f 00                   | table.grow 0
- 000060: 0b                         | end
-000062 func[5]:
- 000063: d0                         | ref.null
- 000064: 41 00                      | i32.const 0
- 000066: fc 0f 01                   | table.grow 1
- 000069: 0b                         | end
-00006b func[6]:
- 00006c: 20 00                      | local.get 0
- 00006e: d1                         | ref.is_null
- 00006f: 0b                         | end
-000071 func[7]:
- 000072: fc 10 00                   | table.size 0
- 000075: 0b                         | end
-000077 func[8]:
- 000078: fc 10 01                   | table.size 1
- 00007b: 0b                         | end
-00007d func[9]:
- 00007e: fc 10 02                   | table.size 2
- 000081: 0b                         | end
+000041 func[0]:
+ 000042: 41 00                      | i32.const 0
+ 000044: 25 00                      | table.get 0
+ 000046: 0b                         | end
+000048 func[1]:
+ 000049: 41 00                      | i32.const 0
+ 00004b: 25 01                      | table.get 1
+ 00004d: 0b                         | end
+00004f func[2]:
+ 000050: 41 00                      | i32.const 0
+ 000052: 20 00                      | local.get 0
+ 000054: 26 00                      | table.set 0
+ 000056: 0b                         | end
+000058 func[3]:
+ 000059: 41 00                      | i32.const 0
+ 00005b: 20 00                      | local.get 0
+ 00005d: 26 01                      | table.set 1
+ 00005f: 0b                         | end
+000061 func[4]:
+ 000062: d0                         | ref.null
+ 000063: 41 00                      | i32.const 0
+ 000065: fc 0f 00                   | table.grow 0
+ 000068: 0b                         | end
+00006a func[5]:
+ 00006b: d0                         | ref.null
+ 00006c: 41 00                      | i32.const 0
+ 00006e: fc 0f 01                   | table.grow 1
+ 000071: 0b                         | end
+000073 func[6]:
+ 000074: 20 00                      | local.get 0
+ 000076: d1                         | ref.is_null
+ 000077: 0b                         | end
+000079 func[7]:
+ 00007a: fc 10 00                   | table.size 0
+ 00007d: 0b                         | end
+00007f func[8]:
+ 000080: fc 10 01                   | table.size 1
+ 000083: 0b                         | end
+000085 func[9]:
+ 000086: fc 10 02                   | table.size 2
+ 000089: 0b                         | end
 ;;; STDOUT ;;)


### PR DESCRIPTION
Split out from #1206