### PR TITLE
wasm-decompile: use symbols from linking section for names.

### DIFF
--- a/docs/decompiler.md
+++ b/docs/decompiler.md
@@ -35,8 +35,9 @@ already be mostly familiar with that.
 
 ### Naming.
 
-wasm-decompile, much like wasm2wat, derives names from import/export
-declarations and the name section where possible. For things that have no
+wasm-decompile, much like wasm2wat, derives names from the name section
+(preferrably), or linker symbols (if available), or import/export (if not
+available in the other 2). For things that have no
 names, names are generated starting from `a`, `b`, `c` and so forth.
 
 In addition, prefixes are used for things that are not arguments/locals:
@@ -47,6 +48,11 @@ in the case of functions using STL types may end up several hundred characters
 long. Besides removing characters not typically part of an identifier, the
 decompiler also strips common keywords/types from these in an effort to
 reduce their size.
+
+Linker symbols are typically only available in wasm .o files, though if useful
+for naming can be retained in fully linked wasm modules using the
+`--emit-reloc` flag to `wasm.ld`. This gives you names for most functions
+even when `--strip-debug` was used.
 
 ### Top level declarations.
 
@@ -98,7 +104,7 @@ These tend to be the hardest to "read" in Wasm code, as they've lost all
 context of the data structures and types the language that Wasm was compiled
 from was operating upon.
 
-wasm-decompile has a few feature to try and make these more readable.
+wasm-decompile has a few features to try and make these more readable.
 
 The basic form looks like an array indexing operation, so `o[2]:int` says: read
 element 2 from `o` when seen as an array of ints. This thus accesses 4 bytes
@@ -121,6 +127,11 @@ in such crazy ways that this "struct detection" fails, for example it falls
 back to indexing operations when there are holes or overlaps in the memory
 layout, or types are mixed, etc. This happens even more so when locals such
 as `o` are being re-used for unrelated things in memory.
+
+For accesses that are not contiguous, but at least of the same type, the
+decompiler will change the pointer type from `o:int` to e.g. `o:float_ptr` (and
+similarly, it will omit the type from the actual access, `o[2]` instead
+of `o[2]:int`).
 
 Additionally, wasm-decompile tried to clean up typical indexing operations.
 For example, when accessing any array of 32-bit elements, generated Wasm

--- a/src/decompiler-ast.h
+++ b/src/decompiler-ast.h
@@ -80,7 +80,7 @@ struct AST {
     if (f) {
       mc.BeginFunc(*f);
       for (Index i = 0; i < f->GetNumParams(); i++) {
-        auto name = IndexToAlphaName(i);
+        auto name = "$" + IndexToAlphaName(i);
         vars_defined.insert(name);
       }
     }

--- a/src/decompiler-naming.h
+++ b/src/decompiler-naming.h
@@ -119,6 +119,11 @@ enum {
 void RenameToContents(std::vector<DataSegment*>& segs, BindingHash& bh) {
   std::string s;
   for (auto seg : segs) {
+    if (seg->name.substr(0, 2) != "d_") {
+      // This segment was named explicitly by a symbol.
+      // FIXME: this is not a great check, a symbol could start with d_.
+      continue;
+    }
     s = "d_";
     for (auto c : seg->data) {
       if (isalnum(c) || c == '_') {
@@ -183,10 +188,19 @@ void RenameAll(Module& module) {
     { "4096ul" },
   };
   RenameToIdentifiers(module.funcs, module.func_bindings, &filter);
-  // Also do this for some other kinds of names.
+  // Also do this for some other kinds of names, but without the keyword
+  // substitution.
   RenameToIdentifiers(module.globals, module.global_bindings, nullptr);
   RenameToIdentifiers(module.tables, module.table_bindings, nullptr);
-
+  RenameToIdentifiers(module.events, module.event_bindings, nullptr);
+  RenameToIdentifiers(module.exports, module.export_bindings, nullptr);
+  RenameToIdentifiers(module.func_types, module.func_type_bindings, nullptr);
+  RenameToIdentifiers(module.memories, module.memory_bindings, nullptr);
+  RenameToIdentifiers(module.data_segments, module.data_segment_bindings,
+                      nullptr);
+  RenameToIdentifiers(module.elem_segments, module.elem_segment_bindings,
+                      nullptr);
+  // Special purpose naming for data segments.
   RenameToContents(module.data_segments, module.data_segment_bindings);
 }
 

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -120,8 +120,7 @@ void NameGenerator::GenerateName(const char* prefix,
                                  Index index,
                                  unsigned disambiguator,
                                  std::string* str) {
-  str->clear();
-  if (!(opts_ & NameOpts::NoDollar)) *str = "$";
+  *str = "$";
   *str += prefix;
   if (index != kInvalidIndex) {
     if (opts_ & NameOpts::AlphaNames) {

--- a/src/generate-names.h
+++ b/src/generate-names.h
@@ -26,7 +26,6 @@ struct Module;
 enum NameOpts {
   None = 0,
   AlphaNames = 1 << 0,
-  NoDollar = 1 << 1,
 };
 
 Result GenerateNames(struct Module*, NameOpts opts = NameOpts::None);

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -88,8 +88,7 @@ int ProgramMain(int argc, char** argv) {
         result = ValidateModule(&module, &errors, options);
       }
       result = GenerateNames(&module,
-                             static_cast<NameOpts>(NameOpts::AlphaNames |
-                                                   NameOpts::NoDollar));
+                             static_cast<NameOpts>(NameOpts::AlphaNames));
       // Must be called after ReadBinaryIr & GenerateNames, and before
       // ApplyNames, see comments at definition.
       RenameAll(module);

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -39,7 +39,7 @@ static std::string s_infile;
 static std::string s_outfile;
 static Features s_features;
 static WriteWatOptions s_write_wat_options;
-static bool s_generate_names;
+static bool s_generate_names = false;
 static bool s_read_debug_names = true;
 static bool s_fail_on_custom_section_error = true;
 static std::unique_ptr<FileStream> s_log_stream;

--- a/test/README.md
+++ b/test/README.md
@@ -140,7 +140,9 @@ The currently supported list of tools (see
   binary files), then parse via `wasm2wat` and display the result
 - `run-gen-wasm-interp`: parse a "gen-wasm" text file, generate a wasm file,
   the run `wasm-interp` on it, which runes all exported functions in an
-  interpreter
+  interpreter.
+- `run-gen-wasm-decompile`: parse a "gen-wasm" text file (which can describe
+  invalid binary files), then parse via `wasm-decompile` and display the result.
 - `run-opcodecnt`: parse a wasm text file, convert it to binary, then display
   opcode usage counts.
 - `run-gen-spec-js`: parse wasm spec test text file, convert it to a JSON file
@@ -149,6 +151,7 @@ The currently supported list of tools (see
 - `run-spec-wasm2c`: similar to `run-gen-spec-js`, but the output instead will
   be C source files, that are then compiled with the default C compiler (`cc`).
   Finally, the native executable is run.
+- `run-wasm-decompile`: parse wat with `wat2wasm` then `wasm-decompile`.
 
 
 ## Test subdirectories

--- a/test/decompile/names.txt
+++ b/test/decompile/names.txt
@@ -1,6 +1,5 @@
-;;; TOOL: run-gen-wasm
-;;; ARGS2: --generate-names
-;; NOTE: same test as in test/decompile/names.txt
+;;; TOOL: run-gen-wasm-decompile
+;; NOTE: same test as in test/binary/names.txt
 magic
 version
 section(TYPE) {
@@ -55,7 +54,7 @@ section(DATA) {
   ;; These can only be named thru symbols.
   memory_index[0]
   offset[i32.const 0 end]
-  data[str("foo")]
+  data[str("Hello, World!")]
   memory_index[0]
   offset[i32.const 10 end]
   data[str("bar")]
@@ -92,23 +91,26 @@ section("linking") {
   }
 }
 (;; STDOUT ;;;
-(module $M0
-  (type $t0 (func (result i32)))
-  (type $t1 (func))
-  (func $F0 (type $t0) (result i32)
-    (local $L0 i32)
-    local.get $L0)
-  (func $F1_NS (type $t1))
-  (func $F2_SYM (type $t1))
-  (func $F3_EXPORT (type $t1))
-  (memory $M0 0)
-  (global $G0_SYM i32 (i32.const 0))
-  (global $G1_EXPORT i32 (i32.const 0))
-  (export "F1_EXPORT" (func $F1_NS))
-  (export "F2_EXPORT" (func $F2_SYM))
-  (export "F3_EXPORT" (func $F3_EXPORT))
-  (export "G0_EXPORT" (global 0))
-  (export "G1_EXPORT" (global 1))
-  (data $D0_SYM (i32.const 0) "foo")
-  (data $D1_SYM (i32.const 10) "bar"))
+memory M_a(initial: 0, max: 0);
+
+global G0_SYM:int = 0;
+export global G1_EXPORT:int = 0;
+
+data D0_SYM(offset: 0) = "Hello, World!";
+data D1_SYM(offset: 10) = "bar";
+
+function F0():int {
+  var L0:int;
+  return L0;
+}
+
+function F1_NS() {
+}
+
+function F2_SYM() {
+}
+
+export function F3_EXPORT() {
+}
+
 ;;; STDOUT ;;)

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -119,6 +119,12 @@ TOOLS = {
         ('RUN', '%(wasm-objdump)s -h %(temp_file)s.wasm'),
         ('VERBOSE-ARGS', ['--print-cmd', '-v']),
     ],
+    'run-gen-wasm-decompile': [
+        ('RUN', '%(gen_wasm_py)s %(in_file)s -o %(temp_file)s.wasm'),
+        ('RUN', '%(wasm-validate)s %(temp_file)s.wasm'),
+        ('RUN', '%(wasm-decompile)s %(temp_file)s.wasm'),
+        ('VERBOSE-ARGS', ['--print-cmd', '-v']),
+    ],
     'run-opcodecnt': [
         ('RUN', '%(wat2wasm)s %(in_file)s -o %(temp_file)s.wasm'),
         ('RUN', '%(wasm-opcodecnt)s %(temp_file)s.wasm'),


### PR DESCRIPTION
This allows wasm .o files to have more readable names, or even final
linked modules if the linking information is preserved (with e.g.
--emit-relocs in LLD).

This is implemented as part of the WABT IR representation, so
benefits wasm2wat as well.

Named obtained this way are only set for functions if the function
doesn't also have a name in the name section, but is preferred over
the export name if there is one.