### PR TITLE
Fix run-tests target on windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -500,7 +500,7 @@ if (NOT EMSCRIPTEN)
     set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
     add_custom_target(run-tests
       COMMAND $<TARGET_FILE:wabt-unittests>
-      COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wabt-unittests>
+      COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
       DEPENDS ${WABT_EXECUTABLES}
       WORKING_DIRECTORY ${WABT_SOURCE_DIR}
       ${USES_TERMINAL}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -499,8 +499,8 @@ if (NOT EMSCRIPTEN)
     find_package(PythonInterp 2.7 REQUIRED)
     set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
     add_custom_target(run-tests
-      COMMAND ${CMAKE_BINARY_DIR}/wabt-unittests
-      COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir ${CMAKE_BINARY_DIR}
+      COMMAND $<TARGET_FILE:wabt-unittests>
+      COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wabt-unittests>
       DEPENDS ${WABT_EXECUTABLES}
       WORKING_DIRECTORY ${WABT_SOURCE_DIR}
       ${USES_TERMINAL}


### PR DESCRIPTION
Under windows binaries end with `.exe` and live a the `Debug` or
`Release` subdirectory so we need to use $<TARGET_FILE> to get the
full executable name.