### PR TITLE
wasm-decompile: Load/Store tracking for struct output.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -246,7 +246,8 @@ add_library(wabt STATIC
   src/config.h
   src/config.cc
   src/decompiler.h
-  src/decompiler-ast.inl
+  src/decompiler-ast.h
+  src/decompiler-ls.h
   src/decompiler.cc
   src/error-formatter.h
   src/error-formatter.cc

--- a/src/common.h
+++ b/src/common.h
@@ -221,6 +221,11 @@ enum class Type : int32_t {
   Any = 0,          // Not actually specified, but useful for type-checking
   Nullref = 1,      // Not actually specified, but used in testing and type-checking
   Hostref = 2,      // Not actually specified, but used in testing and type-checking
+  I8 = 3,           // Not actually specified, but used internally with load/store
+  I8U = 4,          // Not actually specified, but used internally with load/store
+  I16 = 5,          // Not actually specified, but used internally with load/store
+  I16U = 6,         // Not actually specified, but used internally with load/store
+  I32U = 7,         // Not actually specified, but used internally with load/store
 };
 typedef std::vector<Type> TypeVector;
 

--- a/src/decompiler-ast.h
+++ b/src/decompiler-ast.h
@@ -14,28 +14,15 @@
  * limitations under the License.
  */
 
-#include <algorithm>
-#include <array>
-#include <cassert>
-#include <cinttypes>
-#include <cstdarg>
-#include <cstdio>
-#include <iterator>
-#include <map>
-#include <numeric>
-#include <set>
-#include <string>
-#include <vector>
-#include <sstream>
+#ifndef WABT_DECOMPILER_AST_H_
+#define WABT_DECOMPILER_AST_H_
 
 #include "src/cast.h"
-#include "src/common.h"
-#include "src/expr-visitor.h"
+#include "src/generate-names.h"
 #include "src/ir.h"
 #include "src/ir-util.h"
-#include "src/literal.h"
-#include "src/generate-names.h"
-#include "src/stream.h"
+
+#include <set>
 
 namespace wabt {
 
@@ -346,3 +333,5 @@ struct AST {
 };
 
 }  // namespace wabt
+
+#endif  // WABT_DECOMPILER_AST_H_

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -101,6 +101,11 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::Void:
     case Type::Any:
     case Type::Anyref:
+    case Type::I8:
+    case Type::I8U:
+    case Type::I16:
+    case Type::I16U:
+    case Type::I32U:
       // These types are not concrete types and should never exist as a value
       WABT_UNREACHABLE;
   }

--- a/test/decompile/loadstore.txt
+++ b/test/decompile/loadstore.txt
@@ -1,0 +1,83 @@
+;;; TOOL: run-wasm-decompile
+
+(module
+  (memory $m1 1)
+
+  (func $f (param i32 i32) (result) (local i32 i32 i32 i32 i32 i32)
+    ;; Test regular accesses that become a struct.
+    get_local 0
+    f32.load offset=0
+    get_local 2
+    f32.load offset=0
+    f32.add
+    get_local 0
+    f32.load offset=4
+    get_local 2
+    f32.load offset=4
+    f32.add
+    f32.add
+    drop
+    get_local 1
+    i64.load16_u offset=0
+    get_local 3
+    i64.load16_u offset=0
+    i64.add
+    get_local 1
+    i64.load offset=8
+    get_local 3
+    i64.load offset=8
+    i64.add
+    i64.add
+    drop
+    ;; Test things that do not become a struct for various reasons.
+    ;; 1) Mixed type access.
+    get_local 4
+    i32.load offset=0
+    drop
+    get_local 4
+    f32.load offset=0
+    drop
+    ;; 2) Mixed size access.
+    get_local 5
+    i32.load offset=0
+    drop
+    get_local 5
+    i32.load16_s offset=0
+    drop
+    ;; 3) Mixed align requirement access.
+    get_local 6
+    i32.load offset=0
+    drop
+    get_local 6
+    i32.load offset=0 align=1
+    drop
+    ;; 4) Unaligned access / access with unexpected gaps.
+    get_local 7
+    f32.load offset=1
+    drop
+  )
+  (export "f" (func $f))
+)
+
+(;; STDOUT ;;;
+memory M_a(initial: 1, max: 0);
+
+export function f(a:{ a:float, b:float }, b:{ a:ushort, b:long }) {
+  var c:{ a:float, b:float }
+  var d:{ a:ushort, b:long }
+  var e:int;
+  var f:int;
+  var g:int;
+  var h:int;
+  (a.a + c.a) + (a.b + c.b);
+  (b.a + d.a) + (b.b + d.b);
+  e[0]:int;
+  e[0]:float;
+  f[0]:int;
+  f[0]:short;
+  g[0]:int;
+  g[0]:int@1;
+  h[1]:float;
+}
+
+;;; STDOUT ;;)


### PR DESCRIPTION
This tries to make code more readable by summarizing patterns of
load/store ops into "struct" declarations.

Initial version, can probably be improved, but has all essentials
of the idea in place.