### PR TITLE
reference-types: implement type checking for table.get/table.set

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -645,15 +645,14 @@ Result TypeChecker::OnTableInit(uint32_t table, uint32_t segment) {
   return CheckOpcode3(Opcode::TableInit);
 }
 
-Result TypeChecker::OnTableGet(Index table_index) {
+Result TypeChecker::OnTableGet(Type elem_type) {
   Result result = PopAndCheck1Type(Type::I32, "table.get");
-  PushType(Type::Nullref); // TODO: should be the table's type
+  PushType(elem_type);
   return result;
 }
 
-Result TypeChecker::OnTableSet(Index table_index) {
-  // TODO: anyref here should be the table's type
-  return PopAndCheck2Types(Type::I32, Type::Anyref, "table.set");
+Result TypeChecker::OnTableSet(Type elem_type) {
+  return PopAndCheck2Types(Type::I32, elem_type, "table.set");
 }
 
 Result TypeChecker::OnTableGrow(Index segment) {

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -102,11 +102,11 @@ class TypeChecker {
   Result OnTableCopy();
   Result OnElemDrop(Index);
   Result OnTableInit(Index, Index);
-  Result OnTableGet(Index);
-  Result OnTableSet(Index);
-  Result OnTableGrow(Index);
-  Result OnTableSize(Index);
-  Result OnRefFuncExpr(Index);
+  Result OnTableGet(Type elem_type);
+  Result OnTableSet(Type elem_type);
+  Result OnTableGrow(Index table_index);
+  Result OnTableSize(Index table_index);
+  Result OnRefFuncExpr(Index func_index);
   Result OnRefNullExpr();
   Result OnRefIsNullExpr();
   Result OnRethrow();

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -803,16 +803,20 @@ Result Validator::OnTableInitExpr(TableInitExpr* expr) {
 }
 
 Result Validator::OnTableGetExpr(TableGetExpr* expr) {
+  const Table* table;
+  CheckTableVar(&expr->var, &table);
   expr_loc_ = &expr->loc;
   CheckHasTable(&expr->loc, Opcode::TableGet, expr->var.index());
-  typechecker_.OnTableGet(expr->var.index());
+  typechecker_.OnTableGet(table->elem_type);
   return Result::Ok;
 }
 
 Result Validator::OnTableSetExpr(TableSetExpr* expr) {
+  const Table* table;
+  CheckTableVar(&expr->var, &table);
   expr_loc_ = &expr->loc;
   CheckHasTable(&expr->loc, Opcode::TableSet, expr->var.index());
-  typechecker_.OnTableSet(expr->var.index());
+  typechecker_.OnTableSet(table->elem_type);
   return Result::Ok;
 }
 


### PR DESCRIPTION
Tests will follow in the form of the spec tests from the reference-types
repo.

See: #1223 