### PR TITLE
wabt-decompile: cleaned up string composition.

### DIFF
--- a/src/decompiler.h
+++ b/src/decompiler.h
@@ -27,7 +27,7 @@ class Stream;
 struct DecompileOptions {
 };
 
-Result Decompile(Stream&, const Module&, const DecompileOptions&);
+std::string Decompile(const Module&, const DecompileOptions&);
 
 }  // namespace wabt
 

--- a/src/string-view.h
+++ b/src/string-view.h
@@ -187,6 +187,59 @@ inline bool operator>=(string_view x, string_view y) noexcept {
   return x.compare(y) >= 0;
 }
 
+// non-member append.
+inline std::string& operator+=(std::string& x, string_view y) {
+  x.append(y.data(), y.size());
+  return x;
+}
+
+inline std::string operator+(string_view x, string_view y) {
+  std::string s;
+  s.reserve(x.size() + y.size());
+  s.append(x.data(), x.size());
+  s.append(y.data(), y.size());
+  return s;
+}
+
+inline std::string operator+(const std::string& x, string_view y) {
+  return string_view(x) + y;
+}
+
+inline std::string operator+(string_view x, const std::string& y) {
+  return x + string_view(y);
+}
+
+inline std::string operator+(const char* x, string_view y) {
+  return string_view(x) + y;
+}
+
+inline std::string operator+(string_view x, const char* y) {
+  return x + string_view(y);
+}
+
+inline void cat_concatenate(std::string&) {}
+
+template<typename T, typename ...Ts>
+void cat_concatenate(std::string& s, const T& t, const Ts&... args) {
+    s += t;
+    cat_concatenate(s, args...);
+}
+
+inline size_t cat_compute_size() { return 0; }
+
+template<typename T, typename ...Ts>
+size_t cat_compute_size(const T& t, const Ts&... args) {
+    return string_view(t).size() + cat_compute_size(args...);
+}
+
+// Is able to concatenate any combination of string/string_view/char*
+template<typename ...Ts> std::string cat(const Ts&... args) {
+    std::string s;
+    s.reserve(cat_compute_size(args...));
+    cat_concatenate(s, args...);
+    return s;
+}
+
 inline constexpr string_view::string_view() noexcept
     : data_(nullptr), size_(0) {}
 

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -99,9 +99,10 @@ int ProgramMain(int argc, char** argv) {
         WABT_USE(dummy_result);
       }
       if (Succeeded(result)) {
+        auto s = Decompile(module, decompile_options);
         FileStream stream(!outfile.empty() ? FileStream(outfile)
                                              : FileStream(stdout));
-        result = Decompile(stream, module, decompile_options);
+        stream.WriteData(s.data(), s.size());
       }
     }
     FormatErrorsToFile(errors, Location::Type::Binary);

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -80,9 +80,9 @@ import function ns_fi();
 
 export function f(a:int, b:int):int {
   var c:long = 8L;
-  var d:float = 6f;
-  var e:double = 7d;
-  if (e < 10d) { 1[4]:int = (2[3]:int + 5) }
+  var d:float = 6.0f;
+  var e:double = 7.0;
+  if (e < 10.0) { 1[4]:int = (2[3]:int + 5) }
   f(a + g_b, 9);
   loop L_b {
     block B_c {


### PR DESCRIPTION
The code had 3 ways of doing string composition:
- Using + and += on string/string_view
- ostringstream
- wabt::Stream

Of these, the first was by far the most widely used, simply
because decompilation is a hierarchical process, which requires
storing intermediate strings before knowing what surrounds them
(thus unsuitable for streams).

To make the code more uniform, everything was converted to use
the first approach. To not get further performance degradations,
some more efficient concatenation methods were added, that also
work with wabt::string_view.