### PR TITLE
wasm-decompile: Output of other sections + import/export.

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -486,8 +486,8 @@ struct Decompiler {
           CheckImportExport(ExternalKind::Memory, memory_index, m->name);
       stream.Writef("memory %s", m->name.c_str());
       if (!is_import) {
-        stream.Writef("(initial: %ld, max: %ld)", m->page_limits.initial,
-                      m->page_limits.max);
+        stream.Writef("(initial: %" PRIu64 ", max: %" PRIu64 ")",
+                      m->page_limits.initial, m->page_limits.max);
       }
       stream.Writef(";\n");
       memory_index++;
@@ -517,8 +517,8 @@ struct Decompiler {
       stream.Writef("table %s:%s", tab->name.c_str(),
                     GetDecompTypeName(tab->elem_type));
       if (!is_import) {
-        stream.Writef("(min: %ld, max: %ld)", tab->elem_limits.initial,
-                      tab->elem_limits.max);
+        stream.Writef("(min: %" PRIu64 ", max: %" PRIu64 ")",
+                      tab->elem_limits.initial, tab->elem_limits.max);
       }
       stream.Writef(";\n");
       table_index++;

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -439,20 +439,97 @@ struct Decompiler {
     }
   }
 
+  bool CheckImportExport(ExternalKind kind, Index &index, string_view name) {
+    auto is_import = mc.module.IsImport(kind, Var(index++));
+    // TODO: is this the best way to check for export?
+    // FIXME: this doesn't work for functions that get renamed in some way,
+    // as the export has the original name..
+    auto xport = mc.module.GetExport(name);
+    auto is_export = xport && xport->kind == kind;
+    if (is_export) stream.Writef("export ");
+    if (is_import) stream.Writef("import ");
+    return is_import;
+  }
+
+  std::string InitExp(const ExprList &el) {
+    assert(!el.empty());
+    AST ast(mc, nullptr);
+    ast.Construct(el, 1, false);
+    auto val = DecompileExpr(ast.exp_stack[0]);
+    assert(ast.exp_stack.size() == 1 && val.v.size() == 1);
+    return std::move(val.v[0]);
+  }
+
+  // FIXME: Merge with WatWriter::WriteQuotedData somehow.
+  std::string BinaryToString(const std::vector<uint8_t> &in) {
+    std::string s = "\"";
+    static const char s_hexdigits[] = "0123456789abcdef";
+    for (auto c : in) {
+      if (c >= ' ' && c <= '~') {
+        s += c;
+      } else {
+        s += '\\';
+        s += s_hexdigits[c >> 4];
+        s += s_hexdigits[c & 0xf];
+      }
+    }
+    s += '\"';
+    return s;
+  }
+
   void Decompile() {
+    Index memory_index = 0;
+    for (auto m : mc.module.memories) {
+      auto is_import =
+          CheckImportExport(ExternalKind::Memory, memory_index, m->name);
+      stream.Writef("memory %s", m->name.c_str());
+      if (!is_import) {
+        stream.Writef("(initial: %ld, max: %ld)", m->page_limits.initial,
+                      m->page_limits.max);
+      }
+      stream.Writef(";\n");
+    }
+    if (!mc.module.memories.empty()) stream.Writef("\n");
+
+    Index global_index = 0;
     for (auto g : mc.module.globals) {
-      AST ast(mc, nullptr);
-      ast.Construct(g->init_expr, 1, false);
-      auto val = DecompileExpr(ast.exp_stack[0]);
-      assert(ast.exp_stack.size() == 1 && val.v.size() == 1);
-      stream.Writef("global %s:%s = %s\n", g->name.c_str(),
-                    GetDecompTypeName(g->type), val.v[0].c_str());
+      auto is_import =
+          CheckImportExport(ExternalKind::Global, global_index, g->name);
+      stream.Writef("global %s:%s", g->name.c_str(),
+                    GetDecompTypeName(g->type));
+      if (!is_import) {
+        stream.Writef(" = %s", InitExp(g->init_expr).c_str());
+      }
+      stream.Writef(";\n");
     }
     if (!mc.module.globals.empty()) stream.Writef("\n");
+
+    Index table_index = 0;
+    for (auto tab : mc.module.tables) {
+      auto is_import =
+          CheckImportExport(ExternalKind::Table, table_index, tab->name);
+      stream.Writef("table %s:%s", tab->name.c_str(),
+                    GetDecompTypeName(tab->elem_type));
+      if (!is_import) {
+        stream.Writef("(min: %ld, max: %ld)", tab->elem_limits.initial,
+                      tab->elem_limits.max);
+      }
+      stream.Writef(";\n");
+    }
+    if (!mc.module.tables.empty()) stream.Writef("\n");
+
+    for (auto dat : mc.module.data_segments) {
+      stream.Writef("data %s(offset: %s) = %s;\n", dat->name.c_str(),
+                    InitExp(dat->offset).c_str(),
+                    BinaryToString(dat->data).c_str());
+    }
+    if (!mc.module.data_segments.empty()) stream.Writef("\n");
+
     Index func_index = 0;
     for(auto f : mc.module.funcs) {
       cur_func = f;
-      auto is_import = mc.module.IsImport(ExternalKind::Func, Var(func_index));
+      auto is_import =
+          CheckImportExport(ExternalKind::Func, func_index, f->name);
       AST ast(mc, f);
       if (!is_import) ast.Construct(f->exprs, f->GetNumResults(), true);
       stream.Writef("function %s(", f->name.c_str());
@@ -476,7 +553,7 @@ struct Decompiler {
         }
       }
       if (is_import) {
-        stream.Writef(" = import;\n\n");
+        stream.Writef(";");
       } else {
         stream.Writef(" {\n");
         auto val = DecompileExpr(ast.exp_stack[0]);
@@ -484,10 +561,10 @@ struct Decompiler {
         for (auto& s : val.v) {
           stream.Writef("%s\n", s.c_str());
         }
-        stream.Writef("}\n\n");
+        stream.Writef("}");
       }
       mc.EndFunc();
-      func_index++;
+      stream.Writef("\n\n");
     }
   }
 

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -1,7 +1,21 @@
 ;;; TOOL: run-wasm-decompile
 
 (module
-  (memory 1)
+  (import "ns" "fi" (func))
+  (import "ns" "g3" (global i32))
+  (import "ns" "tab3" (table 0 12 funcref))
+  ;; (import "ns" "m1" (memory 1))  ;; Can test only 1 at a time :(
+
+  (memory (export "m2") 1)
+
+  (global $g1 (mut i32) (i32.const 10))
+  (global (export "g2") (mut i32) (i32.const 11))
+
+  (table $tab1 0 10 funcref)
+  (table (export "tab2") 0 11 funcref)
+
+  (data 0 (offset (i32.const 0)) "Hello, World!\n\00")
+
   (func $f (param i32 i32) (result i32) (local i64 f32 f64)
     i64.const 8
     set_local 2
@@ -20,7 +34,7 @@
       i32.store offset=4
     end
     get_local 0
-    get_local 1
+    get_global $g1
     i32.add
     i32.const 9
     call $f
@@ -45,16 +59,31 @@
   ;; so have to make sure special chars get removed.
   (func (export "signature-&<>()") (param) (result))
   (func (export "signature-&[]()") (param) (result))
+  (func $not-exported (param) (result))
   (export "f" (func $f))
 )
 
 (;; STDOUT ;;;
-function f(a:int, b:int):int {
+export memory m2(initial: 1, max: 0);
+
+import global ns_g3:int;
+global g_b:int = 10;
+export global g2:int = 11;
+
+import table ns_tab3:funcref;
+table T_b:funcref(min: 0, max: 10);
+export table tab2:funcref(min: 0, max: 11);
+
+data d_a(offset: 0) = "Hello, World!\0a\00";
+
+import function ns_fi();
+
+export function f(a:int, b:int):int {
   var c:long = 8L;
   var d:float = 6f;
   var e:double = 7d;
   if (e < 10d) { 1[4]:int = (2[3]:int + 5) }
-  f(a + b, 9);
+  f(a + g_b, 9);
   loop L_b {
     block B_c {
       if (if (0) { 1 } else { 2 }) break B_c;
@@ -69,6 +98,9 @@ function signature______() {
 }
 
 function signature_______1() {
+}
+
+function f_e() {
 }
 
 ;;; STDOUT ;;)

--- a/test/decompile/stack-flush.txt
+++ b/test/decompile/stack-flush.txt
@@ -48,7 +48,9 @@
 )
 
 (;; STDOUT ;;;
-function f(a:int, b:int):int {
+memory M_a(initial: 1, max: 0);
+
+export function f(a:int, b:int):int {
   let t0 = s();
   s();
   let t1, t2 = s(), s();
@@ -68,11 +70,11 @@ function f(a:int, b:int):int {
   return t7 == t8;
 }
 
-function s():int {
+export function s():int {
   return 1
 }
 
-function mv():(int, int) {
+export function mv():(int, int) {
   return 1, 2
 }
 

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -140,8 +140,8 @@ TOOLS = {
         ('VERBOSE-ARGS', ['--print-cmd', '-v']),
     ],
     'run-wasm-decompile': [
-        ('RUN', '%(wat2wasm)s --enable-multi-value %(in_file)s -o %(temp_file)s.wasm'),
-        ('RUN', '%(wasm-decompile)s --enable-multi-value %(temp_file)s.wasm'),
+        ('RUN', '%(wat2wasm)s --enable-all %(in_file)s -o %(temp_file)s.wasm'),
+        ('RUN', '%(wasm-decompile)s --enable-all %(temp_file)s.wasm'),
     ]
 }
 


### PR DESCRIPTION
This now outputs memories, globals, tables, and import/export of
these (and functions).

Changed the syntax to be more consistent and refactored how it is
checked.