### PR TITLE
[interp] Unify active and passive segments

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -3749,9 +3749,10 @@ Result Executor::InitializeSegments(DefinedModule* module) {
   }
 
   for (; pass <= Init; ++pass) {
-    for (const ElemSegmentInfo& info : module->active_elem_segments_) {
+    for (Index i : module->active_elem_segments_) {
+      ElemSegment& info = *env_->GetElemSegment(i);
       uint32_t table_size = info.table->size();
-      uint32_t segment_size = info.src.size();
+      uint32_t segment_size = info.elems.size();
       uint32_t copy_size = segment_size;
       if (!CheckBounds(info.dst, copy_size, table_size)) {
         TRAP_MSG(TableAccessOutOfBounds,
@@ -3762,12 +3763,14 @@ Result Executor::InitializeSegments(DefinedModule* module) {
       }
 
       if (pass == Init && copy_size > 0) {
-        std::copy(info.src.begin(), info.src.begin() + copy_size,
+        std::copy(info.elems.begin(), info.elems.begin() + copy_size,
                   info.table->entries.begin() + info.dst);
+        info.elems.clear();
       }
     }
 
-    for (const DataSegmentInfo& info : module->active_data_segments_) {
+    for (Index i: module->active_data_segments_) {
+      DataSegment& info = *env_->GetDataSegment(i);
       uint32_t memory_size = info.memory->data.size();
       uint32_t segment_size = info.data.size();
       uint32_t copy_size = segment_size;
@@ -3782,6 +3785,7 @@ Result Executor::InitializeSegments(DefinedModule* module) {
       if (pass == Init && copy_size > 0) {
         std::copy(info.data.begin(), info.data.begin() + copy_size,
                   info.memory->data.begin() + info.dst);
+        info.data.clear();
       }
     }
   }

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -3769,7 +3769,7 @@ Result Executor::InitializeSegments(DefinedModule* module) {
       }
     }
 
-    for (Index i: module->active_data_segments_) {
+    for (Index i : module->active_data_segments_) {
       DataSegment& info = *env_->GetDataSegment(i);
       uint32_t memory_size = info.memory->data.size();
       uint32_t segment_size = info.data.size();

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -146,32 +146,20 @@ struct Memory {
 
 struct DataSegment {
   DataSegment() = default;
+  DataSegment(Memory* memory, Address dst) : memory(memory), dst(dst) {}
 
+  Memory* memory = nullptr;
+  Address dst = 0;
   std::vector<char> data;
 };
 
 struct ElemSegment {
   ElemSegment() = default;
+  ElemSegment(Table* table, Index dst) : table(table), dst(dst) {}
 
+  Table* table = nullptr;
+  Index dst = 0;
   std::vector<Ref> elems;
-};
-
-struct ElemSegmentInfo {
-  ElemSegmentInfo(Table* table, Index dst) : table(table), dst(dst) {}
-
-  Table* table;
-  Index dst;
-  std::vector<Ref> src;
-};
-
-struct DataSegmentInfo {
-  DataSegmentInfo(Memory* memory,
-                  Address dst)
-      : memory(memory), dst(dst) {}
-
-  Memory* memory;
-  Address dst;
-  std::vector<char> data;
 };
 
 // Opaque handle to a host object.
@@ -386,15 +374,8 @@ struct DefinedModule : Module {
   IstreamOffset istream_start;
   IstreamOffset istream_end;
 
-  // Changes to linear memory and tables should not apply if a validation error
-  // occurs; these vectors cache the changes that must be applied after we know
-  // that there are no validation errors.
-  //
-  // Note that this behavior changed after the bulk memory proposal; in that
-  // case each segment is initialized as it is encountered. If one fails, then
-  // no further segments are processed.
-  std::vector<ElemSegmentInfo> active_elem_segments_;
-  std::vector<DataSegmentInfo> active_data_segments_;
+  std::vector<Index> active_elem_segments_;
+  std::vector<Index> active_data_segments_;
 };
 
 struct HostModule : Module {


### PR DESCRIPTION
This simplifies the code and makes passive segments behave more like
active segments that are dropped on startup.

In also lays the ground work for the "declared" segments type which
is about be land in the next testsuite updated.