### PR TITLE
Fix expected stack layout when typechecking select instruction

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -711,7 +711,7 @@ Result TypeChecker::OnSelect() {
   result |= PeekAndCheckType(0, Type::I32);
   result |= PeekType(1, &type);
   result |= PeekAndCheckType(2, type);
-  PrintStackIfFailed(result, "select", Type::I32, type, type);
+  PrintStackIfFailed(result, "select", type, type, Type::I32);
   result |= DropTypes(3);
   PushType(type);
   return result;

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -2,49 +2,49 @@
 ;;; STDIN_FILE: third_party/testsuite/select.wast
 (;; STDOUT ;;;
 out/test/spec/select.wast:290: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got [i32]
+  error: type mismatch in select, expected [any, any, i32] but got [i32]
   000001c: error: OnSelectExpr callback failed
 out/test/spec/select.wast:297: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i64, i64] but got [i32, i64, i32]
+  error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
   000001e: error: OnSelectExpr callback failed
 out/test/spec/select.wast:301: assert_invalid passed:
-  error: type mismatch in select, expected [i32, f32, f32] but got [i32, f32, i32]
+  error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
   0000021: error: OnSelectExpr callback failed
 out/test/spec/select.wast:305: assert_invalid passed:
-  error: type mismatch in select, expected [i32, f64, f64] but got [i32, f64, i32]
+  error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, i32]
   0000025: error: OnSelectExpr callback failed
 out/test/spec/select.wast:311: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got []
+  error: type mismatch in select, expected [any, any, i32] but got []
   0000018: error: OnSelectExpr callback failed
 out/test/spec/select.wast:319: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got [i32]
+  error: type mismatch in select, expected [any, any, i32] but got [i32]
   000001a: error: OnSelectExpr callback failed
 out/test/spec/select.wast:327: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   000001c: error: OnSelectExpr callback failed
 out/test/spec/select.wast:335: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got []
+  error: type mismatch in select, expected [any, any, i32] but got []
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:344: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got [i32]
+  error: type mismatch in select, expected [any, any, i32] but got [i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:353: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:362: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got []
+  error: type mismatch in select, expected [any, any, i32] but got []
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:371: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got [i32]
+  error: type mismatch in select, expected [any, any, i32] but got [i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:380: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:389: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got []
+  error: type mismatch in select, expected [any, any, i32] but got []
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:398: assert_invalid passed:
-  error: type mismatch in select, expected [i32, any, any] but got [i32]
+  error: type mismatch in select, expected [any, any, i32] but got [i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:407: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]

--- a/test/typecheck/bad-select-cond.txt
+++ b/test/typecheck/bad-select-cond.txt
@@ -1,13 +1,13 @@
 ;;; TOOL: wat2wasm
 ;;; ERROR: 1
 (module
-  (func (result i32)
+  (func (result i64)
+    i64.const 0
+    i64.const 0
     f32.const 0
-    i32.const 0
-    i32.const 0
     select))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-cond.txt:8:5: error: type mismatch in select, expected [i32, i32, i32] but got [f32, i32, i32]
+out/test/typecheck/bad-select-cond.txt:8:5: error: type mismatch in select, expected [i64, i64, i32] but got [i64, i64, f32]
     select))
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value0.txt
+++ b/test/typecheck/bad-select-value0.txt
@@ -8,7 +8,7 @@
     select
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in select, expected [i32, f64, f64] but got [i32, f64, f32]
+out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, f32]
     select
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value1.txt
+++ b/test/typecheck/bad-select-value1.txt
@@ -8,7 +8,7 @@
     select
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in select, expected [i32, i64, i64] but got [i32, i64, f32]
+out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, f32]
     select
     ^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
The i32 condition variable should be the right-most type in the
error report.

Update bad-select-cond.txt to distinguish the difference and
prevent regression.