### PR TITLE
Move validation of func signatures into the parser

### DIFF
--- a/src/validator.h
+++ b/src/validator.h
@@ -37,15 +37,6 @@ struct ValidateOptions {
 Result ValidateScript(const Script*, Errors*, const ValidateOptions&);
 Result ValidateModule(const Module*, Errors*, const ValidateOptions&);
 
-// Validate that all functions that have an explicit function signature and a
-// function type use match.
-//
-// This needs to be separated out because the spec interpreter considers it to
-// be malformed text, not a validation error. We can't handle that error in the
-// parser because the parser doesn't resolve names to indexes, which is
-// required to perform this check.
-Result ValidateFuncSignatures(const Module*, Errors*, const ValidateOptions&);
-
 }  // namespace wabt
 
 #endif /* WABT_VALIDATOR_H_ */

--- a/test/parse/module/reference-types-disabled.txt
+++ b/test/parse/module/reference-types-disabled.txt
@@ -20,4 +20,10 @@ out/test/parse/module/reference-types-disabled.txt:9:5: error: opcode not allowe
 out/test/parse/module/reference-types-disabled.txt:10:5: error: opcode not allowed: table.set
     table.set $t
     ^^^^^^^^^
+out/test/parse/module/reference-types-disabled.txt:9:15: error: undefined table variable "$t"
+    table.get $t
+              ^^
+out/test/parse/module/reference-types-disabled.txt:10:15: error: undefined table variable "$t"
+    table.set $t
+              ^^
 ;;; STDERR ;;)


### PR DESCRIPTION
The previous PR called the validator function to do this, but now the
code is moved entirely into the parser. This is preferable, since a
mismatching function signature is considered malformed text, not a
validation error.