### PR TITLE
wasm-interp: Correctly report failure of start function

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -220,6 +220,7 @@ static wabt::Result ReadAndRunModule(const char* module_filename) {
     } else {
       WriteResult(s_stdout_stream.get(), "error running start function",
                   exec_result.result);
+      return wabt::Result::Error;
     }
   }
   return result;

--- a/test/interp/start-failure.txt
+++ b/test/interp/start-failure.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-interp
+;;; ERROR: 1
+(module
+  (func $start unreachable)
+  (start $start)
+)
+(;; STDOUT ;;;
+error running start function: unreachable executed
+;;; STDOUT ;;)


### PR DESCRIPTION
We were printing the error message but returning success.