### PR TITLE
Update spec testsuite

### DIFF
--- a/src/binary-writer.h
+++ b/src/binary-writer.h
@@ -46,7 +46,7 @@ struct WriteBinaryOptions {
 
 Result WriteBinaryModule(Stream*, const Module*, const WriteBinaryOptions&);
 
-void WriteType(Stream* stream, Type type);
+void WriteType(Stream* stream, Type type, const char* desc = nullptr);
 
 void WriteStr(Stream* stream,
               string_view s,

--- a/src/common.h
+++ b/src/common.h
@@ -226,11 +226,12 @@ typedef std::vector<Type> TypeVector;
 
 // Matches binary format, do not change.
 enum SegmentFlags : uint8_t {
-  SegIndexZero = 0,
-  SegPassive = 1,
-  SegIndexOther = 2,
+  SegFlagsNone = 0,
+  SegPassive = 1,        // bit 0: Is passive
+  SegExplicitIndex = 2,  // bit 1: Has explict index (Inplies table 0 if absent)
+  SegUseElemExprs = 4,   // bit 2: Is elemexpr (Or else index sequence)
 
-  SegFlagMax = SegIndexOther,
+  SegFlagMax = SegUseElemExprs,
 };
 
 enum class RelocType {

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -203,7 +203,7 @@ static void InitEnvironment(Environment* env) {
 
 static wabt::Result ReadAndRunModule(const char* module_filename) {
   wabt::Result result;
-  Environment env;
+  Environment env(s_features);
   InitEnvironment(&env);
 
   Errors errors;
@@ -212,13 +212,13 @@ static wabt::Result ReadAndRunModule(const char* module_filename) {
   FormatErrorsToFile(errors, Location::Type::Binary);
   if (Succeeded(result)) {
     Executor executor(&env, s_trace_stream, s_thread_options);
-    ExecResult exec_result = executor.RunStartFunction(module);
+    ExecResult exec_result = executor.Initialize(module);
     if (exec_result.ok()) {
       if (s_run_all_exports) {
         RunAllExports(module, &executor, RunVerbosity::Verbose);
       }
     } else {
-      WriteResult(s_stdout_stream.get(), "error running start function",
+      WriteResult(s_stdout_stream.get(), "error initialiazing module",
                   exec_result.result);
       return wabt::Result::Error;
     }

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -266,8 +266,9 @@ Result Validator::CheckVar(Index max_index,
     }
     return Result::Ok;
   }
-  PrintError(&var->loc, "%s variable out of range (max %" PRIindex ")", desc,
-             max_index);
+  PrintError(&var->loc,
+             "%s variable out of range: %" PRIindex " (max %" PRIindex ")",
+             desc, var->index(), max_index - 1);
   return Result::Error;
 }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1250,13 +1250,20 @@ void WatWriter::WriteTable(const Table& table) {
 void WatWriter::WriteElemSegment(const ElemSegment& segment) {
   WriteOpenSpace("elem");
   WriteNameOrIndex(segment.name, elem_segment_index_, NextChar::Space);
-  if (segment.is_passive()) {
-    WriteType(segment.elem_type, NextChar::Space);
-  } else {
+
+  if (!segment.is_passive()) {
     WriteInitExpr(segment.offset);
   }
+
+  if (segment.flags & SegUseElemExprs) {
+    WriteType(segment.elem_type, NextChar::Space);
+  } else {
+    assert(segment.elem_type == Type::Funcref);
+    WritePuts("func", NextChar::Space);
+  }
+
   for (const ElemExpr& expr : segment.elem_exprs) {
-    if (segment.is_passive()) {
+    if (segment.flags & SegUseElemExprs) {
       if (expr.kind == ElemExprKind::RefNull) {
         WriteOpenSpace("ref.null");
         WriteCloseSpace();

--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -13,6 +13,6 @@ section(DATA) {
   offset[i32.const 0 end]
   data[str("overflow")]
 }
-(;; STDERR ;;;
-error: data segment is out of bounds: [0, 8) >= max value 0
-;;; STDERR ;;)
+(;; STDOUT ;;;
+error initialiazing module: out of bounds memory access: data segment is out of bounds: [0, 8) >= max value 0
+;;; STDOUT ;;)

--- a/test/binary/bad-duplicate-section-around-custom.txt
+++ b/test/binary/bad-duplicate-section-around-custom.txt
@@ -5,6 +5,6 @@ section(TYPE) { count[0] }
 section("foo") { 1 2 3 4 }
 section(TYPE) { count[0] }
 (;; STDERR ;;;
-0000017: error: section Type out of order
-0000017: error: section Type out of order
+0000017: error: multiple Type sections
+0000017: error: multiple Type sections
 ;;; STDERR ;;)

--- a/test/binary/bad-duplicate-section.txt
+++ b/test/binary/bad-duplicate-section.txt
@@ -4,6 +4,6 @@ version
 section(TYPE) { count[0] }
 section(TYPE) { count[0] }
 (;; STDERR ;;;
-000000d: error: section Type out of order
-000000d: error: section Type out of order
+000000d: error: multiple Type sections
+000000d: error: multiple Type sections
 ;;; STDERR ;;)

--- a/test/desugar/basic.txt
+++ b/test/desugar/basic.txt
@@ -15,7 +15,7 @@
   (import "foo" "bar" (func (;0;) (result i32)))
   (global (;0;) i32 (i32.const 1))
   (table (;0;) 1 1 funcref)
-  (elem (;0;) (i32.const 0) 0)
+  (elem (;0;) (i32.const 0) func 0)
   (memory (;0;) 1 1)
   (data (;0;) (i32.const 0) "hello")
   (func (;1;) (result i32)

--- a/test/dump/bulk-memory.txt
+++ b/test/dump/bulk-memory.txt
@@ -12,7 +12,7 @@
   )
 
   (table 1 anyfunc)
-  (elem funcref 0)
+  (elem func 0)
   (func
     i32.const 0 i32.const 0 i32.const 0 table.init 0
     elem.drop 0
@@ -25,30 +25,30 @@ bulk-memory.wasm:	file format wasm 0x1
 
 Code Disassembly:
 
-00002e func[0]:
+00002c func[0]:
+ 00002d: 41 00                      | i32.const 0
  00002f: 41 00                      | i32.const 0
  000031: 41 00                      | i32.const 0
- 000033: 41 00                      | i32.const 0
- 000035: fc 08 00 00                | memory.init 0 0
- 000039: fc 09 00                   | data.drop 0
+ 000033: fc 08 00 00                | memory.init 0 0
+ 000037: fc 09 00                   | data.drop 0
+ 00003a: 41 00                      | i32.const 0
  00003c: 41 00                      | i32.const 0
  00003e: 41 00                      | i32.const 0
- 000040: 41 00                      | i32.const 0
- 000042: fc 0a 00 00                | memory.copy 0 0
+ 000040: fc 0a 00 00                | memory.copy 0 0
+ 000044: 41 00                      | i32.const 0
  000046: 41 00                      | i32.const 0
  000048: 41 00                      | i32.const 0
- 00004a: 41 00                      | i32.const 0
- 00004c: fc 0b 00                   | memory.fill 0
- 00004f: 0b                         | end
-000051 func[1]:
+ 00004a: fc 0b 00                   | memory.fill 0
+ 00004d: 0b                         | end
+00004f func[1]:
+ 000050: 41 00                      | i32.const 0
  000052: 41 00                      | i32.const 0
  000054: 41 00                      | i32.const 0
- 000056: 41 00                      | i32.const 0
- 000058: fc 0c 00 00                | table.init 0 0
- 00005c: fc 0d 00                   | elem.drop 0
+ 000056: fc 0c 00 00                | table.init 0 0
+ 00005a: fc 0d 00                   | elem.drop 0
+ 00005d: 41 00                      | i32.const 0
  00005f: 41 00                      | i32.const 0
  000061: 41 00                      | i32.const 0
- 000063: 41 00                      | i32.const 0
- 000065: fc 0e 00 00                | table.copy 0 0
- 000069: 0b                         | end
+ 000063: fc 0e 00 00                | table.copy 0 0
+ 000067: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -46,7 +46,7 @@
 000001f: 00                                        ; i32 literal
 0000020: 0b                                        ; end
 0000021: 01                                        ; num elems
-0000022: 00                                        ; elem expr function index
+0000022: 00                                        ; elem function index
 000001b: 07                                        ; FIXUP section size
 ; section "Code" (10)
 0000023: 0a                                        ; section code

--- a/test/dump/invalid-data-segment-no-memory.txt
+++ b/test/dump/invalid-data-segment-no-memory.txt
@@ -10,7 +10,7 @@
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num data segments
 ; data segment header 0
-000000b: 00                                      
+000000b: 00                                        ; segment flags
 000000c: 41                                        ; i32.const
 000000d: 00                                        ; i32 literal
 000000e: 0b                                        ; end

--- a/test/dump/invalid-data-segment-offset.txt
+++ b/test/dump/invalid-data-segment-offset.txt
@@ -19,7 +19,7 @@
 000000e: 00                                        ; section size (guess)
 000000f: 01                                        ; num data segments
 ; data segment header 0
-0000010: 00                                      
+0000010: 00                                        ; segment flags
 0000011: 41                                        ; i32.const
 0000012: 01                                        ; i32 literal
 0000013: 41                                        ; i32.const

--- a/test/dump/invalid-elem-segment-no-table.txt
+++ b/test/dump/invalid-elem-segment-no-table.txt
@@ -33,8 +33,8 @@
 0000018: 00                                        ; i32 literal
 0000019: 0b                                        ; end
 000001a: 02                                        ; num elems
-000001b: 00                                        ; elem expr function index
-000001c: 01                                        ; elem expr function index
+000001b: 00                                        ; elem function index
+000001c: 01                                        ; elem function index
 0000014: 08                                        ; FIXUP section size
 ; section "Code" (10)
 000001d: 0a                                        ; section code

--- a/test/dump/invalid-elem-segment-offset.txt
+++ b/test/dump/invalid-elem-segment-offset.txt
@@ -42,7 +42,7 @@
 000001e: 45                                        ; i32.eqz
 000001f: 0b                                        ; end
 0000020: 01                                        ; num elems
-0000021: 00                                        ; elem expr function index
+0000021: 00                                        ; elem function index
 0000019: 08                                        ; FIXUP section size
 ; section "Code" (10)
 0000022: 0a                                        ; section code

--- a/test/dump/memory-hex.txt
+++ b/test/dump/memory-hex.txt
@@ -20,7 +20,7 @@
 000000f: 00                                        ; section size (guess)
 0000010: 01                                        ; num data segments
 ; data segment header 0
-0000011: 00                                      
+0000011: 00                                        ; segment flags
 0000012: 41                                        ; i32.const
 0000013: 00                                        ; i32 literal
 0000014: 0b                                        ; end

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -21,7 +21,7 @@
 000000e: 00                                        ; section size (guess)
 000000f: 02                                        ; num data segments
 ; data segment header 0
-0000010: 00                                      
+0000010: 00                                        ; segment flags
 0000011: 41                                        ; i32.const
 0000012: 0a                                        ; i32 literal
 0000013: 0b                                        ; end
@@ -29,7 +29,7 @@
 ; data segment data 0
 0000015: 6865 6c6c 6f                              ; data segment data
 ; data segment header 1
-000001a: 00                                      
+000001a: 00                                        ; segment flags
 000001b: 41                                        ; i32.const
 000001c: 14                                        ; i32 literal
 000001d: 0b                                        ; end

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -103,8 +103,8 @@
 0000065: 00                                        ; i32 literal
 0000066: 0b                                        ; end
 0000067: 02                                        ; num elems
-0000068: 02                                        ; elem expr function index
-0000069: 03                                        ; elem expr function index
+0000068: 02                                        ; elem function index
+0000069: 03                                        ; elem function index
 000005d: 8880 8080 00                              ; FIXUP section size
 ; section "Code" (10)
 000006a: 0a                                        ; section code

--- a/test/dump/reference-types.txt
+++ b/test/dump/reference-types.txt
@@ -84,9 +84,9 @@ Table[3]:
  - table[1] type=anyref initial=1
  - table[2] type=funcref initial=1
 Elem[2]:
- - segment[0] flags=2 table=2 count=1 - init i32=0
+ - segment[0] flags=0 table=0 count=1 - init i32=0
   - elem[0] = func[0]
- - segment[1] flags=1 table=0 count=1
+ - segment[1] flags=5 table=0 count=1
   - elem[0] = nullref
 Code[10]:
  - func[0] size=6
@@ -102,45 +102,45 @@ Code[10]:
 
 Code Disassembly:
 
-000048 func[0]:
- 000049: 41 00                      | i32.const 0
- 00004b: 25 00                      | table.get 0
- 00004d: 0b                         | end
-00004f func[1]:
- 000050: 41 00                      | i32.const 0
- 000052: 25 01                      | table.get 1
- 000054: 0b                         | end
-000056 func[2]:
- 000057: 41 00                      | i32.const 0
- 000059: 20 00                      | local.get 0
- 00005b: 26 00                      | table.set 0
- 00005d: 0b                         | end
-00005f func[3]:
- 000060: 41 00                      | i32.const 0
- 000062: 20 00                      | local.get 0
- 000064: 26 01                      | table.set 1
- 000066: 0b                         | end
-000068 func[4]:
- 000069: d0                         | ref.null
- 00006a: 41 00                      | i32.const 0
- 00006c: fc 0f 00                   | table.grow 0
- 00006f: 0b                         | end
-000071 func[5]:
- 000072: d0                         | ref.null
- 000073: 41 00                      | i32.const 0
- 000075: fc 0f 01                   | table.grow 1
- 000078: 0b                         | end
-00007a func[6]:
- 00007b: 20 00                      | local.get 0
- 00007d: d1                         | ref.is_null
- 00007e: 0b                         | end
-000080 func[7]:
- 000081: fc 10 00                   | table.size 0
- 000084: 0b                         | end
-000086 func[8]:
- 000087: fc 10 01                   | table.size 1
- 00008a: 0b                         | end
-00008c func[9]:
- 00008d: fc 10 02                   | table.size 2
- 000090: 0b                         | end
+000047 func[0]:
+ 000048: 41 00                      | i32.const 0
+ 00004a: 25 00                      | table.get 0
+ 00004c: 0b                         | end
+00004e func[1]:
+ 00004f: 41 00                      | i32.const 0
+ 000051: 25 01                      | table.get 1
+ 000053: 0b                         | end
+000055 func[2]:
+ 000056: 41 00                      | i32.const 0
+ 000058: 20 00                      | local.get 0
+ 00005a: 26 00                      | table.set 0
+ 00005c: 0b                         | end
+00005e func[3]:
+ 00005f: 41 00                      | i32.const 0
+ 000061: 20 00                      | local.get 0
+ 000063: 26 01                      | table.set 1
+ 000065: 0b                         | end
+000067 func[4]:
+ 000068: d0                         | ref.null
+ 000069: 41 00                      | i32.const 0
+ 00006b: fc 0f 00                   | table.grow 0
+ 00006e: 0b                         | end
+000070 func[5]:
+ 000071: d0                         | ref.null
+ 000072: 41 00                      | i32.const 0
+ 000074: fc 0f 01                   | table.grow 1
+ 000077: 0b                         | end
+000079 func[6]:
+ 00007a: 20 00                      | local.get 0
+ 00007c: d1                         | ref.is_null
+ 00007d: 0b                         | end
+00007f func[7]:
+ 000080: fc 10 00                   | table.size 0
+ 000083: 0b                         | end
+000085 func[8]:
+ 000086: fc 10 01                   | table.size 1
+ 000089: 0b                         | end
+00008b func[9]:
+ 00008c: fc 10 02                   | table.size 2
+ 00008f: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -49,26 +49,27 @@
 0000023: 00                                        ; i32 literal
 0000024: 0b                                        ; end
 0000025: 01                                        ; num elems
-0000026: 00                                        ; elem expr function index
+0000026: 00                                        ; elem function index
 ; elem segment header 1
 0000027: 02                                        ; segment flags
 0000028: 01                                        ; table index
 0000029: 41                                        ; i32.const
 000002a: 00                                        ; i32 literal
 000002b: 0b                                        ; end
-000002c: 01                                        ; num elems
-000002d: 00                                        ; elem expr function index
-000001f: 0e                                        ; FIXUP section size
+000002c: 00                                        ; elem list type
+000002d: 01                                        ; num elems
+000002e: 00                                        ; elem function index
+000001f: 0f                                        ; FIXUP section size
 ; section "Code" (10)
-000002e: 0a                                        ; section code
-000002f: 00                                        ; section size (guess)
-0000030: 01                                        ; num functions
+000002f: 0a                                        ; section code
+0000030: 00                                        ; section size (guess)
+0000031: 01                                        ; num functions
 ; function body 0
-0000031: 00                                        ; func body size (guess)
-0000032: 00                                        ; local decl count
-0000033: 0b                                        ; end
-0000031: 02                                        ; FIXUP func body size
-000002f: 04                                        ; FIXUP section size
+0000032: 00                                        ; func body size (guess)
+0000033: 00                                        ; local decl count
+0000034: 0b                                        ; end
+0000032: 02                                        ; FIXUP func body size
+0000030: 04                                        ; FIXUP section size
 
 table-multi.wasm:	file format wasm 0x1
 
@@ -91,6 +92,6 @@ Code[1]:
 
 Code Disassembly:
 
-000032 func[0]:
- 000033: 0b                         | end
+000033 func[0]:
+ 000034: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -62,18 +62,18 @@
 000002a: 00                                        ; i32 literal
 000002b: 0b                                        ; end
 000002c: 02                                        ; num elems
-000002d: 01                                        ; elem expr function index
-000002e: 01                                        ; elem expr function index
+000002d: 01                                        ; elem function index
+000002e: 01                                        ; elem function index
 ; elem segment header 1
 000002f: 00                                        ; segment flags
 0000030: 41                                        ; i32.const
 0000031: 02                                        ; i32 literal
 0000032: 0b                                        ; end
 0000033: 04                                        ; num elems
-0000034: 00                                        ; elem expr function index
-0000035: 00                                        ; elem expr function index
-0000036: 01                                        ; elem expr function index
-0000037: 02                                        ; elem expr function index
+0000034: 00                                        ; elem function index
+0000035: 00                                        ; elem function index
+0000036: 01                                        ; elem function index
+0000037: 02                                        ; elem function index
 0000026: 11                                        ; FIXUP section size
 ; section "Code" (10)
 0000038: 0a                                        ; section code

--- a/test/interp/logging-all-opcodes.txt
+++ b/test/interp/logging-all-opcodes.txt
@@ -2651,11 +2651,11 @@
 0001b1a: 00                                        ; i32 literal
 0001b1b: 0b                                        ; end
 0001b1c: 02                                        ; num elems
-0001b1d: 01                                        ; elem expr function index
-0001b1e: 01                                        ; elem expr function index
+0001b1d: 01                                        ; elem function index
+0001b1e: 01                                        ; elem function index
 ; elem segment header 1
-0001b1f: 01                                        ; segment flags
-0001b20: 70                                        ; funcref
+0001b1f: 05                                        ; segment flags
+0001b20: 70                                        ; elem expr list type
 0001b21: 00                                        ; num elems
 0001b16: 0b                                        ; FIXUP section size
 ; section "DataCount" (12)
@@ -7456,7 +7456,7 @@
 0003948: 00                                        ; section size (guess)
 0003949: 01                                        ; num data segments
 ; data segment header 0
-000394a: 01                                      
+000394a: 01                                        ; segment flags
 000394b: 00                                        ; data segment size
 ; data segment data 0
 0003948: 03                                        ; FIXUP section size
@@ -8310,7 +8310,7 @@ BeginModule(version: 1)
     OnElemSegmentElemExpr_RefFunc(index: 0, func_index: 1)
     OnElemSegmentElemExpr_RefFunc(index: 0, func_index: 1)
     EndElemSegment(0)
-    BeginElemSegment(index: 1, table_index: 0, flags: 1, elem_type: funcref)
+    BeginElemSegment(index: 1, table_index: 0, flags: 5, elem_type: funcref)
     OnElemSegmentElemExprCount(index: 1, count: 0)
     EndElemSegment(1)
   EndElemSection
@@ -12985,7 +12985,7 @@ i64.trunc_s:sat/f32() =>
 i64.trunc_u:sat/f32() =>
 i64.trunc_s:sat/f64() =>
 i64.trunc_u:sat/f64() =>
-memory.init() => error: out of bounds memory access
+memory.init() => error: out of bounds memory access: memory.init out of bounds
 data.drop() =>
 memory.copy() =>
 memory.fill() =>

--- a/test/interp/start-failure.txt
+++ b/test/interp/start-failure.txt
@@ -5,5 +5,5 @@
   (start $start)
 )
 (;; STDOUT ;;;
-error running start function: unreachable executed
+error initialiazing module: unreachable executed
 ;;; STDOUT ;;)

--- a/test/interp/tracing-all-opcodes.txt
+++ b/test/interp/tracing-all-opcodes.txt
@@ -1612,7 +1612,7 @@ i64.trunc_u:sat/f64() =>
 #0. 5012: V:1  | i32.const 2
 #0. 5020: V:2  | i32.const 3
 #0. 5028: V:3  | memory.init $0, $0
-memory.init() => error: out of bounds memory access
+memory.init() => error: out of bounds memory access: memory.init out of bounds
 >>> running export "data.drop":
 #0. 5044: V:0  | data.drop $0
 #0. 5052: V:0  | return

--- a/test/parse/expr/bad-getglobal-undefined.txt
+++ b/test/parse/expr/bad-getglobal-undefined.txt
@@ -5,7 +5,7 @@
     get_global 0
     drop))
 (;; STDERR ;;;
-out/test/parse/expr/bad-getglobal-undefined.txt:5:16: error: global variable out of range (max 0)
+out/test/parse/expr/bad-getglobal-undefined.txt:5:16: error: global variable out of range: 0 (max 4294967295)
     get_global 0
                ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-setglobal-undefined.txt
+++ b/test/parse/expr/bad-setglobal-undefined.txt
@@ -4,7 +4,7 @@
           i32.const 1
           set_global 0))
 (;; STDERR ;;;
-out/test/parse/expr/bad-setglobal-undefined.txt:5:22: error: global variable out of range (max 0)
+out/test/parse/expr/bad-setglobal-undefined.txt:5:22: error: global variable out of range: 0 (max 4294967295)
           set_global 0))
                      ^
 ;;; STDERR ;;)

--- a/test/parse/expr/bulk-memory-disabled.txt
+++ b/test/parse/expr/bulk-memory-disabled.txt
@@ -32,6 +32,9 @@ out/test/parse/expr/bulk-memory-disabled.txt:10:41: error: opcode not allowed: m
 out/test/parse/expr/bulk-memory-disabled.txt:11:41: error: opcode not allowed: memory.fill
     i32.const 0 i32.const 0 i32.const 0 memory.fill
                                         ^^^^^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:15:23: error: unexpected token 0, expected ).
+  (elem $elem funcref 0)
+                      ^
 out/test/parse/expr/bulk-memory-disabled.txt:17:41: error: opcode not allowed: table.init
     i32.const 0 i32.const 0 i32.const 0 table.init 0
                                         ^^^^^^^^^^

--- a/test/parse/expr/bulk-memory-named.txt
+++ b/test/parse/expr/bulk-memory-named.txt
@@ -11,7 +11,7 @@
 
   (table 1 anyfunc)
   (elem $elem funcref (ref.func 0) (ref.null))
-  (elem $elem2 funcref 0)
+  (elem $elem2 func 0)
   (func
     i32.const 0 i32.const 0 i32.const 0 table.init $elem
     elem.drop $elem

--- a/test/parse/expr/table-drop.txt
+++ b/test/parse/expr/table-drop.txt
@@ -9,4 +9,4 @@
   (func)
 
   (table 0 funcref)
-  (elem funcref 1))
+  (elem func 1))

--- a/test/parse/expr/table-init.txt
+++ b/test/parse/expr/table-init.txt
@@ -12,4 +12,4 @@
   (func)
 
   (table 0 funcref)
-  (elem funcref 1))
+  (elem func 1))

--- a/test/parse/module/bad-elem-redefinition.txt
+++ b/test/parse/module/bad-elem-redefinition.txt
@@ -7,7 +7,10 @@
   (func))
 
 (;; STDERR ;;;
-out/test/parse/module/bad-elem-redefinition.txt:6:4: error: redefinition of elem "$elem"
+out/test/parse/module/bad-elem-redefinition.txt:5:23: error: unexpected token 0, expected ).
   (elem $elem funcref 0)
-   ^^^^
+                      ^
+out/test/parse/module/bad-elem-redefinition.txt:6:23: error: unexpected token 0, expected ).
+  (elem $elem funcref 0)
+                      ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-func-undefined.txt
+++ b/test/parse/module/bad-export-func-undefined.txt
@@ -2,7 +2,7 @@
 ;;; ERROR: 1
 (module (export "foo" (func 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-func-undefined.txt:3:29: error: function variable out of range (max 0)
+out/test/parse/module/bad-export-func-undefined.txt:3:29: error: function variable out of range: 0 (max 4294967295)
 (module (export "foo" (func 0)))
                             ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-global-undefined.txt
+++ b/test/parse/module/bad-export-global-undefined.txt
@@ -2,7 +2,7 @@
 ;;; ERROR: 1
 (module (export "foo" (global 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-global-undefined.txt:3:31: error: global variable out of range (max 0)
+out/test/parse/module/bad-export-global-undefined.txt:3:31: error: global variable out of range: 0 (max 4294967295)
 (module (export "foo" (global 0)))
                               ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-memory-undefined.txt
+++ b/test/parse/module/bad-export-memory-undefined.txt
@@ -3,7 +3,7 @@
 (module
   (export "mem" (memory 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-memory-undefined.txt:4:25: error: memory variable out of range (max 0)
+out/test/parse/module/bad-export-memory-undefined.txt:4:25: error: memory variable out of range: 0 (max 4294967295)
   (export "mem" (memory 0)))
                         ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-export-table-undefined.txt
+++ b/test/parse/module/bad-export-table-undefined.txt
@@ -2,7 +2,7 @@
 ;;; ERROR: 1
 (module (export "foo" (table 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-export-table-undefined.txt:3:30: error: table variable out of range (max 0)
+out/test/parse/module/bad-export-table-undefined.txt:3:30: error: table variable out of range: 0 (max 4294967295)
 (module (export "foo" (table 0)))
                              ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-global-invalid-getglobal.txt
+++ b/test/parse/module/bad-global-invalid-getglobal.txt
@@ -3,7 +3,7 @@
 (module
   (global i32 (get_global 1)))
 (;; STDERR ;;;
-out/test/parse/module/bad-global-invalid-getglobal.txt:4:27: error: global variable out of range (max 1)
+out/test/parse/module/bad-global-invalid-getglobal.txt:4:27: error: global variable out of range: 1 (max 0)
   (global i32 (get_global 1)))
                           ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-start-too-many.txt
+++ b/test/parse/module/bad-start-too-many.txt
@@ -6,7 +6,7 @@
   (func)
   (func))
 (;; STDERR ;;;
-out/test/parse/module/bad-start-too-many.txt:5:4: error: only one start function allowed
+out/test/parse/module/bad-start-too-many.txt:5:4: error: multiple start sections
   (start 1)
    ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-table-invalid-function.txt
+++ b/test/parse/module/bad-table-invalid-function.txt
@@ -5,7 +5,7 @@
   (func $f)
   (elem (i32.const 0) $f 1))
 (;; STDERR ;;;
-out/test/parse/module/bad-table-invalid-function.txt:6:26: error: function variable out of range (max 1)
+out/test/parse/module/bad-table-invalid-function.txt:6:26: error: function variable out of range: 1 (max 0)
   (elem (i32.const 0) $f 1))
                          ^
 ;;; STDERR ;;)

--- a/test/regress/regress-16.txt
+++ b/test/regress/regress-16.txt
@@ -3,7 +3,7 @@
 (start $2)
 (start 42)
 (;; STDERR ;;;
-out/test/regress/regress-16.txt:3:8: error: undefined function variable "$2"
-(start $2)
-       ^^
+out/test/regress/regress-16.txt:4:2: error: multiple start sections
+(start 42)
+ ^^^^^
 ;;; STDERR ;;)

--- a/test/roundtrip/apply-global-names.txt
+++ b/test/roundtrip/apply-global-names.txt
@@ -18,6 +18,6 @@
   (table $T0 1 funcref)
   (memory $M0 1)
   (global $g1 i32 (global.get $m.g))
-  (elem $e0 (global.get $m.g) $f0)
+  (elem $e0 (global.get $m.g) func $f0)
   (data $d0 (global.get $m.g) "hi"))
 ;;; STDOUT ;;)

--- a/test/roundtrip/bulk-memory.txt
+++ b/test/roundtrip/bulk-memory.txt
@@ -40,7 +40,7 @@
 
   (data "hi")
   (elem funcref (ref.func 0) (ref.null))
-  (elem funcref 1)
+  (elem func 1)
 
 )
 (;; STDOUT ;;;
@@ -73,6 +73,6 @@
   (table (;0;) 0 funcref)
   (memory (;0;) 0)
   (elem (;0;) funcref (ref.func 0) (ref.null))
-  (elem (;1;) funcref (ref.func 1))
+  (elem (;1;) func 1)
   (data (;0;) "hi"))
 ;;; STDOUT ;;)

--- a/test/roundtrip/fold-bulk-memory.txt
+++ b/test/roundtrip/fold-bulk-memory.txt
@@ -12,7 +12,7 @@
   )
 
   (table 1 anyfunc)
-  (elem funcref 0)
+  (elem func 0)
   (func
     i32.const 0 i32.const 0 i32.const 0 table.init 0
     elem.drop 0
@@ -48,6 +48,6 @@
       (i32.const 0)))
   (table (;0;) 1 funcref)
   (memory (;0;) 1)
-  (elem (;0;) funcref (ref.func 0))
+  (elem (;0;) func 0)
   (data (;0;) "a"))
 ;;; STDOUT ;;)

--- a/test/roundtrip/fold-call.txt
+++ b/test/roundtrip/fold-call.txt
@@ -65,5 +65,5 @@
       (i32.const 1)
       (i32.const 2)))
   (table (;0;) 2 2 funcref)
-  (elem (;0;) (i32.const 0) 0 1))
+  (elem (;0;) (i32.const 0) func 0 1))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-bulk-memory-names.txt
+++ b/test/roundtrip/generate-bulk-memory-names.txt
@@ -10,7 +10,7 @@
   )
 
   (table 1 anyfunc)
-  (elem funcref 0)
+  (elem func 0)
   (func
     i32.const 0 i32.const 0 i32.const 0 table.init 0
     elem.drop 0
@@ -33,6 +33,6 @@
     elem.drop $e0)
   (table $T0 1 funcref)
   (memory $M0 1)
-  (elem $e0 funcref (ref.func $f0))
+  (elem $e0 func $f0)
   (data $d0 "a"))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-func-names.txt
+++ b/test/roundtrip/generate-func-names.txt
@@ -18,5 +18,5 @@
   (table $T0 3 3 funcref)
   (export "zero" (func $zero))
   (export "one" (func $one))
-  (elem $e0 (i32.const 0) $zero $one $zero))
+  (elem $e0 (i32.const 0) func $zero $one $zero))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-func-type-names.txt
+++ b/test/roundtrip/generate-func-type-names.txt
@@ -21,5 +21,5 @@
     call_indirect $T0 (type $t0)
     i32.const 1)
   (table $T0 1 1 funcref)
-  (elem $e0 (i32.const 0) $foo.bar))
+  (elem $e0 (i32.const 0) func $foo.bar))
 ;;; STDOUT ;;)

--- a/test/roundtrip/generate-some-names.txt
+++ b/test/roundtrip/generate-some-names.txt
@@ -54,5 +54,5 @@
   (table $T0 1 1 funcref)
   (export "baz" (func $import))
   (export "quux" (func $func0))
-  (elem $e0 (i32.const 0) $import))
+  (elem $e0 (i32.const 0) func $import))
 ;;; STDOUT ;;)

--- a/test/roundtrip/inline-export-table.txt
+++ b/test/roundtrip/inline-export-table.txt
@@ -11,5 +11,5 @@
   (func (;0;) (type 0))
   (func (;1;) (type 0))
   (table (;0;) (export "foo") 2 2 funcref)
-  (elem (;0;) (i32.const 0) 0 1))
+  (elem (;0;) (i32.const 0) func 0 1))
 ;;; STDOUT ;;)

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -97,5 +97,44 @@ out/test/spec/binary.wast:385: assert_malformed passed:
   0000016: error: function signature count != function body count
 out/test/spec/binary.wast:396: assert_malformed passed:
   0000015: error: function signature count != function body count
-48/48 tests passed.
+out/test/spec/binary.wast:425: assert_malformed passed:
+  000000a: error: invalid section size: extends past end
+out/test/spec/binary.wast:436: assert_malformed passed:
+  000000e: error: unfinished section (expected end: 0x11)
+out/test/spec/binary.wast:455: assert_malformed passed:
+  0000027: error: unable to read u32 leb128: string length
+out/test/spec/binary.wast:474: assert_malformed passed:
+  000002b: error: unfinished section (expected end: 0x40)
+out/test/spec/binary.wast:505: assert_malformed passed:
+  000000b: error: invalid table count 1, only 0 bytes left in section
+out/test/spec/binary.wast:521: assert_malformed passed:
+  000000b: error: invalid memory count 1, only 0 bytes left in section
+out/test/spec/binary.wast:537: assert_malformed passed:
+  0000010: error: unable to read i32 leb128: global type
+out/test/spec/binary.wast:548: assert_malformed passed:
+  0000010: error: unfinished section (expected end: 0x15)
+out/test/spec/binary.wast:571: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/binary.wast:592: assert_malformed passed:
+  000001b: error: unfinished section (expected end: 0x20)
+out/test/spec/binary.wast:626: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: elem segment flags
+out/test/spec/binary.wast:644: assert_malformed passed:
+  0000021: error: unfinished section (expected end: 0x27)
+out/test/spec/binary.wast:670: assert_malformed passed:
+  0000016: error: unable to read u32 leb128: data segment flags
+out/test/spec/binary.wast:683: assert_malformed passed:
+  0000016: error: unfinished section (expected end: 0x1c)
+out/test/spec/binary.wast:696: assert_malformed passed:
+  0000015: error: unable to read data: data segment data
+out/test/spec/binary.wast:710: assert_malformed passed:
+  000001a: error: unfinished section (expected end: 0x1b)
+out/test/spec/binary.wast:741: assert_malformed passed:
+  error: invalid depth: 11 (max 2)
+  0000024: error: OnBrTableExpr callback failed
+out/test/spec/binary.wast:763: assert_malformed passed:
+  0000025: error: expected valid block signature type
+out/test/spec/binary.wast:798: assert_malformed passed:
+  0000017: error: multiple Start sections
+67/67 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/binary.txt
+++ b/test/spec/bulk-memory-operations/binary.txt
@@ -58,60 +58,129 @@ out/test/spec/bulk-memory-operations/binary.wast:44: assert_malformed passed:
   0000008: error: bad wasm file version: 0x10000 (expected 0x1)
 out/test/spec/bulk-memory-operations/binary.wast:45: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
-out/test/spec/bulk-memory-operations/binary.wast:50: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:69: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:88: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:106: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:124: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:143: assert_malformed passed:
-  0000020: error: memory.grow reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:163: assert_malformed passed:
-  0000020: error: memory.grow reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:183: assert_malformed passed:
-  0000020: error: memory.grow reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:202: assert_malformed passed:
-  0000020: error: memory.grow reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:140: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/bulk-memory-operations/binary.wast:150: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/bulk-memory-operations/binary.wast:160: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/bulk-memory-operations/binary.wast:171: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/bulk-memory-operations/binary.wast:181: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/bulk-memory-operations/binary.wast:193: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/bulk-memory-operations/binary.wast:201: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/bulk-memory-operations/binary.wast:211: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
 out/test/spec/bulk-memory-operations/binary.wast:221: assert_malformed passed:
-  0000020: error: memory.grow reserved value must be 0
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/bulk-memory-operations/binary.wast:231: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
 out/test/spec/bulk-memory-operations/binary.wast:241: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/bulk-memory-operations/binary.wast:252: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/bulk-memory-operations/binary.wast:262: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/bulk-memory-operations/binary.wast:272: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/bulk-memory-operations/binary.wast:282: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/bulk-memory-operations/binary.wast:295: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:314: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:333: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:351: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:369: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:388: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:408: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:428: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:447: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:466: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/bulk-memory-operations/binary.wast:486: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:260: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:505: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:279: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:524: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:297: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:542: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:315: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:560: assert_malformed passed:
   000001e: error: memory.size reserved value must be 0
-out/test/spec/bulk-memory-operations/binary.wast:334: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:579: assert_malformed passed:
   000001c: error: local count must be < 0x10000000
-out/test/spec/bulk-memory-operations/binary.wast:366: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:611: assert_malformed passed:
   0000013: error: function signature count != function body count
-out/test/spec/bulk-memory-operations/binary.wast:376: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:621: assert_malformed passed:
   000000b: error: function signature count != function body count
-out/test/spec/bulk-memory-operations/binary.wast:385: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:630: assert_malformed passed:
   0000016: error: function signature count != function body count
-out/test/spec/bulk-memory-operations/binary.wast:396: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:641: assert_malformed passed:
   0000015: error: function signature count != function body count
-out/test/spec/bulk-memory-operations/binary.wast:419: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:664: assert_malformed passed:
   000000e: error: data section without memory section
-out/test/spec/bulk-memory-operations/binary.wast:429: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:674: assert_malformed passed:
   000000e: error: data section without memory section
-out/test/spec/bulk-memory-operations/binary.wast:439: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:684: assert_malformed passed:
   error: invalid data_segment_index: 0 (max 0)
   0000026: error: OnMemoryInitExpr callback failed
-out/test/spec/bulk-memory-operations/binary.wast:461: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:706: assert_malformed passed:
   error: invalid data_segment_index: 0 (max 0)
   000001f: error: OnDataDropExpr callback failed
-out/test/spec/bulk-memory-operations/binary.wast:480: assert_malformed passed:
+out/test/spec/bulk-memory-operations/binary.wast:725: assert_malformed passed:
   0000024: error: expected ref.null or ref.func in passive element segment
   0000025: error: expected END opcode after element expression
-out/test/spec/bulk-memory-operations/binary.wast:506: assert_malformed passed:
-  0000022: error: segment elem type must by funcref or anyref
-54/54 tests passed.
+out/test/spec/bulk-memory-operations/binary.wast:751: assert_malformed passed:
+  0000022: error: segment elem expr type must be funcref or anyref (got i32)
+out/test/spec/bulk-memory-operations/binary.wast:832: assert_malformed passed:
+  000000a: error: invalid section size: extends past end
+out/test/spec/bulk-memory-operations/binary.wast:843: assert_malformed passed:
+  000000e: error: unfinished section (expected end: 0x11)
+out/test/spec/bulk-memory-operations/binary.wast:862: assert_malformed passed:
+  0000027: error: unable to read u32 leb128: string length
+out/test/spec/bulk-memory-operations/binary.wast:881: assert_malformed passed:
+  000002b: error: unfinished section (expected end: 0x40)
+out/test/spec/bulk-memory-operations/binary.wast:912: assert_malformed passed:
+  000000b: error: invalid table count 1, only 0 bytes left in section
+out/test/spec/bulk-memory-operations/binary.wast:928: assert_malformed passed:
+  000000b: error: invalid memory count 1, only 0 bytes left in section
+out/test/spec/bulk-memory-operations/binary.wast:944: assert_malformed passed:
+  0000010: error: unable to read i32 leb128: global type
+out/test/spec/bulk-memory-operations/binary.wast:955: assert_malformed passed:
+  0000010: error: unfinished section (expected end: 0x15)
+out/test/spec/bulk-memory-operations/binary.wast:978: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/bulk-memory-operations/binary.wast:999: assert_malformed passed:
+  000001b: error: unfinished section (expected end: 0x20)
+out/test/spec/bulk-memory-operations/binary.wast:1033: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: elem segment flags
+out/test/spec/bulk-memory-operations/binary.wast:1051: assert_malformed passed:
+  0000021: error: unfinished section (expected end: 0x27)
+out/test/spec/bulk-memory-operations/binary.wast:1077: assert_malformed passed:
+  0000016: error: unable to read u32 leb128: data segment flags
+out/test/spec/bulk-memory-operations/binary.wast:1090: assert_malformed passed:
+  0000016: error: unfinished section (expected end: 0x1c)
+out/test/spec/bulk-memory-operations/binary.wast:1103: assert_malformed passed:
+  0000015: error: unable to read data: data segment data
+out/test/spec/bulk-memory-operations/binary.wast:1117: assert_malformed passed:
+  000001a: error: unfinished section (expected end: 0x1b)
+out/test/spec/bulk-memory-operations/binary.wast:1148: assert_malformed passed:
+  error: invalid depth: 11 (max 2)
+  0000024: error: OnBrTableExpr callback failed
+out/test/spec/bulk-memory-operations/binary.wast:1170: assert_malformed passed:
+  0000025: error: expected valid block signature type
+out/test/spec/bulk-memory-operations/binary.wast:1205: assert_malformed passed:
+  0000017: error: multiple Start sections
+88/88 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/bulk.txt
+++ b/test/spec/bulk-memory-operations/bulk.txt
@@ -7,54 +7,52 @@ fill(i32:0, i32:48042, i32:2) =>
 fill(i32:0, i32:0, i32:65536) =>
 out/test/spec/bulk-memory-operations/bulk.wast:43: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 fill(i32:65536, i32:0, i32:0) =>
-out/test/spec/bulk-memory-operations/bulk.wast:52: assert_trap passed: out of bounds memory access: memory.fill out of bounds
+fill(i32:65537, i32:0, i32:0) =>
 copy(i32:10, i32:0, i32:4) =>
 copy(i32:8, i32:10, i32:4) =>
 copy(i32:10, i32:7, i32:6) =>
 copy(i32:65280, i32:0, i32:256) =>
 copy(i32:65024, i32:65280, i32:256) =>
-out/test/spec/bulk-memory-operations/bulk.wast:104: assert_trap passed: out of bounds memory access: memory.copy out of bound
 copy(i32:65536, i32:0, i32:0) =>
 copy(i32:0, i32:65536, i32:0) =>
-out/test/spec/bulk-memory-operations/bulk.wast:114: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/bulk.wast:116: assert_trap passed: out of bounds memory access: memory.copy out of bound
+copy(i32:65537, i32:0, i32:0) =>
+copy(i32:0, i32:65537, i32:0) =>
 init(i32:0, i32:1, i32:2) =>
 init(i32:65532, i32:0, i32:4) =>
-out/test/spec/bulk-memory-operations/bulk.wast:144: assert_trap passed: out of bounds memory access
+out/test/spec/bulk-memory-operations/bulk.wast:135: assert_trap passed: out of bounds memory access: memory.init out of bounds
 init(i32:65536, i32:0, i32:0) =>
 init(i32:0, i32:4, i32:0) =>
-out/test/spec/bulk-memory-operations/bulk.wast:154: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/bulk.wast:156: assert_trap passed: out of bounds memory access
-init_passive() =>
+init(i32:65537, i32:0, i32:0) =>
+init(i32:0, i32:5, i32:0) =>
+init_passive(i32:1) =>
 drop_passive() =>
-out/test/spec/bulk-memory-operations/bulk.wast:176: assert_trap passed: data segment dropped
-out/test/spec/bulk-memory-operations/bulk.wast:177: assert_trap passed: data segment dropped
-out/test/spec/bulk-memory-operations/bulk.wast:178: assert_trap passed: data segment dropped
-out/test/spec/bulk-memory-operations/bulk.wast:179: assert_trap passed: data segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:165: assert_trap passed: data segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:167: assert_trap passed: data segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:168: assert_trap passed: data segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:170: assert_trap passed: data segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:194: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/bulk-memory-operations/bulk.wast:196: assert_trap passed: uninitialized table element
 init(i32:0, i32:1, i32:2) =>
-out/test/spec/bulk-memory-operations/bulk.wast:205: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/bulk.wast:202: assert_trap passed: uninitialized table element
 init(i32:1, i32:2, i32:2) =>
-out/test/spec/bulk-memory-operations/bulk.wast:211: assert_trap passed: out of bounds table access: table.init out of bounds
 init(i32:3, i32:0, i32:0) =>
 init(i32:0, i32:4, i32:0) =>
-out/test/spec/bulk-memory-operations/bulk.wast:220: assert_trap passed: out of bounds table access: table.init out of bounds
-out/test/spec/bulk-memory-operations/bulk.wast:222: assert_trap passed: out of bounds table access: table.init out of bounds
-init_passive() =>
+init(i32:4, i32:0, i32:0) =>
+init(i32:0, i32:5, i32:0) =>
+init_passive(i32:1) =>
 drop_passive() =>
-out/test/spec/bulk-memory-operations/bulk.wast:244: assert_trap passed: element segment dropped
-out/test/spec/bulk-memory-operations/bulk.wast:245: assert_trap passed: element segment dropped
-out/test/spec/bulk-memory-operations/bulk.wast:246: assert_trap passed: element segment dropped
-out/test/spec/bulk-memory-operations/bulk.wast:247: assert_trap passed: element segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:236: assert_trap passed: element segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:238: assert_trap passed: element segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:239: assert_trap passed: element segment dropped
+out/test/spec/bulk-memory-operations/bulk.wast:241: assert_trap passed: element segment dropped
 copy(i32:3, i32:0, i32:3) =>
 copy(i32:0, i32:1, i32:3) =>
 copy(i32:2, i32:0, i32:3) =>
 copy(i32:6, i32:8, i32:2) =>
 copy(i32:8, i32:6, i32:2) =>
-out/test/spec/bulk-memory-operations/bulk.wast:295: assert_trap passed: uninitialized table element
-out/test/spec/bulk-memory-operations/bulk.wast:296: assert_trap passed: out of bounds table access: table.copy out of bounds
 copy(i32:10, i32:0, i32:0) =>
 copy(i32:0, i32:10, i32:0) =>
-out/test/spec/bulk-memory-operations/bulk.wast:305: assert_trap passed: out of bounds table access: table.copy out of bounds
-out/test/spec/bulk-memory-operations/bulk.wast:307: assert_trap passed: out of bounds table access: table.copy out of bounds
-102/102 tests passed.
+copy(i32:11, i32:0, i32:0) =>
+copy(i32:0, i32:11, i32:0) =>
+100/100 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/linking.txt
+++ b/test/spec/bulk-memory-operations/linking.txt
@@ -30,24 +30,12 @@ out/test/spec/bulk-memory-operations/linking.wast:185: assert_trap passed: unini
 out/test/spec/bulk-memory-operations/linking.wast:187: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/linking.wast:188: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/linking.wast:190: assert_trap passed: undefined table index
-out/test/spec/bulk-memory-operations/linking.wast:207: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
 out/test/spec/bulk-memory-operations/linking.wast:216: assert_unlinkable passed:
   error: unknown module field "mem"
   0000027: error: OnImportMemory callback failed
 out/test/spec/bulk-memory-operations/linking.wast:225: assert_trap passed: uninitialized table element
-out/test/spec/bulk-memory-operations/linking.wast:230: assert_unlinkable passed:
-  error: elem segment is out of bounds: [12, 13) >= max value 10
-out/test/spec/bulk-memory-operations/linking.wast:241: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
-out/test/spec/bulk-memory-operations/linking.wast:301: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
 out/test/spec/bulk-memory-operations/linking.wast:326: assert_unlinkable passed:
   error: unknown module field "tab"
   0000037: error: OnImportTable callback failed
-out/test/spec/bulk-memory-operations/linking.wast:339: assert_unlinkable passed:
-  error: data segment is out of bounds: [327680, 327681) >= max value 327680
-out/test/spec/bulk-memory-operations/linking.wast:349: assert_unlinkable passed:
-  error: elem segment is out of bounds: [0, 1) >= max value 0
 94/94 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/memory_copy.txt
+++ b/test/spec/bulk-memory-operations/memory_copy.txt
@@ -11,220 +11,220 @@ test() =>
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_copy.wast:349: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:730: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:1113: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:1494: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:1877: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:2238: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:2619: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:2980: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:3351: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:3712: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:4093: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:4447: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:710: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:1072: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:1433: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:1795: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:2156: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:2517: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:2878: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:3239: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:3600: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:3961: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:4315: assert_invalid passed:
   error: memory.copy requires an imported or defined memory.
   0000030: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4453: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4321: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4460: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4328: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4467: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4335: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4474: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4342: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4481: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4349: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f32]
   000003c: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4488: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4356: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i64]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4495: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4363: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f64]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4502: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4370: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i32]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4509: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4377: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4516: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4384: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i64]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4523: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4391: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4530: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4398: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i32]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4537: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4405: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f32]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4544: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4412: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4551: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4419: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f64]
   0000044: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4558: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4426: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4565: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4433: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f32]
   000003c: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4572: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4440: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i64]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4579: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4447: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f64]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4586: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4454: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i32]
   000003c: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4593: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4461: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f32]
   000003f: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4600: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4468: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i64]
   000003c: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4607: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4475: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f64]
   0000043: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4614: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4482: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4621: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4489: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f32]
   000003c: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4628: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4496: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i64]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4635: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4503: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f64]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4642: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4510: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i32]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4649: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4517: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f32]
   0000043: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4656: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4524: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i64]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4663: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4531: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f64]
   0000047: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4670: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4538: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i32]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4677: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4545: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4684: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4552: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i64]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4691: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4559: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4698: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4566: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4705: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4573: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f32]
   000003c: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4712: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4580: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i64]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4719: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4587: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f64]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4726: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4594: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i32]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4733: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4601: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f32]
   0000039: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4740: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4608: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i64]
   0000036: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4747: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4615: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4754: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4622: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i32]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4761: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4629: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f32]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4768: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4636: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4775: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4643: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f64]
   0000044: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4782: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4650: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i32]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4789: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4657: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f32]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4796: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4664: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4803: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4671: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f64]
   0000044: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4810: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4678: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i32]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4817: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4685: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f32]
   0000043: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4824: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4692: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i64]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4831: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4699: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f64]
   0000047: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4838: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4706: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i32]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4845: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4713: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f32]
   0000040: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4852: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4720: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i64]
   000003d: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4859: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4727: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f64]
   0000044: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4866: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4734: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i32]
   0000044: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4873: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4741: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f32]
   0000047: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4880: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4748: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i64]
   0000044: error: OnMemoryCopyExpr callback failed
-out/test/spec/bulk-memory-operations/memory_copy.wast:4887: assert_invalid passed:
+out/test/spec/bulk-memory-operations/memory_copy.wast:4755: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f64]
   000004b: error: OnMemoryCopyExpr callback failed
 test() =>
 test() =>
-out/test/spec/bulk-memory-operations/memory_copy.wast:4950: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:4956: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:4962: assert_trap passed: out of bounds memory access: memory.copy out of bound
-out/test/spec/bulk-memory-operations/memory_copy.wast:4968: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:4818: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:4824: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:4830: assert_trap passed: out of bounds memory access: memory.copy out of bound
+out/test/spec/bulk-memory-operations/memory_copy.wast:4836: assert_trap passed: out of bounds memory access: memory.copy out of bound
 test() =>
 test() =>
-out/test/spec/bulk-memory-operations/memory_copy.wast:5004: assert_trap passed: out of bounds memory access: memory.copy out of bound
-test() =>
-out/test/spec/bulk-memory-operations/memory_copy.wast:5016: assert_trap passed: out of bounds memory access: memory.copy out of bound
 test() =>
 test() =>
-4548/4548 tests passed.
+test() =>
+test() =>
+test() =>
+4416/4416 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/memory_fill.txt
+++ b/test/spec/bulk-memory-operations/memory_fill.txt
@@ -7,7 +7,7 @@ out/test/spec/bulk-memory-operations/memory_fill.wast:43: assert_trap passed: ou
 out/test/spec/bulk-memory-operations/memory_fill.wast:61: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 test() =>
 test() =>
-out/test/spec/bulk-memory-operations/memory_fill.wast:117: assert_trap passed: out of bounds memory access: memory.fill out of bounds
+test() =>
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_fill.wast:174: assert_invalid passed:
@@ -203,7 +203,7 @@ out/test/spec/bulk-memory-operations/memory_fill.wast:614: assert_invalid passed
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f64]
   000004a: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:637: assert_trap passed: out of bounds memory access: memory.fill out of bounds
-out/test/spec/bulk-memory-operations/memory_fill.wast:661: assert_trap passed: out of bounds memory access: memory.fill out of bounds
-out/test/spec/bulk-memory-operations/memory_fill.wast:685: assert_trap passed: out of bounds memory access: memory.fill out of bounds
-92/92 tests passed.
+out/test/spec/bulk-memory-operations/memory_fill.wast:659: assert_trap passed: out of bounds memory access: memory.fill out of bounds
+out/test/spec/bulk-memory-operations/memory_fill.wast:681: assert_trap passed: out of bounds memory access: memory.fill out of bounds
+89/89 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/memory_init.txt
+++ b/test/spec/bulk-memory-operations/memory_init.txt
@@ -22,12 +22,12 @@ out/test/spec/bulk-memory-operations/memory_init.wast:232: assert_invalid passed
   error: invalid data_segment_index: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed
 test() =>
-out/test/spec/bulk-memory-operations/memory_init.wast:252: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:259: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:266: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:273: assert_trap passed: out of bounds memory access
+out/test/spec/bulk-memory-operations/memory_init.wast:252: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:259: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:266: assert_trap passed: out of bounds memory access: memory.init out of bounds
 test() =>
-out/test/spec/bulk-memory-operations/memory_init.wast:287: assert_trap passed: out of bounds memory access
+test() =>
+test() =>
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:304: assert_invalid passed:
@@ -219,11 +219,11 @@ out/test/spec/bulk-memory-operations/memory_init.wast:792: assert_invalid passed
 out/test/spec/bulk-memory-operations/memory_init.wast:800: assert_invalid passed:
   error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, f64]
   0000048: error: OnMemoryInitExpr callback failed
-out/test/spec/bulk-memory-operations/memory_init.wast:825: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:852: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:879: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:906: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:933: assert_trap passed: out of bounds memory access
-out/test/spec/bulk-memory-operations/memory_init.wast:960: assert_trap passed: out of bounds memory access
-227/227 tests passed.
+out/test/spec/bulk-memory-operations/memory_init.wast:825: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:848: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:871: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:894: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:917: assert_trap passed: out of bounds memory access: memory.init out of bounds
+out/test/spec/bulk-memory-operations/memory_init.wast:940: assert_trap passed: out of bounds memory access: memory.init out of bounds
+215/215 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/table_copy.txt
+++ b/test/spec/bulk-memory-operations/table_copy.txt
@@ -183,9 +183,9 @@ out/test/spec/bulk-memory-operations/table_copy.wast:540: assert_trap passed: ou
 out/test/spec/bulk-memory-operations/table_copy.wast:564: assert_trap passed: out of bounds table access: table.copy out of bounds
 test() =>
 test() =>
-out/test/spec/bulk-memory-operations/table_copy.wast:636: assert_trap passed: out of bounds table access: table.copy out of bounds
 test() =>
-out/test/spec/bulk-memory-operations/table_copy.wast:684: assert_trap passed: out of bounds table access: table.copy out of bounds
+test() =>
+test() =>
 test() =>
 out/test/spec/bulk-memory-operations/table_copy.wast:736: assert_trap passed: out of bounds table access: table.copy out of bounds
 out/test/spec/bulk-memory-operations/table_copy.wast:746: assert_trap passed: uninitialized table element
@@ -204,6 +204,14 @@ out/test/spec/bulk-memory-operations/table_copy.wast:758: assert_trap passed: un
 out/test/spec/bulk-memory-operations/table_copy.wast:759: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:760: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:761: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:762: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:763: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:764: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:765: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:766: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:767: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:768: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:769: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:797: assert_trap passed: out of bounds table access: table.copy out of bounds
 out/test/spec/bulk-memory-operations/table_copy.wast:808: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:809: assert_trap passed: uninitialized table element
@@ -219,7 +227,24 @@ out/test/spec/bulk-memory-operations/table_copy.wast:818: assert_trap passed: un
 out/test/spec/bulk-memory-operations/table_copy.wast:819: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:820: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:821: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:822: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:823: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:824: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:825: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:826: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:827: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:828: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:829: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:830: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:858: assert_trap passed: out of bounds table access: table.copy out of bounds
+out/test/spec/bulk-memory-operations/table_copy.wast:860: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:861: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:862: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:863: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:864: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:865: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:866: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:867: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:868: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:869: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:870: assert_trap passed: uninitialized table element
@@ -237,6 +262,15 @@ out/test/spec/bulk-memory-operations/table_copy.wast:881: assert_trap passed: un
 out/test/spec/bulk-memory-operations/table_copy.wast:882: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:883: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:919: assert_trap passed: out of bounds table access: table.copy out of bounds
+out/test/spec/bulk-memory-operations/table_copy.wast:921: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:922: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:923: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:924: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:925: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:926: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:927: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:928: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:929: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:930: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:931: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:932: assert_trap passed: uninitialized table element
@@ -288,6 +322,14 @@ out/test/spec/bulk-memory-operations/table_copy.wast:1050: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_copy.wast:1051: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1052: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1053: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1054: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1055: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1056: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1057: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1058: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1059: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1060: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1061: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1062: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1063: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1064: assert_trap passed: uninitialized table element
@@ -340,6 +382,9 @@ out/test/spec/bulk-memory-operations/table_copy.wast:1182: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_copy.wast:1183: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1184: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1185: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1186: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1187: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1188: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1224: assert_trap passed: out of bounds table access: table.copy out of bounds
 out/test/spec/bulk-memory-operations/table_copy.wast:1226: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1227: assert_trap passed: uninitialized table element
@@ -363,6 +408,22 @@ out/test/spec/bulk-memory-operations/table_copy.wast:1244: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_copy.wast:1245: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1246: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1285: assert_trap passed: out of bounds table access: table.copy out of bounds
+out/test/spec/bulk-memory-operations/table_copy.wast:1287: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1288: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1289: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1290: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1291: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1292: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1293: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1294: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1295: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1296: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1297: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1298: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1299: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1300: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1301: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_copy.wast:1302: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1303: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1304: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_copy.wast:1305: assert_trap passed: uninitialized table element

--- a/test/spec/bulk-memory-operations/table_init.txt
+++ b/test/spec/bulk-memory-operations/table_init.txt
@@ -74,9 +74,9 @@ out/test/spec/bulk-memory-operations/table_init.wast:357: assert_trap passed: ou
 out/test/spec/bulk-memory-operations/table_init.wast:380: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/bulk-memory-operations/table_init.wast:403: assert_trap passed: out of bounds table access: table.init out of bounds
 test() =>
-out/test/spec/bulk-memory-operations/table_init.wast:449: assert_trap passed: out of bounds table access: table.init out of bounds
 test() =>
-out/test/spec/bulk-memory-operations/table_init.wast:495: assert_trap passed: out of bounds table access: table.init out of bounds
+test() =>
+test() =>
 test() =>
 out/test/spec/bulk-memory-operations/table_init.wast:521: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f32]
@@ -268,6 +268,14 @@ out/test/spec/bulk-memory-operations/table_init.wast:1079: assert_invalid passed
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f64]
   000005c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1115: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/bulk-memory-operations/table_init.wast:1116: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1117: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1118: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1119: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1120: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1121: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1122: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1123: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1124: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1125: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1126: assert_trap passed: uninitialized table element
@@ -293,6 +301,13 @@ out/test/spec/bulk-memory-operations/table_init.wast:1145: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_init.wast:1146: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1147: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1177: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/bulk-memory-operations/table_init.wast:1178: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1179: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1180: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1181: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1182: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1183: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1184: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1185: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1186: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1187: assert_trap passed: uninitialized table element
@@ -319,6 +334,22 @@ out/test/spec/bulk-memory-operations/table_init.wast:1207: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_init.wast:1208: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1209: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1239: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/bulk-memory-operations/table_init.wast:1240: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1241: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1242: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1243: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1244: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1245: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1246: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1247: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1248: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1249: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1250: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1251: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1252: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1253: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1254: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1255: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1256: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1257: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1258: assert_trap passed: uninitialized table element
@@ -464,6 +495,22 @@ out/test/spec/bulk-memory-operations/table_init.wast:1397: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_init.wast:1398: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1399: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1429: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/bulk-memory-operations/table_init.wast:1430: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1431: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1432: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1433: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1434: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1435: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1436: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1437: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1438: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1439: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1440: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1441: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1442: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1443: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1444: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1445: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1446: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1447: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1448: assert_trap passed: uninitialized table element
@@ -609,6 +656,22 @@ out/test/spec/bulk-memory-operations/table_init.wast:1587: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_init.wast:1588: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1589: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1619: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/bulk-memory-operations/table_init.wast:1620: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1621: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1622: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1623: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1624: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1625: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1626: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1627: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1628: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1629: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1630: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1631: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1632: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1633: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1634: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1635: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1636: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1637: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1638: assert_trap passed: uninitialized table element
@@ -658,5 +721,21 @@ out/test/spec/bulk-memory-operations/table_init.wast:1681: assert_trap passed: u
 out/test/spec/bulk-memory-operations/table_init.wast:1682: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1683: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1713: assert_trap passed: out of bounds table access: table.init out of bounds
-635/635 tests passed.
+out/test/spec/bulk-memory-operations/table_init.wast:1714: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1715: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1716: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1717: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1718: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1719: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1720: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1721: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1722: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1723: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1724: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1725: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1726: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1727: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1728: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/table_init.wast:1729: assert_trap passed: uninitialized table element
+643/643 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/const.txt
+++ b/test/spec/const.txt
@@ -2,124 +2,308 @@
 ;;; STDIN_FILE: third_party/testsuite/const.wast
 (;; STDOUT ;;;
 out/test/spec/const.wast:8: assert_malformed passed:
-  out/test/spec/const/const.2.wat:1:18: error: invalid literal "0x100000000"
+  out/test/spec/const/const.2.wat:1:17: error: unexpected token ")", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i32.const) drop)
+                  ^
+out/test/spec/const.wast:12: assert_malformed passed:
+  out/test/spec/const/const.3.wat:1:18: error: unexpected token "0x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i32.const 0x) drop)
+                   ^^
+out/test/spec/const.wast:16: assert_malformed passed:
+  out/test/spec/const/const.4.wat:1:18: error: unexpected token "1x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i32.const 1x) drop)
+                   ^^
+out/test/spec/const.wast:20: assert_malformed passed:
+  out/test/spec/const/const.5.wat:1:18: error: unexpected token "0xg", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i32.const 0xg) drop)
+                   ^^^
+out/test/spec/const.wast:27: assert_malformed passed:
+  out/test/spec/const/const.8.wat:1:17: error: unexpected token ")", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i64.const) drop)
+                  ^
+out/test/spec/const.wast:31: assert_malformed passed:
+  out/test/spec/const/const.9.wat:1:18: error: unexpected token "0x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i64.const 0x) drop)
+                   ^^
+out/test/spec/const.wast:35: assert_malformed passed:
+  out/test/spec/const/const.10.wat:1:18: error: unexpected token "1x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i64.const 1x) drop)
+                   ^^
+out/test/spec/const.wast:39: assert_malformed passed:
+  out/test/spec/const/const.11.wat:1:18: error: unexpected token "0xg", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (i64.const 0xg) drop)
+                   ^^^
+out/test/spec/const.wast:68: assert_malformed passed:
+  out/test/spec/const/const.36.wat:1:17: error: unexpected token ")", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const) drop)
+                  ^
+out/test/spec/const.wast:72: assert_malformed passed:
+  out/test/spec/const/const.37.wat:1:18: error: unexpected token ".0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const .0) drop)
+                   ^^
+out/test/spec/const.wast:76: assert_malformed passed:
+  out/test/spec/const/const.38.wat:1:18: error: unexpected token ".0e0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const .0e0) drop)
+                   ^^^^
+out/test/spec/const.wast:80: assert_malformed passed:
+  out/test/spec/const/const.39.wat:1:18: error: unexpected token "0e", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0e) drop)
+                   ^^
+out/test/spec/const.wast:84: assert_malformed passed:
+  out/test/spec/const/const.40.wat:1:18: error: unexpected token "0e+", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0e+) drop)
+                   ^^^
+out/test/spec/const.wast:88: assert_malformed passed:
+  out/test/spec/const/const.41.wat:1:18: error: unexpected token "0.0e", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0.0e) drop)
+                   ^^^^
+out/test/spec/const.wast:92: assert_malformed passed:
+  out/test/spec/const/const.42.wat:1:18: error: unexpected token "0.0e-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0.0e-) drop)
+                   ^^^^^
+out/test/spec/const.wast:96: assert_malformed passed:
+  out/test/spec/const/const.43.wat:1:18: error: unexpected token "0x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x) drop)
+                   ^^
+out/test/spec/const.wast:100: assert_malformed passed:
+  out/test/spec/const/const.44.wat:1:18: error: unexpected token "1x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 1x) drop)
+                   ^^
+out/test/spec/const.wast:104: assert_malformed passed:
+  out/test/spec/const/const.45.wat:1:18: error: unexpected token "0xg", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0xg) drop)
+                   ^^^
+out/test/spec/const.wast:108: assert_malformed passed:
+  out/test/spec/const/const.46.wat:1:18: error: unexpected token "0x.", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x.) drop)
+                   ^^^
+out/test/spec/const.wast:112: assert_malformed passed:
+  out/test/spec/const/const.47.wat:1:18: error: unexpected token "0x0.g", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0.g) drop)
+                   ^^^^^
+out/test/spec/const.wast:116: assert_malformed passed:
+  out/test/spec/const/const.48.wat:1:18: error: unexpected token "0x0p", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0p) drop)
+                   ^^^^
+out/test/spec/const.wast:120: assert_malformed passed:
+  out/test/spec/const/const.49.wat:1:18: error: unexpected token "0x0p+", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0p+) drop)
+                   ^^^^^
+out/test/spec/const.wast:124: assert_malformed passed:
+  out/test/spec/const/const.50.wat:1:18: error: unexpected token "0x0p-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0p-) drop)
+                   ^^^^^
+out/test/spec/const.wast:128: assert_malformed passed:
+  out/test/spec/const/const.51.wat:1:18: error: unexpected token "0x0.0p", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0.0p) drop)
+                   ^^^^^^
+out/test/spec/const.wast:132: assert_malformed passed:
+  out/test/spec/const/const.52.wat:1:18: error: unexpected token "0x0.0p+", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0.0p+) drop)
+                   ^^^^^^^
+out/test/spec/const.wast:136: assert_malformed passed:
+  out/test/spec/const/const.53.wat:1:18: error: unexpected token "0x0.0p-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0.0p-) drop)
+                   ^^^^^^^
+out/test/spec/const.wast:140: assert_malformed passed:
+  out/test/spec/const/const.54.wat:1:18: error: unexpected token "0x0pA", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f32.const 0x0pA) drop)
+                   ^^^^^
+out/test/spec/const.wast:170: assert_malformed passed:
+  out/test/spec/const/const.79.wat:1:17: error: unexpected token ")", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const) drop)
+                  ^
+out/test/spec/const.wast:174: assert_malformed passed:
+  out/test/spec/const/const.80.wat:1:18: error: unexpected token ".0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const .0) drop)
+                   ^^
+out/test/spec/const.wast:178: assert_malformed passed:
+  out/test/spec/const/const.81.wat:1:18: error: unexpected token ".0e0", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const .0e0) drop)
+                   ^^^^
+out/test/spec/const.wast:182: assert_malformed passed:
+  out/test/spec/const/const.82.wat:1:18: error: unexpected token "0e", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0e) drop)
+                   ^^
+out/test/spec/const.wast:186: assert_malformed passed:
+  out/test/spec/const/const.83.wat:1:18: error: unexpected token "0e+", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0e+) drop)
+                   ^^^
+out/test/spec/const.wast:190: assert_malformed passed:
+  out/test/spec/const/const.84.wat:1:18: error: unexpected token "0.0e", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0.0e) drop)
+                   ^^^^
+out/test/spec/const.wast:194: assert_malformed passed:
+  out/test/spec/const/const.85.wat:1:18: error: unexpected token "0.0e-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0.0e-) drop)
+                   ^^^^^
+out/test/spec/const.wast:198: assert_malformed passed:
+  out/test/spec/const/const.86.wat:1:18: error: unexpected token "0x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x) drop)
+                   ^^
+out/test/spec/const.wast:202: assert_malformed passed:
+  out/test/spec/const/const.87.wat:1:18: error: unexpected token "1x", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 1x) drop)
+                   ^^
+out/test/spec/const.wast:206: assert_malformed passed:
+  out/test/spec/const/const.88.wat:1:18: error: unexpected token "0xg", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0xg) drop)
+                   ^^^
+out/test/spec/const.wast:210: assert_malformed passed:
+  out/test/spec/const/const.89.wat:1:18: error: unexpected token "0x.", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x.) drop)
+                   ^^^
+out/test/spec/const.wast:214: assert_malformed passed:
+  out/test/spec/const/const.90.wat:1:18: error: unexpected token "0x0.g", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0.g) drop)
+                   ^^^^^
+out/test/spec/const.wast:218: assert_malformed passed:
+  out/test/spec/const/const.91.wat:1:18: error: unexpected token "0x0p", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0p) drop)
+                   ^^^^
+out/test/spec/const.wast:222: assert_malformed passed:
+  out/test/spec/const/const.92.wat:1:18: error: unexpected token "0x0p+", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0p+) drop)
+                   ^^^^^
+out/test/spec/const.wast:226: assert_malformed passed:
+  out/test/spec/const/const.93.wat:1:18: error: unexpected token "0x0p-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0p-) drop)
+                   ^^^^^
+out/test/spec/const.wast:230: assert_malformed passed:
+  out/test/spec/const/const.94.wat:1:18: error: unexpected token "0x0.0p", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0.0p) drop)
+                   ^^^^^^
+out/test/spec/const.wast:234: assert_malformed passed:
+  out/test/spec/const/const.95.wat:1:18: error: unexpected token "0x0.0p+", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0.0p+) drop)
+                   ^^^^^^^
+out/test/spec/const.wast:238: assert_malformed passed:
+  out/test/spec/const/const.96.wat:1:18: error: unexpected token "0x0.0p-", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0.0p-) drop)
+                   ^^^^^^^
+out/test/spec/const.wast:242: assert_malformed passed:
+  out/test/spec/const/const.97.wat:1:18: error: unexpected token "0x0pA", expected a numeric literal (e.g. 123, -45, 6.7e8).
+  (func (f64.const 0x0pA) drop)
+                   ^^^^^
+out/test/spec/const.wast:252: assert_malformed passed:
+  out/test/spec/const/const.100.wat:1:18: error: invalid literal "0x100000000"
   (func (i32.const 0x100000000) drop)
                    ^^^^^^^^^^^
-out/test/spec/const.wast:12: assert_malformed passed:
-  out/test/spec/const/const.3.wat:1:18: error: invalid literal "-0x80000001"
+out/test/spec/const.wast:256: assert_malformed passed:
+  out/test/spec/const/const.101.wat:1:18: error: invalid literal "-0x80000001"
   (func (i32.const -0x80000001) drop)
                    ^^^^^^^^^^^
-out/test/spec/const.wast:19: assert_malformed passed:
-  out/test/spec/const/const.6.wat:1:18: error: invalid literal "4294967296"
+out/test/spec/const.wast:263: assert_malformed passed:
+  out/test/spec/const/const.104.wat:1:18: error: invalid literal "4294967296"
   (func (i32.const 4294967296) drop)
                    ^^^^^^^^^^
-out/test/spec/const.wast:23: assert_malformed passed:
-  out/test/spec/const/const.7.wat:1:18: error: invalid literal "-2147483649"
+out/test/spec/const.wast:267: assert_malformed passed:
+  out/test/spec/const/const.105.wat:1:18: error: invalid literal "-2147483649"
   (func (i32.const -2147483649) drop)
                    ^^^^^^^^^^^
-out/test/spec/const.wast:30: assert_malformed passed:
-  out/test/spec/const/const.10.wat:1:18: error: invalid literal "0x10000000000000000"
+out/test/spec/const.wast:274: assert_malformed passed:
+  out/test/spec/const/const.108.wat:1:18: error: invalid literal "0x10000000000000000"
   (func (i64.const 0x10000000000000000) drop)
                    ^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:34: assert_malformed passed:
-  out/test/spec/const/const.11.wat:1:18: error: invalid literal "-0x8000000000000001"
+out/test/spec/const.wast:278: assert_malformed passed:
+  out/test/spec/const/const.109.wat:1:18: error: invalid literal "-0x8000000000000001"
   (func (i64.const -0x8000000000000001) drop)
                    ^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:41: assert_malformed passed:
-  out/test/spec/const/const.14.wat:1:18: error: invalid literal "18446744073709551616"
+out/test/spec/const.wast:285: assert_malformed passed:
+  out/test/spec/const/const.112.wat:1:18: error: invalid literal "18446744073709551616"
   (func (i64.const 18446744073709551616) drop)
                    ^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:45: assert_malformed passed:
-  out/test/spec/const/const.15.wat:1:18: error: invalid literal "-9223372036854775809"
+out/test/spec/const.wast:289: assert_malformed passed:
+  out/test/spec/const/const.113.wat:1:18: error: invalid literal "-9223372036854775809"
   (func (i64.const -9223372036854775809) drop)
                    ^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:60: assert_malformed passed:
-  out/test/spec/const/const.26.wat:1:18: error: invalid literal "0x1p128"
+out/test/spec/const.wast:304: assert_malformed passed:
+  out/test/spec/const/const.124.wat:1:18: error: invalid literal "0x1p128"
   (func (f32.const 0x1p128) drop)
                    ^^^^^^^
-out/test/spec/const.wast:64: assert_malformed passed:
-  out/test/spec/const/const.27.wat:1:18: error: invalid literal "-0x1p128"
+out/test/spec/const.wast:308: assert_malformed passed:
+  out/test/spec/const/const.125.wat:1:18: error: invalid literal "-0x1p128"
   (func (f32.const -0x1p128) drop)
                    ^^^^^^^^
-out/test/spec/const.wast:68: assert_malformed passed:
-  out/test/spec/const/const.28.wat:1:18: error: invalid literal "0x1.ffffffp127"
+out/test/spec/const.wast:312: assert_malformed passed:
+  out/test/spec/const/const.126.wat:1:18: error: invalid literal "0x1.ffffffp127"
   (func (f32.const 0x1.ffffffp127) drop)
                    ^^^^^^^^^^^^^^
-out/test/spec/const.wast:72: assert_malformed passed:
-  out/test/spec/const/const.29.wat:1:18: error: invalid literal "-0x1.ffffffp127"
+out/test/spec/const.wast:316: assert_malformed passed:
+  out/test/spec/const/const.127.wat:1:18: error: invalid literal "-0x1.ffffffp127"
   (func (f32.const -0x1.ffffffp127) drop)
                    ^^^^^^^^^^^^^^^
-out/test/spec/const.wast:79: assert_malformed passed:
-  out/test/spec/const/const.32.wat:1:18: error: invalid literal "1e39"
+out/test/spec/const.wast:323: assert_malformed passed:
+  out/test/spec/const/const.130.wat:1:18: error: invalid literal "1e39"
   (func (f32.const 1e39) drop)
                    ^^^^
-out/test/spec/const.wast:83: assert_malformed passed:
-  out/test/spec/const/const.33.wat:1:18: error: invalid literal "-1e39"
+out/test/spec/const.wast:327: assert_malformed passed:
+  out/test/spec/const/const.131.wat:1:18: error: invalid literal "-1e39"
   (func (f32.const -1e39) drop)
                    ^^^^^
-out/test/spec/const.wast:90: assert_malformed passed:
-  out/test/spec/const/const.36.wat:1:18: error: invalid literal "340282356779733661637539395458142568448"
+out/test/spec/const.wast:334: assert_malformed passed:
+  out/test/spec/const/const.134.wat:1:18: error: invalid literal "340282356779733661637539395458142568448"
   (func (f32.const 340282356779733661637539395458142568448) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:94: assert_malformed passed:
-  out/test/spec/const/const.37.wat:1:18: error: invalid literal "-340282356779733661637539395458142568448"
+out/test/spec/const.wast:338: assert_malformed passed:
+  out/test/spec/const/const.135.wat:1:18: error: invalid literal "-340282356779733661637539395458142568448"
   (func (f32.const -340282356779733661637539395458142568448) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:107: assert_malformed passed:
-  out/test/spec/const/const.46.wat:1:18: error: invalid literal "0x1p1024"
+out/test/spec/const.wast:351: assert_malformed passed:
+  out/test/spec/const/const.144.wat:1:18: error: invalid literal "0x1p1024"
   (func (f64.const 0x1p1024) drop)
                    ^^^^^^^^
-out/test/spec/const.wast:111: assert_malformed passed:
-  out/test/spec/const/const.47.wat:1:18: error: invalid literal "-0x1p1024"
+out/test/spec/const.wast:355: assert_malformed passed:
+  out/test/spec/const/const.145.wat:1:18: error: invalid literal "-0x1p1024"
   (func (f64.const -0x1p1024) drop)
                    ^^^^^^^^^
-out/test/spec/const.wast:115: assert_malformed passed:
-  out/test/spec/const/const.48.wat:1:18: error: invalid literal "0x1.fffffffffffff8p1023"
+out/test/spec/const.wast:359: assert_malformed passed:
+  out/test/spec/const/const.146.wat:1:18: error: invalid literal "0x1.fffffffffffff8p1023"
   (func (f64.const 0x1.fffffffffffff8p1023) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:119: assert_malformed passed:
-  out/test/spec/const/const.49.wat:1:18: error: invalid literal "-0x1.fffffffffffff8p1023"
+out/test/spec/const.wast:363: assert_malformed passed:
+  out/test/spec/const/const.147.wat:1:18: error: invalid literal "-0x1.fffffffffffff8p1023"
   (func (f64.const -0x1.fffffffffffff8p1023) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:126: assert_malformed passed:
-  out/test/spec/const/const.52.wat:1:18: error: invalid literal "1e309"
+out/test/spec/const.wast:370: assert_malformed passed:
+  out/test/spec/const/const.150.wat:1:18: error: invalid literal "1e309"
   (func (f64.const 1e309) drop)
                    ^^^^^
-out/test/spec/const.wast:130: assert_malformed passed:
-  out/test/spec/const/const.53.wat:1:18: error: invalid literal "-1e309"
+out/test/spec/const.wast:374: assert_malformed passed:
+  out/test/spec/const/const.151.wat:1:18: error: invalid literal "-1e309"
   (func (f64.const -1e309) drop)
                    ^^^^^^
-out/test/spec/const.wast:137: assert_malformed passed:
-  out/test/spec/const/const.56.wat:1:18: error: invalid literal "269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
+out/test/spec/const.wast:381: assert_malformed passed:
+  out/test/spec/const/const.154.wat:1:18: error: invalid literal "269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
   (func (f64.const 269653970229347356221791135597556535197105851288767494898376...
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:141: assert_malformed passed:
-  out/test/spec/const/const.57.wat:1:18: error: invalid literal "-269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
+out/test/spec/const.wast:385: assert_malformed passed:
+  out/test/spec/const/const.155.wat:1:18: error: invalid literal "-269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
   (func (f64.const -26965397022934735622179113559755653519710585128876749489837...
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/spec/const.wast:151: assert_malformed passed:
-  out/test/spec/const/const.62.wat:1:18: error: unexpected token "nan:1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/const.wast:395: assert_malformed passed:
+  out/test/spec/const/const.160.wat:1:18: error: unexpected token "nan:1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (func (f32.const nan:1) drop)
                    ^^^^^
-out/test/spec/const.wast:155: assert_malformed passed:
-  out/test/spec/const/const.63.wat:1:18: error: unexpected token "nan:1", expected a numeric literal (e.g. 123, -45, 6.7e8).
+out/test/spec/const.wast:399: assert_malformed passed:
+  out/test/spec/const/const.161.wat:1:18: error: unexpected token "nan:1", expected a numeric literal (e.g. 123, -45, 6.7e8).
   (func (f64.const nan:1) drop)
                    ^^^^^
-out/test/spec/const.wast:160: assert_malformed passed:
-  out/test/spec/const/const.64.wat:1:18: error: invalid literal "nan:0x0"
+out/test/spec/const.wast:404: assert_malformed passed:
+  out/test/spec/const/const.162.wat:1:18: error: invalid literal "nan:0x0"
   (func (f32.const nan:0x0) drop)
                    ^^^^^^^
-out/test/spec/const.wast:164: assert_malformed passed:
-  out/test/spec/const/const.65.wat:1:18: error: invalid literal "nan:0x0"
+out/test/spec/const.wast:408: assert_malformed passed:
+  out/test/spec/const/const.163.wat:1:18: error: invalid literal "nan:0x0"
   (func (f64.const nan:0x0) drop)
                    ^^^^^^^
-out/test/spec/const.wast:169: assert_malformed passed:
-  out/test/spec/const/const.66.wat:1:18: error: invalid literal "nan:0x80_0000"
+out/test/spec/const.wast:413: assert_malformed passed:
+  out/test/spec/const/const.164.wat:1:18: error: invalid literal "nan:0x80_0000"
   (func (f32.const nan:0x80_0000) drop)
                    ^^^^^^^^^^^^^
-out/test/spec/const.wast:173: assert_malformed passed:
-  out/test/spec/const/const.67.wat:1:18: error: invalid literal "nan:0x10_0000_0000_0000"
+out/test/spec/const.wast:417: assert_malformed passed:
+  out/test/spec/const/const.165.wat:1:18: error: invalid literal "nan:0x10_0000_0000_0000"
   (func (f64.const nan:0x10_0000_0000_0000) drop)
                    ^^^^^^^^^^^^^^^^^^^^^^^
-330/330 tests passed.
+376/376 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -1,34 +1,20 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/data.wast
 (;; STDOUT ;;;
-out/test/spec/data.wast:162: assert_unlinkable passed:
-  error: data segment is out of bounds: [0, 1) >= max value 0
-out/test/spec/data.wast:170: assert_unlinkable passed:
-  error: data segment is out of bounds: [0, 1) >= max value 0
-out/test/spec/data.wast:178: assert_unlinkable passed:
-  error: data segment is out of bounds: [0, 1) >= max value 0
-out/test/spec/data.wast:186: assert_unlinkable passed:
-  error: data segment is out of bounds: [1, 1) >= max value 0
-out/test/spec/data.wast:194: assert_unlinkable passed:
-  error: data segment is out of bounds: [1, 1) >= max value 0
-out/test/spec/data.wast:211: assert_unlinkable passed:
-  error: data segment is out of bounds: [666, 667) >= max value 0
-out/test/spec/data.wast:220: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
-out/test/spec/data.wast:227: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
-out/test/spec/data.wast:235: assert_unlinkable passed:
-  error: data segment is out of bounds: [131072, 131073) >= max value 131072
-out/test/spec/data.wast:243: assert_unlinkable passed:
-  error: data segment is out of bounds: [131072, 131073) >= max value 131072
-out/test/spec/data.wast:251: assert_unlinkable passed:
-  error: data segment is out of bounds: [4294967295, 4294967296) >= max value 65536
-out/test/spec/data.wast:258: assert_unlinkable passed:
-  error: data segment is out of bounds: [4294967295, 4294967296) >= max value 65536
-out/test/spec/data.wast:266: assert_unlinkable passed:
-  error: data segment is out of bounds: [4294967196, 4294967197) >= max value 131072
-out/test/spec/data.wast:273: assert_unlinkable passed:
-  error: data segment is out of bounds: [4294967196, 4294967197) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [1, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [1, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [666, 667) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [131072, 131073) >= max value 131072
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [131072, 131073) >= max value 131072
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [4294967295, 4294967296) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [4294967295, 4294967296) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [4294967196, 4294967197) >= max value 131072
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [4294967196, 4294967197) >= max value 65536
 out/test/spec/data.wast:283: assert_invalid passed:
   000000b: error: data section without memory section
 out/test/spec/data.wast:292: assert_invalid passed:

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -1,30 +1,18 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/elem.wast
 (;; STDOUT ;;;
-out/test/spec/elem.wast:143: assert_unlinkable passed:
-  error: elem segment is out of bounds: [0, 1) >= max value 0
-out/test/spec/elem.wast:152: assert_unlinkable passed:
-  error: elem segment is out of bounds: [0, 1) >= max value 0
-out/test/spec/elem.wast:161: assert_unlinkable passed:
-  error: elem segment is out of bounds: [0, 1) >= max value 0
-out/test/spec/elem.wast:170: assert_unlinkable passed:
-  error: elem segment is out of bounds: [1, 1) >= max value 0
-out/test/spec/elem.wast:178: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
-out/test/spec/elem.wast:186: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
-out/test/spec/elem.wast:195: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
-out/test/spec/elem.wast:203: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
-out/test/spec/elem.wast:212: assert_unlinkable passed:
-  error: elem segment is out of bounds: [4294967295, 4294967296) >= max value 10
-out/test/spec/elem.wast:220: assert_unlinkable passed:
-  error: elem segment is out of bounds: [4294967295, 4294967296) >= max value 10
-out/test/spec/elem.wast:229: assert_unlinkable passed:
-  error: elem segment is out of bounds: [4294967286, 4294967287) >= max value 10
-out/test/spec/elem.wast:237: assert_unlinkable passed:
-  error: elem segment is out of bounds: [4294967286, 4294967287) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [1, 1) >= max value 0
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [4294967295, 4294967296) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [4294967295, 4294967296) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [4294967286, 4294967287) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [4294967286, 4294967287) >= max value 10
 out/test/spec/elem.wast:248: assert_invalid passed:
   0000015: error: elem section without table section
 out/test/spec/elem.wast:258: assert_invalid passed:

--- a/test/spec/i32.txt
+++ b/test/spec/i32.txt
@@ -4,260 +4,261 @@
 out/test/spec/i32.wast:62: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:63: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:64: assert_trap passed: integer overflow
-out/test/spec/i32.wast:82: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:65: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:83: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:99: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:84: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:100: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:120: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:101: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:121: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:425: assert_invalid passed:
+out/test/spec/i32.wast:122: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:426: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:433: assert_invalid passed:
+out/test/spec/i32.wast:434: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:442: assert_invalid passed:
+out/test/spec/i32.wast:443: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:451: assert_invalid passed:
+out/test/spec/i32.wast:452: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:460: assert_invalid passed:
+out/test/spec/i32.wast:461: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000021: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:469: assert_invalid passed:
+out/test/spec/i32.wast:470: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:478: assert_invalid passed:
+out/test/spec/i32.wast:479: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:487: assert_invalid passed:
+out/test/spec/i32.wast:488: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:496: assert_invalid passed:
+out/test/spec/i32.wast:497: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:504: assert_invalid passed:
+out/test/spec/i32.wast:505: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:512: assert_invalid passed:
+out/test/spec/i32.wast:513: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:521: assert_invalid passed:
+out/test/spec/i32.wast:522: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000035: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:537: assert_invalid passed:
+out/test/spec/i32.wast:538: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001a: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:546: assert_invalid passed:
+out/test/spec/i32.wast:547: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001a: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:555: assert_invalid passed:
+out/test/spec/i32.wast:556: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:564: assert_invalid passed:
+out/test/spec/i32.wast:565: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:573: assert_invalid passed:
+out/test/spec/i32.wast:574: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:582: assert_invalid passed:
+out/test/spec/i32.wast:583: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:592: assert_invalid passed:
+out/test/spec/i32.wast:593: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:600: assert_invalid passed:
+out/test/spec/i32.wast:601: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:608: assert_invalid passed:
+out/test/spec/i32.wast:609: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:617: assert_invalid passed:
+out/test/spec/i32.wast:618: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:626: assert_invalid passed:
+out/test/spec/i32.wast:627: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:635: assert_invalid passed:
+out/test/spec/i32.wast:636: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:644: assert_invalid passed:
+out/test/spec/i32.wast:645: assert_invalid passed:
   error: type mismatch in drop, expected [any] but got []
   0000021: error: OnDropExpr callback failed
-out/test/spec/i32.wast:653: assert_invalid passed:
+out/test/spec/i32.wast:654: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:662: assert_invalid passed:
+out/test/spec/i32.wast:663: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000023: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:672: assert_invalid passed:
+out/test/spec/i32.wast:673: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000021: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:682: assert_invalid passed:
+out/test/spec/i32.wast:683: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:691: assert_invalid passed:
+out/test/spec/i32.wast:692: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:700: assert_invalid passed:
+out/test/spec/i32.wast:701: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:709: assert_invalid passed:
+out/test/spec/i32.wast:710: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:718: assert_invalid passed:
+out/test/spec/i32.wast:719: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:727: assert_invalid passed:
+out/test/spec/i32.wast:728: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:736: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000018: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:744: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:752: assert_invalid passed:
+out/test/spec/i32.wast:737: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:760: assert_invalid passed:
+out/test/spec/i32.wast:745: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:768: assert_invalid passed:
+out/test/spec/i32.wast:753: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000018: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:761: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:769: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001f: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:777: assert_invalid passed:
+out/test/spec/i32.wast:778: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000021: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:786: assert_invalid passed:
+out/test/spec/i32.wast:787: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000035: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:802: assert_invalid passed:
+out/test/spec/i32.wast:803: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000037: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:818: assert_invalid passed:
+out/test/spec/i32.wast:819: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:827: assert_invalid passed:
+out/test/spec/i32.wast:828: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001c: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:836: assert_invalid passed:
+out/test/spec/i32.wast:837: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:845: assert_invalid passed:
+out/test/spec/i32.wast:846: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001c: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:854: assert_invalid passed:
+out/test/spec/i32.wast:855: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:863: assert_invalid passed:
+out/test/spec/i32.wast:864: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000022: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:872: assert_invalid passed:
+out/test/spec/i32.wast:873: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:881: assert_invalid passed:
+out/test/spec/i32.wast:882: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:890: assert_invalid passed:
+out/test/spec/i32.wast:891: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:899: assert_invalid passed:
+out/test/spec/i32.wast:900: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:908: assert_invalid passed:
+out/test/spec/i32.wast:909: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:917: assert_invalid passed:
+out/test/spec/i32.wast:918: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:929: assert_invalid passed:
+out/test/spec/i32.wast:930: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:930: assert_invalid passed:
+out/test/spec/i32.wast:931: assert_invalid passed:
   error: type mismatch in i32.and, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:931: assert_invalid passed:
+out/test/spec/i32.wast:932: assert_invalid passed:
   error: type mismatch in i32.div_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:932: assert_invalid passed:
+out/test/spec/i32.wast:933: assert_invalid passed:
   error: type mismatch in i32.div_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:933: assert_invalid passed:
+out/test/spec/i32.wast:934: assert_invalid passed:
   error: type mismatch in i32.mul, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:934: assert_invalid passed:
+out/test/spec/i32.wast:935: assert_invalid passed:
   error: type mismatch in i32.or, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:935: assert_invalid passed:
+out/test/spec/i32.wast:936: assert_invalid passed:
   error: type mismatch in i32.rem_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:936: assert_invalid passed:
+out/test/spec/i32.wast:937: assert_invalid passed:
   error: type mismatch in i32.rem_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:937: assert_invalid passed:
+out/test/spec/i32.wast:938: assert_invalid passed:
   error: type mismatch in i32.rotl, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:938: assert_invalid passed:
+out/test/spec/i32.wast:939: assert_invalid passed:
   error: type mismatch in i32.rotr, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:939: assert_invalid passed:
+out/test/spec/i32.wast:940: assert_invalid passed:
   error: type mismatch in i32.shl, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:940: assert_invalid passed:
+out/test/spec/i32.wast:941: assert_invalid passed:
   error: type mismatch in i32.shr_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:941: assert_invalid passed:
+out/test/spec/i32.wast:942: assert_invalid passed:
   error: type mismatch in i32.shr_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:942: assert_invalid passed:
+out/test/spec/i32.wast:943: assert_invalid passed:
   error: type mismatch in i32.sub, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:943: assert_invalid passed:
+out/test/spec/i32.wast:944: assert_invalid passed:
   error: type mismatch in i32.xor, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:944: assert_invalid passed:
+out/test/spec/i32.wast:945: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:945: assert_invalid passed:
+out/test/spec/i32.wast:946: assert_invalid passed:
   error: type mismatch in i32.clz, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i32.wast:946: assert_invalid passed:
+out/test/spec/i32.wast:947: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i32.wast:947: assert_invalid passed:
+out/test/spec/i32.wast:948: assert_invalid passed:
   error: type mismatch in i32.popcnt, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i32.wast:948: assert_invalid passed:
+out/test/spec/i32.wast:949: assert_invalid passed:
   error: type mismatch in i32.eq, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:949: assert_invalid passed:
+out/test/spec/i32.wast:950: assert_invalid passed:
   error: type mismatch in i32.ge_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:950: assert_invalid passed:
+out/test/spec/i32.wast:951: assert_invalid passed:
   error: type mismatch in i32.ge_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:951: assert_invalid passed:
+out/test/spec/i32.wast:952: assert_invalid passed:
   error: type mismatch in i32.gt_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:952: assert_invalid passed:
+out/test/spec/i32.wast:953: assert_invalid passed:
   error: type mismatch in i32.gt_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:953: assert_invalid passed:
+out/test/spec/i32.wast:954: assert_invalid passed:
   error: type mismatch in i32.le_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:954: assert_invalid passed:
+out/test/spec/i32.wast:955: assert_invalid passed:
   error: type mismatch in i32.le_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:955: assert_invalid passed:
+out/test/spec/i32.wast:956: assert_invalid passed:
   error: type mismatch in i32.lt_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:956: assert_invalid passed:
+out/test/spec/i32.wast:957: assert_invalid passed:
   error: type mismatch in i32.lt_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:957: assert_invalid passed:
+out/test/spec/i32.wast:958: assert_invalid passed:
   error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-442/442 tests passed.
+443/443 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/i64.txt
+++ b/test/spec/i64.txt
@@ -4,98 +4,99 @@
 out/test/spec/i64.wast:62: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:63: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:64: assert_trap passed: integer overflow
-out/test/spec/i64.wast:82: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:65: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:83: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:99: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:84: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:100: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:120: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:101: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:121: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:426: assert_invalid passed:
+out/test/spec/i64.wast:122: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:427: assert_invalid passed:
   error: type mismatch in i64.add, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:427: assert_invalid passed:
+out/test/spec/i64.wast:428: assert_invalid passed:
   error: type mismatch in i64.and, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:428: assert_invalid passed:
+out/test/spec/i64.wast:429: assert_invalid passed:
   error: type mismatch in i64.div_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:429: assert_invalid passed:
+out/test/spec/i64.wast:430: assert_invalid passed:
   error: type mismatch in i64.div_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:430: assert_invalid passed:
+out/test/spec/i64.wast:431: assert_invalid passed:
   error: type mismatch in i64.mul, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:431: assert_invalid passed:
+out/test/spec/i64.wast:432: assert_invalid passed:
   error: type mismatch in i64.or, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:432: assert_invalid passed:
+out/test/spec/i64.wast:433: assert_invalid passed:
   error: type mismatch in i64.rem_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:433: assert_invalid passed:
+out/test/spec/i64.wast:434: assert_invalid passed:
   error: type mismatch in i64.rem_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:434: assert_invalid passed:
+out/test/spec/i64.wast:435: assert_invalid passed:
   error: type mismatch in i64.rotl, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:435: assert_invalid passed:
+out/test/spec/i64.wast:436: assert_invalid passed:
   error: type mismatch in i64.rotr, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:436: assert_invalid passed:
+out/test/spec/i64.wast:437: assert_invalid passed:
   error: type mismatch in i64.shl, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:437: assert_invalid passed:
+out/test/spec/i64.wast:438: assert_invalid passed:
   error: type mismatch in i64.shr_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:438: assert_invalid passed:
+out/test/spec/i64.wast:439: assert_invalid passed:
   error: type mismatch in i64.shr_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:439: assert_invalid passed:
+out/test/spec/i64.wast:440: assert_invalid passed:
   error: type mismatch in i64.sub, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:440: assert_invalid passed:
+out/test/spec/i64.wast:441: assert_invalid passed:
   error: type mismatch in i64.xor, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:441: assert_invalid passed:
+out/test/spec/i64.wast:442: assert_invalid passed:
   error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/i64.wast:442: assert_invalid passed:
+out/test/spec/i64.wast:443: assert_invalid passed:
   error: type mismatch in i64.clz, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i64.wast:443: assert_invalid passed:
+out/test/spec/i64.wast:444: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i64.wast:444: assert_invalid passed:
+out/test/spec/i64.wast:445: assert_invalid passed:
   error: type mismatch in i64.popcnt, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i64.wast:445: assert_invalid passed:
+out/test/spec/i64.wast:446: assert_invalid passed:
   error: type mismatch in i64.eq, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:446: assert_invalid passed:
+out/test/spec/i64.wast:447: assert_invalid passed:
   error: type mismatch in i64.ge_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:447: assert_invalid passed:
+out/test/spec/i64.wast:448: assert_invalid passed:
   error: type mismatch in i64.ge_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:448: assert_invalid passed:
+out/test/spec/i64.wast:449: assert_invalid passed:
   error: type mismatch in i64.gt_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:449: assert_invalid passed:
+out/test/spec/i64.wast:450: assert_invalid passed:
   error: type mismatch in i64.gt_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:450: assert_invalid passed:
+out/test/spec/i64.wast:451: assert_invalid passed:
   error: type mismatch in i64.le_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:451: assert_invalid passed:
+out/test/spec/i64.wast:452: assert_invalid passed:
   error: type mismatch in i64.le_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:452: assert_invalid passed:
+out/test/spec/i64.wast:453: assert_invalid passed:
   error: type mismatch in i64.lt_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:453: assert_invalid passed:
+out/test/spec/i64.wast:454: assert_invalid passed:
   error: type mismatch in i64.lt_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:454: assert_invalid passed:
+out/test/spec/i64.wast:455: assert_invalid passed:
   error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-388/388 tests passed.
+389/389 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -159,53 +159,53 @@ out/test/spec/if.wast:884: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
 out/test/spec/if.wast:895: assert_malformed passed:
-  out/test/spec/if/if.53.wat:1:14: error: unexpected label "$l"
-  (func if end $l)
-               ^^
+  out/test/spec/if/if.53.wat:1:26: error: unexpected label "$l"
+  (func i32.const 0 if end $l)
+                           ^^
 out/test/spec/if.wast:899: assert_malformed passed:
-  out/test/spec/if/if.54.wat:1:17: error: mismatching label "$a" != "$l"
-  (func if $a end $l)
-                  ^^
+  out/test/spec/if/if.54.wat:1:29: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a end $l)
+                              ^^
 out/test/spec/if.wast:903: assert_malformed passed:
-  out/test/spec/if/if.55.wat:1:15: error: unexpected label "$l"
-  (func if else $l end)
-                ^^
+  out/test/spec/if/if.55.wat:1:27: error: unexpected label "$l"
+  (func i32.const 0 if else $l end)
+                            ^^
 out/test/spec/if.wast:907: assert_malformed passed:
-  out/test/spec/if/if.56.wat:1:18: error: mismatching label "$a" != "$l"
-  (func if $a else $l end)
-                   ^^
+  out/test/spec/if/if.56.wat:1:30: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $l end)
+                               ^^
 out/test/spec/if.wast:911: assert_malformed passed:
-  out/test/spec/if/if.57.wat:1:19: error: unexpected label "$l"
-  (func if else end $l)
-                    ^^
+  out/test/spec/if/if.57.wat:1:31: error: unexpected label "$l"
+  (func i32.const 0 if else end $l)
+                                ^^
 out/test/spec/if.wast:915: assert_malformed passed:
-  out/test/spec/if/if.58.wat:1:15: error: unexpected label "$l"
-  (func if else $l end $l)
-                ^^
-  out/test/spec/if/if.58.wat:1:22: error: unexpected label "$l"
-  (func if else $l end $l)
-                       ^^
+  out/test/spec/if/if.58.wat:1:27: error: unexpected label "$l"
+  (func i32.const 0 if else $l end $l)
+                            ^^
+  out/test/spec/if/if.58.wat:1:34: error: unexpected label "$l"
+  (func i32.const 0 if else $l end $l)
+                                   ^^
 out/test/spec/if.wast:919: assert_malformed passed:
-  out/test/spec/if/if.59.wat:1:15: error: unexpected label "$l1"
-  (func if else $l1 end $l2)
-                ^^^
-  out/test/spec/if/if.59.wat:1:23: error: unexpected label "$l2"
-  (func if else $l1 end $l2)
-                        ^^^
+  out/test/spec/if/if.59.wat:1:27: error: unexpected label "$l1"
+  (func i32.const 0 if else $l1 end $l2)
+                            ^^^
+  out/test/spec/if/if.59.wat:1:35: error: unexpected label "$l2"
+  (func i32.const 0 if else $l1 end $l2)
+                                    ^^^
 out/test/spec/if.wast:923: assert_malformed passed:
-  out/test/spec/if/if.60.wat:1:22: error: mismatching label "$a" != "$l"
-  (func if $a else end $l)
-                       ^^
+  out/test/spec/if/if.60.wat:1:34: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else end $l)
+                                   ^^
 out/test/spec/if.wast:927: assert_malformed passed:
-  out/test/spec/if/if.61.wat:1:25: error: mismatching label "$a" != "$l"
-  (func if $a else $a end $l)
-                          ^^
+  out/test/spec/if/if.61.wat:1:37: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $a end $l)
+                                      ^^
 out/test/spec/if.wast:931: assert_malformed passed:
-  out/test/spec/if/if.62.wat:1:18: error: mismatching label "$a" != "$l"
-  (func if $a else $l end $l)
-                   ^^
-  out/test/spec/if/if.62.wat:1:25: error: mismatching label "$a" != "$l"
-  (func if $a else $l end $l)
-                          ^^
+  out/test/spec/if/if.62.wat:1:30: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $l end $l)
+                               ^^
+  out/test/spec/if/if.62.wat:1:37: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $l end $l)
+                                      ^^
 150/150 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/linking.txt
+++ b/test/spec/linking.txt
@@ -29,26 +29,20 @@ out/test/spec/linking.wast:185: assert_trap passed: uninitialized table element
 out/test/spec/linking.wast:187: assert_trap passed: uninitialized table element
 out/test/spec/linking.wast:188: assert_trap passed: uninitialized table element
 out/test/spec/linking.wast:190: assert_trap passed: undefined table index
-out/test/spec/linking.wast:207: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
 out/test/spec/linking.wast:216: assert_unlinkable passed:
   error: unknown module field "mem"
   0000027: error: OnImportMemory callback failed
 out/test/spec/linking.wast:225: assert_trap passed: uninitialized table element
-out/test/spec/linking.wast:228: assert_unlinkable passed:
-  error: elem segment is out of bounds: [12, 13) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [12, 13) >= max value 10
 out/test/spec/linking.wast:236: assert_trap passed: uninitialized table element
-out/test/spec/linking.wast:239: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
 out/test/spec/linking.wast:248: assert_trap passed: uninitialized table element
-out/test/spec/linking.wast:299: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
 out/test/spec/linking.wast:324: assert_unlinkable passed:
   error: unknown module field "tab"
   0000037: error: OnImportTable callback failed
-out/test/spec/linking.wast:335: assert_unlinkable passed:
-  error: data segment is out of bounds: [327680, 327681) >= max value 327680
-out/test/spec/linking.wast:345: assert_unlinkable passed:
-  error: elem segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [327680, 327681) >= max value 327680
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [0, 1) >= max value 0
 94/94 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/block.txt
+++ b/test/spec/multi-value/block.txt
@@ -2,221 +2,533 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/block.wast
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
-out/test/spec/multi-value/block.wast:275: assert_malformed passed:
+out/test/spec/multi-value/block.wast:422: assert_malformed passed:
   out/test/spec/multi-value/block/block.1.wat:1:96: error: unexpected token (, expected ).
   ...esult i32)))(func (i32.const 0) (block (type $sig) (result i32) (param i32)))
                                                                      ^
-out/test/spec/multi-value/block.wast:282: assert_malformed passed:
+out/test/spec/multi-value/block.wast:429: assert_malformed passed:
   out/test/spec/multi-value/block/block.2.wat:1:83: error: unexpected token (, expected ).
   ...esult i32)))(func (i32.const 0) (block (param i32) (type $sig) (result i32)))
                                                         ^
-out/test/spec/multi-value/block.wast:289: assert_malformed passed:
+out/test/spec/multi-value/block.wast:436: assert_malformed passed:
   out/test/spec/multi-value/block/block.3.wat:1:96: error: unexpected token (, expected ).
   ...esult i32)))(func (i32.const 0) (block (param i32) (result i32) (type $sig)))
                                                                      ^
-out/test/spec/multi-value/block.wast:296: assert_malformed passed:
+out/test/spec/multi-value/block.wast:443: assert_malformed passed:
   out/test/spec/multi-value/block/block.4.wat:1:84: error: unexpected token (, expected ).
   ...esult i32)))(func (i32.const 0) (block (result i32) (type $sig) (param i32)))
                                                          ^
-out/test/spec/multi-value/block.wast:303: assert_malformed passed:
+out/test/spec/multi-value/block.wast:450: assert_malformed passed:
   out/test/spec/multi-value/block/block.5.wat:1:84: error: unexpected token (, expected ).
   ...esult i32)))(func (i32.const 0) (block (result i32) (param i32) (type $sig)))
                                                          ^
-out/test/spec/multi-value/block.wast:310: assert_malformed passed:
+out/test/spec/multi-value/block.wast:457: assert_malformed passed:
   out/test/spec/multi-value/block/block.6.wat:1:41: error: unexpected token (, expected ).
   (func (i32.const 0) (block (result i32) (param i32)))
                                           ^
-out/test/spec/multi-value/block.wast:317: assert_malformed passed:
+out/test/spec/multi-value/block.wast:464: assert_malformed passed:
   out/test/spec/multi-value/block/block.7.wat:1:35: error: unexpected token $x, expected ).
   (func (i32.const 0) (block (param $x i32) (drop)))
                                     ^^
   out/test/spec/multi-value/block/block.7.wat:1:50: error: unexpected token ), expected EOF.
   (func (i32.const 0) (block (param $x i32) (drop)))
                                                    ^
-out/test/spec/multi-value/block.wast:321: assert_malformed passed:
+out/test/spec/multi-value/block.wast:468: assert_malformed passed:
   out/test/spec/multi-value/block/block.8.wat:1:25: error: expected 0 results, got 1
   (type $sig (func))(func (block (type $sig) (result i32) (i32.const 0)) (unrea...
                           ^
-out/test/spec/multi-value/block.wast:328: assert_malformed passed:
+out/test/spec/multi-value/block.wast:475: assert_malformed passed:
   out/test/spec/multi-value/block/block.9.wat:1:50: error: expected 1 arguments, got 0
   ...func (param i32) (result i32)))(func (block (type $sig) (result i32) (i32....
                                           ^
-out/test/spec/multi-value/block.wast:335: assert_malformed passed:
+out/test/spec/multi-value/block.wast:482: assert_malformed passed:
   out/test/spec/multi-value/block/block.10.wat:1:64: error: expected 1 results, got 0
   ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (drop)...
                                           ^
-out/test/spec/multi-value/block.wast:342: assert_malformed passed:
+out/test/spec/multi-value/block.wast:489: assert_malformed passed:
   out/test/spec/multi-value/block/block.11.wat:1:68: error: expected 2 arguments, got 1
   ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (resul...
                                           ^
-out/test/spec/multi-value/block.wast:350: assert_invalid passed:
+out/test/spec/multi-value/block.wast:497: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:358: assert_invalid passed:
+out/test/spec/multi-value/block.wast:505: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:362: assert_invalid passed:
+out/test/spec/multi-value/block.wast:509: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:366: assert_invalid passed:
+out/test/spec/multi-value/block.wast:513: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:370: assert_invalid passed:
+out/test/spec/multi-value/block.wast:517: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:375: assert_invalid passed:
+out/test/spec/multi-value/block.wast:522: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:381: assert_invalid passed:
+out/test/spec/multi-value/block.wast:528: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i64]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:534: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [f32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:540: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [f64]
+  0000023: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:546: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32, i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:387: assert_invalid passed:
+out/test/spec/multi-value/block.wast:552: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:393: assert_invalid passed:
+out/test/spec/multi-value/block.wast:558: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:564: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:570: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:576: assert_invalid passed:
   error: type mismatch in block, expected [i32, i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:399: assert_invalid passed:
+out/test/spec/multi-value/block.wast:583: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
-  000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:405: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got []
-  000001d: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:411: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
-  0000020: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:417: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:423: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got [i32]
-  0000020: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:429: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
-  000001f: error: OnEndExpr callback failed
-out/test/spec/multi-value/block.wast:435: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
-  0000020: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:442: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001c: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:448: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:454: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001c: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:460: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:467: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:473: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
-  000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:479: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
-  000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:485: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
-  000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:491: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
-  0000021: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:497: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:503: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
-  000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:509: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
-  000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:515: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
-  000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:522: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
-  0000024: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:528: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32, i32]
-  000002b: error: EndFunctionBody callback failed
-out/test/spec/multi-value/block.wast:534: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:540: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
-  000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:546: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
-  0000021: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:553: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:559: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
-  0000020: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:565: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
-  0000021: error: OnBrExpr callback failed
-out/test/spec/multi-value/block.wast:574: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
-  000001e: error: OnUnaryExpr callback failed
-out/test/spec/multi-value/block.wast:580: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  000001e: error: OnBinaryExpr callback failed
-out/test/spec/multi-value/block.wast:586: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
-  000001f: error: OnUnaryExpr callback failed
 out/test/spec/multi-value/block.wast:592: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  000001f: error: OnBinaryExpr callback failed
-out/test/spec/multi-value/block.wast:598: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
-  0000020: error: OnUnaryExpr callback failed
-out/test/spec/multi-value/block.wast:604: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000022: error: OnBinaryExpr callback failed
+  error: type mismatch in block, expected [i32] but got []
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:601: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  0000020: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:611: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
-  000001d: error: OnBlockExpr callback failed
+  000001c: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:617: assert_invalid passed:
-  error: type mismatch in block, expected [i32, f64] but got []
-  000001e: error: OnBlockExpr callback failed
+  error: type mismatch in block, expected [i64] but got []
+  000001c: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:623: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
-  0000022: error: OnBlockExpr callback failed
+  error: type mismatch in block, expected [f32] but got []
+  000001c: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:629: assert_invalid passed:
-  error: type mismatch in block, expected [f32, i32] but got [f32]
-  0000023: error: OnBlockExpr callback failed
+  error: type mismatch in block, expected [f64] but got []
+  000001c: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:635: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
-  000001f: error: OnBlockExpr callback failed
+  error: type mismatch in block, expected [i32, i32] but got []
+  000001d: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:641: assert_invalid passed:
-  error: type mismatch in block, expected [i32, f64] but got []
-  0000020: error: OnBlockExpr callback failed
+  error: type mismatch in block, expected [i32] but got [i64]
+  000001d: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:647: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
-  0000024: error: OnBlockExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/multi-value/block.wast:653: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f64]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:659: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got [i32]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:665: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got [f32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:671: assert_invalid passed:
+  error: type mismatch in block, expected [i64] but got [f64]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:677: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got [i32]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:683: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got [i64]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:689: assert_invalid passed:
+  error: type mismatch in block, expected [f32] but got [f64]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:695: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got [i32]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:701: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got [i64]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:707: assert_invalid passed:
+  error: type mismatch in block, expected [f64] but got [f32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:713: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:719: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:725: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/multi-value/block.wast:732: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:738: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [f32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:744: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got [f64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:750: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [i32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:756: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [f32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:762: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got [f64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:768: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:774: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:780: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got [f64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:786: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got [i32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:792: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got [i64]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:798: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got [f32]
+  0000020: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:805: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:811: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:817: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:823: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:829: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:836: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:842: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:848: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:854: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001c: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:860: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:867: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:873: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:879: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:885: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:892: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:898: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:904: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:910: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:916: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:922: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:928: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:934: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:940: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:946: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:952: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:958: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:964: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:970: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:977: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:983: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:989: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:995: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1001: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1008: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1014: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1020: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1026: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1032: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1038: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1044: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1050: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1056: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [f64]
+  0000025: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1062: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i32]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1068: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1074: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [f32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1080: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1087: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  0000024: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:1093: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i64]
+  0000024: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:1099: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f32]
+  0000027: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:1105: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f64]
+  000002b: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:1111: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32, i32]
+  000002b: error: EndFunctionBody callback failed
+out/test/spec/multi-value/block.wast:1118: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1124: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1130: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1136: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1142: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1149: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1155: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1161: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1167: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1173: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1180: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1188: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f32]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1196: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [f64]
+  0000027: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1204: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [i32]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1212: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f32]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1220: assert_invalid passed:
+  error: type mismatch in br, expected [i64] but got [f64]
+  0000027: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1228: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i32]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1236: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [i64]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1244: assert_invalid passed:
+  error: type mismatch in br, expected [f32] but got [f64]
+  0000027: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1252: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i32]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1260: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [i64]
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1268: assert_invalid passed:
+  error: type mismatch in br, expected [f64] but got [f32]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1276: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/block.wast:1285: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1291: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1297: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1303: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  000001e: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1309: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/multi-value/block.wast:1316: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1322: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1328: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1334: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  000001f: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1340: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/multi-value/block.wast:1347: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1353: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  0000023: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1359: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  0000027: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1365: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1371: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  0000023: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1377: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  0000027: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1383: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1389: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1395: assert_invalid passed:
+  error: type mismatch in f64.floor, expected [f64] but got []
+  0000027: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1401: assert_invalid passed:
+  error: type mismatch in i32.ctz, expected [i32] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1407: assert_invalid passed:
+  error: type mismatch in i64.ctz, expected [i64] but got []
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1413: assert_invalid passed:
+  error: type mismatch in f32.floor, expected [f32] but got []
+  0000023: error: OnUnaryExpr callback failed
+out/test/spec/multi-value/block.wast:1419: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/multi-value/block.wast:1426: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001d: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1432: assert_invalid passed:
+  error: type mismatch in block, expected [i32, f64] but got []
+  000001e: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1438: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000022: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1444: assert_invalid passed:
+  error: type mismatch in block, expected [f32, i32] but got [f32]
+  0000023: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1450: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001f: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1456: assert_invalid passed:
+  error: type mismatch in block, expected [i32, f64] but got []
+  0000020: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1462: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000024: error: OnBlockExpr callback failed
+out/test/spec/multi-value/block.wast:1468: assert_invalid passed:
   error: type mismatch in block, expected [f32, i32] but got [f32]
   0000025: error: OnBlockExpr callback failed
-out/test/spec/multi-value/block.wast:660: assert_malformed passed:
-  out/test/spec/multi-value/block/block.63.wat:1:45: error: unexpected token $x, expected ).
+out/test/spec/multi-value/block.wast:1475: assert_malformed passed:
+  out/test/spec/multi-value/block/block.167.wat:1:45: error: unexpected token $x, expected ).
   (func (param i32) (result i32) block (param $x i32) end)
                                               ^^
-out/test/spec/multi-value/block.wast:664: assert_malformed passed:
-  out/test/spec/multi-value/block/block.64.wat:1:46: error: unexpected token $x, expected ).
+out/test/spec/multi-value/block.wast:1479: assert_malformed passed:
+  out/test/spec/multi-value/block/block.168.wat:1:46: error: unexpected token $x, expected ).
   (func (param i32) (result i32) (block (param $x i32)))
                                                ^^
-out/test/spec/multi-value/block.wast:669: assert_malformed passed:
-  out/test/spec/multi-value/block/block.65.wat:1:17: error: unexpected label "$l"
+out/test/spec/multi-value/block.wast:1485: assert_malformed passed:
+  out/test/spec/multi-value/block/block.169.wat:1:17: error: unexpected label "$l"
   (func block end $l)
                   ^^
-out/test/spec/multi-value/block.wast:673: assert_malformed passed:
-  out/test/spec/multi-value/block/block.66.wat:1:20: error: mismatching label "$a" != "$l"
+out/test/spec/multi-value/block.wast:1489: assert_malformed passed:
+  out/test/spec/multi-value/block/block.170.wat:1:20: error: mismatching label "$a" != "$l"
   (func block $a end $l)
                      ^^
-91/91 tests passed.
+222/222 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/br.txt
+++ b/test/spec/multi-value/br.txt
@@ -2,26 +2,65 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/br.wast
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
-out/test/spec/multi-value/br.wast:462: assert_invalid passed:
+out/test/spec/multi-value/br.wast:471: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/multi-value/br.wast:469: assert_invalid passed:
+out/test/spec/multi-value/br.wast:478: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/multi-value/br.wast:475: assert_invalid passed:
+out/test/spec/multi-value/br.wast:484: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
-out/test/spec/multi-value/br.wast:481: assert_invalid passed:
+out/test/spec/multi-value/br.wast:490: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/br.wast:488: assert_invalid passed:
+out/test/spec/multi-value/br.wast:497: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:506: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:515: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:524: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:535: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:546: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000021: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:558: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000036: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:574: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:586: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:598: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000023: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:610: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:622: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:634: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/multi-value/br.wast:647: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   0000019: error: OnBrExpr callback failed
-out/test/spec/multi-value/br.wast:492: assert_invalid passed:
+out/test/spec/multi-value/br.wast:651: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   000001d: error: OnBrExpr callback failed
-out/test/spec/multi-value/br.wast:496: assert_invalid passed:
+out/test/spec/multi-value/br.wast:655: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
   000001d: error: OnBrExpr callback failed
-81/81 tests passed.
+96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/call.txt
+++ b/test/spec/multi-value/call.txt
@@ -2,39 +2,58 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/call.wast
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
-out/test/spec/multi-value/call.wast:215: assert_invalid passed:
+out/test/spec/multi-value/call.wast:344: assert_trap passed: undefined table index
+out/test/spec/multi-value/call.wast:369: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001b: error: OnConvertExpr callback failed
-out/test/spec/multi-value/call.wast:222: assert_invalid passed:
+out/test/spec/multi-value/call.wast:376: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001f: error: OnConvertExpr callback failed
-out/test/spec/multi-value/call.wast:230: assert_invalid passed:
+out/test/spec/multi-value/call.wast:384: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   000001e: error: OnCallExpr callback failed
-out/test/spec/multi-value/call.wast:237: assert_invalid passed:
+out/test/spec/multi-value/call.wast:391: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
-out/test/spec/multi-value/call.wast:244: assert_invalid passed:
+out/test/spec/multi-value/call.wast:398: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/test/spec/multi-value/call.wast:251: assert_invalid passed:
+out/test/spec/multi-value/call.wast:405: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
-out/test/spec/multi-value/call.wast:259: assert_invalid passed:
+out/test/spec/multi-value/call.wast:413: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/test/spec/multi-value/call.wast:266: assert_invalid passed:
+out/test/spec/multi-value/call.wast:420: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/test/spec/multi-value/call.wast:273: assert_invalid passed:
+out/test/spec/multi-value/call.wast:427: assert_invalid passed:
   error: type mismatch in call, expected [i32, f64] but got [f64, i32]
   000002a: error: OnCallExpr callback failed
-out/test/spec/multi-value/call.wast:280: assert_invalid passed:
+out/test/spec/multi-value/call.wast:434: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got [i32, f64]
   000002a: error: OnCallExpr callback failed
-out/test/spec/multi-value/call.wast:291: assert_invalid passed:
+out/test/spec/multi-value/call.wast:442: assert_invalid passed:
+  error: type mismatch in call, expected [i32] but got []
+  0000020: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:451: assert_invalid passed:
+  error: type mismatch in call, expected [i32, i32] but got [i32]
+  0000023: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:460: assert_invalid passed:
+  error: type mismatch in call, expected [i32] but got []
+  0000020: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:469: assert_invalid passed:
+  error: type mismatch in call, expected [i32, i32] but got [i32]
+  0000023: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:478: assert_invalid passed:
+  error: type mismatch in call, expected [i32] but got []
+  0000022: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:487: assert_invalid passed:
+  error: type mismatch in call, expected [i32, i32] but got [i32]
+  0000025: error: OnCallExpr callback failed
+out/test/spec/multi-value/call.wast:500: assert_invalid passed:
   0000019: error: invalid call function index: 1
-out/test/spec/multi-value/call.wast:295: assert_invalid passed:
+out/test/spec/multi-value/call.wast:504: assert_invalid passed:
   000001d: error: invalid call function index: 1012321300
-55/55 tests passed.
+89/89 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/call_indirect.txt
+++ b/test/spec/multi-value/call_indirect.txt
@@ -2,123 +2,147 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/call_indirect.wast
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
-out/test/spec/multi-value/call_indirect.wast:262: assert_trap passed: indirect call signature mismatch
-out/test/spec/multi-value/call_indirect.wast:263: assert_trap passed: indirect call signature mismatch
-out/test/spec/multi-value/call_indirect.wast:264: assert_trap passed: undefined table index
-out/test/spec/multi-value/call_indirect.wast:265: assert_trap passed: undefined table index
-out/test/spec/multi-value/call_indirect.wast:266: assert_trap passed: undefined table index
-out/test/spec/multi-value/call_indirect.wast:272: assert_trap passed: indirect call signature mismatch
-out/test/spec/multi-value/call_indirect.wast:273: assert_trap passed: indirect call signature mismatch
-out/test/spec/multi-value/call_indirect.wast:302: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:498: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:499: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:500: assert_trap passed: undefined table index
+out/test/spec/multi-value/call_indirect.wast:501: assert_trap passed: undefined table index
+out/test/spec/multi-value/call_indirect.wast:502: assert_trap passed: undefined table index
+out/test/spec/multi-value/call_indirect.wast:508: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:509: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:515: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:516: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:522: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:523: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:529: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:530: assert_trap passed: indirect call signature mismatch
+out/test/spec/multi-value/call_indirect.wast:623: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.1.wat:1:122: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
   out/test/spec/multi-value/call_indirect/call_indirect.1.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:314: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:635: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.2.wat:1:109: error: unexpected token "type", expected an expr.
   ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
   out/test/spec/multi-value/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:326: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:647: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.3.wat:1:122: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
   out/test/spec/multi-value/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:338: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:659: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.4.wat:1:110: error: unexpected token "type", expected an expr.
   ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
   out/test/spec/multi-value/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:350: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:671: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "param", expected an expr.
   ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
   out/test/spec/multi-value/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:362: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:683: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.6.wat:1:67: error: unexpected token "param", expected an expr.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                           ^^^^^
   out/test/spec/multi-value/call_indirect/call_indirect.6.wat:1:106: error: unexpected token ), expected EOF.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:372: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:693: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.7.wat:1:46: error: unexpected token $x, expected ).
-  ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
+  ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
   out/test/spec/multi-value/call_indirect/call_indirect.7.wat:1:82: error: unexpected token ), expected EOF.
-  ...e 0 anyfunc)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
+  ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/test/spec/multi-value/call_indirect.wast:379: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:700: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.8.wat:1:57: error: expected 0 results, got 1
-  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
+  ...0 funcref)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/test/spec/multi-value/call_indirect.wast:389: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:710: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.9.wat:1:82: error: expected 1 arguments, got 0
-  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
+  ...0 funcref)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/test/spec/multi-value/call_indirect.wast:399: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:720: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.10.wat:1:69: error: expected 1 results, got 0
-  ...i32)))(table 0 anyfunc)(func  (call_indirect (type $sig) (param i32) (i32....
+  ...i32)))(table 0 funcref)(func  (call_indirect (type $sig) (param i32) (i32....
                                     ^^^^^^^^^^^^^
-out/test/spec/multi-value/call_indirect.wast:409: assert_malformed passed:
+out/test/spec/multi-value/call_indirect.wast:730: assert_malformed passed:
   out/test/spec/multi-value/call_indirect/call_indirect.11.wat:1:86: error: expected 2 arguments, got 1
-  ...0 anyfunc)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
+  ...0 funcref)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
-out/test/spec/multi-value/call_indirect.wast:424: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:745: assert_invalid passed:
   error: found call_indirect operator, but no table
   000001c: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:432: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:753: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:440: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:761: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:449: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:770: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:457: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:778: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:465: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:786: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/multi-value/call_indirect.wast:473: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:794: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/call_indirect.wast:484: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:805: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:492: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:813: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:501: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:822: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:511: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:832: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:521: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:842: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:531: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:852: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
-out/test/spec/multi-value/call_indirect.wast:545: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:863: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got []
+  0000036: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:876: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  0000039: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:889: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got []
+  0000036: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:902: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  0000039: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:915: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got []
+  000003a: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:931: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  000003d: error: OnCallIndirectExpr callback failed
+out/test/spec/multi-value/call_indirect.wast:951: assert_invalid passed:
   0000021: error: invalid call_indirect signature index
-out/test/spec/multi-value/call_indirect.wast:552: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:958: assert_invalid passed:
   0000025: error: invalid call_indirect signature index
-out/test/spec/multi-value/call_indirect.wast:563: assert_invalid passed:
+out/test/spec/multi-value/call_indirect.wast:969: assert_invalid passed:
   error: invalid func_index: 0 (max 0)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed
-79/79 tests passed.
+155/155 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/func.txt
+++ b/test/spec/multi-value/func.txt
@@ -209,11 +209,11 @@ out/test/spec/multi-value/func.wast:889: assert_malformed passed:
                      ^^^^^
 out/test/spec/multi-value/func.wast:893: assert_malformed passed:
   out/test/spec/multi-value/func/func.66.wat:1:20: error: unexpected token "result", expected an instr.
-  (func (local i32) (result i32) (get_local 0))
+  (func (local i32) (result i32) (local.get 0))
                      ^^^^^^
 out/test/spec/multi-value/func.wast:897: assert_malformed passed:
   out/test/spec/multi-value/func/func.67.wat:1:21: error: unexpected token "param", expected an instr.
-  (func (result i32) (param i32) (get_local 0))
+  (func (result i32) (param i32) (local.get 0))
                       ^^^^^
 158/158 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/if.txt
+++ b/test/spec/multi-value/if.txt
@@ -2,349 +2,404 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/if.wast
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
-out/test/spec/multi-value/if.wast:410: assert_malformed passed:
+out/test/spec/multi-value/if.wast:585: assert_trap passed: undefined table index
+out/test/spec/multi-value/if.wast:726: assert_malformed passed:
   out/test/spec/multi-value/if/if.1.wat:1:95: error: unexpected token "param", expected then block (e.g. (then ...)).
   ...i32.const 0)  (if (type $sig) (result i32) (param i32) (i32.const 1) (then)))
                                                  ^^^^^
   out/test/spec/multi-value/if/if.1.wat:1:121: error: unexpected token "then", expected an instr.
   ...i32.const 0)  (if (type $sig) (result i32) (param i32) (i32.const 1) (then)))
                                                                            ^^^^
-out/test/spec/multi-value/if.wast:419: assert_malformed passed:
+out/test/spec/multi-value/if.wast:735: assert_malformed passed:
   out/test/spec/multi-value/if/if.2.wat:1:82: error: unexpected token "type", expected then block (e.g. (then ...)).
   ...nc (i32.const 0)  (if (param i32) (type $sig) (result i32) (i32.const 1) (...
                                         ^^^^
   out/test/spec/multi-value/if/if.2.wat:1:121: error: unexpected token "then", expected an instr.
   ...i32.const 0)  (if (param i32) (type $sig) (result i32) (i32.const 1) (then)))
                                                                            ^^^^
-out/test/spec/multi-value/if.wast:428: assert_malformed passed:
+out/test/spec/multi-value/if.wast:744: assert_malformed passed:
   out/test/spec/multi-value/if/if.3.wat:1:95: error: unexpected token "type", expected then block (e.g. (then ...)).
   ...i32.const 0)  (if (param i32) (result i32) (type $sig) (i32.const 1) (then)))
                                                  ^^^^
   out/test/spec/multi-value/if/if.3.wat:1:121: error: unexpected token "then", expected an instr.
   ...i32.const 0)  (if (param i32) (result i32) (type $sig) (i32.const 1) (then)))
                                                                            ^^^^
-out/test/spec/multi-value/if.wast:437: assert_malformed passed:
+out/test/spec/multi-value/if.wast:753: assert_malformed passed:
   out/test/spec/multi-value/if/if.4.wat:1:83: error: unexpected token "type", expected then block (e.g. (then ...)).
   ...c (i32.const 0)  (if (result i32) (type $sig) (param i32) (i32.const 1) (t...
                                         ^^^^
   out/test/spec/multi-value/if/if.4.wat:1:121: error: unexpected token "then", expected an instr.
   ...i32.const 0)  (if (result i32) (type $sig) (param i32) (i32.const 1) (then)))
                                                                            ^^^^
-out/test/spec/multi-value/if.wast:446: assert_malformed passed:
+out/test/spec/multi-value/if.wast:762: assert_malformed passed:
   out/test/spec/multi-value/if/if.5.wat:1:83: error: unexpected token "param", expected then block (e.g. (then ...)).
   ...c (i32.const 0)  (if (result i32) (param i32) (type $sig) (i32.const 1) (t...
                                         ^^^^^
   out/test/spec/multi-value/if/if.5.wat:1:121: error: unexpected token "then", expected an instr.
   ...i32.const 0)  (if (result i32) (param i32) (type $sig) (i32.const 1) (then)))
                                                                            ^^^^
-out/test/spec/multi-value/if.wast:455: assert_malformed passed:
+out/test/spec/multi-value/if.wast:771: assert_malformed passed:
   out/test/spec/multi-value/if/if.6.wat:1:39: error: unexpected token "param", expected then block (e.g. (then ...)).
   (func (i32.const 0) (if (result i32) (param i32) (i32.const 1) (then)))
                                         ^^^^^
   out/test/spec/multi-value/if/if.6.wat:1:65: error: unexpected token "then", expected an instr.
   (func (i32.const 0) (if (result i32) (param i32) (i32.const 1) (then)))
                                                                   ^^^^
-out/test/spec/multi-value/if.wast:462: assert_malformed passed:
+out/test/spec/multi-value/if.wast:778: assert_malformed passed:
   out/test/spec/multi-value/if/if.7.wat:1:47: error: unexpected token $x, expected ).
   ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
                                              ^^
   out/test/spec/multi-value/if/if.7.wat:1:69: error: unexpected token (, expected EOF.
   ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
                                                                    ^
-out/test/spec/multi-value/if.wast:470: assert_malformed passed:
+out/test/spec/multi-value/if.wast:786: assert_malformed passed:
   out/test/spec/multi-value/if/if.8.wat:1:40: error: expected 0 results, got 1
   (type $sig (func))(func (i32.const 1)  (if (type $sig) (result i32) (then (i3...
                                          ^
-out/test/spec/multi-value/if.wast:480: assert_malformed passed:
+out/test/spec/multi-value/if.wast:796: assert_malformed passed:
   out/test/spec/multi-value/if/if.9.wat:1:65: error: expected 1 arguments, got 0
   ...) (result i32)))(func (i32.const 1)  (if (type $sig) (result i32) (then (i...
                                           ^
-out/test/spec/multi-value/if.wast:490: assert_malformed passed:
+out/test/spec/multi-value/if.wast:806: assert_malformed passed:
   out/test/spec/multi-value/if/if.10.wat:1:79: error: expected 1 results, got 0
   ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (then (dr...
                                           ^
-out/test/spec/multi-value/if.wast:500: assert_malformed passed:
+out/test/spec/multi-value/if.wast:816: assert_malformed passed:
   out/test/spec/multi-value/if/if.11.wat:1:83: error: expected 2 arguments, got 1
   ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (result i...
                                           ^
-out/test/spec/multi-value/if.wast:510: assert_invalid passed:
+out/test/spec/multi-value/if.wast:826: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:518: assert_invalid passed:
+out/test/spec/multi-value/if.wast:834: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:522: assert_invalid passed:
+out/test/spec/multi-value/if.wast:838: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:526: assert_invalid passed:
+out/test/spec/multi-value/if.wast:842: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:530: assert_invalid passed:
+out/test/spec/multi-value/if.wast:846: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:535: assert_invalid passed:
+out/test/spec/multi-value/if.wast:851: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:539: assert_invalid passed:
+out/test/spec/multi-value/if.wast:855: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:543: assert_invalid passed:
+out/test/spec/multi-value/if.wast:859: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:547: assert_invalid passed:
+out/test/spec/multi-value/if.wast:863: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:552: assert_invalid passed:
+out/test/spec/multi-value/if.wast:868: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:558: assert_invalid passed:
+out/test/spec/multi-value/if.wast:874: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:564: assert_invalid passed:
+out/test/spec/multi-value/if.wast:880: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:570: assert_invalid passed:
+out/test/spec/multi-value/if.wast:886: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:577: assert_invalid passed:
+out/test/spec/multi-value/if.wast:893: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32, i32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:583: assert_invalid passed:
+out/test/spec/multi-value/if.wast:899: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32, i32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:589: assert_invalid passed:
+out/test/spec/multi-value/if.wast:905: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32, i32]
   0000021: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:595: assert_invalid passed:
+out/test/spec/multi-value/if.wast:911: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32, i32]
   0000020: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:602: assert_invalid passed:
+out/test/spec/multi-value/if.wast:918: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:608: assert_invalid passed:
+out/test/spec/multi-value/if.wast:924: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:614: assert_invalid passed:
+out/test/spec/multi-value/if.wast:930: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:621: assert_invalid passed:
+out/test/spec/multi-value/if.wast:937: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:627: assert_invalid passed:
+out/test/spec/multi-value/if.wast:943: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32, i32] but got []
   0000022: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:633: assert_invalid passed:
+out/test/spec/multi-value/if.wast:949: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got []
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:640: assert_invalid passed:
+out/test/spec/multi-value/if.wast:956: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:646: assert_invalid passed:
+out/test/spec/multi-value/if.wast:962: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32, i32] but got []
   0000022: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:653: assert_invalid passed:
+out/test/spec/multi-value/if.wast:969: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:659: assert_invalid passed:
+out/test/spec/multi-value/if.wast:975: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:665: assert_invalid passed:
+out/test/spec/multi-value/if.wast:981: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:672: assert_invalid passed:
+out/test/spec/multi-value/if.wast:988: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got []
   000001f: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:678: assert_invalid passed:
+out/test/spec/multi-value/if.wast:994: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32, i32] but got []
   0000024: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:684: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1000: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got []
   000001f: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:691: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1007: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:697: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1013: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:703: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1019: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:710: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1026: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000020: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:716: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1032: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32, i32] but got [i32]
   0000025: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:722: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1038: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000020: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:729: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1045: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:736: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1052: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32, i32] but got [i32]
   0000027: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:743: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1059: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:751: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1067: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   0000021: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:757: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1073: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
-out/test/spec/multi-value/if.wast:763: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1079: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   0000021: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:770: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1086: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:776: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1092: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   0000024: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:783: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1099: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:793: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1109: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:803: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1119: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
-out/test/spec/multi-value/if.wast:814: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1130: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:820: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1136: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:826: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1142: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:832: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1148: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got []
   0000024: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:839: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1155: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:848: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1164: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:857: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1173: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:866: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1182: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got []
   0000024: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:876: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1192: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:885: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1201: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:894: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1210: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got []
   0000020: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:903: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1219: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got []
   0000025: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:913: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1229: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:922: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1238: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:931: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1247: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got [i64]
   0000021: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:940: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1256: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got [i64]
   0000026: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:949: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1265: assert_invalid passed:
   error: type mismatch in br, expected [i32, i32] but got [i64]
   0000023: error: OnBrExpr callback failed
-out/test/spec/multi-value/if.wast:959: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1275: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
-out/test/spec/multi-value/if.wast:970: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1286: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000019: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1294: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001d: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1303: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001d: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1312: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:976: assert_invalid passed:
-  error: type mismatch in if, expected [i32, f64] but got []
-  0000020: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:982: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got [f32]
-  0000024: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:988: assert_invalid passed:
-  error: type mismatch in if, expected [f32, i32] but got [f32]
-  0000025: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:994: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1321: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000022: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1331: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001d: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1340: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001d: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1349: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001d: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1358: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000019: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1366: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000019: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1374: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001f: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1383: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000036: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1399: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001b: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1408: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001b: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1417: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000021: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:1000: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1426: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001e: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1435: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001e: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1444: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001e: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1454: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001f: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1460: assert_invalid passed:
+  error: type mismatch in if, expected [i32, f64] but got []
+  0000020: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1466: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got [f32]
+  0000024: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1472: assert_invalid passed:
+  error: type mismatch in if, expected [f32, i32] but got [f32]
+  0000025: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1478: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000021: error: OnIfExpr callback failed
+out/test/spec/multi-value/if.wast:1484: assert_invalid passed:
   error: type mismatch in if, expected [i32, f64] but got []
   0000022: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:1006: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1490: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got [f32]
   0000026: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:1012: assert_invalid passed:
+out/test/spec/multi-value/if.wast:1496: assert_invalid passed:
   error: type mismatch in if, expected [f32, i32] but got [f32]
   0000027: error: OnIfExpr callback failed
-out/test/spec/multi-value/if.wast:1019: assert_malformed passed:
-  out/test/spec/multi-value/if/if.86.wat:1:42: error: unexpected token $x, expected ).
+out/test/spec/multi-value/if.wast:1503: assert_malformed passed:
+  out/test/spec/multi-value/if/if.104.wat:1:42: error: unexpected token $x, expected ).
   (func (param i32) (result i32) if (param $x i32) end)
                                            ^^
-out/test/spec/multi-value/if.wast:1023: assert_malformed passed:
-  out/test/spec/multi-value/if/if.87.wat:1:43: error: unexpected token $x, expected ).
+out/test/spec/multi-value/if.wast:1507: assert_malformed passed:
+  out/test/spec/multi-value/if/if.105.wat:1:43: error: unexpected token $x, expected ).
   (func (param i32) (result i32) (if (param $x i32) (then)))
                                             ^^
-out/test/spec/multi-value/if.wast:1028: assert_malformed passed:
-  out/test/spec/multi-value/if/if.88.wat:1:14: error: unexpected label "$l"
-  (func if end $l)
-               ^^
-out/test/spec/multi-value/if.wast:1032: assert_malformed passed:
-  out/test/spec/multi-value/if/if.89.wat:1:17: error: mismatching label "$a" != "$l"
-  (func if $a end $l)
-                  ^^
-out/test/spec/multi-value/if.wast:1036: assert_malformed passed:
-  out/test/spec/multi-value/if/if.90.wat:1:15: error: unexpected label "$l"
-  (func if else $l end)
-                ^^
-out/test/spec/multi-value/if.wast:1040: assert_malformed passed:
-  out/test/spec/multi-value/if/if.91.wat:1:18: error: mismatching label "$a" != "$l"
-  (func if $a else $l end)
-                   ^^
-out/test/spec/multi-value/if.wast:1044: assert_malformed passed:
-  out/test/spec/multi-value/if/if.92.wat:1:19: error: unexpected label "$l"
-  (func if else end $l)
-                    ^^
-out/test/spec/multi-value/if.wast:1048: assert_malformed passed:
-  out/test/spec/multi-value/if/if.93.wat:1:15: error: unexpected label "$l"
-  (func if else $l end $l)
-                ^^
-  out/test/spec/multi-value/if/if.93.wat:1:22: error: unexpected label "$l"
-  (func if else $l end $l)
-                       ^^
-out/test/spec/multi-value/if.wast:1052: assert_malformed passed:
-  out/test/spec/multi-value/if/if.94.wat:1:15: error: unexpected label "$l1"
-  (func if else $l1 end $l2)
-                ^^^
-  out/test/spec/multi-value/if/if.94.wat:1:23: error: unexpected label "$l2"
-  (func if else $l1 end $l2)
-                        ^^^
-out/test/spec/multi-value/if.wast:1056: assert_malformed passed:
-  out/test/spec/multi-value/if/if.95.wat:1:22: error: mismatching label "$a" != "$l"
-  (func if $a else end $l)
-                       ^^
-out/test/spec/multi-value/if.wast:1060: assert_malformed passed:
-  out/test/spec/multi-value/if/if.96.wat:1:25: error: mismatching label "$a" != "$l"
-  (func if $a else $a end $l)
-                          ^^
-out/test/spec/multi-value/if.wast:1064: assert_malformed passed:
-  out/test/spec/multi-value/if/if.97.wat:1:18: error: mismatching label "$a" != "$l"
-  (func if $a else $l end $l)
-                   ^^
-  out/test/spec/multi-value/if/if.97.wat:1:25: error: mismatching label "$a" != "$l"
-  (func if $a else $l end $l)
-                          ^^
-170/170 tests passed.
+out/test/spec/multi-value/if.wast:1512: assert_malformed passed:
+  out/test/spec/multi-value/if/if.106.wat:1:26: error: unexpected label "$l"
+  (func i32.const 0 if end $l)
+                           ^^
+out/test/spec/multi-value/if.wast:1516: assert_malformed passed:
+  out/test/spec/multi-value/if/if.107.wat:1:29: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a end $l)
+                              ^^
+out/test/spec/multi-value/if.wast:1520: assert_malformed passed:
+  out/test/spec/multi-value/if/if.108.wat:1:27: error: unexpected label "$l"
+  (func i32.const 0 if else $l end)
+                            ^^
+out/test/spec/multi-value/if.wast:1524: assert_malformed passed:
+  out/test/spec/multi-value/if/if.109.wat:1:30: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $l end)
+                               ^^
+out/test/spec/multi-value/if.wast:1528: assert_malformed passed:
+  out/test/spec/multi-value/if/if.110.wat:1:31: error: unexpected label "$l"
+  (func i32.const 0 if else end $l)
+                                ^^
+out/test/spec/multi-value/if.wast:1532: assert_malformed passed:
+  out/test/spec/multi-value/if/if.111.wat:1:27: error: unexpected label "$l"
+  (func i32.const 0 if else $l end $l)
+                            ^^
+  out/test/spec/multi-value/if/if.111.wat:1:34: error: unexpected label "$l"
+  (func i32.const 0 if else $l end $l)
+                                   ^^
+out/test/spec/multi-value/if.wast:1536: assert_malformed passed:
+  out/test/spec/multi-value/if/if.112.wat:1:27: error: unexpected label "$l1"
+  (func i32.const 0 if else $l1 end $l2)
+                            ^^^
+  out/test/spec/multi-value/if/if.112.wat:1:35: error: unexpected label "$l2"
+  (func i32.const 0 if else $l1 end $l2)
+                                    ^^^
+out/test/spec/multi-value/if.wast:1540: assert_malformed passed:
+  out/test/spec/multi-value/if/if.113.wat:1:34: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else end $l)
+                                   ^^
+out/test/spec/multi-value/if.wast:1544: assert_malformed passed:
+  out/test/spec/multi-value/if/if.114.wat:1:37: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $a end $l)
+                                      ^^
+out/test/spec/multi-value/if.wast:1548: assert_malformed passed:
+  out/test/spec/multi-value/if/if.115.wat:1:30: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $l end $l)
+                               ^^
+  out/test/spec/multi-value/if/if.115.wat:1:37: error: mismatching label "$a" != "$l"
+  (func i32.const 0 if $a else $l end $l)
+                                      ^^
+238/238 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/loop.txt
+++ b/test/spec/multi-value/loop.txt
@@ -2,140 +2,149 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/loop.wast
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
-out/test/spec/multi-value/loop.wast:394: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:526: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.1.wat:1:95: error: unexpected token (, expected ).
   ...result i32)))(func (i32.const 0) (loop (type $sig) (result i32) (param i32)))
                                                                      ^
-out/test/spec/multi-value/loop.wast:401: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:533: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.2.wat:1:82: error: unexpected token (, expected ).
   ...result i32)))(func (i32.const 0) (loop (param i32) (type $sig) (result i32)))
                                                         ^
-out/test/spec/multi-value/loop.wast:408: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:540: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.3.wat:1:95: error: unexpected token (, expected ).
   ...result i32)))(func (i32.const 0) (loop (param i32) (result i32) (type $sig)))
                                                                      ^
-out/test/spec/multi-value/loop.wast:415: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:547: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.4.wat:1:83: error: unexpected token (, expected ).
   ...result i32)))(func (i32.const 0) (loop (result i32) (type $sig) (param i32)))
                                                          ^
-out/test/spec/multi-value/loop.wast:422: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:554: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.5.wat:1:83: error: unexpected token (, expected ).
   ...result i32)))(func (i32.const 0) (loop (result i32) (param i32) (type $sig)))
                                                          ^
-out/test/spec/multi-value/loop.wast:429: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:561: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.6.wat:1:40: error: unexpected token (, expected ).
   (func (i32.const 0) (loop (result i32) (param i32)))
                                          ^
-out/test/spec/multi-value/loop.wast:436: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:568: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.7.wat:1:34: error: unexpected token $x, expected ).
   (func (i32.const 0) (loop (param $x i32) (drop)))
                                    ^^
   out/test/spec/multi-value/loop/loop.7.wat:1:49: error: unexpected token ), expected EOF.
   (func (i32.const 0) (loop (param $x i32) (drop)))
                                                   ^
-out/test/spec/multi-value/loop.wast:440: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:572: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.8.wat:1:25: error: expected 0 results, got 1
   (type $sig (func))(func (loop (type $sig) (result i32) (i32.const 0)) (unreac...
                           ^
-out/test/spec/multi-value/loop.wast:447: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:579: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.9.wat:1:50: error: expected 1 arguments, got 0
   ...func (param i32) (result i32)))(func (loop (type $sig) (result i32) (i32.c...
                                           ^
-out/test/spec/multi-value/loop.wast:454: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:586: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.10.wat:1:64: error: expected 1 results, got 0
   ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (drop))...
                                           ^
-out/test/spec/multi-value/loop.wast:461: assert_malformed passed:
+out/test/spec/multi-value/loop.wast:593: assert_malformed passed:
   out/test/spec/multi-value/loop/loop.11.wat:1:68: error: expected 2 arguments, got 1
   ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (result...
                                           ^
-out/test/spec/multi-value/loop.wast:469: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:601: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:477: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:609: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/loop.wast:481: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:613: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/loop.wast:485: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:617: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/loop.wast:489: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:621: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
-out/test/spec/multi-value/loop.wast:494: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:626: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:500: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:632: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32, i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:506: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:638: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:512: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:644: assert_invalid passed:
   error: type mismatch in loop, expected [i32, i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:518: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:650: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:524: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:656: assert_invalid passed:
   error: type mismatch in loop, expected [i32, i32] but got []
   000001d: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:530: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:662: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:536: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:668: assert_invalid passed:
   error: type mismatch in loop, expected [i32, i32] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:542: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:674: assert_invalid passed:
   error: type mismatch in loop, expected [i32, i32] but got [i32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:548: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:680: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/test/spec/multi-value/loop.wast:554: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:686: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/multi-value/loop.wast:561: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:693: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:702: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001e: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:711: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  0000020: error: OnEndExpr callback failed
+out/test/spec/multi-value/loop.wast:721: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:567: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:727: assert_invalid passed:
   error: type mismatch in loop, expected [i32, f64] but got []
   000001e: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:573: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:733: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000022: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:579: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:739: assert_invalid passed:
   error: type mismatch in loop, expected [f32, i32] but got [f32]
   0000023: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:585: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:745: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001f: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:591: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:751: assert_invalid passed:
   error: type mismatch in loop, expected [i32, f64] but got []
   0000020: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:597: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:757: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:603: assert_invalid passed:
+out/test/spec/multi-value/loop.wast:763: assert_invalid passed:
   error: type mismatch in loop, expected [f32, i32] but got [f32]
   0000025: error: OnLoopExpr callback failed
-out/test/spec/multi-value/loop.wast:610: assert_malformed passed:
-  out/test/spec/multi-value/loop/loop.36.wat:1:44: error: unexpected token $x, expected ).
+out/test/spec/multi-value/loop.wast:770: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.39.wat:1:44: error: unexpected token $x, expected ).
   (func (param i32) (result i32) loop (param $x i32) end)
                                              ^^
-out/test/spec/multi-value/loop.wast:614: assert_malformed passed:
-  out/test/spec/multi-value/loop/loop.37.wat:1:45: error: unexpected token $x, expected ).
+out/test/spec/multi-value/loop.wast:774: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.40.wat:1:45: error: unexpected token $x, expected ).
   (func (param i32) (result i32) (loop (param $x i32)))
                                               ^^
-out/test/spec/multi-value/loop.wast:619: assert_malformed passed:
-  out/test/spec/multi-value/loop/loop.38.wat:1:16: error: unexpected label "$l"
+out/test/spec/multi-value/loop.wast:779: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.41.wat:1:16: error: unexpected label "$l"
   (func loop end $l)
                  ^^
-out/test/spec/multi-value/loop.wast:623: assert_malformed passed:
-  out/test/spec/multi-value/loop/loop.39.wat:1:19: error: mismatching label "$a" != "$l"
+out/test/spec/multi-value/loop.wast:783: assert_malformed passed:
+  out/test/spec/multi-value/loop/loop.42.wat:1:19: error: mismatching label "$a" != "$l"
   (func loop $a end $l)
                     ^^
-92/92 tests passed.
+119/119 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/mutable-global/linking.txt
+++ b/test/spec/mutable-global/linking.txt
@@ -29,26 +29,20 @@ out/test/spec/mutable-global/linking.wast:185: assert_trap passed: uninitialized
 out/test/spec/mutable-global/linking.wast:187: assert_trap passed: uninitialized table element
 out/test/spec/mutable-global/linking.wast:188: assert_trap passed: uninitialized table element
 out/test/spec/mutable-global/linking.wast:190: assert_trap passed: undefined table index
-out/test/spec/mutable-global/linking.wast:207: assert_unlinkable passed:
-  error: elem segment is out of bounds: [10, 11) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [10, 11) >= max value 10
 out/test/spec/mutable-global/linking.wast:216: assert_unlinkable passed:
   error: unknown module field "mem"
   0000027: error: OnImportMemory callback failed
 out/test/spec/mutable-global/linking.wast:225: assert_trap passed: uninitialized table element
-out/test/spec/mutable-global/linking.wast:228: assert_unlinkable passed:
-  error: elem segment is out of bounds: [12, 13) >= max value 10
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [12, 13) >= max value 10
 out/test/spec/mutable-global/linking.wast:236: assert_trap passed: uninitialized table element
-out/test/spec/mutable-global/linking.wast:239: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
 out/test/spec/mutable-global/linking.wast:248: assert_trap passed: uninitialized table element
-out/test/spec/mutable-global/linking.wast:299: assert_unlinkable passed:
-  error: data segment is out of bounds: [65536, 65537) >= max value 65536
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [65536, 65537) >= max value 65536
 out/test/spec/mutable-global/linking.wast:324: assert_unlinkable passed:
   error: unknown module field "tab"
   0000037: error: OnImportTable callback failed
-out/test/spec/mutable-global/linking.wast:335: assert_unlinkable passed:
-  error: data segment is out of bounds: [327680, 327681) >= max value 327680
-out/test/spec/mutable-global/linking.wast:345: assert_unlinkable passed:
-  error: elem segment is out of bounds: [0, 1) >= max value 0
+assert_unlinkable passed: out of bounds memory access: data segment is out of bounds: [327680, 327681) >= max value 327680
+assert_unlinkable passed: out of bounds table access: elem segment is out of bounds: [0, 1) >= max value 0
 91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/names.txt
+++ b/test/spec/names.txt
@@ -3,5 +3,5 @@
 (;; STDOUT ;;;
 called host spectest.print_i32(i32:42) =>
 called host spectest.print_i32(i32:123) =>
-479/479 tests passed.
+482/482 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/nontrapping-float-to-int-conversions/conversions.txt
+++ b/test/spec/nontrapping-float-to-int-conversions/conversions.txt
@@ -69,5 +69,80 @@ out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:247: assert_
 out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:248: assert_trap passed: invalid conversion to integer
 out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:249: assert_trap passed: invalid conversion to integer
 out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:250: assert_trap passed: invalid conversion to integer
-581/581 tests passed.
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:674: assert_invalid passed:
+  error: type mismatch in i32.wrap_i64, expected [i64] but got [f32]
+  000001e: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:675: assert_invalid passed:
+  error: type mismatch in i32.trunc_f32_s, expected [f32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:676: assert_invalid passed:
+  error: type mismatch in i32.trunc_f32_u, expected [f32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:677: assert_invalid passed:
+  error: type mismatch in i32.trunc_f64_s, expected [f64] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:678: assert_invalid passed:
+  error: type mismatch in i32.trunc_f64_u, expected [f64] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:679: assert_invalid passed:
+  error: type mismatch in i32.reinterpret_f32, expected [f32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:680: assert_invalid passed:
+  error: type mismatch in i64.extend_i32_s, expected [i32] but got [f32]
+  000001e: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:681: assert_invalid passed:
+  error: type mismatch in i64.extend_i32_u, expected [i32] but got [f32]
+  000001e: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:682: assert_invalid passed:
+  error: type mismatch in i64.trunc_f32_s, expected [f32] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:683: assert_invalid passed:
+  error: type mismatch in i64.trunc_f32_u, expected [f32] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:684: assert_invalid passed:
+  error: type mismatch in i64.trunc_f64_s, expected [f64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:685: assert_invalid passed:
+  error: type mismatch in i64.trunc_f64_u, expected [f64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:686: assert_invalid passed:
+  error: type mismatch in i64.reinterpret_f64, expected [f64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:687: assert_invalid passed:
+  error: type mismatch in f32.convert_i32_s, expected [i32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:688: assert_invalid passed:
+  error: type mismatch in f32.convert_i32_u, expected [i32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:689: assert_invalid passed:
+  error: type mismatch in f32.convert_i64_s, expected [i64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:690: assert_invalid passed:
+  error: type mismatch in f32.convert_i64_u, expected [i64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:691: assert_invalid passed:
+  error: type mismatch in f32.demote_f64, expected [f64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:692: assert_invalid passed:
+  error: type mismatch in f32.reinterpret_i32, expected [i32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:693: assert_invalid passed:
+  error: type mismatch in f64.convert_i32_s, expected [i32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:694: assert_invalid passed:
+  error: type mismatch in f64.convert_i32_u, expected [i32] but got [i64]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:695: assert_invalid passed:
+  error: type mismatch in f64.convert_i64_s, expected [i64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:696: assert_invalid passed:
+  error: type mismatch in f64.convert_i64_u, expected [i64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:697: assert_invalid passed:
+  error: type mismatch in f64.promote_f32, expected [f32] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/nontrapping-float-to-int-conversions/conversions.wast:698: assert_invalid passed:
+  error: type mismatch in f64.reinterpret_i64, expected [i64] but got [i32]
+  000001b: error: OnConvertExpr callback failed
+614/614 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -16,5 +16,9 @@ inc() =>
 called host spectest.print_i32(i32:1) =>
 called host spectest.print_i32(i32:2) =>
 called host spectest.print() =>
-14/14 tests passed.
+out/test/spec/start.wast:103: assert_malformed passed:
+  out/test/spec/start/start.9.wat:1:69: error: multiple start sections
+  (module (func $a (unreachable)) (func $b (unreachable)) (start $a) (start $b))
+                                                                      ^^^^^
+15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreachable.txt
+++ b/test/spec/unreachable.txt
@@ -1,56 +1,54 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/unreachable.wast
 (;; STDOUT ;;;
-out/test/spec/unreachable.wast:218: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:219: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:220: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:221: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:222: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:223: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:224: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:225: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:226: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:227: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:228: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:229: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:230: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:231: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:232: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:233: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:234: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:235: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:236: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:237: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:238: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:239: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:241: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:242: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:243: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:244: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:245: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:246: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:247: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:248: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:249: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:250: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:251: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:253: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:252: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:254: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:256: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:257: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:259: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:260: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:261: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:262: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:263: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:264: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:265: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:266: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:267: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:269: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:268: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:270: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:271: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:272: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:274: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:275: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:276: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:278: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:277: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:279: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:280: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:281: assert_trap passed: unreachable executed
-out/test/spec/unreachable.wast:282: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:283: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:284: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:286: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:287: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:288: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:289: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:291: assert_trap passed: unreachable executed
@@ -58,5 +56,8 @@ out/test/spec/unreachable.wast:293: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:294: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:296: assert_trap passed: unreachable executed
 out/test/spec/unreachable.wast:298: assert_trap passed: unreachable executed
-61/61 tests passed.
+out/test/spec/unreachable.wast:299: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:301: assert_trap passed: unreachable executed
+out/test/spec/unreachable.wast:303: assert_trap passed: unreachable executed
+63/63 tests passed.
 ;;; STDOUT ;;)

--- a/test/typecheck/bad-bulk-memory-invalid-segment.txt
+++ b/test/typecheck/bad-bulk-memory-invalid-segment.txt
@@ -16,16 +16,16 @@
   )
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-bulk-memory-invalid-segment.txt:8:53: error: data_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:8:53: error: data_segment variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 memory.init 0
                                                     ^
-out/test/typecheck/bad-bulk-memory-invalid-segment.txt:9:15: error: data_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:9:15: error: data_segment variable out of range: 0 (max 4294967295)
     data.drop 0
               ^
-out/test/typecheck/bad-bulk-memory-invalid-segment.txt:14:52: error: elem_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:14:52: error: elem_segment variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 table.init 0
                                                    ^
-out/test/typecheck/bad-bulk-memory-invalid-segment.txt:15:15: error: elem_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-invalid-segment.txt:15:15: error: elem_segment variable out of range: 0 (max 4294967295)
     elem.drop 0
               ^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-bulk-memory-no-memory.txt
+++ b/test/typecheck/bad-bulk-memory-no-memory.txt
@@ -14,13 +14,13 @@
 out/test/typecheck/bad-bulk-memory-no-memory.txt:7:41: error: memory.init requires an imported or defined memory.
     i32.const 0 i32.const 0 i32.const 0 memory.init 0
                                         ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-no-memory.txt:7:53: error: data_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-no-memory.txt:7:53: error: data_segment variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 memory.init 0
                                                     ^
 out/test/typecheck/bad-bulk-memory-no-memory.txt:8:5: error: data.drop requires an imported or defined memory.
     data.drop 0
     ^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-no-memory.txt:8:15: error: data_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-no-memory.txt:8:15: error: data_segment variable out of range: 0 (max 4294967295)
     data.drop 0
               ^
 out/test/typecheck/bad-bulk-memory-no-memory.txt:9:41: error: memory.copy requires an imported or defined memory.

--- a/test/typecheck/bad-bulk-memory-no-table.txt
+++ b/test/typecheck/bad-bulk-memory-no-table.txt
@@ -16,7 +16,7 @@ out/test/typecheck/bad-bulk-memory-no-table.txt:7:41: error: table.init requires
 out/test/typecheck/bad-bulk-memory-no-table.txt:8:5: error: elem.drop requires table 0 to be an imported or defined table.
     elem.drop 0
     ^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-no-table.txt:8:15: error: elem_segment variable out of range (max 0)
+out/test/typecheck/bad-bulk-memory-no-table.txt:8:15: error: elem_segment variable out of range: 0 (max 4294967295)
     elem.drop 0
               ^
 out/test/typecheck/bad-bulk-memory-no-table.txt:9:41: error: table.copy requires table 0 to be an imported or defined table.

--- a/test/typecheck/bad-bulk-memory-type-mismatch.txt
+++ b/test/typecheck/bad-bulk-memory-type-mismatch.txt
@@ -34,49 +34,7 @@
 
 
 (;; STDERR ;;;
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:13:41: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, i32]
-    f32.const 0 i32.const 0 i32.const 0 memory.init 0
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:14:41: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
-    f32.const 0 i32.const 0 i32.const 0 memory.copy
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:15:41: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i32]
-    f32.const 0 i32.const 0 i32.const 0 memory.fill
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:16:41: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i32]
-    f32.const 0 i32.const 0 i32.const 0 table.init 0
-                                        ^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:17:41: error: type mismatch in table.copy, expected [i32, i32, i32] but got [f32, i32, i32]
-    f32.const 0 i32.const 0 i32.const 0 table.copy
-                                        ^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:20:41: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, i32]
-    i32.const 0 f32.const 0 i32.const 0 memory.init 0
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:21:41: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
-    i32.const 0 f32.const 0 i32.const 0 memory.copy
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:22:41: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i32]
-    i32.const 0 f32.const 0 i32.const 0 memory.fill
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:23:41: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i32]
-    i32.const 0 f32.const 0 i32.const 0 table.init 0
-                                        ^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:24:41: error: type mismatch in table.copy, expected [i32, i32, i32] but got [i32, f32, i32]
-    i32.const 0 f32.const 0 i32.const 0 table.copy
-                                        ^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:27:41: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, i64]
-    i32.const 0 i32.const 0 i64.const 0 memory.init 0
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:28:41: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
-    i32.const 0 i32.const 0 i64.const 0 memory.copy
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:29:41: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, i64]
-    i32.const 0 i32.const 0 i64.const 0 memory.fill
-                                        ^^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:30:41: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, i64]
-    i32.const 0 i32.const 0 i64.const 0 table.init 0
-                                        ^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-type-mismatch.txt:31:41: error: type mismatch in table.copy, expected [i32, i32, i32] but got [i32, i32, i64]
-    i32.const 0 i32.const 0 i64.const 0 table.copy
-                                        ^^^^^^^^^^
+out/test/typecheck/bad-bulk-memory-type-mismatch.txt:9:17: error: unexpected token 0, expected ).
+  (elem funcref 0)
+                ^
 ;;; STDERR ;;)

--- a/test/wasm2c/spec/i32.txt
+++ b/test/wasm2c/spec/i32.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/i32.wast
 (;; STDOUT ;;;
-359/359 tests passed.
+360/360 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/i64.txt
+++ b/test/wasm2c/spec/i64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/i64.wast
 (;; STDOUT ;;;
-359/359 tests passed.
+360/360 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/names.txt
+++ b/test/wasm2c/spec/names.txt
@@ -3,5 +3,5 @@
 (;; STDOUT ;;;
 spectest.print_i32(42)
 spectest.print_i32(123)
-479/479 tests passed.
+482/482 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/unreachable.txt
+++ b/test/wasm2c/spec/unreachable.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/unreachable.wast
 (;; STDOUT ;;;
-61/61 tests passed.
+63/63 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
The only major change to the interpreter is to move segment
initialization out `ReadBinaryInterp` (in the binary reader) and into
interp.cc.  This is because the test suite now expects out of bound
semgments to be reported during initialization rather than reported
as validation errors.

Fixes: #1223