### PR TITLE
Remove build-time dependency on git

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,27 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 2.6)
-project(WABT)
+cmake_minimum_required(VERSION 3.0.0)
+project(WABT VERSION 1.0.13)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# For git users, attempt to generate a more useful version string
+if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+  find_package(Git QUIET REQUIRED)
+  execute_process(COMMAND
+          "${GIT_EXECUTABLE}" --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git describe --tags
+          RESULT_VARIABLE
+              GIT_VERSION_RESULT
+          OUTPUT_VARIABLE
+              GIT_VERSION
+          OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if (${GIT_VERSION_RESULT})
+    message(WARNING "Error running git describe to determine version")
+  else ()
+    set(CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION} (${GIT_VERSION})")
+  endif ()
+endif ()
 
 option(BUILD_TESTS "Build GTest-based tests" ON)
 option(USE_SYSTEM_GTEST "Use system GTest, instead of building" OFF)
@@ -68,22 +85,6 @@ endif ()
 include(CheckTypeSize)
 check_type_size(ssize_t SSIZE_T)
 check_type_size(size_t SIZEOF_SIZE_T)
-
-FIND_PACKAGE(Git QUIET REQUIRED)
-EXECUTE_PROCESS(COMMAND
-        "${GIT_EXECUTABLE}" --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git describe --tags
-        RESULT_VARIABLE
-            GIT_HASH_RESULT
-        OUTPUT_VARIABLE
-            GIT_HASH
-        OUTPUT_STRIP_TRAILING_WHITESPACE)
-
-IF(${GIT_HASH_RESULT} EQUAL 0)
-    SET(WABT_VERSION_INFO "${GIT_HASH}")
-ELSE()
-    MESSAGE(WARNING "Error running git describe to determine version")
-    SET(WABT_VERSION_INFO "(unable to determine version)")
-ENDIF()
 
 configure_file(
   ${WABT_SOURCE_DIR}/src/config.h.in

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#cmakedefine WABT_VERSION_INFO "${WABT_VERSION_INFO}"
+#cmakedefine CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION}"
 
 /* TODO(binji): nice way to define these with WABT_ prefix? */
 

--- a/src/option-parser.cc
+++ b/src/option-parser.cc
@@ -57,7 +57,7 @@ OptionParser::OptionParser(const char* program_name, const char* description)
     exit(0);
   });
   AddOption("version", "Print version information", []() {
-    printf("%s\n", WABT_VERSION_INFO);
+    printf("%s\n", CMAKE_PROJECT_VERSION);
     exit(0);
   });
 }


### PR DESCRIPTION
Add VERSION to project command, which in turn required a cmake
version bump to 3.0.0.

Fixes: #1314