### PR TITLE
reference-types: Table immediate of call_indirect comes first in the …

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1536,9 +1536,9 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
     case TokenType::CallIndirect: {
       Consume();
       auto expr = MakeUnique<CallIndirectExpr>(loc);
+      ParseVarOpt(&expr->table, Var(0));
       CHECK_RESULT(ParseTypeUseOpt(&expr->decl));
       CHECK_RESULT(ParseUnboundFuncSignature(&expr->decl.sig));
-      ParseVarOpt(&expr->table, Var(0));
       *out_expr = std::move(expr);
       break;
     }

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -616,15 +616,12 @@ Result WatWriter::ExprVisitorDelegate::OnCallExpr(CallExpr* expr) {
 Result WatWriter::ExprVisitorDelegate::OnCallIndirectExpr(
     CallIndirectExpr* expr) {
   writer_->WritePutsSpace(Opcode::CallIndirect_Opcode.GetName());
-  writer_->WriteOpenSpace("type");
-  writer_->WriteVar(expr->decl.type_var, NextChar::Space);
-
-  if (expr->table.is_index() && expr->table.index() == 0) {
-    writer_->WriteCloseNewline();
-  } else {
-    writer_->WriteCloseSpace();
-    writer_->WriteVar(expr->table, NextChar::Newline);
+  if (!expr->table.is_index() || expr->table.index() != 0) {
+    writer_->WriteVar(expr->table, NextChar::Space);
   }
+  writer_->WriteOpenSpace("type");
+  writer_->WriteVar(expr->decl.type_var, NextChar::Newline);
+  writer_->WriteCloseNewline();
   return Result::Ok;
 }
 

--- a/test/parse/expr/reference-types-call-indirect.txt
+++ b/test/parse/expr/reference-types-call-indirect.txt
@@ -10,9 +10,9 @@
 
   (func (result i32)
     i32.const 0
-    call_indirect (type 0) $foo)
+    call_indirect $foo (type 0))
 
   (func (result i32)
     i32.const 0
-    call_indirect (type 0) $bar)
+    call_indirect $bar (type 0))
 )

--- a/test/roundtrip/generate-func-type-names.txt
+++ b/test/roundtrip/generate-func-type-names.txt
@@ -18,7 +18,7 @@
   (func $f1 (type $t0))
   (func $f2 (type $t1) (result i32)
     i32.const 0
-    call_indirect (type $t0) $T0
+    call_indirect $T0 (type $t0)
     i32.const 1)
   (table $T0 1 1 funcref)
   (elem $e0 (i32.const 0) $foo.bar))

--- a/test/roundtrip/generate-some-names.txt
+++ b/test/roundtrip/generate-some-names.txt
@@ -45,7 +45,7 @@
     drop
     i32.const 0
     i32.const 1
-    call_indirect (type $t0) $T0
+    call_indirect $T0 (type $t0)
     drop
     local.get $param1
     drop


### PR DESCRIPTION
…text format

The overview document was incorrect until recently which I imagine is
why wabt got this wrong initially.

See https://github.com/WebAssembly/reference-types/issues/59