### PR TITLE
Add Type::RefT to represent (ref $T)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -507,6 +507,7 @@ if (NOT EMSCRIPTEN)
       src/test-option-parser.cc
       src/test-string-view.cc
       src/test-filenames.cc
+      src/test-type.cc
       src/test-utf8.cc
       src/test-wast-parser.cc
     )

--- a/src/interp/interp-util.cc
+++ b/src/interp/interp-util.cc
@@ -64,6 +64,10 @@ std::string TypedValueToString(const TypedValue& tv) {
     case Type::Anyref:
       return StringPrintf("anyref:%" PRIzd, tv.value.Get<Ref>().index);
 
+    case Type::RefT:
+      // TODO
+      return "ref $T";
+
     case Type::Func:
     case Type::Struct:
     case Type::Array:

--- a/src/test-type.cc
+++ b/src/test-type.cc
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2020 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "gtest/gtest.h"
+
+#include "src/common.h"
+#include "src/type.h"
+
+using namespace wabt;
+
+TEST(TypeTest, RefT) {
+  // Skip some indexes to speed up the tests.
+  for (Index i = 0; i < 8388608; i += 16) {
+    Type type = Type::MakeRefT(i);
+
+    EXPECT_EQ(Type::RefT, type);  // Implicit cast to Type::Enum.
+    EXPECT_TRUE(type.IsRef());
+    EXPECT_FALSE(type.IsNullableRef());
+    EXPECT_FALSE(type.IsIndex());
+    EXPECT_TRUE(type.IsRefT());
+    EXPECT_EQ(i, type.GetRefTIndex());
+    EXPECT_STREQ("ref $T", type.GetName());
+
+    auto typevec = type.GetInlineVector();
+    EXPECT_EQ(1u, typevec.size());
+    EXPECT_EQ(typevec[0], type);
+  }
+}

--- a/src/type.h
+++ b/src/type.h
@@ -30,7 +30,7 @@ using TypeVector = std::vector<Type>;
 class Type {
  public:
   // Matches binary format, do not change.
-  enum Enum {
+  enum Enum : int32_t {
     I32 = -0x01,      // 0x7f
     I64 = -0x02,      // 0x7e
     F32 = -0x03,      // 0x7d
@@ -41,6 +41,7 @@ class Type {
     Funcref = -0x10,  // 0x70
     Anyref = -0x11,   // 0x6f
     Nullref = -0x12,  // 0x6e
+    RefT = -0x13,     // 0x6d
     Exnref = -0x18,   // 0x68
     Func = -0x20,     // 0x60
     Struct = -0x21,   // 0x5f
@@ -58,21 +59,20 @@ class Type {
   Type() = default;  // Provided so Type can be member of a union.
   Type(int32_t code) : enum_(static_cast<Enum>(code)) {}
   Type(Enum e) : enum_(e) {}
-  operator Enum() const { return enum_; }
+  operator Enum() const { return IsRefT() ? RefT : enum_; }
 
   bool IsRef() const {
+    return IsNullableRef() || IsRefT();
+  }
+
+  bool IsNullableRef() const {
     return enum_ == Type::Anyref || enum_ == Type::Funcref ||
            enum_ == Type::Nullref || enum_ == Type::Exnref ||
            enum_ == Type::Hostref;
   }
 
-  bool IsNullableRef() const {
-    // Currently all reftypes are nullable
-    return IsRef();
-  }
-
   const char* GetName() const {
-    switch (enum_) {
+    switch (operator Enum()) {
       case Type::I32:     return "i32";
       case Type::I64:     return "i64";
       case Type::F32:     return "f32";
@@ -87,6 +87,7 @@ class Type {
       case Type::Any:     return "any";
       case Type::Anyref:  return "anyref";
       case Type::Nullref: return "nullref";
+      case Type::RefT:    return "ref $T";
       default:            return "<type_index>";
     }
   }
@@ -102,7 +103,7 @@ class Type {
   //   (type $T (func (result i32 i64)))
   //   ...
   //   (block (type $T) ...)
-  // 
+  //
   bool IsIndex() const { return static_cast<int32_t>(enum_) >= 0; }
 
   Index GetIndex() const {
@@ -112,7 +113,7 @@ class Type {
 
   TypeVector GetInlineVector() const {
     assert(!IsIndex());
-    switch (enum_) {
+    switch (operator Enum()) {
       case Type::Void:
         return TypeVector();
 
@@ -124,12 +125,48 @@ class Type {
       case Type::Funcref:
       case Type::Anyref:
       case Type::Nullref:
+      case Type::RefT:
       case Type::Exnref:
         return TypeVector(this, this + 1);
 
       default:
         WABT_UNREACHABLE;
     }
+  }
+
+  // Functions for handling types of the form (ref $T), where $T is an index
+  // into the type section. Rather than storing an additional field in the Type
+  // struct, it's more efficient to use the extra bits in the enum to encode
+  // the index. For example, RefT is encoded as -0x13 (0xffffffff6d):
+  //
+  //    1111 1111 1111 1111 1111 1111 0110 1101
+  //       f    f    f    f    f    f    6    d
+  //
+  // We can store the index in the top bits (making sure to keep the MSB set so
+  // the number remains negative), giving us 23 bits to use for the type index.
+  //
+  //    1nnn nnnn nnnn nnnn nnnn nnnn 0110 1101
+  //
+  static const uint32_t kRefTMask = 0x800000ff;
+  static const uint32_t kRefTSignature =
+      static_cast<uint32_t>(RefT) & kRefTMask;
+
+  static const uint32_t kRefT_IndexMax = 0x7fffff;
+  static const uint32_t kRefT_IndexShift = 8;
+  static const uint32_t kRefT_IndexMask = kRefT_IndexMax << kRefT_IndexShift;
+
+  static Type MakeRefT(Index index) {
+    assert(index <= kRefT_IndexMax);
+    return static_cast<Enum>(kRefTSignature | (index << kRefT_IndexShift));
+  }
+
+  bool IsRefT() const {
+    return (static_cast<uint32_t>(enum_) & kRefTMask) == kRefTSignature;
+  }
+
+  Index GetRefTIndex() const {
+    assert(IsRefT());
+    return (static_cast<uint32_t>(enum_) & kRefT_IndexMask) >> kRefT_IndexShift;
   }
 
  private:


### PR DESCRIPTION
This adds support for handling types of the form (ref $T), where $T is
an index into the type section. Rather than storing an additional field
in the Type struct, it's more efficient to use the extra bits in the
enum to encode the index. For example, RefT is encoded as -0x13
(0xffffffff6d):

```
   1111 1111 1111 1111 1111 1111 0110 1101
      f    f    f    f    f    f    6    d
```

We can store the index in the top bits (making sure to keep the MSB set so
the number remains negative), giving us 23 bits to use for the type index.

```
   1nnn nnnn nnnn nnnn nnnn nnnn 0110 1101
```