### PR TITLE
Update testsuite (w/ reference-types changes)

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -58,6 +58,7 @@ class NameApplier : public ExprVisitor::DelegateNop {
   Result OnDataDropExpr(DataDropExpr*) override;
   Result OnMemoryInitExpr(MemoryInitExpr*) override;
   Result OnElemDropExpr(ElemDropExpr*) override;
+  Result OnTableCopyExpr(TableCopyExpr*) override;
   Result OnTableInitExpr(TableInitExpr*) override;
   Result OnTableGetExpr(TableGetExpr*) override;
   Result OnTableSetExpr(TableSetExpr*) override;
@@ -257,6 +258,12 @@ Result NameApplier::OnMemoryInitExpr(MemoryInitExpr* expr)  {
 
 Result NameApplier::OnElemDropExpr(ElemDropExpr* expr)  {
   CHECK_RESULT(UseNameForElemSegmentVar(&expr->var));
+  return Result::Ok;
+}
+
+Result NameApplier::OnTableCopyExpr(TableCopyExpr* expr) {
+  CHECK_RESULT(UseNameForTableVar(&expr->dst_table));
+  CHECK_RESULT(UseNameForTableVar(&expr->src_table));
   return Result::Ok;
 }
 

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -205,10 +205,10 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnElemSegmentCount(Index count) override;
   Result BeginElemSegment(Index index,
                           Index table_index,
-                          uint8_t flags,
-                          Type elem_type) override;
+                          uint8_t flags) override;
   Result BeginElemSegmentInitExpr(Index index) override;
   Result EndElemSegmentInitExpr(Index index) override;
+  Result OnElemSegmentElemType(Index index, Type elem_type) override;
   Result OnElemSegmentElemExprCount(Index index, Index count) override;
   Result OnElemSegmentElemExpr_RefNull(Index segment_index) override;
   Result OnElemSegmentElemExpr_RefFunc(Index segment_index,
@@ -1022,8 +1022,7 @@ Result BinaryReaderIR::OnElemSegmentCount(Index count) {
 
 Result BinaryReaderIR::BeginElemSegment(Index index,
                                         Index table_index,
-                                        uint8_t flags,
-                                        Type elem_type) {
+                                        uint8_t flags) {
   auto field = MakeUnique<ElemSegmentModuleField>(GetLocation());
   ElemSegment& elem_segment = field->elem_segment;
   elem_segment.table_var = Var(table_index, GetLocation());
@@ -1034,7 +1033,6 @@ Result BinaryReaderIR::BeginElemSegment(Index index,
   } else {
     elem_segment.kind = SegmentKind::Active;
   }
-  elem_segment.elem_type = elem_type;
   module_->AppendField(std::move(field));
   return Result::Ok;
 }
@@ -1048,6 +1046,13 @@ Result BinaryReaderIR::BeginElemSegmentInitExpr(Index index) {
 
 Result BinaryReaderIR::EndElemSegmentInitExpr(Index index) {
   current_init_expr_ = nullptr;
+  return Result::Ok;
+}
+
+Result BinaryReaderIR::OnElemSegmentElemType(Index index, Type elem_type) {
+  assert(index == module_->elem_segments.size() - 1);
+  ElemSegment* segment = module_->elem_segments[index];
+  segment->elem_type = elem_type;
   return Result::Ok;
 }
 

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -368,12 +368,17 @@ Result BinaryReaderLogging::OnSimdShuffleOpExpr(Opcode opcode, v128 value) {
 
 Result BinaryReaderLogging::BeginElemSegment(Index index,
                                              Index table_index,
-                                             uint8_t flags,
-                                             Type elem_type) {
+                                             uint8_t flags) {
   LOGF("BeginElemSegment(index: %" PRIindex ", table_index: %" PRIindex
-       ", flags: %d, elem_type: %s)\n",
-       index, table_index, flags, GetTypeName(elem_type));
-  return reader_->BeginElemSegment(index, table_index, flags, elem_type);
+       ", flags: %d)\n",
+       index, table_index, flags);
+  return reader_->BeginElemSegment(index, table_index, flags);
+}
+
+Result BinaryReaderLogging::OnElemSegmentElemType(Index index, Type elem_type) {
+  LOGF("OnElemSegmentElemType(index: %" PRIindex ", type: %s)\n", index,
+       GetTypeName(elem_type));
+  return reader_->OnElemSegmentElemType(index, elem_type);
 }
 
 Result BinaryReaderLogging::OnDataSegmentData(Index index,

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -231,10 +231,10 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnElemSegmentCount(Index count) override;
   Result BeginElemSegment(Index index,
                           Index table_index,
-                          uint8_t flags,
-                          Type elem_type) override;
+                          uint8_t flags) override;
   Result BeginElemSegmentInitExpr(Index index) override;
   Result EndElemSegmentInitExpr(Index index) override;
+  Result OnElemSegmentElemType(Index index, Type elem_type) override;
   Result OnElemSegmentElemExprCount(Index index, Index count) override;
   Result OnElemSegmentElemExpr_RefNull(Index segment_index) override;
   Result OnElemSegmentElemExpr_RefFunc(Index segment_index,

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -302,12 +302,14 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnElemSegmentCount(Index count) override { return Result::Ok; }
   Result BeginElemSegment(Index index,
                           Index table_index,
-                          uint8_t flags,
-                          Type elem_type) override {
+                          uint8_t flags) override {
     return Result::Ok;
   }
   Result BeginElemSegmentInitExpr(Index index) override { return Result::Ok; }
   Result EndElemSegmentInitExpr(Index index) override { return Result::Ok; }
+  Result OnElemSegmentElemType(Index index, Type elem_type) override {
+    return Result::Ok;
+  }
   Result OnElemSegmentElemExprCount(Index index, Index count) override {
     return Result::Ok;
   }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -799,8 +799,8 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnElemSegmentCount(Index count) override;
   Result BeginElemSegment(Index index,
                           Index table_index,
-                          uint8_t flags,
-                          Type elem_type) override;
+                          uint8_t flags) override;
+  Result OnElemSegmentElemType(Index index, Type elem_type) override;
   Result OnElemSegmentElemExprCount(Index index, Index count) override;
   Result OnElemSegmentElemExpr_RefNull(Index segment_index) override;
   Result OnElemSegmentElemExpr_RefFunc(Index segment_index,
@@ -1273,11 +1273,15 @@ Result BinaryReaderObjdump::OnElemSegmentCount(Index count) {
 
 Result BinaryReaderObjdump::BeginElemSegment(Index index,
                                              Index table_index,
-                                             uint8_t flags,
-                                             Type elem_type) {
+                                             uint8_t flags) {
   table_index_ = table_index;
   elem_index_ = 0;
   elem_flags_ = flags;
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdump::OnElemSegmentElemType(Index index, Type elem_type) {
+  // TODO: Add support for this.
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2220,7 +2220,7 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
     }
     Type elem_type = Type::Funcref;
 
-    CALLBACK(BeginElemSegment, i, table_index, flags, elem_type);
+    CALLBACK(BeginElemSegment, i, table_index, flags);
 
     if (!(flags & SegPassive)) {
       CALLBACK(BeginElemSegmentInitExpr, i);
@@ -2243,7 +2243,10 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
                      GetTypeName(elem_type));
         elem_type = Type::Funcref;
       }
+
     }
+
+    CALLBACK(OnElemSegmentElemType, i, elem_type);
 
     Index num_elem_exprs;
     CHECK_RESULT(ReadCount(&num_elem_exprs, "elem count"));

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2243,7 +2243,6 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
                      GetTypeName(elem_type));
         elem_type = Type::Funcref;
       }
-
     }
 
     CALLBACK(OnElemSegmentElemType, i, elem_type);

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -287,10 +287,10 @@ class BinaryReaderDelegate {
   virtual Result OnElemSegmentCount(Index count) = 0;
   virtual Result BeginElemSegment(Index index,
                                   Index table_index,
-                                  uint8_t flags,
-                                  Type elem_type) = 0;
+                                  uint8_t flags) = 0;
   virtual Result BeginElemSegmentInitExpr(Index index) = 0;
   virtual Result EndElemSegmentInitExpr(Index index) = 0;
+  virtual Result OnElemSegmentElemType(Index index, Type elem_type) = 0;
   virtual Result OnElemSegmentElemExprCount(Index index, Index count) = 0;
   virtual Result OnElemSegmentElemExpr_RefNull(Index segment_index) = 0;
   virtual Result OnElemSegmentElemExpr_RefFunc(Index segment_index,

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -653,6 +653,8 @@ Const::Const(V128Tag, v128 value, const Location& loc_)
 uint8_t ElemSegment::GetFlags(const Module* module) const {
   uint8_t flags = 0;
 
+  bool all_ref_func = elem_type == Type::Funcref;
+
   switch (kind) {
     case SegmentKind::Active: {
       Index table_index = module->GetTableIndex(table_var);
@@ -671,10 +673,11 @@ uint8_t ElemSegment::GetFlags(const Module* module) const {
       break;
   }
 
-  bool all_ref_func = std::all_of(
-      elem_exprs.begin(), elem_exprs.end(), [](const ElemExpr& elem_expr) {
-        return elem_expr.kind == ElemExprKind::RefFunc;
-      });
+  all_ref_func = all_ref_func &&
+                 std::all_of(elem_exprs.begin(), elem_exprs.end(),
+                             [](const ElemExpr& elem_expr) {
+                               return elem_expr.kind == ElemExprKind::RefFunc;
+                             });
   if (!all_ref_func) {
     flags |= SegUseElemExprs;
   }

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -58,6 +58,7 @@ class NameResolver : public ExprVisitor::DelegateNop {
   Result OnDataDropExpr(DataDropExpr*) override;
   Result OnMemoryInitExpr(MemoryInitExpr*) override;
   Result OnElemDropExpr(ElemDropExpr*) override;
+  Result OnTableCopyExpr(TableCopyExpr*) override;
   Result OnTableInitExpr(TableInitExpr*) override;
   Result OnTableGetExpr(TableGetExpr*) override;
   Result OnTableSetExpr(TableSetExpr*) override;
@@ -351,6 +352,12 @@ Result NameResolver::OnMemoryInitExpr(MemoryInitExpr* expr) {
 
 Result NameResolver::OnElemDropExpr(ElemDropExpr* expr) {
   ResolveElemSegmentVar(&expr->var);
+  return Result::Ok;
+}
+
+Result NameResolver::OnTableCopyExpr(TableCopyExpr* expr) {
+  ResolveTableVar(&expr->dst_table);
+  ResolveTableVar(&expr->src_table);
   return Result::Ok;
 }
 

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -84,7 +84,8 @@ class SharedValidator {
 
   Result OnStart(const Location&, Var func_var);
 
-  Result OnElemSegment(const Location&, Var table_var, SegmentKind, Type elem_type);
+  Result OnElemSegment(const Location&, Var table_var, SegmentKind);
+  void OnElemSegmentElemType(Type elem_type);
   Result OnElemSegmentInitExpr_Const(const Location&, Type);
   Result OnElemSegmentInitExpr_GlobalGet(const Location&, Var global_var);
   Result OnElemSegmentInitExpr_Other(const Location&);
@@ -200,6 +201,13 @@ class SharedValidator {
     TypeVector params;
   };
 
+  struct ElemType {
+    ElemType() = default;
+    ElemType(Type element) : element(element) {}
+
+    Type element;
+  };
+
   struct LocalDecl {
     Type type;
     Index end;
@@ -232,7 +240,7 @@ class SharedValidator {
   Result CheckMemoryIndex(Var memory_var, Opcode);
   Result CheckGlobalIndex(Var global_var, GlobalType* out = nullptr);
   Result CheckEventIndex(Var event_var, EventType* out = nullptr);
-  Result CheckElemSegmentIndex(Var elem_segment_var);
+  Result CheckElemSegmentIndex(Var elem_segment_var, ElemType* out = nullptr);
   Result CheckDataSegmentIndex(Var data_segment_var);
 
   Result CheckAlign(const Location&, Address align, Address natural_align);
@@ -258,9 +266,9 @@ class SharedValidator {
   std::vector<MemoryType> memories_;  // Includes imported and defined.
   std::vector<GlobalType> globals_;   // Includes imported and defined.
   std::vector<EventType> events_;     // Includes imported and defined.
+  std::vector<ElemType> elems_;
   Index starts_ = 0;
   Index num_imported_globals_ = 0;
-  Index elem_segments_ = 0;
   Index data_segments_ = 0;
 
   // Includes parameters, since this is only used for validating

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -731,9 +731,10 @@ Result Validator::CheckModule() {
   // Elem segment section.
   for (const ModuleField& field : module->fields) {
     if (auto* f = dyn_cast<ElemSegmentModuleField>(&field)) {
-      result_ |= validator_.OnElemSegment(
-          field.loc, f->elem_segment.table_var, f->elem_segment.kind,
-          f->elem_segment.elem_type);
+      result_ |= validator_.OnElemSegment(field.loc, f->elem_segment.table_var,
+                                          f->elem_segment.kind);
+
+      validator_.OnElemSegmentElemType(f->elem_segment.elem_type);
 
       // Init expr.
       if (f->elem_segment.offset.size() == 1) {

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1820,11 +1820,8 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       Var dst(0, loc);
       Var src(0, loc);
       if (options_->features.reference_types_enabled()) {
-      // TODO: disabled for now, since the spec tests don't currently use.
-#if 0
-        CHECK_RESULT(ParseVar(&dst));
-        CHECK_RESULT(ParseVar(&src));
-#endif
+        ParseVarOpt(&dst, dst);
+        ParseVarOpt(&src, src);
       }
       out_expr->reset(new TableCopyExpr(dst, src, loc));
       break;
@@ -1840,6 +1837,15 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
       Var segment_index(0, loc);
       CHECK_RESULT(ParseVar(&segment_index));
       Var table_index(0, loc);
+      if (ParseVarOpt(&table_index, table_index)) {
+        // Here are the two forms:
+        //
+        //   table.init $elemidx ...
+        //   table.init $tableidx $elemidx ...
+        //
+        // So if both indexes are provided, we need to swap them.
+        std::swap(segment_index, table_index);
+      }
       out_expr->reset(new TableInitExpr(segment_index, table_index, loc));
       break;
     }
@@ -1851,21 +1857,25 @@ Result WastParser::ParsePlainInstr(std::unique_ptr<Expr>* out_expr) {
 
     case TokenType::TableSet:
       ErrorUnlessOpcodeEnabled(Consume());
+      // TODO: Table index.
       CHECK_RESULT(ParsePlainInstrVar<TableSetExpr>(loc, out_expr));
       break;
 
     case TokenType::TableGrow:
       ErrorUnlessOpcodeEnabled(Consume());
+      // TODO: Table index.
       CHECK_RESULT(ParsePlainInstrVar<TableGrowExpr>(loc, out_expr));
       break;
 
     case TokenType::TableSize:
       ErrorUnlessOpcodeEnabled(Consume());
+      // TODO: Table index.
       CHECK_RESULT(ParsePlainInstrVar<TableSizeExpr>(loc, out_expr));
       break;
 
     case TokenType::TableFill:
       ErrorUnlessOpcodeEnabled(Consume());
+      // TODO: Table index.
       CHECK_RESULT(ParsePlainInstrVar<TableFillExpr>(loc, out_expr));
       break;
 

--- a/test/spec/bulk-memory-operations/table_init.txt
+++ b/test/spec/bulk-memory-operations/table_init.txt
@@ -59,7 +59,7 @@ out/test/spec/bulk-memory-operations/table_init.wast:193: assert_invalid passed:
   0000000: error: elem_segment variable out of range: 0 (max 4294967295)
   0000024: error: OnElemDropExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:199: assert_invalid passed:
-  0000000: error: table.init requires table 0 to be an imported or defined table.
+  0000000: error: table variable out of range: 0 (max 4294967295)
   0000000: error: elem_segment variable out of range: 0 (max 4294967295)
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:205: assert_invalid passed:

--- a/test/spec/reference-types/table-sub.txt
+++ b/test/spec/reference-types/table-sub.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table-sub.wast
+;;; ARGS*: --enable-reference-types
+(;; STDOUT ;;;
+out/test/spec/reference-types/table-sub.wast:12: assert_invalid passed:
+  error: type mismatch at table.copy. got anyref, expected funcref
+  000002a: error: OnTableCopyExpr callback failed
+out/test/spec/reference-types/table-sub.wast:23: assert_invalid passed:
+  error: type mismatch at table.init. got anyref, expected funcref
+  000002d: error: OnTableInitExpr callback failed
+2/2 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/reference-types/table_init.txt
+++ b/test/spec/reference-types/table_init.txt
@@ -59,7 +59,7 @@ out/test/spec/reference-types/table_init.wast:193: assert_invalid passed:
   0000000: error: elem_segment variable out of range: 0 (max 4294967295)
   0000024: error: OnElemDropExpr callback failed
 out/test/spec/reference-types/table_init.wast:199: assert_invalid passed:
-  0000000: error: table.init requires table 0 to be an imported or defined table.
+  0000000: error: table variable out of range: 0 (max 4294967295)
   0000000: error: elem_segment variable out of range: 0 (max 4294967295)
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:205: assert_invalid passed:

--- a/test/typecheck/bad-bulk-memory-no-table.txt
+++ b/test/typecheck/bad-bulk-memory-no-table.txt
@@ -9,16 +9,16 @@
   )
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-bulk-memory-no-table.txt:7:41: error: table.init requires table 0 to be an imported or defined table.
+out/test/typecheck/bad-bulk-memory-no-table.txt:7:41: error: table variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 table.init 0
                                         ^^^^^^^^^^
 out/test/typecheck/bad-bulk-memory-no-table.txt:7:52: error: elem_segment variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 table.init 0
                                                    ^
-out/test/typecheck/bad-bulk-memory-no-table.txt:8:41: error: table.copy requires table 0 to be an imported or defined table.
+out/test/typecheck/bad-bulk-memory-no-table.txt:8:41: error: table variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 table.copy
                                         ^^^^^^^^^^
-out/test/typecheck/bad-bulk-memory-no-table.txt:8:41: error: table.copy requires table 0 to be an imported or defined table.
+out/test/typecheck/bad-bulk-memory-no-table.txt:8:41: error: table variable out of range: 0 (max 4294967295)
     i32.const 0 i32.const 0 i32.const 0 table.copy
                                         ^^^^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
The new table-sub test, checks whether the subtyping is handled
properly w/ table.init and table.copy instructions.

The BeginElemSegment callback can't pass the element type anymore, since
it's not known yet. The callback also can't be deferred, since the
BeginElemSegmentInitExpr callback has to happen after the
BeginElemSegment callback, but the reference type is not always known
until after the initializer expression is read. To work around this, I
added a new OnElemSegmentElemType callback.

Other element segment changes:

* The element type must be tracked in the SharedValidator
* A subtle fix: when writing out the segment flags, we need to take into
  account whether the element type of the segment is not funcref, even
  if there are no element expressions. In that case, we have to use flag
  bit 0x4 (SegUseElemExprs).

In addition, the TableCopy and TableInit instructions weren't handling
table indexes fully.

* TableCopy variables are read in the parser (both optional)
* TableCopy names are now resolved + applied
* TableCopy indexes are now validated
* TableInit table variables are read in the parser; this is subtle,
  since the text format has order $table $segment, but the $table is
  optional.