### PR TITLE
Add the old alias for v8x16.shuffle

### DIFF
--- a/src/opcode-code-table.c
+++ b/src/opcode-code-table.c
@@ -38,4 +38,8 @@ uint32_t WabtOpcodeCodeTable[WABT_OPCODE_CODE_TABLE_SIZE] = {
   [(prefix << 8) + code] = Name,
 #include "opcode.def"
 #undef WABT_OPCODE
+
+  // TODO(binji): LLVM still generates 0xfd03 for v8x16.shuffle, see
+  // https://github.com/WebAssembly/wabt/issues/1339
+  [(0xfd << 8) + 0x03] = V8X16Shuffle,
 };

--- a/test/binary/v8x16shuffle-alias.txt
+++ b/test/binary/v8x16shuffle-alias.txt
@@ -1,0 +1,24 @@
+;;; TOOL: run-gen-wasm
+;;; ARGS1: --enable-simd
+;;; ARGS2: --enable-simd
+magic
+version
+section(TYPE) { count[1] function params[0] results[1] v128 }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    v128.const 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    v128.const 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+    0xfd 0x03 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 ;; alias for v8x16.shuffle
+  }
+}
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (result v128)))
+  (func (;0;) (type 0) (result v128)
+    v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000
+    v128.const i32x4 0x00000000 0x00000000 0x00000000 0x00000000
+    v8x16.shuffle  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0  0 ))
+;;; STDOUT ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -263,6 +263,9 @@ NAMED_VALUES = {
     "table.init": (0xfc, 0x0c),
     "elem.drop": (0xfc, 0x0d),
     "table.copy": (0xfc, 0x0e),
+
+    # simd
+    "v128.const": (0xfd, 0x02),
 }
 
 keywords = {


### PR DESCRIPTION
It used to have the encoding 0xfd03, but now is 0xfdc1. It is useful to
keep the old encoding around though.