### PR TITLE
Run update-spec-tests.py and add resulting missing tests

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -982,6 +982,10 @@ Result WastParser::ParseElemModuleField(Module* module) {
     }
   }
 
+  if (!ParseOffsetExprOpt(&field->elem_segment.offset)) {
+    field->elem_segment.flags |= SegPassive;
+  }
+
   if (ParseRefTypeOpt(&field->elem_segment.elem_type)) {
     field->elem_segment.flags |= (SegPassive | SegUseElemExprs);
     // Parse a potentially empty sequence of ElemExprs.
@@ -1001,9 +1005,6 @@ Result WastParser::ParseElemModuleField(Module* module) {
     }
   } else {
     field->elem_segment.elem_type = Type::Funcref;
-    if (!ParseOffsetExprOpt(&field->elem_segment.offset)) {
-      field->elem_segment.flags |= SegPassive;
-    }
     if (PeekMatch(TokenType::Func)) {
       EXPECT(Func);
     }

--- a/test/spec/binary-leb128.txt
+++ b/test/spec/binary-leb128.txt
@@ -1,0 +1,117 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/binary-leb128.wast
+(;; STDOUT ;;;
+out/test/spec/binary-leb128.wast:217: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/binary-leb128.wast:225: assert_malformed passed:
+  000000e: error: unable to read u32 leb128: memory max page count
+out/test/spec/binary-leb128.wast:234: assert_malformed passed:
+  0000010: error: unable to read u32 leb128: data segment flags
+out/test/spec/binary-leb128.wast:245: assert_malformed passed:
+  0000011: error: unable to read u32 leb128: elem segment flags
+out/test/spec/binary-leb128.wast:256: assert_malformed passed:
+  0000009: error: unable to read u32 leb128: section size
+out/test/spec/binary-leb128.wast:267: assert_malformed passed:
+  000000a: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:278: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: function param count
+out/test/spec/binary-leb128.wast:290: assert_malformed passed:
+  000000f: error: unable to read u32 leb128: function result count
+out/test/spec/binary-leb128.wast:302: assert_malformed passed:
+  0000012: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:317: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:332: assert_malformed passed:
+  0000026: error: unable to read u32 leb128: import signature index
+out/test/spec/binary-leb128.wast:347: assert_malformed passed:
+  0000011: error: unable to read u32 leb128: function signature index
+out/test/spec/binary-leb128.wast:359: assert_malformed passed:
+  0000015: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:375: assert_malformed passed:
+  0000019: error: unable to read u32 leb128: export item index
+out/test/spec/binary-leb128.wast:391: assert_malformed passed:
+  0000014: error: unable to read u32 leb128: function body count
+out/test/spec/binary-leb128.wast:404: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/binary-leb128.wast:423: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/binary-leb128.wast:442: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/binary-leb128.wast:461: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/binary-leb128.wast:482: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary-leb128.wast:492: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary-leb128.wast:503: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary-leb128.wast:513: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary-leb128.wast:525: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/binary-leb128.wast:533: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/binary-leb128.wast:541: assert_malformed passed:
+  000000e: error: unable to read u32 leb128: memory max page count
+out/test/spec/binary-leb128.wast:550: assert_malformed passed:
+  000000e: error: unable to read u32 leb128: memory max page count
+out/test/spec/binary-leb128.wast:559: assert_malformed passed:
+  0000010: error: unable to read u32 leb128: data segment flags
+out/test/spec/binary-leb128.wast:570: assert_malformed passed:
+  0000011: error: unable to read u32 leb128: elem segment flags
+out/test/spec/binary-leb128.wast:581: assert_malformed passed:
+  0000009: error: unable to read u32 leb128: section size
+out/test/spec/binary-leb128.wast:592: assert_malformed passed:
+  000000a: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:603: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: function param count
+out/test/spec/binary-leb128.wast:615: assert_malformed passed:
+  000000f: error: unable to read u32 leb128: function result count
+out/test/spec/binary-leb128.wast:627: assert_malformed passed:
+  0000012: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:642: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:657: assert_malformed passed:
+  0000026: error: unable to read u32 leb128: import signature index
+out/test/spec/binary-leb128.wast:672: assert_malformed passed:
+  0000011: error: unable to read u32 leb128: function signature index
+out/test/spec/binary-leb128.wast:685: assert_malformed passed:
+  0000015: error: unable to read u32 leb128: string length
+out/test/spec/binary-leb128.wast:701: assert_malformed passed:
+  0000019: error: unable to read u32 leb128: export item index
+out/test/spec/binary-leb128.wast:717: assert_malformed passed:
+  0000014: error: unable to read u32 leb128: function body count
+out/test/spec/binary-leb128.wast:730: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/binary-leb128.wast:749: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/binary-leb128.wast:768: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/binary-leb128.wast:786: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/binary-leb128.wast:805: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/binary-leb128.wast:824: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/binary-leb128.wast:843: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/binary-leb128.wast:862: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/binary-leb128.wast:884: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary-leb128.wast:894: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary-leb128.wast:904: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary-leb128.wast:914: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/binary-leb128.wast:925: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary-leb128.wast:935: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary-leb128.wast:945: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/binary-leb128.wast:955: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+56/56 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/data.txt
+++ b/test/spec/bulk-memory-operations/data.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/data.wast
+;;; ARGS*: --enable-bulk-memory
+(;; STDOUT ;;;
+error initializing module: out of bounds memory access: data segment is out of bounds: [1, 1) >= max value 0
+error initializing module: out of bounds memory access: data segment is out of bounds: [1, 1) >= max value 0
+out/test/spec/bulk-memory-operations/data.wast:290: assert_invalid passed:
+  000000e: error: data section without memory section
+out/test/spec/bulk-memory-operations/data.wast:299: assert_invalid passed:
+  0000016: error: expected i32 init_expr
+out/test/spec/bulk-memory-operations/data.wast:307: assert_invalid passed:
+  0000017: error: expected END opcode after initializer expression
+out/test/spec/bulk-memory-operations/data.wast:315: assert_invalid passed:
+  0000015: error: unexpected opcode in initializer expression: 0x1
+out/test/spec/bulk-memory-operations/data.wast:323: assert_invalid passed:
+  0000015: error: unexpected opcode in initializer expression: 0x1
+out/test/spec/bulk-memory-operations/data.wast:331: assert_invalid passed:
+  0000017: error: expected END opcode after initializer expression
+18/18 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/elem.txt
+++ b/test/spec/bulk-memory-operations/elem.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/elem.wast
+;;; ARGS*: --enable-bulk-memory
+(;; STDOUT ;;;
+error initializing module: out of bounds table access: elem segment is out of bounds: [1, 1) >= max value 0
+out/test/spec/bulk-memory-operations/elem.wast:299: assert_invalid passed:
+  0000015: error: elem section without table section
+out/test/spec/bulk-memory-operations/elem.wast:309: assert_invalid passed:
+  0000014: error: expected i32 init_expr
+out/test/spec/bulk-memory-operations/elem.wast:317: assert_invalid passed:
+  0000015: error: expected END opcode after initializer expression
+out/test/spec/bulk-memory-operations/elem.wast:325: assert_invalid passed:
+  0000013: error: unexpected opcode in initializer expression: 0x1
+out/test/spec/bulk-memory-operations/elem.wast:333: assert_invalid passed:
+  0000013: error: unexpected opcode in initializer expression: 0x1
+out/test/spec/bulk-memory-operations/elem.wast:341: assert_invalid passed:
+  0000015: error: expected END opcode after initializer expression
+out/test/spec/bulk-memory-operations/elem.wast:404: assert_trap passed: uninitialized table element
+30/30 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/imports.txt
+++ b/test/spec/bulk-memory-operations/imports.txt
@@ -1,0 +1,277 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/imports.wast
+;;; ARGS*: --enable-bulk-memory
+(;; STDOUT ;;;
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32_f32(i32:14, f32:42.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f32(f32:13.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f64_f64(f64:25.000000, f64:53.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+out/test/spec/bulk-memory-operations/imports.wast:91: assert_invalid passed:
+  000001e: error: invalid import signature index
+out/test/spec/bulk-memory-operations/imports.wast:107: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  0000020: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:111: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  0000024: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:116: assert_unlinkable passed:
+  error: import signature mismatch
+  000001e: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:120: assert_unlinkable passed:
+  error: import signature mismatch
+  000001e: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:124: assert_unlinkable passed:
+  error: import signature mismatch
+  000001f: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:128: assert_unlinkable passed:
+  error: import signature mismatch
+  0000021: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:132: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:136: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:140: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:144: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:148: assert_unlinkable passed:
+  error: import signature mismatch
+  0000022: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:152: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:156: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:160: assert_unlinkable passed:
+  error: import signature mismatch
+  0000023: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:164: assert_unlinkable passed:
+  error: import signature mismatch
+  0000024: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:168: assert_unlinkable passed:
+  error: import signature mismatch
+  0000026: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:172: assert_unlinkable passed:
+  error: import signature mismatch
+  0000027: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:176: assert_unlinkable passed:
+  error: import signature mismatch
+  0000027: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:181: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind func, not global
+  0000024: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:185: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind func, not table
+  0000025: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:189: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind func, not memory
+  0000025: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:193: assert_unlinkable passed:
+  error: expected import "spectest.global_i32" to have kind func, not global
+  0000027: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:197: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind func, not table
+  0000022: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:201: assert_unlinkable passed:
+  error: expected import "spectest.memory" to have kind func, not memory
+  0000023: error: OnImportFunc callback failed
+out/test/spec/bulk-memory-operations/imports.wast:235: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001b: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:239: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001f: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:244: assert_unlinkable passed:
+  error: expected import "test.func" to have kind global, not func
+  0000018: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:248: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind global, not table
+  0000020: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:252: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind global, not memory
+  0000020: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:256: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind global, not func
+  0000021: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:260: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind global, not table
+  000001d: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:264: assert_unlinkable passed:
+  error: expected import "spectest.memory" to have kind global, not memory
+  000001e: error: OnImportGlobal callback failed
+out/test/spec/bulk-memory-operations/imports.wast:283: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/imports.wast:286: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/imports.wast:287: assert_trap passed: undefined table index
+out/test/spec/bulk-memory-operations/imports.wast:302: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/imports.wast:305: assert_trap passed: uninitialized table element
+out/test/spec/bulk-memory-operations/imports.wast:306: assert_trap passed: undefined table index
+out/test/spec/bulk-memory-operations/imports.wast:310: assert_invalid passed:
+  error: unknown import module ""
+  0000011: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:314: assert_invalid passed:
+  error: unknown import module ""
+  0000011: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:318: assert_invalid passed:
+  000000b: error: table count (2) must be 0 or 1
+out/test/spec/bulk-memory-operations/imports.wast:335: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001c: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:339: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  0000020: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:344: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+  0000021: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:348: assert_unlinkable passed:
+  error: max size (unspecified) larger than declared (20)
+  0000022: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:352: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+  000001e: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:356: assert_unlinkable passed:
+  error: max size (20) larger than declared (15)
+  000001f: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:361: assert_unlinkable passed:
+  error: expected import "test.func" to have kind table, not func
+  0000019: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:365: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind table, not global
+  000001f: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:369: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind table, not memory
+  0000021: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:373: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind table, not func
+  0000022: error: OnImportTable callback failed
+out/test/spec/bulk-memory-operations/imports.wast:391: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
+out/test/spec/bulk-memory-operations/imports.wast:402: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
+out/test/spec/bulk-memory-operations/imports.wast:405: assert_invalid passed:
+  error: unknown import module ""
+  0000010: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:409: assert_invalid passed:
+  error: unknown import module ""
+  0000010: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:413: assert_invalid passed:
+  000000b: error: memory count must be 0 or 1
+out/test/spec/bulk-memory-operations/imports.wast:428: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001b: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:432: assert_unlinkable passed:
+  error: unknown module field "unknown"
+  000001f: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:437: assert_unlinkable passed:
+  error: actual size (2) smaller than declared (3)
+  0000020: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:441: assert_unlinkable passed:
+  error: max size (unspecified) larger than declared (3)
+  0000021: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:445: assert_unlinkable passed:
+  error: actual size (1) smaller than declared (2)
+  000001e: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:449: assert_unlinkable passed:
+  error: max size (2) larger than declared (1)
+  000001f: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:454: assert_unlinkable passed:
+  error: expected import "test.func-i32" to have kind memory, not func
+  000001c: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:458: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind memory, not global
+  000001e: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:462: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind memory, not table
+  0000020: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:466: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind memory, not func
+  0000021: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:470: assert_unlinkable passed:
+  error: expected import "spectest.global_i32" to have kind memory, not global
+  0000022: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:474: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind memory, not table
+  000001d: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:479: assert_unlinkable passed:
+  error: actual size (1) smaller than declared (2)
+  000001e: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:483: assert_unlinkable passed:
+  error: max size (2) larger than declared (1)
+  000001f: error: OnImportMemory callback failed
+out/test/spec/bulk-memory-operations/imports.wast:501: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.100.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (func))
+          ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:505: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.101.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (global i64))
+          ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:509: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.102.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (table 0 funcref))
+          ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:513: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.103.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (memory 0))
+          ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:518: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.104.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (func))
+                              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:522: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.105.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (global f32))
+                              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:526: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.106.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (table 0 funcref))
+                              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:530: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.107.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (memory 0))
+                              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:535: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.108.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (func))
+                     ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:539: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.109.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (global i32))
+                     ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:543: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.110.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (table 0 funcref))
+                     ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:547: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.111.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (memory 0))
+                     ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:552: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.112.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (func))
+              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:556: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.113.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (global i32))
+              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:560: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.114.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (table 1 3 funcref))
+              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:564: assert_malformed passed:
+  out/test/spec/bulk-memory-operations/imports/imports.115.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (memory 1 2))
+              ^^^^^^
+out/test/spec/bulk-memory-operations/imports.wast:574: assert_unlinkable passed:
+  error: unknown module field "overloaded"
+  000004d: error: OnImportFunc callback failed
+109/109 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/multi-value/binary.txt
+++ b/test/spec/multi-value/binary.txt
@@ -1,0 +1,141 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-value/binary.wast
+;;; ARGS*: --enable-multi-value
+(;; STDOUT ;;;
+out/test/spec/multi-value/binary.wast:6: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/multi-value/binary.wast:7: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/multi-value/binary.wast:8: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/multi-value/binary.wast:9: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:10: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:11: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:12: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:13: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:14: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:15: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:16: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:17: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:18: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:21: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:24: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:25: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:28: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:31: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:34: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/multi-value/binary.wast:37: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/multi-value/binary.wast:38: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/multi-value/binary.wast:39: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/multi-value/binary.wast:40: assert_malformed passed:
+  0000008: error: bad wasm file version: 0 (expected 0x1)
+out/test/spec/multi-value/binary.wast:41: assert_malformed passed:
+  0000008: error: bad wasm file version: 0xd (expected 0x1)
+out/test/spec/multi-value/binary.wast:42: assert_malformed passed:
+  0000008: error: bad wasm file version: 0xe (expected 0x1)
+out/test/spec/multi-value/binary.wast:43: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x100 (expected 0x1)
+out/test/spec/multi-value/binary.wast:44: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x10000 (expected 0x1)
+out/test/spec/multi-value/binary.wast:45: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
+out/test/spec/multi-value/binary.wast:50: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/multi-value/binary.wast:69: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/multi-value/binary.wast:88: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/multi-value/binary.wast:106: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/multi-value/binary.wast:124: assert_malformed passed:
+  0000022: error: call_indirect reserved value must be 0
+out/test/spec/multi-value/binary.wast:143: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/multi-value/binary.wast:163: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/multi-value/binary.wast:183: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/multi-value/binary.wast:202: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/multi-value/binary.wast:221: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/multi-value/binary.wast:241: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/multi-value/binary.wast:260: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/multi-value/binary.wast:279: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/multi-value/binary.wast:297: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/multi-value/binary.wast:315: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/multi-value/binary.wast:334: assert_malformed passed:
+  000001c: error: local count must be < 0x10000000
+out/test/spec/multi-value/binary.wast:366: assert_malformed passed:
+  0000013: error: function signature count != function body count
+out/test/spec/multi-value/binary.wast:376: assert_malformed passed:
+  000000b: error: function signature count != function body count
+out/test/spec/multi-value/binary.wast:385: assert_malformed passed:
+  0000016: error: function signature count != function body count
+out/test/spec/multi-value/binary.wast:396: assert_malformed passed:
+  0000015: error: function signature count != function body count
+out/test/spec/multi-value/binary.wast:425: assert_malformed passed:
+  000000a: error: invalid section size: extends past end
+out/test/spec/multi-value/binary.wast:436: assert_malformed passed:
+  000000e: error: unfinished section (expected end: 0x11)
+out/test/spec/multi-value/binary.wast:455: assert_malformed passed:
+  0000027: error: unable to read u32 leb128: string length
+out/test/spec/multi-value/binary.wast:474: assert_malformed passed:
+  000002b: error: unfinished section (expected end: 0x40)
+out/test/spec/multi-value/binary.wast:505: assert_malformed passed:
+  000000b: error: invalid table count 1, only 0 bytes left in section
+out/test/spec/multi-value/binary.wast:521: assert_malformed passed:
+  000000b: error: invalid memory count 1, only 0 bytes left in section
+out/test/spec/multi-value/binary.wast:537: assert_malformed passed:
+  0000010: error: unable to read i32 leb128: global type
+out/test/spec/multi-value/binary.wast:548: assert_malformed passed:
+  0000010: error: unfinished section (expected end: 0x15)
+out/test/spec/multi-value/binary.wast:571: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/multi-value/binary.wast:592: assert_malformed passed:
+  000001b: error: unfinished section (expected end: 0x20)
+out/test/spec/multi-value/binary.wast:626: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: elem segment flags
+out/test/spec/multi-value/binary.wast:644: assert_malformed passed:
+  0000021: error: unfinished section (expected end: 0x27)
+out/test/spec/multi-value/binary.wast:670: assert_malformed passed:
+  0000016: error: unable to read u32 leb128: data segment flags
+out/test/spec/multi-value/binary.wast:683: assert_malformed passed:
+  0000016: error: unfinished section (expected end: 0x1c)
+out/test/spec/multi-value/binary.wast:696: assert_malformed passed:
+  0000015: error: unable to read data: data segment data
+out/test/spec/multi-value/binary.wast:710: assert_malformed passed:
+  000001a: error: unfinished section (expected end: 0x1b)
+out/test/spec/multi-value/binary.wast:741: assert_malformed passed:
+  error: invalid depth: 11 (max 2)
+  0000024: error: OnBrTableExpr callback failed
+out/test/spec/multi-value/binary.wast:763: assert_malformed passed:
+  0000025: error: expected valid block signature type
+out/test/spec/multi-value/binary.wast:798: assert_malformed passed:
+  0000017: error: multiple Start sections
+67/67 tests passed.
+;;; STDOUT ;;)

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -92,6 +92,7 @@ def main(args):
                        '--enable-saturating-float-to-int')
     ProcessProposalDir('sign-extension-ops', '--enable-sign-extension')
     ProcessProposalDir('bulk-memory-operations', '--enable-bulk-memory')
+    ProcessProposalDir('reference-types', '--enable-reference-types')
 
     return 0
 

--- a/test/wasm2c/spec/binary-leb128.txt
+++ b/test/wasm2c/spec/binary-leb128.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/binary-leb128.wast
+(;; STDOUT ;;;
+0/0 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
This found one bug in the parsing of active elem segments with
uncref style elements.