### PR TITLE
wasm-decompile: blocks now represented as labels

### DIFF
--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -64,15 +64,9 @@
       block
         block
           block
-            i32.const 0
-            drop
             block
-              i32.const 0
-              drop
               local.get 0
               br_table 3 2 1 0 4
-              i32.const 99
-              return
               unreachable
             end
             i32.const 100
@@ -89,6 +83,14 @@
     end
     i32.const 104
     drop
+    block (result i32)  ;; block as an exp.
+    i32.const 2
+    i32.const 0
+    br_if 0
+    drop
+    i32.const 3
+    end
+    set_local 0
     nop
     ref.null
     ref.is_null
@@ -127,33 +129,30 @@ export function f(a:int, b:int):int {
   if (e < 10.0) { 1[4]:int = 2[3]:int + 5 }
   f(a + g_b, 9);
   loop L_b {
-    block B_c {
-      if (if (0) { 1 } else { 2 }) break B_c;
-      continue L_b;
-    }
+    if (if (0) { 1 } else { 2 }) goto B_c;
+    continue L_b;
+    label B_c:
     if (1) continue L_b;
   }
   select_if(1, 2, 1 == 1);
-  block B_e {
-    block B_f {
-      block B_g {
-        block B_h {
-          0;
-          block B_i {
-            0;
-            br_table[B_f, B_g, B_h, B_i, ..B_e](a);
-            return 99;
-            unreachable;
-          }
-          return 100;
-        }
-        return 101;
-      }
-      return 102;
-    }
-    return 103;
-  }
+  br_table[B_f, B_g, B_h, B_i, ..B_e](a);
+  unreachable;
+  label B_i:
+  return 100;
+  label B_h:
+  return 101;
+  label B_g:
+  return 102;
+  label B_f:
+  return 103;
+  label B_e:
   104;
+  a = {
+        2;
+        if (0) goto B_j;
+        3;
+        label B_j:
+      }
   nop;
   is_null(null);
   call_indirect(0);


### PR DESCRIPTION
What was before: `block L { STATS }`
is now `{ STATS; label L: }`
or when possible just: `STATS; label L:`
The latter having no indentation at all, and thus automatically
flattening all `br_table` nestings and other common patterns.

It was initially attempted to create a proper switch out of `br_table`,
but the typical LLVM output is so intertwined (with br/br_if jumping
in and out of the br_table targets etc) that a switch could have only
cleanly applied applied to a small subset of cases. The current
simple label flattening works with all wasm code equally, but is a
a bit more low level.

Also rename `break` into `goto`, reflecting what it is really doing.
Though here, `goto` only ever jumps downwards, backwards jumps to the
`loop` construct are still called `continue`.