### PR TITLE
Omit the DataCount section unless it is required

### DIFF
--- a/src/stream.h
+++ b/src/stream.h
@@ -77,6 +77,8 @@ class Stream {
 
   void MoveData(size_t dst_offset, size_t src_offset, size_t size);
 
+  void Truncate(size_t size);
+
   void WABT_PRINTF_FORMAT(2, 3) Writef(const char* format, ...);
 
   // Specified as uint32_t instead of uint8_t so we can check if the value
@@ -134,6 +136,7 @@ class Stream {
   virtual Result MoveDataImpl(size_t dst_offset,
                               size_t src_offset,
                               size_t size) = 0;
+  virtual Result TruncateImpl(size_t size) = 0;
 
  private:
   template <typename T>
@@ -177,6 +180,7 @@ class MemoryStream : public Stream {
   Result MoveDataImpl(size_t dst_offset,
                       size_t src_offset,
                       size_t size) override;
+  Result TruncateImpl(size_t size) override;
 
  private:
   std::unique_ptr<OutputBuffer> buf_;
@@ -203,6 +207,7 @@ class FileStream : public Stream {
   Result MoveDataImpl(size_t dst_offset,
                       size_t src_offset,
                       size_t size) override;
+  Result TruncateImpl(size_t size) override;
 
  private:
   FILE* file_;

--- a/test/dump/data-count-section-removed.txt
+++ b/test/dump/data-count-section-removed.txt
@@ -1,0 +1,28 @@
+;;; TOOL: run-objdump
+;;; ARGS0: --enable-bulk-memory
+;;; ARGS1: -hx
+(module
+  (memory 1)
+  (data "hi")
+  ;; No data count section, since there is no instruction that requires it.
+)
+(;; STDOUT ;;;
+
+data-count-section-removed.wasm:	file format wasm 0x1
+
+Sections:
+
+   Memory start=0x0000000a end=0x0000000d (size=0x00000003) count: 1
+     Data start=0x0000000f end=0x00000014 (size=0x00000005) count: 1
+
+Section Details:
+
+Memory[1]:
+ - memory[0] pages: initial=1
+Data[1]:
+ - segment[0] passive size=2
+  - 0000000: 6869                                     hi
+
+Code Disassembly:
+
+;;; STDOUT ;;)

--- a/test/dump/data-count-section.txt
+++ b/test/dump/data-count-section.txt
@@ -3,9 +3,11 @@
 ;;; ARGS1: -hx
 (module
   (memory 1)
-  (data (i32.const 0) "hi")
-  (data (i32.const 2) "world")
-  (data (i32.const 7) "goodbye")
+  (data "hi")
+
+  ;; include an instruction that requires the DataCount section, otherwise it
+  ;; will be removed.
+  (func data.drop 0)
 )
 (;; STDOUT ;;;
 
@@ -13,24 +15,32 @@ data-count-section.wasm:	file format wasm 0x1
 
 Sections:
 
-   Memory start=0x0000000a end=0x0000000d (size=0x00000003) count: 1
-DataCount start=0x0000000f end=0x00000010 (size=0x00000001) count: 3
-     Data start=0x00000012 end=0x00000030 (size=0x0000001e) count: 3
+     Type start=0x0000000a end=0x0000000e (size=0x00000004) count: 1
+ Function start=0x00000010 end=0x00000012 (size=0x00000002) count: 1
+   Memory start=0x00000014 end=0x00000017 (size=0x00000003) count: 1
+DataCount start=0x00000019 end=0x0000001a (size=0x00000001) count: 1
+     Code start=0x0000001c end=0x00000023 (size=0x00000007) count: 1
+     Data start=0x00000025 end=0x0000002a (size=0x00000005) count: 1
 
 Section Details:
 
+Type[1]:
+ - type[0] () -> nil
+Function[1]:
+ - func[0] sig=0
 Memory[1]:
  - memory[0] pages: initial=1
 DataCount:
- - data count: 3
-Data[3]:
- - segment[0] memory=0 size=2 - init i32=0
+ - data count: 1
+Code[1]:
+ - func[0] size=5
+Data[1]:
+ - segment[0] passive size=2
   - 0000000: 6869                                     hi
- - segment[1] memory=0 size=5 - init i32=2
-  - 0000002: 776f 726c 64                             world
- - segment[2] memory=0 size=7 - init i32=7
-  - 0000007: 676f 6f64 6279 65                        goodbye
 
 Code Disassembly:
 
+00001e func[0]:
+ 00001f: fc 09 00                   | data.drop 0
+ 000022: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/elem-mvp-compat.txt
+++ b/test/dump/elem-mvp-compat.txt
@@ -27,11 +27,7 @@
 0000014: 0b                                        ; end
 0000015: 00                                        ; num elems
 000000f: 06                                        ; FIXUP section size
-; section "DataCount" (12)
-0000016: 0c                                        ; section code
-0000017: 00                                        ; section size (guess)
-0000018: 00                                        ; data count
-0000017: 01                                        ; FIXUP section size
+; truncate to 22 (0x16)
 
 elem-mvp-compat.wasm:	file format wasm 0x1
 

--- a/test/dump/reference-types.txt
+++ b/test/dump/reference-types.txt
@@ -88,8 +88,6 @@ Elem[2]:
   - elem[0] = func[0]
  - segment[1] flags=5 table=0 count=1
   - elem[0] = nullref
-DataCount:
- - data count: 0
 Code[10]:
  - func[0] size=6
  - func[1] size=6
@@ -104,45 +102,45 @@ Code[10]:
 
 Code Disassembly:
 
-00004c func[0]:
- 00004d: 41 00                      | i32.const 0
- 00004f: 25 00                      | table.get 0
- 000051: 0b                         | end
-000053 func[1]:
- 000054: 41 00                      | i32.const 0
- 000056: 25 01                      | table.get 1
- 000058: 0b                         | end
-00005a func[2]:
- 00005b: 41 00                      | i32.const 0
- 00005d: 20 00                      | local.get 0
- 00005f: 26 00                      | table.set 0
- 000061: 0b                         | end
-000063 func[3]:
- 000064: 41 00                      | i32.const 0
- 000066: 20 00                      | local.get 0
- 000068: 26 01                      | table.set 1
- 00006a: 0b                         | end
-00006c func[4]:
- 00006d: d0                         | ref.null
- 00006e: 41 00                      | i32.const 0
- 000070: fc 0f 00                   | table.grow 0
- 000073: 0b                         | end
-000075 func[5]:
- 000076: d0                         | ref.null
- 000077: 41 00                      | i32.const 0
- 000079: fc 0f 01                   | table.grow 1
- 00007c: 0b                         | end
-00007e func[6]:
- 00007f: 20 00                      | local.get 0
- 000081: d1                         | ref.is_null
- 000082: 0b                         | end
-000084 func[7]:
- 000085: fc 10 00                   | table.size 0
- 000088: 0b                         | end
-00008a func[8]:
- 00008b: fc 10 01                   | table.size 1
- 00008e: 0b                         | end
-000090 func[9]:
- 000091: fc 10 02                   | table.size 2
- 000094: 0b                         | end
+000049 func[0]:
+ 00004a: 41 00                      | i32.const 0
+ 00004c: 25 00                      | table.get 0
+ 00004e: 0b                         | end
+000050 func[1]:
+ 000051: 41 00                      | i32.const 0
+ 000053: 25 01                      | table.get 1
+ 000055: 0b                         | end
+000057 func[2]:
+ 000058: 41 00                      | i32.const 0
+ 00005a: 20 00                      | local.get 0
+ 00005c: 26 00                      | table.set 0
+ 00005e: 0b                         | end
+000060 func[3]:
+ 000061: 41 00                      | i32.const 0
+ 000063: 20 00                      | local.get 0
+ 000065: 26 01                      | table.set 1
+ 000067: 0b                         | end
+000069 func[4]:
+ 00006a: d0                         | ref.null
+ 00006b: 41 00                      | i32.const 0
+ 00006d: fc 0f 00                   | table.grow 0
+ 000070: 0b                         | end
+000072 func[5]:
+ 000073: d0                         | ref.null
+ 000074: 41 00                      | i32.const 0
+ 000076: fc 0f 01                   | table.grow 1
+ 000079: 0b                         | end
+00007b func[6]:
+ 00007c: 20 00                      | local.get 0
+ 00007e: d1                         | ref.is_null
+ 00007f: 0b                         | end
+000081 func[7]:
+ 000082: fc 10 00                   | table.size 0
+ 000085: 0b                         | end
+000087 func[8]:
+ 000088: fc 10 01                   | table.size 1
+ 00008b: 0b                         | end
+00008d func[9]:
+ 00008e: fc 10 02                   | table.size 2
+ 000091: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -60,21 +60,17 @@
 000002d: 01                                        ; num elems
 000002e: 00                                        ; elem function index
 000001f: 0f                                        ; FIXUP section size
-; section "DataCount" (12)
-000002f: 0c                                        ; section code
-0000030: 00                                        ; section size (guess)
-0000031: 00                                        ; data count
-0000030: 01                                        ; FIXUP section size
 ; section "Code" (10)
-0000032: 0a                                        ; section code
-0000033: 00                                        ; section size (guess)
-0000034: 01                                        ; num functions
+000002f: 0a                                        ; section code
+0000030: 00                                        ; section size (guess)
+0000031: 01                                        ; num functions
 ; function body 0
-0000035: 00                                        ; func body size (guess)
-0000036: 00                                        ; local decl count
-0000037: 0b                                        ; end
-0000035: 02                                        ; FIXUP func body size
-0000033: 04                                        ; FIXUP section size
+0000032: 00                                        ; func body size (guess)
+0000033: 00                                        ; local decl count
+0000034: 0b                                        ; end
+0000032: 02                                        ; FIXUP func body size
+0000030: 04                                        ; FIXUP section size
+; truncate to 53 (0x35)
 
 table-multi.wasm:	file format wasm 0x1
 
@@ -92,13 +88,11 @@ Elem[2]:
   - elem[0] = func[0]
  - segment[1] flags=2 table=1 count=1 - init i32=0
   - elem[0] = func[0]
-DataCount:
- - data count: 0
 Code[1]:
  - func[0] size=2
 
 Code Disassembly:
 
-000036 func[0]:
- 000037: 0b                         | end
+000033 func[0]:
+ 000034: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/data.txt
+++ b/test/spec/bulk-memory-operations/data.txt
@@ -3,16 +3,16 @@
 ;;; ARGS*: --enable-bulk-memory
 (;; STDOUT ;;;
 out/test/spec/bulk-memory-operations/data.wast:293: assert_invalid passed:
-  000000e: error: data section without memory section
+  000000b: error: data section without memory section
 out/test/spec/bulk-memory-operations/data.wast:302: assert_invalid passed:
-  0000016: error: expected i32 init_expr
+  0000013: error: expected i32 init_expr
 out/test/spec/bulk-memory-operations/data.wast:310: assert_invalid passed:
-  0000017: error: expected END opcode after initializer expression
+  0000014: error: expected END opcode after initializer expression
 out/test/spec/bulk-memory-operations/data.wast:318: assert_invalid passed:
-  0000015: error: unexpected opcode in initializer expression: 0x1
+  0000012: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/bulk-memory-operations/data.wast:326: assert_invalid passed:
-  0000015: error: unexpected opcode in initializer expression: 0x1
+  0000012: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/bulk-memory-operations/data.wast:334: assert_invalid passed:
-  0000017: error: expected END opcode after initializer expression
+  0000014: error: expected END opcode after initializer expression
 20/20 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/bulk-memory-operations/memory_copy.txt
+++ b/test/spec/bulk-memory-operations/memory_copy.txt
@@ -23,196 +23,196 @@ out/test/spec/bulk-memory-operations/memory_copy.wast:3600: assert_trap passed: 
 out/test/spec/bulk-memory-operations/memory_copy.wast:3961: assert_trap passed: out of bounds memory access: memory.copy out of bound
 out/test/spec/bulk-memory-operations/memory_copy.wast:4315: assert_invalid passed:
   error: memory.copy requires an imported or defined memory.
-  0000030: error: OnMemoryCopyExpr callback failed
+  000002d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4321: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4328: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4335: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4342: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4349: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4356: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4363: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4370: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i32]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4377: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4384: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4391: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4398: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4405: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4412: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4419: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4426: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4433: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4440: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4447: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4454: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4461: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f32]
-  000003f: error: OnMemoryCopyExpr callback failed
+  000003c: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4468: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i64]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4475: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f64]
-  0000043: error: OnMemoryCopyExpr callback failed
+  0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4482: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4489: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4496: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4503: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4510: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4517: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f32]
-  0000043: error: OnMemoryCopyExpr callback failed
+  0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4524: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4531: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f64]
-  0000047: error: OnMemoryCopyExpr callback failed
+  0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4538: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4545: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4552: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4559: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4566: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4573: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4580: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4587: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4594: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i32]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4601: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4608: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4615: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4622: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4629: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4636: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4643: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4650: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4657: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4664: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4671: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4678: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4685: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f32]
-  0000043: error: OnMemoryCopyExpr callback failed
+  0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4692: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4699: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f64]
-  0000047: error: OnMemoryCopyExpr callback failed
+  0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4706: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4713: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4720: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4727: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4734: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i32]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4741: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f32]
-  0000047: error: OnMemoryCopyExpr callback failed
+  0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4748: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/bulk-memory-operations/memory_copy.wast:4755: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f64]
-  000004b: error: OnMemoryCopyExpr callback failed
+  0000048: error: OnMemoryCopyExpr callback failed
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_copy.wast:4818: assert_trap passed: out of bounds memory access: memory.copy out of bound

--- a/test/spec/bulk-memory-operations/memory_fill.txt
+++ b/test/spec/bulk-memory-operations/memory_fill.txt
@@ -12,196 +12,196 @@ test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_fill.wast:174: assert_invalid passed:
   error: memory.fill requires an imported or defined memory.
-  000002f: error: OnMemoryFillExpr callback failed
+  000002c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:180: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:187: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:194: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:201: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:208: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:215: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:222: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:229: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i32]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:236: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:243: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:250: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:257: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:264: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:271: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:278: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:285: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:292: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:299: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:306: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:313: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:320: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f32]
-  000003e: error: OnMemoryFillExpr callback failed
+  000003b: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:327: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i64]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:334: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f64]
-  0000042: error: OnMemoryFillExpr callback failed
+  000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:341: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:348: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:355: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:362: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:369: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:376: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f32]
-  0000042: error: OnMemoryFillExpr callback failed
+  000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:383: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:390: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f64]
-  0000046: error: OnMemoryFillExpr callback failed
+  0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:397: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:404: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:411: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:418: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:425: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:432: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:439: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:446: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:453: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i32]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:460: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:467: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:474: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:481: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:488: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:495: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:502: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:509: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:516: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:523: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:530: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:537: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:544: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f32]
-  0000042: error: OnMemoryFillExpr callback failed
+  000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:551: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:558: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f64]
-  0000046: error: OnMemoryFillExpr callback failed
+  0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:565: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:572: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:579: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:586: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:593: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i32]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:600: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f32]
-  0000046: error: OnMemoryFillExpr callback failed
+  0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:607: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:614: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f64]
-  000004a: error: OnMemoryFillExpr callback failed
+  0000047: error: OnMemoryFillExpr callback failed
 out/test/spec/bulk-memory-operations/memory_fill.wast:637: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 out/test/spec/bulk-memory-operations/memory_fill.wast:659: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 out/test/spec/bulk-memory-operations/memory_fill.wast:681: assert_trap passed: out of bounds memory access: memory.fill out of bounds

--- a/test/spec/bulk-memory-operations/memory_init.txt
+++ b/test/spec/bulk-memory-operations/memory_init.txt
@@ -7,8 +7,7 @@ test() =>
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:189: assert_invalid passed:
-  error: invalid data_segment_index: 0 (max 0)
-  0000027: error: OnDataDropExpr callback failed
+  0000023: error: data.drop requires data count section
 out/test/spec/bulk-memory-operations/memory_init.wast:195: assert_invalid passed:
   error: invalid data_segment_index: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
@@ -16,8 +15,7 @@ test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/bulk-memory-operations/memory_init.wast:223: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/bulk-memory-operations/memory_init.wast:226: assert_invalid passed:
-  error: memory.init requires an imported or defined memory.
-  000002f: error: OnMemoryInitExpr callback failed
+  000002a: error: memory.init requires data count section
 out/test/spec/bulk-memory-operations/memory_init.wast:232: assert_invalid passed:
   error: invalid data_segment_index: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed

--- a/test/spec/bulk-memory-operations/table_init.txt
+++ b/test/spec/bulk-memory-operations/table_init.txt
@@ -57,10 +57,10 @@ out/test/spec/bulk-memory-operations/table_init.wast:190: assert_trap passed: un
 out/test/spec/bulk-memory-operations/table_init.wast:191: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:193: assert_invalid passed:
   error: invalid elem_segment_index: 0 (max 0)
-  0000027: error: OnElemDropExpr callback failed
+  0000024: error: OnElemDropExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:199: assert_invalid passed:
   error: table.init requires an imported or defined table.
-  000002e: error: OnTableInitExpr callback failed
+  000002b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:205: assert_invalid passed:
   0000024: error: elem section without table section
 out/test/spec/bulk-memory-operations/table_init.wast:213: assert_invalid passed:
@@ -81,193 +81,193 @@ test() =>
 out/test/spec/bulk-memory-operations/table_init.wast:541: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/bulk-memory-operations/table_init.wast:544: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:553: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:562: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:571: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:580: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:589: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:598: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:607: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i32]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:616: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:625: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:634: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:643: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:652: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:661: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:670: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:679: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:688: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:697: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:706: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:715: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:724: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f32]
-  000004a: error: OnTableInitExpr callback failed
+  0000047: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:733: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i64]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:742: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f64]
-  000004e: error: OnTableInitExpr callback failed
+  000004b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:751: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:760: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:769: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:778: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:787: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:796: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f32]
-  000004e: error: OnTableInitExpr callback failed
+  000004b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:805: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:814: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f64]
-  0000052: error: OnTableInitExpr callback failed
+  000004f: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:823: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:832: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:841: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:850: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:859: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:868: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:877: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:886: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:895: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i32]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:904: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:913: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:922: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:931: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:940: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:949: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:958: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:967: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:976: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:985: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:994: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1003: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1012: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f32]
-  000004e: error: OnTableInitExpr callback failed
+  000004b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1021: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1030: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f64]
-  0000052: error: OnTableInitExpr callback failed
+  000004f: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1039: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1048: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1057: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1066: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1075: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i32]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1084: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f32]
-  0000052: error: OnTableInitExpr callback failed
+  000004f: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1093: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1102: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f64]
-  0000056: error: OnTableInitExpr callback failed
+  0000053: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:1138: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/bulk-memory-operations/table_init.wast:1139: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:1140: assert_trap passed: uninitialized table element

--- a/test/spec/reference-types/br_table.txt
+++ b/test/spec/reference-types/br_table.txt
@@ -4,69 +4,69 @@
 (;; STDOUT ;;;
 out/test/spec/reference-types/br_table.wast:1513: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000025: error: OnEndExpr callback failed
+  0000022: error: OnEndExpr callback failed
 out/test/spec/reference-types/br_table.wast:1520: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000020: error: OnBrTableExpr callback failed
+  000001d: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1527: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000023: error: OnBrTableExpr callback failed
+  0000020: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1533: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
-  0000026: error: OnBrTableExpr callback failed
+  0000023: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1541: assert_invalid passed:
   error: br_table labels have inconsistent arity: expected 1 got 0
-  0000029: error: OnBrTableExpr callback failed
+  0000026: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1553: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000022: error: OnBrTableExpr callback failed
+  000001f: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1559: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
-  0000021: error: OnBrTableExpr callback failed
+  000001e: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1565: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000024: error: OnBrTableExpr callback failed
+  0000021: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1571: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000026: error: OnBrTableExpr callback failed
+  0000023: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1577: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [... i64]
-  0000025: error: OnBrTableExpr callback failed
+  0000022: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1586: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000025: error: OnEndExpr callback failed
+  0000022: error: OnEndExpr callback failed
 out/test/spec/reference-types/br_table.wast:1593: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000025: error: OnBrTableExpr callback failed
+  0000022: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1605: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000027: error: OnBrTableExpr callback failed
+  0000024: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1617: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  000001f: error: OnBrTableExpr callback failed
+  000001c: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1628: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []
-  0000021: error: OnBrTableExpr callback failed
+  000001e: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1640: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [nullref]
-  0000028: error: OnBrTableExpr callback failed
+  0000025: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1654: assert_invalid passed:
   error: invalid depth: 2 (max 1)
-  0000022: error: OnBrTableExpr callback failed
+  000001f: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1660: assert_invalid passed:
   error: invalid depth: 5 (max 2)
-  0000024: error: OnBrTableExpr callback failed
+  0000021: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1666: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
-  0000027: error: OnBrTableExpr callback failed
+  0000024: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1673: assert_invalid passed:
   error: invalid depth: 2 (max 1)
-  0000022: error: OnBrTableExpr callback failed
+  000001f: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1679: assert_invalid passed:
   error: invalid depth: 5 (max 2)
-  0000024: error: OnBrTableExpr callback failed
+  0000021: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1685: assert_invalid passed:
   error: invalid depth: 268435457 (max 1)
-  0000027: error: OnBrTableExpr callback failed
+  0000024: error: OnBrTableExpr callback failed
 183/183 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/data.txt
+++ b/test/spec/reference-types/data.txt
@@ -3,16 +3,16 @@
 ;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/data.wast:293: assert_invalid passed:
-  000000e: error: data section without memory section
+  000000b: error: data section without memory section
 out/test/spec/reference-types/data.wast:302: assert_invalid passed:
-  0000016: error: expected i32 init_expr
+  0000013: error: expected i32 init_expr
 out/test/spec/reference-types/data.wast:310: assert_invalid passed:
-  0000017: error: expected END opcode after initializer expression
+  0000014: error: expected END opcode after initializer expression
 out/test/spec/reference-types/data.wast:318: assert_invalid passed:
-  0000015: error: unexpected opcode in initializer expression: 0x1
+  0000012: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/reference-types/data.wast:326: assert_invalid passed:
-  0000015: error: unexpected opcode in initializer expression: 0x1
+  0000012: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/reference-types/data.wast:334: assert_invalid passed:
-  0000017: error: expected END opcode after initializer expression
+  0000014: error: expected END opcode after initializer expression
 20/20 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/globals.txt
+++ b/test/spec/reference-types/globals.txt
@@ -5,7 +5,7 @@
 out/test/spec/reference-types/globals.wast:226: assert_trap passed: undefined table index
 out/test/spec/reference-types/globals.wast:248: assert_invalid passed:
   error: can't global.set on immutable global at index 0.
-  000002c: error: OnGlobalSetExpr callback failed
+  0000029: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:257: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
 out/test/spec/reference-types/globals.wast:262: assert_invalid passed:
@@ -43,39 +43,39 @@ out/test/spec/reference-types/globals.wast:357: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
 out/test/spec/reference-types/globals.wast:371: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000024: error: OnGlobalSetExpr callback failed
+  0000021: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:380: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000028: error: OnGlobalSetExpr callback failed
+  0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:390: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000028: error: OnGlobalSetExpr callback failed
+  0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:400: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  000002a: error: OnGlobalSetExpr callback failed
+  0000027: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:410: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  000002d: error: OnGlobalSetExpr callback failed
+  000002a: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:420: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000028: error: OnGlobalSetExpr callback failed
+  0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:430: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000028: error: OnGlobalSetExpr callback failed
+  0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:440: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000028: error: OnGlobalSetExpr callback failed
+  0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:450: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000024: error: OnGlobalSetExpr callback failed
+  0000021: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:459: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000024: error: OnGlobalSetExpr callback failed
+  0000021: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:468: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  000002a: error: OnGlobalSetExpr callback failed
+  0000027: error: OnGlobalSetExpr callback failed
 out/test/spec/reference-types/globals.wast:478: assert_invalid passed:
   error: type mismatch in global.set, expected [i32] but got []
-  0000041: error: OnGlobalSetExpr callback failed
+  000003e: error: OnGlobalSetExpr callback failed
 75/75 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/memory_copy.txt
+++ b/test/spec/reference-types/memory_copy.txt
@@ -23,196 +23,196 @@ out/test/spec/reference-types/memory_copy.wast:3600: assert_trap passed: out of 
 out/test/spec/reference-types/memory_copy.wast:3961: assert_trap passed: out of bounds memory access: memory.copy out of bound
 out/test/spec/reference-types/memory_copy.wast:4315: assert_invalid passed:
   error: memory.copy requires an imported or defined memory.
-  0000030: error: OnMemoryCopyExpr callback failed
+  000002d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4321: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4328: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4335: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4342: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4349: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4356: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4363: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4370: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i32]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4377: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4384: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4391: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4398: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4405: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4412: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4419: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4426: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4433: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4440: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4447: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4454: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4461: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f32]
-  000003f: error: OnMemoryCopyExpr callback failed
+  000003c: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4468: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i64]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4475: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f64]
-  0000043: error: OnMemoryCopyExpr callback failed
+  0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4482: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4489: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4496: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4503: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4510: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4517: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f32]
-  0000043: error: OnMemoryCopyExpr callback failed
+  0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4524: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4531: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f64]
-  0000047: error: OnMemoryCopyExpr callback failed
+  0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4538: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4545: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4552: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4559: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4566: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4573: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f32]
-  000003c: error: OnMemoryCopyExpr callback failed
+  0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4580: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i64]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4587: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4594: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i32]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4601: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f32]
-  0000039: error: OnMemoryCopyExpr callback failed
+  0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4608: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i64]
-  0000036: error: OnMemoryCopyExpr callback failed
+  0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4615: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4622: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4629: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4636: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4643: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4650: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4657: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4664: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4671: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4678: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4685: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f32]
-  0000043: error: OnMemoryCopyExpr callback failed
+  0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4692: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i64]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4699: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f64]
-  0000047: error: OnMemoryCopyExpr callback failed
+  0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4706: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i32]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4713: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f32]
-  0000040: error: OnMemoryCopyExpr callback failed
+  000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4720: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i64]
-  000003d: error: OnMemoryCopyExpr callback failed
+  000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4727: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4734: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i32]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4741: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f32]
-  0000047: error: OnMemoryCopyExpr callback failed
+  0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4748: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i64]
-  0000044: error: OnMemoryCopyExpr callback failed
+  0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/reference-types/memory_copy.wast:4755: assert_invalid passed:
   error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f64]
-  000004b: error: OnMemoryCopyExpr callback failed
+  0000048: error: OnMemoryCopyExpr callback failed
 test() =>
 test() =>
 out/test/spec/reference-types/memory_copy.wast:4818: assert_trap passed: out of bounds memory access: memory.copy out of bound

--- a/test/spec/reference-types/memory_fill.txt
+++ b/test/spec/reference-types/memory_fill.txt
@@ -12,196 +12,196 @@ test() =>
 test() =>
 out/test/spec/reference-types/memory_fill.wast:174: assert_invalid passed:
   error: memory.fill requires an imported or defined memory.
-  000002f: error: OnMemoryFillExpr callback failed
+  000002c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:180: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:187: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:194: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:201: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:208: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:215: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:222: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:229: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i32]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:236: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:243: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:250: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:257: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:264: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:271: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:278: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:285: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:292: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:299: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:306: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:313: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:320: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f32]
-  000003e: error: OnMemoryFillExpr callback failed
+  000003b: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:327: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i64]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:334: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f64]
-  0000042: error: OnMemoryFillExpr callback failed
+  000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:341: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:348: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:355: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:362: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:369: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:376: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f32]
-  0000042: error: OnMemoryFillExpr callback failed
+  000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:383: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:390: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f64]
-  0000046: error: OnMemoryFillExpr callback failed
+  0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:397: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:404: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:411: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:418: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:425: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:432: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f32]
-  000003b: error: OnMemoryFillExpr callback failed
+  0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:439: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i64]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:446: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:453: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i32]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:460: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f32]
-  0000038: error: OnMemoryFillExpr callback failed
+  0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:467: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i64]
-  0000035: error: OnMemoryFillExpr callback failed
+  0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:474: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:481: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:488: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:495: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:502: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:509: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:516: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:523: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:530: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:537: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:544: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f32]
-  0000042: error: OnMemoryFillExpr callback failed
+  000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:551: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i64]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:558: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f64]
-  0000046: error: OnMemoryFillExpr callback failed
+  0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:565: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i32]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:572: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f32]
-  000003f: error: OnMemoryFillExpr callback failed
+  000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:579: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i64]
-  000003c: error: OnMemoryFillExpr callback failed
+  0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:586: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:593: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i32]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:600: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f32]
-  0000046: error: OnMemoryFillExpr callback failed
+  0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:607: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i64]
-  0000043: error: OnMemoryFillExpr callback failed
+  0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:614: assert_invalid passed:
   error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f64]
-  000004a: error: OnMemoryFillExpr callback failed
+  0000047: error: OnMemoryFillExpr callback failed
 out/test/spec/reference-types/memory_fill.wast:637: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 out/test/spec/reference-types/memory_fill.wast:659: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 out/test/spec/reference-types/memory_fill.wast:681: assert_trap passed: out of bounds memory access: memory.fill out of bounds

--- a/test/spec/reference-types/memory_grow.txt
+++ b/test/spec/reference-types/memory_grow.txt
@@ -12,24 +12,24 @@ out/test/spec/reference-types/memory_grow.wast:25: assert_trap passed: out of bo
 out/test/spec/reference-types/memory_grow.wast:286: assert_trap passed: undefined table index
 out/test/spec/reference-types/memory_grow.wast:313: assert_invalid passed:
   error: type mismatch in memory.grow, expected [i32] but got []
-  0000022: error: OnMemoryGrowExpr callback failed
+  000001f: error: OnMemoryGrowExpr callback failed
 out/test/spec/reference-types/memory_grow.wast:322: assert_invalid passed:
   error: type mismatch in memory.grow, expected [i32] but got []
-  0000026: error: OnMemoryGrowExpr callback failed
+  0000023: error: OnMemoryGrowExpr callback failed
 out/test/spec/reference-types/memory_grow.wast:332: assert_invalid passed:
   error: type mismatch in memory.grow, expected [i32] but got []
-  0000026: error: OnMemoryGrowExpr callback failed
+  0000023: error: OnMemoryGrowExpr callback failed
 out/test/spec/reference-types/memory_grow.wast:342: assert_invalid passed:
   error: type mismatch in memory.grow, expected [i32] but got []
-  0000028: error: OnMemoryGrowExpr callback failed
+  0000025: error: OnMemoryGrowExpr callback failed
 out/test/spec/reference-types/memory_grow.wast:353: assert_invalid passed:
   error: type mismatch in memory.grow, expected [i32] but got [f32]
-  0000027: error: OnMemoryGrowExpr callback failed
+  0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/reference-types/memory_grow.wast:363: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000024: error: EndFunctionBody callback failed
+  0000021: error: EndFunctionBody callback failed
 out/test/spec/reference-types/memory_grow.wast:372: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i32]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/memory_init.txt
+++ b/test/spec/reference-types/memory_init.txt
@@ -7,8 +7,7 @@ test() =>
 test() =>
 test() =>
 out/test/spec/reference-types/memory_init.wast:189: assert_invalid passed:
-  error: invalid data_segment_index: 0 (max 0)
-  0000027: error: OnDataDropExpr callback failed
+  0000023: error: data.drop requires data count section
 out/test/spec/reference-types/memory_init.wast:195: assert_invalid passed:
   error: invalid data_segment_index: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
@@ -16,8 +15,7 @@ test() =>
 out/test/spec/reference-types/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/reference-types/memory_init.wast:223: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/reference-types/memory_init.wast:226: assert_invalid passed:
-  error: memory.init requires an imported or defined memory.
-  000002f: error: OnMemoryInitExpr callback failed
+  000002a: error: memory.init requires data count section
 out/test/spec/reference-types/memory_init.wast:232: assert_invalid passed:
   error: invalid data_segment_index: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed

--- a/test/spec/reference-types/select.txt
+++ b/test/spec/reference-types/select.txt
@@ -10,61 +10,61 @@ out/test/spec/reference-types/select.wast:331: assert_trap passed: undefined tab
 out/test/spec/reference-types/select.wast:332: assert_trap passed: undefined table index
 out/test/spec/reference-types/select.wast:373: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [i32]
-  000001f: error: OnSelectExpr callback failed
+  000001c: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:377: assert_invalid passed:
-  0000020: error: invalid arity in select instrcution: 0
+  000001d: error: invalid arity in select instrcution: 0
 out/test/spec/reference-types/select.wast:381: assert_invalid passed:
   000000e: error: result count must be 0 or 1
 out/test/spec/reference-types/select.wast:393: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [nullref, nullref, i32]
-  000001f: error: OnSelectExpr callback failed
+  000001c: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:399: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [anyref, anyref, i32]
-  0000022: error: OnSelectExpr callback failed
+  000001f: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:406: assert_invalid passed:
   error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
-  0000021: error: OnSelectExpr callback failed
+  000001e: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:412: assert_invalid passed:
   error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
-  0000024: error: OnSelectExpr callback failed
+  0000021: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:418: assert_invalid passed:
   error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, i32]
-  0000028: error: OnSelectExpr callback failed
+  0000025: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:426: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got []
-  000001b: error: OnSelectExpr callback failed
+  0000018: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:434: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [i32]
-  000001d: error: OnSelectExpr callback failed
+  000001a: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:442: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
-  000001f: error: OnSelectExpr callback failed
+  000001c: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:450: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got []
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:459: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [i32]
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:468: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:477: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got []
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:486: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [i32]
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:495: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:504: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got []
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:513: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [i32]
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 out/test/spec/reference-types/select.wast:522: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
-  0000023: error: OnSelectExpr callback failed
+  0000020: error: OnSelectExpr callback failed
 148/148 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/table_fill.txt
+++ b/test/spec/reference-types/table_fill.txt
@@ -7,30 +7,30 @@ out/test/spec/reference-types/table_fill.wast:58: assert_trap passed: out of bou
 out/test/spec/reference-types/table_fill.wast:63: assert_trap passed: out of bounds table access: table.fill out of bounds
 out/test/spec/reference-types/table_fill.wast:71: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, anyref, i32] but got []
-  0000023: error: OnTableFillExpr callback failed
+  0000020: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:80: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, anyref, i32] but got [nullref, i32]
-  0000026: error: OnTableFillExpr callback failed
+  0000023: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:89: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, anyref, i32] but got [i32, i32]
-  0000027: error: OnTableFillExpr callback failed
+  0000024: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:98: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, anyref, i32] but got [i32, nullref]
-  0000026: error: OnTableFillExpr callback failed
+  0000023: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:107: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, anyref, i32] but got [f32, nullref, i32]
-  000002b: error: OnTableFillExpr callback failed
+  0000028: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:116: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, anyref, i32]
-  000002a: error: OnTableFillExpr callback failed
+  0000027: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:125: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, anyref, i32] but got [i32, nullref, f32]
-  000002b: error: OnTableFillExpr callback failed
+  0000028: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:135: assert_invalid passed:
   error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, anyref, i32]
-  000002d: error: OnTableFillExpr callback failed
+  000002a: error: OnTableFillExpr callback failed
 out/test/spec/reference-types/table_fill.wast:146: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  000002a: error: EndFunctionBody callback failed
+  0000027: error: EndFunctionBody callback failed
 44/44 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/table_get.txt
+++ b/test/spec/reference-types/table_get.txt
@@ -9,18 +9,18 @@ out/test/spec/reference-types/table_get.wast:35: assert_trap passed: out of boun
 out/test/spec/reference-types/table_get.wast:36: assert_trap passed: out of bounds table access: table.get at 4294967295 >= max value 3
 out/test/spec/reference-types/table_get.wast:42: assert_invalid passed:
   error: type mismatch in table.get, expected [i32] but got []
-  0000023: error: OnTableGetExpr callback failed
+  0000020: error: OnTableGetExpr callback failed
 out/test/spec/reference-types/table_get.wast:51: assert_invalid passed:
   error: type mismatch in table.get, expected [i32] but got [f32]
-  0000028: error: OnTableGetExpr callback failed
+  0000025: error: OnTableGetExpr callback failed
 out/test/spec/reference-types/table_get.wast:61: assert_invalid passed:
   error: type mismatch in function, expected [] but got [anyref]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 out/test/spec/reference-types/table_get.wast:70: assert_invalid passed:
   error: type mismatch in implicit return, expected [funcref] but got [anyref]
-  0000026: error: EndFunctionBody callback failed
+  0000023: error: EndFunctionBody callback failed
 out/test/spec/reference-types/table_get.wast:80: assert_invalid passed:
   error: type mismatch in implicit return, expected [funcref] but got [anyref]
-  0000029: error: EndFunctionBody callback failed
+  0000026: error: EndFunctionBody callback failed
 15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/table_grow.txt
+++ b/test/spec/reference-types/table_grow.txt
@@ -10,24 +10,24 @@ out/test/spec/reference-types/table_grow.wast:34: assert_trap passed: out of bou
 out/test/spec/reference-types/table_grow.wast:35: assert_trap passed: out of bounds table access: table.get at 5 >= max value 5
 out/test/spec/reference-types/table_grow.wast:109: assert_invalid passed:
   error: type mismatch in table.grow, expected [anyref, i32] but got []
-  0000024: error: OnTableGrowExpr callback failed
+  0000021: error: OnTableGrowExpr callback failed
 out/test/spec/reference-types/table_grow.wast:118: assert_invalid passed:
   error: type mismatch in table.grow, expected [anyref, i32] but got [nullref]
-  0000025: error: OnTableGrowExpr callback failed
+  0000022: error: OnTableGrowExpr callback failed
 out/test/spec/reference-types/table_grow.wast:127: assert_invalid passed:
   error: type mismatch in table.grow, expected [anyref, i32] but got [i32]
-  0000026: error: OnTableGrowExpr callback failed
+  0000023: error: OnTableGrowExpr callback failed
 out/test/spec/reference-types/table_grow.wast:136: assert_invalid passed:
   error: type mismatch in table.grow, expected [anyref, i32] but got [nullref, f32]
-  000002a: error: OnTableGrowExpr callback failed
+  0000027: error: OnTableGrowExpr callback failed
 out/test/spec/reference-types/table_grow.wast:145: assert_invalid passed:
   error: type mismatch in table.grow, expected [funcref, i32] but got [anyref, i32]
-  0000029: error: OnTableGrowExpr callback failed
+  0000026: error: OnTableGrowExpr callback failed
 out/test/spec/reference-types/table_grow.wast:155: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000027: error: EndFunctionBody callback failed
+  0000024: error: EndFunctionBody callback failed
 out/test/spec/reference-types/table_grow.wast:164: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i32]
-  0000028: error: EndFunctionBody callback failed
+  0000025: error: EndFunctionBody callback failed
 45/45 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/table_init.txt
+++ b/test/spec/reference-types/table_init.txt
@@ -57,10 +57,10 @@ out/test/spec/reference-types/table_init.wast:190: assert_trap passed: uninitial
 out/test/spec/reference-types/table_init.wast:191: assert_trap passed: uninitialized table element
 out/test/spec/reference-types/table_init.wast:193: assert_invalid passed:
   error: invalid elem_segment_index: 0 (max 0)
-  0000027: error: OnElemDropExpr callback failed
+  0000024: error: OnElemDropExpr callback failed
 out/test/spec/reference-types/table_init.wast:199: assert_invalid passed:
   error: table.init requires an imported or defined table.
-  000002e: error: OnTableInitExpr callback failed
+  000002b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:205: assert_invalid passed:
   0000024: error: elem section without table section
 out/test/spec/reference-types/table_init.wast:213: assert_invalid passed:
@@ -81,193 +81,193 @@ test() =>
 out/test/spec/reference-types/table_init.wast:541: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/reference-types/table_init.wast:544: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:553: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:562: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:571: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:580: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:589: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:598: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:607: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i32]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:616: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:625: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:634: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:643: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:652: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:661: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:670: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:679: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:688: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:697: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:706: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:715: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:724: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f32]
-  000004a: error: OnTableInitExpr callback failed
+  0000047: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:733: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i64]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:742: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f64]
-  000004e: error: OnTableInitExpr callback failed
+  000004b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:751: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:760: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:769: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:778: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:787: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:796: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f32]
-  000004e: error: OnTableInitExpr callback failed
+  000004b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:805: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:814: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f64]
-  0000052: error: OnTableInitExpr callback failed
+  000004f: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:823: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:832: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:841: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:850: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:859: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:868: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f32]
-  0000047: error: OnTableInitExpr callback failed
+  0000044: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:877: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i64]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:886: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:895: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i32]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:904: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f32]
-  0000044: error: OnTableInitExpr callback failed
+  0000041: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:913: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i64]
-  0000041: error: OnTableInitExpr callback failed
+  000003e: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:922: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:931: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:940: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:949: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:958: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:967: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:976: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:985: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:994: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1003: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1012: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f32]
-  000004e: error: OnTableInitExpr callback failed
+  000004b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1021: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i64]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1030: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f64]
-  0000052: error: OnTableInitExpr callback failed
+  000004f: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1039: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i32]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1048: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f32]
-  000004b: error: OnTableInitExpr callback failed
+  0000048: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1057: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i64]
-  0000048: error: OnTableInitExpr callback failed
+  0000045: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1066: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1075: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i32]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1084: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f32]
-  0000052: error: OnTableInitExpr callback failed
+  000004f: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1093: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i64]
-  000004f: error: OnTableInitExpr callback failed
+  000004c: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1102: assert_invalid passed:
   error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f64]
-  0000056: error: OnTableInitExpr callback failed
+  0000053: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:1138: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/reference-types/table_init.wast:1139: assert_trap passed: uninitialized table element
 out/test/spec/reference-types/table_init.wast:1140: assert_trap passed: uninitialized table element

--- a/test/spec/reference-types/table_set.txt
+++ b/test/spec/reference-types/table_set.txt
@@ -12,24 +12,24 @@ out/test/spec/reference-types/table_set.wast:48: assert_trap passed: out of boun
 out/test/spec/reference-types/table_set.wast:49: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 2
 out/test/spec/reference-types/table_set.wast:55: assert_invalid passed:
   error: type mismatch in table.set, expected [i32, anyref] but got []
-  0000022: error: OnTableSetExpr callback failed
+  000001f: error: OnTableSetExpr callback failed
 out/test/spec/reference-types/table_set.wast:64: assert_invalid passed:
   error: type mismatch in table.set, expected [i32, anyref] but got [nullref]
-  0000023: error: OnTableSetExpr callback failed
+  0000020: error: OnTableSetExpr callback failed
 out/test/spec/reference-types/table_set.wast:73: assert_invalid passed:
   error: type mismatch in table.set, expected [i32, anyref] but got [i32]
-  0000024: error: OnTableSetExpr callback failed
+  0000021: error: OnTableSetExpr callback failed
 out/test/spec/reference-types/table_set.wast:82: assert_invalid passed:
   error: type mismatch in table.set, expected [i32, anyref] but got [f32, nullref]
-  0000028: error: OnTableSetExpr callback failed
+  0000025: error: OnTableSetExpr callback failed
 out/test/spec/reference-types/table_set.wast:91: assert_invalid passed:
   error: type mismatch in table.set, expected [i32, funcref] but got [i32, anyref]
-  0000027: error: OnTableSetExpr callback failed
+  0000024: error: OnTableSetExpr callback failed
 out/test/spec/reference-types/table_set.wast:101: assert_invalid passed:
   error: type mismatch in table.set, expected [i32, funcref] but got [i32, anyref]
-  000002a: error: OnTableSetExpr callback failed
+  0000027: error: OnTableSetExpr callback failed
 out/test/spec/reference-types/table_set.wast:112: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  0000027: error: EndFunctionBody callback failed
+  0000024: error: EndFunctionBody callback failed
 25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/table_size.txt
+++ b/test/spec/reference-types/table_size.txt
@@ -4,9 +4,9 @@
 (;; STDOUT ;;;
 out/test/spec/reference-types/table_size.wast:70: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000024: error: EndFunctionBody callback failed
+  0000021: error: EndFunctionBody callback failed
 out/test/spec/reference-types/table_size.wast:79: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i32]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/unreached-invalid.txt
+++ b/test/spec/reference-types/unreached-invalid.txt
@@ -4,334 +4,334 @@
 (;; STDOUT ;;;
 out/test/spec/reference-types/unreached-invalid.wast:4: assert_invalid passed:
   error: invalid local_index: 0 (max 0)
-  000001d: error: OnLocalGetExpr callback failed
+  000001a: error: OnLocalGetExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:8: assert_invalid passed:
   error: invalid global_index: 0 (max 0)
-  000001d: error: OnGlobalGetExpr callback failed
+  000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:12: assert_invalid passed:
-  000001d: error: invalid call function index: 1
+  000001a: error: invalid call function index: 1
 out/test/spec/reference-types/unreached-invalid.wast:16: assert_invalid passed:
   error: invalid depth: 1 (max 0)
-  000001d: error: OnBrExpr callback failed
+  000001a: error: OnBrExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:21: assert_invalid passed:
   error: type mismatch in i64.eqz, expected [i64] but got [i32]
-  000001e: error: OnConvertExpr callback failed
+  000001b: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:27: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
-  0000022: error: EndFunctionBody callback failed
+  000001f: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:33: assert_invalid passed:
   error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
-  0000026: error: OnSelectExpr callback failed
+  0000023: error: OnSelectExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:42: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  000001e: error: EndFunctionBody callback failed
+  000001b: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:46: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  000001d: error: EndFunctionBody callback failed
+  000001a: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:50: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  000001f: error: EndFunctionBody callback failed
+  000001c: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:56: assert_invalid passed:
   error: type mismatch in function, expected [] but got [any]
-  000001d: error: EndFunctionBody callback failed
+  000001a: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:60: assert_invalid passed:
   error: type mismatch in function, expected [] but got [any]
-  000001f: error: EndFunctionBody callback failed
+  000001c: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:64: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000021: error: EndFunctionBody callback failed
+  000001e: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:71: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000022: error: OnConvertExpr callback failed
+  000001f: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:77: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
-  0000024: error: OnConvertExpr callback failed
+  0000021: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:83: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
-  0000023: error: OnCompareExpr callback failed
+  0000020: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:89: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
-  0000026: error: OnCompareExpr callback failed
+  0000023: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:95: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000021: error: OnEndExpr callback failed
+  000001e: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:101: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:107: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:113: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:119: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  000001f: error: EndFunctionBody callback failed
+  000001c: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:125: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:132: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001f: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:138: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
-  0000021: error: OnConvertExpr callback failed
+  000001e: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:144: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
-  0000020: error: OnCompareExpr callback failed
+  000001d: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:150: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
-  0000023: error: OnCompareExpr callback failed
+  0000020: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:156: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000020: error: OnEndExpr callback failed
+  000001d: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:162: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
-  0000028: error: OnEndExpr callback failed
+  0000025: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:168: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000022: error: OnEndExpr callback failed
+  000001f: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:174: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
-  0000026: error: OnEndExpr callback failed
+  0000023: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:180: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  000001e: error: EndFunctionBody callback failed
+  000001b: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:186: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
-  0000024: error: EndFunctionBody callback failed
+  0000021: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:193: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001f: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:199: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001f: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:205: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001f: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:211: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
-  0000021: error: OnConvertExpr callback failed
+  000001e: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:217: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
-  0000020: error: OnCompareExpr callback failed
+  000001d: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:223: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
-  0000023: error: OnCompareExpr callback failed
+  0000020: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:229: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000020: error: OnEndExpr callback failed
+  000001d: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:235: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
-  0000026: error: OnEndExpr callback failed
+  0000023: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:241: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000022: error: OnEndExpr callback failed
+  000001f: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:247: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
-  0000024: error: OnEndExpr callback failed
+  0000021: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:253: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  000001e: error: EndFunctionBody callback failed
+  000001b: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:259: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
-  0000022: error: EndFunctionBody callback failed
+  000001f: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:265: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000021: error: OnConvertExpr callback failed
+  000001e: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:271: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000023: error: OnConvertExpr callback failed
+  0000020: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:277: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000022: error: OnConvertExpr callback failed
+  000001f: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:284: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000022: error: OnConvertExpr callback failed
+  000001f: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:290: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
-  0000024: error: OnConvertExpr callback failed
+  0000021: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:296: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
-  0000023: error: OnCompareExpr callback failed
+  0000020: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:302: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
-  0000026: error: OnCompareExpr callback failed
+  0000023: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:308: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:314: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [... f32]
   error: type mismatch in block, expected [] but got [i32]
-  0000029: error: OnEndExpr callback failed
+  0000026: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:321: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000025: error: OnEndExpr callback failed
+  0000022: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:327: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:334: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000021: error: EndFunctionBody callback failed
+  000001e: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:340: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:348: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000023: error: OnConvertExpr callback failed
+  0000020: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:354: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
-  0000025: error: OnConvertExpr callback failed
+  0000022: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:360: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
-  0000024: error: OnCompareExpr callback failed
+  0000021: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:366: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
-  0000027: error: OnCompareExpr callback failed
+  0000024: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:372: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000024: error: OnEndExpr callback failed
+  0000021: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:378: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [... f32]
   error: type mismatch in block, expected [] but got [i32]
-  000002a: error: OnEndExpr callback failed
+  0000027: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:384: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000026: error: OnEndExpr callback failed
+  0000023: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:390: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
-  0000028: error: OnEndExpr callback failed
+  0000025: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:396: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000022: error: EndFunctionBody callback failed
+  000001f: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:402: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
-  0000026: error: EndFunctionBody callback failed
+  0000023: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:409: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000020: error: OnConvertExpr callback failed
+  000001d: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:415: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
-  0000024: error: OnConvertExpr callback failed
+  0000021: error: OnConvertExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:421: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
-  0000021: error: OnCompareExpr callback failed
+  000001e: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:427: assert_invalid passed:
   error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
-  0000026: error: OnCompareExpr callback failed
+  0000023: error: OnCompareExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:433: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
-  0000021: error: OnEndExpr callback failed
+  000001e: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:439: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [f32]
-  0000025: error: OnEndExpr callback failed
+  0000022: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:445: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:451: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:457: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:463: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:470: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [f64]
-  0000028: error: OnReturnExpr callback failed
+  0000025: error: OnReturnExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:477: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
-  000002c: error: OnBrExpr callback failed
+  0000029: error: OnBrExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:484: assert_invalid passed:
   error: type mismatch in br_if, expected [i32] but got [f32]
-  0000024: error: OnBrIfExpr callback failed
+  0000021: error: OnBrIfExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:490: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:498: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [i32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:507: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:515: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
-  0000025: error: OnBrTableExpr callback failed
+  0000022: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:521: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
-  0000028: error: OnBrTableExpr callback failed
+  0000025: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:527: assert_invalid passed:
   error: br_table labels have inconsistent arity: expected 1 got 0
-  0000026: error: OnBrTableExpr callback failed
+  0000023: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:540: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:546: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  0000023: error: EndFunctionBody callback failed
+  0000020: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:552: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:558: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000026: error: OnEndExpr callback failed
+  0000023: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:565: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000024: error: OnEndExpr callback failed
+  0000021: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:571: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
-  0000025: error: OnEndExpr callback failed
+  0000022: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:577: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [i64]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:584: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000026: error: OnEndExpr callback failed
+  0000023: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:590: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
-  0000028: error: OnEndExpr callback failed
+  0000025: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:596: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [i64]
-  000002a: error: OnEndExpr callback failed
+  0000027: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:604: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000027: error: OnEndExpr callback failed
+  0000024: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:611: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:617: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:623: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
-  0000027: error: EndFunctionBody callback failed
+  0000024: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:629: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000028: error: OnEndExpr callback failed
+  0000025: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:637: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
-  0000023: error: OnEndExpr callback failed
+  0000020: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:643: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  0000023: error: EndFunctionBody callback failed
+  0000020: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:649: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
-  0000025: error: EndFunctionBody callback failed
+  0000022: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:656: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  0000022: error: EndFunctionBody callback failed
+  000001f: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:662: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
-  0000023: error: EndFunctionBody callback failed
+  0000020: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:669: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
-  0000020: error: EndFunctionBody callback failed
+  000001d: error: EndFunctionBody callback failed
 out/test/spec/reference-types/unreached-invalid.wast:676: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
-  0000025: error: OnEndExpr callback failed
+  0000022: error: OnEndExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:687: assert_invalid passed:
   error: type mismatch in i64.extend_i32_u, expected [i32] but got [i64]
-  000001f: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 110/110 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
See #1189 and #1311. Even if bulk memory is enabled, it can be
convenient to omit the DataCount section for MVP compatibility.

This change only includes the DataCount section when an instruction
requires it; either `data.drop` or `memory.init`. It is also omitted if
there are no data segments.

Rather than doing a second pass on the instructions, this implementation
unconditionally writes the DataCount section, but removes it when it is
not needed. This required adding a function to truncate a stream
(Stream::Truncate).