### PR TITLE
Move more functionality into the v128 type

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -335,8 +335,8 @@ Result BinaryReaderLogging::OnF64ConstExpr(uint64_t value_bits) {
 }
 
 Result BinaryReaderLogging::OnV128ConstExpr(v128 value_bits) {
-  LOGF("OnV128ConstExpr(0x%08x 0x%08x 0x%08x 0x%08x)\n", value_bits.v[0],
-       value_bits.v[1], value_bits.v[2], value_bits.v[3]);
+  LOGF("OnV128ConstExpr(0x%08x 0x%08x 0x%08x 0x%08x)\n", value_bits.u32(0),
+       value_bits.u32(1), value_bits.u32(2), value_bits.u32(3));
   return reader_->OnV128ConstExpr(value_bits);
 }
 
@@ -382,8 +382,8 @@ Result BinaryReaderLogging::OnSimdLaneOpExpr(Opcode opcode, uint64_t value) {
 }
 
 Result BinaryReaderLogging::OnSimdShuffleOpExpr(Opcode opcode, v128 value) {
-  LOGF("OnSimdShuffleOpExpr (lane: 0x%08x %08x %08x %08x)\n", value.v[0],
-       value.v[1], value.v[2], value.v[3]);
+  LOGF("OnSimdShuffleOpExpr (lane: 0x%08x %08x %08x %08x)\n", value.u32(0),
+       value.u32(1), value.u32(2), value.u32(3));
   return reader_->OnSimdShuffleOpExpr(opcode, value);
 }
 
@@ -481,8 +481,8 @@ Result BinaryReaderLogging::OnInitExprV128ConstExpr(Index index,
                                                     v128 value_bits) {
   LOGF("OnInitExprV128ConstExpr(index: %" PRIindex
        " value: ( 0x%08x 0x%08x 0x%08x 0x%08x))\n",
-       index, value_bits.v[0], value_bits.v[1], value_bits.v[2],
-       value_bits.v[3]);
+       index, value_bits.u32(0), value_bits.u32(1), value_bits.u32(2),
+       value_bits.u32(3));
   return reader_->OnInitExprV128ConstExpr(index, value_bits);
 }
 

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -631,8 +631,8 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeF64(uint64_t value) {
 Result BinaryReaderObjdumpDisassemble::OnOpcodeV128(v128 value) {
   Offset immediate_len = state->offset - current_opcode_offset;
   // v128 is always dumped as i32x4:
-  LogOpcode(immediate_len, "0x%08x 0x%08x 0x%08x 0x%08x", value.v[0],
-            value.v[1], value.v[2], value.v[3]);
+  LogOpcode(immediate_len, "0x%08x 0x%08x 0x%08x 0x%08x", value.u32(0),
+            value.u32(1), value.u32(2), value.u32(3));
   return Result::Ok;
 }
 
@@ -1355,8 +1355,8 @@ void BinaryReaderObjdump::PrintInitExpr(const InitExpr& expr) {
     }
     case InitExprType::V128: {
       PrintDetails(" - init v128=0x%08x 0x%08x 0x%08x 0x%08x \n",
-                   expr.value.v128_v.v[0], expr.value.v128_v.v[1],
-                   expr.value.v128_v.v[2], expr.value.v128_v.v[3]);
+                   expr.value.v128_v.u32(0), expr.value.v128_v.u32(1),
+                   expr.value.v128_v.u32(2), expr.value.v128_v.u32(3));
       break;
     }
     case InitExprType::Global: {

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2261,7 +2261,7 @@ void CWriter::Write(const SimdShuffleOpExpr& expr) {
   Type result_type = expr.opcode.GetResultType();
   Write(StackVar(1, result_type), " = ", expr.opcode.GetName(), "(",
         StackVar(1), " ", StackVar(0), ", lane Imm: $0x%08x %08x %08x %08x",
-        expr.val.v[0], expr.val.v[1], expr.val.v[2], expr.val.v[3], ")",
+        expr.val.u32(0), expr.val.u32(1), expr.val.u32(2), expr.val.u32(3), ")",
         Newline());
   DropTypes(2);
   PushType(result_type);

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -39,8 +39,8 @@ std::string TypedValueToString(const TypedValue& tv) {
 
     case Type::V128: {
       v128 simd = tv.value.Get<v128>();
-      return StringPrintf("v128 i32x4:0x%08x 0x%08x 0x%08x 0x%08x", simd.v[0],
-                          simd.v[1], simd.v[2], simd.v[3]);
+      return StringPrintf("v128 i32x4:0x%08x 0x%08x 0x%08x 0x%08x", simd.u32(0),
+                          simd.u32(1), simd.u32(2), simd.u32(3));
     }
 
     case Type::Nullref:

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2195,8 +2195,8 @@ std::string Thread::TraceSource::Pick(Index index, Instr instr) {
     case ValueType::F64: return StringPrintf("%g", val.Get<f64>());
     case ValueType::V128: {
       auto v = val.Get<v128>();
-      return StringPrintf("0x%08x 0x%08x 0x%08x 0x%08x", v.v[0], v.v[1], v.v[2],
-                          v.v[3]);
+      return StringPrintf("0x%08x 0x%08x 0x%08x 0x%08x", v.u32(0), v.u32(1),
+                          v.u32(2), v.u32(3));
     }
 
     case ValueType::Nullref: reftype = "nullref"; break;

--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -844,8 +844,8 @@ Istream::Offset Istream::Trace(Stream* stream,
 
     case InstrKind::Imm_V128_Op_0:
       stream->Writef(" i32x4 0x%08x 0x%08x 0x%08x 0x%08x\n",
-                     instr.imm_v128.v[0], instr.imm_v128.v[1],
-                     instr.imm_v128.v[2], instr.imm_v128.v[3]);
+                     instr.imm_v128.u32(0), instr.imm_v128.u32(1),
+                     instr.imm_v128.u32(2), instr.imm_v128.u32(3));
       break;
 
     case InstrKind::Imm_V128_Op_2:
@@ -853,8 +853,8 @@ Istream::Offset Istream::Trace(Stream* stream,
       stream->Writef(
           " %s, %s : (Lane imm: i32x4 0x%08x 0x%08x 0x%08x 0x%08x )\n",
           source->Pick(2, instr).c_str(), source->Pick(1, instr).c_str(),
-          instr.imm_v128.v[0], instr.imm_v128.v[1], instr.imm_v128.v[2],
-          instr.imm_v128.v[3]);
+          instr.imm_v128.u32(0), instr.imm_v128.u32(1), instr.imm_v128.u32(2),
+          instr.imm_v128.u32(3));
       break;
   }
   return offset;

--- a/src/ir.h
+++ b/src/ir.h
@@ -94,12 +94,12 @@ struct Const {
 
   Type type() const { return type_; }
 
-  uint32_t u32() const { return data_[0]; }
-  uint64_t u64() const { return To<uint64_t>(); }
-  uint32_t f32_bits() const { return data_[0]; }
-  uint64_t f64_bits() const { return To<uint64_t>(); }
-  uintptr_t ref_bits() const { return To<uintptr_t>(); }
-  v128 vec128() const { return To<v128>(); }
+  uint32_t u32() const { return data_.u32(0); }
+  uint64_t u64() const { return data_.u64(0); }
+  uint32_t f32_bits() const { return data_.f32_bits(0); }
+  uint64_t f64_bits() const { return data_.f64_bits(0); }
+  uintptr_t ref_bits() const { return data_.To<uintptr_t>(0); }
+  v128 vec128() const { return data_; }
 
   bool is_expected_nan() const { return nan_ != ExpectedNan::None; }
   ExpectedNan expected() const { assert(is_expected_nan()); return nan_; }
@@ -126,23 +126,14 @@ struct Const {
   }
 
   template <typename T>
-  T To() const {
-    static_assert(sizeof(T) <= sizeof(data_), "Invalid cast!");
-    T result;
-    memcpy(&result, &data_[0], sizeof(result));
-    return result;
-  }
-
-  template <typename T>
   void From(Type type, T data) {
-    static_assert(sizeof(T) <= sizeof(data_), "Invalid cast!");
     type_ = type;
-    memcpy(&data_[0], &data, sizeof(data));
+    data_.From<T>(0, data);
     nan_ = ExpectedNan::None;
   }
 
   Type type_;
-  uint32_t data_[4];  // 32 * 4 = 128 bits.
+  v128 data_;
   ExpectedNan nan_ = ExpectedNan::None;
 };
 typedef std::vector<Const> ConstVector;

--- a/src/test-literal.cc
+++ b/src/test-literal.cc
@@ -426,13 +426,13 @@ TEST(ParseUint64, Overflow) {
 }
 
 TEST(ParseUint128, Basic) {
-  AssertUint128Equals({{0, 0, 0, 0}}, "0");
-  AssertUint128Equals({{1, 0, 0, 0}}, "1");
-  AssertUint128Equals({{0x100f0e0d, 0x0c0b0a09, 0x08070605, 0x04030201}},
+  AssertUint128Equals({0, 0, 0, 0}, "0");
+  AssertUint128Equals({1, 0, 0, 0}, "1");
+  AssertUint128Equals({0x100f0e0d, 0x0c0b0a09, 0x08070605, 0x04030201},
                       "5332529520247008778714484145835150861");
-  AssertUint128Equals({{0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}},
+  AssertUint128Equals({0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff},
                       "340282366920938463463374607431768211455");
-  AssertUint128Equals({{0, 0, 1, 0}}, "18446744073709551616");
+  AssertUint128Equals({0, 0, 1, 0}, "18446744073709551616");
 }
 
 TEST(ParseUint128, Invalid) {
@@ -808,22 +808,21 @@ void AssertWriteUint128Equals(const v128& value, const std::string& expected) {
 }
 
 TEST(WriteUint128, Basic) {
-  AssertWriteUint128Equals({{0, 0, 0, 0}}, "0");
-  AssertWriteUint128Equals({{1, 0, 0, 0}}, "1");
-  AssertWriteUint128Equals({{0x100f0e0d, 0x0c0b0a09, 0x08070605, 0x04030201}},
+  AssertWriteUint128Equals({0, 0, 0, 0}, "0");
+  AssertWriteUint128Equals({1, 0, 0, 0}, "1");
+  AssertWriteUint128Equals({0x100f0e0d, 0x0c0b0a09, 0x08070605, 0x04030201},
                            "5332529520247008778714484145835150861");
-  AssertWriteUint128Equals({{0x00112233, 0x44556677, 0x8899aabb, 0xccddeeff}},
+  AssertWriteUint128Equals({0x00112233, 0x44556677, 0x8899aabb, 0xccddeeff},
                            "272314856204801878456120017448021860915");
-  AssertWriteUint128Equals({{0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}},
+  AssertWriteUint128Equals({0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff},
                            "340282366920938463463374607431768211455");
-  AssertWriteUint128Equals({{0, 0, 1, 0}}, "18446744073709551616");
+  AssertWriteUint128Equals({0, 0, 1, 0}, "18446744073709551616");
 }
 
 TEST(WriteUint128, BufferTooSmall) {
   {
     char buffer[20];
-    WriteUint128(buffer, 20,
-                 {{0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff}});
+    WriteUint128(buffer, 20, {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff});
     ASSERT_EQ(buffer[19], '\0');
     std::string actual(buffer, buffer + 19);
     ASSERT_EQ("3402823669209384634", actual);
@@ -831,7 +830,7 @@ TEST(WriteUint128, BufferTooSmall) {
 
   {
     char buffer[3];
-    WriteUint128(buffer, 3, {{123, 0, 0, 0}});
+    WriteUint128(buffer, 3, {123, 0, 0, 0});
     ASSERT_EQ(buffer[0], '1');
     ASSERT_EQ(buffer[1], '2');
     ASSERT_EQ(buffer[2], '\0');

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -462,8 +462,8 @@ void WatWriter::WriteConst(const Const& const_) {
     case Type::V128: {
       WritePutsSpace(Opcode::V128Const_Opcode.GetName());
       auto vec = const_.vec128();
-      Writef("i32x4 0x%08x 0x%08x 0x%08x 0x%08x", vec.v[0], vec.v[1], vec.v[2],
-             vec.v[3]);
+      Writef("i32x4 0x%08x 0x%08x 0x%08x 0x%08x", vec.u32(0), vec.u32(1),
+             vec.u32(2), vec.u32(3));
       WriteNewline(NO_FORCE_NEWLINE);
       break;
     }


### PR DESCRIPTION
* Add lane getters: u{8,16,32,64}, f{32,64}_bits
* Add lane setters: set_u{8,16,32,64}, set_f{32,64}_bits
* Add set_zero, is_zero
* Add To<Type>() and From<Type>()

These changes will make it easier to build v128 values in the
spectest-interp (which needs to be updated to support SIMD spec tests)