### PR TITLE
Refactor Const struct's internal storage

### DIFF
--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -166,19 +166,19 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
 
   /* Always write the values as strings, even though they may be representable
    * as JSON numbers. This way the formatting is consistent. */
-  switch (const_.type) {
+  switch (const_.type()) {
     case Type::I32:
       WriteString("i32");
       WriteSeparator();
       WriteKey("value");
-      json_stream_->Writef("\"%u\"", const_.u32);
+      json_stream_->Writef("\"%u\"", const_.u32());
       break;
 
     case Type::I64:
       WriteString("i64");
       WriteSeparator();
       WriteKey("value");
-      json_stream_->Writef("\"%" PRIu64 "\"", const_.u64);
+      json_stream_->Writef("\"%" PRIu64 "\"", const_.u64());
       break;
 
     case Type::F32: {
@@ -186,14 +186,14 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteString("f32");
       WriteSeparator();
       WriteKey("value");
-      if (const_.is_expected_nan) {
-        if (const_.expected == ExpectedNan::Arithmetic) {
+      if (const_.is_expected_nan()) {
+        if (const_.expected() == ExpectedNan::Arithmetic) {
           WriteString("nan:arithmetic");
         } else {
           WriteString("nan:canonical");
         }
       } else {
-        json_stream_->Writef("\"%u\"", const_.f32_bits);
+        json_stream_->Writef("\"%u\"", const_.f32_bits());
       }
       break;
     }
@@ -203,14 +203,14 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteString("f64");
       WriteSeparator();
       WriteKey("value");
-      if (const_.is_expected_nan) {
-        if (const_.expected == ExpectedNan::Arithmetic) {
+      if (const_.is_expected_nan()) {
+        if (const_.expected() == ExpectedNan::Arithmetic) {
           WriteString("nan:arithmetic");
         } else {
           WriteString("nan:canonical");
         }
       } else {
-        json_stream_->Writef("\"%" PRIu64 "\"", const_.f64_bits);
+        json_stream_->Writef("\"%" PRIu64 "\"", const_.f64_bits());
       }
       break;
     }
@@ -226,7 +226,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteString("funcref");
       WriteSeparator();
       WriteKey("value");
-      int64_t ref_bits = static_cast<int64_t>(const_.ref_bits);
+      int64_t ref_bits = static_cast<int64_t>(const_.ref_bits());
       json_stream_->Writef("\"%" PRIu64 "\"", ref_bits);
       break;
     }
@@ -235,7 +235,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteString("hostref");
       WriteSeparator();
       WriteKey("value");
-      int64_t ref_bits = static_cast<int64_t>(const_.ref_bits);
+      int64_t ref_bits = static_cast<int64_t>(const_.ref_bits());
       json_stream_->Writef("\"%" PRIu64 "\"", ref_bits);
       break;
     }
@@ -245,7 +245,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteSeparator();
       WriteKey("value");
       char buffer[128];
-      WriteUint128(buffer, 128, const_.vec128);
+      WriteUint128(buffer, 128, const_.vec128());
       json_stream_->Writef("\"%s\"", buffer);
       break;
     }

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -487,27 +487,27 @@ void BinaryWriter::WriteExpr(const Func* func, const Expr* expr) {
       break;
     case ExprType::Const: {
       const Const& const_ = cast<ConstExpr>(expr)->const_;
-      switch (const_.type) {
+      switch (const_.type()) {
         case Type::I32: {
           WriteOpcode(stream_, Opcode::I32Const);
-          WriteS32Leb128(stream_, const_.u32, "i32 literal");
+          WriteS32Leb128(stream_, const_.u32(), "i32 literal");
           break;
         }
         case Type::I64:
           WriteOpcode(stream_, Opcode::I64Const);
-          WriteS64Leb128(stream_, const_.u64, "i64 literal");
+          WriteS64Leb128(stream_, const_.u64(), "i64 literal");
           break;
         case Type::F32:
           WriteOpcode(stream_, Opcode::F32Const);
-          stream_->WriteU32(const_.f32_bits, "f32 literal");
+          stream_->WriteU32(const_.f32_bits(), "f32 literal");
           break;
         case Type::F64:
           WriteOpcode(stream_, Opcode::F64Const);
-          stream_->WriteU64(const_.f64_bits, "f64 literal");
+          stream_->WriteU64(const_.f64_bits(), "f64 literal");
           break;
         case Type::V128:
           WriteOpcode(stream_, Opcode::V128Const);
-          stream_->WriteU128(const_.vec128, "v128 literal");
+          stream_->WriteU128(const_.vec128(), "v128 literal");
           break;
         default:
           assert(0);

--- a/src/common.h
+++ b/src/common.h
@@ -212,8 +212,10 @@ enum class SegmentKind {
   Declared,
 };
 
-// Used in test asserts for special expected values "nan:canonical" and "nan:arithmetic"
+// Used in test asserts for special expected values "nan:canonical" and
+// "nan:arithmetic"
 enum class ExpectedNan {
+  None,
   Canonical,
   Arithmetic,
 };

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -637,21 +637,6 @@ void Var::Destroy() {
   }
 }
 
-Const::Const(I32Tag, uint32_t value, const Location& loc_)
-    : loc(loc_), type(Type::I32), u32(value) {}
-
-Const::Const(I64Tag, uint64_t value, const Location& loc_)
-    : loc(loc_), type(Type::I64), u64(value) {}
-
-Const::Const(F32Tag, uint32_t value, const Location& loc_)
-    : loc(loc_), type(Type::F32), f32_bits(value) {}
-
-Const::Const(F64Tag, uint64_t value, const Location& loc_)
-    : loc(loc_), type(Type::F64), f64_bits(value) {}
-
-Const::Const(V128Tag, v128 value, const Location& loc_)
-    : loc(loc_), type(Type::V128), vec128(value) {}
-
 uint8_t ElemSegment::GetFlags(const Module* module) const {
   uint8_t flags = 0;
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -281,7 +281,7 @@ Result Validator::OnCompareExpr(CompareExpr* expr) {
 }
 
 Result Validator::OnConstExpr(ConstExpr* expr) {
-  result_ |= validator_.OnConst(expr->loc, expr->const_.type);
+  result_ |= validator_.OnConst(expr->loc, expr->const_.type());
   return Result::Ok;
 }
 
@@ -680,7 +680,7 @@ Result Validator::CheckModule() {
         switch (expr->type()) {
           case ExprType::Const:
             result_ |= validator_.OnGlobalInitExpr_Const(
-                expr->loc, cast<ConstExpr>(expr)->const_.type);
+                expr->loc, cast<ConstExpr>(expr)->const_.type());
             break;
 
           case ExprType::GlobalGet: {
@@ -746,7 +746,7 @@ Result Validator::CheckModule() {
         switch (expr->type()) {
           case ExprType::Const:
             result_ |= validator_.OnElemSegmentInitExpr_Const(
-                expr->loc, cast<ConstExpr>(expr)->const_.type);
+                expr->loc, cast<ConstExpr>(expr)->const_.type());
             break;
 
           case ExprType::GlobalGet: {
@@ -814,7 +814,7 @@ Result Validator::CheckModule() {
         switch (expr->type()) {
           case ExprType::Const:
             result_ |= validator_.OnDataSegmentInitExpr_Const(
-                expr->loc, cast<ConstExpr>(expr)->const_.type);
+                expr->loc, cast<ConstExpr>(expr)->const_.type());
             break;
 
           case ExprType::GlobalGet: {
@@ -874,8 +874,8 @@ const TypeVector* ScriptValidator::CheckInvoke(const InvokeAction* action) {
   }
   for (size_t i = 0; i < actual_args; ++i) {
     const Const* const_ = &action->args[i];
-    CheckTypeIndex(&const_->loc, const_->type, func->GetParamType(i), "invoke",
-                   i, "argument");
+    CheckTypeIndex(&const_->loc, const_->type(), func->GetParamType(i),
+                   "invoke", i, "argument");
   }
 
   return &func->decl.sig.result_types;
@@ -959,7 +959,7 @@ void ScriptValidator::CheckCommand(const Command* command) {
       // the types that are the result of the action.
       TypeVector actual_types;
       for (auto ex : assert_return_command->expected) {
-        actual_types.push_back(ex.type);
+        actual_types.push_back(ex.type());
       }
       switch (result.kind) {
         case ActionResult::Kind::Types:

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -426,27 +426,25 @@ void WatWriter::WriteEndBlock() {
 }
 
 void WatWriter::WriteConst(const Const& const_) {
-  switch (const_.type) {
+  switch (const_.type()) {
     case Type::I32:
       WritePutsSpace(Opcode::I32Const_Opcode.GetName());
-      Writef("%d", static_cast<int32_t>(const_.u32));
+      Writef("%d", static_cast<int32_t>(const_.u32()));
       WriteNewline(NO_FORCE_NEWLINE);
       break;
 
     case Type::I64:
       WritePutsSpace(Opcode::I64Const_Opcode.GetName());
-      Writef("%" PRId64, static_cast<int64_t>(const_.u64));
+      Writef("%" PRId64, static_cast<int64_t>(const_.u64()));
       WriteNewline(NO_FORCE_NEWLINE);
       break;
 
     case Type::F32: {
       WritePutsSpace(Opcode::F32Const_Opcode.GetName());
       char buffer[128];
-      WriteFloatHex(buffer, 128, const_.f32_bits);
+      WriteFloatHex(buffer, 128, const_.f32_bits());
       WritePutsSpace(buffer);
-      float f32;
-      memcpy(&f32, &const_.f32_bits, sizeof(f32));
-      Writef("(;=%g;)", f32);
+      Writef("(;=%g;)", Bitcast<float>(const_.f32_bits()));
       WriteNewline(NO_FORCE_NEWLINE);
       break;
     }
@@ -454,20 +452,18 @@ void WatWriter::WriteConst(const Const& const_) {
     case Type::F64: {
       WritePutsSpace(Opcode::F64Const_Opcode.GetName());
       char buffer[128];
-      WriteDoubleHex(buffer, 128, const_.f64_bits);
+      WriteDoubleHex(buffer, 128, const_.f64_bits());
       WritePutsSpace(buffer);
-      double f64;
-      memcpy(&f64, &const_.f64_bits, sizeof(f64));
-      Writef("(;=%g;)", f64);
+      Writef("(;=%g;)", Bitcast<double>(const_.f64_bits()));
       WriteNewline(NO_FORCE_NEWLINE);
       break;
     }
 
     case Type::V128: {
       WritePutsSpace(Opcode::V128Const_Opcode.GetName());
-      Writef("i32x4 0x%08x 0x%08x 0x%08x 0x%08x", const_.vec128.v[0],
-             const_.vec128.v[1], const_.vec128.v[2],
-             const_.vec128.v[3]);
+      auto vec = const_.vec128();
+      Writef("i32x4 0x%08x 0x%08x 0x%08x 0x%08x", vec.v[0], vec.v[1], vec.v[2],
+             vec.v[3]);
       WriteNewline(NO_FORCE_NEWLINE);
       break;
     }


### PR DESCRIPTION
Const previously stored each value as a union of bit patterns (uint32_t,
uint64_t, v128, etc). It was then extended to support cases where NaN
value (either arithmetic or canonical) was expected.

    bool is_expected_nan;
    union {
      uint32_t u32;
      uint32_t f32_bits;
      ...
      ExpectedNan expected;
    }

With the SIMD proposal, it's possible for each lane of a f32x4 or f64x2
to be a float or an expected NaN, so this doesn't work anymore. It's
possible to move ExpectedNan out of the union, but it's a bit clumsy to
use properly:

    bool is_expected_nan[4];
    ExpectedNan expected[4];
    union { ... }

Instead, I took this as an opportunity to clean up the class a bit.
First, ExpectedNan is extended to handle the case where it is not a NaN
(i.e. not a not a number), which allows us to remove the bool. Then I
store the rest of the data as an array of `uint32_t`, and provide
accessor functions instead.