### PR TITLE
reference-types: Improve reftype support

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -220,6 +220,7 @@ enum class Type : int32_t {
   ___ = Void,       // Convenient for the opcode table in opcode.h
   Any = 0,          // Not actually specified, but useful for type-checking
   Nullref = 1,      // Not actually specified, but useful for anyref type-checking
+  Foreignref = 2,   // Not actually specified, but useful for anyref type-checking
 };
 typedef std::vector<Type> TypeVector;
 

--- a/src/common.h
+++ b/src/common.h
@@ -219,8 +219,8 @@ enum class Type : int32_t {
   Void = -0x40,     // 0x40
   ___ = Void,       // Convenient for the opcode table in opcode.h
   Any = 0,          // Not actually specified, but useful for type-checking
-  Nullref = 1,  // Not actually specified, but useful for anyref type-checking
-  Hostref = 2,  // Not actually specified, but useful for anyref type-checking
+  Nullref = 1,      // Not actually specified, but used in testing and type-checking
+  Hostref = 2,      // Not actually specified, but used in testing and type-checking
 };
 typedef std::vector<Type> TypeVector;
 

--- a/src/common.h
+++ b/src/common.h
@@ -219,8 +219,8 @@ enum class Type : int32_t {
   Void = -0x40,     // 0x40
   ___ = Void,       // Convenient for the opcode table in opcode.h
   Any = 0,          // Not actually specified, but useful for type-checking
-  Nullref = 1,      // Not actually specified, but useful for anyref type-checking
-  Foreignref = 2,   // Not actually specified, but useful for anyref type-checking
+  Nullref = 1,  // Not actually specified, but useful for anyref type-checking
+  Hostref = 2,  // Not actually specified, but useful for anyref type-checking
 };
 typedef std::vector<Type> TypeVector;
 

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1014,7 +1014,7 @@ wabt::Result BinaryReaderInterp::OnInitExprI64ConstExpr(Index index,
 
 wabt::Result BinaryReaderInterp::OnInitExprRefNull(Index index) {
   init_expr_value_.type = Type::Nullref;
-  init_expr_value_.set_ref({RefType::Func, kInvalidIndex});
+  init_expr_value_.set_ref({RefType::Null, kInvalidIndex});
   return wabt::Result::Ok;
 }
 

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -90,13 +90,17 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::Hostref:
       return StringPrintf("hostref:%" PRIindex, tv.get_ref().index);
 
-    case Type::Anyref:
-      return StringPrintf("anyref:%" PRIindex, tv.get_ref().index);
-
     case Type::Funcref:
       return StringPrintf("funcref:%" PRIindex, tv.get_ref().index);
 
-    default:
+    case Type::Exnref:
+      return StringPrintf("exnref:%" PRIindex, tv.get_ref().index);
+
+    case Type::Func:
+    case Type::Void:
+    case Type::Any:
+    case Type::Anyref:
+      // These types are not concrete types and should never exist as a value
       WABT_UNREACHABLE;
   }
 }

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -60,8 +60,8 @@ std::string RefTypeToString(RefType t) {
       return "null";
     case RefType::Func:
       return "func";
-    case RefType::Foreign:
-      return "foreign";
+    case RefType::Host:
+      return "host";
   }
 }
 
@@ -87,8 +87,8 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::Nullref:
       return StringPrintf("nullref");
 
-    case Type::Foreignref:
-      return StringPrintf("foreignref:%" PRIindex, tv.get_ref().index);
+    case Type::Hostref:
+      return StringPrintf("hostref:%" PRIindex, tv.get_ref().index);
 
     case Type::Anyref:
       return StringPrintf("anyref:%" PRIindex, tv.get_ref().index);

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -101,8 +101,8 @@ struct FuncSignature {
 };
 
 enum class RefType {
-  Null,
   Func,
+  Null,
   Host,
 };
 
@@ -146,6 +146,7 @@ struct ElemSegment {
   bool dropped = false;
 };
 
+// Opaque handle to a host object.
 struct HostObject {};
 
 // ValueTypeRep converts from one type to its representation on the

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -101,14 +101,14 @@ struct FuncSignature {
 };
 
 enum class RefType {
-  Func,
   Null,
-  Host
+  Func,
+  Foreign,
 };
 
 struct Ref {
   RefType kind;
-  Index index;  // Only meaningful for RefType::FUNC
+  Index index;  // Not meaningful for RefType::Null
 };
 
 struct Table {
@@ -146,6 +146,9 @@ struct ElemSegment {
   bool dropped = false;
 };
 
+struct ForeignObject {
+};
+
 // ValueTypeRep converts from one type to its representation on the
 // stack. For example, float -> uint32_t. See Value below.
 template <typename T>
@@ -175,10 +178,32 @@ union Value {
 struct TypedValue {
   TypedValue() {}
   explicit TypedValue(Type type) : type(type) {}
-  TypedValue(Type type, const Value& value) : type(type), value(value) {}
+  TypedValue(Type basetype, const Value& value) : type(basetype), value(value) {
+    SetConcreteType();
+  }
+
+  void SetConcreteType() {
+    // Anyref is an abstract type. The actual type is stored in value.
+    if (type == Type::Anyref) {
+      switch (value.ref.kind) {
+        case RefType::Func:
+          type = Type::Funcref;
+          break;
+        case RefType::Null:
+          type = Type::Nullref;
+          break;
+        case RefType::Foreign:
+          type = Type::Foreignref;
+          break;
+      }
+    }
+  }
 
   void SetZero() { ZeroMemory(value); }
-  void set_ref(Ref x) { value.ref = x; }
+  void set_ref(Ref x) {
+    value.ref = x;
+    SetConcreteType();
+  }
   void set_i32(uint32_t x) { value.i32 = x; }
   void set_i64(uint64_t x) { value.i64 = x; }
   void set_f32(float x) { memcpy(&value.f32_bits, &x, sizeof(x)); }
@@ -396,6 +421,7 @@ class Environment {
   Index GetDataSegmentCount() const { return data_segments_.size(); }
   Index GetElemSegmentCount() const { return elem_segments_.size(); }
   Index GetModuleCount() const { return modules_.size(); }
+  Index GetForeignCount() const { return foreign_objects_.size(); }
 
   Index GetLastModuleIndex() const {
     return modules_.empty() ? kInvalidIndex : modules_.size() - 1;
@@ -487,6 +513,12 @@ class Environment {
   }
 
   template <typename... Args>
+  ForeignObject* EmplaceBackForeign(Args&&... args) {
+    foreign_objects_.emplace_back(std::forward<Args>(args)...);
+    return &foreign_objects_.back();
+  }
+
+  template <typename... Args>
   void EmplaceModuleBinding(Args&&... args) {
     module_bindings_.emplace(std::forward<Args>(args)...);
   }
@@ -522,6 +554,7 @@ class Environment {
   std::vector<Global> globals_;
   std::vector<DataSegment> data_segments_;
   std::vector<ElemSegment> elem_segments_;
+  std::vector<ForeignObject> foreign_objects_;
   std::unique_ptr<OutputBuffer> istream_;
   BindingHash module_bindings_;
   BindingHash registered_module_bindings_;
@@ -691,6 +724,7 @@ bool IsCanonicalNan(uint64_t f64_bits);
 bool IsArithmeticNan(uint32_t f32_bits);
 bool IsArithmeticNan(uint64_t f64_bits);
 
+std::string RefTypeToString(RefType t);
 std::string TypedValueToString(const TypedValue&);
 const char* ResultToString(Result);
 

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -103,7 +103,7 @@ struct FuncSignature {
 enum class RefType {
   Null,
   Func,
-  Foreign,
+  Host,
 };
 
 struct Ref {
@@ -146,8 +146,7 @@ struct ElemSegment {
   bool dropped = false;
 };
 
-struct ForeignObject {
-};
+struct HostObject {};
 
 // ValueTypeRep converts from one type to its representation on the
 // stack. For example, float -> uint32_t. See Value below.
@@ -192,8 +191,8 @@ struct TypedValue {
         case RefType::Null:
           type = Type::Nullref;
           break;
-        case RefType::Foreign:
-          type = Type::Foreignref;
+        case RefType::Host:
+          type = Type::Hostref;
           break;
       }
     }
@@ -421,7 +420,7 @@ class Environment {
   Index GetDataSegmentCount() const { return data_segments_.size(); }
   Index GetElemSegmentCount() const { return elem_segments_.size(); }
   Index GetModuleCount() const { return modules_.size(); }
-  Index GetForeignCount() const { return foreign_objects_.size(); }
+  Index GetHostCount() const { return host_objects_.size(); }
 
   Index GetLastModuleIndex() const {
     return modules_.empty() ? kInvalidIndex : modules_.size() - 1;
@@ -513,9 +512,9 @@ class Environment {
   }
 
   template <typename... Args>
-  ForeignObject* EmplaceBackForeign(Args&&... args) {
-    foreign_objects_.emplace_back(std::forward<Args>(args)...);
-    return &foreign_objects_.back();
+  HostObject* EmplaceBackHostObject(Args&&... args) {
+    host_objects_.emplace_back(std::forward<Args>(args)...);
+    return &host_objects_.back();
   }
 
   template <typename... Args>
@@ -554,7 +553,7 @@ class Environment {
   std::vector<Global> globals_;
   std::vector<DataSegment> data_segments_;
   std::vector<ElemSegment> elem_segments_;
-  std::vector<ForeignObject> foreign_objects_;
+  std::vector<HostObject> host_objects_;
   std::unique_ptr<OutputBuffer> istream_;
   BindingHash module_bindings_;
   BindingHash registered_module_bindings_;

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -170,11 +170,11 @@ Result TypeChecker::CheckTypeStackEnd(const char* desc) {
 
 static bool IsRefType(Type t) {
   return t == Type::Anyref || t == Type::Funcref || t == Type::Nullref ||
-         t == Type::Foreignref;
+         t == Type::Hostref;
 }
 
 static bool IsNullableRefType(Type t) {
-  return t == Type::Anyref || t == Type::Funcref || t == Type::Foreignref;
+  return t == Type::Anyref || t == Type::Funcref || t == Type::Hostref;
 }
 
 Result TypeChecker::CheckType(Type actual, Type expected) {

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -168,14 +168,23 @@ Result TypeChecker::CheckTypeStackEnd(const char* desc) {
   return result;
 }
 
+static bool IsRefType(Type t) {
+  return t == Type::Anyref || t == Type::Funcref || t == Type::Nullref ||
+         t == Type::Foreignref;
+}
+
+static bool IsNullableRefType(Type t) {
+  return t == Type::Anyref || t == Type::Funcref || t == Type::Foreignref;
+}
+
 Result TypeChecker::CheckType(Type actual, Type expected) {
   if (expected == actual || expected == Type::Any || actual == Type::Any) {
     return Result::Ok;
   }
-  if (expected == Type::Anyref && (actual == Type::Funcref || actual == Type::Nullref)) {
+  if (expected == Type::Anyref && IsRefType(actual)) {
     return Result::Ok;
   }
-  if ((expected == Type::Funcref || expected == Type::Anyref) && actual == Type::Nullref) {
+  if (IsNullableRefType(expected) && actual == Type::Nullref) {
     return Result::Ok;
   }
   return Result::Error;

--- a/test/interp/reference-types.txt
+++ b/test/interp/reference-types.txt
@@ -40,10 +40,10 @@
   )
 )
 (;; STDOUT ;;;
-ref_null() => anyref:nullref
+ref_null() => nullref
 ref_is_null() => i32:1
 ref_func() => funcref:1
 table_set() =>
 table_get() => i32:0
-global_set() => anyref:0(1)
+global_set() => funcref:1
 ;;; STDOUT ;;)


### PR DESCRIPTION
Add Hostref type which is an internal subtype of anyref used to
refer to host objects.

Since anyref is an abstract base type it should be be stored directly
on the value stack.  The value stack instead must contain elements of
the concrete RefType enumeration (currently Null, Func, or Foreign).

These changes are needed for the implementation of the C API but are
separately useful for improving conformance with the reftype proposal.

Implement subtyping rules for paramaters and results when using
CallFunction in the interpreter.