### PR TITLE
Update testsuite (for SIMD)

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -151,7 +151,6 @@ struct v128 {
     memcpy(&v[lane * sizeof(T)], &data, sizeof(data));
   }
 
- private:
   uint8_t v[16];
 };
 

--- a/src/interp/interp-math.h
+++ b/src/interp/interp-math.h
@@ -80,7 +80,7 @@ template <typename T> T WABT_VECTORCALL IntNot(T val) { return ~val; }
 template <typename T> T WABT_VECTORCALL IntNeg(T val) { return ~val + 1; }
 template <typename T> T WABT_VECTORCALL Add(T lhs, T rhs) { return CanonNaN(lhs + rhs); }
 template <typename T> T WABT_VECTORCALL Sub(T lhs, T rhs) { return CanonNaN(lhs - rhs); }
-template <typename T> T WABT_VECTORCALL Mul(T lhs, T rhs) { return CanonNaN(lhs * rhs); }
+template <typename T> T WABT_VECTORCALL Mul(T lhs, T rhs) { return CanonNaN(T(lhs * rhs)); }
 template <typename T> T WABT_VECTORCALL IntAnd(T lhs, T rhs) { return lhs & rhs; }
 template <typename T> T WABT_VECTORCALL IntOr(T lhs, T rhs) { return lhs | rhs; }
 template <typename T> T WABT_VECTORCALL IntXor(T lhs, T rhs) { return lhs ^ rhs; }

--- a/src/interp/interp-math.h
+++ b/src/interp/interp-math.h
@@ -80,6 +80,9 @@ template <typename T> T WABT_VECTORCALL IntNot(T val) { return ~val; }
 template <typename T> T WABT_VECTORCALL IntNeg(T val) { return ~val + 1; }
 template <typename T> T WABT_VECTORCALL Add(T lhs, T rhs) { return CanonNaN(lhs + rhs); }
 template <typename T> T WABT_VECTORCALL Sub(T lhs, T rhs) { return CanonNaN(lhs - rhs); }
+// Must cast lhs * rhs to T, since for example, u16 * u16 => int, which cannot
+// represent the value 65535 * 65535 (which UBSan complains about). We always
+// want to wrap, so casting back to T solves this issue.
 template <typename T> T WABT_VECTORCALL Mul(T lhs, T rhs) { return CanonNaN(T(lhs * rhs)); }
 template <typename T> T WABT_VECTORCALL IntAnd(T lhs, T rhs) { return lhs & rhs; }
 template <typename T> T WABT_VECTORCALL IntOr(T lhs, T rhs) { return lhs | rhs; }

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -43,6 +43,12 @@ std::string TypedValueToString(const TypedValue& tv) {
                           simd.u32(1), simd.u32(2), simd.u32(3));
     }
 
+    case Type::I8:  // For SIMD lane.
+      return StringPrintf("i8:%u", tv.value.Get<u32>() & 0xff);
+
+    case Type::I16:  // For SIMD lane.
+      return StringPrintf("i16:%u", tv.value.Get<u32>() & 0xffff);
+
     case Type::Nullref:
       return StringPrintf("nullref");
 
@@ -62,9 +68,7 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::Struct:
     case Type::Void:
     case Type::Any:
-    case Type::I8:
     case Type::I8U:
-    case Type::I16:
     case Type::I16U:
     case Type::I32U:
       // These types are not concrete types and should never exist as a value

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1580,9 +1580,9 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
     case O::V64X2LoadSplat:   return DoSimdLoadSplat<u64x2, u64>(instr, out_trap);
 
     case O::I8X16NarrowI16X8S:    return DoSimdNarrow<s8x16, s16x8>();
-    case O::I8X16NarrowI16X8U:    return DoSimdNarrow<u8x16, u16x8>();
+    case O::I8X16NarrowI16X8U:    return DoSimdNarrow<u8x16, s16x8>();
     case O::I16X8NarrowI32X4S:    return DoSimdNarrow<s16x8, s32x4>();
-    case O::I16X8NarrowI32X4U:    return DoSimdNarrow<u16x8, u32x4>();
+    case O::I16X8NarrowI32X4U:    return DoSimdNarrow<u16x8, s32x4>();
     case O::I16X8WidenLowI8X16S:  return DoSimdWiden<s16x8, s8x16, true>();
     case O::I16X8WidenHighI8X16S: return DoSimdWiden<s16x8, s8x16, false>();
     case O::I16X8WidenLowI8X16U:  return DoSimdWiden<u16x8, u8x16, true>();
@@ -1597,7 +1597,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
     case O::I32X4Load16X4S: return DoSimdLoadExtend<s32x4, s16x4>(instr, out_trap);
     case O::I32X4Load16X4U: return DoSimdLoadExtend<u32x4, u16x4>(instr, out_trap);
     case O::I64X2Load32X2S: return DoSimdLoadExtend<s64x2, s32x2>(instr, out_trap);
-    case O::I64X2Load32X2U: return DoSimdLoadExtend<s64x2, s32x2>(instr, out_trap);
+    case O::I64X2Load32X2U: return DoSimdLoadExtend<u64x2, u32x2>(instr, out_trap);
 
     case O::V128Andnot: return DoSimdBinop(IntAndNot<u64>);
     case O::I8X16AvgrU: return DoSimdBinop(IntAvgr<u8>);

--- a/src/ir.h
+++ b/src/ir.h
@@ -172,7 +172,7 @@ struct Const {
     assert((lane + 1) * sizeof(T) <= sizeof(data_));
     type_ = type;
     data_.From<T>(lane, data);
-    nan_[lane] = ExpectedNan::None;
+    set_expected_nan(lane, ExpectedNan::None);
   }
 
   Type type_;

--- a/src/ir.h
+++ b/src/ir.h
@@ -93,6 +93,19 @@ struct Const {
   }
 
   Type type() const { return type_; }
+  Type lane_type() const { assert(type_ == Type::V128); return lane_type_; }
+
+  int lane_count() const {
+    switch (lane_type()) {
+      case Type::I8:  return 16;
+      case Type::I16: return 8;
+      case Type::I32: return 4;
+      case Type::I64: return 2;
+      case Type::F32: return 4;
+      case Type::F64: return 2;
+      default: WABT_UNREACHABLE;
+    }
+  }
 
   uint32_t u32() const { return data_.u32(0); }
   uint64_t u64() const { return data_.u64(0); }
@@ -101,40 +114,71 @@ struct Const {
   uintptr_t ref_bits() const { return data_.To<uintptr_t>(0); }
   v128 vec128() const { return data_; }
 
-  bool is_expected_nan() const { return nan_ != ExpectedNan::None; }
-  ExpectedNan expected() const { assert(is_expected_nan()); return nan_; }
+  template <typename T>
+  T v128_lane(int lane) const { return data_.To<T>(lane); }
 
   void set_u32(uint32_t x) { From(Type::I32, x); }
   void set_u64(uint64_t x) { From(Type::I64, x); }
   void set_f32(uint32_t x) { From(Type::F32, x); }
   void set_f64(uint64_t x) { From(Type::F64, x); }
-  void set_vec128(v128 x)  { From(Type::V128, x); }
+
+  void set_v128_u8(int lane, uint8_t x) { set_v128_lane(lane, Type::I8, x); }
+  void set_v128_u16(int lane, uint16_t x) { set_v128_lane(lane, Type::I16, x); }
+  void set_v128_u32(int lane, uint32_t x) { set_v128_lane(lane, Type::I32, x); }
+  void set_v128_u64(int lane, uint64_t x) { set_v128_lane(lane, Type::I64, x); }
+  void set_v128_f32(int lane, uint32_t x) { set_v128_lane(lane, Type::F32, x); }
+  void set_v128_f64(int lane, uint64_t x) { set_v128_lane(lane, Type::F64, x); }
 
   // Only used for expectations. (e.g. wast assertions)
-  void set_f32(ExpectedNan nan) { From<float>(Type::F32, 0); nan_ = nan; }
-  void set_f64(ExpectedNan nan) { From<double>(Type::F64, 0); nan_ = nan; }
+  void set_f32(ExpectedNan nan) { set_f32(0); set_expected_nan(0, nan); }
+  void set_f64(ExpectedNan nan) { set_f64(0); set_expected_nan(0, nan); }
   void set_hostref(uintptr_t x) { From(Type::Hostref, x); }
   void set_nullref()            { From<uintptr_t>(Type::Nullref, 0); }
   void set_funcref()            { From<uintptr_t>(Type::Funcref, 0); }
 
+  bool is_expected_nan(int lane = 0) const {
+    return expected_nan(lane) != ExpectedNan::None;
+  }
+
+  ExpectedNan expected_nan(int lane = 0) const {
+    return lane < 4 ? nan_[lane] : ExpectedNan::None;
+  }
+
+  void set_expected_nan(int lane, ExpectedNan nan) {
+    if (lane < 4) {
+      nan_[lane] = nan;
+    }
+  }
+
+  // v128 support
   Location loc;
 
  private:
+  template <typename T>
+  void set_v128_lane(int lane, Type lane_type, T x) {
+    lane_type_ = lane_type;
+    From(Type::V128, x, lane);
+    set_expected_nan(lane, ExpectedNan::None);
+  }
+
   template <typename T>
   Const(Type type, T data, const Location& loc = Location()) : loc(loc) {
     From<T>(type, data);
   }
 
   template <typename T>
-  void From(Type type, T data) {
+  void From(Type type, T data, int lane = 0) {
+    static_assert(sizeof(T) <= sizeof(data_), "Invalid cast!");
+    assert((lane + 1) * sizeof(T) <= sizeof(data_));
     type_ = type;
-    data_.From<T>(0, data);
-    nan_ = ExpectedNan::None;
+    data_.From<T>(lane, data);
+    nan_[lane] = ExpectedNan::None;
   }
 
   Type type_;
+  Type lane_type_;    // Only valid if type_ == Type::V128.
   v128 data_;
-  ExpectedNan nan_ = ExpectedNan::None;
+  ExpectedNan nan_[4];
 };
 typedef std::vector<Const> ConstVector;
 

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -160,10 +160,114 @@ class RegisterCommand : public CommandMixin<CommandType::Register> {
 };
 
 struct ExpectedValue {
-  bool is_expected_nan;
   TypedValue value;
-  ExpectedNan expectedNan;
+  Type lane_type;      // Only valid if value.type == Type::V128.
+  ExpectedNan nan[4];  // One for each v128 lane (up to 4 for f32x4).
 };
+
+int LaneCountFromType(Type type) {
+  switch (type) {
+    case Type::I8: return 16;
+    case Type::I16: return 8;
+    case Type::I32: return 4;
+    case Type::I64: return 2;
+    case Type::F32: return 4;
+    case Type::F64: return 2;
+    default: assert(false); return 0;
+  }
+}
+
+ExpectedValue GetLane(const ExpectedValue& ev, int lane) {
+  int lane_count = LaneCountFromType(ev.lane_type);
+  assert(ev.value.type == Type::V128);
+  assert(lane < lane_count);
+
+  ExpectedValue result;
+  result.value.type = ev.lane_type;
+
+  v128 vec = ev.value.value.Get<v128>();
+
+  for (int lane = 0; lane < lane_count; ++lane) {
+    switch (ev.lane_type) {
+      case Type::I8:
+        result.nan[0] = ExpectedNan::None;
+        result.value.value.Set<u32>(vec.u8(lane));
+        break;
+
+      case Type::I16:
+        result.nan[0] = ExpectedNan::None;
+        result.value.value.Set<u32>(vec.u16(lane));
+        break;
+
+      case Type::I32:
+        result.nan[0] = ExpectedNan::None;
+        result.value.value.Set<u32>(vec.u32(lane));
+        break;
+
+      case Type::I64:
+        result.nan[0] = ExpectedNan::None;
+        result.value.value.Set<u64>(vec.u64(lane));
+        break;
+
+      case Type::F32:
+        result.nan[0] = ev.nan[lane];
+        result.value.value.Set<f32>(Bitcast<f32>(vec.f32_bits(lane)));
+        break;
+
+      case Type::F64:
+        result.nan[0] = ev.nan[lane];
+        result.value.value.Set<f64>(Bitcast<f64>(vec.f64_bits(lane)));
+        break;
+
+      default:
+        WABT_UNREACHABLE;
+    }
+  }
+  return result;
+}
+
+TypedValue GetLane(const TypedValue& tv, Type lane_type, int lane) {
+  int lane_count = LaneCountFromType(lane_type);
+  assert(tv.type == Type::V128);
+  assert(lane < lane_count);
+
+  TypedValue result;
+  result.type = lane_type;
+
+  v128 vec = tv.value.Get<v128>();
+
+  for (int lane = 0; lane < lane_count; ++lane) {
+    switch (lane_type) {
+      case Type::I8:
+        result.value.Set<u32>(vec.u8(lane));
+        break;
+
+      case Type::I16:
+        result.value.Set<u32>(vec.u16(lane));
+        break;
+
+      case Type::I32:
+        result.value.Set<u32>(vec.u32(lane));
+        break;
+
+      case Type::I64:
+        result.value.Set<u64>(vec.u64(lane));
+        break;
+
+      case Type::F32:
+        result.value.Set<f32>(Bitcast<f32>(vec.f32_bits(lane)));
+        break;
+
+      case Type::F64:
+        result.value.Set<f64>(Bitcast<f64>(vec.f64_bits(lane)));
+        break;
+
+      default:
+        WABT_UNREACHABLE;
+    }
+  }
+  return result;
+}
 
 class AssertReturnCommand : public CommandMixin<CommandType::AssertReturn> {
  public:
@@ -221,12 +325,26 @@ class JSONParser {
   wabt::Result ParseKeyStringValue(const char* key, std::string* out_string);
   wabt::Result ParseOptNameStringValue(std::string* out_string);
   wabt::Result ParseLine(uint32_t* out_line_number);
+  wabt::Result ParseType(Type* out_type);
   wabt::Result ParseTypeObject(Type* out_type);
   wabt::Result ParseTypeVector(TypeVector* out_types);
   wabt::Result ParseConst(TypedValue* out_value);
-  wabt::Result ParseConstValue(TypedValue* out_value,
-                         string_view type_str,
-                         string_view value_str);
+  wabt::Result ParseI32Value(uint32_t* out_value, string_view value_str);
+  wabt::Result ParseI64Value(uint64_t* out_value, string_view value_str);
+  wabt::Result ParseF32Value(uint32_t* out_value,
+                             ExpectedNan* out_nan,
+                             string_view value_str);
+  wabt::Result ParseF64Value(uint64_t* out_value,
+                             ExpectedNan* out_nan,
+                             string_view value_str);
+  wabt::Result ParseLaneConstValue(Type lane_type,
+                                   int lane,
+                                   ExpectedValue* out_value,
+                                   string_view value_str);
+  wabt::Result ParseConstValue(Type type,
+                               Value* out_value,
+                               ExpectedNan* out_nan,
+                               string_view value_str);
   wabt::Result ParseConstVector(ValueTypes* out_types, Values* out_values);
   wabt::Result ParseExpectedValue(ExpectedValue* out_value);
   wabt::Result ParseExpectedValues(std::vector<ExpectedValue>* out_values);
@@ -435,43 +553,47 @@ wabt::Result JSONParser::ParseLine(uint32_t* out_line_number) {
   return wabt::Result::Ok;
 }
 
-wabt::Result JSONParser::ParseTypeObject(Type* out_type) {
+wabt::Result JSONParser::ParseType(Type* out_type) {
   std::string type_str;
-  EXPECT("{");
-  PARSE_KEY_STRING_VALUE("type", &type_str);
-  EXPECT("}");
+  CHECK_RESULT(ParseString(&type_str));
 
   if (type_str == "i32") {
     *out_type = Type::I32;
-    return wabt::Result::Ok;
   } else if (type_str == "f32") {
     *out_type = Type::F32;
-    return wabt::Result::Ok;
   } else if (type_str == "i64") {
     *out_type = Type::I64;
-    return wabt::Result::Ok;
   } else if (type_str == "f64") {
     *out_type = Type::F64;
-    return wabt::Result::Ok;
   } else if (type_str == "v128") {
     *out_type = Type::V128;
-    return wabt::Result::Ok;
+  } else if (type_str == "i8") {
+    *out_type = Type::I8;
+  } else if (type_str == "i16") {
+    *out_type = Type::I16;
   } else if (type_str == "funcref") {
     *out_type = Type::Funcref;
-    return wabt::Result::Ok;
   } else if (type_str == "anyref") {
     *out_type = Type::Anyref;
-    return wabt::Result::Ok;
   } else if (type_str == "nullref") {
     *out_type = Type::Nullref;
-    return wabt::Result::Ok;
   } else if (type_str == "exnref") {
     *out_type = Type::Exnref;
-    return wabt::Result::Ok;
+  } else if (type_str == "hostref") {
+    *out_type = Type::Hostref;
   } else {
     PrintError("unknown type: \"%s\"", type_str.c_str());
     return wabt::Result::Error;
   }
+  return wabt::Result::Ok;
+}
+
+wabt::Result JSONParser::ParseTypeObject(Type* out_type) {
+  EXPECT("{");
+  EXPECT_KEY("type");
+  CHECK_RESULT(ParseType(out_type));
+  EXPECT("}");
+  return wabt::Result::Ok;
 }
 
 wabt::Result JSONParser::ParseTypeVector(TypeVector* out_types) {
@@ -491,121 +613,236 @@ wabt::Result JSONParser::ParseTypeVector(TypeVector* out_types) {
 }
 
 wabt::Result JSONParser::ParseConst(TypedValue* out_value) {
-  std::string type_str;
-  std::string value_str;
-  EXPECT("{");
-  PARSE_KEY_STRING_VALUE("type", &type_str);
-  EXPECT(",");
-  PARSE_KEY_STRING_VALUE("value", &value_str);
-  EXPECT("}");
-
-  return ParseConstValue(out_value, type_str, value_str);
+  ExpectedValue expected;
+  CHECK_RESULT(ParseExpectedValue(&expected));
+  *out_value = expected.value;
+  return wabt::Result::Ok;
 }
 
-wabt::Result JSONParser::ParseConstValue(TypedValue* out_value,
-                                   string_view type_str,
-                                   string_view value_str) {
-  const char* value_start = value_str.data();
-  const char* value_end = value_str.data() + value_str.size();
-  if (type_str == "i32") {
-    uint32_t value;
-    if (Failed((ParseInt32(value_start, value_end, &value,
-                           ParseIntType::UnsignedOnly)))) {
-      PrintError("invalid i32 literal");
-      return wabt::Result::Error;
-    }
-    out_value->type = ValueType::I32;
-    out_value->value.Set(value);
-  } else if (type_str == "f32") {
-    uint32_t value_bits;
-    if (Failed(ParseInt32(value_start, value_end, &value_bits,
-                            ParseIntType::UnsignedOnly))) {
+wabt::Result JSONParser::ParseI32Value(uint32_t* out_value,
+                                       string_view value_str) {
+  if (Failed(ParseInt32(value_str.begin(), value_str.end(), out_value,
+                        ParseIntType::UnsignedOnly))) {
+    PrintError("invalid i32 literal");
+    return wabt::Result::Error;
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result JSONParser::ParseI64Value(uint64_t* out_value,
+                                       string_view value_str) {
+  if (Failed(ParseInt64(value_str.begin(), value_str.end(), out_value,
+                        ParseIntType::UnsignedOnly))) {
+    PrintError("invalid i64 literal");
+    return wabt::Result::Error;
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result JSONParser::ParseF32Value(uint32_t* out_value,
+                                       ExpectedNan* out_nan,
+                                       string_view value_str) {
+  *out_value = 0;
+  if (value_str == "nan:canonical") {
+    *out_nan = ExpectedNan::Canonical;
+  } else if (value_str == "nan:arithmetic") {
+    *out_nan = ExpectedNan::Arithmetic;
+  } else {
+    *out_nan = ExpectedNan::None;
+    if (Failed(ParseInt32(value_str.begin(), value_str.end(), out_value,
+                          ParseIntType::UnsignedOnly))) {
       PrintError("invalid f32 literal");
       return wabt::Result::Error;
     }
-    out_value->type = ValueType::F32;
-    out_value->value.Set(Bitcast<f32>(value_bits));
-  } else if (type_str == "i64") {
-    uint64_t value;
-    if (Failed(ParseInt64(value_start, value_end, &value,
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result JSONParser::ParseF64Value(uint64_t* out_value,
+                                       ExpectedNan* out_nan,
+                                       string_view value_str) {
+  if (value_str == "nan:canonical") {
+    *out_value = 0;
+    *out_nan = ExpectedNan::Canonical;
+  } else if (value_str == "nan:arithmetic") {
+    *out_value = 0;
+    *out_nan = ExpectedNan::Arithmetic;
+  } else {
+    *out_nan = ExpectedNan::None;
+    if (Failed(ParseInt64(value_str.begin(), value_str.end(), out_value,
                           ParseIntType::UnsignedOnly))) {
-      PrintError("invalid i64 literal");
-      return wabt::Result::Error;
-    }
-    out_value->type = ValueType::I64;
-    out_value->value.Set(value);
-  } else if (type_str == "f64") {
-    uint64_t value_bits;
-    if (Failed((ParseInt64(value_start, value_end, &value_bits,
-                           ParseIntType::UnsignedOnly)))) {
       PrintError("invalid f64 literal");
       return wabt::Result::Error;
     }
-    out_value->type = ValueType::F64;
-    out_value->value.Set(Bitcast<f64>(value_bits));
-  } else if (type_str == "v128") {
-    v128 value_bits;
-    if (Failed(ParseUint128(value_start, value_end, &value_bits))) {
-      PrintError("invalid v128 literal");
-      return wabt::Result::Error;
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result JSONParser::ParseLaneConstValue(Type lane_type,
+                                             int lane,
+                                             ExpectedValue* out_value,
+                                             string_view value_str) {
+  v128& v = out_value->value.value.v128_;
+
+  switch (lane_type) {
+    case Type::I8: {
+      uint32_t value;
+      CHECK_RESULT(ParseI32Value(&value, value_str));
+      v.set_u8(lane, value);
+      break;
     }
-    out_value->type = ValueType::V128;
-    out_value->value.Set(value_bits);
-  } else if (type_str == "nullref") {
-    out_value->type = ValueType::Nullref;
-    out_value->value.Set(Ref::Null);
-  } else if (type_str == "hostref") {
-    uint32_t value;
-    if (Failed(ParseInt32(value_start, value_end, &value,
-                          ParseIntType::UnsignedOnly))) {
-      PrintError("invalid hostref literal");
-      return wabt::Result::Error;
+
+    case Type::I16: {
+      uint32_t value;
+      CHECK_RESULT(ParseI32Value(&value, value_str));
+      v.set_u16(lane, value);
+      break;
     }
-    out_value->type = ValueType::Hostref;
-    // TODO: hack, just whatever ref is at this index; but skip null (which is
-    // always 0).
-    out_value->value.Set(Ref{value + 1});
-  } else if (type_str == "funcref") {
-    uint32_t value;
-    if (Failed(ParseInt32(value_start, value_end, &value,
-                          ParseIntType::UnsignedOnly))) {
-      PrintError("invalid funcref literal");
-      return wabt::Result::Error;
+
+    case Type::I32: {
+      uint32_t value;
+      CHECK_RESULT(ParseI32Value(&value, value_str));
+      v.set_u32(lane, value);
+      break;
     }
-    out_value->type = ValueType::Funcref;
-    out_value->value.Set(Ref{value});
-  } else {
-    PrintError("unknown concrete type: \"%s\"", type_str.to_string().c_str());
-    return wabt::Result::Error;
+
+    case Type::I64: {
+      uint64_t value;
+      CHECK_RESULT(ParseI64Value(&value, value_str));
+      v.set_u64(lane, value);
+      break;
+    }
+
+    case Type::F32: {
+      ExpectedNan nan;
+      uint32_t value_bits;
+      CHECK_RESULT(ParseF32Value(&value_bits, &nan, value_str));
+      v.set_f32_bits(lane, value_bits);
+      assert(lane < 4);
+      out_value->nan[lane] = nan;
+      break;
+    }
+
+    case Type::F64: {
+      ExpectedNan nan;
+      uint64_t value_bits;
+      CHECK_RESULT(ParseF64Value(&value_bits, &nan, value_str));
+      v.set_f64_bits(lane, value_bits);
+      assert(lane < 2);
+      out_value->nan[lane] = nan;
+      break;
+    }
+
+    default:
+      PrintError("unknown concrete type: \"%s\"", lane_type.GetName());
+      return wabt::Result::Error;
+  }
+  return wabt::Result::Ok;
+}
+
+wabt::Result JSONParser::ParseConstValue(Type type,
+                                         Value* out_value,
+                                         ExpectedNan* out_nan,
+                                         string_view value_str) {
+  *out_nan = ExpectedNan::None;
+
+  switch (type) {
+    case Type::I32: {
+      uint32_t value;
+      CHECK_RESULT(ParseI32Value(&value, value_str));
+      out_value->Set(value);
+      break;
+    }
+
+    case Type::F32: {
+      uint32_t value_bits;
+      CHECK_RESULT(ParseF32Value(&value_bits, out_nan, value_str));
+      out_value->Set(Bitcast<f32>(value_bits));
+      break;
+    }
+
+    case Type::I64: {
+      uint64_t value;
+      CHECK_RESULT(ParseI64Value(&value, value_str));
+      out_value->Set(value);
+      break;
+    }
+
+    case Type::F64: {
+      uint64_t value_bits;
+      CHECK_RESULT(ParseF64Value(&value_bits, out_nan, value_str));
+      out_value->Set(Bitcast<f64>(value_bits));
+      break;
+    }
+
+    case Type::V128:
+      assert(false);  // Should use ParseLaneConstValue instead.
+      break;
+
+    case Type::Nullref: {
+      out_value->Set(Ref::Null);
+      break;
+    }
+
+    case Type::Hostref: {
+      uint32_t value;
+      CHECK_RESULT(ParseI32Value(&value, value_str));
+      // TODO: hack, just whatever ref is at this index; but skip null (which is
+      // always 0).
+      out_value->Set(Ref{value + 1});
+      break;
+    }
+
+    case Type::Funcref: {
+      uint32_t value;
+      CHECK_RESULT(ParseI32Value(&value, value_str));
+      out_value->Set(Ref{value});
+      break;
+    }
+
+    default:
+      PrintError("unknown concrete type: \"%s\"", type.GetName());
+      return wabt::Result::Error;
   }
 
   return wabt::Result::Ok;
 }
 
 wabt::Result JSONParser::ParseExpectedValue(ExpectedValue* out_value) {
-  std::string type_str;
+  Type type;
   std::string value_str;
   EXPECT("{");
-  PARSE_KEY_STRING_VALUE("type", &type_str);
+  EXPECT_KEY("type");
+  CHECK_RESULT(ParseType(&type));
   EXPECT(",");
-  PARSE_KEY_STRING_VALUE("value", &value_str);
+  if (type == Type::V128) {
+    Type lane_type;
+    EXPECT_KEY("lane_type");
+    CHECK_RESULT(ParseType(&lane_type));
+    EXPECT(",");
+    EXPECT_KEY("value");
+    EXPECT("[");
+
+    int lane_count = LaneCountFromType(lane_type);
+    for (int lane = 0; lane < lane_count; ++lane) {
+      CHECK_RESULT(ParseString(&value_str));
+      CHECK_RESULT(ParseLaneConstValue(lane_type, lane, out_value, value_str));
+      if (lane < lane_count - 1) {
+        EXPECT(",");
+      }
+    }
+    EXPECT("]");
+    out_value->value.type = type;
+    out_value->lane_type = lane_type;
+  } else {
+    PARSE_KEY_STRING_VALUE("value", &value_str);
+    CHECK_RESULT(ParseConstValue(type, &out_value->value.value,
+                                 &out_value->nan[0], value_str));
+    out_value->value.type = type;
+  }
   EXPECT("}");
 
-  if (type_str == "f32" || type_str == "f64") {
-    out_value->value.type = type_str == "f32" ? ValueType::F32 : ValueType::F64;
-    if (value_str == "nan:canonical") {
-      out_value->is_expected_nan = true;
-      out_value->expectedNan = ExpectedNan::Canonical;
-      return wabt::Result::Ok;
-    } else if (value_str == "nan:arithmetic") {
-      out_value->is_expected_nan = true;
-      out_value->expectedNan = ExpectedNan::Arithmetic;
-      return wabt::Result::Ok;
-    }
-  }
-
-  out_value->is_expected_nan = false;
-  return ParseConstValue(&out_value->value, type_str, value_str);
+  return wabt::Result::Ok;
 }
 
 wabt::Result JSONParser::ParseExpectedValues(
@@ -906,6 +1143,12 @@ class CommandRunner {
   wabt::Result OnAssertReturnCommand(const AssertReturnCommand*);
   wabt::Result OnAssertTrapCommand(const AssertTrapCommand*);
   wabt::Result OnAssertExhaustionCommand(const AssertExhaustionCommand*);
+
+  wabt::Result CheckAssertReturnResult(const AssertReturnCommand* command,
+                                       int index,
+                                       ExpectedValue expected,
+                                       TypedValue actual,
+                                       bool print_error);
 
   void TallyCommand(wabt::Result);
 
@@ -1323,39 +1566,6 @@ wabt::Result CommandRunner::OnAssertUninstantiableCommand(
   return wabt::Result::Ok;
 }
 
-static bool TypedValuesAreEqual(const TypedValue& expected,
-                                const TypedValue& actual) {
-  assert(expected.type == actual.type || IsReference(expected.type));
-  switch (expected.type) {
-    case Type::I32:
-      return expected.value.Get<u32>() == actual.value.Get<u32>();
-
-    case Type::F32:
-      return Bitcast<u32>(expected.value.Get<f32>()) ==
-             Bitcast<u32>(actual.value.Get<f32>());
-
-    case Type::I64:
-      return expected.value.Get<u64>() == actual.value.Get<u64>();
-
-    case Type::F64:
-      return Bitcast<u64>(expected.value.Get<f64>()) ==
-             Bitcast<u64>(actual.value.Get<f64>());
-
-    case Type::V128:
-      return expected.value.Get<v128>() == actual.value.Get<v128>();
-
-    case Type::Nullref:
-      return actual.value.Get<Ref>() == Ref::Null;
-
-    case Type::Funcref:
-    case Type::Hostref:
-      return expected.value.Get<Ref>() == actual.value.Get<Ref>();
-
-    default:
-      WABT_UNREACHABLE;
-  }
-}
-
 static bool WABT_VECTORCALL IsCanonicalNan(f32 val) {
   const u32 kQuietNan = 0x7fc00000U;
   const u32 kQuietNegNan = 0xffc00000U;
@@ -1378,6 +1588,137 @@ static bool WABT_VECTORCALL IsArithmeticNan(f32 val) {
 static bool WABT_VECTORCALL IsArithmeticNan(f64 val) {
   const u64 kQuietNan = 0x7ff8000000000000ULL;
   return (Bitcast<u64>(val) & kQuietNan) == kQuietNan;
+}
+
+static std::string ExpectedValueToString(const ExpectedValue& ev) {
+  // Extend TypedValueToString to print expected nan values too.
+  switch (ev.value.type) {
+    case Type::F32:
+    case Type::F64:
+      switch (ev.nan[0]) {
+        case ExpectedNan::None:
+          return TypedValueToString(ev.value);
+
+        case ExpectedNan::Arithmetic:
+          return StringPrintf("%s:nan:arithmetic", ev.value.type.GetName());
+
+        case ExpectedNan::Canonical:
+          return StringPrintf("%s:nan:canonical", ev.value.type.GetName());
+      }
+      break;
+
+    case Type::V128: {
+      int lane_count = LaneCountFromType(ev.lane_type);
+      std::string result = "v128 ";
+      for (int lane = 0; lane < lane_count; ++lane) {
+        result += ExpectedValueToString(GetLane(ev, lane));
+      }
+      return result;
+    }
+
+    default:
+      return TypedValueToString(ev.value);
+  }
+}
+
+wabt::Result CommandRunner::CheckAssertReturnResult(
+    const AssertReturnCommand* command,
+    int index,
+    ExpectedValue expected,
+    TypedValue actual,
+    bool print_error) {
+  assert(expected.value.type == actual.type ||
+         IsReference(expected.value.type));
+  bool ok = true;
+  switch (expected.value.type) {
+    case Type::I8:
+    case Type::I16:
+    case Type::I32:
+      ok = expected.value.value.Get<u32>() == actual.value.Get<u32>();
+      break;
+
+    case Type::I64:
+      ok = expected.value.value.Get<u64>() == actual.value.Get<u64>();
+      break;
+
+    case Type::F32:
+      switch (expected.nan[0]) {
+        case ExpectedNan::Arithmetic:
+          ok = IsArithmeticNan(actual.value.Get<f32>());
+          break;
+
+        case ExpectedNan::Canonical:
+          ok = IsCanonicalNan(actual.value.Get<f32>());
+          break;
+
+        case ExpectedNan::None:
+          ok = Bitcast<u32>(expected.value.value.Get<f32>()) ==
+               Bitcast<u32>(actual.value.Get<f32>());
+          break;
+      }
+      break;
+
+    case Type::F64:
+      switch (expected.nan[0]) {
+        case ExpectedNan::Arithmetic:
+          ok = IsArithmeticNan(actual.value.Get<f64>());
+          break;
+
+        case ExpectedNan::Canonical:
+          ok = IsCanonicalNan(actual.value.Get<f64>());
+          break;
+
+        case ExpectedNan::None:
+          ok = Bitcast<u64>(expected.value.value.Get<f64>()) ==
+               Bitcast<u64>(actual.value.Get<f64>());
+          break;
+      }
+      break;
+
+    case Type::V128: {
+      // Compare each lane as if it were its own value.
+      for (int lane = 0; lane < LaneCountFromType(expected.lane_type); ++lane) {
+        ExpectedValue lane_expected = GetLane(expected, lane);
+        TypedValue lane_actual = GetLane(actual, expected.lane_type, lane);
+
+        if (Failed(CheckAssertReturnResult(command, index, lane_expected,
+                                           lane_actual, false))) {
+          PrintError(command->line,
+                     "mismatch in lane %u of result %u of assert_return: "
+                     "expected %s, got %s",
+                     lane, index, ExpectedValueToString(lane_expected).c_str(),
+                     TypedValueToString(lane_actual).c_str());
+          ok = false;
+        }
+      }
+      break;
+    }
+
+    case Type::Nullref:
+      ok = actual.value.Get<Ref>() == Ref::Null;
+      break;
+
+    case Type::Funcref:
+      // A funcref expectation only requires that the reference be a function,
+      // but it doesn't check the actual index.
+      ok = store_.HasValueType(actual.value.Get<Ref>(), Type::Funcref);
+      break;
+
+    case Type::Hostref:
+      ok = expected.value.value.Get<Ref>() == actual.value.Get<Ref>();
+      break;
+
+    default:
+      WABT_UNREACHABLE;
+  }
+
+  if (!ok && print_error) {
+    PrintError(command->line,
+               "mismatch in result %u of assert_return: expected %s, got %s",
+               index, ExpectedValueToString(expected).c_str(),
+               TypedValueToString(actual).c_str());
+  }
+  return ok ? wabt::Result::Ok : wabt::Result::Error;
 }
 
 wabt::Result CommandRunner::OnAssertReturnCommand(
@@ -1404,45 +1745,7 @@ wabt::Result CommandRunner::OnAssertReturnCommand(
     const ExpectedValue& expected = command->expected[i];
     TypedValue actual{action_result.types[i], action_result.values[i]};
 
-    if (expected.is_expected_nan) {
-      bool is_nan;
-      if (expected.expectedNan == ExpectedNan::Arithmetic) {
-        if (expected.value.type == Type::F64) {
-          is_nan = IsArithmeticNan(actual.value.Get<f64>());
-        } else {
-          is_nan = IsArithmeticNan(actual.value.Get<f32>());
-        }
-      } else if (expected.expectedNan == ExpectedNan::Canonical) {
-        if (expected.value.type == Type::F64) {
-          is_nan = IsCanonicalNan(actual.value.Get<f64>());
-        } else {
-          is_nan = IsCanonicalNan(actual.value.Get<f32>());
-        }
-      } else {
-        WABT_UNREACHABLE;
-      }
-      if (!is_nan) {
-        PrintError(command->line, "expected result to be nan, got %s",
-                   TypedValueToString(actual).c_str());
-        result = wabt::Result::Error;
-      }
-    } else if (expected.value.type == Type::Funcref) {
-      if (!store_.HasValueType(actual.value.Get<Ref>(), Type::Funcref)) {
-        PrintError(command->line,
-                   "mismatch in result %" PRIzd
-                   " of assert_return: expected funcref, got %s",
-                   i, TypedValueToString(actual).c_str());
-      }
-    } else {
-      if (!TypedValuesAreEqual(expected.value, actual)) {
-        PrintError(command->line,
-                   "mismatch in result %" PRIzd
-                   " of assert_return: expected %s, got %s",
-                   i, TypedValueToString(expected.value).c_str(),
-                   TypedValueToString(actual).c_str());
-        result = wabt::Result::Error;
-      }
-    }
+    result |= CheckAssertReturnResult(command, i, expected, actual, true);
   }
 
   return result;

--- a/src/type.h
+++ b/src/type.h
@@ -36,8 +36,8 @@ class Type {
     F32 = -0x03,      // 0x7d
     F64 = -0x04,      // 0x7c
     V128 = -0x05,     // 0x7b
-    I8 = -0x06,       // 0x7a  // packed-type only, used in gc and as v128 lane
-    I16 = -0x07,      // 0x79  // packed-type only, used in gc and as v128 lane
+    I8 = -0x06,       // 0x7a  : packed-type only, used in gc and as v128 lane
+    I16 = -0x07,      // 0x79  : packed-type only, used in gc and as v128 lane
     Funcref = -0x10,  // 0x70
     Anyref = -0x11,   // 0x6f
     Nullref = -0x12,  // 0x6e

--- a/src/type.h
+++ b/src/type.h
@@ -36,6 +36,8 @@ class Type {
     F32 = -0x03,      // 0x7d
     F64 = -0x04,      // 0x7c
     V128 = -0x05,     // 0x7b
+    I8 = -0x06,       // 0x7a  // packed-type only, used in gc and as v128 lane
+    I16 = -0x07,      // 0x79  // packed-type only, used in gc and as v128 lane
     Funcref = -0x10,  // 0x70
     Anyref = -0x11,   // 0x6f
     Nullref = -0x12,  // 0x6e
@@ -47,9 +49,7 @@ class Type {
 
     Any = 0,          // Not actually specified, but useful for type-checking
     Hostref = 2,      // Not actually specified, but used in testing and type-checking
-    I8 = 3,    // Not actually specified, but used internally with load/store
     I8U = 4,   // Not actually specified, but used internally with load/store
-    I16 = 5,   // Not actually specified, but used internally with load/store
     I16U = 6,  // Not actually specified, but used internally with load/store
     I32U = 7,  // Not actually specified, but used internally with load/store
   };
@@ -77,6 +77,8 @@ class Type {
       case Type::F32:     return "f32";
       case Type::F64:     return "f64";
       case Type::V128:    return "v128";
+      case Type::I8:      return "i8";
+      case Type::I16:     return "i16";
       case Type::Funcref: return "funcref";
       case Type::Func:    return "func";
       case Type::Exnref:  return "exnref";

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -169,6 +169,8 @@ class WastParser {
   Result ParseTerminatingInstrList(ExprList*);
   Result ParseInstr(ExprList*);
   Result ParsePlainInstr(std::unique_ptr<Expr>*);
+  Result ParseF32(Const*, ConstType type);
+  Result ParseF64(Const*, ConstType type);
   Result ParseConst(Const*, ConstType type);
   Result ParseHostRef(Const*);
   Result ParseExpectedNan(ExpectedNan* expected);
@@ -214,7 +216,7 @@ class WastParser {
   template <typename T>
   Result ParseAssertScriptModuleCommand(TokenType, CommandPtr*);
 
-  Result ParseSimdV128Const(Const*, TokenType);
+  Result ParseSimdV128Const(Const*, TokenType, ConstType);
 
   void CheckImportOrdering(Module*);
 

--- a/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt
+++ b/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt
@@ -6,10 +6,11 @@
     v128.const i32x4 0xff00ff01 0xff00ff0f 0xff00ffff 0xff00ff7f
     v128.const i32x4 0x00550055 0x00550055 0x00550055 0x00550155
     v8x16.shuffle 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 33
+    drop
     ))
 
 (;; STDERR ;;;
-out/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt:8:55: error: shuffle index "33" out-of-range [0, 32)
+out/test/parse/expr/bad-simd-shuffle-lane-index-overflow2.txt:8:5: error: lane index must be less than 32 (got 33)
     v8x16.shuffle 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 33
-                                                      ^^
+    ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/spec/simd/simd_address.txt
+++ b/test/spec/simd/simd_address.txt
@@ -1,0 +1,31 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_address.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_address.wast:86: assert_trap passed: out of bounds memory access: access at 65521+16 >= max value 65536
+out/test/spec/simd/simd_address.wast:104: assert_trap passed: out of bounds memory access: access at 65521+16 >= max value 65536
+out/test/spec/simd/simd_address.wast:107: assert_malformed passed:
+  out/test/spec/simd/simd_address/simd_address.2.wat:1:35: error: unexpected token offset=-1, expected ).
+  (memory 1)(func  (drop (v128.load offset=-1 (i32.const 0))))
+                                    ^^^^^^^^^
+  out/test/spec/simd/simd_address/simd_address.2.wat:1:60: error: unexpected token ), expected EOF.
+  (memory 1)(func  (drop (v128.load offset=-1 (i32.const 0))))
+                                                             ^
+out/test/spec/simd/simd_address.wast:122: assert_trap passed: out of bounds memory access: access at 65521+16 >= max value 65536
+out/test/spec/simd/simd_address.wast:125: assert_malformed passed:
+  out/test/spec/simd/simd_address/simd_address.4.wat:1:30: error: unexpected token offset=-1, expected ).
+  (memory 1)(func  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 ...
+                               ^^^^^^^^^
+  out/test/spec/simd/simd_address/simd_address.4.wat:1:81: error: unexpected token ), expected EOF.
+  ...ory 1)(func  (v128.store offset=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_address.wast:138: assert_malformed passed:
+  out/test/spec/simd/simd_address/simd_address.5.wat:1:34: error: offset must be less than or equal to 0xffffffff
+  (memory 1)(func (drop (v128.load offset=4294967296 (i32.const 0))))
+                                   ^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_address.wast:146: assert_malformed passed:
+  out/test/spec/simd/simd_address/simd_address.6.wat:1:29: error: offset must be less than or equal to 0xffffffff
+  (memory 1)(func (v128.store offset=4294967296 (i32.const 0) (v128.const i32x4...
+                              ^^^^^^^^^^^^^^^^^
+43/43 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_align.txt
+++ b/test/spec/simd/simd_align.txt
@@ -1,0 +1,214 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_align.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_align.wast:54: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (16)
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:58: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (16)
+  0000034: error: OnStoreExpr callback failed
+out/test/spec/simd/simd_align.wast:62: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:66: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:70: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:74: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:78: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:82: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_align.wast:86: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (1)
+  0000024: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_align.wast:90: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000024: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_align.wast:94: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000024: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_align.wast:98: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000024: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_align.wast:105: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.56.wat:1:35: error: unexpected token align=-1, expected ).
+  (memory 1) (func (drop (v128.load align=-1 (i32.const 0))))
+                                    ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.56.wat:1:59: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (v128.load align=-1 (i32.const 0))))
+                                                            ^
+out/test/spec/simd/simd_align.wast:111: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.57.wat:1:35: error: alignment must be power-of-two
+  (memory 1) (func (drop (v128.load align=0 (i32.const 0))))
+                                    ^^^^^^^
+out/test/spec/simd/simd_align.wast:117: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.58.wat:1:35: error: alignment must be power-of-two
+  (memory 1) (func (drop (v128.load align=7 (i32.const 0))))
+                                    ^^^^^^^
+out/test/spec/simd/simd_align.wast:123: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.59.wat:1:30: error: unexpected token align=-1, expected ).
+  (memory 1) (func (v128.store align=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                               ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.59.wat:1:80: error: unexpected token ), expected EOF.
+  (memory 1) (func (v128.store align=-1 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_align.wast:129: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.60.wat:1:30: error: alignment must be power-of-two
+  (memory 0) (func (v128.store align=0 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                               ^^^^^^^
+out/test/spec/simd/simd_align.wast:135: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.61.wat:1:30: error: alignment must be power-of-two
+  (memory 0) (func (v128.store align=7 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                               ^^^^^^^
+out/test/spec/simd/simd_align.wast:141: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.62.wat:1:49: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (i16x8.load8x8_s align=-1 (i32.const 0)))
+                                                  ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.62.wat:1:72: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (i16x8.load8x8_s align=-1 (i32.const 0)))
+                                                                         ^
+out/test/spec/simd/simd_align.wast:147: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.63.wat:1:49: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i16x8.load8x8_s align=0 (i32.const 0)))
+                                                  ^^^^^^^
+out/test/spec/simd/simd_align.wast:153: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.64.wat:1:49: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i16x8.load8x8_s align=7 (i32.const 0)))
+                                                  ^^^^^^^
+out/test/spec/simd/simd_align.wast:159: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.65.wat:1:49: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (i16x8.load8x8_u align=-1 (i32.const 0)))
+                                                  ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.65.wat:1:72: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (i16x8.load8x8_u align=-1 (i32.const 0)))
+                                                                         ^
+out/test/spec/simd/simd_align.wast:165: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.66.wat:1:49: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i16x8.load8x8_u align=0 (i32.const 0)))
+                                                  ^^^^^^^
+out/test/spec/simd/simd_align.wast:171: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.67.wat:1:49: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i16x8.load8x8_u align=7 (i32.const 0)))
+                                                  ^^^^^^^
+out/test/spec/simd/simd_align.wast:177: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.68.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (i32x4.load16x4_s align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.68.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (i32x4.load16x4_s align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:183: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.69.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i32x4.load16x4_s align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:189: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.70.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i32x4.load16x4_s align=7 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:195: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.71.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (i32x4.load16x4_u align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.71.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (i32x4.load16x4_u align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:201: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.72.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i32x4.load16x4_u align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:207: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.73.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i32x4.load16x4_u align=7 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:213: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.74.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (i64x2.load32x2_s align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.74.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (i64x2.load32x2_s align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:219: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.75.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i64x2.load32x2_s align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:225: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.76.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i64x2.load32x2_s align=7 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:231: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.77.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (i64x2.load32x2_u align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.77.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (i64x2.load32x2_u align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:237: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.78.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i64x2.load32x2_u align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:243: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.79.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (i64x2.load32x2_u align=7 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:249: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.80.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (v8x16.load_splat align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.80.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (v8x16.load_splat align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:255: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.81.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (v8x16.load_splat align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:261: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.82.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (v16x8.load_splat align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.82.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (v16x8.load_splat align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:267: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.83.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (v16x8.load_splat align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:273: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.84.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (v32x4.load_splat align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.84.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (v32x4.load_splat align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:279: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.85.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (v32x4.load_splat align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:285: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.86.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (v32x4.load_splat align=3 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:291: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.87.wat:1:50: error: unexpected token align=-1, expected ).
+  (memory 1) (func (result v128) (v64x2.load_splat align=-1 (i32.const 0)))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_align/simd_align.87.wat:1:73: error: unexpected token ), expected EOF.
+  (memory 1) (func (result v128) (v64x2.load_splat align=-1 (i32.const 0)))
+                                                                          ^
+out/test/spec/simd/simd_align.wast:297: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.88.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (v64x2.load_splat align=0 (i32.const 0)))
+                                                   ^^^^^^^
+out/test/spec/simd/simd_align.wast:303: assert_malformed passed:
+  out/test/spec/simd/simd_align/simd_align.89.wat:1:50: error: alignment must be power-of-two
+  (memory 1) (func (result v128) (v64x2.load_splat align=7 (i32.const 0)))
+                                                   ^^^^^^^
+54/54 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_bit_shift.txt
+++ b/test/spec/simd/simd_bit_shift.txt
@@ -1,0 +1,138 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_bit_shift.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_bit_shift.wast:976: assert_invalid passed:
+  error: type mismatch in i8x16.shl, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:977: assert_invalid passed:
+  error: type mismatch in i8x16.shr_s, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:978: assert_invalid passed:
+  error: type mismatch in i8x16.shr_u, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:979: assert_invalid passed:
+  error: type mismatch in i16x8.shl, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:980: assert_invalid passed:
+  error: type mismatch in i16x8.shr_s, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:981: assert_invalid passed:
+  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:982: assert_invalid passed:
+  error: type mismatch in i32x4.shl, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:983: assert_invalid passed:
+  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:984: assert_invalid passed:
+  error: type mismatch in i32x4.shr_u, expected [v128, i32] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:985: assert_invalid passed:
+  error: type mismatch in i64x2.shl, expected [v128, i32] but got [i32, i32]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:986: assert_invalid passed:
+  error: type mismatch in i64x2.shr_s, expected [v128, i32] but got [i32, i32]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:987: assert_invalid passed:
+  error: type mismatch in i64x2.shr_u, expected [v128, i32] but got [i32, i32]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:991: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.14.wat:1:33: error: unexpected token "i8x16.shl_s", expected an instr.
+  (memory 1) (func (result v128) (i8x16.shl_s (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:992: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.15.wat:1:33: error: unexpected token "i8x16.shl_r", expected an instr.
+  (memory 1) (func (result v128) (i8x16.shl_r (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:993: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.16.wat:1:33: error: unexpected token "i8x16.shr", expected an instr.
+  (memory 1) (func (result v128) (i8x16.shr   (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:994: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.17.wat:1:33: error: unexpected token "i16x8.shl_s", expected an instr.
+  (memory 1) (func (result v128) (i16x8.shl_s (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:995: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.18.wat:1:33: error: unexpected token "i16x8.shl_r", expected an instr.
+  (memory 1) (func (result v128) (i16x8.shl_r (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:996: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.19.wat:1:33: error: unexpected token "i16x8.shr", expected an instr.
+  (memory 1) (func (result v128) (i16x8.shr   (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:997: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.20.wat:1:33: error: unexpected token "i32x4.shl_s", expected an instr.
+  (memory 1) (func (result v128) (i32x4.shl_s (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:998: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.21.wat:1:33: error: unexpected token "i32x4.shl_r", expected an instr.
+  (memory 1) (func (result v128) (i32x4.shl_r (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:999: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.22.wat:1:33: error: unexpected token "i32x4.shr", expected an instr.
+  (memory 1) (func (result v128) (i32x4.shr   (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1000: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.23.wat:1:33: error: unexpected token "i64x2.shl_s", expected an instr.
+  (memory 1) (func (result v128) (i64x2.shl_s (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1001: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.24.wat:1:33: error: unexpected token "i64x2.shl_r", expected an instr.
+  (memory 1) (func (result v128) (i64x2.shl_r (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1002: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.25.wat:1:33: error: unexpected token "i64x2.shr", expected an instr.
+  (memory 1) (func (result v128) (i64x2.shr   (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1003: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.26.wat:1:33: error: unexpected token "f32x4.shl", expected an instr.
+  (memory 1) (func (result v128) (f32x4.shl   (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1004: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.27.wat:1:33: error: unexpected token "f32x4.shr_s", expected an instr.
+  (memory 1) (func (result v128) (f32x4.shr_s (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1005: assert_malformed passed:
+  out/test/spec/simd/simd_bit_shift/simd_bit_shift.28.wat:1:33: error: unexpected token "f32x4.shr_u", expected an instr.
+  (memory 1) (func (result v128) (f32x4.shr_u (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_bit_shift.wast:1010: assert_invalid passed:
+  error: type mismatch in i8x16.shl, expected [v128, i32] but got [i32]
+  000001c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1018: assert_invalid passed:
+  error: type mismatch in i8x16.shl, expected [v128, i32] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1026: assert_invalid passed:
+  error: type mismatch in i8x16.shl, expected [v128, i32] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1034: assert_invalid passed:
+  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [i32]
+  000001c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1042: assert_invalid passed:
+  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1050: assert_invalid passed:
+  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1058: assert_invalid passed:
+  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [i32]
+  000001c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1066: assert_invalid passed:
+  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1074: assert_invalid passed:
+  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1082: assert_invalid passed:
+  error: type mismatch in i64x2.shl, expected [v128, i32] but got [i32]
+  000001d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1090: assert_invalid passed:
+  error: type mismatch in i64x2.shr_u, expected [v128, i32] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bit_shift.wast:1098: assert_invalid passed:
+  error: type mismatch in i64x2.shr_s, expected [v128, i32] but got []
+  000001b: error: OnBinaryExpr callback failed
+250/250 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_bitwise.txt
+++ b/test/spec/simd/simd_bitwise.txt
@@ -1,0 +1,90 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_bitwise.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_bitwise.wast:405: assert_invalid passed:
+  error: type mismatch in v128.not, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:407: assert_invalid passed:
+  error: type mismatch in v128.and, expected [v128, v128] but got [i32, v128]
+  000002e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:408: assert_invalid passed:
+  error: type mismatch in v128.and, expected [v128, v128] but got [v128, i32]
+  000002e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:409: assert_invalid passed:
+  error: type mismatch in v128.and, expected [v128, v128] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:411: assert_invalid passed:
+  error: type mismatch in v128.or, expected [v128, v128] but got [i32, v128]
+  000002e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:412: assert_invalid passed:
+  error: type mismatch in v128.or, expected [v128, v128] but got [v128, i32]
+  000002e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:413: assert_invalid passed:
+  error: type mismatch in v128.or, expected [v128, v128] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:415: assert_invalid passed:
+  error: type mismatch in v128.xor, expected [v128, v128] but got [i32, v128]
+  000002e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:416: assert_invalid passed:
+  error: type mismatch in v128.xor, expected [v128, v128] but got [v128, i32]
+  000002e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:417: assert_invalid passed:
+  error: type mismatch in v128.xor, expected [v128, v128] but got [i32, i32]
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:419: assert_invalid passed:
+  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [i32, v128, v128]
+  0000040: error: OnTernaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:420: assert_invalid passed:
+  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128, v128, i32]
+  0000040: error: OnTernaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:421: assert_invalid passed:
+  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [i32, i32, i32]
+  0000020: error: OnTernaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:423: assert_invalid passed:
+  error: type mismatch in v128.andnot, expected [v128, v128] but got [i32, v128]
+  000002f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:424: assert_invalid passed:
+  error: type mismatch in v128.andnot, expected [v128, v128] but got [v128, i32]
+  000002f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:425: assert_invalid passed:
+  error: type mismatch in v128.andnot, expected [v128, v128] but got [i32, i32]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:718: assert_invalid passed:
+  error: type mismatch in v128.not, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:726: assert_invalid passed:
+  error: type mismatch in v128.and, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:734: assert_invalid passed:
+  error: type mismatch in v128.and, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:742: assert_invalid passed:
+  error: type mismatch in v128.or, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:750: assert_invalid passed:
+  error: type mismatch in v128.or, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:758: assert_invalid passed:
+  error: type mismatch in v128.xor, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:766: assert_invalid passed:
+  error: type mismatch in v128.xor, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:774: assert_invalid passed:
+  error: type mismatch in v128.andnot, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:782: assert_invalid passed:
+  error: type mismatch in v128.andnot, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:790: assert_invalid passed:
+  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128, v128]
+  000003e: error: OnTernaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:798: assert_invalid passed:
+  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128]
+  000002c: error: OnTernaryExpr callback failed
+out/test/spec/simd/simd_bitwise.wast:806: assert_invalid passed:
+  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got []
+  000001a: error: OnTernaryExpr callback failed
+167/167 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_boolean.txt
+++ b/test/spec/simd/simd_boolean.txt
@@ -1,0 +1,58 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_boolean.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_boolean.wast:952: assert_invalid passed:
+  error: type mismatch in i8x16.any_true, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:953: assert_invalid passed:
+  error: type mismatch in i8x16.all_true, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:954: assert_invalid passed:
+  error: type mismatch in i16x8.any_true, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:955: assert_invalid passed:
+  error: type mismatch in i16x8.all_true, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:956: assert_invalid passed:
+  error: type mismatch in i32x4.any_true, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:957: assert_invalid passed:
+  error: type mismatch in i32x4.all_true, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:961: assert_malformed passed:
+  out/test/spec/simd/simd_boolean/simd_boolean.8.wat:1:32: error: unexpected token "f32x4.any_true", expected an instr.
+  (memory 1) (func (result i32) (f32x4.any_true (v128.const i32x4 0 0 0 0)))
+                                 ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_boolean.wast:962: assert_malformed passed:
+  out/test/spec/simd/simd_boolean/simd_boolean.9.wat:1:32: error: unexpected token "f32x4.all_true", expected an instr.
+  (memory 1) (func (result i32) (f32x4.all_true (v128.const i32x4 0 0 0 0)))
+                                 ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_boolean.wast:963: assert_malformed passed:
+  out/test/spec/simd/simd_boolean/simd_boolean.10.wat:1:32: error: unexpected token "f64x2.any_true", expected an instr.
+  (memory 1) (func (result i32) (f64x2.any_true (v128.const i32x4 0 0 0 0)))
+                                 ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_boolean.wast:964: assert_malformed passed:
+  out/test/spec/simd/simd_boolean/simd_boolean.11.wat:1:32: error: unexpected token "f64x2.all_true", expected an instr.
+  (memory 1) (func (result i32) (f64x2.all_true (v128.const i32x4 0 0 0 0)))
+                                 ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_boolean.wast:969: assert_invalid passed:
+  error: type mismatch in i8x16.any_true, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:977: assert_invalid passed:
+  error: type mismatch in i8x16.all_true, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:985: assert_invalid passed:
+  error: type mismatch in i16x8.any_true, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:993: assert_invalid passed:
+  error: type mismatch in i16x8.all_true, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:1001: assert_invalid passed:
+  error: type mismatch in i32x4.any_true, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_boolean.wast:1009: assert_invalid passed:
+  error: type mismatch in i32x4.all_true, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+258/258 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_const.txt
+++ b/test/spec/simd/simd_const.txt
@@ -1,0 +1,1765 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_const.wast
+;;; ARGS*: --enable-simd --enable-reference-types
+;;; NOTE: reference types is only required because the test uses two tables
+(;; STDOUT ;;;
+out/test/spec/simd/simd_const.wast:130: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.113.wat:1:25: error: invalid literal "0x100"
+  (func (v128.const i8x16 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100 0x100...
+                          ^^^^^
+out/test/spec/simd/simd_const.wast:134: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.114.wat:1:25: error: invalid literal "-0x81"
+  (func (v128.const i8x16 -0x81 -0x81 -0x81 -0x81 -0x81 -0x81 -0x81 -0x81 -0x81...
+                          ^^^^^
+out/test/spec/simd/simd_const.wast:138: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.115.wat:1:25: error: invalid literal "256"
+  (func (v128.const i8x16 256 256 256 256 256 256 256 256 256 256 256 256 256 2...
+                          ^^^
+out/test/spec/simd/simd_const.wast:142: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.116.wat:1:25: error: invalid literal "-129"
+  (func (v128.const i8x16 -129 -129 -129 -129 -129 -129 -129 -129 -129 -129 -12...
+                          ^^^^
+out/test/spec/simd/simd_const.wast:146: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.117.wat:1:25: error: invalid literal "0x10000"
+  (func (v128.const i16x8 0x10000 0x10000 0x10000 0x10000 0x10000 0x10000 0x100...
+                          ^^^^^^^
+out/test/spec/simd/simd_const.wast:150: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.118.wat:1:25: error: invalid literal "-0x8001"
+  (func (v128.const i16x8 -0x8001 -0x8001 -0x8001 -0x8001 -0x8001 -0x8001 -0x80...
+                          ^^^^^^^
+out/test/spec/simd/simd_const.wast:154: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.119.wat:1:25: error: invalid literal "65536"
+  (func (v128.const i16x8 65536 65536 65536 65536 65536 65536 65536 65536) drop)
+                          ^^^^^
+out/test/spec/simd/simd_const.wast:158: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.120.wat:1:25: error: invalid literal "-32769"
+  (func (v128.const i16x8 -32769 -32769 -32769 -32769 -32769 -32769 -32769 -327...
+                          ^^^^^^
+out/test/spec/simd/simd_const.wast:162: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.121.wat:1:26: error: invalid literal "0x100000000"
+  (func (v128.const i32x4  0x100000000  0x100000000  0x100000000  0x100000000) ...
+                           ^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:166: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.122.wat:1:25: error: invalid literal "-0x80000001"
+  (func (v128.const i32x4 -0x80000001 -0x80000001 -0x80000001 -0x80000001) drop)
+                          ^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:170: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.123.wat:1:26: error: invalid literal "4294967296"
+  (func (v128.const i32x4  4294967296  4294967296  4294967296  4294967296) drop)
+                           ^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:174: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.124.wat:1:25: error: invalid literal "-2147483649"
+  (func (v128.const i32x4 -2147483649 -2147483649 -2147483649 -2147483649) drop)
+                          ^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:178: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.125.wat:1:26: error: invalid literal "0x1p128"
+  (func (v128.const f32x4  0x1p128  0x1p128  0x1p128  0x1p128) drop)
+                           ^^^^^^^
+out/test/spec/simd/simd_const.wast:182: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.126.wat:1:25: error: invalid literal "-0x1p128"
+  (func (v128.const f32x4 -0x1p128 -0x1p128 -0x1p128 -0x1p128) drop)
+                          ^^^^^^^^
+out/test/spec/simd/simd_const.wast:186: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.127.wat:1:26: error: invalid literal "1e39"
+  (func (v128.const f32x4  1e39  1e39  1e39  1e39) drop)
+                           ^^^^
+out/test/spec/simd/simd_const.wast:190: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.128.wat:1:25: error: invalid literal "-1e39"
+  (func (v128.const f32x4 -1e39 -1e39 -1e39 -1e39) drop)
+                          ^^^^^
+out/test/spec/simd/simd_const.wast:194: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.129.wat:1:26: error: invalid literal "340282356779733661637539395458142568448"
+  ...v128.const f32x4  340282356779733661637539395458142568448 3402823567797336...
+                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:199: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.130.wat:1:25: error: invalid literal "-340282356779733661637539395458142568448"
+  ...v128.const f32x4 -340282356779733661637539395458142568448 -340282356779733...
+                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:205: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.131.wat:1:25: error: invalid literal "nan:0x80_0000"
+  (func (v128.const f32x4 nan:0x80_0000 nan:0x80_0000 nan:0x80_0000 nan:0x80_00...
+                          ^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:210: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.132.wat:1:26: error: invalid literal "269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
+  (func (v128.const f64x2  2696539702293473562217911355975565351971058512887674...
+                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:215: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.133.wat:1:25: error: invalid literal "-269653970229347356221791135597556535197105851288767494898376215204735891170042808140884337949150317257310688430271573696351481990334196274152701320055306275479074865864826923114368235135583993416113802762682700913456874855354834422248712838998185022412196739306217084753107265771378949821875606039276187287552"
+  (func (v128.const f64x2 -2696539702293473562217911355975565351971058512887674...
+                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:221: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.134.wat:1:25: error: invalid literal "nan:0x10_0000_0000_0000"
+  (func (v128.const f64x2 nan:0x10_0000_0000_0000 nan:0x10_0000_0000_0000) drop)
+                          ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:227: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.135.wat:1:18: error: Unexpected type at start of simd constant. Expected one of: i8x16, i16x8, i32x4, i64x2, f32x4, f64x2. Found ")".
+  (func (v128.const) drop)
+                   ^
+out/test/spec/simd/simd_const.wast:232: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.136.wat:1:19: error: Unexpected type at start of simd constant. Expected one of: i8x16, i16x8, i32x4, i64x2, f32x4, f64x2. Found "NAT".
+  (func (v128.const 0 0 0 0) drop)
+                    ^
+out/test/spec/simd/simd_const.wast:236: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.137.wat:1:24: error: unexpected token ")", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i8x16) drop)
+                         ^
+out/test/spec/simd/simd_const.wast:240: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:25: error: unexpected token "0x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:28: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:31: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:34: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                   ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:37: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                      ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:40: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                         ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:43: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                            ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:46: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                               ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:49: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                  ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:52: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                     ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:55: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                        ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:58: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                           ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:61: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                              ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:64: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                                 ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:67: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                                    ^^
+  out/test/spec/simd/simd_const/simd_const.138.wat:1:70: error: unexpected token 0x.
+  (func (v128.const i8x16 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                                                       ^^
+out/test/spec/simd/simd_const.wast:244: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:25: error: unexpected token "1x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:28: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:31: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:34: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                   ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:37: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                      ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:40: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                         ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:43: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                            ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:46: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                               ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:49: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                  ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:52: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                     ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:55: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                        ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:58: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                           ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:61: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                              ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:64: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                                 ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:67: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                                    ^^
+  out/test/spec/simd/simd_const/simd_const.139.wat:1:70: error: unexpected token 1x.
+  (func (v128.const i8x16 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                                                       ^^
+out/test/spec/simd/simd_const.wast:248: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:25: error: unexpected token "0xg", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0...
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:29: error: unexpected token 0xg.
+  (func (v128.const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0...
+                              ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:33: error: unexpected token 0xg.
+  (func (v128.const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0...
+                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:37: error: unexpected token 0xg.
+  (func (v128.const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0...
+                                      ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:41: error: unexpected token 0xg.
+  ...c (v128.const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0x...
+                                         ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:45: error: unexpected token 0xg.
+  ...128.const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0x...
+                                         ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:49: error: unexpected token 0xg.
+  ...const i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0x...
+                                         ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:53: error: unexpected token 0xg.
+  ...t i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) d...
+                                         ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:57: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                            ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:61: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:65: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                    ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:69: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                        ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:73: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                            ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:77: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                                ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:81: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                                    ^^^
+  out/test/spec/simd/simd_const/simd_const.140.wat:1:85: error: unexpected token 0xg.
+  ... i8x16 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                                        ^^^
+out/test/spec/simd/simd_const.wast:253: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.141.wat:1:24: error: unexpected token ")", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i16x8) drop)
+                         ^
+out/test/spec/simd/simd_const.wast:257: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:25: error: unexpected token "0x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:28: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:31: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:34: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                   ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:37: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                      ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:40: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                         ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:43: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                            ^^
+  out/test/spec/simd/simd_const/simd_const.142.wat:1:46: error: unexpected token 0x.
+  (func (v128.const i16x8 0x 0x 0x 0x 0x 0x 0x 0x) drop)
+                                               ^^
+out/test/spec/simd/simd_const.wast:261: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:25: error: unexpected token "1x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:28: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:31: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:34: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                   ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:37: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                      ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:40: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                         ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:43: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                            ^^
+  out/test/spec/simd/simd_const/simd_const.143.wat:1:46: error: unexpected token 1x.
+  (func (v128.const i16x8 1x 1x 1x 1x 1x 1x 1x 1x) drop)
+                                               ^^
+out/test/spec/simd/simd_const.wast:265: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:25: error: unexpected token "0xg", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:29: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                              ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:33: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:37: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                      ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:41: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                          ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:45: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                              ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:49: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.144.wat:1:53: error: unexpected token 0xg.
+  (func (v128.const i16x8 0xg 0xg 0xg 0xg 0xg 0xg 0xg 0xg) drop)
+                                                      ^^^
+out/test/spec/simd/simd_const.wast:270: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.145.wat:1:24: error: unexpected token ")", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i32x4) drop)
+                         ^
+out/test/spec/simd/simd_const.wast:274: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.146.wat:1:25: error: unexpected token "0x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i32x4 0x 0x 0x 0x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.146.wat:1:28: error: unexpected token 0x.
+  (func (v128.const i32x4 0x 0x 0x 0x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.146.wat:1:31: error: unexpected token 0x.
+  (func (v128.const i32x4 0x 0x 0x 0x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.146.wat:1:34: error: unexpected token 0x.
+  (func (v128.const i32x4 0x 0x 0x 0x) drop)
+                                   ^^
+out/test/spec/simd/simd_const.wast:278: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.147.wat:1:25: error: unexpected token "1x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i32x4 1x 1x 1x 1x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.147.wat:1:28: error: unexpected token 1x.
+  (func (v128.const i32x4 1x 1x 1x 1x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.147.wat:1:31: error: unexpected token 1x.
+  (func (v128.const i32x4 1x 1x 1x 1x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.147.wat:1:34: error: unexpected token 1x.
+  (func (v128.const i32x4 1x 1x 1x 1x) drop)
+                                   ^^
+out/test/spec/simd/simd_const.wast:282: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.148.wat:1:25: error: unexpected token "0xg", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i32x4 0xg 0xg 0xg 0xg) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.148.wat:1:29: error: unexpected token 0xg.
+  (func (v128.const i32x4 0xg 0xg 0xg 0xg) drop)
+                              ^^^
+  out/test/spec/simd/simd_const/simd_const.148.wat:1:33: error: unexpected token 0xg.
+  (func (v128.const i32x4 0xg 0xg 0xg 0xg) drop)
+                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.148.wat:1:37: error: unexpected token 0xg.
+  (func (v128.const i32x4 0xg 0xg 0xg 0xg) drop)
+                                      ^^^
+out/test/spec/simd/simd_const.wast:287: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.149.wat:1:24: error: unexpected token ")", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i64x2) drop)
+                         ^
+out/test/spec/simd/simd_const.wast:291: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.150.wat:1:25: error: unexpected token "0x", expected a Nat or Integer literal (e.g. 123).
+  (func (v128.const i64x2 0x 0x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.150.wat:1:28: error: unexpected token 0x.
+  (func (v128.const i64x2 0x 0x) drop)
+                             ^^
+out/test/spec/simd/simd_const.wast:295: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.151.wat:1:25: error: unexpected token "1x", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 1x 1x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.151.wat:1:28: error: unexpected token 1x.
+  (func (v128.const f64x2 1x 1x) drop)
+                             ^^
+out/test/spec/simd/simd_const.wast:299: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.152.wat:1:25: error: unexpected token "0xg", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0xg 0xg) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.152.wat:1:29: error: unexpected token 0xg.
+  (func (v128.const f64x2 0xg 0xg) drop)
+                              ^^^
+out/test/spec/simd/simd_const.wast:304: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.153.wat:1:24: error: unexpected token ")", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4) drop)
+                         ^
+out/test/spec/simd/simd_const.wast:308: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.154.wat:1:25: error: unexpected token ".0", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 .0 .0 .0 .0) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.154.wat:1:28: error: unexpected token .0.
+  (func (v128.const f32x4 .0 .0 .0 .0) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.154.wat:1:31: error: unexpected token .0.
+  (func (v128.const f32x4 .0 .0 .0 .0) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.154.wat:1:34: error: unexpected token .0.
+  (func (v128.const f32x4 .0 .0 .0 .0) drop)
+                                   ^^
+out/test/spec/simd/simd_const.wast:312: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.155.wat:1:25: error: unexpected token ".0e0", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 .0e0 .0e0 .0e0 .0e0) drop)
+                          ^^^^
+  out/test/spec/simd/simd_const/simd_const.155.wat:1:30: error: unexpected token .0e0.
+  (func (v128.const f32x4 .0e0 .0e0 .0e0 .0e0) drop)
+                               ^^^^
+  out/test/spec/simd/simd_const/simd_const.155.wat:1:35: error: unexpected token .0e0.
+  (func (v128.const f32x4 .0e0 .0e0 .0e0 .0e0) drop)
+                                    ^^^^
+  out/test/spec/simd/simd_const/simd_const.155.wat:1:40: error: unexpected token .0e0.
+  (func (v128.const f32x4 .0e0 .0e0 .0e0 .0e0) drop)
+                                         ^^^^
+out/test/spec/simd/simd_const.wast:316: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.156.wat:1:25: error: unexpected token "0e", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0e 0e 0e 0e) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.156.wat:1:28: error: unexpected token 0e.
+  (func (v128.const f32x4 0e 0e 0e 0e) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.156.wat:1:31: error: unexpected token 0e.
+  (func (v128.const f32x4 0e 0e 0e 0e) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.156.wat:1:34: error: unexpected token 0e.
+  (func (v128.const f32x4 0e 0e 0e 0e) drop)
+                                   ^^
+out/test/spec/simd/simd_const.wast:320: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.157.wat:1:25: error: unexpected token "0e+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0e+ 0e+ 0e+ 0e+) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.157.wat:1:29: error: unexpected token 0e+.
+  (func (v128.const f32x4 0e+ 0e+ 0e+ 0e+) drop)
+                              ^^^
+  out/test/spec/simd/simd_const/simd_const.157.wat:1:33: error: unexpected token 0e+.
+  (func (v128.const f32x4 0e+ 0e+ 0e+ 0e+) drop)
+                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.157.wat:1:37: error: unexpected token 0e+.
+  (func (v128.const f32x4 0e+ 0e+ 0e+ 0e+) drop)
+                                      ^^^
+out/test/spec/simd/simd_const.wast:324: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.158.wat:1:25: error: unexpected token "0.0e", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0.0e 0.0e 0.0e 0.0e) drop)
+                          ^^^^
+  out/test/spec/simd/simd_const/simd_const.158.wat:1:30: error: unexpected token 0.0e.
+  (func (v128.const f32x4 0.0e 0.0e 0.0e 0.0e) drop)
+                               ^^^^
+  out/test/spec/simd/simd_const/simd_const.158.wat:1:35: error: unexpected token 0.0e.
+  (func (v128.const f32x4 0.0e 0.0e 0.0e 0.0e) drop)
+                                    ^^^^
+  out/test/spec/simd/simd_const/simd_const.158.wat:1:40: error: unexpected token 0.0e.
+  (func (v128.const f32x4 0.0e 0.0e 0.0e 0.0e) drop)
+                                         ^^^^
+out/test/spec/simd/simd_const.wast:328: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.159.wat:1:25: error: unexpected token "0.0e-", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0.0e- 0.0e- 0.0e- 0.0e-) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.159.wat:1:31: error: unexpected token 0.0e-.
+  (func (v128.const f32x4 0.0e- 0.0e- 0.0e- 0.0e-) drop)
+                                ^^^^^
+  out/test/spec/simd/simd_const/simd_const.159.wat:1:37: error: unexpected token 0.0e-.
+  (func (v128.const f32x4 0.0e- 0.0e- 0.0e- 0.0e-) drop)
+                                      ^^^^^
+  out/test/spec/simd/simd_const/simd_const.159.wat:1:43: error: unexpected token 0.0e-.
+  (func (v128.const f32x4 0.0e- 0.0e- 0.0e- 0.0e-) drop)
+                                            ^^^^^
+out/test/spec/simd/simd_const.wast:332: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.160.wat:1:25: error: unexpected token "0x", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x 0x 0x 0x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.160.wat:1:28: error: unexpected token 0x.
+  (func (v128.const f32x4 0x 0x 0x 0x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.160.wat:1:31: error: unexpected token 0x.
+  (func (v128.const f32x4 0x 0x 0x 0x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.160.wat:1:34: error: unexpected token 0x.
+  (func (v128.const f32x4 0x 0x 0x 0x) drop)
+                                   ^^
+out/test/spec/simd/simd_const.wast:336: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.161.wat:1:25: error: unexpected token "1x", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 1x 1x 1x 1x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.161.wat:1:28: error: unexpected token 1x.
+  (func (v128.const f32x4 1x 1x 1x 1x) drop)
+                             ^^
+  out/test/spec/simd/simd_const/simd_const.161.wat:1:31: error: unexpected token 1x.
+  (func (v128.const f32x4 1x 1x 1x 1x) drop)
+                                ^^
+  out/test/spec/simd/simd_const/simd_const.161.wat:1:34: error: unexpected token 1x.
+  (func (v128.const f32x4 1x 1x 1x 1x) drop)
+                                   ^^
+out/test/spec/simd/simd_const.wast:340: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.162.wat:1:25: error: unexpected token "0xg", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0xg 0xg 0xg 0xg) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.162.wat:1:29: error: unexpected token 0xg.
+  (func (v128.const f32x4 0xg 0xg 0xg 0xg) drop)
+                              ^^^
+  out/test/spec/simd/simd_const/simd_const.162.wat:1:33: error: unexpected token 0xg.
+  (func (v128.const f32x4 0xg 0xg 0xg 0xg) drop)
+                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.162.wat:1:37: error: unexpected token 0xg.
+  (func (v128.const f32x4 0xg 0xg 0xg 0xg) drop)
+                                      ^^^
+out/test/spec/simd/simd_const.wast:344: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.163.wat:1:25: error: unexpected token "0x.", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x. 0x. 0x. 0x.) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.163.wat:1:29: error: unexpected token 0x..
+  (func (v128.const f32x4 0x. 0x. 0x. 0x.) drop)
+                              ^^^
+  out/test/spec/simd/simd_const/simd_const.163.wat:1:33: error: unexpected token 0x..
+  (func (v128.const f32x4 0x. 0x. 0x. 0x.) drop)
+                                  ^^^
+  out/test/spec/simd/simd_const/simd_const.163.wat:1:37: error: unexpected token 0x..
+  (func (v128.const f32x4 0x. 0x. 0x. 0x.) drop)
+                                      ^^^
+out/test/spec/simd/simd_const.wast:348: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.164.wat:1:25: error: unexpected token "0x0.g", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0.g 0x0.g 0x0.g 0x0.g) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.164.wat:1:31: error: unexpected token 0x0.g.
+  (func (v128.const f32x4 0x0.g 0x0.g 0x0.g 0x0.g) drop)
+                                ^^^^^
+  out/test/spec/simd/simd_const/simd_const.164.wat:1:37: error: unexpected token 0x0.g.
+  (func (v128.const f32x4 0x0.g 0x0.g 0x0.g 0x0.g) drop)
+                                      ^^^^^
+  out/test/spec/simd/simd_const/simd_const.164.wat:1:43: error: unexpected token 0x0.g.
+  (func (v128.const f32x4 0x0.g 0x0.g 0x0.g 0x0.g) drop)
+                                            ^^^^^
+out/test/spec/simd/simd_const.wast:352: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.165.wat:1:25: error: unexpected token "0x0p", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0p 0x0p 0x0p 0x0p) drop)
+                          ^^^^
+  out/test/spec/simd/simd_const/simd_const.165.wat:1:30: error: unexpected token 0x0p.
+  (func (v128.const f32x4 0x0p 0x0p 0x0p 0x0p) drop)
+                               ^^^^
+  out/test/spec/simd/simd_const/simd_const.165.wat:1:35: error: unexpected token 0x0p.
+  (func (v128.const f32x4 0x0p 0x0p 0x0p 0x0p) drop)
+                                    ^^^^
+  out/test/spec/simd/simd_const/simd_const.165.wat:1:40: error: unexpected token 0x0p.
+  (func (v128.const f32x4 0x0p 0x0p 0x0p 0x0p) drop)
+                                         ^^^^
+out/test/spec/simd/simd_const.wast:356: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.166.wat:1:25: error: unexpected token "0x0p+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0p+ 0x0p+ 0x0p+ 0x0p+) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.166.wat:1:31: error: unexpected token 0x0p+.
+  (func (v128.const f32x4 0x0p+ 0x0p+ 0x0p+ 0x0p+) drop)
+                                ^^^^^
+  out/test/spec/simd/simd_const/simd_const.166.wat:1:37: error: unexpected token 0x0p+.
+  (func (v128.const f32x4 0x0p+ 0x0p+ 0x0p+ 0x0p+) drop)
+                                      ^^^^^
+  out/test/spec/simd/simd_const/simd_const.166.wat:1:43: error: unexpected token 0x0p+.
+  (func (v128.const f32x4 0x0p+ 0x0p+ 0x0p+ 0x0p+) drop)
+                                            ^^^^^
+out/test/spec/simd/simd_const.wast:360: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.167.wat:1:25: error: unexpected token "0x0p-", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0p- 0x0p- 0x0p- 0x0p-) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.167.wat:1:31: error: unexpected token 0x0p-.
+  (func (v128.const f32x4 0x0p- 0x0p- 0x0p- 0x0p-) drop)
+                                ^^^^^
+  out/test/spec/simd/simd_const/simd_const.167.wat:1:37: error: unexpected token 0x0p-.
+  (func (v128.const f32x4 0x0p- 0x0p- 0x0p- 0x0p-) drop)
+                                      ^^^^^
+  out/test/spec/simd/simd_const/simd_const.167.wat:1:43: error: unexpected token 0x0p-.
+  (func (v128.const f32x4 0x0p- 0x0p- 0x0p- 0x0p-) drop)
+                                            ^^^^^
+out/test/spec/simd/simd_const.wast:364: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.168.wat:1:25: error: unexpected token "0x0.0p", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0.0p 0x0.0p 0x0.0p 0x0.0p) drop)
+                          ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.168.wat:1:32: error: unexpected token 0x0.0p.
+  (func (v128.const f32x4 0x0.0p 0x0.0p 0x0.0p 0x0.0p) drop)
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.168.wat:1:39: error: unexpected token 0x0.0p.
+  (func (v128.const f32x4 0x0.0p 0x0.0p 0x0.0p 0x0.0p) drop)
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.168.wat:1:46: error: unexpected token 0x0.0p.
+  (func (v128.const f32x4 0x0.0p 0x0.0p 0x0.0p 0x0.0p) drop)
+                                               ^^^^^^
+out/test/spec/simd/simd_const.wast:368: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.169.wat:1:25: error: unexpected token "0x0.0p+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0.0p+ 0x0.0p+ 0x0.0p+ 0x0.0p+) drop)
+                          ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.169.wat:1:33: error: unexpected token 0x0.0p+.
+  (func (v128.const f32x4 0x0.0p+ 0x0.0p+ 0x0.0p+ 0x0.0p+) drop)
+                                  ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.169.wat:1:41: error: unexpected token 0x0.0p+.
+  (func (v128.const f32x4 0x0.0p+ 0x0.0p+ 0x0.0p+ 0x0.0p+) drop)
+                                          ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.169.wat:1:49: error: unexpected token 0x0.0p+.
+  (func (v128.const f32x4 0x0.0p+ 0x0.0p+ 0x0.0p+ 0x0.0p+) drop)
+                                                  ^^^^^^^
+out/test/spec/simd/simd_const.wast:372: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.170.wat:1:25: error: unexpected token "0x0.0p-", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0.0p- 0x0.0p- 0x0.0p- 0x0.0p-) drop)
+                          ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.170.wat:1:33: error: unexpected token 0x0.0p-.
+  (func (v128.const f32x4 0x0.0p- 0x0.0p- 0x0.0p- 0x0.0p-) drop)
+                                  ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.170.wat:1:41: error: unexpected token 0x0.0p-.
+  (func (v128.const f32x4 0x0.0p- 0x0.0p- 0x0.0p- 0x0.0p-) drop)
+                                          ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.170.wat:1:49: error: unexpected token 0x0.0p-.
+  (func (v128.const f32x4 0x0.0p- 0x0.0p- 0x0.0p- 0x0.0p-) drop)
+                                                  ^^^^^^^
+out/test/spec/simd/simd_const.wast:376: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.171.wat:1:25: error: unexpected token "0x0pA", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 0x0pA 0x0pA 0x0pA 0x0pA) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.171.wat:1:31: error: unexpected token 0x0pA.
+  (func (v128.const f32x4 0x0pA 0x0pA 0x0pA 0x0pA) drop)
+                                ^^^^^
+  out/test/spec/simd/simd_const/simd_const.171.wat:1:37: error: unexpected token 0x0pA.
+  (func (v128.const f32x4 0x0pA 0x0pA 0x0pA 0x0pA) drop)
+                                      ^^^^^
+  out/test/spec/simd/simd_const/simd_const.171.wat:1:43: error: unexpected token 0x0pA.
+  (func (v128.const f32x4 0x0pA 0x0pA 0x0pA 0x0pA) drop)
+                                            ^^^^^
+out/test/spec/simd/simd_const.wast:380: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.172.wat:1:25: error: unexpected token "nan:1", expected a Float literal (e.g. 42.0).
+  (func (v128.const f32x4 nan:1 nan:1 nan:1 nan:1) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.172.wat:1:31: error: unexpected token nan:1.
+  (func (v128.const f32x4 nan:1 nan:1 nan:1 nan:1) drop)
+                                ^^^^^
+  out/test/spec/simd/simd_const/simd_const.172.wat:1:37: error: unexpected token nan:1.
+  (func (v128.const f32x4 nan:1 nan:1 nan:1 nan:1) drop)
+                                      ^^^^^
+  out/test/spec/simd/simd_const/simd_const.172.wat:1:43: error: unexpected token nan:1.
+  (func (v128.const f32x4 nan:1 nan:1 nan:1 nan:1) drop)
+                                            ^^^^^
+out/test/spec/simd/simd_const.wast:384: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.173.wat:1:25: error: invalid literal "nan:0x0"
+  (func (v128.const f32x4 nan:0x0 nan:0x0 nan:0x0 nan:0x0) drop)
+                          ^^^^^^^
+out/test/spec/simd/simd_const.wast:389: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.174.wat:1:24: error: unexpected token ")", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2) drop)
+                         ^
+out/test/spec/simd/simd_const.wast:393: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.175.wat:1:25: error: unexpected token ".0", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 .0 .0) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.175.wat:1:28: error: unexpected token .0.
+  (func (v128.const f64x2 .0 .0) drop)
+                             ^^
+out/test/spec/simd/simd_const.wast:397: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.176.wat:1:25: error: unexpected token ".0e0", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 .0e0 .0e0) drop)
+                          ^^^^
+  out/test/spec/simd/simd_const/simd_const.176.wat:1:30: error: unexpected token .0e0.
+  (func (v128.const f64x2 .0e0 .0e0) drop)
+                               ^^^^
+out/test/spec/simd/simd_const.wast:401: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.177.wat:1:25: error: unexpected token "0e", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0e 0e) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.177.wat:1:28: error: unexpected token 0e.
+  (func (v128.const f64x2 0e 0e) drop)
+                             ^^
+out/test/spec/simd/simd_const.wast:405: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.178.wat:1:25: error: unexpected token "0e+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0e+ 0e+) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.178.wat:1:29: error: unexpected token 0e+.
+  (func (v128.const f64x2 0e+ 0e+) drop)
+                              ^^^
+out/test/spec/simd/simd_const.wast:409: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.179.wat:1:25: error: unexpected token "0.0e+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0.0e+ 0.0e+) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.179.wat:1:31: error: unexpected token 0.0e+.
+  (func (v128.const f64x2 0.0e+ 0.0e+) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:413: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.180.wat:1:25: error: unexpected token "0.0e-", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0.0e- 0.0e-) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.180.wat:1:31: error: unexpected token 0.0e-.
+  (func (v128.const f64x2 0.0e- 0.0e-) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:417: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.181.wat:1:25: error: unexpected token "0x", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x 0x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.181.wat:1:28: error: unexpected token 0x.
+  (func (v128.const f64x2 0x 0x) drop)
+                             ^^
+out/test/spec/simd/simd_const.wast:421: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.182.wat:1:25: error: unexpected token "1x", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 1x 1x) drop)
+                          ^^
+  out/test/spec/simd/simd_const/simd_const.182.wat:1:28: error: unexpected token 1x.
+  (func (v128.const f64x2 1x 1x) drop)
+                             ^^
+out/test/spec/simd/simd_const.wast:425: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.183.wat:1:25: error: unexpected token "0xg", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0xg 0xg) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.183.wat:1:29: error: unexpected token 0xg.
+  (func (v128.const f64x2 0xg 0xg) drop)
+                              ^^^
+out/test/spec/simd/simd_const.wast:429: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.184.wat:1:25: error: unexpected token "0x.", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x. 0x.) drop)
+                          ^^^
+  out/test/spec/simd/simd_const/simd_const.184.wat:1:29: error: unexpected token 0x..
+  (func (v128.const f64x2 0x. 0x.) drop)
+                              ^^^
+out/test/spec/simd/simd_const.wast:433: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.185.wat:1:25: error: unexpected token "0x0.g", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0.g 0x0.g) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.185.wat:1:31: error: unexpected token 0x0.g.
+  (func (v128.const f64x2 0x0.g 0x0.g) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:437: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.186.wat:1:25: error: unexpected token "0x0p", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0p 0x0p) drop)
+                          ^^^^
+  out/test/spec/simd/simd_const/simd_const.186.wat:1:30: error: unexpected token 0x0p.
+  (func (v128.const f64x2 0x0p 0x0p) drop)
+                               ^^^^
+out/test/spec/simd/simd_const.wast:441: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.187.wat:1:25: error: unexpected token "0x0p+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0p+ 0x0p+) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.187.wat:1:31: error: unexpected token 0x0p+.
+  (func (v128.const f64x2 0x0p+ 0x0p+) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:445: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.188.wat:1:25: error: unexpected token "0x0p-", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0p- 0x0p-) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.188.wat:1:31: error: unexpected token 0x0p-.
+  (func (v128.const f64x2 0x0p- 0x0p-) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:449: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.189.wat:1:25: error: unexpected token "0x0.0p", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0.0p 0x0.0p) drop)
+                          ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.189.wat:1:32: error: unexpected token 0x0.0p.
+  (func (v128.const f64x2 0x0.0p 0x0.0p) drop)
+                                 ^^^^^^
+out/test/spec/simd/simd_const.wast:453: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.190.wat:1:25: error: unexpected token "0x0.0p+", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0.0p+ 0x0.0p+) drop)
+                          ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.190.wat:1:33: error: unexpected token 0x0.0p+.
+  (func (v128.const f64x2 0x0.0p+ 0x0.0p+) drop)
+                                  ^^^^^^^
+out/test/spec/simd/simd_const.wast:457: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.191.wat:1:25: error: unexpected token "0x0.0p-", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0.0p- 0x0.0p-) drop)
+                          ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.191.wat:1:33: error: unexpected token 0x0.0p-.
+  (func (v128.const f64x2 0x0.0p- 0x0.0p-) drop)
+                                  ^^^^^^^
+out/test/spec/simd/simd_const.wast:461: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.192.wat:1:25: error: unexpected token "0x0pA", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 0x0pA 0x0pA) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.192.wat:1:31: error: unexpected token 0x0pA.
+  (func (v128.const f64x2 0x0pA 0x0pA) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:465: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.193.wat:1:25: error: unexpected token "nan:1", expected a Float literal (e.g. 42.0).
+  (func (v128.const f64x2 nan:1 nan:1) drop)
+                          ^^^^^
+  out/test/spec/simd/simd_const/simd_const.193.wat:1:31: error: unexpected token nan:1.
+  (func (v128.const f64x2 nan:1 nan:1) drop)
+                                ^^^^^
+out/test/spec/simd/simd_const.wast:469: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.194.wat:1:25: error: invalid literal "nan:0x0"
+  (func (v128.const f64x2 nan:0x0 nan:0x0) drop)
+                          ^^^^^^^
+out/test/spec/simd/simd_const.wast:476: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.195.wat:1:25: error: invalid literal "0x10000000000000000"
+  (func (v128.const i32x4 0x10000000000000000 0x10000000000000000) drop)
+                          ^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:482: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.196.wat:1:41: error: unexpected token 0x1, expected ).
+  (func (v128.const i32x4 0x1 0x1 0x1 0x1 0x1) drop)
+                                          ^^^
+out/test/spec/simd/simd_const.wast:1131: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.389.wat:1:32: error: unexpected token "_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 _100 _100 _100 _100))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.389.wat:1:37: error: unexpected token _100.
+  (global v128 (v128.const i32x4 _100 _100 _100 _100))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.389.wat:1:42: error: unexpected token _100.
+  (global v128 (v128.const i32x4 _100 _100 _100 _100))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.389.wat:1:47: error: unexpected token _100.
+  (global v128 (v128.const i32x4 _100 _100 _100 _100))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1135: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.390.wat:1:32: error: unexpected token "+_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 +_100 +_100 +_100 +_100))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.390.wat:1:38: error: unexpected token +_100.
+  (global v128 (v128.const i32x4 +_100 +_100 +_100 +_100))
+                                       ^^^^^
+  out/test/spec/simd/simd_const/simd_const.390.wat:1:44: error: unexpected token +_100.
+  (global v128 (v128.const i32x4 +_100 +_100 +_100 +_100))
+                                             ^^^^^
+  out/test/spec/simd/simd_const/simd_const.390.wat:1:50: error: unexpected token +_100.
+  (global v128 (v128.const i32x4 +_100 +_100 +_100 +_100))
+                                                   ^^^^^
+out/test/spec/simd/simd_const.wast:1139: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.391.wat:1:32: error: unexpected token "-_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 -_100 -_100 -_100 -_100))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.391.wat:1:38: error: unexpected token -_100.
+  (global v128 (v128.const i32x4 -_100 -_100 -_100 -_100))
+                                       ^^^^^
+  out/test/spec/simd/simd_const/simd_const.391.wat:1:44: error: unexpected token -_100.
+  (global v128 (v128.const i32x4 -_100 -_100 -_100 -_100))
+                                             ^^^^^
+  out/test/spec/simd/simd_const/simd_const.391.wat:1:50: error: unexpected token -_100.
+  (global v128 (v128.const i32x4 -_100 -_100 -_100 -_100))
+                                                   ^^^^^
+out/test/spec/simd/simd_const.wast:1143: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.392.wat:1:32: error: unexpected token "99_", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 99_ 99_ 99_ 99_))
+                                 ^^^
+  out/test/spec/simd/simd_const/simd_const.392.wat:1:36: error: unexpected token 99_.
+  (global v128 (v128.const i32x4 99_ 99_ 99_ 99_))
+                                     ^^^
+  out/test/spec/simd/simd_const/simd_const.392.wat:1:40: error: unexpected token 99_.
+  (global v128 (v128.const i32x4 99_ 99_ 99_ 99_))
+                                         ^^^
+  out/test/spec/simd/simd_const/simd_const.392.wat:1:44: error: unexpected token 99_.
+  (global v128 (v128.const i32x4 99_ 99_ 99_ 99_))
+                                             ^^^
+out/test/spec/simd/simd_const.wast:1147: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.393.wat:1:32: error: unexpected token "1__000", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 1__000 1__000 1__000 1__000))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.393.wat:1:39: error: unexpected token 1__000.
+  (global v128 (v128.const i32x4 1__000 1__000 1__000 1__000))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.393.wat:1:46: error: unexpected token 1__000.
+  (global v128 (v128.const i32x4 1__000 1__000 1__000 1__000))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.393.wat:1:53: error: unexpected token 1__000.
+  (global v128 (v128.const i32x4 1__000 1__000 1__000 1__000))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1151: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.394.wat:1:32: error: unexpected token "_0x100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 _0x100 _0x100 _0x100 _0x100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.394.wat:1:39: error: unexpected token _0x100.
+  (global v128 (v128.const i32x4 _0x100 _0x100 _0x100 _0x100))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.394.wat:1:46: error: unexpected token _0x100.
+  (global v128 (v128.const i32x4 _0x100 _0x100 _0x100 _0x100))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.394.wat:1:53: error: unexpected token _0x100.
+  (global v128 (v128.const i32x4 _0x100 _0x100 _0x100 _0x100))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1155: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.395.wat:1:32: error: unexpected token "0_x100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 0_x100 0_x100 0_x100 0_x100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.395.wat:1:39: error: unexpected token 0_x100.
+  (global v128 (v128.const i32x4 0_x100 0_x100 0_x100 0_x100))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.395.wat:1:46: error: unexpected token 0_x100.
+  (global v128 (v128.const i32x4 0_x100 0_x100 0_x100 0_x100))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.395.wat:1:53: error: unexpected token 0_x100.
+  (global v128 (v128.const i32x4 0_x100 0_x100 0_x100 0_x100))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1159: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.396.wat:1:32: error: unexpected token "0x_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 0x_100 0x_100 0x_100 0x_100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.396.wat:1:39: error: unexpected token 0x_100.
+  (global v128 (v128.const i32x4 0x_100 0x_100 0x_100 0x_100))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.396.wat:1:46: error: unexpected token 0x_100.
+  (global v128 (v128.const i32x4 0x_100 0x_100 0x_100 0x_100))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.396.wat:1:53: error: unexpected token 0x_100.
+  (global v128 (v128.const i32x4 0x_100 0x_100 0x_100 0x_100))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1163: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.397.wat:1:32: error: unexpected token "0x00_", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.397.wat:1:38: error: unexpected token 0x00_.
+  (global v128 (v128.const i32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                       ^^^^^
+  out/test/spec/simd/simd_const/simd_const.397.wat:1:44: error: unexpected token 0x00_.
+  (global v128 (v128.const i32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                             ^^^^^
+  out/test/spec/simd/simd_const/simd_const.397.wat:1:50: error: unexpected token 0x00_.
+  (global v128 (v128.const i32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                                   ^^^^^
+out/test/spec/simd/simd_const.wast:1167: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.398.wat:1:32: error: unexpected token "0xff__ffff", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                 ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.398.wat:1:43: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const i32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                            ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.398.wat:1:54: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const i32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                                       ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.398.wat:1:65: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const i32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                                                  ^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1172: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.399.wat:1:32: error: unexpected token "_100_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 _100_100 _100_100))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.399.wat:1:41: error: unexpected token _100_100.
+  (global v128 (v128.const i64x2 _100_100 _100_100))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1176: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.400.wat:1:32: error: unexpected token "+_100_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 +_100_100 +_100_100))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.400.wat:1:42: error: unexpected token +_100_100.
+  (global v128 (v128.const i64x2 +_100_100 +_100_100))
+                                           ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1180: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.401.wat:1:32: error: unexpected token "-_100_100", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 -_100_100 -_100_100))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.401.wat:1:42: error: unexpected token -_100_100.
+  (global v128 (v128.const i64x2 -_100_100 -_100_100))
+                                           ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1184: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.402.wat:1:32: error: unexpected token "99_99_", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 99_99_ 99_99_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.402.wat:1:39: error: unexpected token 99_99_.
+  (global v128 (v128.const i64x2 99_99_ 99_99_))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1188: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.403.wat:1:32: error: unexpected token "1__000_000", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 1__000_000 1__000_000))
+                                 ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.403.wat:1:43: error: unexpected token 1__000_000.
+  (global v128 (v128.const i64x2 1__000_000 1__000_000))
+                                            ^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1192: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.404.wat:1:32: error: unexpected token "_0x100000", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 _0x100000 _0x100000))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.404.wat:1:42: error: unexpected token _0x100000.
+  (global v128 (v128.const i64x2 _0x100000 _0x100000))
+                                           ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1196: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.405.wat:1:32: error: unexpected token "0_x100000", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 0_x100000 0_x100000))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.405.wat:1:42: error: unexpected token 0_x100000.
+  (global v128 (v128.const i64x2 0_x100000 0_x100000))
+                                           ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1200: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.406.wat:1:32: error: unexpected token "0x_100000", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 0x_100000 0x_100000))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.406.wat:1:42: error: unexpected token 0x_100000.
+  (global v128 (v128.const i64x2 0x_100000 0x_100000))
+                                           ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1204: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.407.wat:1:32: error: unexpected token "0x00_", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 0x00_ 0x00_))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.407.wat:1:38: error: unexpected token 0x00_.
+  (global v128 (v128.const i64x2 0x00_ 0x00_))
+                                       ^^^^^
+out/test/spec/simd/simd_const.wast:1208: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.408.wat:1:32: error: unexpected token "0xff__ffff_ffff_ffff", expected a Nat or Integer literal (e.g. 123).
+  (global v128 (v128.const i64x2 0xff__ffff_ffff_ffff 0xff__ffff_ffff_ffff))
+                                 ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.408.wat:1:53: error: unexpected token 0xff__ffff_ffff_ffff.
+  (global v128 (v128.const i64x2 0xff__ffff_ffff_ffff 0xff__ffff_ffff_ffff))
+                                                      ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1259: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.410.wat:1:32: error: unexpected token "_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 _100 _100 _100 _100))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.410.wat:1:37: error: unexpected token _100.
+  (global v128 (v128.const f32x4 _100 _100 _100 _100))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.410.wat:1:42: error: unexpected token _100.
+  (global v128 (v128.const f32x4 _100 _100 _100 _100))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.410.wat:1:47: error: unexpected token _100.
+  (global v128 (v128.const f32x4 _100 _100 _100 _100))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1263: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.411.wat:1:32: error: unexpected token "+_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 +_100 +_100 +_100 +_100))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.411.wat:1:38: error: unexpected token +_100.
+  (global v128 (v128.const f32x4 +_100 +_100 +_100 +_100))
+                                       ^^^^^
+  out/test/spec/simd/simd_const/simd_const.411.wat:1:44: error: unexpected token +_100.
+  (global v128 (v128.const f32x4 +_100 +_100 +_100 +_100))
+                                             ^^^^^
+  out/test/spec/simd/simd_const/simd_const.411.wat:1:50: error: unexpected token +_100.
+  (global v128 (v128.const f32x4 +_100 +_100 +_100 +_100))
+                                                   ^^^^^
+out/test/spec/simd/simd_const.wast:1267: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.412.wat:1:32: error: unexpected token "-_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 -_100 -_100 -_100 -_100))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.412.wat:1:38: error: unexpected token -_100.
+  (global v128 (v128.const f32x4 -_100 -_100 -_100 -_100))
+                                       ^^^^^
+  out/test/spec/simd/simd_const/simd_const.412.wat:1:44: error: unexpected token -_100.
+  (global v128 (v128.const f32x4 -_100 -_100 -_100 -_100))
+                                             ^^^^^
+  out/test/spec/simd/simd_const/simd_const.412.wat:1:50: error: unexpected token -_100.
+  (global v128 (v128.const f32x4 -_100 -_100 -_100 -_100))
+                                                   ^^^^^
+out/test/spec/simd/simd_const.wast:1271: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.413.wat:1:32: error: unexpected token "99_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 99_ 99_ 99_ 99_))
+                                 ^^^
+  out/test/spec/simd/simd_const/simd_const.413.wat:1:36: error: unexpected token 99_.
+  (global v128 (v128.const f32x4 99_ 99_ 99_ 99_))
+                                     ^^^
+  out/test/spec/simd/simd_const/simd_const.413.wat:1:40: error: unexpected token 99_.
+  (global v128 (v128.const f32x4 99_ 99_ 99_ 99_))
+                                         ^^^
+  out/test/spec/simd/simd_const/simd_const.413.wat:1:44: error: unexpected token 99_.
+  (global v128 (v128.const f32x4 99_ 99_ 99_ 99_))
+                                             ^^^
+out/test/spec/simd/simd_const.wast:1275: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.414.wat:1:32: error: unexpected token "1__000", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1__000 1__000 1__000 1__000))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.414.wat:1:39: error: unexpected token 1__000.
+  (global v128 (v128.const f32x4 1__000 1__000 1__000 1__000))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.414.wat:1:46: error: unexpected token 1__000.
+  (global v128 (v128.const f32x4 1__000 1__000 1__000 1__000))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.414.wat:1:53: error: unexpected token 1__000.
+  (global v128 (v128.const f32x4 1__000 1__000 1__000 1__000))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1279: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.415.wat:1:32: error: unexpected token "_1.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 _1.0 _1.0 _1.0 _1.0))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.415.wat:1:37: error: unexpected token _1.0.
+  (global v128 (v128.const f32x4 _1.0 _1.0 _1.0 _1.0))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.415.wat:1:42: error: unexpected token _1.0.
+  (global v128 (v128.const f32x4 _1.0 _1.0 _1.0 _1.0))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.415.wat:1:47: error: unexpected token _1.0.
+  (global v128 (v128.const f32x4 _1.0 _1.0 _1.0 _1.0))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1283: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.416.wat:1:32: error: unexpected token "1.0_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1.0_ 1.0_ 1.0_ 1.0_))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.416.wat:1:37: error: unexpected token 1.0_.
+  (global v128 (v128.const f32x4 1.0_ 1.0_ 1.0_ 1.0_))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.416.wat:1:42: error: unexpected token 1.0_.
+  (global v128 (v128.const f32x4 1.0_ 1.0_ 1.0_ 1.0_))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.416.wat:1:47: error: unexpected token 1.0_.
+  (global v128 (v128.const f32x4 1.0_ 1.0_ 1.0_ 1.0_))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1287: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.417.wat:1:32: error: unexpected token "1_.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1_.0 1_.0 1_.0 1_.0))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.417.wat:1:37: error: unexpected token 1_.0.
+  (global v128 (v128.const f32x4 1_.0 1_.0 1_.0 1_.0))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.417.wat:1:42: error: unexpected token 1_.0.
+  (global v128 (v128.const f32x4 1_.0 1_.0 1_.0 1_.0))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.417.wat:1:47: error: unexpected token 1_.0.
+  (global v128 (v128.const f32x4 1_.0 1_.0 1_.0 1_.0))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1291: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.418.wat:1:32: error: unexpected token "1._0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1._0 1._0 1._0 1._0))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.418.wat:1:37: error: unexpected token 1._0.
+  (global v128 (v128.const f32x4 1._0 1._0 1._0 1._0))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.418.wat:1:42: error: unexpected token 1._0.
+  (global v128 (v128.const f32x4 1._0 1._0 1._0 1._0))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.418.wat:1:47: error: unexpected token 1._0.
+  (global v128 (v128.const f32x4 1._0 1._0 1._0 1._0))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1295: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.419.wat:1:32: error: unexpected token "_1e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 _1e1 _1e1 _1e1 _1e1))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.419.wat:1:37: error: unexpected token _1e1.
+  (global v128 (v128.const f32x4 _1e1 _1e1 _1e1 _1e1))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.419.wat:1:42: error: unexpected token _1e1.
+  (global v128 (v128.const f32x4 _1e1 _1e1 _1e1 _1e1))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.419.wat:1:47: error: unexpected token _1e1.
+  (global v128 (v128.const f32x4 _1e1 _1e1 _1e1 _1e1))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1299: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.420.wat:1:32: error: unexpected token "1e1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1e1_ 1e1_ 1e1_ 1e1_))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.420.wat:1:37: error: unexpected token 1e1_.
+  (global v128 (v128.const f32x4 1e1_ 1e1_ 1e1_ 1e1_))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.420.wat:1:42: error: unexpected token 1e1_.
+  (global v128 (v128.const f32x4 1e1_ 1e1_ 1e1_ 1e1_))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.420.wat:1:47: error: unexpected token 1e1_.
+  (global v128 (v128.const f32x4 1e1_ 1e1_ 1e1_ 1e1_))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1303: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.421.wat:1:32: error: unexpected token "1_e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1_e1 1_e1 1_e1 1_e1))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.421.wat:1:37: error: unexpected token 1_e1.
+  (global v128 (v128.const f32x4 1_e1 1_e1 1_e1 1_e1))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.421.wat:1:42: error: unexpected token 1_e1.
+  (global v128 (v128.const f32x4 1_e1 1_e1 1_e1 1_e1))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.421.wat:1:47: error: unexpected token 1_e1.
+  (global v128 (v128.const f32x4 1_e1 1_e1 1_e1 1_e1))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1307: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.422.wat:1:32: error: unexpected token "1e_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1e_1 1e_1 1e_1 1e_1))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.422.wat:1:37: error: unexpected token 1e_1.
+  (global v128 (v128.const f32x4 1e_1 1e_1 1e_1 1e_1))
+                                      ^^^^
+  out/test/spec/simd/simd_const/simd_const.422.wat:1:42: error: unexpected token 1e_1.
+  (global v128 (v128.const f32x4 1e_1 1e_1 1e_1 1e_1))
+                                           ^^^^
+  out/test/spec/simd/simd_const/simd_const.422.wat:1:47: error: unexpected token 1e_1.
+  (global v128 (v128.const f32x4 1e_1 1e_1 1e_1 1e_1))
+                                                ^^^^
+out/test/spec/simd/simd_const.wast:1311: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.423.wat:1:32: error: unexpected token "_1.0e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 _1.0e1 _1.0e1 _1.0e1 _1.0e1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.423.wat:1:39: error: unexpected token _1.0e1.
+  (global v128 (v128.const f32x4 _1.0e1 _1.0e1 _1.0e1 _1.0e1))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.423.wat:1:46: error: unexpected token _1.0e1.
+  (global v128 (v128.const f32x4 _1.0e1 _1.0e1 _1.0e1 _1.0e1))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.423.wat:1:53: error: unexpected token _1.0e1.
+  (global v128 (v128.const f32x4 _1.0e1 _1.0e1 _1.0e1 _1.0e1))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1315: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.424.wat:1:32: error: unexpected token "1.0e1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1.0e1_ 1.0e1_ 1.0e1_ 1.0e1_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.424.wat:1:39: error: unexpected token 1.0e1_.
+  (global v128 (v128.const f32x4 1.0e1_ 1.0e1_ 1.0e1_ 1.0e1_))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.424.wat:1:46: error: unexpected token 1.0e1_.
+  (global v128 (v128.const f32x4 1.0e1_ 1.0e1_ 1.0e1_ 1.0e1_))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.424.wat:1:53: error: unexpected token 1.0e1_.
+  (global v128 (v128.const f32x4 1.0e1_ 1.0e1_ 1.0e1_ 1.0e1_))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1319: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.425.wat:1:32: error: unexpected token "1.0_e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1.0_e1 1.0_e1 1.0_e1 1.0_e1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.425.wat:1:39: error: unexpected token 1.0_e1.
+  (global v128 (v128.const f32x4 1.0_e1 1.0_e1 1.0_e1 1.0_e1))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.425.wat:1:46: error: unexpected token 1.0_e1.
+  (global v128 (v128.const f32x4 1.0_e1 1.0_e1 1.0_e1 1.0_e1))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.425.wat:1:53: error: unexpected token 1.0_e1.
+  (global v128 (v128.const f32x4 1.0_e1 1.0_e1 1.0_e1 1.0_e1))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1323: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.426.wat:1:32: error: unexpected token "1.0e_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1.0e_1 1.0e_1 1.0e_1 1.0e_1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.426.wat:1:39: error: unexpected token 1.0e_1.
+  (global v128 (v128.const f32x4 1.0e_1 1.0e_1 1.0e_1 1.0e_1))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.426.wat:1:46: error: unexpected token 1.0e_1.
+  (global v128 (v128.const f32x4 1.0e_1 1.0e_1 1.0e_1 1.0e_1))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.426.wat:1:53: error: unexpected token 1.0e_1.
+  (global v128 (v128.const f32x4 1.0e_1 1.0e_1 1.0e_1 1.0e_1))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1327: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.427.wat:1:32: error: unexpected token "1.0e+_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1.0e+_1 1.0e+_1 1.0e+_1 1.0e+_1))
+                                 ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.427.wat:1:40: error: unexpected token 1.0e+_1.
+  (global v128 (v128.const f32x4 1.0e+_1 1.0e+_1 1.0e+_1 1.0e+_1))
+                                         ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.427.wat:1:48: error: unexpected token 1.0e+_1.
+  (global v128 (v128.const f32x4 1.0e+_1 1.0e+_1 1.0e+_1 1.0e+_1))
+                                                 ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.427.wat:1:56: error: unexpected token 1.0e+_1.
+  (global v128 (v128.const f32x4 1.0e+_1 1.0e+_1 1.0e+_1 1.0e+_1))
+                                                         ^^^^^^^
+out/test/spec/simd/simd_const.wast:1331: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.428.wat:1:32: error: unexpected token "1.0e_+1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 1.0e_+1 1.0e_+1 1.0e_+1 1.0e_+1))
+                                 ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.428.wat:1:40: error: unexpected token 1.0e_+1.
+  (global v128 (v128.const f32x4 1.0e_+1 1.0e_+1 1.0e_+1 1.0e_+1))
+                                         ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.428.wat:1:48: error: unexpected token 1.0e_+1.
+  (global v128 (v128.const f32x4 1.0e_+1 1.0e_+1 1.0e_+1 1.0e_+1))
+                                                 ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.428.wat:1:56: error: unexpected token 1.0e_+1.
+  (global v128 (v128.const f32x4 1.0e_+1 1.0e_+1 1.0e_+1 1.0e_+1))
+                                                         ^^^^^^^
+out/test/spec/simd/simd_const.wast:1335: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.429.wat:1:32: error: unexpected token "_0x100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 _0x100 _0x100 _0x100 _0x100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.429.wat:1:39: error: unexpected token _0x100.
+  (global v128 (v128.const f32x4 _0x100 _0x100 _0x100 _0x100))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.429.wat:1:46: error: unexpected token _0x100.
+  (global v128 (v128.const f32x4 _0x100 _0x100 _0x100 _0x100))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.429.wat:1:53: error: unexpected token _0x100.
+  (global v128 (v128.const f32x4 _0x100 _0x100 _0x100 _0x100))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1339: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.430.wat:1:32: error: unexpected token "0_x100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0_x100 0_x100 0_x100 0_x100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.430.wat:1:39: error: unexpected token 0_x100.
+  (global v128 (v128.const f32x4 0_x100 0_x100 0_x100 0_x100))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.430.wat:1:46: error: unexpected token 0_x100.
+  (global v128 (v128.const f32x4 0_x100 0_x100 0_x100 0_x100))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.430.wat:1:53: error: unexpected token 0_x100.
+  (global v128 (v128.const f32x4 0_x100 0_x100 0_x100 0_x100))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1343: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.431.wat:1:32: error: unexpected token "0x_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x_100 0x_100 0x_100 0x_100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.431.wat:1:39: error: unexpected token 0x_100.
+  (global v128 (v128.const f32x4 0x_100 0x_100 0x_100 0x_100))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.431.wat:1:46: error: unexpected token 0x_100.
+  (global v128 (v128.const f32x4 0x_100 0x_100 0x_100 0x_100))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.431.wat:1:53: error: unexpected token 0x_100.
+  (global v128 (v128.const f32x4 0x_100 0x_100 0x_100 0x_100))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1347: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.432.wat:1:32: error: unexpected token "0x00_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.432.wat:1:38: error: unexpected token 0x00_.
+  (global v128 (v128.const f32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                       ^^^^^
+  out/test/spec/simd/simd_const/simd_const.432.wat:1:44: error: unexpected token 0x00_.
+  (global v128 (v128.const f32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                             ^^^^^
+  out/test/spec/simd/simd_const/simd_const.432.wat:1:50: error: unexpected token 0x00_.
+  (global v128 (v128.const f32x4 0x00_ 0x00_ 0x00_ 0x00_))
+                                                   ^^^^^
+out/test/spec/simd/simd_const.wast:1351: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.433.wat:1:32: error: unexpected token "0xff__ffff", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                 ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.433.wat:1:43: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const f32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                            ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.433.wat:1:54: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const f32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                                       ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.433.wat:1:65: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const f32x4 0xff__ffff 0xff__ffff 0xff__ffff 0xff__ffff))
+                                                                  ^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1355: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.434.wat:1:32: error: unexpected token "0x_1.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x_1.0 0x_1.0 0x_1.0 0x_1.0))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.434.wat:1:39: error: unexpected token 0x_1.0.
+  (global v128 (v128.const f32x4 0x_1.0 0x_1.0 0x_1.0 0x_1.0))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.434.wat:1:46: error: unexpected token 0x_1.0.
+  (global v128 (v128.const f32x4 0x_1.0 0x_1.0 0x_1.0 0x_1.0))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.434.wat:1:53: error: unexpected token 0x_1.0.
+  (global v128 (v128.const f32x4 0x_1.0 0x_1.0 0x_1.0 0x_1.0))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1359: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.435.wat:1:32: error: unexpected token "0x1.0_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1.0_ 0x1.0_ 0x1.0_ 0x1.0_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.435.wat:1:39: error: unexpected token 0x1.0_.
+  (global v128 (v128.const f32x4 0x1.0_ 0x1.0_ 0x1.0_ 0x1.0_))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.435.wat:1:46: error: unexpected token 0x1.0_.
+  (global v128 (v128.const f32x4 0x1.0_ 0x1.0_ 0x1.0_ 0x1.0_))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.435.wat:1:53: error: unexpected token 0x1.0_.
+  (global v128 (v128.const f32x4 0x1.0_ 0x1.0_ 0x1.0_ 0x1.0_))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1363: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.436.wat:1:32: error: unexpected token "0x1_.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1_.0 0x1_.0 0x1_.0 0x1_.0))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.436.wat:1:39: error: unexpected token 0x1_.0.
+  (global v128 (v128.const f32x4 0x1_.0 0x1_.0 0x1_.0 0x1_.0))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.436.wat:1:46: error: unexpected token 0x1_.0.
+  (global v128 (v128.const f32x4 0x1_.0 0x1_.0 0x1_.0 0x1_.0))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.436.wat:1:53: error: unexpected token 0x1_.0.
+  (global v128 (v128.const f32x4 0x1_.0 0x1_.0 0x1_.0 0x1_.0))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1367: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.437.wat:1:32: error: unexpected token "0x1._0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1._0 0x1._0 0x1._0 0x1._0))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.437.wat:1:39: error: unexpected token 0x1._0.
+  (global v128 (v128.const f32x4 0x1._0 0x1._0 0x1._0 0x1._0))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.437.wat:1:46: error: unexpected token 0x1._0.
+  (global v128 (v128.const f32x4 0x1._0 0x1._0 0x1._0 0x1._0))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.437.wat:1:53: error: unexpected token 0x1._0.
+  (global v128 (v128.const f32x4 0x1._0 0x1._0 0x1._0 0x1._0))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1371: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.438.wat:1:32: error: unexpected token "0x_1p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x_1p1 0x_1p1 0x_1p1 0x_1p1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.438.wat:1:39: error: unexpected token 0x_1p1.
+  (global v128 (v128.const f32x4 0x_1p1 0x_1p1 0x_1p1 0x_1p1))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.438.wat:1:46: error: unexpected token 0x_1p1.
+  (global v128 (v128.const f32x4 0x_1p1 0x_1p1 0x_1p1 0x_1p1))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.438.wat:1:53: error: unexpected token 0x_1p1.
+  (global v128 (v128.const f32x4 0x_1p1 0x_1p1 0x_1p1 0x_1p1))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1375: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.439.wat:1:32: error: unexpected token "0x1p1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1p1_ 0x1p1_ 0x1p1_ 0x1p1_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.439.wat:1:39: error: unexpected token 0x1p1_.
+  (global v128 (v128.const f32x4 0x1p1_ 0x1p1_ 0x1p1_ 0x1p1_))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.439.wat:1:46: error: unexpected token 0x1p1_.
+  (global v128 (v128.const f32x4 0x1p1_ 0x1p1_ 0x1p1_ 0x1p1_))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.439.wat:1:53: error: unexpected token 0x1p1_.
+  (global v128 (v128.const f32x4 0x1p1_ 0x1p1_ 0x1p1_ 0x1p1_))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1379: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.440.wat:1:32: error: unexpected token "0x1_p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1_p1 0x1_p1 0x1_p1 0x1_p1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.440.wat:1:39: error: unexpected token 0x1_p1.
+  (global v128 (v128.const f32x4 0x1_p1 0x1_p1 0x1_p1 0x1_p1))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.440.wat:1:46: error: unexpected token 0x1_p1.
+  (global v128 (v128.const f32x4 0x1_p1 0x1_p1 0x1_p1 0x1_p1))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.440.wat:1:53: error: unexpected token 0x1_p1.
+  (global v128 (v128.const f32x4 0x1_p1 0x1_p1 0x1_p1 0x1_p1))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1383: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.441.wat:1:32: error: unexpected token "0x1p_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1p_1 0x1p_1 0x1p_1 0x1p_1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.441.wat:1:39: error: unexpected token 0x1p_1.
+  (global v128 (v128.const f32x4 0x1p_1 0x1p_1 0x1p_1 0x1p_1))
+                                        ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.441.wat:1:46: error: unexpected token 0x1p_1.
+  (global v128 (v128.const f32x4 0x1p_1 0x1p_1 0x1p_1 0x1p_1))
+                                               ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.441.wat:1:53: error: unexpected token 0x1p_1.
+  (global v128 (v128.const f32x4 0x1p_1 0x1p_1 0x1p_1 0x1p_1))
+                                                      ^^^^^^
+out/test/spec/simd/simd_const.wast:1387: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.442.wat:1:32: error: unexpected token "0x_1.0p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x_1.0p1 0x_1.0p1 0x_1.0p1 0x_1.0p1))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.442.wat:1:41: error: unexpected token 0x_1.0p1.
+  (global v128 (v128.const f32x4 0x_1.0p1 0x_1.0p1 0x_1.0p1 0x_1.0p1))
+                                          ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.442.wat:1:50: error: unexpected token 0x_1.0p1.
+  (global v128 (v128.const f32x4 0x_1.0p1 0x_1.0p1 0x_1.0p1 0x_1.0p1))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.442.wat:1:59: error: unexpected token 0x_1.0p1.
+  (global v128 (v128.const f32x4 0x_1.0p1 0x_1.0p1 0x_1.0p1 0x_1.0p1))
+                                                            ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1391: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.443.wat:1:32: error: unexpected token "0x1.0p1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1.0p1_ 0x1.0p1_ 0x1.0p1_ 0x1.0p1_))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.443.wat:1:41: error: unexpected token 0x1.0p1_.
+  (global v128 (v128.const f32x4 0x1.0p1_ 0x1.0p1_ 0x1.0p1_ 0x1.0p1_))
+                                          ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.443.wat:1:50: error: unexpected token 0x1.0p1_.
+  (global v128 (v128.const f32x4 0x1.0p1_ 0x1.0p1_ 0x1.0p1_ 0x1.0p1_))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.443.wat:1:59: error: unexpected token 0x1.0p1_.
+  (global v128 (v128.const f32x4 0x1.0p1_ 0x1.0p1_ 0x1.0p1_ 0x1.0p1_))
+                                                            ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1395: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.444.wat:1:32: error: unexpected token "0x1.0_p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1.0_p1 0x1.0_p1 0x1.0_p1 0x1.0_p1))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.444.wat:1:41: error: unexpected token 0x1.0_p1.
+  (global v128 (v128.const f32x4 0x1.0_p1 0x1.0_p1 0x1.0_p1 0x1.0_p1))
+                                          ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.444.wat:1:50: error: unexpected token 0x1.0_p1.
+  (global v128 (v128.const f32x4 0x1.0_p1 0x1.0_p1 0x1.0_p1 0x1.0_p1))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.444.wat:1:59: error: unexpected token 0x1.0_p1.
+  (global v128 (v128.const f32x4 0x1.0_p1 0x1.0_p1 0x1.0_p1 0x1.0_p1))
+                                                            ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1399: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.445.wat:1:32: error: unexpected token "0x1.0p_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1.0p_1 0x1.0p_1 0x1.0p_1 0x1.0p_1))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.445.wat:1:41: error: unexpected token 0x1.0p_1.
+  (global v128 (v128.const f32x4 0x1.0p_1 0x1.0p_1 0x1.0p_1 0x1.0p_1))
+                                          ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.445.wat:1:50: error: unexpected token 0x1.0p_1.
+  (global v128 (v128.const f32x4 0x1.0p_1 0x1.0p_1 0x1.0p_1 0x1.0p_1))
+                                                   ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.445.wat:1:59: error: unexpected token 0x1.0p_1.
+  (global v128 (v128.const f32x4 0x1.0p_1 0x1.0p_1 0x1.0p_1 0x1.0p_1))
+                                                            ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1403: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.446.wat:1:32: error: unexpected token "0x1.0p+_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.446.wat:1:42: error: unexpected token 0x1.0p+_1.
+  (global v128 (v128.const f32x4 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1))
+                                           ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.446.wat:1:52: error: unexpected token 0x1.0p+_1.
+  (global v128 (v128.const f32x4 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1))
+                                                     ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.446.wat:1:62: error: unexpected token 0x1.0p+_1.
+  (global v128 (v128.const f32x4 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1 0x1.0p+_1))
+                                                               ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1407: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.447.wat:1:32: error: unexpected token "0x1.0p_+1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f32x4 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.447.wat:1:42: error: unexpected token 0x1.0p_+1.
+  (global v128 (v128.const f32x4 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1))
+                                           ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.447.wat:1:52: error: unexpected token 0x1.0p_+1.
+  (global v128 (v128.const f32x4 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1))
+                                                     ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.447.wat:1:62: error: unexpected token 0x1.0p_+1.
+  (global v128 (v128.const f32x4 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1 0x1.0p_+1))
+                                                               ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1412: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.448.wat:1:32: error: unexpected token "_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 _100 _100))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.448.wat:1:37: error: unexpected token _100.
+  (global v128 (v128.const f64x2 _100 _100))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1416: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.449.wat:1:32: error: unexpected token "+_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 +_100 +_100))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.449.wat:1:38: error: unexpected token +_100.
+  (global v128 (v128.const f64x2 +_100 +_100))
+                                       ^^^^^
+out/test/spec/simd/simd_const.wast:1420: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.450.wat:1:32: error: unexpected token "-_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 -_100 -_100))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.450.wat:1:38: error: unexpected token -_100.
+  (global v128 (v128.const f64x2 -_100 -_100))
+                                       ^^^^^
+out/test/spec/simd/simd_const.wast:1424: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.451.wat:1:32: error: unexpected token "99_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 99_ 99_))
+                                 ^^^
+  out/test/spec/simd/simd_const/simd_const.451.wat:1:36: error: unexpected token 99_.
+  (global v128 (v128.const f64x2 99_ 99_))
+                                     ^^^
+out/test/spec/simd/simd_const.wast:1428: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.452.wat:1:32: error: unexpected token "1__000", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1__000 1__000))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.452.wat:1:39: error: unexpected token 1__000.
+  (global v128 (v128.const f64x2 1__000 1__000))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1432: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.453.wat:1:32: error: unexpected token "_1.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 _1.0 _1.0))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.453.wat:1:37: error: unexpected token _1.0.
+  (global v128 (v128.const f64x2 _1.0 _1.0))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1436: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.454.wat:1:32: error: unexpected token "1.0_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1.0_ 1.0_))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.454.wat:1:37: error: unexpected token 1.0_.
+  (global v128 (v128.const f64x2 1.0_ 1.0_))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1440: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.455.wat:1:32: error: unexpected token "1_.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1_.0 1_.0))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.455.wat:1:37: error: unexpected token 1_.0.
+  (global v128 (v128.const f64x2 1_.0 1_.0))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1444: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.456.wat:1:32: error: unexpected token "1._0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1._0 1._0))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.456.wat:1:37: error: unexpected token 1._0.
+  (global v128 (v128.const f64x2 1._0 1._0))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1448: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.457.wat:1:32: error: unexpected token "_1e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 _1e1 _1e1))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.457.wat:1:37: error: unexpected token _1e1.
+  (global v128 (v128.const f64x2 _1e1 _1e1))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1452: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.458.wat:1:32: error: unexpected token "1e1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1e1_ 1e1_))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.458.wat:1:37: error: unexpected token 1e1_.
+  (global v128 (v128.const f64x2 1e1_ 1e1_))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1456: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.459.wat:1:32: error: unexpected token "1_e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1_e1 1_e1))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.459.wat:1:37: error: unexpected token 1_e1.
+  (global v128 (v128.const f64x2 1_e1 1_e1))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1460: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.460.wat:1:32: error: unexpected token "1e_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1e_1 1e_1))
+                                 ^^^^
+  out/test/spec/simd/simd_const/simd_const.460.wat:1:37: error: unexpected token 1e_1.
+  (global v128 (v128.const f64x2 1e_1 1e_1))
+                                      ^^^^
+out/test/spec/simd/simd_const.wast:1464: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.461.wat:1:32: error: unexpected token "_1.0e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 _1.0e1 _1.0e1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.461.wat:1:39: error: unexpected token _1.0e1.
+  (global v128 (v128.const f64x2 _1.0e1 _1.0e1))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1468: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.462.wat:1:32: error: unexpected token "1.0e1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1.0e1_ 1.0e1_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.462.wat:1:39: error: unexpected token 1.0e1_.
+  (global v128 (v128.const f64x2 1.0e1_ 1.0e1_))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1472: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.463.wat:1:32: error: unexpected token "1.0_e1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1.0_e1 1.0_e1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.463.wat:1:39: error: unexpected token 1.0_e1.
+  (global v128 (v128.const f64x2 1.0_e1 1.0_e1))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1476: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.464.wat:1:32: error: unexpected token "1.0e_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1.0e_1 1.0e_1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.464.wat:1:39: error: unexpected token 1.0e_1.
+  (global v128 (v128.const f64x2 1.0e_1 1.0e_1))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1480: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.465.wat:1:32: error: unexpected token "1.0e+_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1.0e+_1 1.0e+_1))
+                                 ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.465.wat:1:40: error: unexpected token 1.0e+_1.
+  (global v128 (v128.const f64x2 1.0e+_1 1.0e+_1))
+                                         ^^^^^^^
+out/test/spec/simd/simd_const.wast:1484: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.466.wat:1:32: error: unexpected token "1.0e_+1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 1.0e_+1 1.0e_+1))
+                                 ^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.466.wat:1:40: error: unexpected token 1.0e_+1.
+  (global v128 (v128.const f64x2 1.0e_+1 1.0e_+1))
+                                         ^^^^^^^
+out/test/spec/simd/simd_const.wast:1488: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.467.wat:1:32: error: unexpected token "_0x100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 _0x100 _0x100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.467.wat:1:39: error: unexpected token _0x100.
+  (global v128 (v128.const f64x2 _0x100 _0x100))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1492: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.468.wat:1:32: error: unexpected token "0_x100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0_x100 0_x100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.468.wat:1:39: error: unexpected token 0_x100.
+  (global v128 (v128.const f64x2 0_x100 0_x100))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1496: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.469.wat:1:32: error: unexpected token "0x_100", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x_100 0x_100))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.469.wat:1:39: error: unexpected token 0x_100.
+  (global v128 (v128.const f64x2 0x_100 0x_100))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1500: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.470.wat:1:32: error: unexpected token "0x00_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x00_ 0x00_))
+                                 ^^^^^
+  out/test/spec/simd/simd_const/simd_const.470.wat:1:38: error: unexpected token 0x00_.
+  (global v128 (v128.const f64x2 0x00_ 0x00_))
+                                       ^^^^^
+out/test/spec/simd/simd_const.wast:1504: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.471.wat:1:32: error: unexpected token "0xff__ffff", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0xff__ffff 0xff__ffff))
+                                 ^^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.471.wat:1:43: error: unexpected token 0xff__ffff.
+  (global v128 (v128.const f64x2 0xff__ffff 0xff__ffff))
+                                            ^^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1508: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.472.wat:1:32: error: unexpected token "0x_1.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x_1.0 0x_1.0))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.472.wat:1:39: error: unexpected token 0x_1.0.
+  (global v128 (v128.const f64x2 0x_1.0 0x_1.0))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1512: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.473.wat:1:32: error: unexpected token "0x1.0_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1.0_ 0x1.0_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.473.wat:1:39: error: unexpected token 0x1.0_.
+  (global v128 (v128.const f64x2 0x1.0_ 0x1.0_))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1516: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.474.wat:1:32: error: unexpected token "0x1_.0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1_.0 0x1_.0))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.474.wat:1:39: error: unexpected token 0x1_.0.
+  (global v128 (v128.const f64x2 0x1_.0 0x1_.0))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1520: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.475.wat:1:32: error: unexpected token "0x1._0", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1._0 0x1._0))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.475.wat:1:39: error: unexpected token 0x1._0.
+  (global v128 (v128.const f64x2 0x1._0 0x1._0))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1524: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.476.wat:1:32: error: unexpected token "0x_1p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x_1p1 0x_1p1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.476.wat:1:39: error: unexpected token 0x_1p1.
+  (global v128 (v128.const f64x2 0x_1p1 0x_1p1))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1528: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.477.wat:1:32: error: unexpected token "0x1p1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1p1_ 0x1p1_))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.477.wat:1:39: error: unexpected token 0x1p1_.
+  (global v128 (v128.const f64x2 0x1p1_ 0x1p1_))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1532: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.478.wat:1:32: error: unexpected token "0x1_p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1_p1 0x1_p1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.478.wat:1:39: error: unexpected token 0x1_p1.
+  (global v128 (v128.const f64x2 0x1_p1 0x1_p1))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1536: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.479.wat:1:32: error: unexpected token "0x1p_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1p_1 0x1p_1))
+                                 ^^^^^^
+  out/test/spec/simd/simd_const/simd_const.479.wat:1:39: error: unexpected token 0x1p_1.
+  (global v128 (v128.const f64x2 0x1p_1 0x1p_1))
+                                        ^^^^^^
+out/test/spec/simd/simd_const.wast:1540: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.480.wat:1:32: error: unexpected token "0x_1.0p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x_1.0p1 0x_1.0p1))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.480.wat:1:41: error: unexpected token 0x_1.0p1.
+  (global v128 (v128.const f64x2 0x_1.0p1 0x_1.0p1))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1544: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.481.wat:1:32: error: unexpected token "0x1.0p1_", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1.0p1_ 0x1.0p1_))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.481.wat:1:41: error: unexpected token 0x1.0p1_.
+  (global v128 (v128.const f64x2 0x1.0p1_ 0x1.0p1_))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1548: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.482.wat:1:32: error: unexpected token "0x1.0_p1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1.0_p1 0x1.0_p1))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.482.wat:1:41: error: unexpected token 0x1.0_p1.
+  (global v128 (v128.const f64x2 0x1.0_p1 0x1.0_p1))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1552: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.483.wat:1:32: error: unexpected token "0x1.0p_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1.0p_1 0x1.0p_1))
+                                 ^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.483.wat:1:41: error: unexpected token 0x1.0p_1.
+  (global v128 (v128.const f64x2 0x1.0p_1 0x1.0p_1))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_const.wast:1556: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.484.wat:1:32: error: unexpected token "0x1.0p+_1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1.0p+_1 0x1.0p+_1))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.484.wat:1:42: error: unexpected token 0x1.0p+_1.
+  (global v128 (v128.const f64x2 0x1.0p+_1 0x1.0p+_1))
+                                           ^^^^^^^^^
+out/test/spec/simd/simd_const.wast:1560: assert_malformed passed:
+  out/test/spec/simd/simd_const/simd_const.485.wat:1:32: error: unexpected token "0x1.0p_+1", expected a Float literal (e.g. 42.0).
+  (global v128 (v128.const f64x2 0x1.0p_+1 0x1.0p_+1))
+                                 ^^^^^^^^^
+  out/test/spec/simd/simd_const/simd_const.485.wat:1:42: error: unexpected token 0x1.0p_+1.
+  (global v128 (v128.const f64x2 0x1.0p_+1 0x1.0p_+1))
+                                           ^^^^^^^^^
+444/444 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_conversions.txt
+++ b/test/spec/simd/simd_conversions.txt
@@ -1,0 +1,246 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_conversions.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_conversions.wast:988: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.1.wat:1:22: error: unexpected token "i32x4.trunc_sat_f32x4", expected an instr.
+  (func (result v128) (i32x4.trunc_sat_f32x4 (v128.const f32x4 0.0 0.0 0.0 0.0)))
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:991: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.2.wat:1:22: error: unexpected token "i32x4.trunc_s_sat_f32x4", expected an instr.
+  (func (result v128) (i32x4.trunc_s_sat_f32x4 (v128.const f32x4 -2.0 -1.0 1.0 ...
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:994: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.3.wat:1:22: error: unexpected token "i32x4.trunc_u_sat_f32x4", expected an instr.
+  (func (result v128) (i32x4.trunc_u_sat_f32x4 (v128.const f32x4 -2.0 -1.0 1.0 ...
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:997: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.4.wat:1:22: error: unexpected token "i32x4.convert_f32x4", expected an instr.
+  (func (result v128) (i32x4.convert_f32x4 (v128.const f32x4 -1 0 1 2)))
+                       ^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1000: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.5.wat:1:22: error: unexpected token "i32x4.convert_s_f32x4", expected an instr.
+  (func (result v128) (i32x4.convert_s_f32x4 (v128.const f32x4 -1 0 1 2)))
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1003: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.6.wat:1:22: error: unexpected token "i32x4.convert_u_f32x4", expected an instr.
+  (func (result v128) (i32x4.convert_u_f32x4 (v128.const f32x4 -1 0 1 2)))
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1007: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.7.wat:1:22: error: unexpected token "i64x2.trunc_sat_f64x2_s", expected an instr.
+  (func (result v128) (i64x2.trunc_sat_f64x2_s (v128.const f64x2 0.0 0.0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1010: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.8.wat:1:22: error: unexpected token "i64x2.trunc_sat_f64x2_u", expected an instr.
+  (func (result v128) (i64x2.trunc_sat_f64x2_u (v128.const f64x2 -2.0 -1.0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1013: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.9.wat:1:22: error: unexpected token "f64x2.convert_i64x2_s", expected an instr.
+  (func (result v128) (f64x2.convert_i64x2_s (v128.const i64x2 1 2)))
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1016: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.10.wat:1:22: error: unexpected token "f64x2.convert_i64x2_u", expected an instr.
+  (func (result v128) (f64x2.convert_i64x2_u (v128.const i64x2 1 2)))
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1020: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.11.wat:1:22: error: unexpected token "i8x16.narrow_i16x8", expected an instr.
+  (func (result v128) (i8x16.narrow_i16x8 (v128.const i16x8 0 0 0 0 0 0 0 0) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1023: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.12.wat:1:22: error: unexpected token "i16x8.narrow_i8x16", expected an instr.
+  (func (result v128) (i16x8.narrow_i8x16 (v128.const i16x8 0 0 0 0 0 0 0 0) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1026: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.13.wat:1:22: error: unexpected token "i16x8.narrow_i8x16_s", expected an instr.
+  (func (result v128) (i16x8.narrow_i8x16_s (v128.const i8x16 0 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1029: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.14.wat:1:22: error: unexpected token "i16x8.narrow_i8x16_u", expected an instr.
+  (func (result v128) (i16x8.narrow_i8x16_u (v128.const i8x16 0 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1032: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.15.wat:1:22: error: unexpected token "i16x8.narrow_i32x4", expected an instr.
+  (func (result v128) (i16x8.narrow_i32x4 (v128.const i16x8 0 0 0 0 0 0 0 0) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1035: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.16.wat:1:22: error: unexpected token "i32x4.narrow_i16x8", expected an instr.
+  (func (result v128) (i32x4.narrow_i16x8 (v128.const i16x8 0 0 0 0 0 0 0 0) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1038: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.17.wat:1:22: error: unexpected token "i32x4.narrow_i16x8_s", expected an instr.
+  (func (result v128) (i32x4.narrow_i16x8_s (v128.const i8x16 0 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1041: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.18.wat:1:22: error: unexpected token "i32x4.narrow_i16x8_u", expected an instr.
+  (func (result v128) (i32x4.narrow_i16x8_u (v128.const i8x16 0 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1045: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.19.wat:1:22: error: unexpected token "i16x8.widen_low_i8x16", expected an instr.
+  (func (result v128) (i16x8.widen_low_i8x16 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1048: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.20.wat:1:22: error: unexpected token "i8x16.widen_low_i16x8_s", expected an instr.
+  (func (result v128) (i8x16.widen_low_i16x8_s (v128.const i16x8 0 0 0 0 0 0 0 ...
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1051: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.21.wat:1:22: error: unexpected token "i8x16.widen_low_i16x8_u", expected an instr.
+  (func (result v128) (i8x16.widen_low_i16x8_u (v128.const i16x8 0 0 0 0 0 0 0 ...
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1054: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.22.wat:1:22: error: unexpected token "i16x8.widen_high_i8x16", expected an instr.
+  (func (result v128) (i16x8.widen_high_i8x16 (v128.const i8x16 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1057: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.23.wat:1:22: error: unexpected token "i8x16.widen_high_i16x8_s", expected an instr.
+  (func (result v128) (i8x16.widen_high_i16x8_s (v128.const i16x8 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1060: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.24.wat:1:22: error: unexpected token "i8x16.widen_high_i16x8_u", expected an instr.
+  (func (result v128) (i8x16.widen_high_i16x8_u (v128.const i16x8 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1063: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.25.wat:1:22: error: unexpected token "i32x4.widen_low_i16x8", expected an instr.
+  (func (result v128) (i32x4.widen_low_i16x8 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                       ^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1066: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.26.wat:1:22: error: unexpected token "i16x8.widen_low_i32x4_s", expected an instr.
+  (func (result v128) (i16x8.widen_low_i32x4_s (v128.const i32x4 0 0 0 0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1069: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.27.wat:1:22: error: unexpected token "i16x8.widen_low_i32x4_u", expected an instr.
+  (func (result v128) (i16x8.widen_low_i32x4_u (v128.const i32x4 0 0 0 0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1072: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.28.wat:1:22: error: unexpected token "i32x4.widen_high_i16x8", expected an instr.
+  (func (result v128) (i32x4.widen_high_i16x8 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1075: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.29.wat:1:22: error: unexpected token "i16x8.widen_high_i32x4_s", expected an instr.
+  (func (result v128) (i16x8.widen_high_i32x4_s (v128.const i32x4 0 0 0 0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1078: assert_malformed passed:
+  out/test/spec/simd/simd_conversions/simd_conversions.30.wat:1:22: error: unexpected token "i16x8.widen_high_i32x4_u", expected an instr.
+  (func (result v128) (i16x8.widen_high_i32x4_u (v128.const i32x4 0 0 0 0)))
+                       ^^^^^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_conversions.wast:1085: assert_invalid passed:
+  error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got [i32]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1086: assert_invalid passed:
+  error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got [i64]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1087: assert_invalid passed:
+  error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got [i32]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1088: assert_invalid passed:
+  error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got [i64]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1089: assert_invalid passed:
+  error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got [i32]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1090: assert_invalid passed:
+  error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got [i64]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1091: assert_invalid passed:
+  error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got [i32]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1092: assert_invalid passed:
+  error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got [i64]
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1094: assert_invalid passed:
+  error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got [i32, i64]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1095: assert_invalid passed:
+  error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got [i32, i64]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1096: assert_invalid passed:
+  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [f32, f64]
+  0000029: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1097: assert_invalid passed:
+  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [f32, f64]
+  0000029: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1099: assert_invalid passed:
+  error: type mismatch in i16x8.widen_low_i8x16_s, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1100: assert_invalid passed:
+  error: type mismatch in i16x8.widen_high_i8x16_s, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1101: assert_invalid passed:
+  error: type mismatch in i16x8.widen_low_i8x16_u, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1102: assert_invalid passed:
+  error: type mismatch in i16x8.widen_high_i8x16_u, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1103: assert_invalid passed:
+  error: type mismatch in i32x4.widen_low_i16x8_s, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1104: assert_invalid passed:
+  error: type mismatch in i32x4.widen_high_i16x8_s, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1105: assert_invalid passed:
+  error: type mismatch in i32x4.widen_low_i16x8_u, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1106: assert_invalid passed:
+  error: type mismatch in i32x4.widen_high_i16x8_u, expected [v128] but got [f32]
+  0000020: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1217: assert_invalid passed:
+  error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got []
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1225: assert_invalid passed:
+  error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got []
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1233: assert_invalid passed:
+  error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got []
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1241: assert_invalid passed:
+  error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got []
+  000001b: error: OnConvertExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1249: assert_invalid passed:
+  error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1257: assert_invalid passed:
+  error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1265: assert_invalid passed:
+  error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1273: assert_invalid passed:
+  error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1281: assert_invalid passed:
+  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1289: assert_invalid passed:
+  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1297: assert_invalid passed:
+  error: type mismatch in i16x8.narrow_i32x4_u, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1305: assert_invalid passed:
+  error: type mismatch in i16x8.narrow_i32x4_u, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1313: assert_invalid passed:
+  error: type mismatch in i16x8.widen_high_i8x16_s, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1321: assert_invalid passed:
+  error: type mismatch in i16x8.widen_high_i8x16_u, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1329: assert_invalid passed:
+  error: type mismatch in i16x8.widen_low_i8x16_s, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1337: assert_invalid passed:
+  error: type mismatch in i16x8.widen_low_i8x16_u, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1345: assert_invalid passed:
+  error: type mismatch in i32x4.widen_high_i16x8_s, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1353: assert_invalid passed:
+  error: type mismatch in i32x4.widen_high_i16x8_u, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1361: assert_invalid passed:
+  error: type mismatch in i32x4.widen_low_i16x8_s, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_conversions.wast:1369: assert_invalid passed:
+  error: type mismatch in i32x4.widen_low_i16x8_u, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+483/483 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_f32x4.txt
+++ b/test/spec/simd/simd_f32x4.txt
@@ -1,0 +1,78 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_f32x4.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_f32x4.wast:2325: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.1.wat:1:33: error: unexpected token "i8x16.abs", expected an instr.
+  (memory 1) (func (result v128) (i8x16.abs (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2326: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.2.wat:1:33: error: unexpected token "i8x16.min", expected an instr.
+  (memory 1) (func (result v128) (i8x16.min (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2327: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.3.wat:1:33: error: unexpected token "i8x16.max", expected an instr.
+  (memory 1) (func (result v128) (i8x16.max (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2328: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.4.wat:1:33: error: unexpected token "i16x8.abs", expected an instr.
+  (memory 1) (func (result v128) (i16x8.abs (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2329: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.5.wat:1:33: error: unexpected token "i16x8.min", expected an instr.
+  (memory 1) (func (result v128) (i16x8.min (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2330: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.6.wat:1:33: error: unexpected token "i16x8.max", expected an instr.
+  (memory 1) (func (result v128) (i16x8.max (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2331: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.7.wat:1:33: error: unexpected token "i32x4.abs", expected an instr.
+  (memory 1) (func (result v128) (i32x4.abs (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2332: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.8.wat:1:33: error: unexpected token "i32x4.min", expected an instr.
+  (memory 1) (func (result v128) (i32x4.min (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2333: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.9.wat:1:33: error: unexpected token "i32x4.max", expected an instr.
+  (memory 1) (func (result v128) (i32x4.max (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2334: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.10.wat:1:33: error: unexpected token "i64x2.abs", expected an instr.
+  (memory 1) (func (result v128) (i64x2.abs (v128.const i32x4 0 0 0 0)))
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2335: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.11.wat:1:33: error: unexpected token "i64x2.min", expected an instr.
+  (memory 1) (func (result v128) (i64x2.min (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2336: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4/simd_f32x4.12.wat:1:33: error: unexpected token "i64x2.max", expected an instr.
+  (memory 1) (func (result v128) (i64x2.max (v128.const i32x4 0 0 0 0) (v128.co...
+                                  ^^^^^^^^^
+out/test/spec/simd/simd_f32x4.wast:2339: assert_invalid passed:
+  error: type mismatch in f32x4.abs, expected [v128] but got [i32]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2340: assert_invalid passed:
+  error: type mismatch in f32x4.min, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2341: assert_invalid passed:
+  error: type mismatch in f32x4.max, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2346: assert_invalid passed:
+  error: type mismatch in f32x4.abs, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2354: assert_invalid passed:
+  error: type mismatch in f32x4.min, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2362: assert_invalid passed:
+  error: type mismatch in f32x4.min, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2370: assert_invalid passed:
+  error: type mismatch in f32x4.max, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4.wast:2378: assert_invalid passed:
+  error: type mismatch in f32x4.max, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+792/792 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_f32x4_arith.txt
+++ b/test/spec/simd/simd_f32x4_arith.txt
@@ -1,0 +1,54 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_f32x4_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_f32x4_arith.wast:5295: assert_invalid passed:
+  error: type mismatch in f32x4.neg, expected [v128] but got [i32]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5296: assert_invalid passed:
+  error: type mismatch in f32x4.sqrt, expected [v128] but got [i32]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5297: assert_invalid passed:
+  error: type mismatch in f32x4.add, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5298: assert_invalid passed:
+  error: type mismatch in f32x4.sub, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5299: assert_invalid passed:
+  error: type mismatch in f32x4.mul, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5300: assert_invalid passed:
+  error: type mismatch in f32x4.div, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5305: assert_invalid passed:
+  error: type mismatch in f32x4.neg, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5313: assert_invalid passed:
+  error: type mismatch in f32x4.sqrt, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5321: assert_invalid passed:
+  error: type mismatch in f32x4.add, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5329: assert_invalid passed:
+  error: type mismatch in f32x4.add, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5337: assert_invalid passed:
+  error: type mismatch in f32x4.sub, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5345: assert_invalid passed:
+  error: type mismatch in f32x4.sub, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5353: assert_invalid passed:
+  error: type mismatch in f32x4.mul, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5361: assert_invalid passed:
+  error: type mismatch in f32x4.mul, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5369: assert_invalid passed:
+  error: type mismatch in f32x4.div, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f32x4_arith.wast:5377: assert_invalid passed:
+  error: type mismatch in f32x4.div, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+1819/1819 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_f32x4_cmp.txt
+++ b/test/spec/simd/simd_f32x4_cmp.txt
@@ -1,0 +1,84 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_f32x4_cmp.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_f32x4_cmp.wast:7779: assert_invalid passed:
+  error: type mismatch in f32x4.eq, expected [v128, v128] but got [i64, f64]
+  0000025: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:7780: assert_invalid passed:
+  error: type mismatch in f32x4.ge, expected [v128, v128] but got [i64, f64]
+  0000025: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:7781: assert_invalid passed:
+  error: type mismatch in f32x4.gt, expected [v128, v128] but got [i64, f64]
+  0000025: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:7782: assert_invalid passed:
+  error: type mismatch in f32x4.le, expected [v128, v128] but got [i64, f64]
+  0000025: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:7783: assert_invalid passed:
+  error: type mismatch in f32x4.lt, expected [v128, v128] but got [i64, f64]
+  0000025: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:7784: assert_invalid passed:
+  error: type mismatch in f32x4.ne, expected [v128, v128] but got [i64, f64]
+  0000025: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:7789: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4_cmp/simd_f32x4_cmp.7.wat:1:65: error: unexpected token "f4x32.eq", expected an instr.
+  ...v128) (param $y v128) (result v128) (f4x32.eq (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f32x4_cmp.wast:7790: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4_cmp/simd_f32x4_cmp.8.wat:1:65: error: unexpected token "f4x32.ge", expected an instr.
+  ...v128) (param $y v128) (result v128) (f4x32.ge (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f32x4_cmp.wast:7791: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4_cmp/simd_f32x4_cmp.9.wat:1:65: error: unexpected token "f4x32.gt", expected an instr.
+  ...v128) (param $y v128) (result v128) (f4x32.gt (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f32x4_cmp.wast:7792: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4_cmp/simd_f32x4_cmp.10.wat:1:65: error: unexpected token "f4x32.le", expected an instr.
+  ...v128) (param $y v128) (result v128) (f4x32.le (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f32x4_cmp.wast:7793: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4_cmp/simd_f32x4_cmp.11.wat:1:65: error: unexpected token "f4x32.lt", expected an instr.
+  ...v128) (param $y v128) (result v128) (f4x32.lt (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f32x4_cmp.wast:7794: assert_malformed passed:
+  out/test/spec/simd/simd_f32x4_cmp/simd_f32x4_cmp.12.wat:1:65: error: unexpected token "f4x32.ne", expected an instr.
+  ...v128) (param $y v128) (result v128) (f4x32.ne (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f32x4_cmp.wast:8073: assert_invalid passed:
+  error: type mismatch in f32x4.eq, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8081: assert_invalid passed:
+  error: type mismatch in f32x4.eq, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8089: assert_invalid passed:
+  error: type mismatch in f32x4.ne, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8097: assert_invalid passed:
+  error: type mismatch in f32x4.ne, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8105: assert_invalid passed:
+  error: type mismatch in f32x4.lt, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8113: assert_invalid passed:
+  error: type mismatch in f32x4.lt, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8121: assert_invalid passed:
+  error: type mismatch in f32x4.le, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8129: assert_invalid passed:
+  error: type mismatch in f32x4.le, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8137: assert_invalid passed:
+  error: type mismatch in f32x4.gt, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8145: assert_invalid passed:
+  error: type mismatch in f32x4.gt, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8153: assert_invalid passed:
+  error: type mismatch in f32x4.ge, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f32x4_cmp.wast:8161: assert_invalid passed:
+  error: type mismatch in f32x4.ge, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+2605/2605 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_f64x2.txt
+++ b/test/spec/simd/simd_f64x2.txt
@@ -1,0 +1,30 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_f64x2.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_f64x2.wast:2387: assert_invalid passed:
+  error: type mismatch in f64x2.abs, expected [v128] but got [i32]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2388: assert_invalid passed:
+  error: type mismatch in f64x2.min, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2389: assert_invalid passed:
+  error: type mismatch in f64x2.max, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2394: assert_invalid passed:
+  error: type mismatch in f64x2.abs, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2402: assert_invalid passed:
+  error: type mismatch in f64x2.min, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2410: assert_invalid passed:
+  error: type mismatch in f64x2.min, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2418: assert_invalid passed:
+  error: type mismatch in f64x2.max, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2.wast:2426: assert_invalid passed:
+  error: type mismatch in f64x2.max, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+801/801 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_f64x2_arith.txt
+++ b/test/spec/simd/simd_f64x2_arith.txt
@@ -1,0 +1,54 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_f64x2_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_f64x2_arith.wast:5302: assert_invalid passed:
+  error: type mismatch in f64x2.neg, expected [v128] but got [i64]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5303: assert_invalid passed:
+  error: type mismatch in f64x2.sqrt, expected [v128] but got [i64]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5304: assert_invalid passed:
+  error: type mismatch in f64x2.add, expected [v128, v128] but got [i64, f64]
+  0000026: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5305: assert_invalid passed:
+  error: type mismatch in f64x2.sub, expected [v128, v128] but got [i64, f64]
+  0000026: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5306: assert_invalid passed:
+  error: type mismatch in f64x2.mul, expected [v128, v128] but got [i64, f64]
+  0000026: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5307: assert_invalid passed:
+  error: type mismatch in f64x2.div, expected [v128, v128] but got [i64, f64]
+  0000026: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5312: assert_invalid passed:
+  error: type mismatch in f64x2.neg, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5320: assert_invalid passed:
+  error: type mismatch in f64x2.sqrt, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5328: assert_invalid passed:
+  error: type mismatch in f64x2.add, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5336: assert_invalid passed:
+  error: type mismatch in f64x2.add, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5344: assert_invalid passed:
+  error: type mismatch in f64x2.sub, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5352: assert_invalid passed:
+  error: type mismatch in f64x2.sub, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5360: assert_invalid passed:
+  error: type mismatch in f64x2.mul, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5368: assert_invalid passed:
+  error: type mismatch in f64x2.mul, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5376: assert_invalid passed:
+  error: type mismatch in f64x2.div, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_f64x2_arith.wast:5384: assert_invalid passed:
+  error: type mismatch in f64x2.div, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+1822/1822 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_f64x2_cmp.txt
+++ b/test/spec/simd/simd_f64x2_cmp.txt
@@ -1,0 +1,84 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_f64x2_cmp.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_f64x2_cmp.wast:7954: assert_malformed passed:
+  out/test/spec/simd/simd_f64x2_cmp/simd_f64x2_cmp.1.wat:1:66: error: unexpected token "f2x64.eq", expected an instr.
+  ...v128) (param $y v128) (result v128) (f2x64.eq (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f64x2_cmp.wast:7955: assert_malformed passed:
+  out/test/spec/simd/simd_f64x2_cmp/simd_f64x2_cmp.2.wat:1:66: error: unexpected token "f2x64.ne", expected an instr.
+  ...v128) (param $y v128) (result v128) (f2x64.ne (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f64x2_cmp.wast:7956: assert_malformed passed:
+  out/test/spec/simd/simd_f64x2_cmp/simd_f64x2_cmp.3.wat:1:66: error: unexpected token "f2x64.lt", expected an instr.
+  ...v128) (param $y v128) (result v128) (f2x64.lt (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f64x2_cmp.wast:7957: assert_malformed passed:
+  out/test/spec/simd/simd_f64x2_cmp/simd_f64x2_cmp.4.wat:1:66: error: unexpected token "f2x64.le", expected an instr.
+  ...v128) (param $y v128) (result v128) (f2x64.le (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f64x2_cmp.wast:7958: assert_malformed passed:
+  out/test/spec/simd/simd_f64x2_cmp/simd_f64x2_cmp.5.wat:1:66: error: unexpected token "f2x64.gt", expected an instr.
+  ...v128) (param $y v128) (result v128) (f2x64.gt (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f64x2_cmp.wast:7959: assert_malformed passed:
+  out/test/spec/simd/simd_f64x2_cmp/simd_f64x2_cmp.6.wat:1:66: error: unexpected token "f2x64.ge", expected an instr.
+  ...v128) (param $y v128) (result v128) (f2x64.ge (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_f64x2_cmp.wast:7962: assert_invalid passed:
+  error: type mismatch in f64x2.eq, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7963: assert_invalid passed:
+  error: type mismatch in f64x2.ne, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7964: assert_invalid passed:
+  error: type mismatch in f64x2.lt, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7965: assert_invalid passed:
+  error: type mismatch in f64x2.le, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7966: assert_invalid passed:
+  error: type mismatch in f64x2.gt, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7967: assert_invalid passed:
+  error: type mismatch in f64x2.ge, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7972: assert_invalid passed:
+  error: type mismatch in f64x2.eq, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7980: assert_invalid passed:
+  error: type mismatch in f64x2.eq, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7988: assert_invalid passed:
+  error: type mismatch in f64x2.ne, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:7996: assert_invalid passed:
+  error: type mismatch in f64x2.ne, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8004: assert_invalid passed:
+  error: type mismatch in f64x2.lt, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8012: assert_invalid passed:
+  error: type mismatch in f64x2.lt, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8020: assert_invalid passed:
+  error: type mismatch in f64x2.le, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8028: assert_invalid passed:
+  error: type mismatch in f64x2.le, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8036: assert_invalid passed:
+  error: type mismatch in f64x2.gt, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8044: assert_invalid passed:
+  error: type mismatch in f64x2.gt, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8052: assert_invalid passed:
+  error: type mismatch in f64x2.ge, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_f64x2_cmp.wast:8060: assert_invalid passed:
+  error: type mismatch in f64x2.ge, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+2683/2683 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i16x8_arith.txt
+++ b/test/spec/simd/simd_i16x8_arith.txt
@@ -1,0 +1,39 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i16x8_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i16x8_arith.wast:528: assert_invalid passed:
+  error: type mismatch in i16x8.neg, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:529: assert_invalid passed:
+  error: type mismatch in i16x8.add, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:530: assert_invalid passed:
+  error: type mismatch in i16x8.sub, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:531: assert_invalid passed:
+  error: type mismatch in i16x8.mul, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:536: assert_invalid passed:
+  error: type mismatch in i16x8.neg, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:544: assert_invalid passed:
+  error: type mismatch in i16x8.add, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:552: assert_invalid passed:
+  error: type mismatch in i16x8.add, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:560: assert_invalid passed:
+  error: type mismatch in i16x8.sub, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:568: assert_invalid passed:
+  error: type mismatch in i16x8.sub, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:576: assert_invalid passed:
+  error: type mismatch in i16x8.mul, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith.wast:584: assert_invalid passed:
+  error: type mismatch in i16x8.mul, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+192/192 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i16x8_arith2.txt
+++ b/test/spec/simd/simd_i16x8_arith2.txt
@@ -1,0 +1,59 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i16x8_arith2.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i16x8_arith2.wast:296: assert_malformed passed:
+  out/test/spec/simd/simd_i16x8_arith2/simd_i16x8_arith2.1.wat:1:33: error: unexpected token "i16x8.avgr", expected an instr.
+  (memory 1) (func (result v128) (i16x8.avgr (v128.const i16x8 0 0 0 0 0 0 0 0)...
+                                  ^^^^^^^^^^
+out/test/spec/simd/simd_i16x8_arith2.wast:297: assert_malformed passed:
+  out/test/spec/simd/simd_i16x8_arith2/simd_i16x8_arith2.2.wat:1:33: error: unexpected token "i16x8.avgr_s", expected an instr.
+  (memory 1) (func (result v128) (i16x8.avgr_s (v128.const i16x8 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^^^
+out/test/spec/simd/simd_i16x8_arith2.wast:300: assert_invalid passed:
+  error: type mismatch in i16x8.min_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:301: assert_invalid passed:
+  error: type mismatch in i16x8.min_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:302: assert_invalid passed:
+  error: type mismatch in i16x8.max_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:303: assert_invalid passed:
+  error: type mismatch in i16x8.max_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:304: assert_invalid passed:
+  error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:309: assert_invalid passed:
+  error: type mismatch in i16x8.min_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:317: assert_invalid passed:
+  error: type mismatch in i16x8.min_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:325: assert_invalid passed:
+  error: type mismatch in i16x8.min_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:333: assert_invalid passed:
+  error: type mismatch in i16x8.min_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:341: assert_invalid passed:
+  error: type mismatch in i16x8.max_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:349: assert_invalid passed:
+  error: type mismatch in i16x8.max_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:357: assert_invalid passed:
+  error: type mismatch in i16x8.max_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:365: assert_invalid passed:
+  error: type mismatch in i16x8.max_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:373: assert_invalid passed:
+  error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_arith2.wast:381: assert_invalid passed:
+  error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+137/137 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i16x8_cmp.txt
+++ b/test/spec/simd/simd_i16x8_cmp.txt
@@ -1,0 +1,96 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i16x8_cmp.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i16x8_cmp.wast:1455: assert_invalid passed:
+  error: type mismatch in i16x8.eq, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1456: assert_invalid passed:
+  error: type mismatch in i16x8.ge_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1457: assert_invalid passed:
+  error: type mismatch in i16x8.ge_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1458: assert_invalid passed:
+  error: type mismatch in i16x8.gt_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1459: assert_invalid passed:
+  error: type mismatch in i16x8.gt_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1460: assert_invalid passed:
+  error: type mismatch in i16x8.le_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1461: assert_invalid passed:
+  error: type mismatch in i16x8.le_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1462: assert_invalid passed:
+  error: type mismatch in i16x8.lt_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1463: assert_invalid passed:
+  error: type mismatch in i16x8.lt_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1464: assert_invalid passed:
+  error: type mismatch in i16x8.ne, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1743: assert_invalid passed:
+  error: type mismatch in i16x8.eq, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1751: assert_invalid passed:
+  error: type mismatch in i16x8.eq, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1759: assert_invalid passed:
+  error: type mismatch in i16x8.ne, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1767: assert_invalid passed:
+  error: type mismatch in i16x8.ne, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1775: assert_invalid passed:
+  error: type mismatch in i16x8.lt_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1783: assert_invalid passed:
+  error: type mismatch in i16x8.lt_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1791: assert_invalid passed:
+  error: type mismatch in i16x8.lt_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1799: assert_invalid passed:
+  error: type mismatch in i16x8.lt_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1807: assert_invalid passed:
+  error: type mismatch in i16x8.le_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1815: assert_invalid passed:
+  error: type mismatch in i16x8.le_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1823: assert_invalid passed:
+  error: type mismatch in i16x8.le_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1831: assert_invalid passed:
+  error: type mismatch in i16x8.le_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1839: assert_invalid passed:
+  error: type mismatch in i16x8.gt_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1847: assert_invalid passed:
+  error: type mismatch in i16x8.gt_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1855: assert_invalid passed:
+  error: type mismatch in i16x8.gt_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1863: assert_invalid passed:
+  error: type mismatch in i16x8.gt_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1871: assert_invalid passed:
+  error: type mismatch in i16x8.ge_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1879: assert_invalid passed:
+  error: type mismatch in i16x8.ge_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1887: assert_invalid passed:
+  error: type mismatch in i16x8.ge_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i16x8_cmp.wast:1895: assert_invalid passed:
+  error: type mismatch in i16x8.ge_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+463/463 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i16x8_sat_arith.txt
+++ b/test/spec/simd/simd_i16x8_sat_arith.txt
@@ -1,0 +1,58 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i16x8_sat_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i16x8_sat_arith.wast:609: assert_malformed passed:
+  out/test/spec/simd/simd_i16x8_sat_arith/simd_i16x8_sat_arith.1.wat:1:22: error: unexpected token "i16x8.add_saturate", expected an instr.
+  (func (result v128) (i16x8.add_saturate (v128.const i16x8 1 1 1 1 1 1 1 1) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i16x8_sat_arith.wast:612: assert_malformed passed:
+  out/test/spec/simd/simd_i16x8_sat_arith/simd_i16x8_sat_arith.2.wat:1:22: error: unexpected token "i16x8.sub_saturate", expected an instr.
+  (func (result v128) (i16x8.sub_saturate (v128.const i16x8 1 1 1 1 1 1 1 1) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i16x8_sat_arith.wast:615: assert_malformed passed:
+  out/test/spec/simd/simd_i16x8_sat_arith/simd_i16x8_sat_arith.3.wat:1:22: error: unexpected token "i16x8.mul_saturate", expected an instr.
+  (func (result v128) (i16x8.mul_saturate (v128.const i16x8 1 1 1 1 1 1 1 1) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i16x8_sat_arith.wast:618: assert_malformed passed:
+  out/test/spec/simd/simd_i16x8_sat_arith/simd_i16x8_sat_arith.4.wat:1:22: error: unexpected token "i16x8.div_saturate", expected an instr.
+  (func (result v128) (i16x8.div_saturate (v128.const i16x8 1 1 1 1 1 1 1 1) (v...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i16x8_sat_arith.wast:623: assert_invalid passed:
+  error: type mismatch in i16x8.add_saturate_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:624: assert_invalid passed:
+  error: type mismatch in i16x8.add_saturate_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:625: assert_invalid passed:
+  error: type mismatch in i16x8.sub_saturate_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:626: assert_invalid passed:
+  error: type mismatch in i16x8.sub_saturate_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:631: assert_invalid passed:
+  error: type mismatch in i16x8.add_saturate_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:639: assert_invalid passed:
+  error: type mismatch in i16x8.add_saturate_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:647: assert_invalid passed:
+  error: type mismatch in i16x8.add_saturate_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:655: assert_invalid passed:
+  error: type mismatch in i16x8.add_saturate_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:663: assert_invalid passed:
+  error: type mismatch in i16x8.sub_saturate_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:671: assert_invalid passed:
+  error: type mismatch in i16x8.sub_saturate_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:679: assert_invalid passed:
+  error: type mismatch in i16x8.sub_saturate_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i16x8_sat_arith.wast:687: assert_invalid passed:
+  error: type mismatch in i16x8.sub_saturate_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+220/220 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i32x4_arith.txt
+++ b/test/spec/simd/simd_i32x4_arith.txt
@@ -1,0 +1,39 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i32x4_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i32x4_arith.wast:528: assert_invalid passed:
+  error: type mismatch in i32x4.neg, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:529: assert_invalid passed:
+  error: type mismatch in i32x4.add, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:530: assert_invalid passed:
+  error: type mismatch in i32x4.sub, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:531: assert_invalid passed:
+  error: type mismatch in i32x4.mul, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:536: assert_invalid passed:
+  error: type mismatch in i32x4.neg, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:544: assert_invalid passed:
+  error: type mismatch in i32x4.add, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:552: assert_invalid passed:
+  error: type mismatch in i32x4.add, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:560: assert_invalid passed:
+  error: type mismatch in i32x4.sub, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:568: assert_invalid passed:
+  error: type mismatch in i32x4.sub, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:576: assert_invalid passed:
+  error: type mismatch in i32x4.mul, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith.wast:584: assert_invalid passed:
+  error: type mismatch in i32x4.mul, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+192/192 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i32x4_arith2.txt
+++ b/test/spec/simd/simd_i32x4_arith2.txt
@@ -1,0 +1,90 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i32x4_arith2.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i32x4_arith2.wast:240: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.1.wat:1:33: error: unexpected token "f32x4.min_s", expected an instr.
+  (memory 1) (func (result v128) (f32x4.min_s (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:241: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.2.wat:1:33: error: unexpected token "f32x4.min_u", expected an instr.
+  (memory 1) (func (result v128) (f32x4.min_u (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:242: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.3.wat:1:33: error: unexpected token "f32x4.max_s", expected an instr.
+  (memory 1) (func (result v128) (f32x4.max_s (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:243: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.4.wat:1:33: error: unexpected token "f32x4.max_u", expected an instr.
+  (memory 1) (func (result v128) (f32x4.max_u (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:244: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.5.wat:1:33: error: unexpected token "i64x2.min_s", expected an instr.
+  (memory 1) (func (result v128) (i64x2.min_s (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:245: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.6.wat:1:33: error: unexpected token "i64x2.min_u", expected an instr.
+  (memory 1) (func (result v128) (i64x2.min_u (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:246: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.7.wat:1:33: error: unexpected token "i64x2.max_s", expected an instr.
+  (memory 1) (func (result v128) (i64x2.max_s (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:247: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.8.wat:1:33: error: unexpected token "i64x2.max_u", expected an instr.
+  (memory 1) (func (result v128) (i64x2.max_u (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:248: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.9.wat:1:33: error: unexpected token "f64x2.min_s", expected an instr.
+  (memory 1) (func (result v128) (f64x2.min_s (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:249: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.10.wat:1:33: error: unexpected token "f64x2.min_u", expected an instr.
+  (memory 1) (func (result v128) (f64x2.min_u (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:250: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.11.wat:1:33: error: unexpected token "f64x2.max_s", expected an instr.
+  (memory 1) (func (result v128) (f64x2.max_s (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:251: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_arith2/simd_i32x4_arith2.12.wat:1:33: error: unexpected token "f64x2.max_u", expected an instr.
+  (memory 1) (func (result v128) (f64x2.max_u (v128.const i32x4 0 0 0 0) (v128....
+                                  ^^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_arith2.wast:254: assert_invalid passed:
+  error: type mismatch in i32x4.min_s, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:255: assert_invalid passed:
+  error: type mismatch in i32x4.min_u, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:256: assert_invalid passed:
+  error: type mismatch in i32x4.max_s, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:257: assert_invalid passed:
+  error: type mismatch in i32x4.max_u, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:262: assert_invalid passed:
+  error: type mismatch in i32x4.min_s, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:270: assert_invalid passed:
+  error: type mismatch in i32x4.min_s, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:278: assert_invalid passed:
+  error: type mismatch in i32x4.min_u, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:286: assert_invalid passed:
+  error: type mismatch in i32x4.min_u, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:294: assert_invalid passed:
+  error: type mismatch in i32x4.max_s, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:302: assert_invalid passed:
+  error: type mismatch in i32x4.max_s, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:310: assert_invalid passed:
+  error: type mismatch in i32x4.max_u, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i32x4_arith2.wast:318: assert_invalid passed:
+  error: type mismatch in i32x4.max_u, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+116/116 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i32x4_cmp.txt
+++ b/test/spec/simd/simd_i32x4_cmp.txt
@@ -1,0 +1,136 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i32x4_cmp.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i32x4_cmp.wast:1461: assert_invalid passed:
+  error: type mismatch in i32x4.eq, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1462: assert_invalid passed:
+  error: type mismatch in i32x4.ge_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1463: assert_invalid passed:
+  error: type mismatch in i32x4.ge_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1464: assert_invalid passed:
+  error: type mismatch in i32x4.gt_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1465: assert_invalid passed:
+  error: type mismatch in i32x4.gt_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1466: assert_invalid passed:
+  error: type mismatch in i32x4.le_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1467: assert_invalid passed:
+  error: type mismatch in i32x4.le_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1468: assert_invalid passed:
+  error: type mismatch in i32x4.lt_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1469: assert_invalid passed:
+  error: type mismatch in i32x4.lt_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1470: assert_invalid passed:
+  error: type mismatch in i32x4.ne, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1749: assert_invalid passed:
+  error: type mismatch in i32x4.eq, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1757: assert_invalid passed:
+  error: type mismatch in i32x4.eq, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1765: assert_invalid passed:
+  error: type mismatch in i32x4.ne, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1773: assert_invalid passed:
+  error: type mismatch in i32x4.ne, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1781: assert_invalid passed:
+  error: type mismatch in i32x4.lt_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1789: assert_invalid passed:
+  error: type mismatch in i32x4.lt_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1797: assert_invalid passed:
+  error: type mismatch in i32x4.lt_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1805: assert_invalid passed:
+  error: type mismatch in i32x4.lt_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1813: assert_invalid passed:
+  error: type mismatch in i32x4.le_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1821: assert_invalid passed:
+  error: type mismatch in i32x4.le_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1829: assert_invalid passed:
+  error: type mismatch in i32x4.le_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1837: assert_invalid passed:
+  error: type mismatch in i32x4.le_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1845: assert_invalid passed:
+  error: type mismatch in i32x4.gt_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1853: assert_invalid passed:
+  error: type mismatch in i32x4.gt_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1861: assert_invalid passed:
+  error: type mismatch in i32x4.gt_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1869: assert_invalid passed:
+  error: type mismatch in i32x4.gt_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1877: assert_invalid passed:
+  error: type mismatch in i32x4.ge_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1885: assert_invalid passed:
+  error: type mismatch in i32x4.ge_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1893: assert_invalid passed:
+  error: type mismatch in i32x4.ge_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1901: assert_invalid passed:
+  error: type mismatch in i32x4.ge_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i32x4_cmp.wast:1910: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.32.wat:1:65: error: unexpected token "i4x32.eq", expected an instr.
+  ...v128) (param $y v128) (result v128) (i4x32.eq (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1911: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.33.wat:1:65: error: unexpected token "i4x32.ne", expected an instr.
+  ...v128) (param $y v128) (result v128) (i4x32.ne (local.get $x) (local.get $y)))
+                                          ^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1912: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.34.wat:1:65: error: unexpected token "i4x32.lt_s", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.lt_s (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1913: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.35.wat:1:65: error: unexpected token "i4x32.lt_u", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.lt_u (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1914: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.36.wat:1:65: error: unexpected token "i4x32.le_s", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.le_s (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1915: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.37.wat:1:65: error: unexpected token "i4x32.le_u", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.le_u (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1916: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.38.wat:1:65: error: unexpected token "i4x32.gt_s", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.gt_s (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1917: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.39.wat:1:65: error: unexpected token "i4x32.gt_u", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.gt_u (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1918: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.40.wat:1:65: error: unexpected token "i4x32.ge_s", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.ge_s (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+out/test/spec/simd/simd_i32x4_cmp.wast:1919: assert_malformed passed:
+  out/test/spec/simd/simd_i32x4_cmp/simd_i32x4_cmp.41.wat:1:65: error: unexpected token "i4x32.ge_u", expected an instr.
+  ...28) (param $y v128) (result v128) (i4x32.ge_u (local.get $x) (local.get $y)))
+                                        ^^^^^^^^^^
+473/473 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i64x2_arith.txt
+++ b/test/spec/simd/simd_i64x2_arith.txt
@@ -1,0 +1,39 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i64x2_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i64x2_arith.wast:546: assert_invalid passed:
+  error: type mismatch in i64x2.neg, expected [v128] but got [i32]
+  000001d: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:547: assert_invalid passed:
+  error: type mismatch in i64x2.add, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:548: assert_invalid passed:
+  error: type mismatch in i64x2.sub, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:549: assert_invalid passed:
+  error: type mismatch in i64x2.mul, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:554: assert_invalid passed:
+  error: type mismatch in i64x2.neg, expected [v128] but got []
+  000001b: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:562: assert_invalid passed:
+  error: type mismatch in i64x2.add, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:570: assert_invalid passed:
+  error: type mismatch in i64x2.add, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:578: assert_invalid passed:
+  error: type mismatch in i64x2.sub, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:586: assert_invalid passed:
+  error: type mismatch in i64x2.sub, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:594: assert_invalid passed:
+  error: type mismatch in i64x2.mul, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i64x2_arith.wast:602: assert_invalid passed:
+  error: type mismatch in i64x2.mul, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+198/198 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i8x16_arith.txt
+++ b/test/spec/simd/simd_i8x16_arith.txt
@@ -1,0 +1,30 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i8x16_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i8x16_arith.wast:354: assert_invalid passed:
+  error: type mismatch in i8x16.neg, expected [v128] but got [i32]
+  000001c: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:355: assert_invalid passed:
+  error: type mismatch in i8x16.add, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:356: assert_invalid passed:
+  error: type mismatch in i8x16.sub, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:361: assert_invalid passed:
+  error: type mismatch in i8x16.neg, expected [v128] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:369: assert_invalid passed:
+  error: type mismatch in i8x16.add, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:377: assert_invalid passed:
+  error: type mismatch in i8x16.add, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:385: assert_invalid passed:
+  error: type mismatch in i8x16.sub, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith.wast:393: assert_invalid passed:
+  error: type mismatch in i8x16.sub, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+129/129 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i8x16_arith2.txt
+++ b/test/spec/simd/simd_i8x16_arith2.txt
@@ -1,0 +1,75 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i8x16_arith2.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i8x16_arith2.wast:296: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_arith2/simd_i8x16_arith2.1.wat:1:33: error: unexpected token "i32x4.avgr_u", expected an instr.
+  (memory 1) (func (result v128) (i32x4.avgr_u (v128.const i8x16 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_arith2.wast:297: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_arith2/simd_i8x16_arith2.2.wat:1:33: error: unexpected token "f32x4.avgr_u", expected an instr.
+  (memory 1) (func (result v128) (f32x4.avgr_u (v128.const i8x16 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_arith2.wast:298: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_arith2/simd_i8x16_arith2.3.wat:1:33: error: unexpected token "i64x2.avgr_u", expected an instr.
+  (memory 1) (func (result v128) (i64x2.avgr_u (v128.const i8x16 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_arith2.wast:299: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_arith2/simd_i8x16_arith2.4.wat:1:33: error: unexpected token "f64x2.avgr_u", expected an instr.
+  (memory 1) (func (result v128) (f64x2.avgr_u (v128.const i8x16 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_arith2.wast:300: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_arith2/simd_i8x16_arith2.5.wat:1:33: error: unexpected token "i8x16.avgr", expected an instr.
+  (memory 1) (func (result v128) (i8x16.avgr (v128.const i8x16 0 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_arith2.wast:301: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_arith2/simd_i8x16_arith2.6.wat:1:33: error: unexpected token "i8x16.avgr_s", expected an instr.
+  (memory 1) (func (result v128) (i8x16.avgr_s (v128.const i8x16 0 0 0 0 0 0 0 ...
+                                  ^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_arith2.wast:304: assert_invalid passed:
+  error: type mismatch in i8x16.min_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:305: assert_invalid passed:
+  error: type mismatch in i8x16.min_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:306: assert_invalid passed:
+  error: type mismatch in i8x16.max_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:307: assert_invalid passed:
+  error: type mismatch in i8x16.max_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:308: assert_invalid passed:
+  error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got [i32, f32]
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:313: assert_invalid passed:
+  error: type mismatch in i8x16.min_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:321: assert_invalid passed:
+  error: type mismatch in i8x16.min_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:329: assert_invalid passed:
+  error: type mismatch in i8x16.min_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:337: assert_invalid passed:
+  error: type mismatch in i8x16.min_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:345: assert_invalid passed:
+  error: type mismatch in i8x16.max_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:353: assert_invalid passed:
+  error: type mismatch in i8x16.max_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:361: assert_invalid passed:
+  error: type mismatch in i8x16.max_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:369: assert_invalid passed:
+  error: type mismatch in i8x16.max_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:377: assert_invalid passed:
+  error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got [v128]
+  000002d: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_arith2.wast:385: assert_invalid passed:
+  error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got []
+  000001b: error: OnBinaryExpr callback failed
+141/141 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i8x16_cmp.txt
+++ b/test/spec/simd/simd_i8x16_cmp.txt
@@ -1,0 +1,96 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i8x16_cmp.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i8x16_cmp.wast:1401: assert_invalid passed:
+  error: type mismatch in i8x16.eq, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1402: assert_invalid passed:
+  error: type mismatch in i8x16.ge_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1403: assert_invalid passed:
+  error: type mismatch in i8x16.ge_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1404: assert_invalid passed:
+  error: type mismatch in i8x16.gt_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1405: assert_invalid passed:
+  error: type mismatch in i8x16.gt_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1406: assert_invalid passed:
+  error: type mismatch in i8x16.le_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1407: assert_invalid passed:
+  error: type mismatch in i8x16.le_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1408: assert_invalid passed:
+  error: type mismatch in i8x16.lt_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1409: assert_invalid passed:
+  error: type mismatch in i8x16.lt_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1410: assert_invalid passed:
+  error: type mismatch in i8x16.ne, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1689: assert_invalid passed:
+  error: type mismatch in i8x16.eq, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1697: assert_invalid passed:
+  error: type mismatch in i8x16.eq, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1705: assert_invalid passed:
+  error: type mismatch in i8x16.ne, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1713: assert_invalid passed:
+  error: type mismatch in i8x16.ne, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1721: assert_invalid passed:
+  error: type mismatch in i8x16.lt_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1729: assert_invalid passed:
+  error: type mismatch in i8x16.lt_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1737: assert_invalid passed:
+  error: type mismatch in i8x16.lt_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1745: assert_invalid passed:
+  error: type mismatch in i8x16.lt_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1753: assert_invalid passed:
+  error: type mismatch in i8x16.le_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1761: assert_invalid passed:
+  error: type mismatch in i8x16.le_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1769: assert_invalid passed:
+  error: type mismatch in i8x16.le_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1777: assert_invalid passed:
+  error: type mismatch in i8x16.le_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1785: assert_invalid passed:
+  error: type mismatch in i8x16.gt_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1793: assert_invalid passed:
+  error: type mismatch in i8x16.gt_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1801: assert_invalid passed:
+  error: type mismatch in i8x16.gt_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1809: assert_invalid passed:
+  error: type mismatch in i8x16.gt_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1817: assert_invalid passed:
+  error: type mismatch in i8x16.ge_s, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1825: assert_invalid passed:
+  error: type mismatch in i8x16.ge_s, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1833: assert_invalid passed:
+  error: type mismatch in i8x16.ge_u, expected [v128, v128] but got [v128]
+  000002c: error: OnCompareExpr callback failed
+out/test/spec/simd/simd_i8x16_cmp.wast:1841: assert_invalid passed:
+  error: type mismatch in i8x16.ge_u, expected [v128, v128] but got []
+  000001a: error: OnCompareExpr callback failed
+443/443 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_i8x16_sat_arith.txt
+++ b/test/spec/simd/simd_i8x16_sat_arith.txt
@@ -1,0 +1,90 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_i8x16_sat_arith.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_i8x16_sat_arith.wast:561: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.1.wat:1:22: error: unexpected token "i8x16.add_saturate", expected an instr.
+  (func (result v128) (i8x16.add_saturate (v128.const i8x16 1 1 1 1 1 1 1 1 1 1...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:564: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.2.wat:1:22: error: unexpected token "i8x16.sub_saturate", expected an instr.
+  (func (result v128) (i8x16.sub_saturate (v128.const i8x16 1 1 1 1 1 1 1 1 1 1...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:567: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.3.wat:1:22: error: unexpected token "i8x16.mul_saturate", expected an instr.
+  (func (result v128) (i8x16.mul_saturate (v128.const i8x16 1 1 1 1 1 1 1 1 1 1...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:570: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.4.wat:1:22: error: unexpected token "i8x16.div_saturate", expected an instr.
+  (func (result v128) (i8x16.div_saturate (v128.const i8x16 1 1 1 1 1 1 1 1 1 1...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:573: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.5.wat:1:22: error: unexpected token "i32x4.add_saturate_s", expected an instr.
+  (func (result v128) (i32x4.add_saturate_s (v128.const i32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:576: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.6.wat:1:22: error: unexpected token "i32x4.add_saturate_u", expected an instr.
+  (func (result v128) (i32x4.add_saturate_u (v128.const i32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:579: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.7.wat:1:22: error: unexpected token "i32x4.sub_saturate_s", expected an instr.
+  (func (result v128) (i32x4.sub_saturate_s (v128.const i32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:582: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.8.wat:1:22: error: unexpected token "i32x4.sub_saturate_u", expected an instr.
+  (func (result v128) (i32x4.sub_saturate_u (v128.const i32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:585: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.9.wat:1:22: error: unexpected token "f32x4.add_saturate_s", expected an instr.
+  (func (result v128) (f32x4.add_saturate_s (v128.const f32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:588: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.10.wat:1:22: error: unexpected token "f32x4.add_saturate_u", expected an instr.
+  (func (result v128) (f32x4.add_saturate_u (v128.const f32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:591: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.11.wat:1:22: error: unexpected token "f32x4.sub_saturate_s", expected an instr.
+  (func (result v128) (f32x4.sub_saturate_s (v128.const f32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:594: assert_malformed passed:
+  out/test/spec/simd/simd_i8x16_sat_arith/simd_i8x16_sat_arith.12.wat:1:22: error: unexpected token "f32x4.sub_saturate_u", expected an instr.
+  (func (result v128) (f32x4.sub_saturate_u (v128.const f32x4 0 0 0 0) (v128.co...
+                       ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_i8x16_sat_arith.wast:599: assert_invalid passed:
+  error: type mismatch in i8x16.add_saturate_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:600: assert_invalid passed:
+  error: type mismatch in i8x16.add_saturate_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:601: assert_invalid passed:
+  error: type mismatch in i8x16.sub_saturate_s, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:602: assert_invalid passed:
+  error: type mismatch in i8x16.sub_saturate_u, expected [v128, v128] but got [i32, f32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:607: assert_invalid passed:
+  error: type mismatch in i8x16.add_saturate_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:615: assert_invalid passed:
+  error: type mismatch in i8x16.add_saturate_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:623: assert_invalid passed:
+  error: type mismatch in i8x16.add_saturate_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:631: assert_invalid passed:
+  error: type mismatch in i8x16.add_saturate_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:639: assert_invalid passed:
+  error: type mismatch in i8x16.sub_saturate_s, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:647: assert_invalid passed:
+  error: type mismatch in i8x16.sub_saturate_s, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:655: assert_invalid passed:
+  error: type mismatch in i8x16.sub_saturate_u, expected [v128, v128] but got [v128]
+  000002c: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_i8x16_sat_arith.wast:663: assert_invalid passed:
+  error: type mismatch in i8x16.sub_saturate_u, expected [v128, v128] but got []
+  000001a: error: OnBinaryExpr callback failed
+212/212 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_lane.txt
+++ b/test/spec/simd/simd_lane.txt
@@ -1,0 +1,908 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_lane.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_lane.wast:398: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.1.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result i32) (i8x16.extract_lane_s  -1 (v128.const i8x16 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.1.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_s  -1 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:399: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.2.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result i32) (i8x16.extract_lane_s 256 (v128.const i8x16 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.2.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_s 256 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:400: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.3.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result i32) (i8x16.extract_lane_u  -1 (v128.const i8x16 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.3.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_u  -1 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:401: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.4.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result i32) (i8x16.extract_lane_u 256 (v128.const i8x16 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.4.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_u 256 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:402: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.5.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result i32) (i16x8.extract_lane_s  -1 (v128.const i16x8 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.5.wat:1:81: error: unexpected token ), expected EOF.
+  ...c (result i32) (i16x8.extract_lane_s  -1 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:403: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.6.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result i32) (i16x8.extract_lane_s 256 (v128.const i16x8 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.6.wat:1:81: error: unexpected token ), expected EOF.
+  ...c (result i32) (i16x8.extract_lane_s 256 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:404: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.7.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result i32) (i16x8.extract_lane_u  -1 (v128.const i16x8 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.7.wat:1:81: error: unexpected token ), expected EOF.
+  ...c (result i32) (i16x8.extract_lane_u  -1 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:405: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.8.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result i32) (i16x8.extract_lane_u 256 (v128.const i16x8 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.8.wat:1:81: error: unexpected token ), expected EOF.
+  ...c (result i32) (i16x8.extract_lane_u 256 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:406: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.9.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result i32) (i32x4.extract_lane  -1 (v128.const i32x4 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.9.wat:1:71: error: unexpected token ), expected EOF.
+  (func (result i32) (i32x4.extract_lane  -1 (v128.const i32x4 0 0 0 0)))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:407: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.10.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result i32) (i32x4.extract_lane 256 (v128.const i32x4 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.10.wat:1:71: error: unexpected token ), expected EOF.
+  (func (result i32) (i32x4.extract_lane 256 (v128.const i32x4 0 0 0 0)))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:408: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.11.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result f32) (f32x4.extract_lane  -1 (v128.const f32x4 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.11.wat:1:71: error: unexpected token ), expected EOF.
+  (func (result f32) (f32x4.extract_lane  -1 (v128.const f32x4 0 0 0 0)))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:409: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.12.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result f32) (f32x4.extract_lane 256 (v128.const f32x4 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.12.wat:1:71: error: unexpected token ), expected EOF.
+  (func (result f32) (f32x4.extract_lane 256 (v128.const f32x4 0 0 0 0)))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:410: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.13.wat:1:22: error: lane index "-1" out-of-range [0, 32)
+  (func (result v128) (i8x16.replace_lane  -1 (v128.const i8x16 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.13.wat:1:110: error: unexpected token ), expected EOF.
+  ...e_lane  -1 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:411: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.14.wat:1:22: error: lane index "256" out-of-range [0, 32)
+  (func (result v128) (i8x16.replace_lane 256 (v128.const i8x16 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.14.wat:1:110: error: unexpected token ), expected EOF.
+  ...e_lane 256 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:412: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.15.wat:1:22: error: lane index "-1" out-of-range [0, 32)
+  (func (result v128) (i16x8.replace_lane  -1 (v128.const i16x8 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.15.wat:1:94: error: unexpected token ), expected EOF.
+  ...8) (i16x8.replace_lane  -1 (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:413: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.16.wat:1:22: error: lane index "256" out-of-range [0, 32)
+  (func (result v128) (i16x8.replace_lane 256 (v128.const i16x8 0 0 0 0 0 0 0 0...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.16.wat:1:94: error: unexpected token ), expected EOF.
+  ...8) (i16x8.replace_lane 256 (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:414: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.17.wat:1:22: error: lane index "-1" out-of-range [0, 32)
+  (func (result v128) (i32x4.replace_lane  -1 (v128.const i32x4 0 0 0 0) (i32.c...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.17.wat:1:86: error: unexpected token ), expected EOF.
+  ...sult v128) (i32x4.replace_lane  -1 (v128.const i32x4 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:415: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.18.wat:1:22: error: lane index "256" out-of-range [0, 32)
+  (func (result v128) (i32x4.replace_lane 256 (v128.const i32x4 0 0 0 0) (i32.c...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.18.wat:1:86: error: unexpected token ), expected EOF.
+  ...sult v128) (i32x4.replace_lane 256 (v128.const i32x4 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:416: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.19.wat:1:22: error: lane index "-1" out-of-range [0, 32)
+  (func (result v128) (f32x4.replace_lane  -1 (v128.const f32x4 0 0 0 0) (i32.c...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.19.wat:1:86: error: unexpected token ), expected EOF.
+  ...sult v128) (f32x4.replace_lane  -1 (v128.const f32x4 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:417: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.20.wat:1:22: error: lane index "256" out-of-range [0, 32)
+  (func (result v128) (f32x4.replace_lane 256 (v128.const f32x4 0 0 0 0) (i32.c...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.20.wat:1:86: error: unexpected token ), expected EOF.
+  ...sult v128) (f32x4.replace_lane 256 (v128.const f32x4 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:418: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.21.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result i64) (i64x2.extract_lane  -1 (v128.const i64x2 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.21.wat:1:67: error: unexpected token ), expected EOF.
+  (func (result i64) (i64x2.extract_lane  -1 (v128.const i64x2 0 0)))
+                                                                    ^
+out/test/spec/simd/simd_lane.wast:419: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.22.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result i64) (i64x2.extract_lane 256 (v128.const i64x2 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.22.wat:1:67: error: unexpected token ), expected EOF.
+  (func (result i64) (i64x2.extract_lane 256 (v128.const i64x2 0 0)))
+                                                                    ^
+out/test/spec/simd/simd_lane.wast:420: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.23.wat:1:21: error: lane index "-1" out-of-range [0, 32)
+  (func (result f64) (f64x2.extract_lane  -1 (v128.const f64x2 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.23.wat:1:67: error: unexpected token ), expected EOF.
+  (func (result f64) (f64x2.extract_lane  -1 (v128.const f64x2 0 0)))
+                                                                    ^
+out/test/spec/simd/simd_lane.wast:421: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.24.wat:1:21: error: lane index "256" out-of-range [0, 32)
+  (func (result f64) (f64x2.extract_lane 256 (v128.const f64x2 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.24.wat:1:67: error: unexpected token ), expected EOF.
+  (func (result f64) (f64x2.extract_lane 256 (v128.const f64x2 0 0)))
+                                                                    ^
+out/test/spec/simd/simd_lane.wast:422: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.25.wat:1:22: error: lane index "-1" out-of-range [0, 32)
+  (func (result v128) (i64x2.replace_lane  -1 (v128.const i64x2 0 0) (i64.const...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.25.wat:1:82: error: unexpected token ), expected EOF.
+  ... (result v128) (i64x2.replace_lane  -1 (v128.const i64x2 0 0) (i64.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:423: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.26.wat:1:22: error: lane index "256" out-of-range [0, 32)
+  (func (result v128) (i64x2.replace_lane 256 (v128.const i64x2 0 0) (i64.const...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.26.wat:1:82: error: unexpected token ), expected EOF.
+  ... (result v128) (i64x2.replace_lane 256 (v128.const i64x2 0 0) (i64.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:424: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.27.wat:1:22: error: lane index "-1" out-of-range [0, 32)
+  (func (result v128) (f64x2.replace_lane  -1 (v128.const f64x2 0 0) (f64.const...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.27.wat:1:82: error: unexpected token ), expected EOF.
+  ... (result v128) (f64x2.replace_lane  -1 (v128.const f64x2 0 0) (f64.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:425: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.28.wat:1:22: error: lane index "256" out-of-range [0, 32)
+  (func (result v128) (f64x2.replace_lane 256 (v128.const f64x2 0 0) (f64.const...
+                       ^^^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.28.wat:1:82: error: unexpected token ), expected EOF.
+  ... (result v128) (f64x2.replace_lane 256 (v128.const f64x2 0 0) (f64.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:429: assert_invalid passed:
+  error: lane index must be less than 16 (got 16)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:430: assert_invalid passed:
+  error: lane index must be less than 16 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:431: assert_invalid passed:
+  error: lane index must be less than 16 (got 16)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:432: assert_invalid passed:
+  error: lane index must be less than 16 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:433: assert_invalid passed:
+  error: lane index must be less than 8 (got 8)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:434: assert_invalid passed:
+  error: lane index must be less than 8 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:435: assert_invalid passed:
+  error: lane index must be less than 8 (got 8)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:436: assert_invalid passed:
+  error: lane index must be less than 8 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:437: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:438: assert_invalid passed:
+  error: lane index must be less than 4 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:439: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:440: assert_invalid passed:
+  error: lane index must be less than 4 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:441: assert_invalid passed:
+  error: lane index must be less than 16 (got 16)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:442: assert_invalid passed:
+  error: lane index must be less than 16 (got 255)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:443: assert_invalid passed:
+  error: lane index must be less than 8 (got 16)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:444: assert_invalid passed:
+  error: lane index must be less than 8 (got 255)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:445: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:446: assert_invalid passed:
+  error: lane index must be less than 4 (got 255)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:447: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:448: assert_invalid passed:
+  error: lane index must be less than 4 (got 255)
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:449: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:450: assert_invalid passed:
+  error: lane index must be less than 2 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:451: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:452: assert_invalid passed:
+  error: lane index must be less than 2 (got 255)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:453: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:454: assert_invalid passed:
+  error: lane index must be less than 2 (got 255)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:455: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  0000036: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:456: assert_invalid passed:
+  error: lane index must be less than 2 (got 255)
+  0000036: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:460: assert_invalid passed:
+  error: lane index must be less than 8 (got 8)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:461: assert_invalid passed:
+  error: lane index must be less than 8 (got 8)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:462: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:463: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:464: assert_invalid passed:
+  error: lane index must be less than 8 (got 8)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:465: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:466: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:467: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:468: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:469: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:470: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  0000036: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:474: assert_invalid passed:
+  error: type mismatch in i8x16.extract_lane_s, expected [v128] but got [i32]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:475: assert_invalid passed:
+  error: type mismatch in i8x16.extract_lane_u, expected [v128] but got [i64]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:476: assert_invalid passed:
+  error: type mismatch in i8x16.extract_lane_s, expected [v128] but got [f32]
+  0000020: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:477: assert_invalid passed:
+  error: type mismatch in i8x16.extract_lane_u, expected [v128] but got [f64]
+  0000024: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:478: assert_invalid passed:
+  error: type mismatch in i32x4.extract_lane, expected [v128] but got [i32]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:479: assert_invalid passed:
+  error: type mismatch in f32x4.extract_lane, expected [v128] but got [f32]
+  0000020: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:480: assert_invalid passed:
+  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32, i32]
+  000001f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:481: assert_invalid passed:
+  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i64, i32]
+  000001f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:482: assert_invalid passed:
+  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32, i32]
+  000001f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:483: assert_invalid passed:
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32, i32]
+  0000022: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:484: assert_invalid passed:
+  error: type mismatch in i64x2.extract_lane, expected [v128] but got [i64]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:485: assert_invalid passed:
+  error: type mismatch in f64x2.extract_lane, expected [v128] but got [f64]
+  0000024: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:486: assert_invalid passed:
+  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32, i32]
+  000001f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:487: assert_invalid passed:
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32, i32]
+  0000022: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:491: assert_invalid passed:
+  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [v128, f32]
+  0000032: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:492: assert_invalid passed:
+  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [v128, f64]
+  0000036: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:493: assert_invalid passed:
+  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [v128, f32]
+  0000032: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:494: assert_invalid passed:
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:496: assert_invalid passed:
+  error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [v128, f64]
+  0000036: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:497: assert_invalid passed:
+  error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [v128, i64]
+  000002f: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:500: assert_invalid passed:
+  error: type mismatch in v8x16.swizzle, expected [v128, v128] but got [i32, v128]
+  000002f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_lane.wast:502: assert_invalid passed:
+  error: type mismatch in v8x16.swizzle, expected [v128, v128] but got [v128, i32]
+  000002f: error: OnBinaryExpr callback failed
+out/test/spec/simd/simd_lane.wast:504: assert_invalid passed:
+  error: type mismatch in v8x16.shuffle, expected [v128, v128] but got [f32, v128]
+  0000041: error: OnSimdShuffleOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:507: assert_invalid passed:
+  error: type mismatch in v8x16.shuffle, expected [v128, v128] but got [v128, f32]
+  0000041: error: OnSimdShuffleOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:512: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.92.wat:1:43: error: unexpected token "0local.get", expected a numeric index or a name (e.g. 12 or $foo).
+  ...am v128) (result v128)local.get 0local.get 0v8x16.shuffle 0 1 2 3 4 5 6 7 ...
+                                     ^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.92.wat:1:54: error: unexpected token 0v8x16.shuffle.
+  ...ult v128)local.get 0local.get 0v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 ...
+                                   ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:517: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.93.wat:1:43: error: unexpected token "0local.get", expected a numeric index or a name (e.g. 12 or $foo).
+  ...am v128) (result v128)local.get 0local.get 0v8x16.shuffle 0 1 2 3 4 5 6 7 ...
+                                     ^^^^^^^^^^
+  out/test/spec/simd/simd_lane/simd_lane.93.wat:1:54: error: unexpected token 0v8x16.shuffle.
+  ...ult v128)local.get 0local.get 0v8x16.shuffle 0 1 2 3 4 5 6 7 8 9 10 11 12 ...
+                                   ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:522: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.94.wat:1:70: error: unexpected token "-1", expected a natural number in range [0, 32).
+  ... 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 -1(v128.const i8x16 15 14 13 12 11 10 ...
+                                         ^^
+  out/test/spec/simd/simd_lane/simd_lane.94.wat:1:185: error: unexpected token ), expected EOF.
+  ... 8 7 6 5 4 3 2 1 0)(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:526: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.95.wat:1:70: error: shuffle index "256" out-of-range [0, 32)
+  ... 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 256(v128.const i8x16 15 14 13 12 11 10...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.95.wat:1:186: error: unexpected token ), expected EOF.
+  ... 8 7 6 5 4 3 2 1 0)(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:530: assert_invalid passed:
+  error: lane index must be less than 32 (got 255)
+  000004e: error: OnSimdShuffleOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:537: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.97.wat:1:21: error: unexpected token "i8x16.extract_lane", expected an instr.
+  (func (result i32) (i8x16.extract_lane 0 (v128.const i8x16 0 0 0 0 0 0 0 0 0 ...
+                      ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:538: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.98.wat:1:21: error: unexpected token "i16x8.extract_lane", expected an instr.
+  (func (result i32) (i16x8.extract_lane 0 (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:539: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.99.wat:1:21: error: unexpected token "i32x4.extract_lane_s", expected an instr.
+  (func (result i32) (i32x4.extract_lane_s 0 (v128.const i32x4 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:540: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.100.wat:1:21: error: unexpected token "i32x4.extract_lane_u", expected an instr.
+  (func (result i32) (i32x4.extract_lane_u 0 (v128.const i32x4 0 0 0 0)))
+                      ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:541: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.101.wat:1:21: error: unexpected token "i64x2.extract_lane_s", expected an instr.
+  (func (result i32) (i64x2.extract_lane_s 0 (v128.const i64x2 0 0)))
+                      ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:542: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.102.wat:1:21: error: unexpected token "i64x2.extract_lane_u", expected an instr.
+  (func (result i32) (i64x2.extract_lane_u 0 (v128.const i64x2 0 0)))
+                      ^^^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:546: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.103.wat:1:22: error: unexpected token "v8x16.shuffle1", expected an instr.
+  (func (result v128) (v8x16.shuffle1 (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 ...
+                       ^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:550: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.104.wat:1:22: error: unexpected token "v8x16.shuffle2_imm", expected an instr.
+  (func (result v128) (v8x16.shuffle2_imm  0  1  2  3  4  5  6  7  8  9 10 11 1...
+                       ^^^^^^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:556: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.105.wat:1:22: error: unexpected token "i8x16.swizzle", expected an instr.
+  (func (result v128) (i8x16.swizzle (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 1...
+                       ^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:560: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.106.wat:1:22: error: unexpected token "i8x16.shuffle", expected an instr.
+  (func (result v128) (i8x16.shuffle  0  1  2  3  4  5  6  7  8  9 10 11 12 13 ...
+                       ^^^^^^^^^^^^^
+out/test/spec/simd/simd_lane.wast:571: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.107.wat:1:54: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...) (result i32) (i8x16.extract_lane_s (local.get 0) (v128.const i8x16 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.107.wat:1:68: error: unexpected token (, expected EOF.
+  ... (i8x16.extract_lane_s (local.get 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
+                                          ^
+out/test/spec/simd/simd_lane.wast:572: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.108.wat:1:54: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...) (result i32) (i8x16.extract_lane_u (local.get 0) (v128.const i8x16 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.108.wat:1:68: error: unexpected token (, expected EOF.
+  ... (i8x16.extract_lane_u (local.get 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
+                                          ^
+out/test/spec/simd/simd_lane.wast:573: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.109.wat:1:54: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...) (result i32) (i16x8.extract_lane_s (local.get 0) (v128.const i16x8 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.109.wat:1:68: error: unexpected token (, expected EOF.
+  ...i32) (i16x8.extract_lane_s (local.get 0) (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                              ^
+out/test/spec/simd/simd_lane.wast:574: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.110.wat:1:54: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...) (result i32) (i16x8.extract_lane_u (local.get 0) (v128.const i16x8 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.110.wat:1:68: error: unexpected token (, expected EOF.
+  ...i32) (i16x8.extract_lane_u (local.get 0) (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                              ^
+out/test/spec/simd/simd_lane.wast:575: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.111.wat:1:52: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...32) (result i32) (i32x4.extract_lane (local.get 0) (v128.const i32x4 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.111.wat:1:66: error: unexpected token (, expected EOF.
+  ...) (result i32) (i32x4.extract_lane (local.get 0) (v128.const i32x4 0 0 0 0)))
+                                                      ^
+out/test/spec/simd/simd_lane.wast:576: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.112.wat:1:52: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...32) (result f32) (f32x4.extract_lane (local.get 0) (v128.const f32x4 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.112.wat:1:66: error: unexpected token (, expected EOF.
+  ...) (result f32) (f32x4.extract_lane (local.get 0) (v128.const f32x4 0 0 0 0)))
+                                                      ^
+out/test/spec/simd/simd_lane.wast:577: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.113.wat:1:53: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...2) (result v128) (i8x16.replace_lane (local.get 0) (v128.const i8x16 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.113.wat:1:67: error: unexpected token (, expected EOF.
+  ...8) (i8x16.replace_lane (local.get 0) (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
+                                          ^
+out/test/spec/simd/simd_lane.wast:578: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.114.wat:1:53: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...2) (result v128) (i16x8.replace_lane (local.get 0) (v128.const i16x8 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.114.wat:1:67: error: unexpected token (, expected EOF.
+  ...8) (i16x8.replace_lane (local.get 0) (v128.const i16x8 0 0 0 0 0 0 0 0) (i...
+                                          ^
+out/test/spec/simd/simd_lane.wast:579: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.115.wat:1:53: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...2) (result v128) (i32x4.replace_lane (local.get 0) (v128.const i32x4 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.115.wat:1:67: error: unexpected token (, expected EOF.
+  ...8) (i32x4.replace_lane (local.get 0) (v128.const i32x4 0 0 0 0) (i32.const...
+                                          ^
+out/test/spec/simd/simd_lane.wast:580: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.116.wat:1:53: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...2) (result v128) (f32x4.replace_lane (local.get 0) (v128.const f32x4 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.116.wat:1:67: error: unexpected token (, expected EOF.
+  ...8) (f32x4.replace_lane (local.get 0) (v128.const f32x4 0 0 0 0) (f32.const...
+                                          ^
+out/test/spec/simd/simd_lane.wast:581: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.117.wat:1:49: error: unexpected token "(", expected a natural number in range [0, 32).
+  ...m v128) (result v128) (v8x16.shuffle (local.get 0) (v128.const i8x16 15 14...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.117.wat:1:63: error: unexpected token (, expected EOF.
+  ...t v128) (v8x16.shuffle (local.get 0) (v128.const i8x16 15 14 13 12 11 10 9...
+                                          ^
+out/test/spec/simd/simd_lane.wast:586: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.118.wat:1:52: error: unexpected token "(", expected a natural number (e.g. 123).
+  ... i32) (result i64) (i64x2.extract_lane (local.get 0) (v128.const i64x2 0 0)))
+                                            ^
+  out/test/spec/simd/simd_lane/simd_lane.118.wat:1:66: error: unexpected token (, expected EOF.
+  ... i32) (result i64) (i64x2.extract_lane (local.get 0) (v128.const i64x2 0 0)))
+                                                          ^
+out/test/spec/simd/simd_lane.wast:587: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.119.wat:1:52: error: unexpected token "(", expected a natural number (e.g. 123).
+  ... i32) (result f64) (f64x2.extract_lane (local.get 0) (v128.const f64x2 0 0)))
+                                            ^
+  out/test/spec/simd/simd_lane/simd_lane.119.wat:1:66: error: unexpected token (, expected EOF.
+  ... i32) (result f64) (f64x2.extract_lane (local.get 0) (v128.const f64x2 0 0)))
+                                                          ^
+out/test/spec/simd/simd_lane.wast:588: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.120.wat:1:53: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...2) (result v128) (i64x2.replace_lane (local.get 0) (v128.const i64x2 0 0) ...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.120.wat:1:67: error: unexpected token (, expected EOF.
+  ...128) (i64x2.replace_lane (local.get 0) (v128.const i64x2 0 0) (i64.const 1)))
+                                            ^
+out/test/spec/simd/simd_lane.wast:589: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.121.wat:1:53: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...2) (result v128) (f64x2.replace_lane (local.get 0) (v128.const f64x2 0 0) ...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.121.wat:1:67: error: unexpected token (, expected EOF.
+  ...8) (f64x2.replace_lane (local.get 0) (v128.const f64x2 0 0) (f64.const 1.0)))
+                                          ^
+out/test/spec/simd/simd_lane.wast:593: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.122.wat:1:42: error: unexpected token "1.5", expected a natural number (e.g. 123).
+  ... (result i32) (i8x16.extract_lane_s 1.5 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.122.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_s 1.5 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:594: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.123.wat:1:42: error: unexpected token "nan", expected a natural number (e.g. 123).
+  ... (result i32) (i8x16.extract_lane_u nan (v128.const i8x16 0 0 0 0 0 0 0 0 ...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.123.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_u nan (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:595: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.124.wat:1:42: error: unexpected token "inf", expected a natural number (e.g. 123).
+  ...c (result i32) (i16x8.extract_lane_s inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                          ^^^
+  out/test/spec/simd/simd_lane/simd_lane.124.wat:1:81: error: unexpected token ), expected EOF.
+  ...c (result i32) (i16x8.extract_lane_s inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:596: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.125.wat:1:42: error: unexpected token "-inf", expected a natural number (e.g. 123).
+  ... (result i32) (i16x8.extract_lane_u -inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                         ^^^^
+  out/test/spec/simd/simd_lane/simd_lane.125.wat:1:82: error: unexpected token ), expected EOF.
+  ... (result i32) (i16x8.extract_lane_u -inf (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:597: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.126.wat:1:40: error: unexpected token "nan", expected a natural number (e.g. 123).
+  (func (result i32) (i32x4.extract_lane nan (v128.const i32x4 0 0 0 0)))
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.126.wat:1:71: error: unexpected token ), expected EOF.
+  (func (result i32) (i32x4.extract_lane nan (v128.const i32x4 0 0 0 0)))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:598: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.127.wat:1:40: error: unexpected token "nan", expected a natural number (e.g. 123).
+  (func (result f32) (f32x4.extract_lane nan (v128.const f32x4 0 0 0 0)))
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.127.wat:1:71: error: unexpected token ), expected EOF.
+  (func (result f32) (f32x4.extract_lane nan (v128.const f32x4 0 0 0 0)))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:599: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.128.wat:1:41: error: unexpected token "-2.5", expected a natural number (e.g. 123).
+  ... (result v128) (i8x16.replace_lane -2.5 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
+                                        ^^^^
+  out/test/spec/simd/simd_lane/simd_lane.128.wat:1:111: error: unexpected token ), expected EOF.
+  ..._lane -2.5 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:600: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.129.wat:1:41: error: unexpected token "nan", expected a natural number (e.g. 123).
+  ...c (result v128) (i16x8.replace_lane nan (v128.const i16x8 0 0 0 0 0 0 0 0)...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.129.wat:1:94: error: unexpected token ), expected EOF.
+  ...8) (i16x8.replace_lane nan (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:601: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.130.wat:1:41: error: unexpected token "inf", expected a natural number (e.g. 123).
+  ...c (result v128) (i32x4.replace_lane inf (v128.const i32x4 0 0 0 0) (i32.co...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.130.wat:1:86: error: unexpected token ), expected EOF.
+  ...sult v128) (i32x4.replace_lane inf (v128.const i32x4 0 0 0 0) (i32.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:602: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.131.wat:1:41: error: unexpected token "-inf", expected a natural number (e.g. 123).
+  ... (result v128) (f32x4.replace_lane -inf (v128.const f32x4 0 0 0 0) (f32.co...
+                                        ^^^^
+  out/test/spec/simd/simd_lane/simd_lane.131.wat:1:89: error: unexpected token ), expected EOF.
+  ...t v128) (f32x4.replace_lane -inf (v128.const f32x4 0 0 0 0) (f32.const 1.1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:604: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.132.wat:1:40: error: unexpected token "nan", expected a natural number (e.g. 123).
+  (func (result i64) (i64x2.extract_lane nan (v128.const i64x2 0 0)))
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.132.wat:1:67: error: unexpected token ), expected EOF.
+  (func (result i64) (i64x2.extract_lane nan (v128.const i64x2 0 0)))
+                                                                    ^
+out/test/spec/simd/simd_lane.wast:605: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.133.wat:1:40: error: unexpected token "nan", expected a natural number (e.g. 123).
+  (func (result f64) (f64x2.extract_lane nan (v128.const f64x2 0 0)))
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.133.wat:1:67: error: unexpected token ), expected EOF.
+  (func (result f64) (f64x2.extract_lane nan (v128.const f64x2 0 0)))
+                                                                    ^
+out/test/spec/simd/simd_lane.wast:606: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.134.wat:1:41: error: unexpected token "inf", expected a natural number (e.g. 123).
+  ...c (result v128) (i64x2.replace_lane inf (v128.const i64x2 0 0) (i64.const ...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.134.wat:1:82: error: unexpected token ), expected EOF.
+  ... (result v128) (i64x2.replace_lane inf (v128.const i64x2 0 0) (i64.const 1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:607: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.135.wat:1:41: error: unexpected token "-inf", expected a natural number (e.g. 123).
+  ... (result v128) (f64x2.replace_lane -inf (v128.const f64x2 0 0) (f64.const ...
+                                        ^^^^
+  out/test/spec/simd/simd_lane/simd_lane.135.wat:1:85: error: unexpected token ), expected EOF.
+  ...esult v128) (f64x2.replace_lane -inf (v128.const f64x2 0 0) (f64.const 1.1)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:610: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.136.wat:1:36: error: unexpected token "(", expected a natural number in range [0, 32).
+  (func (result v128) (v8x16.shuffle (v128.const i8x16 16 17 18 19 20 21 22 23 ...
+                                     ^
+  out/test/spec/simd/simd_lane/simd_lane.136.wat:1:103: error: unexpected token (, expected EOF.
+  ...20 21 22 23 24 25 26 27 28 29 30 31) (v128.const i8x16 15 14 13 12 11 10 9...
+                                          ^
+out/test/spec/simd/simd_lane.wast:614: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.137.wat:1:71: error: unexpected token "15.0", expected a natural number in range [0, 32).
+  ...0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15.0) (v128.const i8x16 15 14 13 12 11 ...
+                                        ^^^^
+  out/test/spec/simd/simd_lane/simd_lane.137.wat:1:191: error: unexpected token ), expected EOF.
+  ...8 7 6 5 4 3 2 1 0) (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:618: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.138.wat:1:36: error: unexpected token "0.5", expected a natural number in range [0, 32).
+  (func (result v128) (v8x16.shuffle 0.5 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) (...
+                                     ^^^
+out/test/spec/simd/simd_lane.wast:622: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.139.wat:1:36: error: unexpected token "-inf", expected a natural number in range [0, 32).
+  (func (result v128) (v8x16.shuffle -inf 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) ...
+                                     ^^^^
+out/test/spec/simd/simd_lane.wast:626: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.140.wat:1:71: error: unexpected token "inf", expected a natural number in range [0, 32).
+  ... 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 inf) (v128.const i8x16 15 14 13 12 11 ...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.140.wat:1:190: error: unexpected token ), expected EOF.
+  ...8 7 6 5 4 3 2 1 0) (v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:630: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.141.wat:1:36: error: unexpected token "nan", expected a natural number in range [0, 32).
+  (func (result v128) (v8x16.shuffle nan 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15) (...
+                                     ^^^
+out/test/spec/simd/simd_lane.wast:907: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.161.wat:1:42: error: unexpected token "1.0", expected a natural number (e.g. 123).
+  ... (result i32) (i8x16.extract_lane_s 1.0 (v128.const i8x16 0 0 0 0 0 0 0 0 ...
+                                         ^^^
+  out/test/spec/simd/simd_lane/simd_lane.161.wat:1:97: error: unexpected token ), expected EOF.
+  ...i8x16.extract_lane_s 1.0 (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                 ^
+out/test/spec/simd/simd_lane.wast:912: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.162.wat:1:79: error: unexpected token "(", expected a natural number (e.g. 123).
+  ... (result i32)  (i8x16.extract_lane_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.162.wat:1:129: error: unexpected token ), expected EOF.
+  ...)  (i8x16.extract_lane_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
+                                                                                ^
+out/test/spec/simd/simd_lane.wast:920: assert_invalid passed:
+  error: type mismatch in i8x16.extract_lane_s, expected [v128] but got []
+  000001b: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:928: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.164.wat:1:74: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i8x16.extract_lane_s-arg-empty (result i32)  (i8x16.extract_lane_s))
+                                                                           ^
+out/test/spec/simd/simd_lane.wast:936: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.165.wat:1:79: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...mpty (result i32)  (i16x8.extract_lane_u (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                              ^
+  out/test/spec/simd/simd_lane/simd_lane.165.wat:1:113: error: unexpected token ), expected EOF.
+  ...mpty (result i32)  (i16x8.extract_lane_u (v128.const i16x8 0 0 0 0 0 0 0 0)))
+                                                                                ^
+out/test/spec/simd/simd_lane.wast:944: assert_invalid passed:
+  error: type mismatch in i16x8.extract_lane_u, expected [v128] but got []
+  000001b: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:952: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.167.wat:1:74: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i16x8.extract_lane_u-arg-empty (result i32)  (i16x8.extract_lane_u))
+                                                                           ^
+out/test/spec/simd/simd_lane.wast:960: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.168.wat:1:75: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...-1st-arg-empty (result i32)  (i32x4.extract_lane (v128.const i32x4 0 0 0 0)))
+                                                      ^
+  out/test/spec/simd/simd_lane/simd_lane.168.wat:1:101: error: unexpected token ), expected EOF.
+  ...-1st-arg-empty (result i32)  (i32x4.extract_lane (v128.const i32x4 0 0 0 0)))
+                                                                                ^
+out/test/spec/simd/simd_lane.wast:968: assert_invalid passed:
+  error: type mismatch in i32x4.extract_lane, expected [v128] but got []
+  000001b: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:976: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.170.wat:1:70: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i32x4.extract_lane-arg-empty (result i32)  (i32x4.extract_lane))
+                                                                       ^
+out/test/spec/simd/simd_lane.wast:984: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.171.wat:1:75: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...lane-1st-arg-empty (result i64)  (i64x2.extract_lane (v128.const i64x2 0 0)))
+                                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.171.wat:1:97: error: unexpected token ), expected EOF.
+  ...lane-1st-arg-empty (result i64)  (i64x2.extract_lane (v128.const i64x2 0 0)))
+                                                                                ^
+out/test/spec/simd/simd_lane.wast:992: assert_invalid passed:
+  error: type mismatch in i64x2.extract_lane, expected [v128] but got []
+  000001b: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1000: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.173.wat:1:70: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i64x2.extract_lane-arg-empty (result i64)  (i64x2.extract_lane))
+                                                                       ^
+out/test/spec/simd/simd_lane.wast:1008: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.174.wat:1:75: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...-1st-arg-empty (result f32)  (f32x4.extract_lane (v128.const f32x4 0 0 0 0)))
+                                                      ^
+  out/test/spec/simd/simd_lane/simd_lane.174.wat:1:101: error: unexpected token ), expected EOF.
+  ...-1st-arg-empty (result f32)  (f32x4.extract_lane (v128.const f32x4 0 0 0 0)))
+                                                                                ^
+out/test/spec/simd/simd_lane.wast:1016: assert_invalid passed:
+  error: type mismatch in f32x4.extract_lane, expected [v128] but got []
+  000001b: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1024: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.176.wat:1:70: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $f32x4.extract_lane-arg-empty (result f32)  (f32x4.extract_lane))
+                                                                       ^
+out/test/spec/simd/simd_lane.wast:1032: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.177.wat:1:75: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...lane-1st-arg-empty (result f64)  (f64x2.extract_lane (v128.const f64x2 0 0)))
+                                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.177.wat:1:97: error: unexpected token ), expected EOF.
+  ...lane-1st-arg-empty (result f64)  (f64x2.extract_lane (v128.const f64x2 0 0)))
+                                                                                ^
+out/test/spec/simd/simd_lane.wast:1040: assert_invalid passed:
+  error: type mismatch in f64x2.extract_lane, expected [v128] but got []
+  000001b: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1048: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.179.wat:1:70: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $f64x2.extract_lane-arg-empty (result f64)  (f64x2.extract_lane))
+                                                                       ^
+out/test/spec/simd/simd_lane.wast:1056: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.180.wat:1:76: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...y (result v128)  (i8x16.replace_lane (v128.const i8x16 0 0 0 0 0 0 0 0 0 0...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.180.wat:1:127: error: unexpected token (, expected EOF.
+  ...place_lane (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                   ^
+out/test/spec/simd/simd_lane.wast:1064: assert_invalid passed:
+  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1072: assert_invalid passed:
+  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [v128]
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1080: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.183.wat:1:71: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i8x16.replace_lane-arg-empty (result v128)  (i8x16.replace_lane))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:1088: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.184.wat:1:76: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...y (result v128)  (i16x8.replace_lane (v128.const i16x8 0 0 0 0 0 0 0 0) (i...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.184.wat:1:111: error: unexpected token (, expected EOF.
+  ...v128)  (i16x8.replace_lane (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
+                                                                   ^
+out/test/spec/simd/simd_lane.wast:1096: assert_invalid passed:
+  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i32]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1104: assert_invalid passed:
+  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [v128]
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1112: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.187.wat:1:71: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i16x8.replace_lane-arg-empty (result v128)  (i16x8.replace_lane))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:1120: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.188.wat:1:76: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...y (result v128)  (i32x4.replace_lane (v128.const i32x4 0 0 0 0) (i32.const...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.188.wat:1:103: error: unexpected token (, expected EOF.
+  ...(result v128)  (i32x4.replace_lane (v128.const i32x4 0 0 0 0) (i32.const 1)))
+                                                                   ^
+out/test/spec/simd/simd_lane.wast:1128: assert_invalid passed:
+  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1136: assert_invalid passed:
+  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [v128]
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1144: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.191.wat:1:71: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i32x4.replace_lane-arg-empty (result v128)  (i32x4.replace_lane))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:1152: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.192.wat:1:76: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...y (result v128)  (f32x4.replace_lane (v128.const f32x4 0 0 0 0) (f32.const...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.192.wat:1:103: error: unexpected token (, expected EOF.
+  ...esult v128)  (f32x4.replace_lane (v128.const f32x4 0 0 0 0) (f32.const 1.0)))
+                                                                 ^
+out/test/spec/simd/simd_lane.wast:1160: assert_invalid passed:
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32]
+  0000020: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1168: assert_invalid passed:
+  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128]
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1176: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.195.wat:1:71: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $f32x4.replace_lane-arg-empty (result v128)  (f32x4.replace_lane))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:1184: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.196.wat:1:76: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...pty (result v128)  (i64x2.replace_lane (v128.const i64x2 0 0) (i64.const 1)))
+                                            ^
+  out/test/spec/simd/simd_lane/simd_lane.196.wat:1:99: error: unexpected token (, expected EOF.
+  ...pty (result v128)  (i64x2.replace_lane (v128.const i64x2 0 0) (i64.const 1)))
+                                                                   ^
+out/test/spec/simd/simd_lane.wast:1192: assert_invalid passed:
+  error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [i64]
+  000001d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1200: assert_invalid passed:
+  error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [v128]
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1208: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.199.wat:1:71: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $i64x2.replace_lane-arg-empty (result v128)  (i64x2.replace_lane))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:1216: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.200.wat:1:76: error: unexpected token "(", expected a natural number (e.g. 123).
+  ...y (result v128)  (f64x2.replace_lane (v128.const f64x2 0 0) (f64.const 1.0)))
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.200.wat:1:99: error: unexpected token (, expected EOF.
+  ...y (result v128)  (f64x2.replace_lane (v128.const f64x2 0 0) (f64.const 1.0)))
+                                                                 ^
+out/test/spec/simd/simd_lane.wast:1224: assert_invalid passed:
+  error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [f64]
+  0000024: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1232: assert_invalid passed:
+  error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [v128]
+  000002d: error: OnSimdLaneOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1240: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.203.wat:1:71: error: unexpected token ")", expected a natural number (e.g. 123).
+  (func $f64x2.replace_lane-arg-empty (result v128)  (f64x2.replace_lane))
+                                                                        ^
+out/test/spec/simd/simd_lane.wast:1248: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.204.wat:1:69: error: unexpected token "(", expected a natural number in range [0, 32).
+  ...pty (result v128)  (v8x16.shuffle    (v128.const i8x16 0 1 2 3 5 6 6 7 8 9...
+                                          ^
+  out/test/spec/simd/simd_lane/simd_lane.204.wat:1:129: error: unexpected token (, expected EOF.
+  ... 3 5 6 6 7 8 9 10 11 12 13 14 15)    (v128.const i8x16 1 2 3 5 6 6 7 8 9 1...
+                                          ^
+out/test/spec/simd/simd_lane.wast:1259: assert_invalid passed:
+  error: type mismatch in v8x16.shuffle, expected [v128, v128] but got [v128]
+  000003c: error: OnSimdShuffleOpExpr callback failed
+out/test/spec/simd/simd_lane.wast:1269: assert_malformed passed:
+  out/test/spec/simd/simd_lane/simd_lane.206.wat:1:61: error: unexpected token ")", expected a natural number in range [0, 32).
+  (func $v8x16.shuffle-arg-empty (result v128)  (v8x16.shuffle))
+                                                              ^
+461/461 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_load.txt
+++ b/test/spec/simd/simd_load.txt
@@ -1,0 +1,42 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_load.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_load.wast:141: assert_malformed passed:
+  out/test/spec/simd/simd_load/simd_load.14.wat:1:37: error: unexpected token "v128.load8", expected an expr.
+  (memory 1)(func (local v128) (drop (v128.load8 (i32.const 0))))
+                                      ^^^^^^^^^^
+  out/test/spec/simd/simd_load/simd_load.14.wat:1:62: error: unexpected token ), expected EOF.
+  (memory 1)(func (local v128) (drop (v128.load8 (i32.const 0))))
+                                                               ^
+out/test/spec/simd/simd_load.wast:148: assert_malformed passed:
+  out/test/spec/simd/simd_load/simd_load.15.wat:1:37: error: unexpected token "v128.load16", expected an expr.
+  (memory 1)(func (local v128) (drop (v128.load16 (i32.const 0))))
+                                      ^^^^^^^^^^^
+  out/test/spec/simd/simd_load/simd_load.15.wat:1:63: error: unexpected token ), expected EOF.
+  (memory 1)(func (local v128) (drop (v128.load16 (i32.const 0))))
+                                                                ^
+out/test/spec/simd/simd_load.wast:155: assert_malformed passed:
+  out/test/spec/simd/simd_load/simd_load.16.wat:1:37: error: unexpected token "v128.load32", expected an expr.
+  (memory 1)(func (local v128) (drop (v128.load32 (i32.const 0))))
+                                      ^^^^^^^^^^^
+  out/test/spec/simd/simd_load/simd_load.16.wat:1:63: error: unexpected token ), expected EOF.
+  (memory 1)(func (local v128) (drop (v128.load32 (i32.const 0))))
+                                                                ^
+out/test/spec/simd/simd_load.wast:166: assert_invalid passed:
+  error: type mismatch in v128.load, expected [i32] but got [f32]
+  0000027: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load.wast:170: assert_invalid passed:
+  error: type mismatch in br_if, expected [i32] but got [v128]
+  0000028: error: OnBrIfExpr callback failed
+out/test/spec/simd/simd_load.wast:174: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [v128]
+  0000025: error: EndFunctionBody callback failed
+out/test/spec/simd/simd_load.wast:182: assert_invalid passed:
+  0000000: error: local variable out of range (max 0)
+  000001e: error: OnLocalGetExpr callback failed
+out/test/spec/simd/simd_load.wast:186: assert_invalid passed:
+  error: type mismatch in v128.load, expected [i32] but got []
+  0000020: error: OnLoadExpr callback failed
+25/25 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_load_extend.txt
+++ b/test/spec/simd/simd_load_extend.txt
@@ -1,0 +1,90 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_load_extend.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_load_extend.wast:208: assert_trap passed: out of bounds memory access: access at 4294967295+8 >= max value 65536
+out/test/spec/simd/simd_load_extend.wast:209: assert_trap passed: out of bounds memory access: access at 4294967295+8 >= max value 65536
+out/test/spec/simd/simd_load_extend.wast:210: assert_trap passed: out of bounds memory access: access at 65536+8 >= max value 65536
+out/test/spec/simd/simd_load_extend.wast:211: assert_trap passed: out of bounds memory access: access at 65536+8 >= max value 65536
+out/test/spec/simd/simd_load_extend.wast:212: assert_trap passed: out of bounds memory access: access at 65529+8 >= max value 65536
+out/test/spec/simd/simd_load_extend.wast:213: assert_trap passed: out of bounds memory access: access at 65529+8 >= max value 65536
+out/test/spec/simd/simd_load_extend.wast:216: assert_invalid passed:
+  error: type mismatch in i16x8.load8x8_s, expected [i32] but got [f32]
+  0000027: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:217: assert_invalid passed:
+  error: type mismatch in i16x8.load8x8_u, expected [i32] but got [f32]
+  0000027: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:218: assert_invalid passed:
+  error: type mismatch in i32x4.load16x4_s, expected [i32] but got [f64]
+  000002b: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:219: assert_invalid passed:
+  error: type mismatch in i32x4.load16x4_u, expected [i32] but got [f64]
+  000002b: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:220: assert_invalid passed:
+  error: type mismatch in i64x2.load32x2_s, expected [i32] but got [v128]
+  0000034: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:221: assert_invalid passed:
+  error: type mismatch in i64x2.load32x2_u, expected [i32] but got [v128]
+  0000034: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:226: assert_invalid passed:
+  error: type mismatch in i16x8.load8x8_s, expected [i32] but got []
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:234: assert_invalid passed:
+  error: type mismatch in i16x8.load8x8_u, expected [i32] but got []
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:242: assert_invalid passed:
+  error: type mismatch in i32x4.load16x4_s, expected [i32] but got []
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:250: assert_invalid passed:
+  error: type mismatch in i32x4.load16x4_u, expected [i32] but got []
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:258: assert_invalid passed:
+  error: type mismatch in i64x2.load32x2_s, expected [i32] but got []
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:266: assert_invalid passed:
+  error: type mismatch in i64x2.load32x2_u, expected [i32] but got []
+  0000022: error: OnLoadExpr callback failed
+out/test/spec/simd/simd_load_extend.wast:276: assert_malformed passed:
+  out/test/spec/simd/simd_load_extend/simd_load_extend.13.wat:1:25: error: unexpected token "i16x8.load16x4_s", expected an expr.
+  (memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_extend/simd_load_extend.13.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i16x8.load16x4_s (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_extend.wast:277: assert_malformed passed:
+  out/test/spec/simd/simd_load_extend/simd_load_extend.14.wat:1:25: error: unexpected token "i16x8.load16x4_u", expected an expr.
+  (memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_extend/simd_load_extend.14.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i16x8.load16x4_u (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_extend.wast:278: assert_malformed passed:
+  out/test/spec/simd/simd_load_extend/simd_load_extend.15.wat:1:25: error: unexpected token "i32x4.load32x2_s", expected an expr.
+  (memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_extend/simd_load_extend.15.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i32x4.load32x2_s (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_extend.wast:279: assert_malformed passed:
+  out/test/spec/simd/simd_load_extend/simd_load_extend.16.wat:1:25: error: unexpected token "i32x4.load32x2_u", expected an expr.
+  (memory 1) (func (drop (i32x4.load32x2_u (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_extend/simd_load_extend.16.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i32x4.load32x2_u (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_extend.wast:280: assert_malformed passed:
+  out/test/spec/simd/simd_load_extend/simd_load_extend.17.wat:1:25: error: unexpected token "i64x2.load64x1_s", expected an expr.
+  (memory 1) (func (drop (i64x2.load64x1_s (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_extend/simd_load_extend.17.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i64x2.load64x1_s (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_extend.wast:281: assert_malformed passed:
+  out/test/spec/simd/simd_load_extend/simd_load_extend.18.wat:1:25: error: unexpected token "i64x2.load64x1_u", expected an expr.
+  (memory 1) (func (drop (i64x2.load64x1_u (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_extend/simd_load_extend.18.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i64x2.load64x1_u (i32.const 0))))
+                                                         ^
+96/96 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_load_splat.txt
+++ b/test/spec/simd/simd_load_splat.txt
@@ -1,0 +1,86 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_load_splat.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_load_splat.wast:119: assert_trap passed: out of bounds memory access: access at 4294967295+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:120: assert_trap passed: out of bounds memory access: access at 4294967295+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:121: assert_trap passed: out of bounds memory access: access at 4294967295+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:122: assert_trap passed: out of bounds memory access: access at 4294967295+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:123: assert_trap passed: out of bounds memory access: access at 65536+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:124: assert_trap passed: out of bounds memory access: access at 65535+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:125: assert_trap passed: out of bounds memory access: access at 65533+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:126: assert_trap passed: out of bounds memory access: access at 65529+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:128: assert_trap passed: out of bounds memory access: access at 65536+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:129: assert_trap passed: out of bounds memory access: access at 65537+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:130: assert_trap passed: out of bounds memory access: access at 65550+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:131: assert_trap passed: out of bounds memory access: access at 65535+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:132: assert_trap passed: out of bounds memory access: access at 65536+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:133: assert_trap passed: out of bounds memory access: access at 65549+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:134: assert_trap passed: out of bounds memory access: access at 65533+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:135: assert_trap passed: out of bounds memory access: access at 65534+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:136: assert_trap passed: out of bounds memory access: access at 65547+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:137: assert_trap passed: out of bounds memory access: access at 65529+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:138: assert_trap passed: out of bounds memory access: access at 65530+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:139: assert_trap passed: out of bounds memory access: access at 65543+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:141: assert_trap passed: out of bounds memory access: access at 65536+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:142: assert_trap passed: out of bounds memory access: access at 65535+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:143: assert_trap passed: out of bounds memory access: access at 65533+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:144: assert_trap passed: out of bounds memory access: access at 65529+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:145: assert_trap passed: out of bounds memory access: access at 65537+1 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:146: assert_trap passed: out of bounds memory access: access at 65536+2 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:147: assert_trap passed: out of bounds memory access: access at 65534+4 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:148: assert_trap passed: out of bounds memory access: access at 65530+8 >= max value 65536
+out/test/spec/simd/simd_load_splat.wast:209: assert_invalid passed:
+  error: type mismatch in v8x16.load_splat, expected [i32] but got [v128]
+  0000034: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:210: assert_invalid passed:
+  error: type mismatch in v16x8.load_splat, expected [i32] but got [v128]
+  0000034: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:211: assert_invalid passed:
+  error: type mismatch in v32x4.load_splat, expected [i32] but got [v128]
+  0000034: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:212: assert_invalid passed:
+  error: type mismatch in v64x2.load_splat, expected [i32] but got [v128]
+  0000034: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:217: assert_malformed passed:
+  out/test/spec/simd/simd_load_splat/simd_load_splat.6.wat:1:25: error: unexpected token "i8x16.load_splat", expected an expr.
+  (memory 1) (func (drop (i8x16.load_splat (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_splat/simd_load_splat.6.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i8x16.load_splat (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_splat.wast:218: assert_malformed passed:
+  out/test/spec/simd/simd_load_splat/simd_load_splat.7.wat:1:25: error: unexpected token "i16x8.load_splat", expected an expr.
+  (memory 1) (func (drop (i16x8.load_splat (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_splat/simd_load_splat.7.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i16x8.load_splat (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_splat.wast:219: assert_malformed passed:
+  out/test/spec/simd/simd_load_splat/simd_load_splat.8.wat:1:25: error: unexpected token "i32x4.load_splat", expected an expr.
+  (memory 1) (func (drop (i32x4.load_splat (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_splat/simd_load_splat.8.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i32x4.load_splat (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_splat.wast:220: assert_malformed passed:
+  out/test/spec/simd/simd_load_splat/simd_load_splat.9.wat:1:25: error: unexpected token "i64x2.load_splat", expected an expr.
+  (memory 1) (func (drop (i64x2.load_splat (i32.const 0))))
+                          ^^^^^^^^^^^^^^^^
+  out/test/spec/simd/simd_load_splat/simd_load_splat.9.wat:1:56: error: unexpected token ), expected EOF.
+  (memory 1) (func (drop (i64x2.load_splat (i32.const 0))))
+                                                         ^
+out/test/spec/simd/simd_load_splat.wast:226: assert_invalid passed:
+  error: type mismatch in v8x16.load_splat, expected [i32] but got []
+  0000022: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:234: assert_invalid passed:
+  error: type mismatch in v16x8.load_splat, expected [i32] but got []
+  0000022: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:242: assert_invalid passed:
+  error: type mismatch in v32x4.load_splat, expected [i32] but got []
+  0000022: error: OnLoadSplatExpr callback failed
+out/test/spec/simd/simd_load_splat.wast:250: assert_invalid passed:
+  error: type mismatch in v64x2.load_splat, expected [i32] but got []
+  0000022: error: OnLoadSplatExpr callback failed
+120/120 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_splat.txt
+++ b/test/spec/simd/simd_splat.txt
@@ -1,0 +1,76 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_splat.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_splat.wast:122: assert_malformed passed:
+  out/test/spec/simd/simd_splat/simd_splat.1.wat:1:22: error: unexpected token "v128.splat", expected an instr.
+  (func (result v128) (v128.splat (i32.const 0)))
+                       ^^^^^^^^^^
+out/test/spec/simd/simd_splat.wast:127: assert_invalid passed:
+  error: type mismatch in i8x16.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:128: assert_invalid passed:
+  error: type mismatch in i8x16.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:129: assert_invalid passed:
+  error: type mismatch in i8x16.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:130: assert_invalid passed:
+  error: type mismatch in i16x8.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:131: assert_invalid passed:
+  error: type mismatch in i16x8.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:132: assert_invalid passed:
+  error: type mismatch in i16x8.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:133: assert_invalid passed:
+  error: type mismatch in i32x4.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:134: assert_invalid passed:
+  error: type mismatch in i32x4.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:135: assert_invalid passed:
+  error: type mismatch in i32x4.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:136: assert_invalid passed:
+  error: type mismatch in f32x4.splat, expected [f32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:137: assert_invalid passed:
+  error: type mismatch in f32x4.splat, expected [f32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:138: assert_invalid passed:
+  error: type mismatch in f32x4.splat, expected [f32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:139: assert_invalid passed:
+  error: type mismatch in i64x2.splat, expected [i64] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:140: assert_invalid passed:
+  error: type mismatch in i64x2.splat, expected [i64] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:141: assert_invalid passed:
+  error: type mismatch in f64x2.splat, expected [f64] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:142: assert_invalid passed:
+  error: type mismatch in f64x2.splat, expected [f64] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:384: assert_invalid passed:
+  error: type mismatch in i8x16.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:392: assert_invalid passed:
+  error: type mismatch in i16x8.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:400: assert_invalid passed:
+  error: type mismatch in i32x4.splat, expected [i32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:408: assert_invalid passed:
+  error: type mismatch in f32x4.splat, expected [f32] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:416: assert_invalid passed:
+  error: type mismatch in i64x2.splat, expected [i64] but got []
+  000001a: error: OnUnaryExpr callback failed
+out/test/spec/simd/simd_splat.wast:424: assert_invalid passed:
+  error: type mismatch in f64x2.splat, expected [f64] but got []
+  000001a: error: OnUnaryExpr callback failed
+181/181 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_store.txt
+++ b/test/spec/simd/simd_store.txt
@@ -1,0 +1,36 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_store.wast
+;;; ARGS*: --enable-simd
+(;; STDOUT ;;;
+out/test/spec/simd/simd_store.wast:103: assert_malformed passed:
+  out/test/spec/simd/simd_store/simd_store.2.wat:1:18: error: unexpected token "v128.store8", expected an instr.
+  (memory 1)(func (v128.store8 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                   ^^^^^^^^^^^
+out/test/spec/simd/simd_store.wast:110: assert_malformed passed:
+  out/test/spec/simd/simd_store/simd_store.3.wat:1:18: error: unexpected token "v128.store16", expected an instr.
+  (memory 1)(func (v128.store16 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                   ^^^^^^^^^^^^
+out/test/spec/simd/simd_store.wast:117: assert_malformed passed:
+  out/test/spec/simd/simd_store/simd_store.4.wat:1:18: error: unexpected token "v128.store32", expected an instr.
+  (memory 1)(func (v128.store32 (i32.const 0) (v128.const i32x4 0 0 0 0)))
+                   ^^^^^^^^^^^^
+out/test/spec/simd/simd_store.wast:128: assert_invalid passed:
+  error: type mismatch in v128.store, expected [i32, v128] but got [f32, v128]
+  0000037: error: OnStoreExpr callback failed
+out/test/spec/simd/simd_store.wast:132: assert_invalid passed:
+  error: type mismatch in v128.store, expected [i32, v128] but got []
+  0000024: error: OnStoreExpr callback failed
+out/test/spec/simd/simd_store.wast:136: assert_invalid passed:
+  error: type mismatch in implicit return, expected [v128] but got []
+  0000036: error: EndFunctionBody callback failed
+out/test/spec/simd/simd_store.wast:144: assert_invalid passed:
+  error: type mismatch in v128.store, expected [i32, v128] but got [v128]
+  0000032: error: OnStoreExpr callback failed
+out/test/spec/simd/simd_store.wast:152: assert_invalid passed:
+  error: type mismatch in v128.store, expected [i32, v128] but got [i32]
+  0000022: error: OnStoreExpr callback failed
+out/test/spec/simd/simd_store.wast:160: assert_invalid passed:
+  error: type mismatch in v128.store, expected [i32, v128] but got []
+  0000020: error: OnStoreExpr callback failed
+26/26 tests passed.
+;;; STDOUT ;;)

--- a/test/spectest-interp-assert-failure.txt
+++ b/test/spectest-interp-assert-failure.txt
@@ -14,7 +14,7 @@
 (assert_return (invoke "func32nan") (f32.const nan:canonical))
 (assert_return (invoke "func64nan") (f64.const nan:canonical))
 (;; STDOUT ;;;
-out/test/spectest-interp-assert-failure.txt:10: expected result to be nan, got f32:0.100000
-out/test/spectest-interp-assert-failure.txt:11: expected result to be nan, got f64:0.200000
+out/test/spectest-interp-assert-failure.txt:10: mismatch in result 0 of assert_return: expected f32:nan:canonical, got f32:0.100000
+out/test/spectest-interp-assert-failure.txt:11: mismatch in result 0 of assert_return: expected f64:nan:arithmetic, got f64:0.200000
 4/6 tests passed.
 ;;; STDOUT ;;)

--- a/test/spectest-interp-invalid-literal.txt
+++ b/test/spectest-interp-invalid-literal.txt
@@ -13,5 +13,5 @@
   ]
 }
 (;; STDERR ;;;
-out/test/spectest-interp-invalid-literal.txt:11:50: invalid i32 literal
+out/test/spectest-interp-invalid-literal.txt:11:49: invalid i32 literal
 ;;; STDERR ;;)

--- a/test/typecheck/bad-simd-lane.txt
+++ b/test/typecheck/bad-simd-lane.txt
@@ -20,43 +20,7 @@
   (func (result i32) v128.const i32x4 0 0 0 0 i8x16.extract_lane_s 0x100000000)
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-simd-lane.txt:5:47: error: lane index must be less than 16 (got 16)
-  (func (result i32) v128.const i32x4 0 0 0 0 i8x16.extract_lane_s 16)
-                                              ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:6:47: error: lane index must be less than 16 (got 16)
-  (func (result i32) v128.const i32x4 0 0 0 0 i8x16.extract_lane_u 16)
-                                              ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:7:47: error: lane index must be less than 8 (got 8)
-  (func (result i32) v128.const i32x4 0 0 0 0 i16x8.extract_lane_s 8)
-                                              ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:8:47: error: lane index must be less than 8 (got 8)
-  (func (result i32) v128.const i32x4 0 0 0 0 i16x8.extract_lane_u 8)
-                                              ^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:9:47: error: lane index must be less than 4 (got 4)
-  (func (result i32) v128.const i32x4 0 0 0 0 i32x4.extract_lane 4)
-                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:10:47: error: lane index must be less than 4 (got 4)
-  (func (result f32) v128.const i32x4 0 0 0 0 f32x4.extract_lane 4)
-                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:11:47: error: lane index must be less than 2 (got 2)
-  (func (result f64) v128.const i32x4 0 0 0 0 f64x2.extract_lane 2)
-                                              ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:13:60: error: lane index must be less than 16 (got 16)
-...unc (result v128) v128.const i32x4 0 0 0 0 i32.const 0 i8x16.replace_lane 16)
-                                                          ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:14:60: error: lane index must be less than 8 (got 8)
-  (func (result v128) v128.const i32x4 0 0 0 0 i32.const 0 i16x8.replace_lane 8)
-                                                           ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:15:60: error: lane index must be less than 4 (got 4)
-  (func (result v128) v128.const i32x4 0 0 0 0 i32.const 0 i32x4.replace_lane 4)
-                                                           ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:16:60: error: lane index must be less than 4 (got 4)
-  (func (result v128) v128.const i32x4 0 0 0 0 f32.const 0 f32x4.replace_lane 4)
-                                                           ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:17:60: error: lane index must be less than 2 (got 2)
-  (func (result v128) v128.const i32x4 0 0 0 0 f64.const 0 f64x2.replace_lane 2)
-                                                           ^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-simd-lane.txt:20:47: error: lane index must be less than 16 (got 4294967296)
+out/test/typecheck/bad-simd-lane.txt:20:47: error: lane index "0x100000000" out-of-range [0, 32)
   (func (result i32) v128.const i32x4 0 0 0 0 i8x16.extract_lane_s 0x100000000)
                                               ^^^^^^^^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -92,6 +92,7 @@ def main(args):
     ProcessProposalDir('sign-extension-ops', '--enable-sign-extension')
     ProcessProposalDir('bulk-memory-operations', '--enable-bulk-memory')
     ProcessProposalDir('reference-types', '--enable-reference-types')
+    ProcessProposalDir('simd', '--enable-simd')
 
     return 0
 


### PR DESCRIPTION
Lots of changes necessary to make this work, as well as some bug fixes.

The main change is allowing `nan:canonical` and `nan:arithmetic` as a
possible value for each lane of a `v128`. This needs to propogate
through the parser, IR, the JSON format, and the spec interpreter.

This also changes the format of the spec JSON file, where a SIMD value
is now stored as a list of values instead of a single u128:

```
{"type": "v128", "lane_type": "i32", "value": ["0", "0", "0", "0"]}
```

Since the lane type can be `i8` and `i16`, these types can now be used
in more places (not just the decompiler). They'll be used for the GC
proposal too (for packed values), so I've updated them to use the binary
value specified for that proposal.

Here are the actual SIMD fixes:

* SIMD lanes are malformed if they don't match the binary format, but
  invalid if they are smaller than the lane width. For example,
  `i8x16.extract_lane_s` is malformed if the lane is >= 256, because the
  lane is stored as a byte. But it is invalid if the lane is >= 16.
* The `i8x16.narrow_i16x8_u`, `i16x8.narrow_i32x4_u` and
  `i64x2.load_32x2_u` instructions were not handling sign-extension
  propoerly.

TODO: This code is pretty clumsy now; it would be better to have a
universal `Value` and `ExpectedValue` that can be used everywhere, so
the logic doesn't need to be duplicated.