### PR TITLE
Always run ResolveNames after parsing .wast/.wat

### DIFF
--- a/src/emscripten-exported.json
+++ b/src/emscripten-exported.json
@@ -31,7 +31,6 @@
 "_wabt_read_binary_result_get_result",
 "_wabt_read_binary_result_release_module",
 "_wabt_reference_types_enabled",
-"_wabt_resolve_names_module",
 "_wabt_sat_float_to_int_enabled",
 "_wabt_set_bulk_memory_enabled",
 "_wabt_set_exceptions_enabled",

--- a/src/emscripten-helpers.cc
+++ b/src/emscripten-helpers.cc
@@ -36,7 +36,6 @@
 #include "src/filenames.h"
 #include "src/generate-names.h"
 #include "src/ir.h"
-#include "src/resolve-names.h"
 #include "src/stream.h"
 #include "src/validator.h"
 #include "src/wast-lexer.h"
@@ -142,11 +141,6 @@ WabtReadBinaryResult* wabt_read_binary(const void* data,
       wabt::ReadBinaryIr(filename, data, size, options, errors, module);
   result->module.reset(module);
   return result;
-}
-
-wabt::Result::Enum wabt_resolve_names_module(wabt::Module* module,
-                                             wabt::Errors* errors) {
-  return ResolveNamesModule(module, errors);
 }
 
 wabt::Result::Enum wabt_validate_module(wabt::Module* module,

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -32,7 +32,6 @@
 #include "src/interp/interp.h"
 #include "src/literal.h"
 #include "src/option-parser.h"
-#include "src/resolve-names.h"
 #include "src/stream.h"
 #include "src/validator.h"
 #include "src/wast-lexer.h"
@@ -1073,12 +1072,9 @@ wabt::Result CommandRunner::ReadInvalidTextModule(string_view module_filename,
     result = ParseWastScript(lexer.get(), &script, &errors, &options);
     if (Succeeded(result)) {
       wabt::Module* module = script->GetFirstModule();
-      result = ResolveNamesModule(module, &errors);
-      if (Succeeded(result)) {
-        ValidateOptions options(s_features);
-        // Don't do a full validation, just validate the function signatures.
-        result = ValidateFuncSignatures(module, &errors, options);
-      }
+      ValidateOptions options(s_features);
+      // Don't do a full validation, just validate the function signatures.
+      result = ValidateFuncSignatures(module, &errors, options);
     }
   }
 

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -139,25 +139,21 @@ int ProgramMain(int argc, char** argv) {
   WastParseOptions parse_wast_options(s_features);
   result = ParseWatModule(lexer.get(), &module, &errors, &parse_wast_options);
 
-  if (Succeeded(result)) {
-    result = ResolveNamesModule(module.get(), &errors);
+  if (Succeeded(result) && s_validate) {
+    ValidateOptions options(s_features);
+    result = ValidateModule(module.get(), &errors, options);
+  }
 
-    if (Succeeded(result) && s_validate) {
-      ValidateOptions options(s_features);
-      result = ValidateModule(module.get(), &errors, options);
-    }
+  if (Succeeded(result)) {
+    MemoryStream stream(s_log_stream.get());
+    s_write_binary_options.features = s_features;
+    result = WriteBinaryModule(&stream, module.get(), s_write_binary_options);
 
     if (Succeeded(result)) {
-      MemoryStream stream(s_log_stream.get());
-      s_write_binary_options.features = s_features;
-      result = WriteBinaryModule(&stream, module.get(), s_write_binary_options);
-
-      if (Succeeded(result)) {
-        if (s_outfile.empty()) {
-          s_outfile = DefaultOuputName(s_infile);
-        }
-        WriteBufferToFile(s_outfile.c_str(), stream.output_buffer());
+      if (s_outfile.empty()) {
+        s_outfile = DefaultOuputName(s_infile);
       }
+      WriteBufferToFile(s_outfile.c_str(), stream.output_buffer());
     }
   }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -21,6 +21,7 @@
 #include "src/cast.h"
 #include "src/expr-visitor.h"
 #include "src/make-unique.h"
+#include "src/resolve-names.h"
 #include "src/stream.h"
 #include "src/utf8.h"
 
@@ -2805,7 +2806,9 @@ Result ParseWatModule(WastLexer* lexer,
   assert(out_module != nullptr);
   assert(options != nullptr);
   WastParser parser(lexer, errors, options);
-  return parser.ParseModule(out_module);
+  CHECK_RESULT(parser.ParseModule(out_module));
+  CHECK_RESULT(ResolveNamesModule(out_module->get(), errors));
+  return Result::Ok;
 }
 
 Result ParseWastScript(WastLexer* lexer,
@@ -2815,7 +2818,9 @@ Result ParseWastScript(WastLexer* lexer,
   assert(out_script != nullptr);
   assert(options != nullptr);
   WastParser parser(lexer, errors, options);
-  return parser.ParseScript(out_script);
+  CHECK_RESULT(parser.ParseScript(out_script));
+  CHECK_RESULT(ResolveNamesScript(out_script->get(), errors));
+  return Result::Ok;
 }
 
 }  // namespace wabt


### PR DESCRIPTION
Resolving names (i.e. remapping variable names to indexes) is meant to
be part of the parsing process. The spec even considers an unmapped
variable name to be "malformed" text.

This PR moves in that direction, by always running ResolveNames after
parsing text. The next step would be to integrate this more closely with
the parser itself.