### PR TITLE
Share validator between IR + binary-reader-interp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,6 +283,8 @@ set(WABT_LIBRARY_SRC
   src/option-parser.cc
   src/resolve-names.h
   src/resolve-names.cc
+  src/shared-validator.h
+  src/shared-validator.cc
   src/stream.h
   src/stream.cc
   src/string-view.h

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -1,0 +1,1165 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "src/shared-validator.h"
+
+#include <algorithm>
+#include <cinttypes>
+#include <limits>
+
+namespace wabt {
+
+TypeVector SharedValidator::ToTypeVector(Index count, const Type* types) {
+  return TypeVector(&types[0], &types[count]);
+}
+
+SharedValidator::SharedValidator(Errors* errors, const ValidateOptions& options)
+    : options_(options), errors_(errors), typechecker_(options.features) {
+  typechecker_.set_error_callback(
+      [this](const char* msg) { OnTypecheckerError(msg); });
+}
+
+Result WABT_PRINTF_FORMAT(3, 4) SharedValidator::PrintError(const Location& loc,
+                                                            const char* format,
+                                                            ...) {
+  WABT_SNPRINTF_ALLOCA(buffer, length, format);
+  errors_->emplace_back(ErrorLevel::Error, loc, buffer);
+  return Result::Error;
+}
+
+void SharedValidator::OnTypecheckerError(const char* msg) {
+  PrintError(*expr_loc_, "%s", msg);
+}
+
+Result SharedValidator::OnType(const Location& loc,
+                               Index param_count,
+                               const Type* param_types,
+                               Index result_count,
+                               const Type* result_types) {
+  types_.push_back(FuncType{ToTypeVector(param_count, param_types),
+                            ToTypeVector(result_count, result_types)});
+  return Result::Ok;
+}
+
+Result SharedValidator::OnFunction(const Location& loc, Var sig_var) {
+  Result result = Result::Ok;
+  CHECK_RESULT(CheckTypeIndex(sig_var));
+  FuncType& type = types_[sig_var.index()];
+  if (!options_.features.multi_value_enabled() && type.results.size() > 1) {
+    result |=
+        PrintError(loc, "multiple result values not currently supported.");
+  }
+  funcs_.push_back(type);
+  return result;
+}
+
+Result SharedValidator::CheckLimits(const Location& loc,
+                                    const Limits& limits,
+                                    uint64_t absolute_max,
+                                    const char* desc) {
+  Result result = Result::Ok;
+  if (limits.initial > absolute_max) {
+    result |=
+        PrintError(loc, "initial %s (%" PRIu64 ") must be <= (%" PRIu64 ")",
+                   desc, limits.initial, absolute_max);
+  }
+
+  if (limits.has_max) {
+    if (limits.max > absolute_max) {
+      result |= PrintError(loc, "max %s (%" PRIu64 ") must be <= (%" PRIu64 ")",
+                           desc, limits.max, absolute_max);
+    }
+
+    if (limits.max < limits.initial) {
+      result |= PrintError(
+          loc, "max %s (%" PRIu64 ") must be >= initial %s (%" PRIu64 ")", desc,
+          limits.max, desc, limits.initial);
+    }
+  }
+  return result;
+}
+
+Result SharedValidator::OnTable(const Location& loc,
+                                Type elem_type,
+                                const Limits& limits) {
+  Result result = Result::Ok;
+  if (tables_.size() > 0 && !options_.features.reference_types_enabled()) {
+    result |= PrintError(loc, "only one table allowed");
+  }
+  result |= CheckLimits(loc, limits, UINT32_MAX, "elems");
+
+  if (limits.is_shared) {
+    result |= PrintError(loc, "tables may not be shared");
+  }
+  if (elem_type != Type::Funcref &&
+      !options_.features.reference_types_enabled()) {
+    result |= PrintError(loc, "tables must have funcref type");
+  }
+  if (!IsRefType(elem_type)) {
+    result |= PrintError(loc, "tables must have reference types");
+  }
+
+  tables_.push_back(TableType{elem_type, limits});
+  return result;
+}
+
+Result SharedValidator::OnMemory(const Location& loc, const Limits& limits) {
+  Result result = Result::Ok;
+  if (memories_.size() > 0) {
+    result |= PrintError(loc, "only one memory block allowed");
+  }
+  result |= CheckLimits(loc, limits, WABT_MAX_PAGES, "pages");
+
+  if (limits.is_shared) {
+    if (!options_.features.threads_enabled()) {
+      result |= PrintError(loc, "memories may not be shared");
+    } else if (!limits.has_max) {
+      result |= PrintError(loc, "shared memories must have max sizes");
+    }
+  }
+
+  memories_.push_back(MemoryType{limits});
+  return result;
+}
+
+Result SharedValidator::OnGlobalImport(const Location& loc,
+                                       Type type,
+                                       bool mutable_) {
+  Result result = Result::Ok;
+  if (mutable_ && !options_.features.mutable_globals_enabled()) {
+    result |= PrintError(loc, "mutable globals cannot be imported");
+  }
+  globals_.push_back(GlobalType{type, mutable_});
+  ++num_imported_globals_;
+  return result;
+}
+
+Result SharedValidator::OnGlobal(const Location& loc,
+                                 Type type,
+                                 bool mutable_) {
+  globals_.push_back(GlobalType{type, mutable_});
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckType(const Location& loc,
+                                  Type actual,
+                                  Type expected,
+                                  const char* desc) {
+  if (Failed(TypeChecker::CheckType(actual, expected))) {
+    PrintError(loc, "type mismatch at %s. got %s, expected %s", desc,
+               GetTypeName(actual), GetTypeName(expected));
+    return Result::Error;
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::OnGlobalInitExpr_Const(const Location& loc,
+                                               Type actual) {
+  return CheckType(loc, actual, globals_.back().type,
+                   "global initializer expression");
+}
+
+Result SharedValidator::OnGlobalInitExpr_GlobalGet(const Location& loc,
+                                                   Var ref_global_var) {
+  Result result = Result::Ok;
+  GlobalType ref_global;
+  CHECK_RESULT(CheckGlobalIndex(ref_global_var, &ref_global));
+
+  if (ref_global_var.index() >= num_imported_globals_) {
+    result |= PrintError(
+        ref_global_var.loc,
+        "initializer expression can only reference an imported global");
+  }
+
+  if (ref_global.mutable_) {
+    result |= PrintError(
+        loc, "initializer expression cannot reference a mutable global");
+  }
+
+  result |= CheckType(loc, ref_global.type, globals_.back().type,
+                      "global initializer expression");
+  return result;
+}
+
+Result SharedValidator::OnGlobalInitExpr_RefNull(const Location& loc) {
+  return CheckType(loc, Type::Nullref, globals_.back().type,
+                   "global initializer expression");
+}
+
+Result SharedValidator::OnGlobalInitExpr_RefFunc(const Location& loc,
+                                                 Var func_var) {
+  CHECK_RESULT(CheckFuncIndex(func_var));
+  init_expr_funcs_.push_back(func_var);
+  return CheckType(loc, Type::Funcref, globals_.back().type,
+                   "global initializer expression");
+}
+
+Result SharedValidator::OnGlobalInitExpr_Other(const Location& loc) {
+  return PrintError(loc,
+                    "invalid global initializer expression, must be a constant "
+                    "expression; either *.const or "
+                    "global.get.");
+}
+
+// TODO: Remove; this is here only to match previous error output.
+Result SharedValidator::OnGlobalInitExpr_None(const Location& loc) {
+  return CheckType(loc, Type::Void, globals_.back().type,
+                   "global initializer expression");
+}
+
+Result SharedValidator::OnEvent(const Location& loc, Var sig_var) {
+  CHECK_RESULT(CheckTypeIndex(sig_var));
+  Result result = Result::Ok;
+  FuncType& type = types_[sig_var.index()];
+  if (!type.results.empty()) {
+    result |= PrintError(loc, "Event signature must have 0 results.");
+  }
+  events_.push_back(EventType{type.params});
+  return result;
+}
+
+Result SharedValidator::OnExport(const Location& loc,
+                                 ExternalKind kind,
+                                 Var item_var,
+                                 string_view name) {
+  Result result = Result::Ok;
+  auto name_str = name.to_string();
+  if (export_names_.find(name_str) != export_names_.end()) {
+    result |= PrintError(loc, "duplicate export \"" PRIstringview "\"",
+                         WABT_PRINTF_STRING_VIEW_ARG(name));
+  }
+  export_names_.insert(name_str);
+
+  switch (kind) {
+    case ExternalKind::Func:
+      result |= CheckFuncIndex(item_var);
+      break;
+
+    case ExternalKind::Table:
+      result |= CheckTableIndex(item_var);
+      break;
+
+    case ExternalKind::Memory:
+      result |= CheckMemoryIndex(item_var);
+      break;
+
+    case ExternalKind::Global:
+      result |= CheckGlobalIndex(item_var, nullptr);
+      break;
+
+    case ExternalKind::Event:
+      result |= CheckEventIndex(item_var);
+      break;
+  }
+  return result;
+}
+
+Result SharedValidator::OnStart(const Location& loc, Var func_var) {
+  Result result = Result::Ok;
+  if (starts_++ > 0) {
+    result |= PrintError(loc, "only one start function allowed");
+  }
+  FuncType& func_type = funcs_[func_var.index()];
+  if (func_type.params.size() != 0) {
+    result |= PrintError(loc, "start function must be nullary");
+  }
+  if (func_type.results.size() != 0) {
+    result |= PrintError(loc, "start function must not return anything");
+  }
+  return result;
+}
+
+Result SharedValidator::OnElemSegment(const Location& loc,
+                                      Var table_var,
+                                      SegmentKind kind,
+                                      Type elem_type) {
+  Result result = Result::Ok;
+  if (kind == SegmentKind::Active) {
+    result |= CheckTableIndex(table_var);
+  }
+  ++elem_segments_;
+  return result;
+}
+
+Result SharedValidator::OnElemSegmentInitExpr_Const(const Location& loc,
+                                                    Type type) {
+  return CheckType(loc, type, Type::I32, "elem segment offset");
+}
+
+Result SharedValidator::OnElemSegmentInitExpr_GlobalGet(const Location& loc,
+                                                        Var global_var) {
+  Result result = Result::Ok;
+  GlobalType ref_global;
+  CHECK_RESULT(CheckGlobalIndex(global_var, &ref_global));
+
+  if (ref_global.mutable_) {
+    result |= PrintError(
+        loc, "initializer expression cannot reference a mutable global");
+  }
+
+  result |= CheckType(loc, ref_global.type, Type::I32, "elem segment offset");
+  return result;
+}
+
+Result SharedValidator::OnElemSegmentInitExpr_Other(const Location& loc) {
+  return PrintError(loc,
+                    "invalid elem segment offset, must be a constant "
+                    "expression; either i32.const or "
+                    "global.get.");
+}
+
+Result SharedValidator::OnElemSegmentElemExpr_RefNull(const Location& loc) {
+  return Result::Ok;
+}
+
+Result SharedValidator::OnElemSegmentElemExpr_RefFunc(const Location& loc,
+                                                      Var func_var) {
+  Result result = Result::Ok;
+  CHECK_RESULT(CheckFuncIndex(func_var));
+  declared_funcs_.insert(func_var.index());
+  return result;
+}
+
+Result SharedValidator::OnElemSegmentElemExpr_Other(const Location& loc) {
+  return PrintError(loc,
+                    "invalid elem expression expression; must be either "
+                    "ref.null or ref.func.");
+}
+
+void SharedValidator::OnDataCount(Index count) {
+  data_segments_ = count;
+}
+
+Result SharedValidator::OnDataSegment(const Location& loc,
+                                      Var memory_var,
+                                      SegmentKind kind) {
+  Result result = Result::Ok;
+  if (kind == SegmentKind::Active) {
+    result |= CheckMemoryIndex(memory_var);
+  }
+  return result;
+}
+
+Result SharedValidator::OnDataSegmentInitExpr_Const(const Location& loc,
+                                                    Type type) {
+  return CheckType(loc, type, Type::I32, "data segment offset");
+}
+
+Result SharedValidator::OnDataSegmentInitExpr_GlobalGet(const Location& loc,
+                                                        Var global_var) {
+  Result result = Result::Ok;
+  GlobalType ref_global;
+  CHECK_RESULT(CheckGlobalIndex(global_var, &ref_global));
+
+  if (ref_global.mutable_) {
+    result |= PrintError(
+        loc, "initializer expression cannot reference a mutable global");
+  }
+
+  result |= CheckType(loc, ref_global.type, Type::I32, "data segment offset");
+  return result;
+}
+
+Result SharedValidator::OnDataSegmentInitExpr_Other(const Location& loc) {
+  return PrintError(loc,
+                    "invalid data segment offset, must be a constant "
+                    "expression; either i32.const or "
+                    "global.get.");
+}
+
+Result SharedValidator::CheckDeclaredFunc(Var func_var) {
+  if (declared_funcs_.count(func_var.index()) == 0) {
+    return PrintError(func_var.loc,
+                      "function is not declared in any elem sections");
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::EndModule() {
+  // Verify that any ref.func used in init expressions for globals are
+  // mentioned in an elems section.  This can't be done while process the
+  // globals because the global section comes before the elem section.
+  for (Var func_var : init_expr_funcs_) {
+    CHECK_RESULT(CheckDeclaredFunc(func_var));
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckIndex(Var var, Index max_index, const char* desc) {
+  if (var.index() >= max_index) {
+    return PrintError(
+        var.loc, "%s variable out of range: %" PRIindex " (max %" PRIindex ")",
+        desc, var.index(), max_index - 1);
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckLocalIndex(Var local_var, Type* out_type) {
+  auto iter = std::upper_bound(
+      locals_.begin(), locals_.end(), local_var.index(),
+      [](Index index, const LocalDecl& decl) { return index < decl.end; });
+  if (iter == locals_.end()) {
+    // TODO: better error
+    return PrintError(local_var.loc, "local variable out of range (max %u)",
+                      GetLocalCount());
+  }
+  *out_type = iter->type;
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckTypeIndex(Var sig_var) {
+  return CheckIndex(sig_var, types_.size(), "function type");
+}
+
+Result SharedValidator::CheckFuncIndex(Var func_var) {
+  return CheckIndex(func_var, funcs_.size(), "function");
+}
+
+Result SharedValidator::CheckMemoryIndex(Var memory_var) {
+  return CheckIndex(memory_var, memories_.size(), "memory");
+}
+
+// TODO: Remove; this is only used to match previous error output.
+Result SharedValidator::CheckMemoryIndex(Var memory_var, Opcode opcode) {
+  if (memory_var.index() >= memories_.size()) {
+    return PrintError(memory_var.loc,
+                      "%s requires an imported or defined memory.",
+                      opcode.GetName());
+  }
+  return Result::Ok;
+}
+
+// TODO: Remove; only used for Atomic operations, and they allow non-shared
+// memory now.
+Result SharedValidator::CheckSharedMemoryIndex(Var memory_var, Opcode opcode) {
+  CHECK_RESULT(CheckIndex(memory_var, memories_.size(), "memory"));
+  MemoryType& memory = memories_[memory_var.index()];
+  if (!memory.limits.is_shared) {
+    return PrintError(memory_var.loc, "%s requires memory to be shared.",
+                      opcode.GetName());
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckTableIndex(Var table_var) {
+  return CheckIndex(table_var, tables_.size(), "table");
+}
+
+// TODO: Remove; this is only used to match previous error output.
+Result SharedValidator::CheckTableIndex(Var table_var, Opcode opcode) {
+  if (table_var.index() >= tables_.size()) {
+    return PrintError(
+        table_var.loc,
+        "%s requires table %u to be an imported or defined table.",
+        opcode.GetName(), table_var.index());
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckGlobalIndex(Var global_var,
+                                         GlobalType* out_global_type) {
+  Result result = CheckIndex(global_var, globals_.size(), "global");
+  if (out_global_type) {
+    *out_global_type = Succeeded(result) ? globals_[global_var.index()]
+                                         : GlobalType{Type::Any, true};
+  }
+  return result;
+}
+
+Result SharedValidator::CheckEventIndex(Var event_var) {
+  return CheckIndex(event_var, events_.size(), "event");
+}
+
+Result SharedValidator::CheckElemSegmentIndex(Var elem_segment_var) {
+  return CheckIndex(elem_segment_var, elem_segments_, "elem_segment");
+}
+
+Result SharedValidator::CheckDataSegmentIndex(Var data_segment_var) {
+  return CheckIndex(data_segment_var, data_segments_, "data_segment");
+}
+
+Result SharedValidator::CheckBlockSignature(const Location& loc,
+                                            Opcode opcode,
+                                            Type sig_type,
+                                            TypeVector* out_param_types,
+                                            TypeVector* out_result_types) {
+  Result result = Result::Ok;
+
+  if (IsTypeIndex(sig_type)) {
+    Index sig_index = GetTypeIndex(sig_type);
+    if (Failed(CheckTypeIndex(Var(sig_index, loc)))) {
+      out_param_types->clear();
+      out_result_types->clear();
+      return Result::Error;
+    }
+    FuncType& func_type = types_[sig_index];
+
+    if (!func_type.params.empty() && !options_.features.multi_value_enabled()) {
+      result |= PrintError(loc, "%s params not currently supported.",
+                           opcode.GetName());
+    }
+    if (func_type.results.size() > 1 &&
+        !options_.features.multi_value_enabled()) {
+      result |= PrintError(loc, "multiple %s results not currently supported.",
+                           opcode.GetName());
+    }
+
+    *out_param_types = func_type.params;
+    *out_result_types = func_type.results;
+  } else {
+    out_param_types->clear();
+    *out_result_types = GetInlineTypeVector(sig_type);
+  }
+
+  return result;
+}
+
+Result SharedValidator::BeginFunctionBody(const Location& loc,
+                                          Index func_index) {
+  expr_loc_ = &loc;
+  locals_.clear();
+  if (func_index < funcs_.size()) {
+    for (Type type : funcs_[func_index].params) {
+      // TODO: Coalesce parameters of the same type?
+      locals_.push_back(LocalDecl{type, GetLocalCount() + 1});
+    }
+    return typechecker_.BeginFunction(funcs_[func_index].results);
+  } else {
+    // Signature isn't available, use empty.
+    return typechecker_.BeginFunction(TypeVector());
+  }
+}
+
+Result SharedValidator::EndFunctionBody(const Location& loc) {
+  // TODO: Use this location.
+#if 0
+  expr_loc_ = &loc;
+#endif
+  return typechecker_.EndFunction();
+}
+
+Result SharedValidator::OnLocalDecl(const Location& loc,
+                                    Index count,
+                                    Type type) {
+  const auto max_locals = std::numeric_limits<Index>::max();
+  if (count > max_locals - GetLocalCount()) {
+    PrintError(loc, "local count must be < 0x10000000");
+    return Result::Error;
+  }
+  locals_.push_back(LocalDecl{type, GetLocalCount() + count});
+  return Result::Ok;
+}
+
+Index SharedValidator::GetLocalCount() const {
+  return locals_.empty() ? 0 : locals_.back().end;
+}
+
+static bool is_power_of_two(uint32_t x) {
+  return x && ((x & (x - 1)) == 0);
+}
+
+Result SharedValidator::CheckAlign(const Location& loc,
+                                   Address alignment,
+                                   Address natural_alignment) {
+  if (!is_power_of_two(alignment)) {
+    PrintError(loc, "alignment (%u) must be a power of 2", alignment);
+    return Result::Error;
+  }
+  if (alignment > natural_alignment) {
+    PrintError(loc, "alignment must not be larger than natural alignment (%u)",
+               natural_alignment);
+    return Result::Error;
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::CheckAtomicAlign(const Location& loc,
+                                         Address alignment,
+                                         Address natural_alignment) {
+  if (!is_power_of_two(alignment)) {
+    PrintError(loc, "alignment (%u) must be a power of 2", alignment);
+    return Result::Error;
+  }
+  if (alignment != natural_alignment) {
+    PrintError(loc, "alignment must be equal to natural alignment (%u)",
+               natural_alignment);
+    return Result::Error;
+  }
+  return Result::Ok;
+}
+
+Result SharedValidator::OnAtomicLoad(const Location& loc,
+                                     Opcode opcode,
+                                     Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckSharedMemoryIndex(Var(0, loc), opcode);
+  result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnAtomicLoad(opcode);
+  return result;
+}
+
+Result SharedValidator::OnAtomicNotify(const Location& loc,
+                                       Opcode opcode,
+                                       Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckSharedMemoryIndex(Var(0, loc), opcode);
+  result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnAtomicNotify(opcode);
+  return result;
+}
+
+Result SharedValidator::OnAtomicRmwCmpxchg(const Location& loc,
+                                           Opcode opcode,
+                                           Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckSharedMemoryIndex(Var(0, loc), opcode);
+  result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnAtomicRmwCmpxchg(opcode);
+  return result;
+}
+
+Result SharedValidator::OnAtomicRmw(const Location& loc,
+                                    Opcode opcode,
+                                    Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckSharedMemoryIndex(Var(0, loc), opcode);
+  result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnAtomicRmw(opcode);
+  return result;
+}
+
+Result SharedValidator::OnAtomicStore(const Location& loc,
+                                      Opcode opcode,
+                                      Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckSharedMemoryIndex(Var(0, loc), opcode);
+  result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnAtomicStore(opcode);
+  return result;
+}
+
+Result SharedValidator::OnAtomicWait(const Location& loc,
+                                     Opcode opcode,
+                                     Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckSharedMemoryIndex(Var(0, loc), opcode);
+  result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnAtomicWait(opcode);
+  return result;
+}
+
+Result SharedValidator::OnBinary(const Location& loc, Opcode opcode) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnBinary(opcode);
+  return result;
+}
+
+Result SharedValidator::OnBlock(const Location& loc, Type sig_type) {
+  Result result = Result::Ok;
+  TypeVector param_types, result_types;
+  expr_loc_ = &loc;
+  result |= CheckBlockSignature(loc, Opcode::Block, sig_type, &param_types,
+                                &result_types);
+  result |= typechecker_.OnBlock(param_types, result_types);
+  return result;
+}
+
+Result SharedValidator::OnBr(const Location& loc, Var depth) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnBr(depth.index());
+  return result;
+}
+
+Result SharedValidator::OnBrIf(const Location& loc, Var depth) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnBrIf(depth.index());
+  return result;
+}
+
+Result SharedValidator::OnBrOnExn(const Location& loc,
+                                  Var depth,
+                                  Var event_var) {
+  Result result = Result::Ok;
+  result |= CheckEventIndex(event_var);
+  EventType& event_type = events_[event_var.index()];
+  expr_loc_ = &loc;
+  result |= typechecker_.OnBrOnExn(depth.index(), event_type.params);
+  return result;
+}
+
+Result SharedValidator::BeginBrTable(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.BeginBrTable();
+  return result;
+}
+
+Result SharedValidator::OnBrTableTarget(const Location& loc, Var depth) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnBrTableTarget(depth.index());
+  return result;
+}
+
+Result SharedValidator::EndBrTable(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.EndBrTable();
+  return result;
+}
+
+Result SharedValidator::OnCall(const Location& loc, Var func_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckFuncIndex(func_var);
+  FuncType& func_type = funcs_[func_var.index()];
+  result |= typechecker_.OnCall(func_type.params, func_type.results);
+  return result;
+}
+
+Result SharedValidator::OnCallIndirect(const Location& loc,
+                                       Var sig_var,
+                                       Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckTypeIndex(sig_var);
+  result |= CheckTableIndex(table_var);
+  FuncType& func_type = types_[sig_var.index()];
+  result |= typechecker_.OnCallIndirect(func_type.params, func_type.results);
+  return result;
+}
+
+Result SharedValidator::OnCatch(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnCatch();
+  return result;
+}
+
+Result SharedValidator::OnCompare(const Location& loc, Opcode opcode) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnCompare(opcode);
+  return result;
+}
+
+Result SharedValidator::OnConst(const Location& loc, Type type) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnConst(type);
+  return result;
+}
+
+Result SharedValidator::OnConvert(const Location& loc, Opcode opcode) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnConvert(opcode);
+  return result;
+}
+
+Result SharedValidator::OnDataDrop(const Location& loc, Var segment_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  // TODO: Remove, data.drop doesn't require a memory.
+#if 1
+  result |= CheckMemoryIndex(Var(0, loc), Opcode::DataDrop);
+#endif
+  result |= CheckDataSegmentIndex(segment_var);
+  result |= typechecker_.OnDataDrop(segment_var.index());
+  return result;
+}
+
+Result SharedValidator::OnDrop(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnDrop();
+  return result;
+}
+
+Result SharedValidator::OnElemDrop(const Location& loc, Var segment_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  // TODO: Remove, elem.drop doesn't require a table.
+#if 1
+  result |= CheckTableIndex(Var(0, loc), Opcode::ElemDrop);
+#endif
+  result |= CheckElemSegmentIndex(segment_var);
+  result |= typechecker_.OnElemDrop(segment_var.index());
+  return result;
+}
+
+Result SharedValidator::OnElse(const Location& loc) {
+  Result result = Result::Ok;
+  // TODO: Re-enable; this is only used to match previous error output.
+#if 0
+  expr_loc_ = &loc;
+#endif
+  result |= typechecker_.OnElse();
+  return result;
+}
+
+Result SharedValidator::OnEnd(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnEnd();
+  return result;
+}
+
+Result SharedValidator::OnGlobalGet(const Location& loc, Var global_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  GlobalType global_type;
+  result |= CheckGlobalIndex(global_var, &global_type);
+  result |= typechecker_.OnGlobalGet(global_type.type);
+  return result;
+}
+
+Result SharedValidator::OnGlobalSet(const Location& loc, Var global_var) {
+  Result result = Result::Ok;
+  GlobalType global_type;
+  result |= CheckGlobalIndex(global_var, &global_type);
+  if (!global_type.mutable_) {
+    result |= PrintError(
+        loc, "can't global.set on immutable global at index %" PRIindex ".",
+        global_var.index());
+  }
+  expr_loc_ = &loc;
+  result |= typechecker_.OnGlobalSet(global_type.type);
+  return result;
+}
+
+Result SharedValidator::OnIf(const Location& loc, Type sig_type) {
+  Result result = Result::Ok;
+  TypeVector param_types, result_types;
+  expr_loc_ = &loc;
+  result |= CheckBlockSignature(loc, Opcode::If, sig_type, &param_types,
+                                &result_types);
+  result |= typechecker_.OnIf(param_types, result_types);
+  return result;
+}
+
+Result SharedValidator::OnLoad(const Location& loc,
+                               Opcode opcode,
+                               Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc));
+  result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnLoad(opcode);
+  return result;
+}
+
+Result SharedValidator::OnLoadSplat(const Location& loc,
+                                    Opcode opcode,
+                                    Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc));
+  result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnLoad(opcode);
+  return result;
+}
+
+Result SharedValidator::OnLocalGet(const Location& loc, Var local_var) {
+  Result result = Result::Ok;
+  Type type = Type::Any;
+  expr_loc_ = &loc;
+  result |= CheckLocalIndex(local_var, &type);
+  result |= typechecker_.OnLocalGet(type);
+  return result;
+}
+
+Result SharedValidator::OnLocalSet(const Location& loc, Var local_var) {
+  Result result = Result::Ok;
+  Type type = Type::Any;
+  expr_loc_ = &loc;
+  result |= CheckLocalIndex(local_var, &type);
+  result |= typechecker_.OnLocalSet(type);
+  return result;
+}
+
+Result SharedValidator::OnLocalTee(const Location& loc, Var local_var) {
+  Result result = Result::Ok;
+  Type type = Type::Any;
+  expr_loc_ = &loc;
+  result |= CheckLocalIndex(local_var, &type);
+  result |= typechecker_.OnLocalTee(type);
+  return result;
+}
+
+Result SharedValidator::OnLoop(const Location& loc, Type sig_type) {
+  Result result = Result::Ok;
+  TypeVector param_types, result_types;
+  expr_loc_ = &loc;
+  result |= CheckBlockSignature(loc, Opcode::Loop, sig_type, &param_types,
+                                &result_types);
+  result |= typechecker_.OnLoop(param_types, result_types);
+  return result;
+}
+
+Result SharedValidator::OnMemoryCopy(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc), Opcode::MemoryCopy);
+  result |= typechecker_.OnMemoryCopy();
+  return result;
+}
+
+Result SharedValidator::OnMemoryFill(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc), Opcode::MemoryFill);
+  result |= typechecker_.OnMemoryFill();
+  return result;
+}
+
+Result SharedValidator::OnMemoryGrow(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc));
+  result |= typechecker_.OnMemoryGrow();
+  return result;
+}
+
+Result SharedValidator::OnMemoryInit(const Location& loc, Var segment_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc), Opcode::MemoryInit);
+  result |= CheckDataSegmentIndex(segment_var);
+  result |= typechecker_.OnMemoryInit(segment_var.index());
+  return result;
+}
+
+Result SharedValidator::OnMemorySize(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc));
+  result |= typechecker_.OnMemorySize();
+  return result;
+}
+
+Result SharedValidator::OnNop(const Location& loc) {
+  expr_loc_ = &loc;
+  return Result::Ok;
+}
+
+Result SharedValidator::OnRefFunc(const Location& loc, Var func_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckDeclaredFunc(func_var);
+  result |= typechecker_.OnRefFuncExpr(func_var.index());
+  return result;
+}
+
+Result SharedValidator::OnRefIsNull(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnRefIsNullExpr();
+  return result;
+}
+
+Result SharedValidator::OnRefNull(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnRefNullExpr();
+  return result;
+}
+
+Result SharedValidator::OnRethrow(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnRethrow();
+  return result;
+}
+
+Result SharedValidator::OnReturnCall(const Location& loc, Var func_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  FuncType& func_type = funcs_[func_var.index()];
+  result |= typechecker_.OnReturnCall(func_type.params, func_type.results);
+  return result;
+}
+
+Result SharedValidator::OnReturnCallIndirect(const Location& loc,
+                                             Var sig_var,
+                                             Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckTableIndex(table_var, Opcode::ReturnCallIndirect);
+  FuncType& func_type = types_[sig_var.index()];
+  result |=
+      typechecker_.OnReturnCallIndirect(func_type.params, func_type.results);
+  return result;
+}
+
+Result SharedValidator::OnReturn(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnReturn();
+  return result;
+}
+
+Result SharedValidator::OnSelect(const Location& loc, Type result_type) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnSelect(result_type);
+  return result;
+}
+
+Result SharedValidator::OnSimdLaneOp(const Location& loc,
+                                     Opcode opcode,
+                                     uint64_t value) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnSimdLaneOp(opcode, value);
+  return result;
+}
+
+Result SharedValidator::OnSimdShuffleOp(const Location& loc,
+                                        Opcode opcode,
+                                        v128 value) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnSimdShuffleOp(opcode, value);
+  return result;
+}
+
+Result SharedValidator::OnStore(const Location& loc,
+                                Opcode opcode,
+                                Address alignment) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckMemoryIndex(Var(0, loc));
+  result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
+  result |= typechecker_.OnStore(opcode);
+  return result;
+}
+
+Result SharedValidator::OnTableCopy(const Location& loc,
+                                    Var dst_var,
+                                    Var src_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= CheckTableIndex(dst_var, Opcode::TableCopy);
+  // TODO: Re-enable; this is only used to match previous error output.
+#if 0
+  result |= CheckTableIndex(src_var, Opcode::TableCopy);
+#endif
+  result |= typechecker_.OnTableCopy();
+  return result;
+}
+
+Result SharedValidator::OnTableFill(const Location& loc, Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  TableType& table_type = tables_[table_var.index()];
+  result |= typechecker_.OnTableFill(table_type.element);
+  return result;
+}
+
+Result SharedValidator::OnTableGet(const Location& loc, Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  TableType& table_type = tables_[table_var.index()];
+  result |= typechecker_.OnTableGet(table_type.element);
+  return result;
+}
+
+Result SharedValidator::OnTableGrow(const Location& loc, Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  TableType& table_type = tables_[table_var.index()];
+  result |= typechecker_.OnTableGrow(table_type.element);
+  return result;
+}
+
+Result SharedValidator::OnTableInit(const Location& loc,
+                                    Var segment_var,
+                                    Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  // TODO: Re-order, and change CHECK_RESULT to result |= ; this is only used
+  // to match previous error output.
+  result |= typechecker_.OnTableInit(table_var.index(), segment_var.index());
+  CHECK_RESULT(CheckTableIndex(table_var, Opcode::TableInit));
+  result |= CheckElemSegmentIndex(segment_var);
+  return result;
+}
+
+Result SharedValidator::OnTableSet(const Location& loc, Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  TableType& table_type = tables_[table_var.index()];
+  result |= typechecker_.OnTableSet(table_type.element);
+  return result;
+}
+
+Result SharedValidator::OnTableSize(const Location& loc, Var table_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnTableSize();
+  return result;
+}
+
+Result SharedValidator::OnTernary(const Location& loc, Opcode opcode) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnTernary(opcode);
+  return result;
+}
+
+Result SharedValidator::OnThrow(const Location& loc, Var event_var) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  EventType& event_type = events_[event_var.index()];
+  result |= typechecker_.OnThrow(event_type.params);
+  return result;
+}
+
+Result SharedValidator::OnTry(const Location& loc, Type sig_type) {
+  Result result = Result::Ok;
+  TypeVector param_types, result_types;
+  expr_loc_ = &loc;
+  result |= CheckBlockSignature(loc, Opcode::Try, sig_type, &param_types,
+                                &result_types);
+  result |= typechecker_.OnTry(param_types, result_types);
+  return result;
+}
+
+Result SharedValidator::OnUnary(const Location& loc, Opcode opcode) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnUnary(opcode);
+  return result;
+}
+
+Result SharedValidator::OnUnreachable(const Location& loc) {
+  Result result = Result::Ok;
+  expr_loc_ = &loc;
+  result |= typechecker_.OnUnreachable();
+  return result;
+}
+
+}  // namespace wabt

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_SHARED_VALIDATOR_H_
+#define WABT_SHARED_VALIDATOR_H_
+
+#include <set>
+#include <string>
+#include <vector>
+
+#include "src/common.h"
+#include "src/error.h"
+#include "src/feature.h"
+#include "src/ir.h"
+#include "src/opcode.h"
+#include "src/type-checker.h"
+
+namespace wabt {
+
+struct ValidateOptions {
+  ValidateOptions() = default;
+  ValidateOptions(const Features& features) : features(features) {}
+
+  Features features;
+};
+
+class SharedValidator {
+ public:
+  WABT_DISALLOW_COPY_AND_ASSIGN(SharedValidator);
+  SharedValidator(Errors*, const ValidateOptions& options);
+
+  // TODO: Move into SharedValidator?
+  using Label = TypeChecker::Label;
+  size_t type_stack_size() const { return typechecker_.type_stack_size(); }
+  Result GetLabel(Index depth, Label** out_label) {
+    return typechecker_.GetLabel(depth, out_label);
+  }
+
+  Result WABT_PRINTF_FORMAT(3, 4)
+      PrintError(const Location& loc, const char* fmt, ...);
+
+  void OnTypecheckerError(const char* msg);
+
+  Index GetLocalCount() const;
+
+  Result EndModule();
+
+  Result OnType(const Location&,
+                Index param_count,
+                const Type* param_types,
+                Index result_count,
+                const Type* result_types);
+
+  Result OnFunction(const Location&, Var sig_var);
+  Result OnTable(const Location&, Type elem_type, const Limits&);
+  Result OnMemory(const Location&, const Limits&);
+  Result OnGlobalImport(const Location&, Type type, bool mutable_);
+  Result OnGlobal(const Location&, Type type, bool mutable_);
+  Result OnGlobalInitExpr_Const(const Location&, Type);
+  Result OnGlobalInitExpr_GlobalGet(const Location&, Var global_var);
+  Result OnGlobalInitExpr_RefNull(const Location&);
+  Result OnGlobalInitExpr_RefFunc(const Location&, Var func_var);
+  Result OnGlobalInitExpr_Other(const Location&);
+  Result OnGlobalInitExpr_None(const Location&);
+  Result OnEvent(const Location&, Var sig_var);
+
+  Result OnExport(const Location&,
+                  ExternalKind,
+                  Var item_var,
+                  string_view name);
+
+  Result OnStart(const Location&, Var func_var);
+
+  Result OnElemSegment(const Location&, Var table_var, SegmentKind, Type elem_type);
+  Result OnElemSegmentInitExpr_Const(const Location&, Type);
+  Result OnElemSegmentInitExpr_GlobalGet(const Location&, Var global_var);
+  Result OnElemSegmentInitExpr_Other(const Location&);
+  Result OnElemSegmentElemExpr_RefNull(const Location&);
+  Result OnElemSegmentElemExpr_RefFunc(const Location&, Var func_var);
+  Result OnElemSegmentElemExpr_Other(const Location&);
+
+  void OnDataCount(Index count);
+
+  Result OnDataSegment(const Location&, Var memory_var, SegmentKind);
+  Result OnDataSegmentInitExpr_Const(const Location&, Type);
+  Result OnDataSegmentInitExpr_GlobalGet(const Location&, Var global_var);
+  Result OnDataSegmentInitExpr_Other(const Location&);
+
+  Result BeginFunctionBody(const Location&, Index func_index);
+  Result EndFunctionBody(const Location&);
+  Result OnLocalDecl(const Location&, Index count, Type type);
+
+  Result OnAtomicLoad(const Location&, Opcode, Address align);
+  Result OnAtomicNotify(const Location&, Opcode, Address align);
+  Result OnAtomicRmwCmpxchg(const Location&, Opcode, Address align);
+  Result OnAtomicRmw(const Location&, Opcode, Address align);
+  Result OnAtomicStore(const Location&, Opcode, Address align);
+  Result OnAtomicWait(const Location&, Opcode, Address align);
+  Result OnBinary(const Location&, Opcode);
+  Result OnBlock(const Location&, Type sig_type);
+  Result OnBr(const Location&, Var depth);
+  Result OnBrIf(const Location&, Var depth);
+  Result OnBrOnExn(const Location&, Var depth, Var event_index);
+  Result BeginBrTable(const Location&);
+  Result OnBrTableTarget(const Location&, Var depth);
+  Result EndBrTable(const Location&);
+  Result OnCall(const Location&, Var func_var);
+  Result OnCallIndirect(const Location&, Var sig_var, Var table_var);
+  Result OnCatch(const Location&);
+  Result OnCompare(const Location&, Opcode);
+  Result OnConst(const Location&, Type);
+  Result OnConvert(const Location&, Opcode);
+  Result OnDataDrop(const Location&, Var segment_var);
+  Result OnDrop(const Location&);
+  Result OnElemDrop(const Location&, Var segment_var);
+  Result OnElse(const Location&);
+  Result OnEnd(const Location&);
+  Result OnGlobalGet(const Location&, Var);
+  Result OnGlobalSet(const Location&, Var);
+  Result OnIf(const Location&, Type sig_type);
+  Result OnLoad(const Location&, Opcode, Address align);
+  Result OnLoadSplat(const Location&, Opcode, Address align);
+  Result OnLocalGet(const Location&, Var);
+  Result OnLocalSet(const Location&, Var);
+  Result OnLocalTee(const Location&, Var);
+  Result OnLoop(const Location&, Type sig_type);
+  Result OnMemoryCopy(const Location&);
+  Result OnMemoryFill(const Location&);
+  Result OnMemoryGrow(const Location&);
+  Result OnMemoryInit(const Location&, Var segment_var);
+  Result OnMemorySize(const Location&);
+  Result OnNop(const Location&);
+  Result OnRefFunc(const Location&, Var func_var);
+  Result OnRefIsNull(const Location&);
+  Result OnRefNull(const Location&);
+  Result OnRethrow(const Location&);
+  Result OnReturnCall(const Location&, Var func_var);
+  Result OnReturnCallIndirect(const Location&, Var sig_var, Var table_var);
+  Result OnReturn(const Location&);
+  Result OnSelect(const Location&, Type result_type);
+  Result OnSimdLaneOp(const Location&, Opcode, uint64_t lane_idx);
+  Result OnSimdShuffleOp(const Location&, Opcode, v128 lane_idx);
+  Result OnStore(const Location&, Opcode, Address align);
+  Result OnTableCopy(const Location&, Var dst_var, Var src_var);
+  Result OnTableFill(const Location&, Var table_var);
+  Result OnTableGet(const Location&, Var table_var);
+  Result OnTableGrow(const Location&, Var table_var);
+  Result OnTableInit(const Location&, Var segment_var, Var table_var);
+  Result OnTableSet(const Location&, Var table_var);
+  Result OnTableSize(const Location&, Var table_var);
+  Result OnTernary(const Location&, Opcode);
+  Result OnThrow(const Location&, Var event_var);
+  Result OnTry(const Location&, Type sig_type);
+  Result OnUnary(const Location&, Opcode);
+  Result OnUnreachable(const Location&);
+
+ private:
+  struct FuncType {
+    TypeVector params;
+    TypeVector results;
+  };
+
+  struct TableType {
+    Type element;
+    Limits limits;
+  };
+
+  struct MemoryType {
+    Limits limits;
+  };
+
+  struct GlobalType {
+    Type type;
+    bool mutable_;
+  };
+
+  struct EventType {
+    TypeVector params;
+  };
+
+  struct LocalDecl {
+    Type type;
+    Index end;
+  };
+
+  Result CheckType(const Location&,
+                   Type actual,
+                   Type expected,
+                   const char* desc);
+  Result CheckLimits(const Location&,
+                     const Limits&,
+                     uint64_t absolute_max,
+                     const char* desc);
+
+  Result CheckLocalIndex(Var local_var, Type* out_type);
+
+  Result CheckDeclaredFunc(Var func_var);
+
+  Result CheckIndex(Var var, Index max_index, const char* desc);
+  Result CheckTypeIndex(Var sig_var);
+  Result CheckFuncIndex(Var func_var);
+  Result CheckTableIndex(Var table_var);
+  Result CheckTableIndex(Var table_var, Opcode);
+  Result CheckMemoryIndex(Var memory_var);
+  Result CheckMemoryIndex(Var memory_var, Opcode);
+  Result CheckSharedMemoryIndex(Var memory_var, Opcode);
+  Result CheckGlobalIndex(Var global_var, GlobalType* out);
+  Result CheckEventIndex(Var event_var);
+  Result CheckElemSegmentIndex(Var elem_segment_var);
+  Result CheckDataSegmentIndex(Var data_segment_var);
+
+  Result CheckAlign(const Location&, Address align, Address natural_align);
+  Result CheckAtomicAlign(const Location&, Address align, Address natural_align);
+
+  Result CheckBlockSignature(const Location&,
+                             Opcode,
+                             Type sig_type,
+                             TypeVector* out_param_types,
+                             TypeVector* out_result_types);
+
+  TypeVector ToTypeVector(Index count, const Type* types);
+
+  ValidateOptions options_;
+  Errors* errors_;
+  TypeChecker typechecker_;  // TODO: Move into SharedValidator.
+  // Cached for access by OnTypecheckerError.
+  const Location* expr_loc_ = nullptr;
+
+  std::vector<FuncType> types_;
+  std::vector<FuncType> funcs_;       // Includes imported and defined.
+  std::vector<TableType> tables_;     // Includes imported and defined.
+  std::vector<MemoryType> memories_;  // Includes imported and defined.
+  std::vector<GlobalType> globals_;   // Includes imported and defined.
+  std::vector<EventType> events_;     // Includes imported and defined.
+  Index starts_ = 0;
+  Index num_imported_globals_ = 0;
+  Index elem_segments_ = 0;
+  Index data_segments_ = 0;
+
+  // Includes parameters, since this is only used for validating
+  // local.{get,set,tee} instructions.
+  std::vector<LocalDecl> locals_;
+
+  std::set<std::string> export_names_;  // Used to check for duplicates.
+  std::set<Index> declared_funcs_;      // TODO: optimize?
+  std::vector<Var> init_expr_funcs_;
+};
+
+}  // namespace wabt
+
+#endif  // WABT_SHARED_VALIDATOR_H_

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -768,11 +768,12 @@ Result TypeChecker::OnTernary(Opcode opcode) {
 }
 
 Result TypeChecker::OnSimdLaneOp(Opcode opcode, uint64_t lane_idx) {
-  Result result = Result::Error;
+  Result result = Result::Ok;
   uint32_t lane_count = opcode.GetSimdLaneCount();
   if (lane_idx >= lane_count) {
     PrintError("lane index must be less than %d (got %" PRIu64 ")", lane_count,
                lane_idx);
+    result = Result::Error;
   }
 
   switch (opcode) {
@@ -784,7 +785,7 @@ Result TypeChecker::OnSimdLaneOp(Opcode opcode, uint64_t lane_idx) {
     case Opcode::F32X4ExtractLane:
     case Opcode::I64X2ExtractLane:
     case Opcode::F64X2ExtractLane:
-      result = CheckOpcode1(opcode);
+      result |= CheckOpcode1(opcode);
       break;
     case Opcode::I8X16ReplaceLane:
     case Opcode::I16X8ReplaceLane:
@@ -792,7 +793,7 @@ Result TypeChecker::OnSimdLaneOp(Opcode opcode, uint64_t lane_idx) {
     case Opcode::F32X4ReplaceLane:
     case Opcode::I64X2ReplaceLane:
     case Opcode::F64X2ReplaceLane:
-      result = CheckOpcode2(opcode);
+      result |= CheckOpcode2(opcode);
       break;
     default:
       WABT_UNREACHABLE;
@@ -801,16 +802,17 @@ Result TypeChecker::OnSimdLaneOp(Opcode opcode, uint64_t lane_idx) {
 }
 
 Result TypeChecker::OnSimdShuffleOp(Opcode opcode, v128 lane_idx) {
-  Result result = Result::Error;
+  Result result = Result::Ok;
   uint8_t simd_data[16];
   memcpy(simd_data, &lane_idx, 16);
   for (int i = 0; i < 16; i++) {
     if (simd_data[i] >= 32) {
       PrintError("lane index must be less than 32 (got %d)", simd_data[i]);
+      result = Result::Error;
     }
   }
 
-  result = CheckOpcode2(opcode);
+  result |= CheckOpcode2(opcode);
   return result;
 }
 

--- a/src/validator.h
+++ b/src/validator.h
@@ -19,18 +19,12 @@
 
 #include "src/error.h"
 #include "src/feature.h"
+#include "src/shared-validator.h"
 
 namespace wabt {
 
 struct Module;
 struct Script;
-
-struct ValidateOptions {
-  ValidateOptions() = default;
-  ValidateOptions(const Features& features) : features(features) {}
-
-  Features features;
-};
 
 // Perform all checks on the script. It is valid if and only if this function
 // succeeds.
@@ -39,4 +33,4 @@ Result ValidateModule(const Module*, Errors*, const ValidateOptions&);
 
 }  // namespace wabt
 
-#endif /* WABT_VALIDATOR_H_ */
+#endif // WABT_VALIDATOR_H_

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1695,7 +1695,7 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
     case TokenType::CallIndirect: {
       Consume();
       auto expr = MakeUnique<CallIndirectExpr>(loc);
-      ParseVarOpt(&expr->table, Var(0));
+      ParseVarOpt(&expr->table, Var(0, loc));
       CHECK_RESULT(ParseTypeUseOpt(&expr->decl));
       CHECK_RESULT(ParseUnboundFuncSignature(&expr->decl.sig));
       *out_expr = std::move(expr);
@@ -1712,7 +1712,7 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       auto expr = MakeUnique<ReturnCallIndirectExpr>(loc);
       CHECK_RESULT(ParseTypeUseOpt(&expr->decl));
       CHECK_RESULT(ParseUnboundFuncSignature(&expr->decl.sig));
-      ParseVarOpt(&expr->table, Var(0));
+      ParseVarOpt(&expr->table, Var(0, loc));
       *out_expr = std::move(expr);
       break;
     }
@@ -1816,8 +1816,8 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
 
     case TokenType::TableCopy: {
       ErrorUnlessOpcodeEnabled(Consume());
-      Var dst(0);
-      Var src(0);
+      Var dst(0, loc);
+      Var src(0, loc);
       if (options_->features.reference_types_enabled()) {
       // TODO: disabled for now, since the spec tests don't currently use.
 #if 0
@@ -1836,9 +1836,9 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
 
     case TokenType::TableInit: {
       ErrorUnlessOpcodeEnabled(Consume());
-      Var segment_index(0);
+      Var segment_index(0, loc);
       CHECK_RESULT(ParseVar(&segment_index));
-      Var table_index(0);
+      Var table_index(0, loc);
       out_expr->reset(new TableInitExpr(segment_index, table_index, loc));
       break;
     }

--- a/test/parse/func/bad-result-multi.txt
+++ b/test/parse/func/bad-result-multi.txt
@@ -1,8 +1,10 @@
 ;;; TOOL: wat2wasm
 ;;; ERROR: 1
-(module (func (result i32 i64)))
+(module (func (result i32 i64)
+  i32.const 0
+  i64.const 0))
 (;; STDERR ;;;
 out/test/parse/func/bad-result-multi.txt:3:10: error: multiple result values not currently supported.
-(module (func (result i32 i64)))
+(module (func (result i32 i64)
          ^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-26.txt
+++ b/test/regress/regress-26.txt
@@ -14,6 +14,6 @@ section(ELEM) {
   addr[end]
 }
 (;; STDERR ;;;
-error: type mismatch in elem segment initializer expression, expected i32 but got void
+error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
 0000013: error: EndElemSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-27.txt
+++ b/test/regress/regress-27.txt
@@ -14,6 +14,6 @@ section(DATA) {
   data[str("test")]
 }
 (;; STDERR ;;;
-error: type mismatch in data segment initializer expression, expected i32 but got void
+error: invalid data segment offset, must be a constant expression; either i32.const or global.get.
 0000012: error: EndDataSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/spec/bulk-memory-operations/imports.txt
+++ b/test/spec/bulk-memory-operations/imports.txt
@@ -85,7 +85,8 @@ out/test/spec/bulk-memory-operations/imports.wast:302: assert_trap passed: unini
 out/test/spec/bulk-memory-operations/imports.wast:305: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/imports.wast:306: assert_trap passed: undefined table index
 out/test/spec/bulk-memory-operations/imports.wast:310: assert_invalid passed:
-  0000017: error: table count (2) must be 0 or 1
+  error: only one table allowed
+  0000017: error: OnImportTable callback failed
 out/test/spec/bulk-memory-operations/imports.wast:314: assert_invalid passed:
   0000014: error: table count (2) must be 0 or 1
 out/test/spec/bulk-memory-operations/imports.wast:318: assert_invalid passed:
@@ -113,7 +114,8 @@ out/test/spec/bulk-memory-operations/imports.wast:373: assert_unlinkable passed:
 out/test/spec/bulk-memory-operations/imports.wast:391: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/bulk-memory-operations/imports.wast:402: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/bulk-memory-operations/imports.wast:405: assert_invalid passed:
-  0000015: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000015: error: OnImportMemory callback failed
 out/test/spec/bulk-memory-operations/imports.wast:409: assert_invalid passed:
   0000013: error: memory count (2) must be 0 or 1
 out/test/spec/bulk-memory-operations/imports.wast:413: assert_invalid passed:

--- a/test/spec/bulk-memory-operations/memory_init.txt
+++ b/test/spec/bulk-memory-operations/memory_init.txt
@@ -9,7 +9,7 @@ test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:189: assert_invalid passed:
   0000023: error: data.drop requires data count section
 out/test/spec/bulk-memory-operations/memory_init.wast:195: assert_invalid passed:
-  error: invalid data_segment_index: 4 (max 1)
+  0000000: error: data_segment variable out of range: 4 (max 0)
   000002c: error: OnDataDropExpr callback failed
 test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
@@ -17,7 +17,7 @@ out/test/spec/bulk-memory-operations/memory_init.wast:223: assert_trap passed: o
 out/test/spec/bulk-memory-operations/memory_init.wast:226: assert_invalid passed:
   000002a: error: memory.init requires data count section
 out/test/spec/bulk-memory-operations/memory_init.wast:232: assert_invalid passed:
-  error: invalid data_segment_index: 1 (max 1)
+  0000000: error: data_segment variable out of range: 1 (max 0)
   0000034: error: OnMemoryInitExpr callback failed
 test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:252: assert_trap passed: out of bounds memory access: memory.init out of bounds

--- a/test/spec/bulk-memory-operations/table_init.txt
+++ b/test/spec/bulk-memory-operations/table_init.txt
@@ -56,10 +56,11 @@ out/test/spec/bulk-memory-operations/table_init.wast:189: assert_trap passed: un
 out/test/spec/bulk-memory-operations/table_init.wast:190: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:191: assert_trap passed: uninitialized table element
 out/test/spec/bulk-memory-operations/table_init.wast:193: assert_invalid passed:
-  error: invalid elem_segment_index: 0 (max 0)
+  error: elem.drop requires table 0 to be an imported or defined table.
+  0000000: error: elem_segment variable out of range: 0 (max 4294967295)
   0000024: error: OnElemDropExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:199: assert_invalid passed:
-  error: found table.init operator, but no table
+  0000000: error: table.init requires table 0 to be an imported or defined table.
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:205: assert_invalid passed:
   0000024: error: elem section without table section

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -80,7 +80,7 @@ out/test/spec/call_indirect.wast:701: assert_malformed passed:
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
 out/test/spec/call_indirect.wast:716: assert_invalid passed:
-  error: found call_indirect operator, but no table
+  0000000: error: table variable out of range: 0 (max 4294967295)
   000001c: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:724: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
@@ -141,7 +141,7 @@ out/test/spec/call_indirect.wast:922: assert_invalid passed:
 out/test/spec/call_indirect.wast:929: assert_invalid passed:
   0000025: error: invalid call_indirect signature index
 out/test/spec/call_indirect.wast:940: assert_invalid passed:
-  error: invalid func_index: 0 (max 0)
+  0000000: error: function variable out of range: 0 (max 4294967295)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed
 151/151 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/globals.txt
+++ b/test/spec/globals.txt
@@ -16,19 +16,19 @@ out/test/spec/globals.wast:267: assert_invalid passed:
 out/test/spec/globals.wast:272: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/globals.wast:277: assert_invalid passed:
-  error: type mismatch in global, expected i32 but got f32.
+  error: type mismatch at global initializer expression. got f32, expected i32
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/globals.wast:282: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
 out/test/spec/globals.wast:287: assert_invalid passed:
-  error: type mismatch in global, expected i32 but got void.
+  error: invalid global initializer expression, must be a constant expression; either *.const or global.get.
   000000e: error: EndGlobalInitExpr callback failed
 out/test/spec/globals.wast:292: assert_invalid passed:
-  error: initializer expression can only reference an imported global
-  000000f: error: OnInitExprGlobalGetExpr callback failed
+  0000000: error: initializer expression can only reference an imported global
+  0000010: error: EndGlobalInitExpr callback failed
 out/test/spec/globals.wast:297: assert_invalid passed:
-  error: initializer expression can only reference an imported global
-  000000f: error: OnInitExprGlobalGetExpr callback failed
+  0000000: error: global variable out of range: 1 (max 0)
+  0000010: error: EndGlobalInitExpr callback failed
 out/test/spec/globals.wast:305: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
 out/test/spec/globals.wast:318: assert_malformed passed:

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -84,7 +84,8 @@ out/test/spec/imports.wast:302: assert_trap passed: uninitialized table element
 out/test/spec/imports.wast:305: assert_trap passed: uninitialized table element
 out/test/spec/imports.wast:306: assert_trap passed: undefined table index
 out/test/spec/imports.wast:310: assert_invalid passed:
-  0000017: error: table count (2) must be 0 or 1
+  error: only one table allowed
+  0000017: error: OnImportTable callback failed
 out/test/spec/imports.wast:314: assert_invalid passed:
   0000014: error: table count (2) must be 0 or 1
 out/test/spec/imports.wast:318: assert_invalid passed:
@@ -112,7 +113,8 @@ out/test/spec/imports.wast:373: assert_unlinkable passed:
 out/test/spec/imports.wast:391: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/imports.wast:402: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/imports.wast:405: assert_invalid passed:
-  0000015: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000015: error: OnImportMemory callback failed
 out/test/spec/imports.wast:409: assert_invalid passed:
   0000013: error: memory count (2) must be 0 or 1
 out/test/spec/imports.wast:413: assert_invalid passed:

--- a/test/spec/local_get.txt
+++ b/test/spec/local_get.txt
@@ -32,22 +32,22 @@ out/test/spec/local_get.wast:193: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:201: assert_invalid passed:
-  error: invalid local_index: 3 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001d: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:205: assert_invalid passed:
-  error: invalid local_index: 14324343 (max 2)
+  0000000: error: local variable out of range (max 2)
   0000020: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:210: assert_invalid passed:
-  error: invalid local_index: 2 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001b: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:214: assert_invalid passed:
-  error: invalid local_index: 714324343 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001f: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:219: assert_invalid passed:
-  error: invalid local_index: 3 (max 3)
+  0000000: error: local variable out of range (max 3)
   000001e: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:223: assert_invalid passed:
-  error: invalid local_index: 214324343 (max 3)
+  0000000: error: local variable out of range (max 3)
   0000021: error: OnLocalGetExpr callback failed
 35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/local_set.txt
+++ b/test/spec/local_set.txt
@@ -83,22 +83,22 @@ out/test/spec/local_set.wast:329: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   0000025: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:337: assert_invalid passed:
-  error: invalid local_index: 3 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001f: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:341: assert_invalid passed:
-  error: invalid local_index: 14324343 (max 2)
+  0000000: error: local variable out of range (max 2)
   0000022: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:346: assert_invalid passed:
-  error: invalid local_index: 2 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001d: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:350: assert_invalid passed:
-  error: invalid local_index: 714324343 (max 2)
+  0000000: error: local variable out of range (max 2)
   0000021: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:355: assert_invalid passed:
-  error: invalid local_index: 3 (max 3)
+  0000000: error: local variable out of range (max 3)
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:359: assert_invalid passed:
-  error: invalid local_index: 214324343 (max 3)
+  0000000: error: local variable out of range (max 3)
   0000023: error: OnLocalSetExpr callback failed
 52/52 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/local_tee.txt
+++ b/test/spec/local_tee.txt
@@ -98,22 +98,22 @@ out/test/spec/local_tee.wast:589: assert_invalid passed:
   error: type mismatch in local.tee, expected [i32] but got []
   000001f: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:602: assert_invalid passed:
-  error: invalid local_index: 3 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001d: error: OnLocalGetExpr callback failed
 out/test/spec/local_tee.wast:606: assert_invalid passed:
-  error: invalid local_index: 14324343 (max 2)
+  0000000: error: local variable out of range (max 2)
   0000020: error: OnLocalGetExpr callback failed
 out/test/spec/local_tee.wast:611: assert_invalid passed:
-  error: invalid local_index: 2 (max 2)
+  0000000: error: local variable out of range (max 2)
   000001b: error: OnLocalGetExpr callback failed
 out/test/spec/local_tee.wast:615: assert_invalid passed:
-  error: invalid local_index: 714324343 (max 2)
+  0000000: error: local variable out of range (max 2)
   0000021: error: OnLocalGetExpr callback failed
 out/test/spec/local_tee.wast:620: assert_invalid passed:
-  error: invalid local_index: 3 (max 3)
+  0000000: error: local variable out of range (max 3)
   000001e: error: OnLocalGetExpr callback failed
 out/test/spec/local_tee.wast:624: assert_invalid passed:
-  error: invalid local_index: 214324343 (max 3)
+  0000000: error: local variable out of range (max 3)
   0000021: error: OnLocalGetExpr callback failed
 out/test/spec/local_tee.wast:629: assert_invalid passed:
   error: type mismatch in local.tee, expected [i32] but got [f32]

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -12,22 +12,22 @@ out/test/spec/memory.wast:19: assert_invalid passed:
 out/test/spec/memory.wast:20: assert_invalid passed:
   000000b: error: data section without memory section
 out/test/spec/memory.wast:23: assert_invalid passed:
-  error: f32.load requires an imported or defined memory.
+  error: memory variable out of range: 0 (max 4294967295)
   000001c: error: OnLoadExpr callback failed
 out/test/spec/memory.wast:27: assert_invalid passed:
-  error: f32.store requires an imported or defined memory.
+  error: memory variable out of range: 0 (max 4294967295)
   0000021: error: OnStoreExpr callback failed
 out/test/spec/memory.wast:31: assert_invalid passed:
-  error: i32.load8_s requires an imported or defined memory.
+  error: memory variable out of range: 0 (max 4294967295)
   000001c: error: OnLoadExpr callback failed
 out/test/spec/memory.wast:35: assert_invalid passed:
-  error: i32.store8 requires an imported or defined memory.
+  error: memory variable out of range: 0 (max 4294967295)
   000001e: error: OnStoreExpr callback failed
 out/test/spec/memory.wast:39: assert_invalid passed:
-  error: memory.size requires an imported or defined memory.
+  error: memory variable out of range: 0 (max 4294967295)
   0000019: error: OnMemorySizeExpr callback failed
 out/test/spec/memory.wast:43: assert_invalid passed:
-  error: memory.grow requires an imported or defined memory.
+  error: memory variable out of range: 0 (max 4294967295)
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory.wast:49: assert_invalid passed:
   000000e: error: memory initial size must be <= max size

--- a/test/spec/multi-value/call_indirect.txt
+++ b/test/spec/multi-value/call_indirect.txt
@@ -81,7 +81,7 @@ out/test/spec/multi-value/call_indirect.wast:730: assert_malformed passed:
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
 out/test/spec/multi-value/call_indirect.wast:745: assert_invalid passed:
-  error: found call_indirect operator, but no table
+  0000000: error: table variable out of range: 0 (max 4294967295)
   000001c: error: OnCallIndirectExpr callback failed
 out/test/spec/multi-value/call_indirect.wast:753: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
@@ -142,7 +142,7 @@ out/test/spec/multi-value/call_indirect.wast:951: assert_invalid passed:
 out/test/spec/multi-value/call_indirect.wast:958: assert_invalid passed:
   0000025: error: invalid call_indirect signature index
 out/test/spec/multi-value/call_indirect.wast:969: assert_invalid passed:
-  error: invalid func_index: 0 (max 0)
+  0000000: error: function variable out of range: 0 (max 4294967295)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed
 155/155 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/mutable-global/globals.txt
+++ b/test/spec/mutable-global/globals.txt
@@ -3,6 +3,7 @@
 (;; STDOUT ;;;
 out/test/spec/mutable-global/globals.wast:50: assert_invalid passed:
   error: can't global.set on immutable global at index 0.
+  error: type mismatch in global.set, expected [f32] but got [i32]
   0000026: error: OnGlobalSetExpr callback failed
 out/test/spec/mutable-global/globals.wast:59: assert_invalid passed:
   0000013: error: expected END opcode after initializer expression
@@ -15,19 +16,19 @@ out/test/spec/mutable-global/globals.wast:74: assert_invalid passed:
 out/test/spec/mutable-global/globals.wast:79: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/mutable-global/globals.wast:84: assert_invalid passed:
-  error: type mismatch in global, expected i32 but got f32.
+  error: type mismatch at global initializer expression. got f32, expected i32
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/mutable-global/globals.wast:89: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
 out/test/spec/mutable-global/globals.wast:94: assert_invalid passed:
-  error: type mismatch in global, expected i32 but got void.
+  error: invalid global initializer expression, must be a constant expression; either *.const or global.get.
   000000e: error: EndGlobalInitExpr callback failed
 out/test/spec/mutable-global/globals.wast:99: assert_invalid passed:
-  error: initializer expression can only reference an imported global
-  000000f: error: OnInitExprGlobalGetExpr callback failed
+  0000000: error: initializer expression can only reference an imported global
+  0000010: error: EndGlobalInitExpr callback failed
 out/test/spec/mutable-global/globals.wast:104: assert_invalid passed:
-  error: initializer expression can only reference an imported global
-  000000f: error: OnInitExprGlobalGetExpr callback failed
+  0000000: error: global variable out of range: 1 (max 0)
+  0000010: error: EndGlobalInitExpr callback failed
 out/test/spec/mutable-global/globals.wast:112: assert_malformed passed:
   0000019: error: unable to read string: import field name
 out/test/spec/mutable-global/globals.wast:125: assert_malformed passed:

--- a/test/spec/reference-types/globals.txt
+++ b/test/spec/reference-types/globals.txt
@@ -17,22 +17,22 @@ out/test/spec/reference-types/globals.wast:272: assert_invalid passed:
 out/test/spec/reference-types/globals.wast:277: assert_invalid passed:
   000000e: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/reference-types/globals.wast:282: assert_invalid passed:
-  error: type mismatch in global, expected i32 but got f32.
+  error: type mismatch at global initializer expression. got f32, expected i32
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/reference-types/globals.wast:287: assert_invalid passed:
   0000010: error: expected END opcode after initializer expression
 out/test/spec/reference-types/globals.wast:292: assert_invalid passed:
-  error: type mismatch in global, expected i32 but got void.
+  error: invalid global initializer expression, must be a constant expression; either *.const or global.get.
   000000e: error: EndGlobalInitExpr callback failed
 out/test/spec/reference-types/globals.wast:297: assert_invalid passed:
-  error: type mismatch in global, expected funcref but got anyref.
+  error: type mismatch at global initializer expression. got anyref, expected funcref
   0000018: error: EndGlobalInitExpr callback failed
 out/test/spec/reference-types/globals.wast:302: assert_invalid passed:
-  error: initializer expression can only reference an imported global
-  000000f: error: OnInitExprGlobalGetExpr callback failed
+  0000000: error: initializer expression can only reference an imported global
+  0000010: error: EndGlobalInitExpr callback failed
 out/test/spec/reference-types/globals.wast:307: assert_invalid passed:
-  error: initializer expression can only reference an imported global
-  000000f: error: OnInitExprGlobalGetExpr callback failed
+  0000000: error: global variable out of range: 1 (max 0)
+  0000010: error: EndGlobalInitExpr callback failed
 out/test/spec/reference-types/globals.wast:315: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
 out/test/spec/reference-types/globals.wast:328: assert_malformed passed:

--- a/test/spec/reference-types/imports.txt
+++ b/test/spec/reference-types/imports.txt
@@ -111,7 +111,8 @@ out/test/spec/reference-types/imports.wast:385: assert_unlinkable passed:
 out/test/spec/reference-types/imports.wast:403: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/reference-types/imports.wast:414: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/reference-types/imports.wast:417: assert_invalid passed:
-  0000015: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000015: error: OnImportMemory callback failed
 out/test/spec/reference-types/imports.wast:421: assert_invalid passed:
   0000013: error: memory count (2) must be 0 or 1
 out/test/spec/reference-types/imports.wast:425: assert_invalid passed:

--- a/test/spec/reference-types/memory_init.txt
+++ b/test/spec/reference-types/memory_init.txt
@@ -9,7 +9,7 @@ test() =>
 out/test/spec/reference-types/memory_init.wast:189: assert_invalid passed:
   0000023: error: data.drop requires data count section
 out/test/spec/reference-types/memory_init.wast:195: assert_invalid passed:
-  error: invalid data_segment_index: 4 (max 1)
+  0000000: error: data_segment variable out of range: 4 (max 0)
   000002c: error: OnDataDropExpr callback failed
 test() =>
 out/test/spec/reference-types/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
@@ -17,7 +17,7 @@ out/test/spec/reference-types/memory_init.wast:223: assert_trap passed: out of b
 out/test/spec/reference-types/memory_init.wast:226: assert_invalid passed:
   000002a: error: memory.init requires data count section
 out/test/spec/reference-types/memory_init.wast:232: assert_invalid passed:
-  error: invalid data_segment_index: 1 (max 1)
+  0000000: error: data_segment variable out of range: 1 (max 0)
   0000034: error: OnMemoryInitExpr callback failed
 test() =>
 out/test/spec/reference-types/memory_init.wast:252: assert_trap passed: out of bounds memory access: memory.init out of bounds

--- a/test/spec/reference-types/ref_func.txt
+++ b/test/spec/reference-types/ref_func.txt
@@ -5,13 +5,13 @@
 set-g() =>
 set-f() =>
 out/test/spec/reference-types/ref_func.wast:71: assert_invalid passed:
-  error: function is not declared in any elem sections: 7
-  0000027: error: EndModule callback failed
+  0000000: error: function variable out of range: 7 (max 1)
+  0000027: error: EndGlobalInitExpr callback failed
 out/test/spec/reference-types/ref_func.wast:80: assert_invalid passed:
-  error: function is not declared in any elem sections: 0
+  0000000: error: function is not declared in any elem sections
   0000020: error: EndModule callback failed
 out/test/spec/reference-types/ref_func.wast:84: assert_invalid passed:
-  error: function is not declared in any elem sections: 0
+  0000000: error: function is not declared in any elem sections
   0000019: error: OnRefFuncExpr callback failed
 13/13 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/table_init.txt
+++ b/test/spec/reference-types/table_init.txt
@@ -56,10 +56,11 @@ out/test/spec/reference-types/table_init.wast:189: assert_trap passed: uninitial
 out/test/spec/reference-types/table_init.wast:190: assert_trap passed: uninitialized table element
 out/test/spec/reference-types/table_init.wast:191: assert_trap passed: uninitialized table element
 out/test/spec/reference-types/table_init.wast:193: assert_invalid passed:
-  error: invalid elem_segment_index: 0 (max 0)
+  error: elem.drop requires table 0 to be an imported or defined table.
+  0000000: error: elem_segment variable out of range: 0 (max 4294967295)
   0000024: error: OnElemDropExpr callback failed
 out/test/spec/reference-types/table_init.wast:199: assert_invalid passed:
-  error: found table.init operator, but no table
+  0000000: error: table.init requires table 0 to be an imported or defined table.
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:205: assert_invalid passed:
   0000024: error: elem section without table section

--- a/test/spec/reference-types/unreached-invalid.txt
+++ b/test/spec/reference-types/unreached-invalid.txt
@@ -3,10 +3,10 @@
 ;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/unreached-invalid.wast:4: assert_invalid passed:
-  error: invalid local_index: 0 (max 0)
+  0000000: error: local variable out of range (max 0)
   000001a: error: OnLocalGetExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:8: assert_invalid passed:
-  error: invalid global_index: 0 (max 0)
+  0000000: error: global variable out of range: 0 (max 4294967295)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:12: assert_invalid passed:
   000001a: error: invalid call function index: 1

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/unreached-invalid.wast
 (;; STDOUT ;;;
 out/test/spec/unreached-invalid.wast:4: assert_invalid passed:
-  error: invalid local_index: 0 (max 0)
+  0000000: error: local variable out of range (max 0)
   000001a: error: OnLocalGetExpr callback failed
 out/test/spec/unreached-invalid.wast:8: assert_invalid passed:
-  error: invalid global_index: 0 (max 0)
+  0000000: error: global variable out of range: 0 (max 4294967295)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/unreached-invalid.wast:12: assert_invalid passed:
   000001a: error: invalid call function index: 1


### PR DESCRIPTION
The TypeChecker was already shared, but the rest of the other validation
logic was duplicated. This change creates a SharedValidator which is
used by both the Validator and the BinaryReaderInterp classes.

The validator is structured similarly to TypeChecker as a collection of
functions. It's assumed that the functions will be called in the same
order as sections occur in the binary format. The IR valiator does this
too, even though it's possible to validate components out-of-order in
that case.

This change also splits Module validation and Script validation into two
different classes. It should have been written this way in the first
place, and it's nice to do as part of this change since the module
validator logic is mostly moved into the SharedValidator anyway.

Next steps:

* Remove all validation from BinaryReader and move it into the
  SharedValidator.
* Move the TypeChecker into the SharedValidator (maybe not necessary)
* Ensure that validation occurs before creating IR from binary (use
  SharedValidator in BinaryReaderIR? or maybe create
  BinaryReaderValidator passthru that both BinaryReaderIR and
  BinaryReaderInterp use?)
* Rename Validator -> IRValidator, SharedValidator -> Validator