### PR TITLE
actions: Avoid triggering both branch and pr builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  create:
+    tags:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
This adds some more nuanced triggering for github actions.