### PR TITLE
wasm-decompile: escape hatch for variables used outside scope.

### DIFF
--- a/src/decompiler-naming.h
+++ b/src/decompiler-naming.h
@@ -19,6 +19,8 @@
 
 #include "src/decompiler-ast.h"
 
+#include <set>
+
 namespace wabt {
 
 inline void RenameToIdentifier(std::string& name, Index i,

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -102,6 +102,17 @@
     call_indirect
     i32.const 0
   )
+  (func $g (param) (result) (local i32)
+    ;; This is rare, but requires special handling: uses of local outside scope
+    ;; of first definition.
+    loop
+      i32.const 1
+      tee_local 0
+      br_if 0
+    end
+    get_local 0
+    drop
+  )
   ;; LLD outputs a name section with de-mangled C++ function signatures as names,
   ;; so have to make sure special chars get removed.
   (func (export "void signature-&<>(int a)") (param) (result))
@@ -169,13 +180,22 @@ export function f(a:int, b:int):int {
   return 0;
 }
 
+function f_c() {
+  var a:int;
+  loop L_a {
+    a = 1;
+    if (a) continue L_a;
+  }
+  a;
+}
+
 function signature() {
 }
 
 function signature_1() {
 }
 
-function f_e() {
+function f_f() {
 }
 
 ;;; STDOUT ;;)


### PR DESCRIPTION
The decompiler assumes it can define a variable where it is first
assigned to, which works for almost all cases, but occasionally there
is a use of a variable outside of the scope where it was defined.

This detects that case, and makes sure that variable is pre-declared.