### PR TITLE
Move ValidateFuncSignatures after ParseModuleWat

### DIFF
--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1067,15 +1067,9 @@ wabt::Result CommandRunner::ReadInvalidTextModule(string_view module_filename,
       module_filename, file_data.data(), file_data.size());
   Errors errors;
   if (Succeeded(result)) {
-    std::unique_ptr<::Script> script;
+    std::unique_ptr<wabt::Module> module;
     WastParseOptions options(s_features);
-    result = ParseWastScript(lexer.get(), &script, &errors, &options);
-    if (Succeeded(result)) {
-      wabt::Module* module = script->GetFirstModule();
-      ValidateOptions options(s_features);
-      // Don't do a full validation, just validate the function signatures.
-      result = ValidateFuncSignatures(module, &errors, options);
-    }
+    result = ParseWatModule(lexer.get(), &module, &errors, &options);
   }
 
   auto line_finder = lexer->MakeLineFinder();

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -24,6 +24,7 @@
 #include "src/resolve-names.h"
 #include "src/stream.h"
 #include "src/utf8.h"
+#include "src/validator.h"
 
 #define WABT_TRACING 0
 #include "src/tracing.h"
@@ -2808,6 +2809,8 @@ Result ParseWatModule(WastLexer* lexer,
   WastParser parser(lexer, errors, options);
   CHECK_RESULT(parser.ParseModule(out_module));
   CHECK_RESULT(ResolveNamesModule(out_module->get(), errors));
+  CHECK_RESULT(ValidateFuncSignatures(out_module->get(), errors,
+                                      ValidateOptions(options->features)));
   return Result::Ok;
 }
 

--- a/test/parse/func/bad-sig-result-type-mismatch.txt
+++ b/test/parse/func/bad-sig-result-type-mismatch.txt
@@ -7,7 +7,4 @@
 out/test/parse/func/bad-sig-result-type-mismatch.txt:5:4: error: type mismatch for result 0 of function. got i64, expected f32
   (func (type $t) (param i32) (result i64)))
    ^^^^
-out/test/parse/func/bad-sig-result-type-mismatch.txt:5:4: error: type mismatch in implicit return, expected [i64] but got []
-  (func (type $t) (param i32) (result i64)))
-   ^^^^
 ;;; STDERR ;;)

--- a/test/parse/func/bad-sig-result-type-not-void.txt
+++ b/test/parse/func/bad-sig-result-type-not-void.txt
@@ -7,7 +7,4 @@
 out/test/parse/func/bad-sig-result-type-not-void.txt:5:4: error: expected 0 results, got 1
   (func (type $t) (param i32) (result f32)))
    ^^^^
-out/test/parse/func/bad-sig-result-type-not-void.txt:5:4: error: type mismatch in implicit return, expected [f32] but got []
-  (func (type $t) (param i32) (result f32)))
-   ^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-30.txt
+++ b/test/regress/regress-30.txt
@@ -7,7 +7,7 @@ out/test/regress/regress-30.txt:3: assert_malformed passed:
   out/test/regress/regress-30/regress-30.0.wat:1:1: error: unexpected char
   €
   ^
-  out/test/regress/regress-30/regress-30.0.wat:1:2: error: unexpected token "EOF", expected a module field or a command.
+  out/test/regress/regress-30/regress-30.0.wat:1:2: error: unexpected token "EOF", expected a module field or a module.
   €
    ^
 1/1 tests passed.


### PR DESCRIPTION
Validating function signatures (i.e. making sure a named function type
matches its explicit signature) really should be parse of text parsing.

Example:

   (type $F (func (param i32) (result i32)))
   ...
   (call_indirect (type $F) (param f32) (result i32)  ;; ERROR!

This change doesn't quite get us there, but it's closer. The next step
will be to remove `ValidateFuncSignatures` entirely and perform those
checks in the parser itself.