### PR TITLE
wasm-decompile: absolute accesses refer to data segments

### DIFF
--- a/src/decompiler-ls.h
+++ b/src/decompiler-ls.h
@@ -78,7 +78,7 @@ struct LoadStoreTracking {
   };
 
   struct LSVar {
-    std::map<uint32_t, LSAccess> accesses;
+    std::map<uint64_t, LSAccess> accesses;
     bool struct_layout = true;
     Type same_type = Type::Any;
     Address same_align = kInvalidAddress;
@@ -119,7 +119,7 @@ struct LoadStoreTracking {
     }
   }
 
-  void LoadStore(uint32_t offset, Opcode opc, Type type, Address align,
+  void LoadStore(uint64_t offset, Opcode opc, Type type, Address align,
                  const Node& addr_exp) {
     auto byte_size = opc.GetMemorySize();
     type = GetMemoryType(type, opc);
@@ -178,7 +178,7 @@ struct LoadStoreTracking {
         var.second.struct_layout = false;
         continue;
       }
-      uint32_t cur_offset = 0;
+      uint64_t cur_offset = 0;
       uint32_t idx = 0;
       for (auto& access : var.second.accesses) {
         access.second.idx = idx++;
@@ -234,7 +234,7 @@ struct LoadStoreTracking {
     return "";
   }
 
-  std::string GenAccess(uint32_t offset, const Node& addr_exp) const {
+  std::string GenAccess(uint64_t offset, const Node& addr_exp) const {
     auto name = AddrExpName(addr_exp);
     if (name.empty()) {
       return "";

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -132,7 +132,7 @@ export function f(a:int, b:int):int {
   var c:long = 8L;
   var d:float = 6.0f;
   var e:double = 7.0;
-  if (e < 10.0) { 1[1]:int = 2[3]:int@1 + 5 }
+  if (e < 10.0) { d_a[5@4]:int = d_a[5]:int@1 + 5 }
   f(a + g_b, 9);
   loop L_b {
     if (if (0) { 1 } else { 2 }) goto B_c;

--- a/test/decompile/loadstore.txt
+++ b/test/decompile/loadstore.txt
@@ -3,6 +3,8 @@
 (module
   (memory $m1 1)
 
+  (data 0 (offset (i32.const 10)) "Hello, World!\n\00")
+
   (func $f (param i32 i32) (result) (local i32 i32 i32 i32 i32 i32)
     ;; Test regular accesses that become a struct.
     get_local 0
@@ -95,12 +97,18 @@
     i32.add
     i32.load offset=4
     i32.store offset=4
+    ;; Test naming of absolute addresses referring to data sections.
+    i32.const 16
+    i32.load8_u offset=1  ;; Refers to the 'W'
+    drop
   )
   (export "f" (func $f))
 )
 
 (;; STDOUT ;;;
 memory M_a(initial: 1, max: 0);
+
+data d_a(offset: 10) = "Hello, World!\0a\00";
 
 export function f(a:{ a:float, b:float }, b:{ a:ushort, b:long }) {
   var c:{ a:float, b:float }
@@ -121,6 +129,7 @@ export function f(a:{ a:float, b:float }, b:{ a:ushort, b:long }) {
   a[b]:int = a[b]:int;
   a[b + 1]:int = a[b + 1]:int;
   (a + (b << 3))[1]:int = a[b + 1]:int;
+  d_a[7]:ubyte;
 }
 
 ;;; STDOUT ;;)


### PR DESCRIPTION
This makes them easier to look up than the large integer
constants LLVM output is full of.