### PR TITLE
wasm-decompile: overhauled name filtering.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -248,6 +248,7 @@ add_library(wabt STATIC
   src/decompiler.h
   src/decompiler-ast.h
   src/decompiler-ls.h
+  src/decompiler-naming.h
   src/decompiler.cc
   src/error-formatter.h
   src/error-formatter.cc

--- a/src/decompiler-naming.h
+++ b/src/decompiler-naming.h
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2019 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_DECOMPILER_NAMING_H_
+#define WABT_DECOMPILER_NAMING_H_
+
+#include "src/decompiler-ast.h"
+
+namespace wabt {
+
+inline void RenameToIdentifier(std::string& name, Index i,
+                               BindingHash& bh,
+                               const std::set<string_view>* filter) {
+  // Filter out non-identifier characters, and try to reduce the size of
+  // gigantic C++ signature names.
+  std::string s;
+  size_t nesting = 0;
+  size_t read = 0;
+  size_t word_start = 0;
+  for (auto c : name) {
+    read++;
+    // We most certainly don't want to parse the entirety of C++ signatures,
+    // but these names are sometimes several lines long, so would be great
+    // to trim down. One quick way to do that is to remove anything between
+    // nested (), which usually means the parameter list.
+    if (c == '(') {
+      nesting++;
+    }
+    if (c == ')') {
+      nesting--;
+    }
+    if (nesting) {
+      continue;
+    }
+    if (!isalnum(static_cast<unsigned char>(c))) {
+      c = '_';
+    }
+    if (c == '_') {
+      if (s.empty()) {
+        continue;  // Skip leading.
+      }
+      if (s.back() == '_') {
+        continue;  // Consecutive.
+      }
+    }
+    s += c;
+    if (filter && (c == '_' || read == name.size())) {
+      // We found a "word" inside a snake_case identifier.
+      auto word_end = s.size();
+      if (c == '_') {
+        word_end--;
+      }
+      assert(word_end > word_start);
+      auto word = string_view(s.c_str() + word_start, word_end - word_start);
+      if (filter->find(word) != filter->end()) {
+        s.resize(word_start);
+      }
+      word_start = s.size();
+    }
+  }
+  if (!s.empty() && s.back() == '_') {
+    s.pop_back();  // Trailing.
+  }
+  // If after all this culling, we're still gigantic (STL identifier can
+  // easily be hundreds of chars in size), just cut the identifier
+  // down, it will be disambiguated below, if needed.
+  const size_t max_identifier_length = 100;
+  if (s.size() > max_identifier_length) {
+    s.resize(max_identifier_length);
+  }
+  // Remove original binding first, such that it doesn't match with our
+  // new name.
+  bh.erase(name);
+  // Find a unique name.
+  Index disambiguator = 0;
+  auto base_len = s.size();
+  for (;;) {
+    if (bh.count(s) == 0) {
+      break;
+    }
+    disambiguator++;
+    s.resize(base_len);
+    s += '_';
+    s += std::to_string(disambiguator);
+  }
+  // Replace name in bindings.
+  name = s;
+  bh.emplace(s, Binding(i));
+}
+
+template<typename T>
+void RenameToIdentifiers(std::vector<T*>& things, BindingHash& bh,
+                         const std::set<string_view>* filter) {
+  Index i = 0;
+  for (auto thing : things) {
+    RenameToIdentifier(thing->name, i++, bh, filter);
+  }
+}
+
+// Function names may contain arbitrary C++ syntax, so we want to
+// filter those to look like identifiers. A function name may be set
+// by a name section (applied in ReadBinaryIr, called before this function)
+// or by an export (applied by GenerateNames, called before this function),
+// to both the Func and func_bindings.
+// Those names then further perculate down the IR in ApplyNames (called after
+// this function).
+// To not have to add too many decompiler-specific code into those systems
+// (using a callback??) we instead rename everything here.
+void RenameAll(Module& module) {
+  // We also filter common C++ keywords/STL idents that make for huge
+  // identifiers.
+  // FIXME: this can obviously give bad results if the input is not C++..
+  std::set<string_view> filter = {
+    { "const" },
+    { "std" },
+    { "allocator" },
+    { "char" },
+    { "basic" },
+    { "traits" },
+    { "wchar" },
+    { "t" },
+    { "void" },
+    { "int" },
+    { "unsigned" },
+    { "2" },
+    { "cxxabiv1" },
+    { "short" },
+    { "4096ul" },
+  };
+  RenameToIdentifiers(module.funcs, module.func_bindings, &filter);
+  // Also do this for some other kinds of names.
+  RenameToIdentifiers(module.globals, module.global_bindings, nullptr);
+  RenameToIdentifiers(module.tables, module.table_bindings, nullptr);
+}
+
+}  // namespace wabt
+
+#endif  // WABT_DECOMPILER_NAMING_H_

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -18,6 +18,7 @@
 
 #include "src/decompiler-ast.h"
 #include "src/decompiler-ls.h"
+#include "src/decompiler-naming.h"
 
 #include "src/stream.h"
 
@@ -68,8 +69,10 @@ struct Decompiler {
     return std::string(amount, ' ');
   }
 
-  string_view OpcodeToToken(Opcode opcode) {
-    return opcode.GetDecomp();
+  std::string OpcodeToToken(Opcode opcode) {
+    std::string s = opcode.GetDecomp();
+    std::replace(s.begin(), s.end(), '.', '_');
+    return s;
   }
 
   void IndentValue(Value &val, size_t amount, string_view first_indent) {

--- a/src/decompiler.h
+++ b/src/decompiler.h
@@ -27,6 +27,8 @@ class Stream;
 struct DecompileOptions {
 };
 
+void RenameAll(Module&);
+
 std::string Decompile(const Module&, const DecompileOptions&);
 
 }  // namespace wabt

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -122,11 +122,7 @@ void NameGenerator::GenerateName(const char* prefix,
                                  std::string* str) {
   str->clear();
   if (!(opts_ & NameOpts::NoDollar)) *str = "$";
-  if (opts_ & NameOpts::OnlyAlphaNum) {
-    for (auto p = prefix; *p; p++) *str += isalnum(*p) ? *p : '_';
-  } else {
-    *str += prefix;
-  }
+  *str += prefix;
   if (index != kInvalidIndex) {
     if (opts_ & NameOpts::AlphaNames) {
       // For params and locals, do not use a prefix char.

--- a/src/generate-names.h
+++ b/src/generate-names.h
@@ -27,7 +27,6 @@ enum NameOpts {
   None = 0,
   AlphaNames = 1 << 0,
   NoDollar = 1 << 1,
-  OnlyAlphaNum = 1 << 2,
 };
 
 Result GenerateNames(struct Module*, NameOpts opts = NameOpts::None);

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -87,11 +87,12 @@ int ProgramMain(int argc, char** argv) {
         ValidateOptions options(features);
         result = ValidateModule(&module, &errors, options);
       }
-      // FIXME: do we need these?
       result = GenerateNames(&module,
                              static_cast<NameOpts>(NameOpts::AlphaNames |
-                                                   NameOpts::NoDollar |
-                                                   NameOpts::OnlyAlphaNum));
+                                                   NameOpts::NoDollar));
+      // Must be called after ReadBinaryIr & GenerateNames, and before
+      // ApplyNames, see comments at definition.
+      RenameAll(module);
       if (Succeeded(result)) {
         /* TODO(binji): This shouldn't fail; if a name can't be applied
          * (because the index is invalid, say) it should just be skipped. */

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -57,8 +57,8 @@
   )
   ;; LLD outputs a name section with de-mangled C++ function signatures as names,
   ;; so have to make sure special chars get removed.
-  (func (export "signature-&<>()") (param) (result))
-  (func (export "signature-&[]()") (param) (result))
+  (func (export "void signature-&<>(int a)") (param) (result))
+  (func (export "void signature-&[](int a)") (param) (result))
   (func $not-exported (param) (result))
   (export "f" (func $f))
 )
@@ -94,10 +94,10 @@ export function f(a:int, b:int):int {
   return 1;
 }
 
-function signature______() {
+function signature() {
 }
 
-function signature_______1() {
+function signature_1() {
 }
 
 function f_e() {


### PR DESCRIPTION
The previous implementation was too simplistic, as it didn't do the
renaming at the correct location (such that it can catch all
occurrences), and was also very ineffective in cutting down gigantic
STL signatures to something managable. This version creates more
usable identifiers in almost all cases.