### PR TITLE
Add TypeEntry, base class for type section entries

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -876,11 +876,11 @@ Result BinaryWriter::WriteModule() {
   stream_->WriteU32(WABT_BINARY_MAGIC, "WASM_BINARY_MAGIC");
   stream_->WriteU32(WABT_BINARY_VERSION, "WASM_BINARY_VERSION");
 
-  if (module_->func_types.size()) {
+  if (module_->types.size()) {
     BeginKnownSection(BinarySection::Type);
-    WriteU32Leb128(stream_, module_->func_types.size(), "num types");
-    for (size_t i = 0; i < module_->func_types.size(); ++i) {
-      const FuncType* func_type = module_->func_types[i];
+    WriteU32Leb128(stream_, module_->types.size(), "num types");
+    for (size_t i = 0; i < module_->types.size(); ++i) {
+      const FuncType* func_type = cast<FuncType>(module_->types[i]);
       const FuncSignature* sig = &func_type->sig;
       WriteHeader("type", i);
       WriteType(stream_, Type::Func);

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -886,11 +886,12 @@ void CWriter::WriteSourceTop() {
 
 void CWriter::WriteFuncTypes() {
   Write(Newline());
-  Writef("static u32 func_types[%" PRIzd "];", module_->func_types.size());
+  Writef("static u32 func_types[%" PRIzd "];", module_->types.size());
   Write(Newline(), Newline());
   Write("static void init_func_types(void) {", Newline());
   Index func_type_index = 0;
-  for (FuncType* func_type : module_->func_types) {
+  for (TypeEntry* type : module_->types) {
+    FuncType* func_type = cast<FuncType>(type);
     Index num_params = func_type->GetNumParams();
     Index num_results = func_type->GetNumResults();
     Write("  func_types[", func_type_index, "] = wasm_rt_register_func_type(",

--- a/src/decompiler-naming.h
+++ b/src/decompiler-naming.h
@@ -196,7 +196,7 @@ void RenameAll(Module& module) {
   RenameToIdentifiers(module.tables, module.table_bindings, nullptr);
   RenameToIdentifiers(module.events, module.event_bindings, nullptr);
   RenameToIdentifiers(module.exports, module.export_bindings, nullptr);
-  RenameToIdentifiers(module.func_types, module.func_type_bindings, nullptr);
+  RenameToIdentifiers(module.types, module.type_bindings, nullptr);
   RenameToIdentifiers(module.memories, module.memory_bindings, nullptr);
   RenameToIdentifiers(module.data_segments, module.data_segment_bindings,
                       nullptr);

--- a/src/generate-names.cc
+++ b/src/generate-names.cc
@@ -86,7 +86,7 @@ class NameGenerator : public ExprVisitor::DelegateNop {
 
   Result VisitFunc(Index func_index, Func* func);
   Result VisitGlobal(Index global_index, Global* global);
-  Result VisitFuncType(Index func_type_index, FuncType* func_type);
+  Result VisitType(Index func_type_index, TypeEntry* type);
   Result VisitTable(Index table_index, Table* table);
   Result VisitMemory(Index memory_index, Memory* memory);
   Result VisitEvent(Index event_index, Event* event);
@@ -241,10 +241,9 @@ Result NameGenerator::VisitGlobal(Index global_index, Global* global) {
   return Result::Ok;
 }
 
-Result NameGenerator::VisitFuncType(Index func_type_index,
-                                    FuncType* func_type) {
-  MaybeGenerateAndBindName(&module_->func_type_bindings, "t", func_type_index,
-                           &func_type->name);
+Result NameGenerator::VisitType(Index type_index, TypeEntry* type) {
+  MaybeGenerateAndBindName(&module_->type_bindings, "t", type_index,
+                           &type->name);
   return Result::Ok;
 }
 
@@ -411,7 +410,7 @@ Result NameGenerator::VisitModule(Module* module) {
   }
 
   VisitAll(module->globals, &NameGenerator::VisitGlobal);
-  VisitAll(module->func_types, &NameGenerator::VisitFuncType);
+  VisitAll(module->types, &NameGenerator::VisitType);
   VisitAll(module->funcs, &NameGenerator::VisitFunc);
   VisitAll(module->tables, &NameGenerator::VisitTable);
   VisitAll(module->memories, &NameGenerator::VisitMemory);

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -128,7 +128,7 @@ Index Module::GetMemoryIndex(const Var& var) const {
 }
 
 Index Module::GetFuncTypeIndex(const Var& var) const {
-  return func_type_bindings.FindIndex(var);
+  return type_bindings.FindIndex(var);
 }
 
 Index Module::GetEventIndex(const Var& var) const {
@@ -310,16 +310,16 @@ const FuncType* Module::GetFuncType(const Var& var) const {
 }
 
 FuncType* Module::GetFuncType(const Var& var) {
-  Index index = func_type_bindings.FindIndex(var);
-  if (index >= func_types.size()) {
+  Index index = type_bindings.FindIndex(var);
+  if (index >= types.size()) {
     return nullptr;
   }
-  return func_types[index];
+  return cast<FuncType>(types[index]);
 }
 
 Index Module::GetFuncTypeIndex(const FuncSignature& sig) const {
-  for (size_t i = 0; i < func_types.size(); ++i) {
-    if (func_types[i]->sig == sig) {
+  for (size_t i = 0; i < types.size(); ++i) {
+    if (cast<FuncType>(types[i])->sig == sig) {
       return i;
     }
   }
@@ -380,13 +380,12 @@ void Module::AppendField(std::unique_ptr<FuncModuleField> field) {
   fields.push_back(std::move(field));
 }
 
-void Module::AppendField(std::unique_ptr<FuncTypeModuleField> field) {
-  FuncType& func_type = field->func_type;
-  if (!func_type.name.empty()) {
-    func_type_bindings.emplace(func_type.name,
-                               Binding(field->loc, func_types.size()));
+void Module::AppendField(std::unique_ptr<TypeModuleField> field) {
+  TypeEntry& type = *field->type;
+  if (!type.name.empty()) {
+    type_bindings.emplace(type.name, Binding(field->loc, types.size()));
   }
-  func_types.push_back(&func_type);
+  types.push_back(&type);
   fields.push_back(std::move(field));
 }
 
@@ -506,8 +505,8 @@ void Module::AppendField(std::unique_ptr<ModuleField> field) {
       AppendField(cast<ExportModuleField>(std::move(field)));
       break;
 
-    case ModuleFieldType::FuncType:
-      AppendField(cast<FuncTypeModuleField>(std::move(field)));
+    case ModuleFieldType::Type:
+      AppendField(cast<TypeModuleField>(std::move(field)));
       break;
 
     case ModuleFieldType::Table:

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -186,7 +186,7 @@ void NameResolver::ResolveGlobalVar(Var* var) {
 }
 
 void NameResolver::ResolveFuncTypeVar(Var* var) {
-  ResolveVar(&current_module_->func_type_bindings, var, "function type");
+  ResolveVar(&current_module_->type_bindings, var, "type");
 }
 
 void NameResolver::ResolveTableVar(Var* var) {
@@ -477,7 +477,7 @@ Result NameResolver::VisitModule(Module* module) {
   CheckDuplicateBindings(&module->elem_segment_bindings, "elem");
   CheckDuplicateBindings(&module->func_bindings, "function");
   CheckDuplicateBindings(&module->global_bindings, "global");
-  CheckDuplicateBindings(&module->func_type_bindings, "function type");
+  CheckDuplicateBindings(&module->type_bindings, "type");
   CheckDuplicateBindings(&module->table_bindings, "table");
   CheckDuplicateBindings(&module->memory_bindings, "memory");
   CheckDuplicateBindings(&module->event_bindings, "event");

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -584,12 +584,18 @@ Result Validator::CheckModule() {
 
   // Type section.
   for (const ModuleField& field : module->fields) {
-    if (auto* f = dyn_cast<FuncTypeModuleField>(&field)) {
-      result_ |=
-          validator_.OnType(field.loc, f->func_type.sig.param_types.size(),
-                            f->func_type.sig.param_types.data(),
-                            f->func_type.sig.result_types.size(),
-                            f->func_type.sig.result_types.data());
+    if (auto* f = dyn_cast<TypeModuleField>(&field)) {
+      switch (f->type->kind()) {
+        case TypeEntryKind::Func: {
+          FuncType* func_type = cast<FuncType>(f->type.get());
+          result_ |=
+              validator_.OnType(field.loc, func_type->sig.param_types.size(),
+                                func_type->sig.param_types.data(),
+                                func_type->sig.result_types.size(),
+                                func_type->sig.result_types.data());
+          break;
+        }
+      }
     }
   }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -260,8 +260,8 @@ void ResolveImplicitlyDefinedFunctionType(const Location& loc,
   if (!decl.has_func_type) {
     Index func_type_index = module->GetFuncTypeIndex(decl.sig);
     if (func_type_index == kInvalidIndex) {
-      auto func_type_field = MakeUnique<FuncTypeModuleField>(loc);
-      func_type_field->func_type.sig = decl.sig;
+      auto func_type_field = MakeUnique<TypeModuleField>(loc);
+      cast<FuncType>(func_type_field->type.get())->sig = decl.sig;
       module->AppendField(std::move(func_type_field));
     }
   }
@@ -1182,13 +1182,14 @@ Result WastParser::ParseFuncModuleField(Module* module) {
 Result WastParser::ParseTypeModuleField(Module* module) {
   WABT_TRACE(ParseTypeModuleField);
   EXPECT(Lpar);
-  auto field = MakeUnique<FuncTypeModuleField>(GetLocation());
+  auto field = MakeUnique<TypeModuleField>(GetLocation());
+  FuncType& func_type = *cast<FuncType>(field->type.get());
   EXPECT(Type);
-  ParseBindVarOpt(&field->func_type.name);
+  ParseBindVarOpt(&func_type.name);
   EXPECT(Lpar);
   EXPECT(Func);
   BindingHash bindings;
-  CHECK_RESULT(ParseFuncSignature(&field->func_type.sig, &bindings));
+  CHECK_RESULT(ParseFuncSignature(&func_type.sig, &bindings));
   CHECK_RESULT(ErrorIfLpar({"param", "result"}));
   EXPECT(Rpar);
   EXPECT(Rpar);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1418,8 +1418,9 @@ Result WatWriter::WriteModule() {
       case ModuleFieldType::DataSegment:
         WriteDataSegment(cast<DataSegmentModuleField>(&field)->data_segment);
         break;
-      case ModuleFieldType::FuncType:
-        WriteFuncType(cast<FuncTypeModuleField>(&field)->func_type);
+      case ModuleFieldType::Type:
+        WriteFuncType(
+            *cast<FuncType>(cast<TypeModuleField>(&field)->type.get()));
         break;
       case ModuleFieldType::Start:
         WriteStartFunction(cast<StartModuleField>(&field)->start);


### PR DESCRIPTION
The type section currently only has one form: functions. With the GC
proposal, at least two more forms are added: struct and array. To
facilitate this:

* Rename FuncTypeModuleField -> TypeModuleField
* Rename Module::func_types -> Module::types
* Rename func_type_bindings -> type_bindings
* TypeEntry is added as a base class of FuncType
* TypeModuleField stores a unique_ptr to a TypeEntry