### PR TITLE
Remove validation from the BinaryReader

### DIFF
--- a/test/binary/bad-export-func.txt
+++ b/test/binary/bad-export-func.txt
@@ -4,7 +4,8 @@ version
 section(TYPE) { count[1] function params[0] results[0] }
 section(FUNCTION) { count[1] sig[0] }
 section(EXPORT) { count[1] str("foo") func_kind func[1] }
+section(CODE) { count[1] func { locals[0] } }
 (;; STDERR ;;;
-000001b: error: invalid export func index: 1
-000001b: error: invalid export func index: 1
+out/test/binary/bad-export-func/bad-export-func.wasm:000001b: error: function variable out of range: 1 (max 1)
+out/test/binary/bad-export-func/bad-export-func.wasm:000001b: error: function variable out of range: 1 (max 1)
 ;;; STDERR ;;)

--- a/test/binary/bad-function-sig.txt
+++ b/test/binary/bad-function-sig.txt
@@ -3,7 +3,8 @@ magic
 version
 section(TYPE) { count[1] function params[1] i32 results[1] i32 }
 section(FUNCTION) { count[1] type[1] }
+section(CODE) { count[1] func { locals[0] } }
 (;; STDERR ;;;
-0000014: error: invalid function signature index: 1
-0000014: error: invalid function signature index: 1
+out/test/binary/bad-function-sig/bad-function-sig.wasm:0000014: error: function type variable out of range: 1 (max 1)
+out/test/binary/bad-function-sig/bad-function-sig.wasm:0000014: error: function type variable out of range: 1 (max 1)
 ;;; STDERR ;;)

--- a/test/binary/bad-function-too-many-results.txt
+++ b/test/binary/bad-function-too-many-results.txt
@@ -3,6 +3,6 @@ magic
 version
 section(TYPE) { count[1] function params[0] results[2] i32 i32 }
 (;; STDERR ;;;
-000000e: error: result count must be 0 or 1
-000000e: error: result count must be 0 or 1
+out/test/binary/bad-function-too-many-results/bad-function-too-many-results.wasm:0000010: error: multiple result values not currently supported.
+out/test/binary/bad-function-too-many-results/bad-function-too-many-results.wasm:0000010: error: multiple result values not currently supported.
 ;;; STDERR ;;)

--- a/test/binary/bad-import-sig.txt
+++ b/test/binary/bad-import-sig.txt
@@ -4,6 +4,6 @@ version
 section(TYPE) { count[1] function params[0] results[1] i32 }
 section(IMPORT) { count[1] str("module") str("func") func_kind type[1] }
 (;; STDERR ;;;
-0000020: error: invalid import signature index
-0000020: error: invalid import signature index
+out/test/binary/bad-import-sig/bad-import-sig.wasm:0000020: error: function type variable out of range: 1 (max 1)
+out/test/binary/bad-import-sig/bad-import-sig.wasm:0000020: error: function type variable out of range: 1 (max 1)
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-init-max-size.txt
+++ b/test/binary/bad-memory-init-max-size.txt
@@ -8,6 +8,6 @@ section(MEMORY) {
   max[1]
 }
 (;; STDERR ;;;
-000000e: error: memory initial size must be <= max size
-000000e: error: memory initial size must be <= max size
+out/test/binary/bad-memory-init-max-size/bad-memory-init-max-size.wasm:000000e: error: max pages (1) must be >= initial pages (2)
+out/test/binary/bad-memory-init-max-size/bad-memory-init-max-size.wasm:000000e: error: max pages (1) must be >= initial pages (2)
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-init-size.txt
+++ b/test/binary/bad-memory-init-size.txt
@@ -7,6 +7,6 @@ section(MEMORY) {
   initial[leb_u32(65537)]
 }
 (;; STDERR ;;;
-000000f: error: invalid memory initial size
-000000f: error: invalid memory initial size
+out/test/binary/bad-memory-init-size/bad-memory-init-size.wasm:000000f: error: initial pages (65537) must be <= (65536)
+out/test/binary/bad-memory-init-size/bad-memory-init-size.wasm:000000f: error: initial pages (65537) must be <= (65536)
 ;;; STDERR ;;)

--- a/test/binary/bad-memory-max-size.txt
+++ b/test/binary/bad-memory-max-size.txt
@@ -8,6 +8,6 @@ section(MEMORY) {
   max[leb_u32(65537)]
 }
 (;; STDERR ;;;
-0000010: error: invalid memory max size
-0000010: error: invalid memory max size
+out/test/binary/bad-memory-max-size/bad-memory-max-size.wasm:0000010: error: max pages (65537) must be <= (65536)
+out/test/binary/bad-memory-max-size/bad-memory-max-size.wasm:0000010: error: max pages (65537) must be <= (65536)
 ;;; STDERR ;;)

--- a/test/binary/bad-segment-no-memory.txt
+++ b/test/binary/bad-segment-no-memory.txt
@@ -7,6 +7,6 @@ section(DATA) {
   data[str("hi")]
 }
 (;; STDERR ;;;
-000000b: error: data section without memory section
-000000b: error: data section without memory section
+000000c: error: invalid data segment flags: 0x41
+000000c: error: invalid data segment flags: 0x41
 ;;; STDERR ;;)

--- a/test/binary/bad-start-func.txt
+++ b/test/binary/bad-start-func.txt
@@ -4,7 +4,8 @@ version
 section(TYPE) { count[1] function params[0] results[0] }
 section(FUNCTION) { count[1] sig[0] }
 section(START) { func[1] }
+section(CODE) { count[1] func { locals[0] } }
 (;; STDERR ;;;
-0000015: error: invalid start function index: 1
-0000015: error: invalid start function index: 1
+out/test/binary/bad-start-func/bad-start-func.wasm:0000015: error: function variable out of range: 1 (max 1)
+out/test/binary/bad-start-func/bad-start-func.wasm:0000015: error: function variable out of range: 1 (max 1)
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-block-sig-multi.txt
+++ b/test/parse/expr/bad-block-sig-multi.txt
@@ -15,7 +15,7 @@
       drop
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-block-sig-multi.txt:5:5: error: multiple block results not currently supported.
+out/test/parse/expr/bad-block-sig-multi.txt:5:5: error: multiple result values not currently supported.
     block (result i32 i32)
     ^^^^^
 out/test/parse/expr/bad-block-sig-multi.txt:14:5: error: block params not currently supported.

--- a/test/parse/expr/bad-if-sig-multi.txt
+++ b/test/parse/expr/bad-if-sig-multi.txt
@@ -22,7 +22,7 @@
       drop
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-if-sig-multi.txt:6:5: error: multiple if results not currently supported.
+out/test/parse/expr/bad-if-sig-multi.txt:6:5: error: multiple result values not currently supported.
     if (result i32 i32)
     ^^
 out/test/parse/expr/bad-if-sig-multi.txt:19:5: error: if params not currently supported.

--- a/test/parse/expr/bad-loop-sig-multi.txt
+++ b/test/parse/expr/bad-loop-sig-multi.txt
@@ -15,7 +15,7 @@
       drop
     end))
 (;; STDERR ;;;
-out/test/parse/expr/bad-loop-sig-multi.txt:5:5: error: multiple loop results not currently supported.
+out/test/parse/expr/bad-loop-sig-multi.txt:5:5: error: multiple result values not currently supported.
     loop (result i32 i32)
     ^^^^
 out/test/parse/expr/bad-loop-sig-multi.txt:14:5: error: loop params not currently supported.

--- a/test/parse/expr/bad-try-sig-multi.txt
+++ b/test/parse/expr/bad-try-sig-multi.txt
@@ -22,7 +22,7 @@
     end
     return))
 (;; STDERR ;;;
-out/test/parse/expr/bad-try-sig-multi.txt:6:5: error: multiple try results not currently supported.
+out/test/parse/expr/bad-try-sig-multi.txt:6:5: error: multiple result values not currently supported.
     try (result i32 i32)
     ^^^
 out/test/parse/expr/bad-try-sig-multi.txt:18:5: error: try params not currently supported.

--- a/test/spec/bulk-memory-operations/binary.txt
+++ b/test/spec/bulk-memory-operations/binary.txt
@@ -129,9 +129,9 @@ out/test/spec/bulk-memory-operations/binary.wast:630: assert_malformed passed:
 out/test/spec/bulk-memory-operations/binary.wast:641: assert_malformed passed:
   0000015: error: function signature count != function body count
 out/test/spec/bulk-memory-operations/binary.wast:664: assert_malformed passed:
-  000000e: error: data section without memory section
+  000000e: error: data segment count does not equal count in DataCount section
 out/test/spec/bulk-memory-operations/binary.wast:674: assert_malformed passed:
-  000000e: error: data section without memory section
+  000000e: error: data segment count does not equal count in DataCount section
 out/test/spec/bulk-memory-operations/binary.wast:684: assert_malformed passed:
   0000024: error: memory.init requires data count section
 out/test/spec/bulk-memory-operations/binary.wast:706: assert_malformed passed:

--- a/test/spec/bulk-memory-operations/data.txt
+++ b/test/spec/bulk-memory-operations/data.txt
@@ -3,7 +3,8 @@
 ;;; ARGS*: --enable-bulk-memory
 (;; STDOUT ;;;
 out/test/spec/bulk-memory-operations/data.wast:293: assert_invalid passed:
-  000000b: error: data section without memory section
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
 out/test/spec/bulk-memory-operations/data.wast:302: assert_invalid passed:
   0000013: error: expected i32 init_expr
 out/test/spec/bulk-memory-operations/data.wast:310: assert_invalid passed:

--- a/test/spec/bulk-memory-operations/elem.txt
+++ b/test/spec/bulk-memory-operations/elem.txt
@@ -3,7 +3,8 @@
 ;;; ARGS*: --enable-bulk-memory
 (;; STDOUT ;;;
 out/test/spec/bulk-memory-operations/elem.wast:300: assert_invalid passed:
-  0000015: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  0000016: error: BeginElemSegment callback failed
 out/test/spec/bulk-memory-operations/elem.wast:310: assert_invalid passed:
   0000014: error: expected i32 init_expr
 out/test/spec/bulk-memory-operations/elem.wast:318: assert_invalid passed:

--- a/test/spec/bulk-memory-operations/imports.txt
+++ b/test/spec/bulk-memory-operations/imports.txt
@@ -13,7 +13,8 @@ called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/bulk-memory-operations/imports.wast:91: assert_invalid passed:
-  000001e: error: invalid import signature index
+  0000000: error: function type variable out of range: 1 (max 1)
+  000001e: error: OnImportFunc callback failed
 out/test/spec/bulk-memory-operations/imports.wast:107: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/bulk-memory-operations/imports.wast:111: assert_unlinkable passed:
@@ -88,9 +89,11 @@ out/test/spec/bulk-memory-operations/imports.wast:310: assert_invalid passed:
   error: only one table allowed
   0000017: error: OnImportTable callback failed
 out/test/spec/bulk-memory-operations/imports.wast:314: assert_invalid passed:
-  0000014: error: table count (2) must be 0 or 1
+  error: only one table allowed
+  0000017: error: OnTable callback failed
 out/test/spec/bulk-memory-operations/imports.wast:318: assert_invalid passed:
-  000000b: error: table count (2) must be 0 or 1
+  error: only one table allowed
+  0000011: error: OnTable callback failed
 out/test/spec/bulk-memory-operations/imports.wast:335: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/bulk-memory-operations/imports.wast:339: assert_unlinkable passed:
@@ -117,9 +120,11 @@ out/test/spec/bulk-memory-operations/imports.wast:405: assert_invalid passed:
   error: only one memory block allowed
   0000015: error: OnImportMemory callback failed
 out/test/spec/bulk-memory-operations/imports.wast:409: assert_invalid passed:
-  0000013: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000015: error: OnMemory callback failed
 out/test/spec/bulk-memory-operations/imports.wast:413: assert_invalid passed:
-  000000b: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  000000f: error: OnMemory callback failed
 out/test/spec/bulk-memory-operations/imports.wast:428: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/bulk-memory-operations/imports.wast:432: assert_unlinkable passed:

--- a/test/spec/bulk-memory-operations/table_init.txt
+++ b/test/spec/bulk-memory-operations/table_init.txt
@@ -63,9 +63,12 @@ out/test/spec/bulk-memory-operations/table_init.wast:199: assert_invalid passed:
   0000000: error: elem_segment variable out of range: 0 (max 0)
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:205: assert_invalid passed:
-  0000024: error: elem section without table section
+  0000000: error: elem_segment variable out of range: 4 (max 1)
+  0000035: error: OnElemDropExpr callback failed
 out/test/spec/bulk-memory-operations/table_init.wast:213: assert_invalid passed:
-  0000024: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  0000000: error: elem_segment variable out of range: 4 (max 1)
+  000003c: error: OnTableInitExpr callback failed
 test() =>
 out/test/spec/bulk-memory-operations/table_init.wast:265: assert_trap passed: out of bounds table access: table.init out of bounds
 test() =>

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -51,8 +51,10 @@ out/test/spec/call.wast:444: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000025: error: OnCallExpr callback failed
 out/test/spec/call.wast:457: assert_invalid passed:
-  0000019: error: invalid call function index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  0000019: error: OnCallExpr callback failed
 out/test/spec/call.wast:461: assert_invalid passed:
-  000001d: error: invalid call function index: 1012321300
+  0000000: error: function variable out of range: 1012321300 (max 1)
+  000001d: error: OnCallExpr callback failed
 82/82 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -137,9 +137,11 @@ out/test/spec/call_indirect.wast:902: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000003d: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:922: assert_invalid passed:
-  0000021: error: invalid call_indirect signature index
+  0000000: error: function type variable out of range: 1 (max 1)
+  0000022: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:929: assert_invalid passed:
-  0000025: error: invalid call_indirect signature index
+  0000000: error: function type variable out of range: 1012321300 (max 1)
+  0000026: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:940: assert_invalid passed:
   0000000: error: function variable out of range: 0 (max 0)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -30,7 +30,8 @@ out/test/spec/data.wast:266: assert_unlinkable passed:
 out/test/spec/data.wast:273: assert_unlinkable passed:
   error: out of bounds memory access: data segment is out of bounds: [4294967196, 4294967197) >= max value 65536
 out/test/spec/data.wast:283: assert_invalid passed:
-  000000b: error: data section without memory section
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
 out/test/spec/data.wast:292: assert_invalid passed:
   0000013: error: expected i32 init_expr
 out/test/spec/data.wast:300: assert_invalid passed:

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -26,7 +26,8 @@ out/test/spec/elem.wast:229: assert_unlinkable passed:
 out/test/spec/elem.wast:237: assert_unlinkable passed:
   error: out of bounds table access: elem segment is out of bounds: [4294967286, 4294967287) >= max value 10
 out/test/spec/elem.wast:248: assert_invalid passed:
-  0000015: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  0000016: error: BeginElemSegment callback failed
 out/test/spec/elem.wast:258: assert_invalid passed:
   0000014: error: expected i32 init_expr
 out/test/spec/elem.wast:266: assert_invalid passed:

--- a/test/spec/exports.txt
+++ b/test/spec/exports.txt
@@ -2,7 +2,8 @@
 ;;; STDIN_FILE: third_party/testsuite/exports.wast
 (;; STDOUT ;;;
 out/test/spec/exports.wast:29: assert_invalid passed:
-  0000019: error: invalid export func index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  0000019: error: OnExport callback failed
 out/test/spec/exports.wast:33: assert_invalid passed:
   error: duplicate export "a"
   000001d: error: OnExport callback failed
@@ -19,7 +20,8 @@ out/test/spec/exports.wast:49: assert_invalid passed:
   error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/exports.wast:78: assert_invalid passed:
-  0000017: error: invalid export global index: 1
+  0000000: error: global variable out of range: 1 (max 1)
+  0000017: error: OnExport callback failed
 out/test/spec/exports.wast:82: assert_invalid passed:
   error: duplicate export "a"
   000001b: error: OnExport callback failed
@@ -36,7 +38,8 @@ out/test/spec/exports.wast:98: assert_invalid passed:
   error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exports.wast:126: assert_invalid passed:
-  0000015: error: invalid export table index: 1
+  0000000: error: table variable out of range: 1 (max 1)
+  0000015: error: OnExport callback failed
 out/test/spec/exports.wast:130: assert_invalid passed:
   error: duplicate export "a"
   0000019: error: OnExport callback failed
@@ -50,7 +53,8 @@ out/test/spec/exports.wast:147: assert_invalid passed:
   error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exports.wast:175: assert_invalid passed:
-  0000014: error: invalid export memory index: 1
+  0000000: error: memory variable out of range: 1 (max 1)
+  0000014: error: OnExport callback failed
 out/test/spec/exports.wast:179: assert_invalid passed:
   error: duplicate export "a"
   0000018: error: OnExport callback failed

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -2,7 +2,8 @@
 ;;; STDIN_FILE: third_party/testsuite/func.wast
 (;; STDOUT ;;;
 out/test/spec/func.wast:303: assert_invalid passed:
-  000001a: error: invalid function signature index: 2
+  0000000: error: function type variable out of range: 2 (max 2)
+  000001a: error: OnFunction callback failed
 out/test/spec/func.wast:387: assert_malformed passed:
   out/test/spec/func/func.4.wat:1:76: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (type $sig) (result i32) (param i32) (i32.const 0))
@@ -65,9 +66,11 @@ out/test/spec/func.wast:485: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/func.wast:493: assert_invalid passed:
-  000000e: error: result count must be 0 or 1
+  error: multiple result values not currently supported.
+  0000010: error: OnFuncType callback failed
 out/test/spec/func.wast:497: assert_invalid passed:
-  000000e: error: result count must be 0 or 1
+  error: multiple result values not currently supported.
+  0000010: error: OnFuncType callback failed
 out/test/spec/func.wast:506: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000019: error: EndFunctionBody callback failed

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -4,9 +4,11 @@
 called host spectest.print_i32(i32:83) =>
 four(i32:83) =>
 out/test/spec/func_ptrs.wast:32: assert_invalid passed:
-  000000b: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  000000c: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:33: assert_invalid passed:
-  0000015: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  0000016: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:36: assert_invalid passed:
   0000014: error: expected i32 init_expr
 out/test/spec/func_ptrs.wast:40: assert_invalid passed:
@@ -14,9 +16,11 @@ out/test/spec/func_ptrs.wast:40: assert_invalid passed:
 out/test/spec/func_ptrs.wast:44: assert_invalid passed:
   0000013: error: unexpected opcode in initializer expression: 0x1
 out/test/spec/func_ptrs.wast:48: assert_invalid passed:
-  000000c: error: invalid function signature index: 42
+  0000000: error: function type variable out of range: 42 (max 0)
+  000000c: error: OnFunction callback failed
 out/test/spec/func_ptrs.wast:49: assert_invalid passed:
-  0000020: error: invalid import signature index
+  0000000: error: function type variable out of range: 43 (max 0)
+  0000020: error: OnImportFunc callback failed
 out/test/spec/func_ptrs.wast:78: assert_trap passed: undefined table index
 out/test/spec/func_ptrs.wast:79: assert_trap passed: undefined table index
 out/test/spec/func_ptrs.wast:80: assert_trap passed: undefined table index

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -12,7 +12,8 @@ called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/imports.wast:91: assert_invalid passed:
-  000001e: error: invalid import signature index
+  0000000: error: function type variable out of range: 1 (max 1)
+  000001e: error: OnImportFunc callback failed
 out/test/spec/imports.wast:107: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/imports.wast:111: assert_unlinkable passed:
@@ -87,9 +88,11 @@ out/test/spec/imports.wast:310: assert_invalid passed:
   error: only one table allowed
   0000017: error: OnImportTable callback failed
 out/test/spec/imports.wast:314: assert_invalid passed:
-  0000014: error: table count (2) must be 0 or 1
+  error: only one table allowed
+  0000017: error: OnTable callback failed
 out/test/spec/imports.wast:318: assert_invalid passed:
-  000000b: error: table count (2) must be 0 or 1
+  error: only one table allowed
+  0000011: error: OnTable callback failed
 out/test/spec/imports.wast:335: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/imports.wast:339: assert_unlinkable passed:
@@ -116,9 +119,11 @@ out/test/spec/imports.wast:405: assert_invalid passed:
   error: only one memory block allowed
   0000015: error: OnImportMemory callback failed
 out/test/spec/imports.wast:409: assert_invalid passed:
-  0000013: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000015: error: OnMemory callback failed
 out/test/spec/imports.wast:413: assert_invalid passed:
-  000000b: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  000000f: error: OnMemory callback failed
 out/test/spec/imports.wast:428: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/imports.wast:432: assert_unlinkable passed:

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -2,15 +2,20 @@
 ;;; STDIN_FILE: third_party/testsuite/memory.wast
 (;; STDOUT ;;;
 out/test/spec/memory.wast:8: assert_invalid passed:
-  000000b: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  000000f: error: OnMemory callback failed
 out/test/spec/memory.wast:9: assert_invalid passed:
-  0000021: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000023: error: OnMemory callback failed
 out/test/spec/memory.wast:18: assert_invalid passed:
-  000000b: error: data section without memory section
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:19: assert_invalid passed:
-  000000b: error: data section without memory section
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:20: assert_invalid passed:
-  000000b: error: data section without memory section
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:23: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   000001c: error: OnLoadExpr callback failed
@@ -30,18 +35,25 @@ out/test/spec/memory.wast:43: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory.wast:49: assert_invalid passed:
-  000000e: error: memory initial size must be <= max size
+  error: max pages (0) must be >= initial pages (1)
+  000000e: error: OnMemory callback failed
 out/test/spec/memory.wast:53: assert_invalid passed:
-  000000f: error: invalid memory initial size
+  error: initial pages (65537) must be <= (65536)
+  000000f: error: OnMemory callback failed
 out/test/spec/memory.wast:57: assert_invalid passed:
-  0000011: error: invalid memory initial size
+  error: initial pages (2147483648) must be <= (65536)
+  0000011: error: OnMemory callback failed
 out/test/spec/memory.wast:61: assert_invalid passed:
-  0000011: error: invalid memory initial size
+  error: initial pages (4294967295) must be <= (65536)
+  0000011: error: OnMemory callback failed
 out/test/spec/memory.wast:65: assert_invalid passed:
-  0000010: error: invalid memory max size
+  error: max pages (65537) must be <= (65536)
+  0000010: error: OnMemory callback failed
 out/test/spec/memory.wast:69: assert_invalid passed:
-  0000012: error: invalid memory max size
+  error: max pages (2147483648) must be <= (65536)
+  0000012: error: OnMemory callback failed
 out/test/spec/memory.wast:73: assert_invalid passed:
-  0000012: error: invalid memory max size
+  error: max pages (4294967295) must be <= (65536)
+  0000012: error: OnMemory callback failed
 63/63 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/binary.txt
+++ b/test/spec/multi-value/binary.txt
@@ -134,7 +134,8 @@ out/test/spec/multi-value/binary.wast:741: assert_malformed passed:
   error: invalid depth: 11 (max 2)
   0000024: error: OnBrTableExpr callback failed
 out/test/spec/multi-value/binary.wast:763: assert_malformed passed:
-  0000025: error: expected valid block signature type
+  error: function type variable out of range: 11 (max 1)
+  0000025: error: OnBlockExpr callback failed
 out/test/spec/multi-value/binary.wast:798: assert_malformed passed:
   0000017: error: multiple Start sections
 67/67 tests passed.

--- a/test/spec/multi-value/call.txt
+++ b/test/spec/multi-value/call.txt
@@ -52,8 +52,10 @@ out/test/spec/multi-value/call.wast:499: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000025: error: OnCallExpr callback failed
 out/test/spec/multi-value/call.wast:512: assert_invalid passed:
-  0000019: error: invalid call function index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  0000019: error: OnCallExpr callback failed
 out/test/spec/multi-value/call.wast:516: assert_invalid passed:
-  000001d: error: invalid call function index: 1012321300
+  0000000: error: function variable out of range: 1012321300 (max 1)
+  000001d: error: OnCallExpr callback failed
 90/90 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-value/call_indirect.txt
+++ b/test/spec/multi-value/call_indirect.txt
@@ -138,9 +138,11 @@ out/test/spec/multi-value/call_indirect.wast:931: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000003d: error: OnCallIndirectExpr callback failed
 out/test/spec/multi-value/call_indirect.wast:951: assert_invalid passed:
-  0000021: error: invalid call_indirect signature index
+  0000000: error: function type variable out of range: 1 (max 1)
+  0000022: error: OnCallIndirectExpr callback failed
 out/test/spec/multi-value/call_indirect.wast:958: assert_invalid passed:
-  0000025: error: invalid call_indirect signature index
+  0000000: error: function type variable out of range: 1012321300 (max 1)
+  0000026: error: OnCallIndirectExpr callback failed
 out/test/spec/multi-value/call_indirect.wast:969: assert_invalid passed:
   0000000: error: function variable out of range: 0 (max 0)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed

--- a/test/spec/multi-value/func.txt
+++ b/test/spec/multi-value/func.txt
@@ -3,7 +3,8 @@
 ;;; ARGS*: --enable-multi-value
 (;; STDOUT ;;;
 out/test/spec/multi-value/func.wast:436: assert_invalid passed:
-  000001a: error: invalid function signature index: 2
+  0000000: error: function type variable out of range: 2 (max 2)
+  000001a: error: OnFunction callback failed
 out/test/spec/multi-value/func.wast:520: assert_malformed passed:
   out/test/spec/multi-value/func/func.4.wat:1:76: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (type $sig) (result i32) (param i32) (i32.const 0))

--- a/test/spec/reference-types/binary.txt
+++ b/test/spec/reference-types/binary.txt
@@ -173,9 +173,9 @@ out/test/spec/reference-types/binary.wast:937: assert_malformed passed:
 out/test/spec/reference-types/binary.wast:948: assert_malformed passed:
   0000015: error: function signature count != function body count
 out/test/spec/reference-types/binary.wast:971: assert_malformed passed:
-  000000e: error: data section without memory section
+  000000e: error: data segment count does not equal count in DataCount section
 out/test/spec/reference-types/binary.wast:981: assert_malformed passed:
-  000000e: error: data section without memory section
+  000000e: error: data segment count does not equal count in DataCount section
 out/test/spec/reference-types/binary.wast:991: assert_malformed passed:
   0000024: error: memory.init requires data count section
 out/test/spec/reference-types/binary.wast:1013: assert_malformed passed:

--- a/test/spec/reference-types/data.txt
+++ b/test/spec/reference-types/data.txt
@@ -3,7 +3,8 @@
 ;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/data.wast:293: assert_invalid passed:
-  000000b: error: data section without memory section
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
 out/test/spec/reference-types/data.wast:302: assert_invalid passed:
   0000013: error: expected i32 init_expr
 out/test/spec/reference-types/data.wast:310: assert_invalid passed:

--- a/test/spec/reference-types/elem.txt
+++ b/test/spec/reference-types/elem.txt
@@ -5,7 +5,8 @@
 out/test/spec/reference-types/elem.wast:320: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/reference-types/elem.wast:330: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/reference-types/elem.wast:335: assert_invalid passed:
-  0000015: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  0000016: error: BeginElemSegment callback failed
 out/test/spec/reference-types/elem.wast:345: assert_invalid passed:
   0000014: error: expected i32 init_expr
 out/test/spec/reference-types/elem.wast:353: assert_invalid passed:

--- a/test/spec/reference-types/exports.txt
+++ b/test/spec/reference-types/exports.txt
@@ -3,7 +3,8 @@
 ;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/exports.wast:29: assert_invalid passed:
-  0000019: error: invalid export func index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  0000019: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:33: assert_invalid passed:
   error: duplicate export "a"
   000001d: error: OnExport callback failed
@@ -20,7 +21,8 @@ out/test/spec/reference-types/exports.wast:49: assert_invalid passed:
   error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:78: assert_invalid passed:
-  0000017: error: invalid export global index: 1
+  0000000: error: global variable out of range: 1 (max 1)
+  0000017: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:82: assert_invalid passed:
   error: duplicate export "a"
   000001b: error: OnExport callback failed
@@ -37,7 +39,8 @@ out/test/spec/reference-types/exports.wast:98: assert_invalid passed:
   error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:125: assert_invalid passed:
-  0000015: error: invalid export table index: 1
+  0000000: error: table variable out of range: 1 (max 1)
+  0000015: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:129: assert_invalid passed:
   error: duplicate export "a"
   0000019: error: OnExport callback failed
@@ -54,7 +57,8 @@ out/test/spec/reference-types/exports.wast:145: assert_invalid passed:
   error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:173: assert_invalid passed:
-  0000014: error: invalid export memory index: 1
+  0000000: error: memory variable out of range: 1 (max 1)
+  0000014: error: OnExport callback failed
 out/test/spec/reference-types/exports.wast:177: assert_invalid passed:
   error: duplicate export "a"
   0000018: error: OnExport callback failed

--- a/test/spec/reference-types/imports.txt
+++ b/test/spec/reference-types/imports.txt
@@ -13,7 +13,8 @@ called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/reference-types/imports.wast:92: assert_invalid passed:
-  000001e: error: invalid import signature index
+  0000000: error: function type variable out of range: 1 (max 1)
+  000001e: error: OnImportFunc callback failed
 out/test/spec/reference-types/imports.wast:108: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/reference-types/imports.wast:112: assert_unlinkable passed:
@@ -114,9 +115,11 @@ out/test/spec/reference-types/imports.wast:417: assert_invalid passed:
   error: only one memory block allowed
   0000015: error: OnImportMemory callback failed
 out/test/spec/reference-types/imports.wast:421: assert_invalid passed:
-  0000013: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  0000015: error: OnMemory callback failed
 out/test/spec/reference-types/imports.wast:425: assert_invalid passed:
-  000000b: error: memory count (2) must be 0 or 1
+  error: only one memory block allowed
+  000000f: error: OnMemory callback failed
 out/test/spec/reference-types/imports.wast:440: assert_unlinkable passed:
   error: invalid import "test.unknown"
 out/test/spec/reference-types/imports.wast:444: assert_unlinkable passed:

--- a/test/spec/reference-types/select.txt
+++ b/test/spec/reference-types/select.txt
@@ -14,7 +14,8 @@ out/test/spec/reference-types/select.wast:373: assert_invalid passed:
 out/test/spec/reference-types/select.wast:377: assert_invalid passed:
   000001d: error: invalid arity in select instrcution: 0
 out/test/spec/reference-types/select.wast:381: assert_invalid passed:
-  000000e: error: result count must be 0 or 1
+  error: multiple result values not currently supported.
+  0000010: error: OnFuncType callback failed
 out/test/spec/reference-types/select.wast:393: assert_invalid passed:
   error: type mismatch in select, expected [any, any, i32] but got [nullref, nullref, i32]
   000001c: error: OnSelectExpr callback failed

--- a/test/spec/reference-types/table_init.txt
+++ b/test/spec/reference-types/table_init.txt
@@ -63,9 +63,12 @@ out/test/spec/reference-types/table_init.wast:199: assert_invalid passed:
   0000000: error: elem_segment variable out of range: 0 (max 0)
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/reference-types/table_init.wast:205: assert_invalid passed:
-  0000024: error: elem section without table section
+  0000000: error: elem_segment variable out of range: 4 (max 1)
+  0000035: error: OnElemDropExpr callback failed
 out/test/spec/reference-types/table_init.wast:213: assert_invalid passed:
-  0000024: error: elem section without table section
+  0000000: error: table variable out of range: 0 (max 0)
+  0000000: error: elem_segment variable out of range: 4 (max 1)
+  000003c: error: OnTableInitExpr callback failed
 test() =>
 out/test/spec/reference-types/table_init.wast:265: assert_trap passed: out of bounds table access: table.init out of bounds
 test() =>

--- a/test/spec/reference-types/unreached-invalid.txt
+++ b/test/spec/reference-types/unreached-invalid.txt
@@ -9,7 +9,8 @@ out/test/spec/reference-types/unreached-invalid.wast:8: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:12: assert_invalid passed:
-  000001a: error: invalid call function index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  000001a: error: OnCallExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:16: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   000001a: error: OnBrExpr callback failed

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -2,7 +2,8 @@
 ;;; STDIN_FILE: third_party/testsuite/start.wast
 (;; STDOUT ;;;
 out/test/spec/start.wast:2: assert_invalid passed:
-  0000015: error: invalid start function index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  0000015: error: OnStartFunction callback failed
 out/test/spec/start.wast:7: assert_invalid passed:
   error: start function must not return anything
   0000016: error: OnStartFunction callback failed

--- a/test/spec/type.txt
+++ b/test/spec/type.txt
@@ -11,8 +11,10 @@ out/test/spec/type.wast:48: assert_malformed passed:
   (type (func (result $x i32)))
                       ^^
 out/test/spec/type.wast:53: assert_invalid passed:
-  000000e: error: result count must be 0 or 1
+  error: multiple result values not currently supported.
+  0000010: error: OnFuncType callback failed
 out/test/spec/type.wast:57: assert_invalid passed:
-  000000e: error: result count must be 0 or 1
+  error: multiple result values not currently supported.
+  0000010: error: OnFuncType callback failed
 4/4 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -8,7 +8,8 @@ out/test/spec/unreached-invalid.wast:8: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/unreached-invalid.wast:12: assert_invalid passed:
-  000001a: error: invalid call function index: 1
+  0000000: error: function variable out of range: 1 (max 1)
+  000001a: error: OnCallExpr callback failed
 out/test/spec/unreached-invalid.wast:16: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   000001a: error: OnBrExpr callback failed


### PR DESCRIPTION
Validation should only happen in ValidateModule, BinaryReader should
only check whether the binary is malformed.

This change also fixes a few places in BinaryReaderIR where an index is
assumed to be valid.