### PR TITLE
Allow anyref globals to store ref subtypes

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -946,17 +946,16 @@ wabt::Result BinaryReaderInterp::BeginGlobal(Index index,
                                              Type type,
                                              bool mutable_) {
   assert(TranslateGlobalIndexToEnv(index) == env_->GetGlobalCount());
-  env_->EmplaceBackGlobal(TypedValue(type), mutable_);
+  env_->EmplaceBackGlobal(type, mutable_);
   init_expr_value_.type = Type::Void;
   return wabt::Result::Ok;
 }
 
 wabt::Result BinaryReaderInterp::EndGlobalInitExpr(Index index) {
   Global* global = GetGlobalByModuleIndex(index);
-  if (Failed(typechecker_.CheckType(init_expr_value_.type, global->typed_value.type))) {
+  if (Failed(typechecker_.CheckType(init_expr_value_.type, global->type))) {
     PrintError("type mismatch in global, expected %s but got %s.",
-               GetTypeName(global->typed_value.type),
-               GetTypeName(init_expr_value_.type));
+               GetTypeName(global->type), GetTypeName(init_expr_value_.type));
     return wabt::Result::Error;
   }
   global->typed_value = init_expr_value_;
@@ -1656,7 +1655,7 @@ wabt::Result BinaryReaderInterp::OnGlobalSetExpr(Index global_index) {
                global_index);
     return wabt::Result::Error;
   }
-  CHECK_RESULT(typechecker_.OnGlobalSet(global->typed_value.type));
+  CHECK_RESULT(typechecker_.OnGlobalSet(global->type));
   CHECK_RESULT(EmitOpcode(Opcode::GlobalSet));
   CHECK_RESULT(EmitI32(TranslateGlobalIndexToEnv(global_index)));
   return wabt::Result::Ok;

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -315,7 +315,7 @@ std::pair<Memory*, Index> HostModule::AppendMemoryExport(string_view name,
 std::pair<Global*, Index> HostModule::AppendGlobalExport(string_view name,
                                                          Type type,
                                                          bool mutable_) {
-  Global* global = env->EmplaceBackGlobal(TypedValue(type), mutable_);
+  Global* global = env->EmplaceBackGlobal(type, mutable_);
   Index global_env_index = env->GetGlobalCount() - 1;
   Index export_index =
       AppendExport(ExternalKind::Global, global_env_index, name);

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -90,14 +90,14 @@ static const IstreamOffset kInvalidIstreamOffset = ~0;
 
 struct FuncSignature {
   FuncSignature() = default;
-  FuncSignature(std::vector<Type> param_types, std::vector<Type> result_types);
+  FuncSignature(TypeVector param_types, TypeVector result_types);
   FuncSignature(Index param_count,
                 Type* param_types,
                 Index result_count,
                 Type* result_types);
 
-  std::vector<Type> param_types;
-  std::vector<Type> result_types;
+  TypeVector param_types;
+  TypeVector result_types;
 };
 
 enum class RefType {
@@ -206,12 +206,14 @@ typedef std::vector<TypedValue> TypedValues;
 
 struct Global {
   Global() : mutable_(false), import_index(kInvalidIndex) {}
-  Global(const TypedValue& typed_value, bool mutable_)
-      : typed_value(typed_value), mutable_(mutable_) {}
+  Global(Type& type, bool mutable_) : type(type), mutable_(mutable_) {
+    typed_value.type = type;
+  }
 
+  Type type;
   TypedValue typed_value;
   bool mutable_;
-  Index import_index; /* or kInvalidIndex if not imported */
+  Index import_index = kInvalidIndex; /* kInvalidIndex if not imported */
 };
 
 struct Import {

--- a/test/interp/reference-types.txt
+++ b/test/interp/reference-types.txt
@@ -5,7 +5,7 @@
   (table $t 1 anyfunc)
   (elem $t funcref (ref.null))
   (elem $t funcref (ref.func 1) (ref.null))
-  (global $g anyref (ref.null))
+  (global $g (mut anyref) (ref.null))
 
   (func $ref_null (export "ref_null") (result anyref)
     ref.null
@@ -32,6 +32,12 @@
     table.get $t
     ref.is_null
   )
+
+  (func $global_set (export "global_set") (result anyref)
+    ref.func $ref_is_null
+    global.set $g
+    global.get $g
+  )
 )
 (;; STDOUT ;;;
 ref_null() => anyref:nullref
@@ -39,4 +45,5 @@ ref_is_null() => i32:1
 ref_func() => funcref:1
 table_set() =>
 table_get() => i32:0
+global_set() => anyref:0(1)
 ;;; STDOUT ;;)


### PR DESCRIPTION
This requires the type of a global to be distinct from its current
TypedValue contents.