### PR TITLE
Convert Type from an enum into a class

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -350,15 +350,15 @@ Result BinaryReaderIR::AppendExpr(std::unique_ptr<Expr> expr) {
 
 void BinaryReaderIR::SetBlockDeclaration(BlockDeclaration* decl,
                                          Type sig_type) {
-  if (IsTypeIndex(sig_type)) {
-    Index type_index = GetTypeIndex(sig_type);
+  if (sig_type.IsIndex()) {
+    Index type_index = sig_type.GetIndex();
     decl->has_func_type = true;
     decl->type_var = Var(type_index);
     decl->sig = cast<FuncType>(module_->types[type_index])->sig;
   } else {
     decl->has_func_type = false;
     decl->sig.param_types.clear();
-    decl->sig.result_types = GetInlineTypeVector(sig_type);
+    decl->sig.result_types = sig_type.GetInlineVector();
   }
 }
 

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -77,10 +77,10 @@ void BinaryReaderLogging::WriteIndent() {
 }
 
 void BinaryReaderLogging::LogType(Type type) {
-  if (IsTypeIndex(type)) {
-    LOGF_NOINDENT("typeidx[%d]", static_cast<int>(type));
+  if (type.IsIndex()) {
+    LOGF_NOINDENT("typeidx[%d]", type.GetIndex());
   } else {
-    LOGF_NOINDENT("%s", GetTypeName(type));
+    LOGF_NOINDENT("%s", type.GetName());
   }
 }
 
@@ -175,7 +175,7 @@ Result BinaryReaderLogging::OnImportTable(Index import_index,
   SPrintLimits(buf, sizeof(buf), elem_limits);
   LOGF("OnImportTable(import_index: %" PRIindex ", table_index: %" PRIindex
        ", elem_type: %s, %s)\n",
-       import_index, table_index, GetTypeName(elem_type), buf);
+       import_index, table_index, elem_type.GetName(), buf);
   return reader_->OnImportTable(import_index, module_name, field_name,
                                 table_index, elem_type, elem_limits);
 }
@@ -203,8 +203,7 @@ Result BinaryReaderLogging::OnImportGlobal(Index import_index,
   LOGF("OnImportGlobal(import_index: %" PRIindex ", global_index: %" PRIindex
        ", type: %s, mutable: "
        "%s)\n",
-       import_index, global_index, GetTypeName(type),
-       mutable_ ? "true" : "false");
+       import_index, global_index, type.GetName(), mutable_ ? "true" : "false");
   return reader_->OnImportGlobal(import_index, module_name, field_name,
                                  global_index, type, mutable_);
 }
@@ -227,7 +226,7 @@ Result BinaryReaderLogging::OnTable(Index index,
   char buf[100];
   SPrintLimits(buf, sizeof(buf), elem_limits);
   LOGF("OnTable(index: %" PRIindex ", elem_type: %s, %s)\n", index,
-       GetTypeName(elem_type), buf);
+       elem_type.GetName(), buf);
   return reader_->OnTable(index, elem_type, elem_limits);
 }
 
@@ -240,7 +239,7 @@ Result BinaryReaderLogging::OnMemory(Index index, const Limits* page_limits) {
 
 Result BinaryReaderLogging::BeginGlobal(Index index, Type type, bool mutable_) {
   LOGF("BeginGlobal(index: %" PRIindex ", type: %s, mutable: %s)\n", index,
-       GetTypeName(type), mutable_ ? "true" : "false");
+       type.GetName(), mutable_ ? "true" : "false");
   return reader_->BeginGlobal(index, type, mutable_);
 }
 
@@ -263,7 +262,7 @@ Result BinaryReaderLogging::OnLocalDecl(Index decl_index,
                                         Index count,
                                         Type type) {
   LOGF("OnLocalDecl(index: %" PRIindex ", count: %" PRIindex ", type: %s)\n",
-       decl_index, count, GetTypeName(type));
+       decl_index, count, type.GetName());
   return reader_->OnLocalDecl(decl_index, count, type);
 }
 
@@ -344,7 +343,7 @@ Result BinaryReaderLogging::OnLoopExpr(Type sig_type) {
 }
 
 Result BinaryReaderLogging::OnSelectExpr(Type return_type) {
-  LOGF("OnSelectExpr(return_type: %s)\n", GetTypeName(return_type));
+  LOGF("OnSelectExpr(return_type: %s)\n", return_type.GetName());
   return reader_->OnSelectExpr(return_type);
 }
 
@@ -377,7 +376,7 @@ Result BinaryReaderLogging::BeginElemSegment(Index index,
 
 Result BinaryReaderLogging::OnElemSegmentElemType(Index index, Type elem_type) {
   LOGF("OnElemSegmentElemType(index: %" PRIindex ", type: %s)\n", index,
-       GetTypeName(elem_type));
+       elem_type.GetName());
   return reader_->OnElemSegmentElemType(index, elem_type);
 }
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -422,12 +422,12 @@ class BinaryReaderObjdumpDisassemble : public BinaryReaderObjdumpBase {
 };
 
 std::string BinaryReaderObjdumpDisassemble::BlockSigToString(Type type) const {
-  if (IsTypeIndex(type)) {
-    return StringPrintf("type[%d]", GetTypeIndex(type));
+  if (type.IsIndex()) {
+    return StringPrintf("type[%d]", type.GetIndex());
   } else if (type == Type::Void) {
     return "";
   } else {
-    return GetTypeName(type);
+    return type.GetName();
   }
 }
 
@@ -484,7 +484,7 @@ Result BinaryReaderObjdumpDisassemble::OnLocalDecl(Index decl_index,
   }
   local_index_ += count;
 
-  printf("] type=%s\n", GetTypeName(type));
+  printf("] type=%s\n", type.GetName());
 
   last_opcode_end = current_opcode_offset + data_size;
   current_opcode_offset = last_opcode_end;
@@ -1042,7 +1042,7 @@ Result BinaryReaderObjdump::OnType(Index index,
     if (i != 0) {
       printf(", ");
     }
-    printf("%s", GetTypeName(param_types[i]));
+    printf("%s", param_types[i].GetName());
   }
   printf(") -> ");
   switch (result_count) {
@@ -1050,7 +1050,7 @@ Result BinaryReaderObjdump::OnType(Index index,
       printf("nil");
       break;
     case 1:
-      printf("%s", GetTypeName(result_types[0]));
+      printf("%s", result_types[0].GetName());
       break;
     default:
       printf("(");
@@ -1058,7 +1058,7 @@ Result BinaryReaderObjdump::OnType(Index index,
         if (i != 0) {
           printf(", ");
         }
-        printf("%s", GetTypeName(result_types[i]));
+        printf("%s", result_types[i].GetName());
       }
       printf(")");
       break;
@@ -1140,7 +1140,7 @@ Result BinaryReaderObjdump::OnImportTable(Index import_index,
                                           Type elem_type,
                                           const Limits* elem_limits) {
   PrintDetails(" - table[%" PRIindex "] type=%s initial=%" PRId64, table_index,
-               GetTypeName(elem_type), elem_limits->initial);
+               elem_type.GetName(), elem_limits->initial);
   if (elem_limits->has_max) {
     PrintDetails(" max=%" PRId64, elem_limits->max);
   }
@@ -1173,7 +1173,7 @@ Result BinaryReaderObjdump::OnImportGlobal(Index import_index,
                                            Type type,
                                            bool mutable_) {
   PrintDetails(" - global[%" PRIindex "] %s mutable=%d", global_index,
-               GetTypeName(type), mutable_);
+               type.GetName(), mutable_);
   PrintDetails(" <- " PRIstringview "." PRIstringview "\n",
                WABT_PRINTF_STRING_VIEW_ARG(module_name),
                WABT_PRINTF_STRING_VIEW_ARG(field_name));
@@ -1219,7 +1219,7 @@ Result BinaryReaderObjdump::OnTable(Index index,
                                     Type elem_type,
                                     const Limits* elem_limits) {
   PrintDetails(" - table[%" PRIindex "] type=%s initial=%" PRId64, index,
-               GetTypeName(elem_type), elem_limits->initial);
+               elem_type.GetName(), elem_limits->initial);
   if (elem_limits->has_max) {
     PrintDetails(" max=%" PRId64, elem_limits->max);
   }
@@ -1303,8 +1303,8 @@ Result BinaryReaderObjdump::OnGlobalCount(Index count) {
 }
 
 Result BinaryReaderObjdump::BeginGlobal(Index index, Type type, bool mutable_) {
-  PrintDetails(" - global[%" PRIindex "] %s mutable=%d", index,
-               GetTypeName(type), mutable_);
+  PrintDetails(" - global[%" PRIindex "] %s mutable=%d", index, type.GetName(),
+               mutable_);
   string_view name = GetGlobalName(index);
   if (!name.empty()) {
     PrintDetails(" <" PRIstringview ">", WABT_PRINTF_STRING_VIEW_ARG(name));

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -120,10 +120,10 @@ void OpcodeInfo::Write(Stream& stream) {
 
     case Kind::BlockSig: {
       auto type = *GetData<Type>();
-      if (IsTypeIndex(type)) {
-        stream.Writef(" type:%d", static_cast<int>(type));
+      if (type.IsIndex()) {
+        stream.Writef(" type:%d", type.GetIndex());
       } else if (type != Type::Void) {
-        stream.Writef(" %s", GetTypeName(type));
+        stream.Writef(" %s", type.GetName());
       }
       break;
     }

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -413,11 +413,11 @@ bool BinaryReader::IsBlockType(Type type) {
     return true;
   }
 
-  if (!(options_.features.multi_value_enabled() && IsTypeIndex(type))) {
+  if (!(options_.features.multi_value_enabled() && type.IsIndex())) {
     return false;
   }
 
-  return GetTypeIndex(type) < num_signatures_;
+  return type.GetIndex() < num_signatures_;
 }
 
 Index BinaryReader::NumTotalFuncs() {
@@ -525,7 +525,7 @@ Result BinaryReader::ReadInitExpr(Index index, bool require_i32) {
 
 Result BinaryReader::ReadTable(Type* out_elem_type, Limits* out_elem_limits) {
   CHECK_RESULT(ReadType(out_elem_type, "table elem type"));
-  ERROR_UNLESS(IsRefType(*out_elem_type),
+  ERROR_UNLESS(out_elem_type->IsRef(),
                "table elem type must be a reference type");
 
   uint32_t flags;
@@ -2232,15 +2232,15 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
     if (flags & (SegPassive | SegExplicitIndex)) {
       if (flags & SegUseElemExprs) {
         CHECK_RESULT(ReadType(&elem_type, "table elem type"));
-        ERROR_UNLESS(IsRefType(elem_type),
+        ERROR_UNLESS(elem_type.IsRef(),
                      "segment elem expr type must be a reference type (got %s)",
-                     GetTypeName(elem_type));
+                     elem_type.GetName());
       } else {
         ExternalKind kind;
         CHECK_RESULT(ReadExternalKind(&kind, "export kind"));
         ERROR_UNLESS(kind == ExternalKind::Func,
                      "segment elem type must be func (%s)",
-                     GetTypeName(elem_type));
+                     elem_type.GetName());
         elem_type = Type::Funcref;
       }
     }

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -156,7 +156,7 @@ void BinaryWriterSpec::WriteVar(const Var& var) {
 void BinaryWriterSpec::WriteTypeObject(Type type) {
   json_stream_->Writef("{");
   WriteKey("type");
-  WriteString(GetTypeName(type));
+  WriteString(type.GetName());
   json_stream_->Writef("}");
 }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -55,7 +55,7 @@ void WriteOpcode(Stream* stream, Opcode opcode) {
 }
 
 void WriteType(Stream* stream, Type type, const char* desc) {
-  WriteS32Leb128(stream, type, desc ? desc : GetTypeName(type));
+  WriteS32Leb128(stream, type, desc ? desc : type.GetName());
 }
 
 void WriteLimits(Stream* stream, const Limits* limits) {

--- a/src/interp/interp-inl.h
+++ b/src/interp/interp-inl.h
@@ -337,7 +337,7 @@ bool operator!=(const RefPtr<U>& lhs, const RefPtr<V>& rhs) {
 }
 
 //// ValueType ////
-inline bool IsReference(ValueType type) { return IsRefType(type); }
+inline bool IsReference(ValueType type) { return type.IsRef(); }
 template <> inline bool HasType<s32>(ValueType type) { return type == ValueType::I32; }
 template <> inline bool HasType<u32>(ValueType type) { return type == ValueType::I32; }
 template <> inline bool HasType<s64>(ValueType type) { return type == ValueType::I64; }

--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -536,7 +536,7 @@ static void print_sig(const FuncType& sig) {
       fprintf(stderr, ", ");
     }
     first = false;
-    fprintf(stderr, "%s", GetTypeName(Type));
+    fprintf(stderr, "%s", Type.GetName());
   }
   fprintf(stderr, ") -> (");
   first = true;
@@ -545,7 +545,7 @@ static void print_sig(const FuncType& sig) {
       fprintf(stderr, ", ");
     }
     first = false;
-    fprintf(stderr, "%s", GetTypeName(Type));
+    fprintf(stderr, "%s", Type.GetName());
   }
   fprintf(stderr, ")\n");
 #endif

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -32,7 +32,7 @@ const char* GetName(Mutability mut) {
 }
 
 const char* GetName(ValueType type) {
-  return GetTypeName(type);
+  return type.GetName();
 }
 
 const char* GetName(ExternKind kind) {

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -108,7 +108,7 @@ Result SharedValidator::OnTable(const Location& loc,
       !options_.features.reference_types_enabled()) {
     result |= PrintError(loc, "tables must have funcref type");
   }
-  if (!IsRefType(elem_type)) {
+  if (!elem_type.IsRef()) {
     result |= PrintError(loc, "tables must have reference types");
   }
 
@@ -160,7 +160,7 @@ Result SharedValidator::CheckType(const Location& loc,
                                   const char* desc) {
   if (Failed(TypeChecker::CheckType(actual, expected))) {
     PrintError(loc, "type mismatch at %s. got %s, expected %s", desc,
-               GetTypeName(actual), GetTypeName(expected));
+               actual.GetName(), expected.GetName());
     return Result::Error;
   }
   return Result::Ok;
@@ -501,8 +501,8 @@ Result SharedValidator::CheckBlockSignature(const Location& loc,
                                             TypeVector* out_result_types) {
   Result result = Result::Ok;
 
-  if (IsTypeIndex(sig_type)) {
-    Index sig_index = GetTypeIndex(sig_type);
+  if (sig_type.IsIndex()) {
+    Index sig_index = sig_type.GetIndex();
     FuncType func_type;
     result |= CheckTypeIndex(Var(sig_index, loc), &func_type);
 
@@ -520,7 +520,7 @@ Result SharedValidator::CheckBlockSignature(const Location& loc,
     *out_result_types = func_type.results;
   } else {
     out_param_types->clear();
-    *out_result_types = GetInlineTypeVector(sig_type);
+    *out_result_types = sig_type.GetInlineVector();
   }
 
   return result;

--- a/src/token.cc
+++ b/src/token.cc
@@ -81,7 +81,7 @@ std::string Token::to_string() const {
     return text_.to_string();
   } else {
     assert(HasType());
-    return GetTypeName(type_);
+    return type_.GetName();
   }
 }
 

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -30,7 +30,7 @@ std::string TypesToString(const TypeVector& types,
   }
 
   for (size_t i = 0; i < types.size(); ++i) {
-    result += GetTypeName(types[i]);
+    result += types[i].GetName();
     if (i < types.size() - 1) {
       result += ", ";
     }
@@ -169,13 +169,13 @@ static bool IsSubtype(Type sub, Type super) {
   if (super == sub) {
     return true;
   }
-  if (IsRefType(super) != IsRefType(sub)) {
+  if (super.IsRef() != sub.IsRef()) {
     return false;
   }
   if (super == Type::Anyref) {
-    return IsRefType(sub);
+    return sub.IsRef();
   }
-  if (IsNullableRefType(super)) {
+  if (super.IsNullableRef()) {
     return sub == Type::Nullref;
   }
   return false;
@@ -731,7 +731,7 @@ Result TypeChecker::OnSelect(Type expected) {
   result |= PeekType(1, &type1);
   result |= PeekType(2, &type2);
   if (expected == Type::Any) {
-    if (IsRefType(type1) || IsRefType(type2)) {
+    if (type1.IsRef() || type2.IsRef()) {
       result = Result::Error;
     } else {
       result |= CheckType(type1, type2);

--- a/src/type.h
+++ b/src/type.h
@@ -87,6 +87,18 @@ class Type {
     }
   }
 
+  // Functions for handling types that are an index into the type section.
+  // These are always positive integers. They occur in the binary format in
+  // block signatures, e.g.
+  //
+  //   (block (result i32 i64) ...)
+  //
+  // is encoded as
+  //
+  //   (type $T (func (result i32 i64)))
+  //   ...
+  //   (block (type $T) ...)
+  // 
   bool IsIndex() const { return static_cast<int32_t>(enum_) >= 0; }
 
   Index GetIndex() const {

--- a/src/type.h
+++ b/src/type.h
@@ -22,103 +22,103 @@
 
 namespace wabt {
 
+class Type;
+
 using Index = uint32_t;
+using TypeVector = std::vector<Type>;
 
-// Matches binary format, do not change.
-enum class Type : int32_t {
-  I32 = -0x01,      // 0x7f
-  I64 = -0x02,      // 0x7e
-  F32 = -0x03,      // 0x7d
-  F64 = -0x04,      // 0x7c
-  V128 = -0x05,     // 0x7b
-  Funcref = -0x10,  // 0x70
-  Anyref = -0x11,   // 0x6f
-  Nullref = -0x12,  // 0x6e
-  Exnref = -0x18,   // 0x68
-  Func = -0x20,     // 0x60
-  Void = -0x40,     // 0x40
-  ___ = Void,       // Convenient for the opcode table in opcode.h
-  Any = 0,          // Not actually specified, but useful for type-checking
-  Hostref = 2,  // Not actually specified, but used in testing and type-checking
-  I8 = 3,       // Not actually specified, but used internally with load/store
-  I8U = 4,      // Not actually specified, but used internally with load/store
-  I16 = 5,      // Not actually specified, but used internally with load/store
-  I16U = 6,     // Not actually specified, but used internally with load/store
-  I32U = 7,     // Not actually specified, but used internally with load/store
+class Type {
+ public:
+  // Matches binary format, do not change.
+  enum Enum {
+    I32 = -0x01,      // 0x7f
+    I64 = -0x02,      // 0x7e
+    F32 = -0x03,      // 0x7d
+    F64 = -0x04,      // 0x7c
+    V128 = -0x05,     // 0x7b
+    Funcref = -0x10,  // 0x70
+    Anyref = -0x11,   // 0x6f
+    Nullref = -0x12,  // 0x6e
+    Exnref = -0x18,   // 0x68
+    Func = -0x20,     // 0x60
+    Void = -0x40,     // 0x40
+    ___ = Void,       // Convenient for the opcode table in opcode.h
+
+    Any = 0,          // Not actually specified, but useful for type-checking
+    Hostref = 2,      // Not actually specified, but used in testing and type-checking
+    I8 = 3,    // Not actually specified, but used internally with load/store
+    I8U = 4,   // Not actually specified, but used internally with load/store
+    I16 = 5,   // Not actually specified, but used internally with load/store
+    I16U = 6,  // Not actually specified, but used internally with load/store
+    I32U = 7,  // Not actually specified, but used internally with load/store
+  };
+
+  Type() = default;  // Provided so Type can be member of a union.
+  Type(int32_t code) : enum_(static_cast<Enum>(code)) {}
+  Type(Enum e) : enum_(e) {}
+  operator Enum() const { return enum_; }
+
+  bool IsRef() const {
+    return enum_ == Type::Anyref || enum_ == Type::Funcref ||
+           enum_ == Type::Nullref || enum_ == Type::Exnref ||
+           enum_ == Type::Hostref;
+  }
+
+  bool IsNullableRef() const {
+    // Currently all reftypes are nullable
+    return IsRef();
+  }
+
+  const char* GetName() const {
+    switch (enum_) {
+      case Type::I32:     return "i32";
+      case Type::I64:     return "i64";
+      case Type::F32:     return "f32";
+      case Type::F64:     return "f64";
+      case Type::V128:    return "v128";
+      case Type::Funcref: return "funcref";
+      case Type::Func:    return "func";
+      case Type::Exnref:  return "exnref";
+      case Type::Void:    return "void";
+      case Type::Any:     return "any";
+      case Type::Anyref:  return "anyref";
+      case Type::Nullref: return "nullref";
+      default:            return "<type_index>";
+    }
+  }
+
+  bool IsIndex() const { return static_cast<int32_t>(enum_) >= 0; }
+
+  Index GetIndex() const {
+    assert(IsIndex());
+    return static_cast<Index>(enum_);
+  }
+
+  TypeVector GetInlineVector() const {
+    assert(!IsIndex());
+    switch (enum_) {
+      case Type::Void:
+        return TypeVector();
+
+      case Type::I32:
+      case Type::I64:
+      case Type::F32:
+      case Type::F64:
+      case Type::V128:
+      case Type::Funcref:
+      case Type::Anyref:
+      case Type::Nullref:
+      case Type::Exnref:
+        return TypeVector(this, this + 1);
+
+      default:
+        WABT_UNREACHABLE;
+    }
+  }
+
+ private:
+  Enum enum_;
 };
-typedef std::vector<Type> TypeVector;
-
-inline bool IsRefType(Type t) {
-  return t == Type::Anyref || t == Type::Funcref || t == Type::Nullref ||
-         t == Type::Exnref || t == Type::Hostref;
-}
-
-inline bool IsNullableRefType(Type t) {
-  /* Currently all reftypes are nullable */
-  return IsRefType(t);
-}
-
-inline const char* GetTypeName(Type type) {
-  switch (type) {
-    case Type::I32:
-      return "i32";
-    case Type::I64:
-      return "i64";
-    case Type::F32:
-      return "f32";
-    case Type::F64:
-      return "f64";
-    case Type::V128:
-      return "v128";
-    case Type::Funcref:
-      return "funcref";
-    case Type::Func:
-      return "func";
-    case Type::Exnref:
-      return "exnref";
-    case Type::Void:
-      return "void";
-    case Type::Any:
-      return "any";
-    case Type::Anyref:
-      return "anyref";
-    case Type::Nullref:
-      return "nullref";
-    default:
-      return "<type_index>";
-  }
-}
-
-inline bool IsTypeIndex(Type type) {
-  return static_cast<int32_t>(type) >= 0;
-}
-
-inline Index GetTypeIndex(Type type) {
-  assert(IsTypeIndex(type));
-  return static_cast<Index>(type);
-}
-
-inline TypeVector GetInlineTypeVector(Type type) {
-  assert(!IsTypeIndex(type));
-  switch (type) {
-    case Type::Void:
-      return TypeVector();
-
-    case Type::I32:
-    case Type::I64:
-    case Type::F32:
-    case Type::F64:
-    case Type::V128:
-    case Type::Funcref:
-    case Type::Anyref:
-    case Type::Nullref:
-    case Type::Exnref:
-      return TypeVector(&type, &type + 1);
-
-    default:
-      WABT_UNREACHABLE;
-  }
-}
 
 }  // namespace wabt
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -179,9 +179,9 @@ void ScriptValidator::CheckTypeIndex(const Location* loc,
                                      Index index,
                                      const char* index_kind) {
   if (Failed(TypeChecker::CheckType(actual, expected))) {
-    PrintError(
-        loc, "type mismatch for %s %" PRIindex " of %s. got %s, expected %s",
-        index_kind, index, desc, GetTypeName(actual), GetTypeName(expected));
+    PrintError(loc,
+               "type mismatch for %s %" PRIindex " of %s. got %s, expected %s",
+               index_kind, index, desc, actual.GetName(), expected.GetName());
   }
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -276,12 +276,11 @@ Result CheckTypeIndex(const Location& loc,
                       Errors* errors) {
   // Types must match exactly; no subtyping should be allowed.
   if (actual != expected) {
-    errors->emplace_back(
-        ErrorLevel::Error, loc,
-        StringPrintf("type mismatch for %s %" PRIindex
-                     " of %s. got %s, expected %s",
-                     index_kind, index, desc, GetTypeName(actual),
-                     GetTypeName(expected)));
+    errors->emplace_back(ErrorLevel::Error, loc,
+                         StringPrintf("type mismatch for %s %" PRIindex
+                                      " of %s. got %s, expected %s",
+                                      index_kind, index, desc, actual.GetName(),
+                                      expected.GetName()));
     return Result::Error;
   }
   return Result::Ok;
@@ -788,7 +787,7 @@ Result WastParser::ParseValueType(Type* out_type) {
   }
 
   if (!is_enabled) {
-    Error(token.loc, "value type not allowed: %s", GetTypeName(type));
+    Error(token.loc, "value type not allowed: %s", type.GetName());
     return Result::Error;
   }
 
@@ -813,7 +812,7 @@ Result WastParser::ParseRefType(Type* out_type) {
   Token token = Consume();
   Type type = token.type();
   if (type == Type::Anyref && !options_->features.reference_types_enabled()) {
-    Error(token.loc, "value type not allowed: %s", GetTypeName(type));
+    Error(token.loc, "value type not allowed: %s", type.GetName());
     return Result::Error;
   }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -377,7 +377,7 @@ void WatWriter::WriteBrVar(const Var& var, NextChar next_char) {
 }
 
 void WatWriter::WriteType(Type type, NextChar next_char) {
-  const char* type_name = GetTypeName(type);
+  const char* type_name = type.GetName();
   assert(type_name);
   WritePuts(type_name, next_char);
 }


### PR DESCRIPTION
This is similar to the way Opcode is structured, which allows us to hang
member functions off of the enumeration.

The primary motivator for this change is the GC proposal (and the
function-references proposal) where a Type can be parameterized:

     (type $T (struct ...))
     (func
       (local (ref $T)
       ...
     )

In this case the type is ref, with a parameter of the type index. Making
Type a class will make it easier to store this additional information.