### PR TITLE
reference-types: Add reference-types spec tests

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -783,6 +783,7 @@ DEFINE_END(EndRelocSection)
 
 DEFINE_INDEX_INDEX(OnInitExprGlobalGetExpr, "index", "global_index")
 DEFINE_INDEX(OnInitExprRefNull)
+DEFINE_INDEX_INDEX(OnInitExprRefFunc, "index", "func_index")
 
 DEFINE_BEGIN(BeginDylinkSection)
 DEFINE_INDEX(OnDylinkNeededCount)

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -344,6 +344,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnInitExprI32ConstExpr(Index index, uint32_t value) override;
   Result OnInitExprI64ConstExpr(Index index, uint64_t value) override;
   Result OnInitExprRefNull(Index index) override;
+  Result OnInitExprRefFunc(Index index, Index func_index) override;
 
  private:
   void Indent();

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -497,6 +497,9 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnInitExprRefNull(Index index) override {
     return Result::Ok;
   }
+  Result OnInitExprRefFunc(Index index, Index func_index) override {
+    return Result::Ok;
+  }
 };
 
 }  // namespace wabt

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -497,6 +497,13 @@ Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
       CALLBACK(OnInitExprRefNull, index);
       break;
 
+    case Opcode::RefFunc: {
+      Index func_index;
+      CHECK_RESULT(ReadIndex(&func_index, "init_expr ref.func index"));
+      CALLBACK(OnInitExprRefFunc, index, func_index);
+      break;
+    }
+
     case Opcode::End:
       return Result::Ok;
 

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -413,6 +413,7 @@ class BinaryReaderDelegate {
   virtual Result OnInitExprI32ConstExpr(Index index, uint32_t value) = 0;
   virtual Result OnInitExprI64ConstExpr(Index index, uint64_t value) = 0;
   virtual Result OnInitExprRefNull(Index index) = 0;
+  virtual Result OnInitExprRefFunc(Index index, Index func_index) = 0;
 
   const State* state = nullptr;
 };

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -203,9 +203,23 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
     }
 
     case Type::Nullref:
-    case Type::Funcref:
-    case Type::Anyref: {
-      WriteString("ref");
+      WriteString("nullref");
+      WriteSeparator();
+      WriteKey("value");
+      json_stream_->Writef("\"0\"");
+      break;
+
+    case Type::Funcref: {
+      WriteString("funcref");
+      WriteSeparator();
+      WriteKey("value");
+      int64_t ref_bits = static_cast<int64_t>(const_.ref_bits);
+      json_stream_->Writef("\"%" PRIu64 "\"", ref_bits);
+      break;
+    }
+
+    case Type::Hostref: {
+      WriteString("hostref");
       WriteSeparator();
       WriteKey("value");
       int64_t ref_bits = static_cast<int64_t>(const_.ref_bits);
@@ -224,7 +238,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
     }
 
     default:
-      assert(0);
+      WABT_UNREACHABLE;
   }
 
   json_stream_->Writef("}");

--- a/src/common.h
+++ b/src/common.h
@@ -376,6 +376,16 @@ static WABT_INLINE const char* GetSymbolTypeName(SymbolType type) {
 
 /* type */
 
+static WABT_INLINE bool IsRefType(Type t) {
+  return t == Type::Anyref || t == Type::Funcref || t == Type::Nullref ||
+         t == Type::Hostref;
+}
+
+static WABT_INLINE bool IsNullableRefType(Type t) {
+  /* Currently all reftypes are nullable */
+  return IsRefType(t);
+}
+
 static WABT_INLINE const char* GetTypeName(Type type) {
   switch (type) {
     case Type::I32:

--- a/src/interp/interp-disassemble.cc
+++ b/src/interp/interp-disassemble.cc
@@ -586,13 +586,28 @@ void Environment::Disassemble(Stream* stream,
       }
 
       case Opcode::TableGet:
+        stream->Writef("%s %u %%[-1]\n", opcode.GetName(), ReadU32(&pc));
+        break;
+
       case Opcode::TableSet:
+        stream->Writef("%s $%u %%[-1] %%[-2]\n", opcode.GetName(), ReadU32(&pc));
+        break;
+
       case Opcode::TableGrow:
       case Opcode::TableSize:
+        stream->Writef("%s %u\n", opcode.GetName(), ReadU32(&pc));
+        break;
+
       case Opcode::RefNull:
-      case Opcode::RefIsNull:
+        stream->Writef("%s\n", opcode.GetName());
+        break;
+
       case Opcode::RefFunc:
-        WABT_UNREACHABLE;
+        stream->Writef("%s $%u\n", opcode.GetName(), ReadU32(&pc));
+        break;
+
+      case Opcode::RefIsNull:
+        stream->Writef("%s %%[-1]\n", opcode.GetName());
         break;
 
       case Opcode::MemoryInit:
@@ -634,6 +649,7 @@ void Environment::Disassemble(Stream* stream,
       case Opcode::Rethrow:
       case Opcode::Throw:
       case Opcode::Try:
+        fprintf(stderr, "unknown opcode: %#x\n", static_cast<uint32_t>(opcode));
         WABT_UNREACHABLE;
         break;
     }

--- a/src/interp/interp-trace.cc
+++ b/src/interp/interp-trace.cc
@@ -699,10 +699,19 @@ void Thread::Trace(Stream* stream) {
     case Opcode::TableSet:
     case Opcode::TableGrow:
     case Opcode::TableSize:
+
     case Opcode::RefNull:
+      stream->Writef("%s\n", opcode.GetName());
+      break;
+
     case Opcode::RefIsNull:
+      stream->Writef("%s %s:%08x\n", opcode.GetName(),
+                     RefTypeToString(Pick(1).ref.kind).c_str(),
+                     Pick(1).ref.index);
+      break;
+
     case Opcode::RefFunc:
-      WABT_UNREACHABLE;
+      stream->Writef("%s $%u\n", opcode.GetName(), ReadU32At(pc));
       break;
 
     case Opcode::MemoryInit:

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -104,8 +104,8 @@ class TypeChecker {
   Result OnTableInit(Index, Index);
   Result OnTableGet(Type elem_type);
   Result OnTableSet(Type elem_type);
-  Result OnTableGrow(Index table_index);
-  Result OnTableSize(Index table_index);
+  Result OnTableGrow(Type elem_type);
+  Result OnTableSize();
   Result OnRefFuncExpr(Index func_index);
   Result OnRefNullExpr();
   Result OnRefIsNullExpr();

--- a/test/dump/reference-types.txt
+++ b/test/dump/reference-types.txt
@@ -84,7 +84,7 @@ Table[3]:
  - table[1] type=anyref initial=1
  - table[2] type=funcref initial=1
 Elem[2]:
- - segment[0] flags=0 table=0 count=1 - init i32=0
+ - segment[0] flags=2 table=2 count=1 - init i32=0
   - elem[0] = func[0]
  - segment[1] flags=5 table=0 count=1
   - elem[0] = nullref
@@ -102,45 +102,45 @@ Code[10]:
 
 Code Disassembly:
 
-000047 func[0]:
- 000048: 41 00                      | i32.const 0
- 00004a: 25 00                      | table.get 0
- 00004c: 0b                         | end
-00004e func[1]:
- 00004f: 41 00                      | i32.const 0
- 000051: 25 01                      | table.get 1
- 000053: 0b                         | end
-000055 func[2]:
- 000056: 41 00                      | i32.const 0
- 000058: 20 00                      | local.get 0
- 00005a: 26 00                      | table.set 0
- 00005c: 0b                         | end
-00005e func[3]:
- 00005f: 41 00                      | i32.const 0
- 000061: 20 00                      | local.get 0
- 000063: 26 01                      | table.set 1
- 000065: 0b                         | end
-000067 func[4]:
- 000068: d0                         | ref.null
- 000069: 41 00                      | i32.const 0
- 00006b: fc 0f 00                   | table.grow 0
- 00006e: 0b                         | end
-000070 func[5]:
- 000071: d0                         | ref.null
- 000072: 41 00                      | i32.const 0
- 000074: fc 0f 01                   | table.grow 1
- 000077: 0b                         | end
-000079 func[6]:
- 00007a: 20 00                      | local.get 0
- 00007c: d1                         | ref.is_null
- 00007d: 0b                         | end
-00007f func[7]:
- 000080: fc 10 00                   | table.size 0
- 000083: 0b                         | end
-000085 func[8]:
- 000086: fc 10 01                   | table.size 1
- 000089: 0b                         | end
-00008b func[9]:
- 00008c: fc 10 02                   | table.size 2
- 00008f: 0b                         | end
+000049 func[0]:
+ 00004a: 41 00                      | i32.const 0
+ 00004c: 25 00                      | table.get 0
+ 00004e: 0b                         | end
+000050 func[1]:
+ 000051: 41 00                      | i32.const 0
+ 000053: 25 01                      | table.get 1
+ 000055: 0b                         | end
+000057 func[2]:
+ 000058: 41 00                      | i32.const 0
+ 00005a: 20 00                      | local.get 0
+ 00005c: 26 00                      | table.set 0
+ 00005e: 0b                         | end
+000060 func[3]:
+ 000061: 41 00                      | i32.const 0
+ 000063: 20 00                      | local.get 0
+ 000065: 26 01                      | table.set 1
+ 000067: 0b                         | end
+000069 func[4]:
+ 00006a: d0                         | ref.null
+ 00006b: 41 00                      | i32.const 0
+ 00006d: fc 0f 00                   | table.grow 0
+ 000070: 0b                         | end
+000072 func[5]:
+ 000073: d0                         | ref.null
+ 000074: 41 00                      | i32.const 0
+ 000076: fc 0f 01                   | table.grow 1
+ 000079: 0b                         | end
+00007b func[6]:
+ 00007c: 20 00                      | local.get 0
+ 00007e: d1                         | ref.is_null
+ 00007f: 0b                         | end
+000081 func[7]:
+ 000082: fc 10 00                   | table.size 0
+ 000085: 0b                         | end
+000087 func[8]:
+ 000088: fc 10 01                   | table.size 1
+ 00008b: 0b                         | end
+00008d func[9]:
+ 00008e: fc 10 02                   | table.size 2
+ 000091: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/interp/basic-tracing.txt
+++ b/test/interp/basic-tracing.txt
@@ -20,6 +20,7 @@
     i32.const 3
     call $fib))
 (;; STDOUT ;;;
+>>> initializing segments
 >>> running export "main":
 #0.  100: V:0  | i32.const 3
 #0.  108: V:1  | call @0

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -441,6 +441,7 @@
   (; 0xfe 0x4e ;) (func (export "i64.atomic.rmw32.cmpxchg_u") i32.const 1 i64.const 2 i64.const 3 i64.atomic.rmw32.cmpxchg_u offset=3 drop)
 )
 (;; STDOUT ;;;
+>>> initializing segments
 >>> running export "unreachable":
 #0.    4: V:0  | unreachable
 unreachable() => error: unreachable executed

--- a/test/spec/reference-types/binary.txt
+++ b/test/spec/reference-types/binary.txt
@@ -1,0 +1,185 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/binary.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/binary.wast:6: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/reference-types/binary.wast:7: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/reference-types/binary.wast:8: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/reference-types/binary.wast:9: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:10: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:11: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:12: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:13: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:14: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:15: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:16: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:17: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:18: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:21: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:24: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:25: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:28: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:31: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:34: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/reference-types/binary.wast:37: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/reference-types/binary.wast:38: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/reference-types/binary.wast:39: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/reference-types/binary.wast:40: assert_malformed passed:
+  0000008: error: bad wasm file version: 0 (expected 0x1)
+out/test/spec/reference-types/binary.wast:41: assert_malformed passed:
+  0000008: error: bad wasm file version: 0xd (expected 0x1)
+out/test/spec/reference-types/binary.wast:42: assert_malformed passed:
+  0000008: error: bad wasm file version: 0xe (expected 0x1)
+out/test/spec/reference-types/binary.wast:43: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x100 (expected 0x1)
+out/test/spec/reference-types/binary.wast:44: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x10000 (expected 0x1)
+out/test/spec/reference-types/binary.wast:45: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
+out/test/spec/reference-types/binary.wast:148: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/reference-types/binary.wast:156: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/reference-types/binary.wast:175: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/reference-types/binary.wast:194: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/reference-types/binary.wast:213: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/reference-types/binary.wast:234: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/reference-types/binary.wast:244: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/reference-types/binary.wast:255: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/reference-types/binary.wast:265: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/reference-types/binary.wast:277: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/reference-types/binary.wast:285: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/reference-types/binary.wast:293: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/reference-types/binary.wast:312: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/reference-types/binary.wast:331: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/reference-types/binary.wast:349: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/reference-types/binary.wast:368: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/reference-types/binary.wast:387: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/reference-types/binary.wast:406: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/reference-types/binary.wast:425: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/reference-types/binary.wast:447: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/reference-types/binary.wast:457: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/reference-types/binary.wast:467: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/reference-types/binary.wast:477: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/reference-types/binary.wast:488: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/reference-types/binary.wast:498: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/reference-types/binary.wast:508: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/reference-types/binary.wast:518: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/reference-types/binary.wast:530: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/reference-types/binary.wast:550: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/reference-types/binary.wast:570: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/reference-types/binary.wast:589: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/reference-types/binary.wast:608: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/reference-types/binary.wast:628: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/reference-types/binary.wast:647: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/reference-types/binary.wast:666: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/reference-types/binary.wast:684: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/reference-types/binary.wast:702: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/reference-types/binary.wast:721: assert_malformed passed:
+  000001c: error: local count must be < 0x10000000
+out/test/spec/reference-types/binary.wast:753: assert_malformed passed:
+  0000013: error: function signature count != function body count
+out/test/spec/reference-types/binary.wast:763: assert_malformed passed:
+  000000b: error: function signature count != function body count
+out/test/spec/reference-types/binary.wast:772: assert_malformed passed:
+  0000016: error: function signature count != function body count
+out/test/spec/reference-types/binary.wast:783: assert_malformed passed:
+  0000015: error: function signature count != function body count
+out/test/spec/reference-types/binary.wast:812: assert_malformed passed:
+  000000a: error: invalid section size: extends past end
+out/test/spec/reference-types/binary.wast:823: assert_malformed passed:
+  000000e: error: unfinished section (expected end: 0x11)
+out/test/spec/reference-types/binary.wast:842: assert_malformed passed:
+  0000027: error: unable to read u32 leb128: string length
+out/test/spec/reference-types/binary.wast:861: assert_malformed passed:
+  000002b: error: unfinished section (expected end: 0x40)
+out/test/spec/reference-types/binary.wast:892: assert_malformed passed:
+  000000b: error: invalid table count 1, only 0 bytes left in section
+out/test/spec/reference-types/binary.wast:908: assert_malformed passed:
+  000000b: error: invalid memory count 1, only 0 bytes left in section
+out/test/spec/reference-types/binary.wast:924: assert_malformed passed:
+  0000010: error: unable to read i32 leb128: global type
+out/test/spec/reference-types/binary.wast:935: assert_malformed passed:
+  0000010: error: unfinished section (expected end: 0x15)
+out/test/spec/reference-types/binary.wast:958: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/reference-types/binary.wast:979: assert_malformed passed:
+  000001b: error: unfinished section (expected end: 0x20)
+out/test/spec/reference-types/binary.wast:1013: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: elem segment flags
+out/test/spec/reference-types/binary.wast:1031: assert_malformed passed:
+  0000021: error: unfinished section (expected end: 0x27)
+out/test/spec/reference-types/binary.wast:1057: assert_malformed passed:
+  0000016: error: unable to read u32 leb128: data segment flags
+out/test/spec/reference-types/binary.wast:1070: assert_malformed passed:
+  0000016: error: unfinished section (expected end: 0x1c)
+out/test/spec/reference-types/binary.wast:1083: assert_malformed passed:
+  0000015: error: unable to read data: data segment data
+out/test/spec/reference-types/binary.wast:1097: assert_malformed passed:
+  000001a: error: unfinished section (expected end: 0x1b)
+out/test/spec/reference-types/binary.wast:1128: assert_malformed passed:
+  error: invalid depth: 11 (max 2)
+  0000024: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/binary.wast:1150: assert_malformed passed:
+  0000025: error: expected valid block signature type
+out/test/spec/reference-types/binary.wast:1185: assert_malformed passed:
+  0000017: error: multiple Start sections
+89/89 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/exports.txt
+++ b/test/spec/reference-types/exports.txt
@@ -1,0 +1,71 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/exports.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/exports.wast:29: assert_invalid passed:
+  0000019: error: invalid export func index: 1
+out/test/spec/reference-types/exports.wast:33: assert_invalid passed:
+  error: duplicate export "a"
+  000001d: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:37: assert_invalid passed:
+  error: duplicate export "a"
+  000001e: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:41: assert_invalid passed:
+  error: duplicate export "a"
+  0000025: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:45: assert_invalid passed:
+  error: duplicate export "a"
+  0000023: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:49: assert_invalid passed:
+  error: duplicate export "a"
+  0000022: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:78: assert_invalid passed:
+  0000017: error: invalid export global index: 1
+out/test/spec/reference-types/exports.wast:82: assert_invalid passed:
+  error: duplicate export "a"
+  000001b: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:86: assert_invalid passed:
+  error: duplicate export "a"
+  0000020: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:90: assert_invalid passed:
+  error: duplicate export "a"
+  0000025: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:94: assert_invalid passed:
+  error: duplicate export "a"
+  0000021: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:98: assert_invalid passed:
+  error: duplicate export "a"
+  0000020: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:125: assert_invalid passed:
+  0000015: error: invalid export table index: 1
+out/test/spec/reference-types/exports.wast:129: assert_invalid passed:
+  error: duplicate export "a"
+  0000019: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:133: assert_invalid passed:
+  error: duplicate export "a"
+  000001c: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:137: assert_invalid passed:
+  error: duplicate export "a"
+  0000023: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:141: assert_invalid passed:
+  error: duplicate export "a"
+  0000021: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:145: assert_invalid passed:
+  error: duplicate export "a"
+  000001e: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:173: assert_invalid passed:
+  0000014: error: invalid export memory index: 1
+out/test/spec/reference-types/exports.wast:177: assert_invalid passed:
+  error: duplicate export "a"
+  0000018: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:186: assert_invalid passed:
+  error: duplicate export "a"
+  0000022: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:190: assert_invalid passed:
+  error: duplicate export "a"
+  0000020: error: OnExport callback failed
+out/test/spec/reference-types/exports.wast:194: assert_invalid passed:
+  error: duplicate export "a"
+  000001e: error: OnExport callback failed
+29/29 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/globals.txt
+++ b/test/spec/reference-types/globals.txt
@@ -1,0 +1,81 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/globals.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/globals.wast:226: assert_trap passed: undefined table index
+out/test/spec/reference-types/globals.wast:248: assert_invalid passed:
+  error: can't global.set on immutable global at index 0.
+  0000029: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:257: assert_invalid passed:
+  0000013: error: expected END opcode after initializer expression
+out/test/spec/reference-types/globals.wast:262: assert_invalid passed:
+  000000e: error: unexpected opcode in initializer expression: 0x20
+out/test/spec/reference-types/globals.wast:267: assert_invalid passed:
+  0000013: error: expected END opcode after initializer expression
+out/test/spec/reference-types/globals.wast:272: assert_invalid passed:
+  0000010: error: expected END opcode after initializer expression
+out/test/spec/reference-types/globals.wast:277: assert_invalid passed:
+  000000e: error: unexpected opcode in initializer expression: 0x1
+out/test/spec/reference-types/globals.wast:282: assert_invalid passed:
+  error: type mismatch in global, expected i32 but got f32.
+  0000013: error: EndGlobalInitExpr callback failed
+out/test/spec/reference-types/globals.wast:287: assert_invalid passed:
+  0000010: error: expected END opcode after initializer expression
+out/test/spec/reference-types/globals.wast:292: assert_invalid passed:
+  error: type mismatch in global, expected i32 but got void.
+  000000e: error: EndGlobalInitExpr callback failed
+out/test/spec/reference-types/globals.wast:297: assert_invalid passed:
+  error: unknown import module ""
+  0000010: error: OnImportGlobal callback failed
+out/test/spec/reference-types/globals.wast:302: assert_invalid passed:
+  error: initializer expression can only reference an imported global
+  000000f: error: OnInitExprGlobalGetExpr callback failed
+out/test/spec/reference-types/globals.wast:307: assert_invalid passed:
+  error: initializer expression can only reference an imported global
+  000000f: error: OnInitExprGlobalGetExpr callback failed
+out/test/spec/reference-types/globals.wast:315: assert_malformed passed:
+  0000026: error: global mutability must be 0 or 1
+out/test/spec/reference-types/globals.wast:328: assert_malformed passed:
+  0000026: error: global mutability must be 0 or 1
+out/test/spec/reference-types/globals.wast:345: assert_malformed passed:
+  0000011: error: global mutability must be 0 or 1
+out/test/spec/reference-types/globals.wast:357: assert_malformed passed:
+  0000011: error: global mutability must be 0 or 1
+out/test/spec/reference-types/globals.wast:371: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000021: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:380: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:390: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:400: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000027: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:410: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  000002a: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:420: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:430: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:440: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:450: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000021: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:459: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000021: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:468: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  0000027: error: OnGlobalSetExpr callback failed
+out/test/spec/reference-types/globals.wast:478: assert_invalid passed:
+  error: type mismatch in global.set, expected [i32] but got []
+  000003e: error: OnGlobalSetExpr callback failed
+75/75 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/imports.txt
+++ b/test/spec/reference-types/imports.txt
@@ -1,0 +1,275 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/imports.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32_f32(i32:14, f32:42.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f32(f32:13.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f64_f64(f64:25.000000, f64:53.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+out/test/spec/reference-types/imports.wast:92: assert_invalid passed:
+  000001e: error: invalid import signature index
+out/test/spec/reference-types/imports.wast:108: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  0000020: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:112: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  0000024: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:117: assert_unlinkable passed:
+  error: import signature mismatch
+  000001e: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:121: assert_unlinkable passed:
+  error: import signature mismatch
+  000001e: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:125: assert_unlinkable passed:
+  error: import signature mismatch
+  000001f: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:129: assert_unlinkable passed:
+  error: import signature mismatch
+  0000021: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:133: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:137: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:141: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:145: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:149: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:153: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:157: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:161: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:165: assert_unlinkable passed:
+  error: import signature mismatch
+  0000024: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:169: assert_unlinkable passed:
+  error: import signature mismatch
+  0000026: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:173: assert_unlinkable passed:
+  error: import signature mismatch
+  0000027: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:177: assert_unlinkable passed:
+  error: import signature mismatch
+  0000027: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:182: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind func, not global
+  0000024: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:186: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind func, not table
+  0000025: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:190: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind func, not memory
+  0000025: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:194: assert_unlinkable passed:
+  error: expected import "spectest.global_i32" to have kind func, not global
+  0000027: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:198: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind func, not table
+  0000022: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:202: assert_unlinkable passed:
+  error: expected import "spectest.memory" to have kind func, not memory
+  0000023: error: OnImportFunc callback failed
+out/test/spec/reference-types/imports.wast:236: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001b: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:240: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001f: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:245: assert_unlinkable passed:
+  error: expected import "test.func" to have kind global, not func
+  0000018: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:249: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind global, not table
+  0000020: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:253: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind global, not memory
+  0000020: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:257: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind global, not func
+  0000021: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:261: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind global, not table
+  000001d: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:265: assert_unlinkable passed:
+  error: expected import "spectest.memory" to have kind global, not memory
+  000001e: error: OnImportGlobal callback failed
+out/test/spec/reference-types/imports.wast:284: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/imports.wast:287: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/imports.wast:288: assert_trap passed: undefined table index
+out/test/spec/reference-types/imports.wast:303: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/imports.wast:306: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/imports.wast:307: assert_trap passed: undefined table index
+out/test/spec/reference-types/imports.wast:339: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001c: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:343: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  0000020: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:348: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+  0000021: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:352: assert_unlinkable passed:
+  error: max size (unspecified) larger than declared (20)
+  0000022: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:356: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+  0000021: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:360: assert_unlinkable passed:
+  error: max size (20) larger than declared (18)
+  0000021: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:364: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+  000001e: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:368: assert_unlinkable passed:
+  error: max size (20) larger than declared (15)
+  000001f: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:373: assert_unlinkable passed:
+  error: expected import "test.func" to have kind table, not func
+  0000019: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:377: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind table, not global
+  000001f: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:381: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind table, not memory
+  0000021: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:385: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind table, not func
+  0000022: error: OnImportTable callback failed
+out/test/spec/reference-types/imports.wast:403: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
+out/test/spec/reference-types/imports.wast:414: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
+out/test/spec/reference-types/imports.wast:417: assert_invalid passed:
+  error: unknown import module ""
+  0000010: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:421: assert_invalid passed:
+  error: unknown import module ""
+  0000010: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:425: assert_invalid passed:
+  000000b: error: memory count must be 0 or 1
+out/test/spec/reference-types/imports.wast:440: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001b: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:444: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001f: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:449: assert_unlinkable passed:
+  error: actual size (2) smaller than declared (3)
+  0000020: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:453: assert_unlinkable passed:
+  error: max size (unspecified) larger than declared (3)
+  0000021: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:457: assert_unlinkable passed:
+  error: actual size (1) smaller than declared (2)
+  000001e: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:461: assert_unlinkable passed:
+  error: max size (2) larger than declared (1)
+  000001f: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:466: assert_unlinkable passed:
+  error: expected import "test.func-i32" to have kind memory, not func
+  000001c: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:470: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind memory, not global
+  000001e: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:474: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind memory, not table
+  0000020: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:478: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind memory, not func
+  0000021: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:482: assert_unlinkable passed:
+  error: expected import "spectest.global_i32" to have kind memory, not global
+  0000022: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:486: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind memory, not table
+  000001d: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:491: assert_unlinkable passed:
+  error: actual size (1) smaller than declared (2)
+  000001e: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:495: assert_unlinkable passed:
+  error: max size (2) larger than declared (1)
+  000001f: error: OnImportMemory callback failed
+out/test/spec/reference-types/imports.wast:513: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.109.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (func))
+          ^^^^^^
+out/test/spec/reference-types/imports.wast:517: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.110.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (global i64))
+          ^^^^^^
+out/test/spec/reference-types/imports.wast:521: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.111.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (table 0 funcref))
+          ^^^^^^
+out/test/spec/reference-types/imports.wast:525: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.112.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (memory 0))
+          ^^^^^^
+out/test/spec/reference-types/imports.wast:530: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.113.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (func))
+                              ^^^^^^
+out/test/spec/reference-types/imports.wast:534: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.114.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (global f32))
+                              ^^^^^^
+out/test/spec/reference-types/imports.wast:538: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.115.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (table 0 funcref))
+                              ^^^^^^
+out/test/spec/reference-types/imports.wast:542: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.116.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (memory 0))
+                              ^^^^^^
+out/test/spec/reference-types/imports.wast:547: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.117.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (func))
+                     ^^^^^^
+out/test/spec/reference-types/imports.wast:551: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.118.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (global i32))
+                     ^^^^^^
+out/test/spec/reference-types/imports.wast:555: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.119.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (table 0 funcref))
+                     ^^^^^^
+out/test/spec/reference-types/imports.wast:559: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.120.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (memory 0))
+                     ^^^^^^
+out/test/spec/reference-types/imports.wast:564: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.121.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (func))
+              ^^^^^^
+out/test/spec/reference-types/imports.wast:568: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.122.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (global i32))
+              ^^^^^^
+out/test/spec/reference-types/imports.wast:572: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.123.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (table 1 3 funcref))
+              ^^^^^^
+out/test/spec/reference-types/imports.wast:576: assert_malformed passed:
+  out/test/spec/reference-types/imports/imports.124.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (memory 1 2))
+              ^^^^^^
+out/test/spec/reference-types/imports.wast:586: assert_unlinkable passed:
+  error: unknown module field "overloaded"
+  000004d: error: OnImportFunc callback failed
+108/108 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/linking.txt
+++ b/test/spec/reference-types/linking.txt
@@ -1,0 +1,58 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/linking.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/linking.wast:28: assert_unlinkable passed:
+  error: import signature mismatch
+  0000025: error: OnImportFunc callback failed
+out/test/spec/reference-types/linking.wast:32: assert_unlinkable passed:
+  error: import signature mismatch
+  0000026: error: OnImportFunc callback failed
+out/test/spec/reference-types/linking.wast:87: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected mutable but got immutable.
+  000001a: error: OnImportGlobal callback failed
+out/test/spec/reference-types/linking.wast:91: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected immutable but got mutable.
+  0000016: error: OnImportGlobal callback failed
+out/test/spec/reference-types/linking.wast:107: assert_unlinkable passed:
+  error: type mismatch in imported global, expected anyref but got funcref.
+  000001c: error: OnImportGlobal callback failed
+out/test/spec/reference-types/linking.wast:119: assert_unlinkable passed:
+  error: type mismatch in imported global, expected funcref but got anyref.
+  000001b: error: OnImportGlobal callback failed
+out/test/spec/reference-types/linking.wast:165: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:166: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:168: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:170: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:171: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:173: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:175: assert_trap passed: undefined table index
+out/test/spec/reference-types/linking.wast:176: assert_trap passed: undefined table index
+out/test/spec/reference-types/linking.wast:177: assert_trap passed: undefined table index
+out/test/spec/reference-types/linking.wast:178: assert_trap passed: undefined table index
+out/test/spec/reference-types/linking.wast:181: assert_trap passed: indirect call signature mismatch
+out/test/spec/reference-types/linking.wast:213: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:214: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:216: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:217: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:219: assert_trap passed: undefined table index
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
+out/test/spec/reference-types/linking.wast:245: assert_unlinkable passed:
+  error: unknown module field "mem"
+  0000027: error: OnImportMemory callback failed
+out/test/spec/reference-types/linking.wast:254: assert_trap passed: uninitialized table element
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [12, 13) >= max value 10
+out/test/spec/reference-types/linking.wast:265: assert_trap passed: uninitialized table element
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
+out/test/spec/reference-types/linking.wast:277: assert_trap passed: uninitialized table element
+out/test/spec/reference-types/linking.wast:288: assert_unlinkable passed:
+  error: type mismatch in imported table, expected funcref but got anyref.
+  000001b: error: OnImportTable callback failed
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
+out/test/spec/reference-types/linking.wast:366: assert_unlinkable passed:
+  error: unknown module field "tab"
+  0000037: error: OnImportTable callback failed
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [327680, 327681) >= max value 327680
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [0, 1) >= max value 0
+97/97 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/memory_grow.txt
+++ b/test/spec/reference-types/memory_grow.txt
@@ -1,0 +1,35 @@
+;;; SLOW:
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/memory_grow.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/memory_grow.wast:15: assert_trap passed: out of bounds memory access: access at 0+4 >= max value 0
+out/test/spec/reference-types/memory_grow.wast:16: assert_trap passed: out of bounds memory access: access at 0+4 >= max value 0
+out/test/spec/reference-types/memory_grow.wast:17: assert_trap passed: out of bounds memory access: access at 65536+4 >= max value 0
+out/test/spec/reference-types/memory_grow.wast:18: assert_trap passed: out of bounds memory access: access at 65536+4 >= max value 0
+out/test/spec/reference-types/memory_grow.wast:24: assert_trap passed: out of bounds memory access: access at 65536+4 >= max value 65536
+out/test/spec/reference-types/memory_grow.wast:25: assert_trap passed: out of bounds memory access: access at 65536+4 >= max value 65536
+out/test/spec/reference-types/memory_grow.wast:286: assert_trap passed: undefined table index
+out/test/spec/reference-types/memory_grow.wast:313: assert_invalid passed:
+  error: type mismatch in memory.grow, expected [i32] but got []
+  000001f: error: OnMemoryGrowExpr callback failed
+out/test/spec/reference-types/memory_grow.wast:322: assert_invalid passed:
+  error: type mismatch in memory.grow, expected [i32] but got []
+  0000023: error: OnMemoryGrowExpr callback failed
+out/test/spec/reference-types/memory_grow.wast:332: assert_invalid passed:
+  error: type mismatch in memory.grow, expected [i32] but got []
+  0000023: error: OnMemoryGrowExpr callback failed
+out/test/spec/reference-types/memory_grow.wast:342: assert_invalid passed:
+  error: type mismatch in memory.grow, expected [i32] but got []
+  0000025: error: OnMemoryGrowExpr callback failed
+out/test/spec/reference-types/memory_grow.wast:353: assert_invalid passed:
+  error: type mismatch in memory.grow, expected [i32] but got [f32]
+  0000024: error: OnMemoryGrowExpr callback failed
+out/test/spec/reference-types/memory_grow.wast:363: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  0000021: error: EndFunctionBody callback failed
+out/test/spec/reference-types/memory_grow.wast:372: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i32]
+  0000022: error: EndFunctionBody callback failed
+91/91 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/ref_func.txt
+++ b/test/spec/reference-types/ref_func.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/ref_func.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+set-g() =>
+set-f() =>
+out/test/spec/reference-types/ref_func.wast:58: assert_invalid passed:
+  error: unknown import module "M"
+  0000019: error: OnImportFunc callback failed
+11/11 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/ref_is_null.txt
+++ b/test/spec/reference-types/ref_is_null.txt
@@ -1,0 +1,8 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/ref_is_null.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+init(hostref:0) =>
+deinit() =>
+13/13 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/ref_null.txt
+++ b/test/spec/reference-types/ref_null.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/ref_null.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+2/2 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/table_get.txt
+++ b/test/spec/reference-types/table_get.txt
@@ -1,0 +1,26 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_get.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+init(hostref:1) =>
+out/test/spec/reference-types/table_get.wast:32: assert_trap passed: out of bounds table access: table.get at 2 >= max value 2
+out/test/spec/reference-types/table_get.wast:33: assert_trap passed: out of bounds table access: table.get at 3 >= max value 3
+out/test/spec/reference-types/table_get.wast:34: assert_trap passed: out of bounds table access: table.get at 4294967295 >= max value 2
+out/test/spec/reference-types/table_get.wast:35: assert_trap passed: out of bounds table access: table.get at 4294967295 >= max value 3
+out/test/spec/reference-types/table_get.wast:41: assert_invalid passed:
+  error: type mismatch in table.get, expected [i32] but got []
+  0000020: error: OnTableGetExpr callback failed
+out/test/spec/reference-types/table_get.wast:50: assert_invalid passed:
+  error: type mismatch in table.get, expected [i32] but got [f32]
+  0000025: error: OnTableGetExpr callback failed
+out/test/spec/reference-types/table_get.wast:60: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [anyref]
+  0000022: error: EndFunctionBody callback failed
+out/test/spec/reference-types/table_get.wast:69: assert_invalid passed:
+  error: type mismatch in implicit return, expected [funcref] but got [anyref]
+  0000023: error: EndFunctionBody callback failed
+out/test/spec/reference-types/table_get.wast:79: assert_invalid passed:
+  error: type mismatch in implicit return, expected [funcref] but got [anyref]
+  0000026: error: EndFunctionBody callback failed
+15/15 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/table_grow.txt
+++ b/test/spec/reference-types/table_grow.txt
@@ -1,0 +1,33 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_grow.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/table_grow.wast:14: assert_trap passed: out of bounds table access: table.set at 0 >= max value 0
+out/test/spec/reference-types/table_grow.wast:15: assert_trap passed: out of bounds table access: table.get at 0 >= max value 0
+out/test/spec/reference-types/table_grow.wast:22: assert_trap passed: out of bounds table access: table.set at 1 >= max value 1
+out/test/spec/reference-types/table_grow.wast:23: assert_trap passed: out of bounds table access: table.get at 1 >= max value 1
+out/test/spec/reference-types/table_grow.wast:34: assert_trap passed: out of bounds table access: table.set at 5 >= max value 5
+out/test/spec/reference-types/table_grow.wast:35: assert_trap passed: out of bounds table access: table.get at 5 >= max value 5
+out/test/spec/reference-types/table_grow.wast:109: assert_invalid passed:
+  error: type mismatch in table.grow, expected [anyref, i32] but got []
+  0000021: error: OnTableGrowExpr callback failed
+out/test/spec/reference-types/table_grow.wast:118: assert_invalid passed:
+  error: type mismatch in table.grow, expected [anyref, i32] but got [nullref]
+  0000022: error: OnTableGrowExpr callback failed
+out/test/spec/reference-types/table_grow.wast:127: assert_invalid passed:
+  error: type mismatch in table.grow, expected [anyref, i32] but got [i32]
+  0000023: error: OnTableGrowExpr callback failed
+out/test/spec/reference-types/table_grow.wast:136: assert_invalid passed:
+  error: type mismatch in table.grow, expected [anyref, i32] but got [nullref, f32]
+  0000027: error: OnTableGrowExpr callback failed
+out/test/spec/reference-types/table_grow.wast:145: assert_invalid passed:
+  error: type mismatch in table.grow, expected [funcref, i32] but got [anyref, i32]
+  0000026: error: OnTableGrowExpr callback failed
+out/test/spec/reference-types/table_grow.wast:155: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  0000024: error: EndFunctionBody callback failed
+out/test/spec/reference-types/table_grow.wast:164: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i32]
+  0000025: error: EndFunctionBody callback failed
+45/45 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/table_set.txt
+++ b/test/spec/reference-types/table_set.txt
@@ -1,0 +1,35 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_set.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/table_set.wast:40: assert_trap passed: out of bounds table access: table.set at 2 >= max value 1
+out/test/spec/reference-types/table_set.wast:41: assert_trap passed: out of bounds table access: table.set at 3 >= max value 2
+out/test/spec/reference-types/table_set.wast:42: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 1
+out/test/spec/reference-types/table_set.wast:43: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 2
+out/test/spec/reference-types/table_set.wast:45: assert_trap passed: out of bounds table access: table.set at 2 >= max value 1
+out/test/spec/reference-types/table_set.wast:46: assert_trap passed: out of bounds table access: table.set at 3 >= max value 2
+out/test/spec/reference-types/table_set.wast:47: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 1
+out/test/spec/reference-types/table_set.wast:48: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 2
+out/test/spec/reference-types/table_set.wast:54: assert_invalid passed:
+  error: type mismatch in table.set, expected [i32, anyref] but got []
+  000001f: error: OnTableSetExpr callback failed
+out/test/spec/reference-types/table_set.wast:63: assert_invalid passed:
+  error: type mismatch in table.set, expected [i32, anyref] but got [nullref]
+  0000020: error: OnTableSetExpr callback failed
+out/test/spec/reference-types/table_set.wast:72: assert_invalid passed:
+  error: type mismatch in table.set, expected [i32, anyref] but got [i32]
+  0000021: error: OnTableSetExpr callback failed
+out/test/spec/reference-types/table_set.wast:81: assert_invalid passed:
+  error: type mismatch in table.set, expected [i32, anyref] but got [f32, nullref]
+  0000025: error: OnTableSetExpr callback failed
+out/test/spec/reference-types/table_set.wast:90: assert_invalid passed:
+  error: type mismatch in table.set, expected [i32, funcref] but got [i32, anyref]
+  0000024: error: OnTableSetExpr callback failed
+out/test/spec/reference-types/table_set.wast:100: assert_invalid passed:
+  error: type mismatch in table.set, expected [i32, funcref] but got [i32, anyref]
+  0000027: error: OnTableSetExpr callback failed
+out/test/spec/reference-types/table_set.wast:111: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  0000024: error: EndFunctionBody callback failed
+25/25 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/table_size.txt
+++ b/test/spec/reference-types/table_size.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_size.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/table_size.wast:70: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  0000021: error: EndFunctionBody callback failed
+out/test/spec/reference-types/table_size.wast:79: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i32]
+  0000022: error: EndFunctionBody callback failed
+38/38 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
This change add all but one (table_fill) of the the reference-types
spec tests and includes various fixes that were needed to make them
pass.

The table.fill implementation and testing will be a followup.

Fixes: #1223