### PR TITLE
wasm-decompile: Fixed arbitrary characters appearing in function names.

### DIFF
--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -120,8 +120,13 @@ void NameGenerator::GenerateName(const char* prefix,
                                  Index index,
                                  unsigned disambiguator,
                                  std::string* str) {
+  str->clear();
   if (!(opts_ & NameOpts::NoDollar)) *str = "$";
-  *str += prefix;
+  if (opts_ & NameOpts::OnlyAlphaNum) {
+    for (auto p = prefix; *p; p++) *str += isalnum(*p) ? *p : '_';
+  } else {
+    *str += prefix;
+  }
   if (index != kInvalidIndex) {
     if (opts_ & NameOpts::AlphaNames) {
       // For params and locals, do not use a prefix char.

--- a/src/generate-names.h
+++ b/src/generate-names.h
@@ -26,7 +26,8 @@ struct Module;
 enum NameOpts {
   None = 0,
   AlphaNames = 1 << 0,
-  NoDollar = 1 << 0,
+  NoDollar = 1 << 1,
+  OnlyAlphaNum = 1 << 2,
 };
 
 Result GenerateNames(struct Module*, NameOpts opts = NameOpts::None);

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -90,7 +90,8 @@ int ProgramMain(int argc, char** argv) {
       // FIXME: do we need these?
       result = GenerateNames(&module,
                              static_cast<NameOpts>(NameOpts::AlphaNames |
-                                                   NameOpts::NoDollar));
+                                                   NameOpts::NoDollar |
+                                                   NameOpts::OnlyAlphaNum));
       if (Succeeded(result)) {
         /* TODO(binji): This shouldn't fail; if a name can't be applied
          * (because the index is invalid, say) it should just be skipped. */

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -41,6 +41,10 @@
     end
     i32.const 1
   )
+  ;; LLD outputs a name section with de-mangled C++ function signatures as names,
+  ;; so have to make sure special chars get removed.
+  (func (export "signature-&<>()") (param) (result))
+  (func (export "signature-&[]()") (param) (result))
   (export "f" (func $f))
 )
 
@@ -59,6 +63,12 @@ function f(a:int, b:int):int {
     if (1) continue L_b;
   }
   return 1;
+}
+
+function signature______() {
+}
+
+function signature_______1() {
 }
 
 ;;; STDOUT ;;)


### PR DESCRIPTION
In particular, LLD may stick entire C++ signatures in names, that
WABT then uses with wasm2wat, but are not appropriate for wasm-decompile
function names.