### PR TITLE
interpreter: Move `env` member up to Module base class.

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1947,7 +1947,7 @@ wabt::Result ReadBinaryInterp(Environment* env,
 
   std::unique_ptr<OutputBuffer> istream = env->ReleaseIstream();
   IstreamOffset istream_offset = istream->size();
-  DefinedModule* module = new DefinedModule();
+  DefinedModule* module = new DefinedModule(env);
 
   BinaryReaderInterp reader(env, module, std::move(istream), errors,
                             options.features);

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -282,13 +282,11 @@ struct Export {
 };
 
 class Environment;
-struct DefinedModule;
-struct HostModule;
 
 struct Module {
   WABT_DISALLOW_COPY_AND_ASSIGN(Module);
-  explicit Module(bool is_host);
-  Module(string_view name, bool is_host);
+  Module(Environment* env, bool is_host);
+  Module(Environment* env, string_view name, bool is_host);
   virtual ~Module() = default;
 
   // Function exports are special-cased to allow for overloading functions by
@@ -306,10 +304,13 @@ struct Module {
   Index memory_index; /* kInvalidIndex if not defined */
   Index table_index;  /* kInvalidIndex if not defined */
   bool is_host;
+
+ protected:
+  Environment* env;
 };
 
 struct DefinedModule : Module {
-  DefinedModule();
+  explicit DefinedModule(Environment* env);
   static bool classof(const Module* module) { return !module->is_host; }
 
   Index OnUnknownFuncExport(string_view name, Index sig_index) override {
@@ -360,9 +361,6 @@ struct HostModule : Module {
   std::function<
       Index(Environment*, HostModule*, string_view name, Index sig_index)>
       on_unknown_func_export;
-
- private:
-  Environment* env_;
 };
 
 class Environment {


### PR DESCRIPTION
This is needed as part of implementing the C API on top of the
interpreter.

Also remove the trailing `_` to match other struct members in this
file.

Also remove unneeded forward decls.