### PR TITLE
Always generate DataCount section, even if number of datas is 0

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1133,8 +1133,7 @@ Result BinaryWriter::WriteModule() {
     EndSection();
   }
 
-  if (options_.features.bulk_memory_enabled() &&
-      module_->data_segments.size()) {
+  if (options_.features.bulk_memory_enabled()) {
     // Keep track of the data count section offset so it can be removed if
     // it isn't needed.
     data_count_start_ = stream_->offset();

--- a/test/dump/elem-mvp-compat.txt
+++ b/test/dump/elem-mvp-compat.txt
@@ -27,6 +27,12 @@
 0000014: 0b                                        ; end
 0000015: 00                                        ; num elems
 000000f: 06                                        ; FIXUP section size
+; section "DataCount" (12)
+0000016: 0c                                        ; section code
+0000017: 00                                        ; section size (guess)
+0000018: 00                                        ; data count
+0000017: 01                                        ; FIXUP section size
+; move data: [19, 19) -> [16, 16)
 ; truncate to 22 (0x16)
 
 elem-mvp-compat.wasm:	file format wasm 0x1

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -60,16 +60,22 @@
 000002d: 01                                        ; num elems
 000002e: 00                                        ; elem function index
 000001f: 0f                                        ; FIXUP section size
-; section "Code" (10)
-000002f: 0a                                        ; section code
+; section "DataCount" (12)
+000002f: 0c                                        ; section code
 0000030: 00                                        ; section size (guess)
-0000031: 01                                        ; num functions
+0000031: 00                                        ; data count
+0000030: 01                                        ; FIXUP section size
+; section "Code" (10)
+0000032: 0a                                        ; section code
+0000033: 00                                        ; section size (guess)
+0000034: 01                                        ; num functions
 ; function body 0
-0000032: 00                                        ; func body size (guess)
-0000033: 00                                        ; local decl count
-0000034: 0b                                        ; end
-0000032: 02                                        ; FIXUP func body size
-0000030: 04                                        ; FIXUP section size
+0000035: 00                                        ; func body size (guess)
+0000036: 00                                        ; local decl count
+0000037: 0b                                        ; end
+0000035: 02                                        ; FIXUP func body size
+0000033: 04                                        ; FIXUP section size
+; move data: [32, 38) -> [2f, 35)
 ; truncate to 53 (0x35)
 
 table-multi.wasm:	file format wasm 0x1

--- a/test/spec/bulk-memory-operations/memory_init.txt
+++ b/test/spec/bulk-memory-operations/memory_init.txt
@@ -7,7 +7,8 @@ test() =>
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:189: assert_invalid passed:
-  0000023: error: data.drop requires data count section
+  0000000: error: data_segment variable out of range: 0 (max 0)
+  0000027: error: OnDataDropExpr callback failed
 out/test/spec/bulk-memory-operations/memory_init.wast:195: assert_invalid passed:
   0000000: error: data_segment variable out of range: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
@@ -15,7 +16,9 @@ test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/bulk-memory-operations/memory_init.wast:223: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/bulk-memory-operations/memory_init.wast:226: assert_invalid passed:
-  000002a: error: memory.init requires data count section
+  error: memory variable out of range: 0 (max 0)
+  0000000: error: data_segment variable out of range: 1 (max 0)
+  000002f: error: OnMemoryInitExpr callback failed
 out/test/spec/bulk-memory-operations/memory_init.wast:232: assert_invalid passed:
   0000000: error: data_segment variable out of range: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed

--- a/test/spec/reference-types/memory_init.txt
+++ b/test/spec/reference-types/memory_init.txt
@@ -7,7 +7,8 @@ test() =>
 test() =>
 test() =>
 out/test/spec/reference-types/memory_init.wast:189: assert_invalid passed:
-  0000023: error: data.drop requires data count section
+  0000000: error: data_segment variable out of range: 0 (max 0)
+  0000027: error: OnDataDropExpr callback failed
 out/test/spec/reference-types/memory_init.wast:195: assert_invalid passed:
   0000000: error: data_segment variable out of range: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
@@ -15,7 +16,9 @@ test() =>
 out/test/spec/reference-types/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/reference-types/memory_init.wast:223: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/reference-types/memory_init.wast:226: assert_invalid passed:
-  000002a: error: memory.init requires data count section
+  error: memory variable out of range: 0 (max 0)
+  0000000: error: data_segment variable out of range: 1 (max 0)
+  000002f: error: OnMemoryInitExpr callback failed
 out/test/spec/reference-types/memory_init.wast:232: assert_invalid passed:
   0000000: error: data_segment variable out of range: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed


### PR DESCRIPTION
The bulk-memory spec requires that a DataCount section is always
present if a memory.init or data.drop instruction is present in
the following code section. This requirement remains even if the
number of datas is 0, so remove that condition.

Fixes #1368