### PR TITLE
Use standard C++11 on GNU/Clang compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,15 +118,7 @@ else ()
     -Wuninitialized
   )
 
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wold-style-cast")
-
-  if(NOT CYGWIN)
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-  else()
-      # On Cygwin, POSIX extensions are not visible with std=c++11 
-      # because it defines __STRICT_ANSI__.
-      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++11")
-  endif()
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wold-style-cast")
 
   if (WERROR)
     add_definitions(-Werror)
@@ -141,11 +133,9 @@ else ()
   # definition, and some libcs (e.g. glibc2.17 and earlier) follow that.
   add_definitions(-D__STDC_LIMIT_MACROS=1 -D__STDC_FORMAT_MACROS=1)
 
-  if (MINGW)
-    # _POSIX is needed to ensure we use mingw printf
-    # instead of the VC runtime one.
-    add_definitions(-D_POSIX)
-  endif ()
+  # On MINGW, _POSIX_C_SOURCE is needed to ensure we use mingw printf
+  # instead of the VC runtime one.
+  add_definitions(-D_POSIX_C_SOURCE=200809L)
 
   if (COMPILER_IS_GNU)
     # disable -Wclobbered: it seems to be guessing incorrectly about a local

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,7 @@ else ()
     -Wuninitialized
   )
 
+  set(CMAKE_CXX_EXTENSIONS OFF)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wold-style-cast")
 
   if (WERROR)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ include(CheckSymbolExists)
 check_include_file("alloca.h" HAVE_ALLOCA_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
-check_symbol_exists(sysconf "unistd.h" HAVE_SYSCONF)
 check_symbol_exists(strcasecmp "strings.h" HAVE_STRCASECMP)
 
 if (WIN32)

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -22,6 +22,7 @@
 #include <cstdio>
 #include <cstring>
 #include <vector>
+#include <strings.h>
 
 #include "src/binary-reader-nop.h"
 #include "src/filenames.h"

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -22,7 +22,10 @@
 #include <cstdio>
 #include <cstring>
 #include <vector>
+
+#if HAVE_STRCASECMP
 #include <strings.h>
+#endif
 
 #include "src/binary-reader-nop.h"
 #include "src/filenames.h"

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -33,9 +33,6 @@
 /* Whether snprintf is defined by stdio.h */
 #cmakedefine01 HAVE_SNPRINTF
 
-/* Whether sysconf is defined by unistd.h */
-#cmakedefine01 HAVE_SYSCONF
-
 /* Whether ssize_t is defined by stddef.h */
 #cmakedefine01 HAVE_SSIZE_T
 

--- a/src/test-hexfloat.cc
+++ b/src/test-hexfloat.cc
@@ -22,10 +22,6 @@
 
 #include "src/literal.h"
 
-#if HAVE_SYSCONF
-#include <unistd.h>
-#endif
-
 #define FOREACH_UINT32_MULTIPLIER 1
 
 #define FOREACH_UINT32(bits) \
@@ -74,13 +70,9 @@ class ThreadedTest : public ::testing::Test {
   static const int kDefaultNumThreads = 2;
 
   virtual void SetUp() {
-#if HAVE_SYSCONF
-    num_threads_ = sysconf(_SC_NPROCESSORS_ONLN);
-    if (num_threads_ == -1)
+    num_threads_ = std::thread::hardware_concurrency();
+    if (num_threads_ == 0)
       num_threads_ = kDefaultNumThreads;
-#else
-    num_threads_ = kDefaultNumThreads;
-#endif
   }
 
   virtual void RunShard(int shard) = 0;


### PR DESCRIPTION
Following up #1332 . Enforce standard C++11 in more sane way.

- `binary-reader-objdump.cc` -- it lacked `<strings.h>` to import `strcasecmp` which is not part of standard C++
- Adjust CMake variables to use `std=c++11` everywhere. `CMAKE_CXX_EXTENSIONS OFF` is required to teach CMake 3.1+ not to inject `std=gnu++11` reliably. `_POSIX` on MinGW is no longer required with `_POSIX_C_SOURCE`.