### PR TITLE
Move event section before global section

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1011,6 +1011,19 @@ Result BinaryWriter::WriteModule() {
     EndSection();
   }
 
+  assert(module_->events.size() >= module_->num_event_imports);
+  Index num_events = module_->events.size() - module_->num_event_imports;
+  if (num_events) {
+    BeginKnownSection(BinarySection::Event);
+    WriteU32Leb128(stream_, num_events, "event count");
+    for (size_t i = 0; i < num_events; ++i) {
+      WriteHeader("event", i);
+      const Event* event = module_->events[i + module_->num_event_imports];
+      WriteEventType(event);
+    }
+    EndSection();
+  }
+
   assert(module_->globals.size() >= module_->num_global_imports);
   Index num_globals = module_->globals.size() - module_->num_global_imports;
   if (num_globals) {
@@ -1021,19 +1034,6 @@ Result BinaryWriter::WriteModule() {
       const Global* global = module_->globals[i + module_->num_global_imports];
       WriteGlobalHeader(global);
       WriteInitExpr(global->init_expr);
-    }
-    EndSection();
-  }
-
-  assert(module_->events.size() >= module_->num_event_imports);
-  Index num_events = module_->events.size() - module_->num_event_imports;
-  if (num_events) {
-    BeginKnownSection(BinarySection::Event);
-    WriteU32Leb128(stream_, num_events, "event count");
-    for (size_t i = 0; i < num_events; ++i) {
-      WriteHeader("event", i);
-      const Event* event = module_->events[i + module_->num_event_imports];
-      WriteEventType(event);
     }
     EndSection();
   }

--- a/src/binary.h
+++ b/src/binary.h
@@ -36,8 +36,8 @@
   V(Function, function, 3)             \
   V(Table, table, 4)                   \
   V(Memory, memory, 5)                 \
-  V(Global, global, 6)                 \
   V(Event, event, 13)                  \
+  V(Global, global, 6)                 \
   V(Export, export, 7)                 \
   V(Start, start, 8)                   \
   V(Elem, elem, 9)                     \

--- a/test/binary/bad-event-after-global.txt
+++ b/test/binary/bad-event-after-global.txt
@@ -3,7 +3,7 @@
 ;;; ARGS2: --enable-exceptions
 magic
 version
-section(EXPORT) { count[0] }
+section(GLOBAL) { count[0] }
 section(EVENT) { count[0] }
 (;; STDERR ;;;
 000000d: error: section Event out of order

--- a/test/binary/bad-event-before-memory.txt
+++ b/test/binary/bad-event-before-memory.txt
@@ -4,8 +4,8 @@
 magic
 version
 section(EVENT) { count[0] }
-section(GLOBAL) { count[0] }
+section(MEMORY) { count[0] }
 (;; STDERR ;;;
-000000d: error: section Global out of order
-000000d: error: section Global out of order
+000000d: error: section Memory out of order
+000000d: error: section Memory out of order
 ;;; STDERR ;;)


### PR DESCRIPTION
We decided move the event section before the global section in
WebAssembly/exception-handling#98.