### PR TITLE
Parse ArrayTypes

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -58,6 +58,7 @@ class BinaryReaderIR : public BinaryReaderNop {
                     Index result_count,
                     Type* result_types) override;
   Result OnStructType(Index index, Index field_count, TypeMut* fields) override;
+  Result OnArrayType(Index index, TypeMut field) override;
 
   Result OnImportCount(Index count) override;
   Result OnImportFunc(Index import_index,
@@ -417,6 +418,16 @@ Result BinaryReaderIR::OnStructType(Index index,
     struct_type->fields[i].mutable_ = fields[i].mutable_;
   }
   field->type = std::move(struct_type);
+  module_->AppendField(std::move(field));
+  return Result::Ok;
+}
+
+Result BinaryReaderIR::OnArrayType(Index index, TypeMut type_mut) {
+  auto field = MakeUnique<TypeModuleField>(GetLocation());
+  auto array_type = MakeUnique<ArrayType>();
+  array_type->field.type = type_mut.type;
+  array_type->field.mutable_ = type_mut.mutable_;
+  field->type = std::move(array_type);
   module_->AppendField(std::move(field));
   return Result::Ok;
 }

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -99,6 +99,16 @@ void BinaryReaderLogging::LogTypes(TypeVector& types) {
   LogTypes(types.size(), types.data());
 }
 
+void BinaryReaderLogging::LogField(TypeMut field) {
+  if (field.mutable_) {
+    LOGF_NOINDENT("(mut ");
+  }
+  LogType(field.type);
+  if (field.mutable_) {
+    LOGF_NOINDENT(")");
+  }
+}
+
 bool BinaryReaderLogging::OnError(const Error& error) {
   return reader_->OnError(error);
 }
@@ -149,19 +159,20 @@ Result BinaryReaderLogging::OnStructType(Index index,
   LOGF("OnStructType(index: %" PRIindex ", fields: ", index);
   LOGF_NOINDENT("[");
   for (Index i = 0; i < field_count; ++i) {
-    if (fields[i].mutable_) {
-      LOGF_NOINDENT("(mut ");
-    }
-    LogType(fields[i].type);
-    if (fields[i].mutable_) {
-      LOGF_NOINDENT(")");
-    }
+    LogField(fields[i]);
     if (i != field_count - 1) {
       LOGF_NOINDENT(", ");
     }
   }
   LOGF_NOINDENT("])\n");
   return reader_->OnStructType(index, field_count, fields);
+}
+
+Result BinaryReaderLogging::OnArrayType(Index index, TypeMut field) {
+  LOGF("OnArrayType(index: %" PRIindex ", field: ", index);
+  LogField(field);
+  LOGF_NOINDENT(")\n");
+  return reader_->OnArrayType(index, field);
 }
 
 Result BinaryReaderLogging::OnImport(Index index,

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -48,6 +48,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
                     Index result_count,
                     Type* result_types) override;
   Result OnStructType(Index index, Index field_count, TypeMut* fields) override;
+  Result OnArrayType(Index index, TypeMut field) override;
   Result EndTypeSection() override;
 
   Result BeginImportSection(Offset size) override;
@@ -355,6 +356,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   void LogType(Type type);
   void LogTypes(Index type_count, Type* types);
   void LogTypes(TypeVector& types);
+  void LogField(TypeMut field);
 
   Stream* stream_;
   BinaryReaderDelegate* reader_;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -56,6 +56,9 @@ class BinaryReaderNop : public BinaryReaderDelegate {
                       TypeMut* fields) override {
     return Result::Ok;
   }
+  Result OnArrayType(Index index, TypeMut field) override {
+    return Result::Ok;
+  }
   Result EndTypeSection() override { return Result::Ok; }
 
   /* Import section */

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -732,6 +732,7 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
                     Index result_count,
                     Type* result_types) override;
   Result OnStructType(Index index, Index field_count, TypeMut* fields) override;
+  Result OnArrayType(Index index, TypeMut field) override;
 
   Result OnImportCount(Index count) override;
   Result OnImportFunc(Index import_index,
@@ -1083,6 +1084,22 @@ Result BinaryReaderObjdump::OnStructType(Index index,
     if (fields[i].mutable_) {
       printf(")");
     }
+  }
+  printf(")\n");
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdump::OnArrayType(Index index, TypeMut field) {
+  if (!ShouldPrintDetails()) {
+    return Result::Ok;
+  }
+  printf(" - type[%" PRIindex "] (array", index);
+  if (field.mutable_) {
+    printf(" (mut");
+  }
+  printf(" %s", field.type.GetName());
+  if (field.mutable_) {
+    printf(")");
   }
   printf(")\n");
   return Result::Ok;

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -97,6 +97,7 @@ class BinaryReaderDelegate {
   virtual Result OnStructType(Index index,
                               Index field_count,
                               TypeMut* fields) = 0;
+  virtual Result OnArrayType(Index index, TypeMut field) = 0;
   virtual Result EndTypeSection() = 0;
 
   /* Import section */

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -915,6 +915,15 @@ Result BinaryWriter::WriteModule() {
           }
           break;
         }
+
+        case TypeEntryKind::Array: {
+          const ArrayType* array_type = cast<ArrayType>(type);
+          WriteHeader("array type", i);
+          WriteType(stream_, Type::Array);
+          WriteType(stream_, array_type->field.type);
+          stream_->WriteU8(array_type->field.mutable_, "field mutability");
+          break;
+        }
       }
     }
     EndSection();

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -60,6 +60,7 @@ std::string TypedValueToString(const TypedValue& tv) {
 
     case Type::Func:
     case Type::Struct:
+    case Type::Array:
     case Type::Void:
     case Type::Any:
     case Type::I8:

--- a/src/ir.h
+++ b/src/ir.h
@@ -162,6 +162,7 @@ struct FuncSignature {
 enum class TypeEntryKind {
   Func,
   Struct,
+  Array,
 };
 
 class TypeEntry {
@@ -217,6 +218,18 @@ class StructType : public TypeEntry {
       : TypeEntry(TypeEntryKind::Struct) {}
 
   std::vector<Field> fields;
+};
+
+class ArrayType : public TypeEntry {
+ public:
+  static bool classof(const TypeEntry* entry) {
+    return entry->kind() == TypeEntryKind::Array;
+  }
+
+  explicit ArrayType(string_view name = string_view())
+      : TypeEntry(TypeEntryKind::Array) {}
+
+  Field field;
 };
 
 struct FuncDeclaration {

--- a/src/lexer-keywords.txt
+++ b/src/lexer-keywords.txt
@@ -16,6 +16,7 @@ struct TokenInfo {
 };
 %%
 anyref, Type::Anyref
+array, TokenType::Array
 assert_exhaustion, TokenType::AssertExhaustion
 assert_invalid, TokenType::AssertInvalid
 assert_malformed, TokenType::AssertMalformed

--- a/src/prebuilt/lexer-keywords.cc
+++ b/src/prebuilt/lexer-keywords.cc
@@ -150,7 +150,7 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 537,
+      TOTAL_KEYWORDS = 538,
       MIN_WORD_LENGTH = 2,
       MAX_WORD_LENGTH = 26,
       MIN_HASH_VALUE = 3,
@@ -160,1385 +160,1386 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
   static struct TokenInfo wordlist[] =
     {
       {""}, {""}, {""},
-#line 126 "src/lexer-keywords.txt"
+#line 127 "src/lexer-keywords.txt"
       {"f64", Type::F64},
       {""},
-#line 75 "src/lexer-keywords.txt"
+#line 76 "src/lexer-keywords.txt"
       {"f32", Type::F32},
       {""},
-#line 449 "src/lexer-keywords.txt"
+#line 450 "src/lexer-keywords.txt"
       {"if", TokenType::If, Opcode::If},
-#line 400 "src/lexer-keywords.txt"
+#line 401 "src/lexer-keywords.txt"
       {"i64", Type::I64},
       {""},
-#line 271 "src/lexer-keywords.txt"
+#line 272 "src/lexer-keywords.txt"
       {"i32", Type::I32},
-#line 465 "src/lexer-keywords.txt"
+#line 466 "src/lexer-keywords.txt"
       {"mut", TokenType::Mut},
       {""}, {""},
-#line 113 "src/lexer-keywords.txt"
+#line 114 "src/lexer-keywords.txt"
       {"f64.lt", TokenType::Compare, Opcode::F64Lt},
-#line 63 "src/lexer-keywords.txt"
+#line 64 "src/lexer-keywords.txt"
       {"f32.lt", TokenType::Compare, Opcode::F32Lt},
       {""}, {""},
-#line 495 "src/lexer-keywords.txt"
+#line 496 "src/lexer-keywords.txt"
       {"then", TokenType::Then},
-#line 42 "src/lexer-keywords.txt"
+#line 43 "src/lexer-keywords.txt"
       {"else", TokenType::Else, Opcode::Else},
       {""},
-#line 147 "src/lexer-keywords.txt"
+#line 148 "src/lexer-keywords.txt"
       {"funcref", Type::Funcref},
-#line 452 "src/lexer-keywords.txt"
+#line 453 "src/lexer-keywords.txt"
       {"item", TokenType::Item},
-#line 44 "src/lexer-keywords.txt"
+#line 45 "src/lexer-keywords.txt"
       {"event", TokenType::Event},
-#line 41 "src/lexer-keywords.txt"
+#line 42 "src/lexer-keywords.txt"
       {"elem", TokenType::Elem},
       {""},
-#line 111 "src/lexer-keywords.txt"
+#line 112 "src/lexer-keywords.txt"
       {"f64.le", TokenType::Compare, Opcode::F64Le},
-#line 61 "src/lexer-keywords.txt"
+#line 62 "src/lexer-keywords.txt"
       {"f32.le", TokenType::Compare, Opcode::F32Le},
-#line 373 "src/lexer-keywords.txt"
-      {"i64.lt_s", TokenType::Compare, Opcode::I64LtS},
-#line 245 "src/lexer-keywords.txt"
-      {"i32.lt_s", TokenType::Compare, Opcode::I32LtS},
-#line 115 "src/lexer-keywords.txt"
-      {"f64.min", TokenType::Binary, Opcode::F64Min},
-#line 65 "src/lexer-keywords.txt"
-      {"f32.min", TokenType::Binary, Opcode::F32Min},
 #line 374 "src/lexer-keywords.txt"
-      {"i64.lt_u", TokenType::Compare, Opcode::I64LtU},
+      {"i64.lt_s", TokenType::Compare, Opcode::I64LtS},
 #line 246 "src/lexer-keywords.txt"
+      {"i32.lt_s", TokenType::Compare, Opcode::I32LtS},
+#line 116 "src/lexer-keywords.txt"
+      {"f64.min", TokenType::Binary, Opcode::F64Min},
+#line 66 "src/lexer-keywords.txt"
+      {"f32.min", TokenType::Binary, Opcode::F32Min},
+#line 375 "src/lexer-keywords.txt"
+      {"i64.lt_u", TokenType::Compare, Opcode::I64LtU},
+#line 247 "src/lexer-keywords.txt"
       {"i32.lt_u", TokenType::Compare, Opcode::I32LtU},
-#line 364 "src/lexer-keywords.txt"
-      {"i64.le_s", TokenType::Compare, Opcode::I64LeS},
-#line 238 "src/lexer-keywords.txt"
-      {"i32.le_s", TokenType::Compare, Opcode::I32LeS},
-#line 380 "src/lexer-keywords.txt"
-      {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
-#line 252 "src/lexer-keywords.txt"
-      {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
 #line 365 "src/lexer-keywords.txt"
-      {"i64.le_u", TokenType::Compare, Opcode::I64LeU},
+      {"i64.le_s", TokenType::Compare, Opcode::I64LeS},
 #line 239 "src/lexer-keywords.txt"
-      {"i32.le_u", TokenType::Compare, Opcode::I32LeU},
+      {"i32.le_s", TokenType::Compare, Opcode::I32LeS},
 #line 381 "src/lexer-keywords.txt"
-      {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
+      {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
 #line 253 "src/lexer-keywords.txt"
+      {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
+#line 366 "src/lexer-keywords.txt"
+      {"i64.le_u", TokenType::Compare, Opcode::I64LeU},
+#line 240 "src/lexer-keywords.txt"
+      {"i32.le_u", TokenType::Compare, Opcode::I32LeU},
+#line 382 "src/lexer-keywords.txt"
+      {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
+#line 254 "src/lexer-keywords.txt"
       {"i32.rem_u", TokenType::Binary, Opcode::I32RemU},
-#line 469 "src/lexer-keywords.txt"
+#line 470 "src/lexer-keywords.txt"
       {"nullref", Type::Nullref},
-#line 494 "src/lexer-keywords.txt"
+#line 495 "src/lexer-keywords.txt"
       {"table", TokenType::Table},
-#line 146 "src/lexer-keywords.txt"
+#line 147 "src/lexer-keywords.txt"
       {"field", TokenType::Field},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 483 "src/lexer-keywords.txt"
+#line 484 "src/lexer-keywords.txt"
       {"select", TokenType::Select, Opcode::Select},
       {""},
-#line 464 "src/lexer-keywords.txt"
+#line 465 "src/lexer-keywords.txt"
       {"module", TokenType::Module},
-#line 116 "src/lexer-keywords.txt"
+#line 117 "src/lexer-keywords.txt"
       {"f64.mul", TokenType::Binary, Opcode::F64Mul},
-#line 66 "src/lexer-keywords.txt"
+#line 67 "src/lexer-keywords.txt"
       {"f32.mul", TokenType::Binary, Opcode::F32Mul},
-#line 43 "src/lexer-keywords.txt"
+#line 44 "src/lexer-keywords.txt"
       {"end", TokenType::End, Opcode::End},
-#line 470 "src/lexer-keywords.txt"
+#line 471 "src/lexer-keywords.txt"
       {"offset", TokenType::Offset},
-#line 485 "src/lexer-keywords.txt"
+#line 486 "src/lexer-keywords.txt"
       {"start", TokenType::Start},
-#line 375 "src/lexer-keywords.txt"
+#line 376 "src/lexer-keywords.txt"
       {"i64.mul", TokenType::Binary, Opcode::I64Mul},
-#line 247 "src/lexer-keywords.txt"
+#line 248 "src/lexer-keywords.txt"
       {"i32.mul", TokenType::Binary, Opcode::I32Mul},
       {""}, {""}, {""}, {""},
-#line 97 "src/lexer-keywords.txt"
+#line 98 "src/lexer-keywords.txt"
       {"f64.abs", TokenType::Unary, Opcode::F64Abs},
-#line 46 "src/lexer-keywords.txt"
+#line 47 "src/lexer-keywords.txt"
       {"f32.abs", TokenType::Unary, Opcode::F32Abs},
-#line 124 "src/lexer-keywords.txt"
+#line 125 "src/lexer-keywords.txt"
       {"f64.sub", TokenType::Binary, Opcode::F64Sub},
-#line 73 "src/lexer-keywords.txt"
+#line 74 "src/lexer-keywords.txt"
       {"f32.sub", TokenType::Binary, Opcode::F32Sub},
-#line 119 "src/lexer-keywords.txt"
+#line 120 "src/lexer-keywords.txt"
       {"f64.ne", TokenType::Compare, Opcode::F64Ne},
-#line 69 "src/lexer-keywords.txt"
+#line 70 "src/lexer-keywords.txt"
       {"f32.ne", TokenType::Compare, Opcode::F32Ne},
-#line 145 "src/lexer-keywords.txt"
+#line 146 "src/lexer-keywords.txt"
       {"f64x2", TokenType::F64X2},
-#line 391 "src/lexer-keywords.txt"
+#line 392 "src/lexer-keywords.txt"
       {"i64.sub", TokenType::Binary, Opcode::I64Sub},
-#line 262 "src/lexer-keywords.txt"
+#line 263 "src/lexer-keywords.txt"
       {"i32.sub", TokenType::Binary, Opcode::I32Sub},
-#line 376 "src/lexer-keywords.txt"
+#line 377 "src/lexer-keywords.txt"
       {"i64.ne", TokenType::Compare, Opcode::I64Ne},
-#line 248 "src/lexer-keywords.txt"
+#line 249 "src/lexer-keywords.txt"
       {"i32.ne", TokenType::Compare, Opcode::I32Ne},
-#line 413 "src/lexer-keywords.txt"
+#line 414 "src/lexer-keywords.txt"
       {"i64x2", TokenType::I64X2},
-#line 492 "src/lexer-keywords.txt"
+#line 493 "src/lexer-keywords.txt"
       {"table.set", TokenType::TableSet, Opcode::TableSet},
-#line 37 "src/lexer-keywords.txt"
+#line 38 "src/lexer-keywords.txt"
       {"data", TokenType::Data},
       {""}, {""}, {""},
-#line 478 "src/lexer-keywords.txt"
+#line 479 "src/lexer-keywords.txt"
       {"result", TokenType::Result},
-#line 99 "src/lexer-keywords.txt"
+#line 100 "src/lexer-keywords.txt"
       {"f64.ceil", TokenType::Unary, Opcode::F64Ceil},
-#line 48 "src/lexer-keywords.txt"
+#line 49 "src/lexer-keywords.txt"
       {"f32.ceil", TokenType::Unary, Opcode::F32Ceil},
-#line 491 "src/lexer-keywords.txt"
+#line 492 "src/lexer-keywords.txt"
       {"table.init", TokenType::TableInit, Opcode::TableInit},
       {""},
-#line 482 "src/lexer-keywords.txt"
+#line 483 "src/lexer-keywords.txt"
       {"return", TokenType::Return, Opcode::Return},
       {""}, {""}, {""}, {""},
-#line 100 "src/lexer-keywords.txt"
+#line 101 "src/lexer-keywords.txt"
       {"f64.const", TokenType::Const, Opcode::F64Const},
-#line 49 "src/lexer-keywords.txt"
+#line 50 "src/lexer-keywords.txt"
       {"f32.const", TokenType::Const, Opcode::F32Const},
-#line 310 "src/lexer-keywords.txt"
+#line 311 "src/lexer-keywords.txt"
       {"i64.and", TokenType::Binary, Opcode::I64And},
-#line 196 "src/lexer-keywords.txt"
+#line 197 "src/lexer-keywords.txt"
       {"i32.and", TokenType::Binary, Opcode::I32And},
       {""},
-#line 349 "src/lexer-keywords.txt"
+#line 350 "src/lexer-keywords.txt"
       {"i64.const", TokenType::Const, Opcode::I64Const},
-#line 226 "src/lexer-keywords.txt"
+#line 227 "src/lexer-keywords.txt"
       {"i32.const", TokenType::Const, Opcode::I32Const},
-#line 31 "src/lexer-keywords.txt"
+#line 32 "src/lexer-keywords.txt"
       {"br", TokenType::Br, Opcode::Br},
       {""},
-#line 486 "src/lexer-keywords.txt"
+#line 487 "src/lexer-keywords.txt"
       {"struct", TokenType::Struct},
       {""}, {""}, {""},
-#line 484 "src/lexer-keywords.txt"
+#line 485 "src/lexer-keywords.txt"
       {"shared", TokenType::Shared},
-#line 382 "src/lexer-keywords.txt"
+#line 383 "src/lexer-keywords.txt"
       {"i64.rotl", TokenType::Binary, Opcode::I64Rotl},
-#line 254 "src/lexer-keywords.txt"
+#line 255 "src/lexer-keywords.txt"
       {"i32.rotl", TokenType::Binary, Opcode::I32Rotl},
-#line 98 "src/lexer-keywords.txt"
+#line 99 "src/lexer-keywords.txt"
       {"f64.add", TokenType::Binary, Opcode::F64Add},
-#line 47 "src/lexer-keywords.txt"
+#line 48 "src/lexer-keywords.txt"
       {"f32.add", TokenType::Binary, Opcode::F32Add},
       {""}, {""},
-#line 148 "src/lexer-keywords.txt"
+#line 149 "src/lexer-keywords.txt"
       {"func", TokenType::Func},
-#line 309 "src/lexer-keywords.txt"
+#line 310 "src/lexer-keywords.txt"
       {"i64.add", TokenType::Binary, Opcode::I64Add},
-#line 195 "src/lexer-keywords.txt"
+#line 196 "src/lexer-keywords.txt"
       {"i32.add", TokenType::Binary, Opcode::I32Add},
-#line 488 "src/lexer-keywords.txt"
+#line 489 "src/lexer-keywords.txt"
       {"table.fill", TokenType::TableFill, Opcode::TableFill},
-#line 27 "src/lexer-keywords.txt"
+#line 28 "src/lexer-keywords.txt"
       {"block", TokenType::Block, Opcode::Block},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 140 "src/lexer-keywords.txt"
+#line 141 "src/lexer-keywords.txt"
       {"f64x2.ne", TokenType::Compare, Opcode::F64X2Ne},
       {""}, {""},
-#line 135 "src/lexer-keywords.txt"
+#line 136 "src/lexer-keywords.txt"
       {"f64x2.lt", TokenType::Compare, Opcode::F64X2Lt},
-#line 137 "src/lexer-keywords.txt"
+#line 138 "src/lexer-keywords.txt"
       {"f64x2.min", TokenType::Binary, Opcode::F64X2Min},
       {""}, {""}, {""}, {""},
-#line 479 "src/lexer-keywords.txt"
+#line 480 "src/lexer-keywords.txt"
       {"rethrow", TokenType::Rethrow, Opcode::Rethrow},
       {""},
-#line 30 "src/lexer-keywords.txt"
+#line 31 "src/lexer-keywords.txt"
       {"br_table", TokenType::BrTable, Opcode::BrTable},
-#line 474 "src/lexer-keywords.txt"
+#line 475 "src/lexer-keywords.txt"
       {"ref.host", TokenType::RefHost},
       {""}, {""},
-#line 134 "src/lexer-keywords.txt"
+#line 135 "src/lexer-keywords.txt"
       {"f64x2.le", TokenType::Compare, Opcode::F64X2Le},
       {""}, {""},
-#line 475 "src/lexer-keywords.txt"
+#line 476 "src/lexer-keywords.txt"
       {"ref.is_null", TokenType::RefIsNull, Opcode::RefIsNull},
       {""}, {""},
-#line 123 "src/lexer-keywords.txt"
+#line 124 "src/lexer-keywords.txt"
       {"f64.store", TokenType::Store, Opcode::F64Store},
-#line 72 "src/lexer-keywords.txt"
+#line 73 "src/lexer-keywords.txt"
       {"f32.store", TokenType::Store, Opcode::F32Store},
-#line 388 "src/lexer-keywords.txt"
+#line 389 "src/lexer-keywords.txt"
       {"i64.store32", TokenType::Store, Opcode::I64Store32},
-#line 33 "src/lexer-keywords.txt"
+#line 34 "src/lexer-keywords.txt"
       {"call", TokenType::Call, Opcode::Call},
       {""},
-#line 390 "src/lexer-keywords.txt"
+#line 391 "src/lexer-keywords.txt"
       {"i64.store", TokenType::Store, Opcode::I64Store},
-#line 261 "src/lexer-keywords.txt"
+#line 262 "src/lexer-keywords.txt"
       {"i32.store", TokenType::Store, Opcode::I32Store},
       {""}, {""}, {""},
-#line 456 "src/lexer-keywords.txt"
+#line 457 "src/lexer-keywords.txt"
       {"local", TokenType::Local},
-#line 138 "src/lexer-keywords.txt"
+#line 139 "src/lexer-keywords.txt"
       {"f64x2.mul", TokenType::Binary, Opcode::F64X2Mul},
       {""}, {""}, {""}, {""},
-#line 405 "src/lexer-keywords.txt"
+#line 406 "src/lexer-keywords.txt"
       {"i64x2.mul", TokenType::Binary, Opcode::I64X2Mul},
-#line 493 "src/lexer-keywords.txt"
+#line 494 "src/lexer-keywords.txt"
       {"table.size", TokenType::TableSize, Opcode::TableSize},
       {""}, {""},
-#line 112 "src/lexer-keywords.txt"
+#line 113 "src/lexer-keywords.txt"
       {"f64.load", TokenType::Load, Opcode::F64Load},
-#line 62 "src/lexer-keywords.txt"
+#line 63 "src/lexer-keywords.txt"
       {"f32.load", TokenType::Load, Opcode::F32Load},
-#line 55 "src/lexer-keywords.txt"
+#line 56 "src/lexer-keywords.txt"
       {"f32.demote_f64", TokenType::Convert, Opcode::F32DemoteF64},
       {""},
-#line 144 "src/lexer-keywords.txt"
+#line 145 "src/lexer-keywords.txt"
       {"f64x2.sub", TokenType::Binary, Opcode::F64X2Sub},
-#line 372 "src/lexer-keywords.txt"
+#line 373 "src/lexer-keywords.txt"
       {"i64.load", TokenType::Load, Opcode::I64Load},
-#line 244 "src/lexer-keywords.txt"
+#line 245 "src/lexer-keywords.txt"
       {"i32.load", TokenType::Load, Opcode::I32Load},
       {""}, {""},
-#line 412 "src/lexer-keywords.txt"
+#line 413 "src/lexer-keywords.txt"
       {"i64x2.sub", TokenType::Binary, Opcode::I64X2Sub},
       {""},
-#line 351 "src/lexer-keywords.txt"
+#line 352 "src/lexer-keywords.txt"
       {"i64.div_s", TokenType::Binary, Opcode::I64DivS},
-#line 228 "src/lexer-keywords.txt"
+#line 229 "src/lexer-keywords.txt"
       {"i32.div_s", TokenType::Binary, Opcode::I32DivS},
       {""},
-#line 454 "src/lexer-keywords.txt"
+#line 455 "src/lexer-keywords.txt"
       {"local.set", TokenType::LocalSet, Opcode::LocalSet},
-#line 352 "src/lexer-keywords.txt"
+#line 353 "src/lexer-keywords.txt"
       {"i64.div_u", TokenType::Binary, Opcode::I64DivU},
-#line 229 "src/lexer-keywords.txt"
+#line 230 "src/lexer-keywords.txt"
       {"i32.div_u", TokenType::Binary, Opcode::I32DivU},
-#line 366 "src/lexer-keywords.txt"
+#line 367 "src/lexer-keywords.txt"
       {"i64.load16_s", TokenType::Load, Opcode::I64Load16S},
-#line 240 "src/lexer-keywords.txt"
+#line 241 "src/lexer-keywords.txt"
       {"i32.load16_s", TokenType::Load, Opcode::I32Load16S},
       {""},
-#line 24 "src/lexer-keywords.txt"
+#line 25 "src/lexer-keywords.txt"
       {"assert_unlinkable", TokenType::AssertUnlinkable},
-#line 367 "src/lexer-keywords.txt"
+#line 368 "src/lexer-keywords.txt"
       {"i64.load16_u", TokenType::Load, Opcode::I64Load16U},
-#line 241 "src/lexer-keywords.txt"
+#line 242 "src/lexer-keywords.txt"
       {"i32.load16_u", TokenType::Load, Opcode::I32Load16U},
-#line 451 "src/lexer-keywords.txt"
+#line 452 "src/lexer-keywords.txt"
       {"invoke", TokenType::Invoke},
-#line 127 "src/lexer-keywords.txt"
+#line 128 "src/lexer-keywords.txt"
       {"f64x2.abs", TokenType::Unary, Opcode::F64X2Abs},
       {""},
-#line 455 "src/lexer-keywords.txt"
+#line 456 "src/lexer-keywords.txt"
       {"local.tee", TokenType::LocalTee, Opcode::LocalTee},
       {""}, {""},
-#line 476 "src/lexer-keywords.txt"
+#line 477 "src/lexer-keywords.txt"
       {"ref.null", TokenType::RefNull, Opcode::RefNull},
       {""},
-#line 350 "src/lexer-keywords.txt"
+#line 351 "src/lexer-keywords.txt"
       {"i64.ctz", TokenType::Unary, Opcode::I64Ctz},
-#line 227 "src/lexer-keywords.txt"
+#line 228 "src/lexer-keywords.txt"
       {"i32.ctz", TokenType::Unary, Opcode::I32Ctz},
       {""},
-#line 117 "src/lexer-keywords.txt"
+#line 118 "src/lexer-keywords.txt"
       {"f64.nearest", TokenType::Unary, Opcode::F64Nearest},
-#line 67 "src/lexer-keywords.txt"
+#line 68 "src/lexer-keywords.txt"
       {"f32.nearest", TokenType::Unary, Opcode::F32Nearest},
       {""},
-#line 347 "src/lexer-keywords.txt"
+#line 348 "src/lexer-keywords.txt"
       {"i64.atomic.wait", TokenType::AtomicWait, Opcode::I64AtomicWait},
-#line 224 "src/lexer-keywords.txt"
+#line 225 "src/lexer-keywords.txt"
       {"i32.atomic.wait", TokenType::AtomicWait, Opcode::I32AtomicWait},
       {""}, {""},
-#line 383 "src/lexer-keywords.txt"
+#line 384 "src/lexer-keywords.txt"
       {"i64.rotr", TokenType::Binary, Opcode::I64Rotr},
-#line 255 "src/lexer-keywords.txt"
+#line 256 "src/lexer-keywords.txt"
       {"i32.rotr", TokenType::Binary, Opcode::I32Rotr},
       {""},
-#line 344 "src/lexer-keywords.txt"
+#line 345 "src/lexer-keywords.txt"
       {"i64.atomic.store32", TokenType::AtomicStore, Opcode::I64AtomicStore32},
-#line 20 "src/lexer-keywords.txt"
+#line 21 "src/lexer-keywords.txt"
       {"assert_invalid", TokenType::AssertInvalid},
       {""},
-#line 346 "src/lexer-keywords.txt"
+#line 347 "src/lexer-keywords.txt"
       {"i64.atomic.store", TokenType::AtomicStore, Opcode::I64AtomicStore},
-#line 223 "src/lexer-keywords.txt"
+#line 224 "src/lexer-keywords.txt"
       {"i32.atomic.store", TokenType::AtomicStore, Opcode::I32AtomicStore},
       {""}, {""},
-#line 348 "src/lexer-keywords.txt"
+#line 349 "src/lexer-keywords.txt"
       {"i64.clz", TokenType::Unary, Opcode::I64Clz},
-#line 225 "src/lexer-keywords.txt"
+#line 226 "src/lexer-keywords.txt"
       {"i32.clz", TokenType::Unary, Opcode::I32Clz},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 368 "src/lexer-keywords.txt"
+#line 369 "src/lexer-keywords.txt"
       {"i64.load32_s", TokenType::Load, Opcode::I64Load32S},
       {""}, {""}, {""},
-#line 369 "src/lexer-keywords.txt"
+#line 370 "src/lexer-keywords.txt"
       {"i64.load32_u", TokenType::Load, Opcode::I64Load32U},
       {""},
-#line 128 "src/lexer-keywords.txt"
+#line 129 "src/lexer-keywords.txt"
       {"f64x2.add", TokenType::Binary, Opcode::F64X2Add},
       {""},
-#line 22 "src/lexer-keywords.txt"
+#line 23 "src/lexer-keywords.txt"
       {"assert_return", TokenType::AssertReturn},
       {""}, {""},
-#line 401 "src/lexer-keywords.txt"
+#line 402 "src/lexer-keywords.txt"
       {"i64x2.add", TokenType::Binary, Opcode::I64X2Add},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 389 "src/lexer-keywords.txt"
+#line 390 "src/lexer-keywords.txt"
       {"i64.store8", TokenType::Store, Opcode::I64Store8},
-#line 260 "src/lexer-keywords.txt"
+#line 261 "src/lexer-keywords.txt"
       {"i32.store8", TokenType::Store, Opcode::I32Store8},
       {""},
-#line 508 "src/lexer-keywords.txt"
+#line 509 "src/lexer-keywords.txt"
       {"v128", Type::V128},
       {""},
-#line 38 "src/lexer-keywords.txt"
+#line 39 "src/lexer-keywords.txt"
       {"declare", TokenType::Declare},
-#line 370 "src/lexer-keywords.txt"
+#line 371 "src/lexer-keywords.txt"
       {"i64.load8_s", TokenType::Load, Opcode::I64Load8S},
-#line 242 "src/lexer-keywords.txt"
+#line 243 "src/lexer-keywords.txt"
       {"i32.load8_s", TokenType::Load, Opcode::I32Load8S},
       {""}, {""},
-#line 371 "src/lexer-keywords.txt"
+#line 372 "src/lexer-keywords.txt"
       {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
-#line 243 "src/lexer-keywords.txt"
+#line 244 "src/lexer-keywords.txt"
       {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 554 "src/lexer-keywords.txt"
+#line 555 "src/lexer-keywords.txt"
       {"set_local", TokenType::LocalSet, Opcode::LocalSet},
       {""}, {""}, {""}, {""}, {""},
-#line 555 "src/lexer-keywords.txt"
+#line 556 "src/lexer-keywords.txt"
       {"tee_local", TokenType::LocalTee, Opcode::LocalTee},
       {""}, {""},
-#line 522 "src/lexer-keywords.txt"
+#line 523 "src/lexer-keywords.txt"
       {"f32.demote/f64", TokenType::Convert, Opcode::F32DemoteF64},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 392 "src/lexer-keywords.txt"
-      {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
-#line 263 "src/lexer-keywords.txt"
-      {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
 #line 393 "src/lexer-keywords.txt"
-      {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
+      {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
 #line 264 "src/lexer-keywords.txt"
+      {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
+#line 394 "src/lexer-keywords.txt"
+      {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
+#line 265 "src/lexer-keywords.txt"
       {"i32.trunc_f32_u", TokenType::Convert, Opcode::I32TruncF32U},
       {""}, {""},
-#line 394 "src/lexer-keywords.txt"
-      {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
-#line 265 "src/lexer-keywords.txt"
-      {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
 #line 395 "src/lexer-keywords.txt"
-      {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
+      {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
 #line 266 "src/lexer-keywords.txt"
+      {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
+#line 396 "src/lexer-keywords.txt"
+      {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
+#line 267 "src/lexer-keywords.txt"
       {"i32.trunc_f64_u", TokenType::Convert, Opcode::I32TruncF64U},
-#line 481 "src/lexer-keywords.txt"
+#line 482 "src/lexer-keywords.txt"
       {"return_call", TokenType::ReturnCall, Opcode::ReturnCall},
-#line 314 "src/lexer-keywords.txt"
+#line 315 "src/lexer-keywords.txt"
       {"i64.atomic.load", TokenType::AtomicLoad, Opcode::I64AtomicLoad},
-#line 199 "src/lexer-keywords.txt"
+#line 200 "src/lexer-keywords.txt"
       {"i32.atomic.load", TokenType::AtomicLoad, Opcode::I32AtomicLoad},
-#line 333 "src/lexer-keywords.txt"
+#line 334 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8SubU},
-#line 211 "src/lexer-keywords.txt"
+#line 212 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8SubU},
-#line 387 "src/lexer-keywords.txt"
+#line 388 "src/lexer-keywords.txt"
       {"i64.store16", TokenType::Store, Opcode::I64Store16},
-#line 259 "src/lexer-keywords.txt"
+#line 260 "src/lexer-keywords.txt"
       {"i32.store16", TokenType::Store, Opcode::I32Store16},
-#line 32 "src/lexer-keywords.txt"
+#line 33 "src/lexer-keywords.txt"
       {"call_indirect", TokenType::CallIndirect, Opcode::CallIndirect},
-#line 125 "src/lexer-keywords.txt"
+#line 126 "src/lexer-keywords.txt"
       {"f64.trunc", TokenType::Unary, Opcode::F64Trunc},
-#line 74 "src/lexer-keywords.txt"
+#line 75 "src/lexer-keywords.txt"
       {"f32.trunc", TokenType::Unary, Opcode::F32Trunc},
       {""}, {""}, {""}, {""}, {""},
-#line 106 "src/lexer-keywords.txt"
+#line 107 "src/lexer-keywords.txt"
       {"f64.div", TokenType::Binary, Opcode::F64Div},
-#line 56 "src/lexer-keywords.txt"
+#line 57 "src/lexer-keywords.txt"
       {"f32.div", TokenType::Binary, Opcode::F32Div},
       {""}, {""},
-#line 21 "src/lexer-keywords.txt"
+#line 22 "src/lexer-keywords.txt"
       {"assert_malformed", TokenType::AssertMalformed},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 330 "src/lexer-keywords.txt"
+#line 331 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AndU},
-#line 208 "src/lexer-keywords.txt"
+#line 209 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AndU},
       {""}, {""},
-#line 505 "src/lexer-keywords.txt"
+#line 506 "src/lexer-keywords.txt"
       {"v128.not", TokenType::Unary, Opcode::V128Not},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 336 "src/lexer-keywords.txt"
+#line 337 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I64AtomicRmwAdd},
-#line 214 "src/lexer-keywords.txt"
+#line 215 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I32AtomicRmwAdd},
       {""}, {""}, {""}, {""},
-#line 101 "src/lexer-keywords.txt"
+#line 102 "src/lexer-keywords.txt"
       {"f64.convert_i32_s", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 50 "src/lexer-keywords.txt"
+#line 51 "src/lexer-keywords.txt"
       {"f32.convert_i32_s", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 329 "src/lexer-keywords.txt"
+#line 330 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AddU},
-#line 207 "src/lexer-keywords.txt"
+#line 208 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AddU},
       {""}, {""}, {""},
-#line 103 "src/lexer-keywords.txt"
+#line 104 "src/lexer-keywords.txt"
       {"f64.convert_i64_s", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 52 "src/lexer-keywords.txt"
+#line 53 "src/lexer-keywords.txt"
       {"f32.convert_i64_s", TokenType::Convert, Opcode::F32ConvertI64S},
-#line 339 "src/lexer-keywords.txt"
+#line 340 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I64AtomicRmwOr},
-#line 217 "src/lexer-keywords.txt"
+#line 218 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I32AtomicRmwOr},
-#line 326 "src/lexer-keywords.txt"
+#line 327 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32SubU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 500 "src/lexer-keywords.txt"
+#line 501 "src/lexer-keywords.txt"
       {"v128.andnot", TokenType::Binary, Opcode::V128Andnot},
-#line 343 "src/lexer-keywords.txt"
+#line 344 "src/lexer-keywords.txt"
       {"i64.atomic.store16", TokenType::AtomicStore, Opcode::I64AtomicStore16},
-#line 221 "src/lexer-keywords.txt"
+#line 222 "src/lexer-keywords.txt"
       {"i32.atomic.store16", TokenType::AtomicStore, Opcode::I32AtomicStore16},
       {""},
-#line 467 "src/lexer-keywords.txt"
+#line 468 "src/lexer-keywords.txt"
       {"nan:canonical", TokenType::NanCanonical},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 501 "src/lexer-keywords.txt"
+#line 502 "src/lexer-keywords.txt"
       {"v128.and", TokenType::Binary, Opcode::V128And},
       {""}, {""}, {""}, {""},
-#line 149 "src/lexer-keywords.txt"
+#line 150 "src/lexer-keywords.txt"
       {"get", TokenType::Get},
-#line 337 "src/lexer-keywords.txt"
+#line 338 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I64AtomicRmwAnd},
-#line 215 "src/lexer-keywords.txt"
+#line 216 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I32AtomicRmwAnd},
       {""}, {""}, {""},
-#line 313 "src/lexer-keywords.txt"
+#line 314 "src/lexer-keywords.txt"
       {"i64.atomic.load8_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad8U},
-#line 198 "src/lexer-keywords.txt"
+#line 199 "src/lexer-keywords.txt"
       {"i32.atomic.load8_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad8U},
       {""}, {""}, {""}, {""},
-#line 545 "src/lexer-keywords.txt"
+#line 546 "src/lexer-keywords.txt"
       {"i64.trunc_s/f32", TokenType::Convert, Opcode::I64TruncF32S},
-#line 533 "src/lexer-keywords.txt"
+#line 534 "src/lexer-keywords.txt"
       {"i32.trunc_s/f32", TokenType::Convert, Opcode::I32TruncF32S},
-#line 549 "src/lexer-keywords.txt"
+#line 550 "src/lexer-keywords.txt"
       {"i64.trunc_u/f32", TokenType::Convert, Opcode::I64TruncF32U},
-#line 537 "src/lexer-keywords.txt"
+#line 538 "src/lexer-keywords.txt"
       {"i32.trunc_u/f32", TokenType::Convert, Opcode::I32TruncF32U},
       {""}, {""},
-#line 546 "src/lexer-keywords.txt"
+#line 547 "src/lexer-keywords.txt"
       {"i64.trunc_s/f64", TokenType::Convert, Opcode::I64TruncF64S},
-#line 534 "src/lexer-keywords.txt"
+#line 535 "src/lexer-keywords.txt"
       {"i32.trunc_s/f64", TokenType::Convert, Opcode::I32TruncF64S},
-#line 550 "src/lexer-keywords.txt"
+#line 551 "src/lexer-keywords.txt"
       {"i64.trunc_u/f64", TokenType::Convert, Opcode::I64TruncF64U},
-#line 538 "src/lexer-keywords.txt"
+#line 539 "src/lexer-keywords.txt"
       {"i32.trunc_u/f64", TokenType::Convert, Opcode::I32TruncF64U},
-#line 507 "src/lexer-keywords.txt"
+#line 508 "src/lexer-keywords.txt"
       {"v128.store", TokenType::Store, Opcode::V128Store},
       {""}, {""}, {""},
-#line 323 "src/lexer-keywords.txt"
+#line 324 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AndU},
       {""},
-#line 96 "src/lexer-keywords.txt"
+#line 97 "src/lexer-keywords.txt"
       {"f32x4", TokenType::F32X4},
       {""}, {""}, {""}, {""},
-#line 301 "src/lexer-keywords.txt"
+#line 302 "src/lexer-keywords.txt"
       {"i32x4", TokenType::I32X4},
       {""}, {""},
-#line 28 "src/lexer-keywords.txt"
+#line 29 "src/lexer-keywords.txt"
       {"br_if", TokenType::BrIf, Opcode::BrIf},
-#line 396 "src/lexer-keywords.txt"
+#line 397 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f32_s", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 267 "src/lexer-keywords.txt"
+#line 268 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f32_s", TokenType::Convert, Opcode::I32TruncSatF32S},
-#line 480 "src/lexer-keywords.txt"
+#line 481 "src/lexer-keywords.txt"
       {"return_call_indirect", TokenType::ReturnCallIndirect, Opcode::ReturnCallIndirect},
       {""},
-#line 397 "src/lexer-keywords.txt"
+#line 398 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f32_u", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 268 "src/lexer-keywords.txt"
+#line 269 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f32_u", TokenType::Convert, Opcode::I32TruncSatF32U},
       {""},
-#line 312 "src/lexer-keywords.txt"
+#line 313 "src/lexer-keywords.txt"
       {"i64.atomic.load32_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad32U},
-#line 322 "src/lexer-keywords.txt"
+#line 323 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AddU},
       {""},
-#line 319 "src/lexer-keywords.txt"
+#line 320 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16SubU},
-#line 204 "src/lexer-keywords.txt"
+#line 205 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16SubU},
-#line 129 "src/lexer-keywords.txt"
+#line 130 "src/lexer-keywords.txt"
       {"f64x2.div", TokenType::Binary, Opcode::F64X2Div},
       {""}, {""}, {""},
-#line 340 "src/lexer-keywords.txt"
+#line 341 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I64AtomicRmwSub},
-#line 218 "src/lexer-keywords.txt"
+#line 219 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I32AtomicRmwSub},
       {""},
-#line 503 "src/lexer-keywords.txt"
+#line 504 "src/lexer-keywords.txt"
       {"v128.const", TokenType::Const, Opcode::V128Const},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 504 "src/lexer-keywords.txt"
+#line 505 "src/lexer-keywords.txt"
       {"v128.load", TokenType::Load, Opcode::V128Load},
       {""},
-#line 502 "src/lexer-keywords.txt"
+#line 503 "src/lexer-keywords.txt"
       {"v128.bitselect", TokenType::Ternary, Opcode::V128BitSelect},
       {""}, {""},
-#line 311 "src/lexer-keywords.txt"
+#line 312 "src/lexer-keywords.txt"
       {"i64.atomic.load16_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad16U},
-#line 197 "src/lexer-keywords.txt"
+#line 198 "src/lexer-keywords.txt"
       {"i32.atomic.load16_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad16U},
       {""}, {""}, {""},
-#line 498 "src/lexer-keywords.txt"
+#line 499 "src/lexer-keywords.txt"
       {"type", TokenType::Type},
-#line 489 "src/lexer-keywords.txt"
+#line 490 "src/lexer-keywords.txt"
       {"table.get", TokenType::TableGet, Opcode::TableGet},
-#line 450 "src/lexer-keywords.txt"
+#line 451 "src/lexer-keywords.txt"
       {"import", TokenType::Import},
       {""},
-#line 45 "src/lexer-keywords.txt"
+#line 46 "src/lexer-keywords.txt"
       {"export", TokenType::Export},
       {""}, {""},
-#line 506 "src/lexer-keywords.txt"
+#line 507 "src/lexer-keywords.txt"
       {"v128.or", TokenType::Binary, Opcode::V128Or},
-#line 91 "src/lexer-keywords.txt"
+#line 92 "src/lexer-keywords.txt"
       {"f32x4.ne", TokenType::Compare, Opcode::F32X4Ne},
       {""},
-#line 324 "src/lexer-keywords.txt"
+#line 325 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw32CmpxchgU},
-#line 86 "src/lexer-keywords.txt"
+#line 87 "src/lexer-keywords.txt"
       {"f32x4.lt", TokenType::Compare, Opcode::F32X4Lt},
-#line 88 "src/lexer-keywords.txt"
+#line 89 "src/lexer-keywords.txt"
       {"f32x4.min", TokenType::Binary, Opcode::F32X4Min},
-#line 294 "src/lexer-keywords.txt"
+#line 295 "src/lexer-keywords.txt"
       {"i32x4.ne", TokenType::Compare, Opcode::I32X4Ne},
       {""},
-#line 290 "src/lexer-keywords.txt"
+#line 291 "src/lexer-keywords.txt"
       {"i32x4.min_s", TokenType::Binary, Opcode::I32X4MinS},
       {""},
-#line 325 "src/lexer-keywords.txt"
+#line 326 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32OrU},
       {""},
-#line 291 "src/lexer-keywords.txt"
+#line 292 "src/lexer-keywords.txt"
       {"i32x4.min_u", TokenType::Binary, Opcode::I32X4MinU},
       {""}, {""}, {""},
-#line 85 "src/lexer-keywords.txt"
+#line 86 "src/lexer-keywords.txt"
       {"f32x4.le", TokenType::Compare, Opcode::F32X4Le},
-#line 286 "src/lexer-keywords.txt"
+#line 287 "src/lexer-keywords.txt"
       {"i32x4.lt_s", TokenType::Compare, Opcode::I32X4LtS},
       {""},
-#line 287 "src/lexer-keywords.txt"
+#line 288 "src/lexer-keywords.txt"
       {"i32x4.lt_u", TokenType::Compare, Opcode::I32X4LtU},
-#line 316 "src/lexer-keywords.txt"
+#line 317 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AndU},
-#line 201 "src/lexer-keywords.txt"
+#line 202 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AndU},
       {""},
-#line 282 "src/lexer-keywords.txt"
-      {"i32x4.le_s", TokenType::Compare, Opcode::I32X4LeS},
-#line 133 "src/lexer-keywords.txt"
-      {"f64x2.gt", TokenType::Compare, Opcode::F64X2Gt},
 #line 283 "src/lexer-keywords.txt"
+      {"i32x4.le_s", TokenType::Compare, Opcode::I32X4LeS},
+#line 134 "src/lexer-keywords.txt"
+      {"f64x2.gt", TokenType::Compare, Opcode::F64X2Gt},
+#line 284 "src/lexer-keywords.txt"
       {"i32x4.le_u", TokenType::Compare, Opcode::I32X4LeU},
       {""},
-#line 102 "src/lexer-keywords.txt"
+#line 103 "src/lexer-keywords.txt"
       {"f64.convert_i32_u", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 51 "src/lexer-keywords.txt"
+#line 52 "src/lexer-keywords.txt"
       {"f32.convert_i32_u", TokenType::Convert, Opcode::F32ConvertI32U},
       {""}, {""}, {""},
-#line 472 "src/lexer-keywords.txt"
+#line 473 "src/lexer-keywords.txt"
       {"quote", TokenType::Quote},
-#line 89 "src/lexer-keywords.txt"
+#line 90 "src/lexer-keywords.txt"
       {"f32x4.mul", TokenType::Binary, Opcode::F32X4Mul},
-#line 104 "src/lexer-keywords.txt"
+#line 105 "src/lexer-keywords.txt"
       {"f64.convert_i64_u", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 53 "src/lexer-keywords.txt"
+#line 54 "src/lexer-keywords.txt"
       {"f32.convert_i64_u", TokenType::Convert, Opcode::F32ConvertI64U},
-#line 132 "src/lexer-keywords.txt"
+#line 133 "src/lexer-keywords.txt"
       {"f64x2.ge", TokenType::Compare, Opcode::F64X2Ge},
       {""},
-#line 292 "src/lexer-keywords.txt"
+#line 293 "src/lexer-keywords.txt"
       {"i32x4.mul", TokenType::Binary, Opcode::I32X4Mul},
-#line 315 "src/lexer-keywords.txt"
+#line 316 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AddU},
-#line 200 "src/lexer-keywords.txt"
+#line 201 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AddU},
       {""}, {""}, {""}, {""},
-#line 152 "src/lexer-keywords.txt"
+#line 153 "src/lexer-keywords.txt"
       {"global", TokenType::Global},
-#line 95 "src/lexer-keywords.txt"
+#line 96 "src/lexer-keywords.txt"
       {"f32x4.sub", TokenType::Binary, Opcode::F32X4Sub},
       {""}, {""},
-#line 122 "src/lexer-keywords.txt"
+#line 123 "src/lexer-keywords.txt"
       {"f64.sqrt", TokenType::Unary, Opcode::F64Sqrt},
-#line 71 "src/lexer-keywords.txt"
+#line 72 "src/lexer-keywords.txt"
       {"f32.sqrt", TokenType::Unary, Opcode::F32Sqrt},
-#line 300 "src/lexer-keywords.txt"
+#line 301 "src/lexer-keywords.txt"
       {"i32x4.sub", TokenType::Binary, Opcode::I32X4Sub},
-#line 524 "src/lexer-keywords.txt"
+#line 525 "src/lexer-keywords.txt"
       {"f64.convert_s/i32", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 518 "src/lexer-keywords.txt"
+#line 519 "src/lexer-keywords.txt"
       {"f32.convert_s/i32", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 526 "src/lexer-keywords.txt"
+#line 527 "src/lexer-keywords.txt"
       {"f64.convert_u/i32", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 520 "src/lexer-keywords.txt"
+#line 521 "src/lexer-keywords.txt"
       {"f32.convert_u/i32", TokenType::Convert, Opcode::F32ConvertI32U},
       {""}, {""}, {""},
-#line 457 "src/lexer-keywords.txt"
+#line 458 "src/lexer-keywords.txt"
       {"loop", TokenType::Loop, Opcode::Loop},
       {""}, {""}, {""},
-#line 39 "src/lexer-keywords.txt"
+#line 40 "src/lexer-keywords.txt"
       {"drop", TokenType::Drop, Opcode::Drop},
       {""}, {""},
-#line 76 "src/lexer-keywords.txt"
+#line 77 "src/lexer-keywords.txt"
       {"f32x4.abs", TokenType::Unary, Opcode::F32X4Abs},
       {""},
-#line 151 "src/lexer-keywords.txt"
+#line 152 "src/lexer-keywords.txt"
       {"global.set", TokenType::GlobalSet, Opcode::GlobalSet},
-#line 471 "src/lexer-keywords.txt"
+#line 472 "src/lexer-keywords.txt"
       {"param", TokenType::Param},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 496 "src/lexer-keywords.txt"
+#line 497 "src/lexer-keywords.txt"
       {"throw", TokenType::Throw, Opcode::Throw},
       {""},
-#line 317 "src/lexer-keywords.txt"
+#line 318 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw16CmpxchgU},
-#line 202 "src/lexer-keywords.txt"
+#line 203 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw16CmpxchgU},
-#line 110 "src/lexer-keywords.txt"
+#line 111 "src/lexer-keywords.txt"
       {"f64.gt", TokenType::Compare, Opcode::F64Gt},
-#line 60 "src/lexer-keywords.txt"
+#line 61 "src/lexer-keywords.txt"
       {"f32.gt", TokenType::Compare, Opcode::F32Gt},
       {""}, {""}, {""},
-#line 318 "src/lexer-keywords.txt"
+#line 319 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16OrU},
-#line 203 "src/lexer-keywords.txt"
+#line 204 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16OrU},
       {""}, {""}, {""}, {""}, {""},
-#line 109 "src/lexer-keywords.txt"
+#line 110 "src/lexer-keywords.txt"
       {"f64.ge", TokenType::Compare, Opcode::F64Ge},
-#line 59 "src/lexer-keywords.txt"
+#line 60 "src/lexer-keywords.txt"
       {"f32.ge", TokenType::Compare, Opcode::F32Ge},
-#line 362 "src/lexer-keywords.txt"
+#line 363 "src/lexer-keywords.txt"
       {"i64.gt_s", TokenType::Compare, Opcode::I64GtS},
-#line 236 "src/lexer-keywords.txt"
+#line 237 "src/lexer-keywords.txt"
       {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
-#line 453 "src/lexer-keywords.txt"
+#line 454 "src/lexer-keywords.txt"
       {"local.get", TokenType::LocalGet, Opcode::LocalGet},
       {""},
-#line 363 "src/lexer-keywords.txt"
+#line 364 "src/lexer-keywords.txt"
       {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
-#line 237 "src/lexer-keywords.txt"
+#line 238 "src/lexer-keywords.txt"
       {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
-#line 360 "src/lexer-keywords.txt"
+#line 361 "src/lexer-keywords.txt"
       {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
-#line 234 "src/lexer-keywords.txt"
+#line 235 "src/lexer-keywords.txt"
       {"i32.ge_s", TokenType::Compare, Opcode::I32GeS},
       {""}, {""},
-#line 361 "src/lexer-keywords.txt"
+#line 362 "src/lexer-keywords.txt"
       {"i64.ge_u", TokenType::Compare, Opcode::I64GeU},
-#line 235 "src/lexer-keywords.txt"
+#line 236 "src/lexer-keywords.txt"
       {"i32.ge_u", TokenType::Compare, Opcode::I32GeU},
       {""}, {""},
-#line 356 "src/lexer-keywords.txt"
+#line 357 "src/lexer-keywords.txt"
       {"i64.extend32_s", TokenType::Unary, Opcode::I64Extend32S},
-#line 77 "src/lexer-keywords.txt"
+#line 78 "src/lexer-keywords.txt"
       {"f32x4.add", TokenType::Binary, Opcode::F32X4Add},
       {""}, {""},
-#line 490 "src/lexer-keywords.txt"
+#line 491 "src/lexer-keywords.txt"
       {"table.grow", TokenType::TableGrow, Opcode::TableGrow},
       {""},
-#line 273 "src/lexer-keywords.txt"
+#line 274 "src/lexer-keywords.txt"
       {"i32x4.add", TokenType::Binary, Opcode::I32X4Add},
-#line 358 "src/lexer-keywords.txt"
+#line 359 "src/lexer-keywords.txt"
       {"i64.extend_i32_s", TokenType::Convert, Opcode::I64ExtendI32S},
-#line 142 "src/lexer-keywords.txt"
+#line 143 "src/lexer-keywords.txt"
       {"f64x2.splat", TokenType::Unary, Opcode::F64X2Splat},
       {""}, {""},
-#line 359 "src/lexer-keywords.txt"
+#line 360 "src/lexer-keywords.txt"
       {"i64.extend_i32_u", TokenType::Convert, Opcode::I64ExtendI32U},
-#line 29 "src/lexer-keywords.txt"
+#line 30 "src/lexer-keywords.txt"
       {"br_on_exn", TokenType::BrOnExn, Opcode::BrOnExn},
-#line 411 "src/lexer-keywords.txt"
+#line 412 "src/lexer-keywords.txt"
       {"i64x2.splat", TokenType::Unary, Opcode::I64X2Splat},
       {""}, {""}, {""}, {""}, {""},
-#line 384 "src/lexer-keywords.txt"
+#line 385 "src/lexer-keywords.txt"
       {"i64.shl", TokenType::Binary, Opcode::I64Shl},
-#line 256 "src/lexer-keywords.txt"
+#line 257 "src/lexer-keywords.txt"
       {"i32.shl", TokenType::Binary, Opcode::I32Shl},
       {""}, {""}, {""}, {""}, {""},
-#line 377 "src/lexer-keywords.txt"
+#line 378 "src/lexer-keywords.txt"
       {"i64.or", TokenType::Binary, Opcode::I64Or},
-#line 249 "src/lexer-keywords.txt"
+#line 250 "src/lexer-keywords.txt"
       {"i32.or", TokenType::Binary, Opcode::I32Or},
       {""},
-#line 357 "src/lexer-keywords.txt"
+#line 358 "src/lexer-keywords.txt"
       {"i64.extend8_s", TokenType::Unary, Opcode::I64Extend8S},
-#line 233 "src/lexer-keywords.txt"
+#line 234 "src/lexer-keywords.txt"
       {"i32.extend8_s", TokenType::Unary, Opcode::I32Extend8S},
-#line 355 "src/lexer-keywords.txt"
+#line 356 "src/lexer-keywords.txt"
       {"i64.extend16_s", TokenType::Unary, Opcode::I64Extend16S},
-#line 232 "src/lexer-keywords.txt"
+#line 233 "src/lexer-keywords.txt"
       {"i32.extend16_s", TokenType::Unary, Opcode::I32Extend16S},
-#line 354 "src/lexer-keywords.txt"
+#line 355 "src/lexer-keywords.txt"
       {"i64.eqz", TokenType::Convert, Opcode::I64Eqz},
-#line 231 "src/lexer-keywords.txt"
+#line 232 "src/lexer-keywords.txt"
       {"i32.eqz", TokenType::Convert, Opcode::I32Eqz},
       {""},
-#line 477 "src/lexer-keywords.txt"
+#line 478 "src/lexer-keywords.txt"
       {"register", TokenType::Register},
       {""}, {""}, {""}, {""}, {""},
-#line 143 "src/lexer-keywords.txt"
+#line 144 "src/lexer-keywords.txt"
       {"f64x2.sqrt", TokenType::Unary, Opcode::F64X2Sqrt},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 542 "src/lexer-keywords.txt"
+#line 543 "src/lexer-keywords.txt"
       {"i64.extend_s/i32", TokenType::Convert, Opcode::I64ExtendI32S},
       {""},
-#line 543 "src/lexer-keywords.txt"
+#line 544 "src/lexer-keywords.txt"
       {"i64.extend_u/i32", TokenType::Convert, Opcode::I64ExtendI32U},
       {""}, {""}, {""},
-#line 385 "src/lexer-keywords.txt"
+#line 386 "src/lexer-keywords.txt"
       {"i64.shr_s", TokenType::Binary, Opcode::I64ShrS},
-#line 257 "src/lexer-keywords.txt"
+#line 258 "src/lexer-keywords.txt"
       {"i32.shr_s", TokenType::Binary, Opcode::I32ShrS},
       {""},
 #line 18 "src/lexer-keywords.txt"
       {"anyref", Type::Anyref},
-#line 386 "src/lexer-keywords.txt"
+#line 387 "src/lexer-keywords.txt"
       {"i64.shr_u", TokenType::Binary, Opcode::I64ShrU},
-#line 258 "src/lexer-keywords.txt"
+#line 259 "src/lexer-keywords.txt"
       {"i32.shr_u", TokenType::Binary, Opcode::I32ShrU},
       {""}, {""}, {""},
-#line 274 "src/lexer-keywords.txt"
+#line 275 "src/lexer-keywords.txt"
       {"i32x4.all_true", TokenType::Unary, Opcode::I32X4AllTrue},
       {""}, {""}, {""},
-#line 461 "src/lexer-keywords.txt"
+#line 462 "src/lexer-keywords.txt"
       {"memory.init", TokenType::MemoryInit, Opcode::MemoryInit},
       {""}, {""}, {""},
-#line 531 "src/lexer-keywords.txt"
+#line 532 "src/lexer-keywords.txt"
       {"get_local", TokenType::LocalGet, Opcode::LocalGet},
       {""}, {""},
-#line 462 "src/lexer-keywords.txt"
+#line 463 "src/lexer-keywords.txt"
       {"memory.size", TokenType::MemorySize, Opcode::MemorySize},
       {""}, {""},
-#line 34 "src/lexer-keywords.txt"
+#line 35 "src/lexer-keywords.txt"
       {"catch", TokenType::Catch, Opcode::Catch},
       {""}, {""},
-#line 108 "src/lexer-keywords.txt"
+#line 109 "src/lexer-keywords.txt"
       {"f64.floor", TokenType::Unary, Opcode::F64Floor},
-#line 58 "src/lexer-keywords.txt"
+#line 59 "src/lexer-keywords.txt"
       {"f32.floor", TokenType::Unary, Opcode::F32Floor},
       {""}, {""}, {""}, {""}, {""},
-#line 439 "src/lexer-keywords.txt"
+#line 440 "src/lexer-keywords.txt"
       {"i8x16.ne", TokenType::Compare, Opcode::I8X16Ne},
       {""},
-#line 434 "src/lexer-keywords.txt"
+#line 435 "src/lexer-keywords.txt"
       {"i8x16.min_s", TokenType::Binary, Opcode::I8X16MinS},
       {""}, {""}, {""},
-#line 435 "src/lexer-keywords.txt"
+#line 436 "src/lexer-keywords.txt"
       {"i8x16.min_u", TokenType::Binary, Opcode::I8X16MinU},
       {""}, {""}, {""}, {""},
-#line 430 "src/lexer-keywords.txt"
+#line 431 "src/lexer-keywords.txt"
       {"i8x16.lt_s", TokenType::Compare, Opcode::I8X16LtS},
       {""},
-#line 431 "src/lexer-keywords.txt"
+#line 432 "src/lexer-keywords.txt"
       {"i8x16.lt_u", TokenType::Compare, Opcode::I8X16LtU},
-#line 459 "src/lexer-keywords.txt"
+#line 460 "src/lexer-keywords.txt"
       {"memory.fill", TokenType::MemoryFill, Opcode::MemoryFill},
-#line 473 "src/lexer-keywords.txt"
+#line 474 "src/lexer-keywords.txt"
       {"ref.func", TokenType::RefFunc, Opcode::RefFunc},
       {""},
-#line 428 "src/lexer-keywords.txt"
+#line 429 "src/lexer-keywords.txt"
       {"i8x16.le_s", TokenType::Compare, Opcode::I8X16LeS},
       {""},
-#line 429 "src/lexer-keywords.txt"
+#line 430 "src/lexer-keywords.txt"
       {"i8x16.le_u", TokenType::Compare, Opcode::I8X16LeU},
       {""}, {""},
-#line 448 "src/lexer-keywords.txt"
+#line 449 "src/lexer-keywords.txt"
       {"i8x16", TokenType::I8X16},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 408 "src/lexer-keywords.txt"
+#line 409 "src/lexer-keywords.txt"
       {"i64x2.shl", TokenType::Binary, Opcode::I64X2Shl},
       {""}, {""}, {""},
-#line 306 "src/lexer-keywords.txt"
+#line 307 "src/lexer-keywords.txt"
       {"i32x4.widen_low_i16x8_s", TokenType::Unary, Opcode::I32X4WidenLowI16X8S},
       {""},
-#line 307 "src/lexer-keywords.txt"
+#line 308 "src/lexer-keywords.txt"
       {"i32x4.widen_low_i16x8_u", TokenType::Unary, Opcode::I32X4WidenLowI16X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 447 "src/lexer-keywords.txt"
+#line 448 "src/lexer-keywords.txt"
       {"i8x16.sub", TokenType::Binary, Opcode::I8X16Sub},
       {""}, {""}, {""},
-#line 120 "src/lexer-keywords.txt"
+#line 121 "src/lexer-keywords.txt"
       {"f64.promote_f32", TokenType::Convert, Opcode::F64PromoteF32},
       {""}, {""},
-#line 19 "src/lexer-keywords.txt"
+#line 20 "src/lexer-keywords.txt"
       {"assert_exhaustion", TokenType::AssertExhaustion},
       {""},
-#line 70 "src/lexer-keywords.txt"
+#line 71 "src/lexer-keywords.txt"
       {"f32.reinterpret_i32", TokenType::Convert, Opcode::F32ReinterpretI32},
       {""}, {""}, {""},
-#line 121 "src/lexer-keywords.txt"
+#line 122 "src/lexer-keywords.txt"
       {"f64.reinterpret_i64", TokenType::Convert, Opcode::F64ReinterpretI64},
       {""}, {""}, {""},
-#line 553 "src/lexer-keywords.txt"
+#line 554 "src/lexer-keywords.txt"
       {"set_global", TokenType::GlobalSet, Opcode::GlobalSet},
-#line 409 "src/lexer-keywords.txt"
+#line 410 "src/lexer-keywords.txt"
       {"i64x2.shr_s", TokenType::Binary, Opcode::I64X2ShrS},
       {""}, {""}, {""},
-#line 410 "src/lexer-keywords.txt"
+#line 411 "src/lexer-keywords.txt"
       {"i64x2.shr_u", TokenType::Binary, Opcode::I64X2ShrU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 331 "src/lexer-keywords.txt"
+#line 332 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw8CmpxchgU},
-#line 209 "src/lexer-keywords.txt"
+#line 210 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw8CmpxchgU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 398 "src/lexer-keywords.txt"
+#line 399 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f64_s", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 269 "src/lexer-keywords.txt"
+#line 270 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f64_s", TokenType::Convert, Opcode::I32TruncSatF64S},
       {""}, {""},
-#line 399 "src/lexer-keywords.txt"
+#line 400 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f64_u", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 270 "src/lexer-keywords.txt"
+#line 271 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f64_u", TokenType::Convert, Opcode::I32TruncSatF64U},
-#line 80 "src/lexer-keywords.txt"
+#line 81 "src/lexer-keywords.txt"
       {"f32x4.div", TokenType::Binary, Opcode::F32X4Div},
       {""}, {""},
-#line 417 "src/lexer-keywords.txt"
+#line 418 "src/lexer-keywords.txt"
       {"i8x16.add", TokenType::Binary, Opcode::I8X16Add},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 403 "src/lexer-keywords.txt"
-      {"i64x2.load32x2_s", TokenType::Load, Opcode::I64X2Load32X2S},
-#line 414 "src/lexer-keywords.txt"
-      {"i64.xor", TokenType::Binary, Opcode::I64Xor},
-#line 308 "src/lexer-keywords.txt"
-      {"i32.xor", TokenType::Binary, Opcode::I32Xor},
-      {""},
 #line 404 "src/lexer-keywords.txt"
+      {"i64x2.load32x2_s", TokenType::Load, Opcode::I64X2Load32X2S},
+#line 415 "src/lexer-keywords.txt"
+      {"i64.xor", TokenType::Binary, Opcode::I64Xor},
+#line 309 "src/lexer-keywords.txt"
+      {"i32.xor", TokenType::Binary, Opcode::I32Xor},
+#line 19 "src/lexer-keywords.txt"
+      {"array", TokenType::Array},
+#line 405 "src/lexer-keywords.txt"
       {"i64x2.load32x2_u", TokenType::Load, Opcode::I64X2Load32X2U},
-#line 332 "src/lexer-keywords.txt"
+#line 333 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8OrU},
-#line 210 "src/lexer-keywords.txt"
+#line 211 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8OrU},
       {""},
-#line 181 "src/lexer-keywords.txt"
+#line 182 "src/lexer-keywords.txt"
       {"i16x8.ne", TokenType::Compare, Opcode::I16X8Ne},
       {""},
-#line 175 "src/lexer-keywords.txt"
+#line 176 "src/lexer-keywords.txt"
       {"i16x8.min_s", TokenType::Binary, Opcode::I16X8MinS},
       {""}, {""}, {""},
-#line 176 "src/lexer-keywords.txt"
+#line 177 "src/lexer-keywords.txt"
       {"i16x8.min_u", TokenType::Binary, Opcode::I16X8MinU},
       {""}, {""}, {""}, {""},
-#line 171 "src/lexer-keywords.txt"
+#line 172 "src/lexer-keywords.txt"
       {"i16x8.lt_s", TokenType::Compare, Opcode::I16X8LtS},
       {""},
-#line 172 "src/lexer-keywords.txt"
+#line 173 "src/lexer-keywords.txt"
       {"i16x8.lt_u", TokenType::Compare, Opcode::I16X8LtU},
       {""}, {""}, {""},
-#line 167 "src/lexer-keywords.txt"
+#line 168 "src/lexer-keywords.txt"
       {"i16x8.le_s", TokenType::Compare, Opcode::I16X8LeS},
       {""},
-#line 168 "src/lexer-keywords.txt"
+#line 169 "src/lexer-keywords.txt"
       {"i16x8.le_u", TokenType::Compare, Opcode::I16X8LeU},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 445 "src/lexer-keywords.txt"
+#line 446 "src/lexer-keywords.txt"
       {"i8x16.sub_saturate_s", TokenType::Binary, Opcode::I8X16SubSaturateS},
       {""},
-#line 446 "src/lexer-keywords.txt"
+#line 447 "src/lexer-keywords.txt"
       {"i8x16.sub_saturate_u", TokenType::Binary, Opcode::I8X16SubSaturateU},
       {""}, {""},
-#line 528 "src/lexer-keywords.txt"
+#line 529 "src/lexer-keywords.txt"
       {"f64.promote/f32", TokenType::Convert, Opcode::F64PromoteF32},
-#line 177 "src/lexer-keywords.txt"
+#line 178 "src/lexer-keywords.txt"
       {"i16x8.mul", TokenType::Binary, Opcode::I16X8Mul},
-#line 118 "src/lexer-keywords.txt"
+#line 119 "src/lexer-keywords.txt"
       {"f64.neg", TokenType::Unary, Opcode::F64Neg},
-#line 68 "src/lexer-keywords.txt"
+#line 69 "src/lexer-keywords.txt"
       {"f32.neg", TokenType::Unary, Opcode::F32Neg},
-#line 84 "src/lexer-keywords.txt"
+#line 85 "src/lexer-keywords.txt"
       {"f32x4.gt", TokenType::Compare, Opcode::F32X4Gt},
-#line 523 "src/lexer-keywords.txt"
+#line 524 "src/lexer-keywords.txt"
       {"f32.reinterpret/i32", TokenType::Convert, Opcode::F32ReinterpretI32},
       {""}, {""}, {""},
-#line 529 "src/lexer-keywords.txt"
+#line 530 "src/lexer-keywords.txt"
       {"f64.reinterpret/i64", TokenType::Convert, Opcode::F64ReinterpretI64},
       {""}, {""},
-#line 418 "src/lexer-keywords.txt"
+#line 419 "src/lexer-keywords.txt"
       {"i8x16.all_true", TokenType::Unary, Opcode::I8X16AllTrue},
       {""},
-#line 189 "src/lexer-keywords.txt"
-      {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
 #line 190 "src/lexer-keywords.txt"
+      {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
+#line 191 "src/lexer-keywords.txt"
       {"i16x8", TokenType::I16X8},
-#line 83 "src/lexer-keywords.txt"
+#line 84 "src/lexer-keywords.txt"
       {"f32x4.ge", TokenType::Compare, Opcode::F32X4Ge},
-#line 280 "src/lexer-keywords.txt"
+#line 281 "src/lexer-keywords.txt"
       {"i32x4.gt_s", TokenType::Compare, Opcode::I32X4GtS},
       {""},
-#line 281 "src/lexer-keywords.txt"
+#line 282 "src/lexer-keywords.txt"
       {"i32x4.gt_u", TokenType::Compare, Opcode::I32X4GtU},
       {""}, {""}, {""},
-#line 278 "src/lexer-keywords.txt"
+#line 279 "src/lexer-keywords.txt"
       {"i32x4.ge_s", TokenType::Compare, Opcode::I32X4GeS},
       {""},
-#line 279 "src/lexer-keywords.txt"
+#line 280 "src/lexer-keywords.txt"
       {"i32x4.ge_u", TokenType::Compare, Opcode::I32X4GeU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 499 "src/lexer-keywords.txt"
+#line 500 "src/lexer-keywords.txt"
       {"unreachable", TokenType::Unreachable, Opcode::Unreachable},
       {""}, {""}, {""},
-#line 525 "src/lexer-keywords.txt"
+#line 526 "src/lexer-keywords.txt"
       {"f64.convert_s/i64", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 519 "src/lexer-keywords.txt"
+#line 520 "src/lexer-keywords.txt"
       {"f32.convert_s/i64", TokenType::Convert, Opcode::F32ConvertI64S},
-#line 527 "src/lexer-keywords.txt"
+#line 528 "src/lexer-keywords.txt"
       {"f64.convert_u/i64", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 521 "src/lexer-keywords.txt"
+#line 522 "src/lexer-keywords.txt"
       {"f32.convert_u/i64", TokenType::Convert, Opcode::F32ConvertI64U},
       {""}, {""},
-#line 512 "src/lexer-keywords.txt"
+#line 513 "src/lexer-keywords.txt"
       {"v64x2.load_splat", TokenType::Load, Opcode::V64X2LoadSplat},
-#line 328 "src/lexer-keywords.txt"
+#line 329 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XorU},
       {""}, {""},
-#line 107 "src/lexer-keywords.txt"
+#line 108 "src/lexer-keywords.txt"
       {"f64.eq", TokenType::Compare, Opcode::F64Eq},
-#line 57 "src/lexer-keywords.txt"
+#line 58 "src/lexer-keywords.txt"
       {"f32.eq", TokenType::Compare, Opcode::F32Eq},
       {""}, {""},
-#line 131 "src/lexer-keywords.txt"
+#line 132 "src/lexer-keywords.txt"
       {"f64x2.extract_lane", TokenType::SimdLaneOp, Opcode::F64X2ExtractLane},
-#line 353 "src/lexer-keywords.txt"
+#line 354 "src/lexer-keywords.txt"
       {"i64.eq", TokenType::Compare, Opcode::I64Eq},
-#line 230 "src/lexer-keywords.txt"
+#line 231 "src/lexer-keywords.txt"
       {"i32.eq", TokenType::Compare, Opcode::I32Eq},
       {""}, {""},
-#line 402 "src/lexer-keywords.txt"
+#line 403 "src/lexer-keywords.txt"
       {"i64x2.extract_lane", TokenType::SimdLaneOp, Opcode::I64X2ExtractLane},
-#line 139 "src/lexer-keywords.txt"
+#line 140 "src/lexer-keywords.txt"
       {"f64x2.neg", TokenType::Unary, Opcode::F64X2Neg},
       {""}, {""}, {""}, {""},
-#line 406 "src/lexer-keywords.txt"
+#line 407 "src/lexer-keywords.txt"
       {"i64x2.neg", TokenType::Unary, Opcode::I64X2Neg},
-#line 415 "src/lexer-keywords.txt"
+#line 416 "src/lexer-keywords.txt"
       {"i8x16.add_saturate_s", TokenType::Binary, Opcode::I8X16AddSaturateS},
       {""},
-#line 416 "src/lexer-keywords.txt"
+#line 417 "src/lexer-keywords.txt"
       {"i8x16.add_saturate_u", TokenType::Binary, Opcode::I8X16AddSaturateU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 466 "src/lexer-keywords.txt"
+#line 467 "src/lexer-keywords.txt"
       {"nan:arithmetic", TokenType::NanArithmetic},
       {""}, {""},
-#line 156 "src/lexer-keywords.txt"
+#line 157 "src/lexer-keywords.txt"
       {"i16x8.add", TokenType::Binary, Opcode::I16X8Add},
-#line 468 "src/lexer-keywords.txt"
+#line 469 "src/lexer-keywords.txt"
       {"nop", TokenType::Nop, Opcode::Nop},
-#line 547 "src/lexer-keywords.txt"
+#line 548 "src/lexer-keywords.txt"
       {"i64.trunc_s:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 535 "src/lexer-keywords.txt"
+#line 536 "src/lexer-keywords.txt"
       {"i32.trunc_s:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32S},
-#line 551 "src/lexer-keywords.txt"
+#line 552 "src/lexer-keywords.txt"
       {"i64.trunc_u:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 539 "src/lexer-keywords.txt"
+#line 540 "src/lexer-keywords.txt"
       {"i32.trunc_u:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32U},
       {""},
-#line 548 "src/lexer-keywords.txt"
+#line 549 "src/lexer-keywords.txt"
       {"i64.trunc_s:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 536 "src/lexer-keywords.txt"
+#line 537 "src/lexer-keywords.txt"
       {"i32.trunc_s:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64S},
-#line 552 "src/lexer-keywords.txt"
+#line 553 "src/lexer-keywords.txt"
       {"i64.trunc_u:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 540 "src/lexer-keywords.txt"
+#line 541 "src/lexer-keywords.txt"
       {"i32.trunc_u:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64U},
-#line 150 "src/lexer-keywords.txt"
+#line 151 "src/lexer-keywords.txt"
       {"global.get", TokenType::GlobalGet, Opcode::GlobalGet},
       {""}, {""}, {""}, {""},
-#line 515 "src/lexer-keywords.txt"
+#line 516 "src/lexer-keywords.txt"
       {"v8x16.swizzle", TokenType::Binary, Opcode::V8X16Swizzle},
       {""}, {""},
-#line 93 "src/lexer-keywords.txt"
+#line 94 "src/lexer-keywords.txt"
       {"f32x4.splat", TokenType::Unary, Opcode::F32X4Splat},
       {""},
-#line 327 "src/lexer-keywords.txt"
+#line 328 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XchgU},
       {""}, {""},
-#line 299 "src/lexer-keywords.txt"
+#line 300 "src/lexer-keywords.txt"
       {"i32x4.splat", TokenType::Unary, Opcode::I32X4Splat},
       {""}, {""}, {""},
-#line 509 "src/lexer-keywords.txt"
+#line 510 "src/lexer-keywords.txt"
       {"v128.xor", TokenType::Binary, Opcode::V128Xor},
       {""}, {""}, {""}, {""}, {""},
-#line 141 "src/lexer-keywords.txt"
+#line 142 "src/lexer-keywords.txt"
       {"f64x2.replace_lane", TokenType::SimdLaneOp, Opcode::F64X2ReplaceLane},
       {""}, {""}, {""}, {""},
-#line 407 "src/lexer-keywords.txt"
+#line 408 "src/lexer-keywords.txt"
       {"i64x2.replace_lane", TokenType::SimdLaneOp, Opcode::I64X2ReplaceLane},
       {""}, {""},
-#line 321 "src/lexer-keywords.txt"
+#line 322 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XorU},
-#line 206 "src/lexer-keywords.txt"
+#line 207 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XorU},
-#line 187 "src/lexer-keywords.txt"
+#line 188 "src/lexer-keywords.txt"
       {"i16x8.sub_saturate_s", TokenType::Binary, Opcode::I16X8SubSaturateS},
       {""},
-#line 188 "src/lexer-keywords.txt"
+#line 189 "src/lexer-keywords.txt"
       {"i16x8.sub_saturate_u", TokenType::Binary, Opcode::I16X8SubSaturateU},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 94 "src/lexer-keywords.txt"
+#line 95 "src/lexer-keywords.txt"
       {"f32x4.sqrt", TokenType::Unary, Opcode::F32X4Sqrt},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 157 "src/lexer-keywords.txt"
+#line 158 "src/lexer-keywords.txt"
       {"i16x8.all_true", TokenType::Unary, Opcode::I16X8AllTrue},
-#line 345 "src/lexer-keywords.txt"
+#line 346 "src/lexer-keywords.txt"
       {"i64.atomic.store8", TokenType::AtomicStore, Opcode::I64AtomicStore8},
-#line 222 "src/lexer-keywords.txt"
+#line 223 "src/lexer-keywords.txt"
       {"i32.atomic.store8", TokenType::AtomicStore, Opcode::I32AtomicStore8},
       {""}, {""}, {""},
-#line 335 "src/lexer-keywords.txt"
+#line 336 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XorU},
-#line 213 "src/lexer-keywords.txt"
+#line 214 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XorU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 288 "src/lexer-keywords.txt"
+#line 289 "src/lexer-keywords.txt"
       {"i32x4.max_s", TokenType::Binary, Opcode::I32X4MaxS},
       {""}, {""},
-#line 130 "src/lexer-keywords.txt"
+#line 131 "src/lexer-keywords.txt"
       {"f64x2.eq", TokenType::Compare, Opcode::F64X2Eq},
-#line 289 "src/lexer-keywords.txt"
+#line 290 "src/lexer-keywords.txt"
       {"i32x4.max_u", TokenType::Binary, Opcode::I32X4MaxU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 114 "src/lexer-keywords.txt"
+#line 115 "src/lexer-keywords.txt"
       {"f64.max", TokenType::Binary, Opcode::F64Max},
-#line 64 "src/lexer-keywords.txt"
+#line 65 "src/lexer-keywords.txt"
       {"f32.max", TokenType::Binary, Opcode::F32Max},
       {""}, {""}, {""}, {""}, {""},
-#line 320 "src/lexer-keywords.txt"
+#line 321 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XchgU},
-#line 205 "src/lexer-keywords.txt"
+#line 206 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XchgU},
       {""}, {""}, {""},
-#line 517 "src/lexer-keywords.txt"
+#line 518 "src/lexer-keywords.txt"
       {"anyfunc", Type::Funcref},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 154 "src/lexer-keywords.txt"
+#line 155 "src/lexer-keywords.txt"
       {"i16x8.add_saturate_s", TokenType::Binary, Opcode::I16X8AddSaturateS},
       {""},
-#line 155 "src/lexer-keywords.txt"
+#line 156 "src/lexer-keywords.txt"
       {"i16x8.add_saturate_u", TokenType::Binary, Opcode::I16X8AddSaturateU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 296 "src/lexer-keywords.txt"
+#line 297 "src/lexer-keywords.txt"
       {"i32x4.shl", TokenType::Binary, Opcode::I32X4Shl},
-#line 426 "src/lexer-keywords.txt"
+#line 427 "src/lexer-keywords.txt"
       {"i8x16.gt_s", TokenType::Compare, Opcode::I8X16GtS},
       {""},
-#line 427 "src/lexer-keywords.txt"
+#line 428 "src/lexer-keywords.txt"
       {"i8x16.gt_u", TokenType::Compare, Opcode::I8X16GtU},
-#line 23 "src/lexer-keywords.txt"
+#line 24 "src/lexer-keywords.txt"
       {"assert_trap", TokenType::AssertTrap},
       {""}, {""},
-#line 424 "src/lexer-keywords.txt"
+#line 425 "src/lexer-keywords.txt"
       {"i8x16.ge_s", TokenType::Compare, Opcode::I8X16GeS},
       {""},
-#line 425 "src/lexer-keywords.txt"
+#line 426 "src/lexer-keywords.txt"
       {"i8x16.ge_u", TokenType::Compare, Opcode::I8X16GeU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 378 "src/lexer-keywords.txt"
+#line 379 "src/lexer-keywords.txt"
       {"i64.popcnt", TokenType::Unary, Opcode::I64Popcnt},
-#line 250 "src/lexer-keywords.txt"
+#line 251 "src/lexer-keywords.txt"
       {"i32.popcnt", TokenType::Unary, Opcode::I32Popcnt},
       {""}, {""}, {""}, {""},
-#line 297 "src/lexer-keywords.txt"
+#line 298 "src/lexer-keywords.txt"
       {"i32x4.shr_s", TokenType::Binary, Opcode::I32X4ShrS},
       {""}, {""}, {""},
-#line 298 "src/lexer-keywords.txt"
+#line 299 "src/lexer-keywords.txt"
       {"i32x4.shr_u", TokenType::Binary, Opcode::I32X4ShrU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 460 "src/lexer-keywords.txt"
+#line 461 "src/lexer-keywords.txt"
       {"memory.grow", TokenType::MemoryGrow, Opcode::MemoryGrow},
       {""}, {""}, {""}, {""}, {""},
-#line 136 "src/lexer-keywords.txt"
+#line 137 "src/lexer-keywords.txt"
       {"f64x2.max", TokenType::Binary, Opcode::F64X2Max},
       {""}, {""}, {""}, {""},
-#line 251 "src/lexer-keywords.txt"
+#line 252 "src/lexer-keywords.txt"
       {"i32.reinterpret_f32", TokenType::Convert, Opcode::I32ReinterpretF32},
       {""}, {""}, {""},
-#line 379 "src/lexer-keywords.txt"
+#line 380 "src/lexer-keywords.txt"
       {"i64.reinterpret_f64", TokenType::Convert, Opcode::I64ReinterpretF64},
       {""}, {""}, {""},
-#line 530 "src/lexer-keywords.txt"
+#line 531 "src/lexer-keywords.txt"
       {"get_global", TokenType::GlobalGet, Opcode::GlobalGet},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 444 "src/lexer-keywords.txt"
+#line 445 "src/lexer-keywords.txt"
       {"i8x16.splat", TokenType::Unary, Opcode::I8X16Splat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 272 "src/lexer-keywords.txt"
+#line 273 "src/lexer-keywords.txt"
       {"i32.wrap_i64", TokenType::Convert, Opcode::I32WrapI64},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 284 "src/lexer-keywords.txt"
+#line 285 "src/lexer-keywords.txt"
       {"i32x4.load16x4_s", TokenType::Load, Opcode::I32X4Load16X4S},
       {""}, {""}, {""},
-#line 285 "src/lexer-keywords.txt"
+#line 286 "src/lexer-keywords.txt"
       {"i32x4.load16x4_u", TokenType::Load, Opcode::I32X4Load16X4U},
       {""},
-#line 497 "src/lexer-keywords.txt"
+#line 498 "src/lexer-keywords.txt"
       {"try", TokenType::Try, Opcode::Try},
       {""}, {""},
-#line 165 "src/lexer-keywords.txt"
+#line 166 "src/lexer-keywords.txt"
       {"i16x8.gt_s", TokenType::Compare, Opcode::I16X8GtS},
       {""},
-#line 166 "src/lexer-keywords.txt"
+#line 167 "src/lexer-keywords.txt"
       {"i16x8.gt_u", TokenType::Compare, Opcode::I16X8GtU},
-#line 302 "src/lexer-keywords.txt"
+#line 303 "src/lexer-keywords.txt"
       {"i32x4.trunc_sat_f32x4_s", TokenType::Unary, Opcode::I32X4TruncSatF32X4S},
       {""},
-#line 303 "src/lexer-keywords.txt"
+#line 304 "src/lexer-keywords.txt"
       {"i32x4.trunc_sat_f32x4_u", TokenType::Unary, Opcode::I32X4TruncSatF32X4U},
-#line 163 "src/lexer-keywords.txt"
+#line 164 "src/lexer-keywords.txt"
       {"i16x8.ge_s", TokenType::Compare, Opcode::I16X8GeS},
       {""},
-#line 164 "src/lexer-keywords.txt"
+#line 165 "src/lexer-keywords.txt"
       {"i16x8.ge_u", TokenType::Compare, Opcode::I16X8GeU},
       {""},
-#line 432 "src/lexer-keywords.txt"
+#line 433 "src/lexer-keywords.txt"
       {"i8x16.max_s", TokenType::Binary, Opcode::I8X16MaxS},
       {""},
-#line 463 "src/lexer-keywords.txt"
+#line 464 "src/lexer-keywords.txt"
       {"memory", TokenType::Memory},
       {""},
-#line 433 "src/lexer-keywords.txt"
+#line 434 "src/lexer-keywords.txt"
       {"i8x16.max_u", TokenType::Binary, Opcode::I8X16MaxU},
       {""}, {""}, {""}, {""},
-#line 40 "src/lexer-keywords.txt"
+#line 41 "src/lexer-keywords.txt"
       {"elem.drop", TokenType::ElemDrop, Opcode::ElemDrop},
       {""},
-#line 275 "src/lexer-keywords.txt"
+#line 276 "src/lexer-keywords.txt"
       {"i32x4.any_true", TokenType::Unary, Opcode::I32X4AnyTrue},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 36 "src/lexer-keywords.txt"
+#line 37 "src/lexer-keywords.txt"
       {"data.drop", TokenType::DataDrop, Opcode::DataDrop},
       {""}, {""}, {""}, {""},
-#line 26 "src/lexer-keywords.txt"
+#line 27 "src/lexer-keywords.txt"
       {"binary", TokenType::Bin},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 511 "src/lexer-keywords.txt"
+#line 512 "src/lexer-keywords.txt"
       {"v32x4.load_splat", TokenType::Load, Opcode::V32X4LoadSplat},
       {""},
-#line 532 "src/lexer-keywords.txt"
+#line 533 "src/lexer-keywords.txt"
       {"i32.reinterpret/f32", TokenType::Convert, Opcode::I32ReinterpretF32},
       {""}, {""}, {""},
-#line 544 "src/lexer-keywords.txt"
+#line 545 "src/lexer-keywords.txt"
       {"i64.reinterpret/f64", TokenType::Convert, Opcode::I64ReinterpretF64},
       {""},
-#line 82 "src/lexer-keywords.txt"
+#line 83 "src/lexer-keywords.txt"
       {"f32x4.extract_lane", TokenType::SimdLaneOp, Opcode::F32X4ExtractLane},
       {""}, {""}, {""}, {""},
-#line 277 "src/lexer-keywords.txt"
+#line 278 "src/lexer-keywords.txt"
       {"i32x4.extract_lane", TokenType::SimdLaneOp, Opcode::I32X4ExtractLane},
-#line 90 "src/lexer-keywords.txt"
+#line 91 "src/lexer-keywords.txt"
       {"f32x4.neg", TokenType::Unary, Opcode::F32X4Neg},
       {""}, {""}, {""}, {""},
-#line 293 "src/lexer-keywords.txt"
+#line 294 "src/lexer-keywords.txt"
       {"i32x4.neg", TokenType::Unary, Opcode::I32X4Neg},
       {""}, {""}, {""},
-#line 441 "src/lexer-keywords.txt"
+#line 442 "src/lexer-keywords.txt"
       {"i8x16.shl", TokenType::Binary, Opcode::I8X16Shl},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 420 "src/lexer-keywords.txt"
+#line 421 "src/lexer-keywords.txt"
       {"i8x16.avgr_u", TokenType::Binary, Opcode::I8X16AvgrU},
       {""},
-#line 541 "src/lexer-keywords.txt"
+#line 542 "src/lexer-keywords.txt"
       {"i32.wrap/i64", TokenType::Convert, Opcode::I32WrapI64},
       {""}, {""}, {""},
-#line 186 "src/lexer-keywords.txt"
+#line 187 "src/lexer-keywords.txt"
       {"i16x8.splat", TokenType::Unary, Opcode::I16X8Splat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 487 "src/lexer-keywords.txt"
+#line 488 "src/lexer-keywords.txt"
       {"table.copy", TokenType::TableCopy, Opcode::TableCopy},
       {""}, {""}, {""}, {""},
-#line 442 "src/lexer-keywords.txt"
+#line 443 "src/lexer-keywords.txt"
       {"i8x16.shr_s", TokenType::Binary, Opcode::I8X16ShrS},
       {""}, {""}, {""},
-#line 443 "src/lexer-keywords.txt"
+#line 444 "src/lexer-keywords.txt"
       {"i8x16.shr_u", TokenType::Binary, Opcode::I8X16ShrU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 92 "src/lexer-keywords.txt"
+#line 93 "src/lexer-keywords.txt"
       {"f32x4.replace_lane", TokenType::SimdLaneOp, Opcode::F32X4ReplaceLane},
       {""}, {""}, {""}, {""},
-#line 295 "src/lexer-keywords.txt"
+#line 296 "src/lexer-keywords.txt"
       {"i32x4.replace_lane", TokenType::SimdLaneOp, Opcode::I32X4ReplaceLane},
       {""}, {""},
-#line 342 "src/lexer-keywords.txt"
+#line 343 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I64AtomicRmwXor},
-#line 220 "src/lexer-keywords.txt"
+#line 221 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I32AtomicRmwXor},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 173 "src/lexer-keywords.txt"
+#line 174 "src/lexer-keywords.txt"
       {"i16x8.max_s", TokenType::Binary, Opcode::I16X8MaxS},
       {""}, {""}, {""},
-#line 174 "src/lexer-keywords.txt"
+#line 175 "src/lexer-keywords.txt"
       {"i16x8.max_u", TokenType::Binary, Opcode::I16X8MaxU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 78 "src/lexer-keywords.txt"
+#line 79 "src/lexer-keywords.txt"
       {"f32x4.convert_i32x4_s", TokenType::Unary, Opcode::F32X4ConvertI32X4S},
       {""},
-#line 79 "src/lexer-keywords.txt"
+#line 80 "src/lexer-keywords.txt"
       {"f32x4.convert_i32x4_u", TokenType::Unary, Opcode::F32X4ConvertI32X4U},
       {""}, {""},
-#line 81 "src/lexer-keywords.txt"
+#line 82 "src/lexer-keywords.txt"
       {"f32x4.eq", TokenType::Compare, Opcode::F32X4Eq},
       {""}, {""}, {""}, {""},
-#line 276 "src/lexer-keywords.txt"
+#line 277 "src/lexer-keywords.txt"
       {"i32x4.eq", TokenType::Compare, Opcode::I32X4Eq},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 183 "src/lexer-keywords.txt"
+#line 184 "src/lexer-keywords.txt"
       {"i16x8.shl", TokenType::Binary, Opcode::I16X8Shl},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 159 "src/lexer-keywords.txt"
+#line 160 "src/lexer-keywords.txt"
       {"i16x8.avgr_u", TokenType::Binary, Opcode::I16X8AvgrU},
       {""}, {""},
-#line 514 "src/lexer-keywords.txt"
+#line 515 "src/lexer-keywords.txt"
       {"v8x16.shuffle", TokenType::SimdShuffleOp, Opcode::V8X16Shuffle},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 419 "src/lexer-keywords.txt"
+#line 420 "src/lexer-keywords.txt"
       {"i8x16.any_true", TokenType::Unary, Opcode::I8X16AnyTrue},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 184 "src/lexer-keywords.txt"
+#line 185 "src/lexer-keywords.txt"
       {"i16x8.shr_s", TokenType::Binary, Opcode::I16X8ShrS},
       {""}, {""}, {""},
-#line 185 "src/lexer-keywords.txt"
+#line 186 "src/lexer-keywords.txt"
       {"i16x8.shr_u", TokenType::Binary, Opcode::I16X8ShrU},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 513 "src/lexer-keywords.txt"
+#line 514 "src/lexer-keywords.txt"
       {"v8x16.load_splat", TokenType::Load, Opcode::V8X16LoadSplat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 422 "src/lexer-keywords.txt"
+#line 423 "src/lexer-keywords.txt"
       {"i8x16.extract_lane_s", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneS},
       {""},
-#line 423 "src/lexer-keywords.txt"
+#line 424 "src/lexer-keywords.txt"
       {"i8x16.extract_lane_u", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneU},
       {""},
-#line 438 "src/lexer-keywords.txt"
+#line 439 "src/lexer-keywords.txt"
       {"i8x16.neg", TokenType::Unary, Opcode::I8X16Neg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 87 "src/lexer-keywords.txt"
+#line 88 "src/lexer-keywords.txt"
       {"f32x4.max", TokenType::Binary, Opcode::F32X4Max},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 440 "src/lexer-keywords.txt"
+#line 441 "src/lexer-keywords.txt"
       {"i8x16.replace_lane", TokenType::SimdLaneOp, Opcode::I8X16ReplaceLane},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 25 "src/lexer-keywords.txt"
+#line 26 "src/lexer-keywords.txt"
       {"atomic.notify", TokenType::AtomicNotify, Opcode::AtomicNotify},
-#line 193 "src/lexer-keywords.txt"
+#line 194 "src/lexer-keywords.txt"
       {"i16x8.widen_low_i8x16_s", TokenType::Unary, Opcode::I16X8WidenLowI8X16S},
       {""},
-#line 194 "src/lexer-keywords.txt"
+#line 195 "src/lexer-keywords.txt"
       {"i16x8.widen_low_i8x16_u", TokenType::Unary, Opcode::I16X8WidenLowI8X16U},
       {""}, {""}, {""}, {""},
-#line 334 "src/lexer-keywords.txt"
+#line 335 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XchgU},
-#line 212 "src/lexer-keywords.txt"
+#line 213 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XchgU},
       {""}, {""}, {""}, {""}, {""},
-#line 35 "src/lexer-keywords.txt"
+#line 36 "src/lexer-keywords.txt"
       {"current_memory", TokenType::MemorySize, Opcode::MemorySize},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 158 "src/lexer-keywords.txt"
+#line 159 "src/lexer-keywords.txt"
       {"i16x8.any_true", TokenType::Unary, Opcode::I16X8AnyTrue},
       {""}, {""},
-#line 105 "src/lexer-keywords.txt"
+#line 106 "src/lexer-keywords.txt"
       {"f64.copysign", TokenType::Binary, Opcode::F64Copysign},
-#line 54 "src/lexer-keywords.txt"
+#line 55 "src/lexer-keywords.txt"
       {"f32.copysign", TokenType::Binary, Opcode::F32Copysign},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 421 "src/lexer-keywords.txt"
+#line 422 "src/lexer-keywords.txt"
       {"i8x16.eq", TokenType::Compare, Opcode::I8X16Eq},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 510 "src/lexer-keywords.txt"
+#line 511 "src/lexer-keywords.txt"
       {"v16x8.load_splat", TokenType::Load, Opcode::V16X8LoadSplat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 161 "src/lexer-keywords.txt"
+#line 162 "src/lexer-keywords.txt"
       {"i16x8.extract_lane_s", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneS},
       {""},
-#line 162 "src/lexer-keywords.txt"
+#line 163 "src/lexer-keywords.txt"
       {"i16x8.extract_lane_u", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneU},
       {""},
-#line 180 "src/lexer-keywords.txt"
+#line 181 "src/lexer-keywords.txt"
       {"i16x8.neg", TokenType::Unary, Opcode::I16X8Neg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 178 "src/lexer-keywords.txt"
+#line 179 "src/lexer-keywords.txt"
       {"i16x8.narrow_i32x4_s", TokenType::Binary, Opcode::I16X8NarrowI32X4S},
       {""},
-#line 179 "src/lexer-keywords.txt"
+#line 180 "src/lexer-keywords.txt"
       {"i16x8.narrow_i32x4_u", TokenType::Binary, Opcode::I16X8NarrowI32X4U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 169 "src/lexer-keywords.txt"
+#line 170 "src/lexer-keywords.txt"
       {"i16x8.load8x8_s", TokenType::Load, Opcode::I16X8Load8X8S},
       {""},
-#line 170 "src/lexer-keywords.txt"
+#line 171 "src/lexer-keywords.txt"
       {"i16x8.load8x8_u", TokenType::Load, Opcode::I16X8Load8X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 182 "src/lexer-keywords.txt"
+#line 183 "src/lexer-keywords.txt"
       {"i16x8.replace_lane", TokenType::SimdLaneOp, Opcode::I16X8ReplaceLane},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 436 "src/lexer-keywords.txt"
+#line 437 "src/lexer-keywords.txt"
       {"i8x16.narrow_i16x8_s", TokenType::Binary, Opcode::I8X16NarrowI16X8S},
       {""},
-#line 437 "src/lexer-keywords.txt"
+#line 438 "src/lexer-keywords.txt"
       {"i8x16.narrow_i16x8_u", TokenType::Binary, Opcode::I8X16NarrowI16X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 304 "src/lexer-keywords.txt"
+#line 305 "src/lexer-keywords.txt"
       {"i32x4.widen_high_i16x8_s", TokenType::Unary, Opcode::I32X4WidenHighI16X8S},
       {""},
-#line 305 "src/lexer-keywords.txt"
+#line 306 "src/lexer-keywords.txt"
       {"i32x4.widen_high_i16x8_u", TokenType::Unary, Opcode::I32X4WidenHighI16X8U},
-#line 338 "src/lexer-keywords.txt"
+#line 339 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmwCmpxchg},
-#line 216 "src/lexer-keywords.txt"
+#line 217 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmwCmpxchg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 160 "src/lexer-keywords.txt"
+#line 161 "src/lexer-keywords.txt"
       {"i16x8.eq", TokenType::Compare, Opcode::I16X8Eq},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 153 "src/lexer-keywords.txt"
+#line 154 "src/lexer-keywords.txt"
       {"grow_memory", TokenType::MemoryGrow, Opcode::MemoryGrow},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1570,7 +1571,7 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 458 "src/lexer-keywords.txt"
+#line 459 "src/lexer-keywords.txt"
       {"memory.copy", TokenType::MemoryCopy, Opcode::MemoryCopy},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1580,16 +1581,16 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 341 "src/lexer-keywords.txt"
+#line 342 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I64AtomicRmwXchg},
-#line 219 "src/lexer-keywords.txt"
+#line 220 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I32AtomicRmwXchg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 191 "src/lexer-keywords.txt"
+#line 192 "src/lexer-keywords.txt"
       {"i16x8.widen_high_i8x16_s", TokenType::Unary, Opcode::I16X8WidenHighI8X16S},
       {""},
-#line 192 "src/lexer-keywords.txt"
+#line 193 "src/lexer-keywords.txt"
       {"i16x8.widen_high_i8x16_u", TokenType::Unary, Opcode::I16X8WidenHighI8X16U}
     };
 

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -68,6 +68,11 @@ Result SharedValidator::OnStructType(const Location&,
   return Result::Ok;
 }
 
+Result SharedValidator::OnArrayType(const Location&, TypeMut field) {
+  array_types_.emplace(num_types_++, ArrayType{field});
+  return Result::Ok;
+}
+
 Result SharedValidator::OnFunction(const Location& loc, Var sig_var) {
   Result result = Result::Ok;
   FuncType type;

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -67,6 +67,7 @@ class SharedValidator {
                     Index result_count,
                     const Type* result_types);
   Result OnStructType(const Location&, Index field_count, TypeMut* fields);
+  Result OnArrayType(const Location&, TypeMut field);
 
   Result OnFunction(const Location&, Var sig_var);
   Result OnTable(const Location&, Type elem_type, const Limits&);
@@ -188,6 +189,13 @@ class SharedValidator {
     TypeMutVector fields;
   };
 
+  struct ArrayType {
+    ArrayType() = default;
+    ArrayType(TypeMut field) : field(field) {}
+
+    TypeMut field;
+  };
+
   struct TableType {
     TableType() = default;
     TableType(Type element, Limits limits) : element(element), limits(limits) {}
@@ -275,6 +283,7 @@ class SharedValidator {
   Index num_types_ = 0;
   std::map<Index, FuncType> func_types_;
   std::map<Index, StructType> struct_types_;
+  std::map<Index, ArrayType> array_types_;
 
   std::vector<FuncType> funcs_;       // Includes imported and defined.
   std::vector<TableType> tables_;     // Includes imported and defined.

--- a/src/token.def
+++ b/src/token.def
@@ -20,6 +20,7 @@
 
 /* Tokens with no additional data (i.e. bare). */
 WABT_TOKEN(Invalid, "Invalid")
+WABT_TOKEN(Array, "array")
 WABT_TOKEN(AssertExhaustion, "assert_exhaustion")
 WABT_TOKEN(AssertInvalid, "assert_invalid")
 WABT_TOKEN(AssertMalformed, "assert_malformed")

--- a/src/type.h
+++ b/src/type.h
@@ -42,6 +42,7 @@ class Type {
     Exnref = -0x18,   // 0x68
     Func = -0x20,     // 0x60
     Struct = -0x21,   // 0x5f
+    Array = -0x22,    // 0x5e
     Void = -0x40,     // 0x40
     ___ = Void,       // Convenient for the opcode table in opcode.h
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -606,6 +606,14 @@ Result Validator::CheckModule() {
                                              type_muts.data());
           break;
         }
+
+        case TypeEntryKind::Array: {
+          ArrayType* array_type = cast<ArrayType>(f->type.get());
+          result_ |= validator_.OnArrayType(
+              field.loc,
+              TypeMut{array_type->field.type, array_type->field.mutable_});
+          break;
+        }
       }
     }
   }

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -153,6 +153,7 @@ class WatWriter : ModuleContext {
   void WriteImport(const Import& import);
   void WriteExport(const Export& export_);
   void WriteTypeEntry(const TypeEntry& type);
+  void WriteField(const Field& field);
   void WriteStartFunction(const Var& start);
 
   class ExprVisitorDelegate;
@@ -1379,20 +1380,32 @@ void WatWriter::WriteTypeEntry(const TypeEntry& type) {
         // TODO: Write shorthand if there is no name.
         WriteOpenSpace("field");
         WriteNameOrIndex(field.name, field_index++, NextChar::Space);
-        if (field.mutable_) {
-          WriteOpenSpace("mut");
-        }
-        WriteType(field.type, NextChar::Space);
-        if (field.mutable_) {
-          WriteCloseSpace();
-        }
+        WriteField(field);
         WriteCloseSpace();
       }
       WriteCloseSpace();
       break;
     }
+
+    case TypeEntryKind::Array: {
+      auto* array_type = cast<ArrayType>(&type);
+      WriteOpenSpace("array");
+      WriteField(array_type->field);
+      WriteCloseSpace();
+      break;
+    }
   }
   WriteCloseNewline();
+}
+
+void WatWriter::WriteField(const Field& field) {
+  if (field.mutable_) {
+    WriteOpenSpace("mut");
+  }
+  WriteType(field.type, NextChar::Space);
+  if (field.mutable_) {
+    WriteCloseSpace();
+  }
 }
 
 void WatWriter::WriteStartFunction(const Var& start) {

--- a/test/dump/array.txt
+++ b/test/dump/array.txt
@@ -1,0 +1,18 @@
+;;; TOOL: run-objdump
+;;; ARGS0: --enable-gc
+;;; ARGS1: -x
+(type (array i32))
+(type (array (mut i64)))
+(;; STDOUT ;;;
+
+array.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type[2]:
+ - type[0] (array i32)
+ - type[1] (array (mut i64))
+
+Code Disassembly:
+
+;;; STDOUT ;;)

--- a/test/parse/module/array-mut-field.txt
+++ b/test/parse/module/array-mut-field.txt
@@ -1,0 +1,3 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-gc
+(type (array (mut f32)))

--- a/test/parse/module/array.txt
+++ b/test/parse/module/array.txt
@@ -1,0 +1,3 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-gc
+(type (array i32))

--- a/test/parse/module/bad-array-no-fields.txt
+++ b/test/parse/module/bad-array-no-fields.txt
@@ -1,0 +1,9 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-gc
+;;; ERROR: 1
+(type (array))
+(;; STDERR ;;;
+out/test/parse/module/bad-array-no-fields.txt:4:13: error: unexpected token ")", expected i32, i64, f32, f64, v128 or anyref.
+(type (array))
+            ^
+;;; STDERR ;;)

--- a/test/parse/module/bad-array-too-many-fields.txt
+++ b/test/parse/module/bad-array-too-many-fields.txt
@@ -1,0 +1,9 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-gc
+;;; ERROR: 1
+(type (array i32 i32))
+(;; STDERR ;;;
+out/test/parse/module/bad-array-too-many-fields.txt:4:18: error: unexpected token i32, expected ).
+(type (array i32 i32))
+                 ^^^
+;;; STDERR ;;)


### PR DESCRIPTION
The following formats are supported:

* (type (array i32))
* (type (array (field i32)))
* (type (array (field (mut i32))))

This PR adds support for reading/writing binary and text, but no
interpreter support yet.