### PR TITLE
Error on memory.init|data.drop without DataCount

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1433,8 +1433,8 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::MemoryInit: {
         Index segment;
-        ERROR_UNLESS(data_count_ != kInvalidIndex,
-                     "memory.init requires data count section");
+        ERROR_IF(data_count_ == kInvalidIndex,
+                 "memory.init requires data count section");
         CHECK_RESULT(ReadIndex(&segment, "elem segment index"));
         uint8_t reserved;
         CHECK_RESULT(ReadU8(&reserved, "reserved memory index"));
@@ -1445,8 +1445,8 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::DataDrop:
-        ERROR_UNLESS(data_count_ != kInvalidIndex,
-                     "data.drop requires data count section");
+        ERROR_IF(data_count_ == kInvalidIndex,
+                 "data.drop requires data count section");
         // Fallthrough.
       case Opcode::ElemDrop: {
         Index segment;

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1433,6 +1433,8 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::MemoryInit: {
         Index segment;
+        ERROR_UNLESS(data_count_ != kInvalidIndex,
+                     "memory.init requires data count section");
         CHECK_RESULT(ReadIndex(&segment, "elem segment index"));
         uint8_t reserved;
         CHECK_RESULT(ReadU8(&reserved, "reserved memory index"));
@@ -1443,6 +1445,9 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
       }
 
       case Opcode::DataDrop:
+        ERROR_UNLESS(data_count_ != kInvalidIndex,
+                     "data.drop requires data count section");
+        // Fallthrough.
       case Opcode::ElemDrop: {
         Index segment;
         CHECK_RESULT(ReadIndex(&segment, "segment index"));

--- a/test/binary/bad-data-drop-no-data-count.txt
+++ b/test/binary/bad-data-drop-no-data-count.txt
@@ -1,0 +1,23 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-bulk-memory
+;;; ARGS2: --enable-bulk-memory
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    data.drop 0
+  }
+}
+section(DATA) {
+  count[1]
+  flags[1]
+  data[str("")]
+}
+(;; STDERR ;;;
+0000019: error: data.drop requires data count section
+0000019: error: data.drop requires data count section
+;;; STDERR ;;)

--- a/test/binary/bad-memory-init-no-data-count.txt
+++ b/test/binary/bad-memory-init-no-data-count.txt
@@ -1,0 +1,31 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-bulk-memory
+;;; ARGS2: --enable-bulk-memory
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[leb_u32(0)]
+}
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    i32.const leb_i32(0)
+    i32.const leb_i32(0)
+    i32.const leb_i32(0)
+    memory.init 0 0
+  }
+}
+section(DATA) {
+  count[1]
+  flags[1]
+  data[str("")]
+}
+(;; STDERR ;;;
+0000024: error: memory.init requires data count section
+0000024: error: memory.init requires data count section
+;;; STDERR ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -255,6 +255,15 @@ NAMED_VALUES = {
     "i64.reinterpret/f64": 0xbd,
     "f32.reinterpret/i32": 0xbe,
     "f64.reinterpret/i64": 0xbf,
+
+    # bulk memory
+    "memory.init": (0xfc, 0x08),
+    "data.drop": (0xfc, 0x09),
+    "memory.copy": (0xfc, 0x0a),
+    "memory.fill": (0xfc, 0x0b),
+    "table.init": (0xfc, 0x0c),
+    "elem.drop": (0xfc, 0x0d),
+    "table.copy": (0xfc, 0x0e),
 }
 
 keywords = {

--- a/test/spec/bulk-memory-operations/binary.txt
+++ b/test/spec/bulk-memory-operations/binary.txt
@@ -133,11 +133,9 @@ out/test/spec/bulk-memory-operations/binary.wast:664: assert_malformed passed:
 out/test/spec/bulk-memory-operations/binary.wast:674: assert_malformed passed:
   000000e: error: data section without memory section
 out/test/spec/bulk-memory-operations/binary.wast:684: assert_malformed passed:
-  error: invalid data_segment_index: 0 (max 0)
-  0000026: error: OnMemoryInitExpr callback failed
+  0000024: error: memory.init requires data count section
 out/test/spec/bulk-memory-operations/binary.wast:706: assert_malformed passed:
-  error: invalid data_segment_index: 0 (max 0)
-  000001f: error: OnDataDropExpr callback failed
+  000001e: error: data.drop requires data count section
 out/test/spec/bulk-memory-operations/binary.wast:725: assert_malformed passed:
   0000024: error: expected ref.null or ref.func in passive element segment
   0000025: error: expected END opcode after element expression


### PR DESCRIPTION
See #1176. This was working in the spec interpreter because of the way
the segment indexes are handled, but it's better to handle it earlier in
the binary reader.