### PR TITLE
Initial support for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-16.04, macos-latest, windows-latest]
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '2.7'
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - name: mkdir
+      run: mkdir -p out
+    - name: cmake
+      run: cmake ..
+      working-directory: out
+    - name: build
+      run: cmake --build out
+    - name: test
+      run: cmake --build out --target run-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -496,7 +496,13 @@ if (NOT EMSCRIPTEN)
     endif ()
 
     # test running
-    find_package(PythonInterp 2.7 REQUIRED)
+    # TODO(sbc): Requrie python3 for running tests.
+    # For now we don't set a version here due to and issue with github actions
+    # where python 2.7 is in the PATH as "python.exe" but a mingw version is
+    # installed as "python2.7.exe" and cmake will alwasy choose the later (which
+    # we don't want) if we specify 2.7 explictly here.
+    # See: https://github.com/actions/setup-python/issues/40
+    find_package(PythonInterp REQUIRED)
     set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
     add_custom_target(run-tests
       COMMAND $<TARGET_FILE:wabt-unittests>


### PR DESCRIPTION
This adds a basic workflow that builds and tests wabt on all three
desktop platforms.
    
The plan is to extend this to completely replace travis and appveyor
in the future.

Fixes: #1168