### PR TITLE
reference-types: add final test: br_table

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -369,6 +369,7 @@ BinaryReaderInterp::BinaryReaderInterp(Environment* env,
       errors_(errors),
       env_(env),
       module_(module),
+      typechecker_(features),
       istream_(std::move(istream)),
       istream_offset_(istream_.output_buffer().size()) {
   typechecker_.set_error_callback(

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "src/common.h"
+#include "src/feature.h"
 #include "src/opcode.h"
 
 namespace wabt {
@@ -46,8 +47,7 @@ class TypeChecker {
     bool unreachable;
   };
 
-  TypeChecker() = default;
-  explicit TypeChecker(const ErrorCallback&);
+  explicit TypeChecker(const Features& features) : features_(features) {}
 
   void set_error_callback(const ErrorCallback& error_callback) {
     error_callback_ = error_callback;
@@ -177,6 +177,7 @@ class TypeChecker {
   // Cache the expected br_table signature. It will be initialized to `nullptr`
   // to represent "any".
   TypeVector* br_table_sig_ = nullptr;
+  Features features_;
 };
 
 }  // namespace wabt

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -228,7 +228,10 @@ class Validator : public ExprVisitor::Delegate {
 Validator::Validator(Errors* errors,
                      const Script* script,
                      const ValidateOptions& options)
-    : options_(options), errors_(errors), script_(script) {
+    : options_(options),
+      errors_(errors),
+      script_(script),
+      typechecker_(options.features) {
   typechecker_.set_error_callback(
       [this](const char* msg) { OnTypecheckerError(msg); });
 }

--- a/test/spec/reference-types/br_table.txt
+++ b/test/spec/reference-types/br_table.txt
@@ -1,0 +1,72 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/br_table.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/br_table.wast:1498: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  0000022: error: OnEndExpr callback failed
+out/test/spec/reference-types/br_table.wast:1505: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  000001d: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1512: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  0000020: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1518: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got [i64]
+  0000023: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1526: assert_invalid passed:
+  error: br_table labels have inconsistent arity: expected 1 got 0
+  0000026: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1538: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  000001f: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1544: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got [i64]
+  000001e: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1550: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  0000021: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1556: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  0000023: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1562: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got [... i64]
+  0000022: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1571: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  0000022: error: OnEndExpr callback failed
+out/test/spec/reference-types/br_table.wast:1578: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  0000022: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1590: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  0000024: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1602: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  000001c: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1613: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got []
+  000001e: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1625: assert_invalid passed:
+  error: type mismatch in br_table, expected [i32] but got [nullref]
+  0000025: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1639: assert_invalid passed:
+  error: invalid depth: 2 (max 1)
+  000001f: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1645: assert_invalid passed:
+  error: invalid depth: 5 (max 2)
+  0000021: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1651: assert_invalid passed:
+  error: invalid depth: 268435457 (max 1)
+  0000024: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1658: assert_invalid passed:
+  error: invalid depth: 2 (max 1)
+  000001f: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1664: assert_invalid passed:
+  error: invalid depth: 5 (max 2)
+  0000021: error: OnBrTableExpr callback failed
+out/test/spec/reference-types/br_table.wast:1670: assert_invalid passed:
+  error: invalid depth: 268435457 (max 1)
+  0000024: error: OnBrTableExpr callback failed
+183/183 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/unreached-invalid.txt
+++ b/test/spec/reference-types/unreached-invalid.txt
@@ -262,7 +262,7 @@ out/test/spec/reference-types/unreached-invalid.wast:521: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
   0000025: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:527: assert_invalid passed:
-  error: br_table labels have inconsistent types: expected [f32], got []
+  error: br_table labels have inconsistent arity: expected 1 got 0
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:540: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]


### PR DESCRIPTION
This requires some slighly different validation rules for MVP vs
interface-types.

There is a test in unreachable-invalid.wast that was removed in the
reference-types repo:
  type-br_table-label-num-vs-label-num-after-unreachable

This test depends on the old validation rules and still exists in the
master testsuite so we need to continue to support both sets of rules
for now.