### PR TITLE
Add explicit -o flag to wast2json tests

### DIFF
--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -49,7 +49,7 @@ TOOLS = {
     ],
     'wast2json': [
         ('RUN', '%(wast2json)s'),
-        ('ARGS', ['%(in_file)s']),
+        ('ARGS', ['%(in_file)s', '-o', '%(out_dir)s/out.json']),
         ('VERBOSE-ARGS', ['-v']),
     ],
     'wat-desugar': [


### PR DESCRIPTION
Otherwise the new default behavior (as of #1287) is to write the CWD
which we don't want when running tests.

Writing to CWD rather than alongside the input file is deliberate and
desirable and matches the behavior of other compilers such as clang
gcc and wat2wasm.