### PR TITLE
Improve help/usage message on invalid arguments

### DIFF
--- a/src/option-parser.cc
+++ b/src/option-parser.cc
@@ -135,7 +135,11 @@ int OptionParser::Match(const char* s,
 
 void OptionParser::Errorf(const char* format, ...) {
   WABT_SNPRINTF_ALLOCA(buffer, length, format);
-  on_error_(buffer);
+  std::string msg(program_name_);
+  msg += ": ";
+  msg += buffer;
+  msg += "\nTry '--help' for more information.";
+  on_error_(msg.c_str());
 }
 
 void OptionParser::DefaultError(const std::string& message) {
@@ -257,9 +261,8 @@ void OptionParser::Parse(int argc, char* argv[]) {
   // For now, all arguments must be provided. Check that the last Argument was
   // handled at least once.
   if (!arguments_.empty() && arguments_.back().handled_count == 0) {
-    PrintHelp();
     for (size_t i = arg_index; i < arguments_.size(); ++i) {
-      Errorf("expected %s argument.\n", arguments_[i].name.c_str());
+      Errorf("expected %s argument.", arguments_[i].name.c_str());
     }
   }
 }

--- a/src/test-option-parser.cc
+++ b/src/test-option-parser.cc
@@ -20,6 +20,8 @@
 
 using namespace wabt;
 
+#define ERROR_ENDING "\nTry '--help' for more information."
+
 TEST(OptionParser, LongFlag) {
   bool flag = false;
   OptionParser parser("prog", "desc");
@@ -48,13 +50,22 @@ TEST(OptionParser, ShortFlagCombined) {
   EXPECT_EQ(7, count);
 }
 
-TEST(OptionParser, UnknownFlag) {
+TEST(OptionParser, UnknownShortOption) {
   std::string error;
   OptionParser parser("prog", "desc");
   parser.SetErrorCallback([&](const char* msg) { error = msg; });
   const char* args[] = {"prog name", "-f"};
   parser.Parse(2, const_cast<char**>(args));
-  EXPECT_EQ("unknown option '-f'", error);
+  EXPECT_EQ(error, "prog: unknown option '-f'" ERROR_ENDING);
+}
+
+TEST(OptionParser, UnknownLongOption) {
+  std::string error;
+  OptionParser parser("prog", "desc");
+  parser.SetErrorCallback([&](const char* msg) { error = msg; });
+  const char* args[] = {"prog name", "--foo"};
+  parser.Parse(2, const_cast<char**>(args));
+  EXPECT_EQ(error, "prog: unknown option '--foo'" ERROR_ENDING);
 }
 
 TEST(OptionParser, ShortAndLongParam) {
@@ -77,7 +88,18 @@ TEST(OptionParser, MissingParam) {
   const char* args[] = {"prog name", "--param"};
   parser.Parse(2, const_cast<char**>(args));
   EXPECT_EQ("", param);
-  EXPECT_EQ("option '--param' requires argument", error);
+  EXPECT_EQ(error, "prog: option '--param' requires argument" ERROR_ENDING);
+}
+
+TEST(OptionParser, MissingArgument) {
+  std::string error;
+  OptionParser parser("prog", "desc");
+  parser.AddArgument("arg", OptionParser::ArgumentCount::One,
+                     [&](const char* arg) {});
+  parser.SetErrorCallback([&](const char* msg) { error = msg; });
+  const char* args[] = {"prog name"};
+  parser.Parse(1, const_cast<char**>(args));
+  EXPECT_EQ(error, "prog: expected arg argument." ERROR_ENDING);
 }
 
 TEST(OptionParser, FlagCombinedAfterShortParam) {
@@ -94,7 +116,7 @@ TEST(OptionParser, FlagCombinedAfterShortParam) {
   parser.Parse(3, const_cast<char**>(args));
   EXPECT_EQ("", param);
   EXPECT_TRUE(has_x);
-  EXPECT_EQ("unexpected argument 'stuff'", error);
+  EXPECT_EQ(error, "prog: unexpected argument 'stuff'" ERROR_ENDING);
 }
 
 
@@ -116,7 +138,7 @@ TEST(OptionParser, TooManyArguments) {
                      [&](const char* arg) {});
   const char* args[] = {"prog name", "hello", "goodbye"};
   parser.Parse(3, const_cast<char**>(args));
-  EXPECT_EQ("unexpected argument 'goodbye'", error);
+  EXPECT_EQ(error, "prog: unexpected argument 'goodbye'" ERROR_ENDING);
 }
 
 TEST(OptionParser, OneOrMoreArguments) {

--- a/test/too-many-arguments.txt
+++ b/test/too-many-arguments.txt
@@ -2,5 +2,6 @@
 ;;; ARGS: foo.txt bar.txt
 ;;; ERROR: 1
 (;; STDERR ;;;
-unexpected argument 'bar.txt'
+wat2wasm: unexpected argument 'bar.txt'
+Try '--help' for more information.
 ;;; STDERR ;;)


### PR DESCRIPTION
Don't print the full help message unless we actually ask for it,
but instead suggest `--help` as an option.

Also, print the program name before the error string.

Both these things seem match the GNU utilities I'm used to and I kind
like not seeing and entire screen of help text when I forget an
argument.