### PR TITLE
Fix interpreter garbage collector

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -254,7 +254,8 @@ void Store::DeleteRoot(RootList::Index index) {
 }
 
 void Store::Collect() {
-  marks_.resize(objects_.size());
+  size_t object_count = objects_.size();
+  marks_.resize(object_count);
   std::fill(marks_.begin(), marks_.end(), false);
 
   // First mark all roots.
@@ -266,11 +267,11 @@ void Store::Collect() {
 
   // TODO: better GC algo.
   // Loop through all newly marked objects and mark their referents.
-  std::vector<bool> all_marked(marks_.size(), false);
+  std::vector<bool> all_marked(object_count, false);
   bool new_marked;
   do {
     new_marked = false;
-    for (size_t i = 0; i < marks_.size(); ++i) {
+    for (size_t i = 0; i < object_count; ++i) {
       if (!all_marked[i] && marks_[i]) {
         all_marked[i] = true;
         objects_.Get(i)->Mark(*this);
@@ -280,7 +281,7 @@ void Store::Collect() {
   } while (new_marked);
 
   // Delete all unmarked objects.
-  for (size_t i = 0; i < all_marked.size(); ++i) {
+  for (size_t i = 0; i < object_count; ++i) {
     if (objects_.IsUsed(i) && !all_marked[i]) {
       objects_.Delete(i);
     }

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -254,10 +254,34 @@ void Store::DeleteRoot(RootList::Index index) {
 }
 
 void Store::Collect() {
+  marks_.resize(objects_.size());
   std::fill(marks_.begin(), marks_.end(), false);
-  Mark(roots_.list);
-  for (size_t i = 0; i < marks_.size(); ++i) {
-    if (!marks_[i]) {
+
+  // First mark all roots.
+  for (RootList::Index i = 0; i < roots_.size(); ++i) {
+    if (roots_.IsUsed(i)) {
+      Mark(roots_.Get(i));
+    }
+  }
+
+  // TODO: better GC algo.
+  // Loop through all newly marked objects and mark their referents.
+  std::vector<bool> all_marked(marks_.size(), false);
+  bool new_marked;
+  do {
+    new_marked = false;
+    for (size_t i = 0; i < marks_.size(); ++i) {
+      if (!all_marked[i] && marks_[i]) {
+        all_marked[i] = true;
+        objects_.Get(i)->Mark(*this);
+        new_marked = true;
+      }
+    }
+  } while (new_marked);
+
+  // Delete all unmarked objects.
+  for (size_t i = 0; i < all_marked.size(); ++i) {
+    if (objects_.IsUsed(i) && !all_marked[i]) {
       objects_.Delete(i);
     }
   }
@@ -1094,6 +1118,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
       break;
 
     case O::Select: {
+      // TODO: need to mark whether this is a ref.
       auto cond = Pop<u32>();
       Value false_ = Pop();
       Value true_ = Pop();


### PR DESCRIPTION
The interpreter has a garbage colletor (Store::Collect), that *almost*
worked.

In particular, the free list had no fast way to determine whether an
object was used or not. This is necessary when iterating over objects to
actually delete them. This commit adds an `is_free_` vector for this
purpose.

The `Store::Collect` method was also not correct; it was calling
`Store::Mark(Ref)` on each of the GC roots, but that only marks the ref
itself, it doesn't iterate over the Object's references. This commit
updates Collect to iterate over all marked objects iteratively until
steady-state is reached. It's potentially quadratic in the number of
objects as currently written, so there's definitely room for
improvement.