### PR TITLE
Support reading from stdin in ReadFile

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -114,6 +114,9 @@ Result BinaryReaderObjdumpBase::BeginModule(uint32_t version) {
       break;
     case ObjdumpMode::Prepass: {
       string_view basename = GetBasename(options_->filename);
+      if (basename == "-") {
+        basename = "<stdin>";
+      }
       printf("%s:\tfile format wasm %#x\n", basename.to_string().c_str(),
              version);
       break;

--- a/src/common.cc
+++ b/src/common.cc
@@ -53,27 +53,46 @@ const char* g_reloc_type_name[] = {
 };
 WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(g_reloc_type_name) == kRelocTypeCount);
 
+static Result ReadStdin(std::vector<uint8_t>* out_data) {
+  out_data->resize(0);
+  uint8_t buffer[4096];
+  while (true) {
+    size_t bytes_read = fread(buffer, 1, sizeof(buffer), stdin);
+    if (bytes_read == 0) {
+      if (ferror(stdin)) {
+        fprintf(stderr, "error reading from stdin\n");
+        return Result::Error;
+      }
+      return Result::Ok;
+    }
+    size_t old_size = out_data->size();
+    out_data->resize(old_size + bytes_read);
+    memcpy(out_data->data() + old_size, buffer, bytes_read);
+  }
+}
+
 Result ReadFile(string_view filename, std::vector<uint8_t>* out_data) {
   std::string filename_str = filename.to_string();
   const char* filename_cstr = filename_str.c_str();
 
+  if (filename.size() == 1 && filename[0] == '-') {
+    return ReadStdin(out_data);
+  }
+
   struct stat statbuf;
   if (stat(filename_cstr, &statbuf) < 0) {
-    perror("stat failed");
+    fprintf(stderr, "%s: %s\n", filename_cstr, strerror(errno));
     return Result::Error;
   }
 
   if (!(statbuf.st_mode & S_IFREG)) {
-    fprintf(stderr, "%s is not a regular file.\n", filename_cstr);
+    fprintf(stderr, "%s: not a regular file\n", filename_cstr);
     return Result::Error;
   }
 
   FILE* infile = fopen(filename_cstr, "rb");
   if (!infile) {
-    const char format[] = "unable to read file %s";
-    char msg[PATH_MAX + sizeof(format)];
-    wabt_snprintf(msg, sizeof(msg), format, filename_cstr);
-    perror(msg);
+    fprintf(stderr, "%s: %s\n", filename_cstr, strerror(errno));
     return Result::Error;
   }
 
@@ -98,7 +117,7 @@ Result ReadFile(string_view filename, std::vector<uint8_t>* out_data) {
 
   out_data->resize(size);
   if (size != 0 && fread(out_data->data(), size, 1, infile) != 1) {
-    perror("fread failed");
+    fprintf(stderr, "%s: fread failed\n", filename_cstr);
     fclose(infile);
     return Result::Error;
   }

--- a/src/common.cc
+++ b/src/common.cc
@@ -75,7 +75,7 @@ Result ReadFile(string_view filename, std::vector<uint8_t>* out_data) {
   std::string filename_str = filename.to_string();
   const char* filename_cstr = filename_str.c_str();
 
-  if (filename.size() == 1 && filename[0] == '-') {
+  if (filename == "-") {
     return ReadStdin(out_data);
   }
 

--- a/src/common.cc
+++ b/src/common.cc
@@ -60,7 +60,7 @@ static Result ReadStdin(std::vector<uint8_t>* out_data) {
     size_t bytes_read = fread(buffer, 1, sizeof(buffer), stdin);
     if (bytes_read == 0) {
       if (ferror(stdin)) {
-        fprintf(stderr, "error reading from stdin\n");
+        fprintf(stderr, "error reading from stdin: %s\n", strerror(errno));
         return Result::Error;
       }
       return Result::Ok;
@@ -117,7 +117,7 @@ Result ReadFile(string_view filename, std::vector<uint8_t>* out_data) {
 
   out_data->resize(size);
   if (size != 0 && fread(out_data->data(), size, 1, infile) != 1) {
-    fprintf(stderr, "%s: fread failed\n", filename_cstr);
+    fprintf(stderr, "%s: fread failed: %s\n", filename_cstr, strerror(errno));
     fclose(infile);
     return Result::Error;
   }

--- a/test/README.md
+++ b/test/README.md
@@ -105,6 +105,7 @@ The currently supported list of keys:
 - `ARGS`: additional args to pass to the executable
 - `ARGS{N}`: additional args to the Nth `RUN` command (zero-based)
 - `ARGS*`: additional args to all `RUN` commands
+- `STDIN`: name of a file to be read and used stdin of the executable
 - `ENV`: environment variables to set, separated by spaces
 - `ERROR`: the expected return value from the executable, defaults to 0
 - `SLOW`: if defined, this test's timeout is increased (currently by 3x).

--- a/test/dump/bad-directory.txt
+++ b/test/dump/bad-directory.txt
@@ -1,5 +1,5 @@
 ;;; RUN: %(wasm-objdump)s -d third_party/
 ;;; ERROR: 1
 (;; STDERR ;;;
-third_party/ is not a regular file.
+third_party/: not a regular file
 ;;; STDERR ;;)

--- a/test/parse/stdin.txt
+++ b/test/parse/stdin.txt
@@ -1,0 +1,24 @@
+;;; RUN: %(wat2wasm)s -o %(out_dir)s/tmp.wasm
+;;; ARGS: -
+;;; STDIN: %(in_file)s
+;;; RUN: %(wasm-objdump)s -x
+;;; STDIN: %(out_dir)s/tmp.wasm
+;;; ARGS: -
+(module
+  (func (result i32)
+    i32.const 42
+    return)
+)
+(;; STDOUT ;;;
+
+-:	file format wasm 0x1
+
+Section Details:
+
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Code[1]:
+ - func[0] size=5
+;;; STDOUT ;;)

--- a/test/parse/stdin.txt
+++ b/test/parse/stdin.txt
@@ -11,7 +11,7 @@
 )
 (;; STDOUT ;;;
 
--:	file format wasm 0x1
+<stdin>:	file format wasm 0x1
 
 Section Details:
 

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -205,6 +205,7 @@ class CommandTemplate(object):
     def __init__(self, exe):
         self.args = SplitArgs(exe)
         self.verbose_args = []
+        self.stdin = None
         self.expected_returncode = 0
 
     def AppendArgs(self, args):
@@ -219,6 +220,9 @@ class CommandTemplate(object):
                 self.verbose_args.append([])
             self.verbose_args[level] += SplitArgs(level_args)
 
+    def SetStdin(self, filename):
+        self.stdin = filename
+
     def _Format(self, cmd, variables):
         return [arg % variables for arg in cmd]
 
@@ -231,14 +235,18 @@ class CommandTemplate(object):
         if extra_args:
             args += extra_args
         args = self._Format(args, variables)
-        return Command(self, FixPythonExecutable(args))
+        stdin = self.stdin
+        if stdin:
+            stdin = stdin % variables
+        return Command(self, FixPythonExecutable(args), stdin)
 
 
 class Command(object):
 
-    def __init__(self, template, args):
+    def __init__(self, template, args, stdin):
         self.template = template
         self.args = args
+        self.stdin = stdin
 
     def GetExpectedReturncode(self):
         return self.template.expected_returncode
@@ -265,17 +273,21 @@ class Command(object):
             kwargs = {}
             if not IS_WINDOWS:
                 kwargs['preexec_fn'] = os.setsid
+            stdin_data = None
+            if self.stdin:
+                stdin_data = open(self.stdin).read()
 
             # http://stackoverflow.com/a/10012262: subprocess with a timeout
             # http://stackoverflow.com/a/22582602: kill subprocess and children
             process = subprocess.Popen(self.args, cwd=cwd, env=env,
                                        stdout=None if console_out else subprocess.PIPE,
                                        stderr=None if console_out else subprocess.PIPE,
+                                       stdin=None if not self.stdin else subprocess.PIPE,
                                        **kwargs)
             timer = threading.Timer(timeout, KillProcess)
             try:
                 timer.start()
-                stdout, stderr = process.communicate()
+                stdout, stderr = process.communicate(input=stdin_data)
             finally:
                 returncode = process.returncode
                 process = None
@@ -472,6 +484,8 @@ class TestInfo(object):
             pass
         elif key == 'TOOL':
             self.SetTool(value)
+        elif key == 'STDIN':
+            self.GetLastCommand().SetStdin(value)
         elif key == 'ENV':
             # Pattern: FOO=1 BAR=stuff
             self.env = dict(x.split('=') for x in value.split())

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -275,7 +275,7 @@ class Command(object):
                 kwargs['preexec_fn'] = os.setsid
             stdin_data = None
             if self.stdin:
-                stdin_data = open(self.stdin).read()
+                stdin_data = open(self.stdin, 'rb').read()
 
             # http://stackoverflow.com/a/10012262: subprocess with a timeout
             # http://stackoverflow.com/a/22582602: kill subprocess and children


### PR DESCRIPTION
This allows tools that read input files to use the special `-` filename
to read from stdin.

Also, improve the error reported in general in ReadFile.

See: #386