### PR TITLE
Fix parse error with table and elem exprs

### DIFF
--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -118,10 +118,10 @@ class WastParser {
   bool ParseVarOpt(Var* out_var, Var default_var = Var());
   Result ParseOffsetExpr(ExprList* out_expr_list);
   bool ParseOffsetExprOpt(ExprList* out_expr_list);
-  Result ParseTextList(std::vector<uint8_t>* out_data);
   bool ParseTextListOpt(std::vector<uint8_t>* out_data);
   Result ParseVarList(VarVector* out_var_list);
-  Result ParseElemExprVarList(ElemExprVector* out_list);
+  bool ParseElemExprOpt(ElemExpr* out_elem_expr);
+  bool ParseElemExprListOpt(ElemExprVector* out_list);
   bool ParseElemExprVarListOpt(ElemExprVector* out_list);
   Result ParseValueType(Type* out_type);
   Result ParseValueTypeList(TypeVector* out_type_list);

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -118,6 +118,7 @@ class WastParser {
   bool ParseVarOpt(Var* out_var, Var default_var = Var());
   Result ParseOffsetExpr(ExprList* out_expr_list);
   bool ParseOffsetExprOpt(ExprList* out_expr_list);
+  Result ParseTextList(std::vector<uint8_t>* out_data);
   bool ParseTextListOpt(std::vector<uint8_t>* out_data);
   Result ParseVarList(VarVector* out_var_list);
   bool ParseElemExprOpt(ElemExpr* out_elem_expr);

--- a/test/parse/expr/bad-brtable-no-vars.txt
+++ b/test/parse/expr/bad-brtable-no-vars.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func br_table))
+(;; STDERR ;;;
+out/test/parse/expr/bad-brtable-no-vars.txt:3:23: error: unexpected token ")", expected a numeric index or a name (e.g. 12 or $foo).
+(module (func br_table))
+                      ^
+;;; STDERR ;;)

--- a/test/parse/expr/bad-brtable-no-vars.txt
+++ b/test/parse/expr/bad-brtable-no-vars.txt
@@ -2,7 +2,7 @@
 ;;; ERROR: 1
 (module (func br_table))
 (;; STDERR ;;;
-out/test/parse/expr/bad-brtable-no-vars.txt:3:23: error: unexpected token ")", expected a numeric index or a name (e.g. 12 or $foo).
+out/test/parse/expr/bad-brtable-no-vars.txt:3:23: error: unexpected token ")", expected a var (e.g. 12 or $foo).
 (module (func br_table))
                       ^
 ;;; STDERR ;;)

--- a/test/parse/module/bad-table-elem.txt
+++ b/test/parse/module/bad-table-elem.txt
@@ -1,0 +1,9 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+  (table funcref (elem garbage)))
+(;; STDERR ;;;
+out/test/parse/module/bad-table-elem.txt:4:24: error: unexpected token garbage, expected ).
+  (table funcref (elem garbage)))
+                       ^^^^^^^
+;;; STDERR ;;)

--- a/test/parse/module/table-elem-expr.txt
+++ b/test/parse/module/table-elem-expr.txt
@@ -1,0 +1,5 @@
+;;; TOOL: wat2wasm
+(module
+  (func)
+  (func)
+  (table funcref (elem (ref.func 1) (ref.func 0))))

--- a/test/parse/module/table-elem-var.txt
+++ b/test/parse/module/table-elem-var.txt
@@ -1,0 +1,5 @@
+;;; TOOL: wat2wasm
+(module
+  (func)
+  (func)
+  (table funcref (elem 0 1 0)))


### PR DESCRIPTION
See #1291. There are two issues:
1. The `(table funcref (elem ...))` syntax did not support elem exprs
2. There was no error produced when the elem var list couldn't be parsed

I also fixed a similar issue with var lists (e.g. `br_table`). There's
another bug with text lists (i.e. list of strings), but it's more
involved so I left TODOs instead of doing it here.