### PR TITLE
wasm-decompile: friendlier general load/store ops.

### DIFF
--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -28,7 +28,7 @@
     if
       i32.const 1
       i32.const 2
-      i32.load offset=3
+      i32.load offset=3 align=1
       i32.const 5
       i32.add
       i32.store offset=4
@@ -126,7 +126,7 @@ export function f(a:int, b:int):int {
   var c:long = 8L;
   var d:float = 6.0f;
   var e:double = 7.0;
-  if (e < 10.0) { 1[4]:int = 2[3]:int + 5 }
+  if (e < 10.0) { 1[1]:int = 2[3]:int@1 + 5 }
   f(a + g_b, 9);
   loop L_b {
     if (if (0) { 1 } else { 2 }) goto B_c;

--- a/test/decompile/loadstore.txt
+++ b/test/decompile/loadstore.txt
@@ -53,8 +53,48 @@
     drop
     ;; 4) Unaligned access / access with unexpected gaps.
     get_local 7
-    f32.load offset=1
+    f32.load offset=1 align=1
     drop
+    ;; Test index rewriting.
+    ;; code that does (base + (index << 2))[0]:int is super common.
+    get_local 0
+    get_local 1
+    i32.const 2
+    i32.shl
+    i32.add
+    get_local 0
+    get_local 1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=0
+    i32.store offset=0
+    ;; Same with non-zero offsets.
+    get_local 0
+    get_local 1
+    i32.const 2
+    i32.shl
+    i32.add
+    get_local 0
+    get_local 1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    i32.store offset=4
+    ;; If the shift amount does not match, it doesn't work.
+    get_local 0
+    get_local 1
+    i32.const 3
+    i32.shl
+    i32.add
+    get_local 0
+    get_local 1
+    i32.const 2
+    i32.shl
+    i32.add
+    i32.load offset=4
+    i32.store offset=4
   )
   (export "f" (func $f))
 )
@@ -77,7 +117,10 @@ export function f(a:{ a:float, b:float }, b:{ a:ushort, b:long }) {
   f[0]:short;
   g[0]:int;
   g[0]:int@1;
-  h[1]:float;
+  h[1]:float@1;
+  a[b]:int = a[b]:int;
+  a[b + 1]:int = a[b + 1]:int;
+  (a + (b << 3))[1]:int = a[b + 1]:int;
 }
 
 ;;; STDOUT ;;)


### PR DESCRIPTION
- Now has an index that is relative to the type.
- Now detects the common case where the index is shifted to
  produce a new base address.