### PR TITLE
Avoid os.path.relpath in gen-spec-js.py

### DIFF
--- a/test/find_exe.py
+++ b/test/find_exe.py
@@ -29,9 +29,6 @@ EXECUTABLES = [
     'wasm2c', 'wasm-strip', 'wasm-decompile'
 ]
 
-GEN_WASM_PY = os.path.join(SCRIPT_DIR, 'gen-wasm.py')
-GEN_SPEC_JS_PY = os.path.join(SCRIPT_DIR, 'gen-spec-js.py')
-
 
 def GetDefaultPath():
     return os.path.join(REPO_ROOT_DIR, 'bin')

--- a/test/gen-spec-js.py
+++ b/test/gen-spec-js.py
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+"""Convert a JSON descrption of a spec test into a JavaScript."""
+
 import argparse
 try:
     from cStringIO import StringIO
@@ -488,7 +490,7 @@ class JSWriter(object):
 
 
 def main(args):
-    parser = argparse.ArgumentParser()
+    parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument('-o', '--output', metavar='PATH', help='output file.')
     parser.add_argument('-P', '--prefix', metavar='PATH', help='prefix file.',
                         default=os.path.join(SCRIPT_DIR, 'gen-spec-prefix.js'))
@@ -532,8 +534,7 @@ def main(args):
             if assert_commands:
                 wasm_path = os.path.join(json_dir, module_command['filename'])
                 new_module_filename = extender.Extend(wasm_path, assert_commands)
-                module_command['filename'] = os.path.relpath(new_module_filename,
-                                                             json_dir)
+                module_command['filename'] = new_module_filename
 
         output = StringIO()
         if options.prefix:

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -39,6 +39,7 @@ OUT_DIR = os.path.join(REPO_ROOT_DIR, 'out')
 DEFAULT_TIMEOUT = 10    # seconds
 SLOW_TIMEOUT_MULTIPLIER = 3
 
+
 # default configurations for tests
 TOOLS = {
     'wat2wasm': [
@@ -902,8 +903,8 @@ def main(args):
     variables = {}
     variables['test_dir'] = os.path.abspath(TEST_DIR)
     variables['bindir'] = options.bindir
-    variables['gen_wasm_py'] = find_exe.GEN_WASM_PY
-    variables['gen_spec_js_py'] = find_exe.GEN_SPEC_JS_PY
+    variables['gen_wasm_py'] = os.path.join(TEST_DIR, 'gen-wasm.py')
+    variables['gen_spec_js_py'] = os.path.join(TEST_DIR, 'gen-spec-js.py')
     for exe_basename in find_exe.EXECUTABLES:
         exe_override = os.path.join(options.bindir, exe_basename)
         variables[exe_basename] = find_exe.FindExecutable(exe_basename,


### PR DESCRIPTION
relpath here was failing with on windows when TMPDIR is on a different
drive.  This is because `new_module_filename` lives in the TMPDIR
where and json_dir might be on different drive.

These paths don't get embedded in the final JS anyway because we
embed them directly binary strings so its not important that they are
relative.