### PR TITLE
Cygwin build fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,7 +118,15 @@ else ()
     -Wuninitialized
   )
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wold-style-cast")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
+
+  if(NOT CYGWIN)
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+  else()
+      # On Cygwin, POSIX extensions are not visible with std=c++11 
+      # because it defines __STRICT_ANSI__.
+      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
+  endif()
 
   if (WERROR)
     add_definitions(-Werror)

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -598,7 +598,7 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32(uint32_t value) {
 Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32Uint32(uint32_t value,
                                                             uint32_t value2) {
   Offset immediate_len = state->offset - current_opcode_offset;
-  LogOpcode(immediate_len, "%lu %lu", value, value2);
+  LogOpcode(immediate_len, "%u %u", value, value2);
   return Result::Ok;
 }
 

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -302,7 +302,7 @@ struct Decompiler {
         if (se.opcode == Opcode::I32Shl &&
             const_exp.etype == ExprType::Const) {
           auto& ce = *cast<ConstExpr>(const_exp.e);
-          if (ce.const_.type == Type::I32 && (1 << ce.const_.u32) == align) {
+          if (ce.const_.type == Type::I32 && (1U << ce.const_.u32) == align) {
             // Pfew, case detected :( Lets re-write this in Haskell.
             // TODO: we're decompiling these twice.
             // The thing to the left of << is going to be part of the index.


### PR DESCRIPTION
Build fixes to run wabt tools on Cygwin64. I haven't tested it much, but at least it runs DOOM https://github.com/okuoku/freestandoom/issues/2 with the interpreter + WASM C-API :)

- CMakeLists.txt -- Cygwin's libc(newlib) doesn't export POSIX API `fileno` under `-std=c++11`; use `-std=gnu++11` instead.
- binary-reader-objdump.cc: Use proper format string. Using `%lu` here would take some garbage, as argument is `uint32_t`. I guess it can be `PRIu32` but followed other occurrences there.
- (not Cygwin specific) decompiler.cc: Use unsigned `1U` 
