### PR TITLE
Add exnref value type to parser

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -407,8 +407,7 @@ bool BinaryReader::IsConcreteType(Type type) {
       return options_.features.reference_types_enabled();
 
     case Type::Exnref:
-      return options_.features.reference_types_enabled() &&
-             options_.features.exceptions_enabled();
+      return options_.features.exceptions_enabled();
 
     default:
       return false;

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -37,6 +37,10 @@ void Features::AddOptions(OptionParser* parser) {
 }
 
 void Features::UpdateDependencies() {
+  // Exception handling requires reference types.
+  if (exceptions_enabled_) {
+    reference_types_enabled_ = true;
+  }
   // Reference types requires bulk memory.
   if (reference_types_enabled_) {
     bulk_memory_enabled_ = true;

--- a/src/lexer-keywords.txt
+++ b/src/lexer-keywords.txt
@@ -43,6 +43,7 @@ elem, TokenType::Elem
 else, TokenType::Else, Opcode::Else
 end, TokenType::End, Opcode::End
 event, TokenType::Event
+exnref, Type::Exnref
 export, TokenType::Export
 f32.abs, TokenType::Unary, Opcode::F32Abs
 f32.add, TokenType::Binary, Opcode::F32Add

--- a/src/prebuilt/lexer-keywords.cc
+++ b/src/prebuilt/lexer-keywords.cc
@@ -46,7 +46,7 @@ struct TokenInfo {
     Opcode opcode;
   };
 };
-/* maximum key range = 2187, duplicates = 0 */
+/* maximum key range = 2163, duplicates = 0 */
 
 class Perfect_Hash
 {
@@ -61,32 +61,32 @@ Perfect_Hash::hash (const char *str, size_t len)
 {
   static unsigned short asso_values[] =
     {
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210,    9,   42, 2210,  111,
-        10,  137,    9,  385,  126,  321,  259,  525,   12, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210,    9,   29,   63,   12,  110,
-        22,   15,    9,  401,  552,   12,   63,   18,   39,   10,
-        26,   63,  334,  479,   57,    9,    9,   11,   41,   17,
-       315,  431,  263, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210, 2210,
-      2210, 2210, 2210, 2210, 2210, 2210, 2210
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176,    6,   53, 2176,  128,
+         4,   62,    3,  195,  161,  180,  112,  514,   26, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176,    3,   11,   70,   19,  155,
+        33,    7,    4,  371,  595,   11,   38,    8,   17,    5,
+        50,   46,  355,  549,   82,    3,    3,    6,   94,   21,
+       351,  612,   85, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176, 2176,
+      2176, 2176, 2176, 2176, 2176, 2176, 2176
     };
   unsigned int hval = len;
 
@@ -150,1431 +150,1428 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 541,
+      TOTAL_KEYWORDS = 542,
       MIN_WORD_LENGTH = 2,
       MAX_WORD_LENGTH = 26,
-      MIN_HASH_VALUE = 23,
-      MAX_HASH_VALUE = 2209
+      MIN_HASH_VALUE = 13,
+      MAX_HASH_VALUE = 2175
     };
 
   static struct TokenInfo wordlist[] =
     {
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""},
-#line 453 "src/lexer-keywords.txt"
-      {"if", TokenType::If, Opcode::If},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 127 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 128 "src/lexer-keywords.txt"
       {"f64", Type::F64},
-#line 469 "src/lexer-keywords.txt"
+#line 470 "src/lexer-keywords.txt"
       {"mut", TokenType::Mut},
-#line 76 "src/lexer-keywords.txt"
+#line 77 "src/lexer-keywords.txt"
       {"f32", Type::F32},
-#line 403 "src/lexer-keywords.txt"
+      {""},
+#line 454 "src/lexer-keywords.txt"
+      {"if", TokenType::If, Opcode::If},
+      {""}, {""},
+#line 404 "src/lexer-keywords.txt"
       {"i64", Type::I64},
-      {""},
-#line 273 "src/lexer-keywords.txt"
-      {"i32", Type::I32},
-      {""}, {""}, {""}, {""}, {""},
-#line 456 "src/lexer-keywords.txt"
-      {"item", TokenType::Item},
-      {""},
 #line 43 "src/lexer-keywords.txt"
       {"else", TokenType::Else, Opcode::Else},
+#line 274 "src/lexer-keywords.txt"
+      {"i32", Type::I32},
 #line 42 "src/lexer-keywords.txt"
       {"elem", TokenType::Elem},
-      {""}, {""}, {""}, {""}, {""},
-#line 498 "src/lexer-keywords.txt"
-      {"table", TokenType::Table},
-      {""},
-#line 114 "src/lexer-keywords.txt"
+#line 115 "src/lexer-keywords.txt"
       {"f64.lt", TokenType::Compare, Opcode::F64Lt},
-#line 64 "src/lexer-keywords.txt"
+#line 65 "src/lexer-keywords.txt"
       {"f32.lt", TokenType::Compare, Opcode::F32Lt},
-#line 499 "src/lexer-keywords.txt"
-      {"then", TokenType::Then},
+      {""},
+#line 457 "src/lexer-keywords.txt"
+      {"item", TokenType::Item},
 #line 45 "src/lexer-keywords.txt"
       {"event", TokenType::Event},
-      {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""},
+#line 113 "src/lexer-keywords.txt"
+      {"f64.le", TokenType::Compare, Opcode::F64Le},
+#line 63 "src/lexer-keywords.txt"
+      {"f32.le", TokenType::Compare, Opcode::F32Le},
+      {""}, {""}, {""}, {""},
+#line 499 "src/lexer-keywords.txt"
+      {"table", TokenType::Table},
+#line 377 "src/lexer-keywords.txt"
+      {"i64.lt_s", TokenType::Compare, Opcode::I64LtS},
+#line 248 "src/lexer-keywords.txt"
+      {"i32.lt_s", TokenType::Compare, Opcode::I32LtS},
+      {""}, {""},
+#line 368 "src/lexer-keywords.txt"
+      {"i64.le_s", TokenType::Compare, Opcode::I64LeS},
+#line 241 "src/lexer-keywords.txt"
+      {"i32.le_s", TokenType::Compare, Opcode::I32LeS},
+#line 378 "src/lexer-keywords.txt"
+      {"i64.lt_u", TokenType::Compare, Opcode::I64LtU},
+#line 249 "src/lexer-keywords.txt"
+      {"i32.lt_u", TokenType::Compare, Opcode::I32LtU},
+#line 384 "src/lexer-keywords.txt"
+      {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
+#line 255 "src/lexer-keywords.txt"
+      {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
+#line 369 "src/lexer-keywords.txt"
+      {"i64.le_u", TokenType::Compare, Opcode::I64LeU},
+#line 242 "src/lexer-keywords.txt"
+      {"i32.le_u", TokenType::Compare, Opcode::I32LeU},
+      {""}, {""},
+#line 385 "src/lexer-keywords.txt"
+      {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
+#line 256 "src/lexer-keywords.txt"
+      {"i32.rem_u", TokenType::Binary, Opcode::I32RemU},
+      {""},
+#line 148 "src/lexer-keywords.txt"
+      {"field", TokenType::Field},
+#line 497 "src/lexer-keywords.txt"
+      {"table.set", TokenType::TableSet, Opcode::TableSet},
+#line 99 "src/lexer-keywords.txt"
+      {"f64.abs", TokenType::Unary, Opcode::F64Abs},
+#line 48 "src/lexer-keywords.txt"
+      {"f32.abs", TokenType::Unary, Opcode::F32Abs},
+      {""},
+#line 126 "src/lexer-keywords.txt"
+      {"f64.sub", TokenType::Binary, Opcode::F64Sub},
+#line 75 "src/lexer-keywords.txt"
+      {"f32.sub", TokenType::Binary, Opcode::F32Sub},
+#line 469 "src/lexer-keywords.txt"
+      {"module", TokenType::Module},
+#line 500 "src/lexer-keywords.txt"
+      {"then", TokenType::Then},
+#line 488 "src/lexer-keywords.txt"
+      {"select", TokenType::Select, Opcode::Select},
+#line 475 "src/lexer-keywords.txt"
+      {"offset", TokenType::Offset},
+      {""},
+#line 395 "src/lexer-keywords.txt"
+      {"i64.sub", TokenType::Binary, Opcode::I64Sub},
+#line 265 "src/lexer-keywords.txt"
+      {"i32.sub", TokenType::Binary, Opcode::I32Sub},
+      {""}, {""}, {""},
+#line 121 "src/lexer-keywords.txt"
+      {"f64.ne", TokenType::Compare, Opcode::F64Ne},
+#line 71 "src/lexer-keywords.txt"
+      {"f32.ne", TokenType::Compare, Opcode::F32Ne},
+#line 46 "src/lexer-keywords.txt"
+      {"exnref", Type::Exnref},
 #line 44 "src/lexer-keywords.txt"
       {"end", TokenType::End, Opcode::End},
       {""},
-#line 112 "src/lexer-keywords.txt"
-      {"f64.le", TokenType::Compare, Opcode::F64Le},
-#line 62 "src/lexer-keywords.txt"
-      {"f32.le", TokenType::Compare, Opcode::F32Le},
 #line 147 "src/lexer-keywords.txt"
-      {"field", TokenType::Field},
-#line 98 "src/lexer-keywords.txt"
-      {"f64.abs", TokenType::Unary, Opcode::F64Abs},
-#line 47 "src/lexer-keywords.txt"
-      {"f32.abs", TokenType::Unary, Opcode::F32Abs},
-#line 125 "src/lexer-keywords.txt"
-      {"f64.sub", TokenType::Binary, Opcode::F64Sub},
-#line 74 "src/lexer-keywords.txt"
-      {"f32.sub", TokenType::Binary, Opcode::F32Sub},
-#line 32 "src/lexer-keywords.txt"
-      {"br", TokenType::Br, Opcode::Br},
-#line 394 "src/lexer-keywords.txt"
-      {"i64.sub", TokenType::Binary, Opcode::I64Sub},
-#line 264 "src/lexer-keywords.txt"
-      {"i32.sub", TokenType::Binary, Opcode::I32Sub},
-      {""},
-#line 376 "src/lexer-keywords.txt"
-      {"i64.lt_s", TokenType::Compare, Opcode::I64LtS},
-#line 247 "src/lexer-keywords.txt"
-      {"i32.lt_s", TokenType::Compare, Opcode::I32LtS},
-      {""},
-#line 468 "src/lexer-keywords.txt"
-      {"module", TokenType::Module},
-#line 377 "src/lexer-keywords.txt"
-      {"i64.lt_u", TokenType::Compare, Opcode::I64LtU},
-#line 248 "src/lexer-keywords.txt"
-      {"i32.lt_u", TokenType::Compare, Opcode::I32LtU},
-#line 367 "src/lexer-keywords.txt"
-      {"i64.le_s", TokenType::Compare, Opcode::I64LeS},
-#line 240 "src/lexer-keywords.txt"
-      {"i32.le_s", TokenType::Compare, Opcode::I32LeS},
-      {""},
-#line 148 "src/lexer-keywords.txt"
+      {"f64x2", TokenType::F64X2},
+#line 149 "src/lexer-keywords.txt"
       {"funcref", Type::Funcref},
-#line 368 "src/lexer-keywords.txt"
-      {"i64.le_u", TokenType::Compare, Opcode::I64LeU},
-#line 241 "src/lexer-keywords.txt"
-      {"i32.le_u", TokenType::Compare, Opcode::I32LeU},
-      {""}, {""}, {""},
-#line 496 "src/lexer-keywords.txt"
-      {"table.set", TokenType::TableSet, Opcode::TableSet},
-#line 383 "src/lexer-keywords.txt"
-      {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
-#line 254 "src/lexer-keywords.txt"
-      {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
-      {""},
-#line 487 "src/lexer-keywords.txt"
-      {"select", TokenType::Select, Opcode::Select},
-#line 384 "src/lexer-keywords.txt"
-      {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
-#line 255 "src/lexer-keywords.txt"
-      {"i32.rem_u", TokenType::Binary, Opcode::I32RemU},
-#line 489 "src/lexer-keywords.txt"
-      {"start", TokenType::Start},
-#line 38 "src/lexer-keywords.txt"
-      {"data", TokenType::Data},
-      {""},
-#line 482 "src/lexer-keywords.txt"
-      {"result", TokenType::Result},
-      {""}, {""},
-#line 99 "src/lexer-keywords.txt"
-      {"f64.add", TokenType::Binary, Opcode::F64Add},
-#line 48 "src/lexer-keywords.txt"
-      {"f32.add", TokenType::Binary, Opcode::F32Add},
-#line 474 "src/lexer-keywords.txt"
-      {"offset", TokenType::Offset},
-#line 312 "src/lexer-keywords.txt"
-      {"i64.add", TokenType::Binary, Opcode::I64Add},
-#line 197 "src/lexer-keywords.txt"
-      {"i32.add", TokenType::Binary, Opcode::I32Add},
-#line 495 "src/lexer-keywords.txt"
-      {"table.init", TokenType::TableInit, Opcode::TableInit},
-      {""},
-#line 313 "src/lexer-keywords.txt"
-      {"i64.and", TokenType::Binary, Opcode::I64And},
-#line 198 "src/lexer-keywords.txt"
-      {"i32.and", TokenType::Binary, Opcode::I32And},
-#line 490 "src/lexer-keywords.txt"
-      {"struct", TokenType::Struct},
-      {""},
-#line 473 "src/lexer-keywords.txt"
-      {"nullref", Type::Nullref},
-#line 116 "src/lexer-keywords.txt"
-      {"f64.min", TokenType::Binary, Opcode::F64Min},
-#line 66 "src/lexer-keywords.txt"
-      {"f32.min", TokenType::Binary, Opcode::F32Min},
-#line 120 "src/lexer-keywords.txt"
-      {"f64.ne", TokenType::Compare, Opcode::F64Ne},
-#line 70 "src/lexer-keywords.txt"
-      {"f32.ne", TokenType::Compare, Opcode::F32Ne},
-      {""},
-#line 379 "src/lexer-keywords.txt"
+#line 380 "src/lexer-keywords.txt"
       {"i64.ne", TokenType::Compare, Opcode::I64Ne},
-#line 250 "src/lexer-keywords.txt"
+#line 251 "src/lexer-keywords.txt"
       {"i32.ne", TokenType::Compare, Opcode::I32Ne},
-#line 31 "src/lexer-keywords.txt"
-      {"br_table", TokenType::BrTable, Opcode::BrTable},
+      {""}, {""}, {""},
+#line 417 "src/lexer-keywords.txt"
+      {"i64x2", TokenType::I64X2},
+      {""},
+#line 490 "src/lexer-keywords.txt"
+      {"start", TokenType::Start},
+      {""}, {""}, {""},
+#line 493 "src/lexer-keywords.txt"
+      {"table.fill", TokenType::TableFill, Opcode::TableFill},
+#line 474 "src/lexer-keywords.txt"
+      {"nullref", Type::Nullref},
       {""}, {""},
-#line 354 "src/lexer-keywords.txt"
-      {"i64.div_s", TokenType::Binary, Opcode::I64DivS},
-#line 230 "src/lexer-keywords.txt"
-      {"i32.div_s", TokenType::Binary, Opcode::I32DivS},
-      {""},
-#line 455 "src/lexer-keywords.txt"
-      {"invoke", TokenType::Invoke},
-#line 355 "src/lexer-keywords.txt"
-      {"i64.div_u", TokenType::Binary, Opcode::I64DivU},
-#line 231 "src/lexer-keywords.txt"
-      {"i32.div_u", TokenType::Binary, Opcode::I32DivU},
-#line 488 "src/lexer-keywords.txt"
-      {"shared", TokenType::Shared},
-      {""},
-#line 486 "src/lexer-keywords.txt"
-      {"return", TokenType::Return, Opcode::Return},
-#line 107 "src/lexer-keywords.txt"
-      {"f64.div", TokenType::Binary, Opcode::F64Div},
-#line 57 "src/lexer-keywords.txt"
-      {"f32.div", TokenType::Binary, Opcode::F32Div},
-      {""},
 #line 28 "src/lexer-keywords.txt"
       {"block", TokenType::Block, Opcode::Block},
-      {""}, {""},
-#line 117 "src/lexer-keywords.txt"
-      {"f64.mul", TokenType::Binary, Opcode::F64Mul},
-#line 67 "src/lexer-keywords.txt"
-      {"f32.mul", TokenType::Binary, Opcode::F32Mul},
-      {""},
-#line 378 "src/lexer-keywords.txt"
-      {"i64.mul", TokenType::Binary, Opcode::I64Mul},
-#line 249 "src/lexer-keywords.txt"
-      {"i32.mul", TokenType::Binary, Opcode::I32Mul},
       {""}, {""}, {""},
-#line 492 "src/lexer-keywords.txt"
-      {"table.fill", TokenType::TableFill, Opcode::TableFill},
-#line 149 "src/lexer-keywords.txt"
-      {"func", TokenType::Func},
-      {""}, {""}, {""},
-#line 100 "src/lexer-keywords.txt"
-      {"f64.ceil", TokenType::Unary, Opcode::F64Ceil},
-#line 49 "src/lexer-keywords.txt"
-      {"f32.ceil", TokenType::Unary, Opcode::F32Ceil},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""},
+#line 31 "src/lexer-keywords.txt"
+      {"br_table", TokenType::BrTable, Opcode::BrTable},
 #line 101 "src/lexer-keywords.txt"
-      {"f64.const", TokenType::Const, Opcode::F64Const},
+      {"f64.ceil", TokenType::Unary, Opcode::F64Ceil},
 #line 50 "src/lexer-keywords.txt"
-      {"f32.const", TokenType::Const, Opcode::F32Const},
-      {""},
-#line 352 "src/lexer-keywords.txt"
-      {"i64.const", TokenType::Const, Opcode::I64Const},
-#line 228 "src/lexer-keywords.txt"
-      {"i32.const", TokenType::Const, Opcode::I32Const},
-#line 146 "src/lexer-keywords.txt"
-      {"f64x2", TokenType::F64X2},
-      {""}, {""},
-#line 416 "src/lexer-keywords.txt"
-      {"i64x2", TokenType::I64X2},
-      {""}, {""},
-#line 478 "src/lexer-keywords.txt"
-      {"ref.host", TokenType::RefHost},
-      {""}, {""},
+      {"f32.ceil", TokenType::Unary, Opcode::F32Ceil},
 #line 483 "src/lexer-keywords.txt"
-      {"rethrow", TokenType::Rethrow, Opcode::Rethrow},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 385 "src/lexer-keywords.txt"
-      {"i64.rotl", TokenType::Binary, Opcode::I64Rotl},
-#line 256 "src/lexer-keywords.txt"
-      {"i32.rotl", TokenType::Binary, Opcode::I32Rotl},
-      {""}, {""},
-#line 34 "src/lexer-keywords.txt"
-      {"call", TokenType::Call, Opcode::Call},
-      {""}, {""},
-#line 124 "src/lexer-keywords.txt"
-      {"f64.store", TokenType::Store, Opcode::F64Store},
-#line 73 "src/lexer-keywords.txt"
-      {"f32.store", TokenType::Store, Opcode::F32Store},
-      {""},
-#line 393 "src/lexer-keywords.txt"
-      {"i64.store", TokenType::Store, Opcode::I64Store},
-#line 263 "src/lexer-keywords.txt"
-      {"i32.store", TokenType::Store, Opcode::I32Store},
-      {""}, {""}, {""},
-#line 460 "src/lexer-keywords.txt"
-      {"local", TokenType::Local},
-      {""},
-#line 391 "src/lexer-keywords.txt"
-      {"i64.store32", TokenType::Store, Opcode::I64Store32},
-#line 113 "src/lexer-keywords.txt"
-      {"f64.load", TokenType::Load, Opcode::F64Load},
-#line 63 "src/lexer-keywords.txt"
-      {"f32.load", TokenType::Load, Opcode::F32Load},
-#line 509 "src/lexer-keywords.txt"
-      {"v128.not", TokenType::Unary, Opcode::V128Not},
-#line 375 "src/lexer-keywords.txt"
-      {"i64.load", TokenType::Load, Opcode::I64Load},
-#line 246 "src/lexer-keywords.txt"
-      {"i32.load", TokenType::Load, Opcode::I32Load},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 145 "src/lexer-keywords.txt"
-      {"f64x2.sub", TokenType::Binary, Opcode::F64X2Sub},
-      {""},
-#line 458 "src/lexer-keywords.txt"
-      {"local.set", TokenType::LocalSet, Opcode::LocalSet},
-#line 415 "src/lexer-keywords.txt"
-      {"i64x2.sub", TokenType::Binary, Opcode::I64X2Sub},
-      {""}, {""}, {""},
-#line 386 "src/lexer-keywords.txt"
-      {"i64.rotr", TokenType::Binary, Opcode::I64Rotr},
-#line 257 "src/lexer-keywords.txt"
-      {"i32.rotr", TokenType::Binary, Opcode::I32Rotr},
-      {""}, {""},
-#line 141 "src/lexer-keywords.txt"
-      {"f64x2.ne", TokenType::Compare, Opcode::F64X2Ne},
-#line 136 "src/lexer-keywords.txt"
+      {"result", TokenType::Result},
+#line 32 "src/lexer-keywords.txt"
+      {"br", TokenType::Br, Opcode::Br},
+#line 118 "src/lexer-keywords.txt"
+      {"f64.mul", TokenType::Binary, Opcode::F64Mul},
+#line 68 "src/lexer-keywords.txt"
+      {"f32.mul", TokenType::Binary, Opcode::F32Mul},
+#line 137 "src/lexer-keywords.txt"
       {"f64x2.lt", TokenType::Compare, Opcode::F64X2Lt},
       {""},
-#line 459 "src/lexer-keywords.txt"
-      {"local.tee", TokenType::LocalTee, Opcode::LocalTee},
+#line 386 "src/lexer-keywords.txt"
+      {"i64.rotl", TokenType::Binary, Opcode::I64Rotl},
+#line 257 "src/lexer-keywords.txt"
+      {"i32.rotl", TokenType::Binary, Opcode::I32Rotl},
+#line 38 "src/lexer-keywords.txt"
+      {"data", TokenType::Data},
+#line 379 "src/lexer-keywords.txt"
+      {"i64.mul", TokenType::Binary, Opcode::I64Mul},
+#line 250 "src/lexer-keywords.txt"
+      {"i32.mul", TokenType::Binary, Opcode::I32Mul},
+      {""},
+#line 136 "src/lexer-keywords.txt"
+      {"f64x2.le", TokenType::Compare, Opcode::F64X2Le},
       {""}, {""},
-#line 505 "src/lexer-keywords.txt"
-      {"v128.and", TokenType::Binary, Opcode::V128And},
+#line 496 "src/lexer-keywords.txt"
+      {"table.init", TokenType::TableInit, Opcode::TableInit},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 140 "src/lexer-keywords.txt"
+      {"f64x2.mul", TokenType::Binary, Opcode::F64X2Mul},
+#line 491 "src/lexer-keywords.txt"
+      {"struct", TokenType::Struct},
+#line 146 "src/lexer-keywords.txt"
+      {"f64x2.sub", TokenType::Binary, Opcode::F64X2Sub},
+#line 100 "src/lexer-keywords.txt"
+      {"f64.add", TokenType::Binary, Opcode::F64Add},
+#line 49 "src/lexer-keywords.txt"
+      {"f32.add", TokenType::Binary, Opcode::F32Add},
+      {""}, {""},
+#line 409 "src/lexer-keywords.txt"
+      {"i64x2.mul", TokenType::Binary, Opcode::I64X2Mul},
+      {""},
+#line 416 "src/lexer-keywords.txt"
+      {"i64x2.sub", TokenType::Binary, Opcode::I64X2Sub},
+#line 313 "src/lexer-keywords.txt"
+      {"i64.add", TokenType::Binary, Opcode::I64Add},
+#line 198 "src/lexer-keywords.txt"
+      {"i32.add", TokenType::Binary, Opcode::I32Add},
+      {""},
+#line 456 "src/lexer-keywords.txt"
+      {"invoke", TokenType::Invoke},
+      {""},
+#line 355 "src/lexer-keywords.txt"
+      {"i64.div_s", TokenType::Binary, Opcode::I64DivS},
+#line 231 "src/lexer-keywords.txt"
+      {"i32.div_s", TokenType::Binary, Opcode::I32DivS},
+      {""},
+#line 142 "src/lexer-keywords.txt"
+      {"f64x2.ne", TokenType::Compare, Opcode::F64X2Ne},
+#line 498 "src/lexer-keywords.txt"
+      {"table.size", TokenType::TableSize, Opcode::TableSize},
+#line 489 "src/lexer-keywords.txt"
+      {"shared", TokenType::Shared},
+#line 356 "src/lexer-keywords.txt"
+      {"i64.div_u", TokenType::Binary, Opcode::I64DivU},
+#line 232 "src/lexer-keywords.txt"
+      {"i32.div_u", TokenType::Binary, Opcode::I32DivU},
+      {""}, {""},
+#line 102 "src/lexer-keywords.txt"
+      {"f64.const", TokenType::Const, Opcode::F64Const},
+#line 51 "src/lexer-keywords.txt"
+      {"f32.const", TokenType::Const, Opcode::F32Const},
+#line 314 "src/lexer-keywords.txt"
+      {"i64.and", TokenType::Binary, Opcode::I64And},
+#line 199 "src/lexer-keywords.txt"
+      {"i32.and", TokenType::Binary, Opcode::I32And},
+      {""}, {""},
+#line 479 "src/lexer-keywords.txt"
+      {"ref.host", TokenType::RefHost},
+#line 353 "src/lexer-keywords.txt"
+      {"i64.const", TokenType::Const, Opcode::I64Const},
+#line 229 "src/lexer-keywords.txt"
+      {"i32.const", TokenType::Const, Opcode::I32Const},
+      {""},
+#line 125 "src/lexer-keywords.txt"
+      {"f64.store", TokenType::Store, Opcode::F64Store},
+#line 74 "src/lexer-keywords.txt"
+      {"f32.store", TokenType::Store, Opcode::F32Store},
+      {""}, {""}, {""}, {""}, {""},
+#line 394 "src/lexer-keywords.txt"
+      {"i64.store", TokenType::Store, Opcode::I64Store},
+#line 264 "src/lexer-keywords.txt"
+      {"i32.store", TokenType::Store, Opcode::I32Store},
+      {""},
+#line 392 "src/lexer-keywords.txt"
+      {"i64.store32", TokenType::Store, Opcode::I64Store32},
+#line 117 "src/lexer-keywords.txt"
+      {"f64.min", TokenType::Binary, Opcode::F64Min},
+#line 67 "src/lexer-keywords.txt"
+      {"f32.min", TokenType::Binary, Opcode::F32Min},
+      {""}, {""},
+#line 129 "src/lexer-keywords.txt"
+      {"f64x2.abs", TokenType::Unary, Opcode::F64X2Abs},
+      {""}, {""}, {""},
+#line 484 "src/lexer-keywords.txt"
+      {"rethrow", TokenType::Rethrow, Opcode::Rethrow},
+      {""}, {""},
+#line 350 "src/lexer-keywords.txt"
+      {"i64.atomic.store", TokenType::AtomicStore, Opcode::I64AtomicStore},
+#line 226 "src/lexer-keywords.txt"
+      {"i32.atomic.store", TokenType::AtomicStore, Opcode::I32AtomicStore},
+      {""}, {""}, {""}, {""},
+#line 348 "src/lexer-keywords.txt"
+      {"i64.atomic.store32", TokenType::AtomicStore, Opcode::I64AtomicStore32},
+#line 34 "src/lexer-keywords.txt"
+      {"call", TokenType::Call, Opcode::Call},
+#line 487 "src/lexer-keywords.txt"
+      {"return", TokenType::Return, Opcode::Return},
+      {""}, {""},
+#line 481 "src/lexer-keywords.txt"
+      {"ref.null", TokenType::RefNull, Opcode::RefNull},
+      {""},
+#line 461 "src/lexer-keywords.txt"
+      {"local", TokenType::Local},
+#line 139 "src/lexer-keywords.txt"
+      {"f64x2.min", TokenType::Binary, Opcode::F64X2Min},
+      {""},
+#line 114 "src/lexer-keywords.txt"
+      {"f64.load", TokenType::Load, Opcode::F64Load},
+#line 64 "src/lexer-keywords.txt"
+      {"f32.load", TokenType::Load, Opcode::F32Load},
+      {""}, {""}, {""}, {""},
+#line 459 "src/lexer-keywords.txt"
+      {"local.set", TokenType::LocalSet, Opcode::LocalSet},
+#line 376 "src/lexer-keywords.txt"
+      {"i64.load", TokenType::Load, Opcode::I64Load},
+#line 247 "src/lexer-keywords.txt"
+      {"i32.load", TokenType::Load, Opcode::I32Load},
+#line 98 "src/lexer-keywords.txt"
+      {"f32x4", TokenType::F32X4},
+      {""},
+#line 150 "src/lexer-keywords.txt"
+      {"func", TokenType::Func},
+#line 513 "src/lexer-keywords.txt"
+      {"v128", Type::V128},
+      {""},
+#line 460 "src/lexer-keywords.txt"
+      {"local.tee", TokenType::LocalTee, Opcode::LocalTee},
+      {""},
+#line 305 "src/lexer-keywords.txt"
+      {"i32x4", TokenType::I32X4},
+      {""},
+#line 108 "src/lexer-keywords.txt"
+      {"f64.div", TokenType::Binary, Opcode::F64Div},
+#line 58 "src/lexer-keywords.txt"
+      {"f32.div", TokenType::Binary, Opcode::F32Div},
+      {""}, {""},
+#line 351 "src/lexer-keywords.txt"
+      {"i64.atomic.wait", TokenType::AtomicWait, Opcode::I64AtomicWait},
+#line 227 "src/lexer-keywords.txt"
+      {"i32.atomic.wait", TokenType::AtomicWait, Opcode::I32AtomicWait},
+      {""},
+#line 354 "src/lexer-keywords.txt"
+      {"i64.ctz", TokenType::Unary, Opcode::I64Ctz},
+#line 230 "src/lexer-keywords.txt"
+      {"i32.ctz", TokenType::Unary, Opcode::I32Ctz},
+      {""}, {""},
+#line 480 "src/lexer-keywords.txt"
+      {"ref.is_null", TokenType::RefIsNull, Opcode::RefIsNull},
+      {""}, {""}, {""}, {""},
+#line 119 "src/lexer-keywords.txt"
+      {"f64.nearest", TokenType::Unary, Opcode::F64Nearest},
+#line 69 "src/lexer-keywords.txt"
+      {"f32.nearest", TokenType::Unary, Opcode::F32Nearest},
+#line 387 "src/lexer-keywords.txt"
+      {"i64.rotr", TokenType::Binary, Opcode::I64Rotr},
+#line 258 "src/lexer-keywords.txt"
+      {"i32.rotr", TokenType::Binary, Opcode::I32Rotr},
+#line 88 "src/lexer-keywords.txt"
+      {"f32x4.lt", TokenType::Compare, Opcode::F32X4Lt},
+#line 352 "src/lexer-keywords.txt"
+      {"i64.clz", TokenType::Unary, Opcode::I64Clz},
+#line 228 "src/lexer-keywords.txt"
+      {"i32.clz", TokenType::Unary, Opcode::I32Clz},
+      {""}, {""}, {""}, {""}, {""},
+#line 87 "src/lexer-keywords.txt"
+      {"f32x4.le", TokenType::Compare, Opcode::F32X4Le},
+      {""}, {""},
+#line 372 "src/lexer-keywords.txt"
+      {"i64.load32_s", TokenType::Load, Opcode::I64Load32S},
+#line 290 "src/lexer-keywords.txt"
+      {"i32x4.lt_s", TokenType::Compare, Opcode::I32X4LtS},
+#line 130 "src/lexer-keywords.txt"
+      {"f64x2.add", TokenType::Binary, Opcode::F64X2Add},
+      {""},
+#line 291 "src/lexer-keywords.txt"
+      {"i32x4.lt_u", TokenType::Compare, Opcode::I32X4LtU},
+#line 286 "src/lexer-keywords.txt"
+      {"i32x4.le_s", TokenType::Compare, Opcode::I32X4LeS},
+#line 373 "src/lexer-keywords.txt"
+      {"i64.load32_u", TokenType::Load, Opcode::I64Load32U},
+      {""},
+#line 287 "src/lexer-keywords.txt"
+      {"i32x4.le_u", TokenType::Compare, Opcode::I32X4LeU},
+#line 405 "src/lexer-keywords.txt"
+      {"i64x2.add", TokenType::Binary, Opcode::I64X2Add},
+#line 510 "src/lexer-keywords.txt"
+      {"v128.not", TokenType::Unary, Opcode::V128Not},
+      {""},
+#line 91 "src/lexer-keywords.txt"
+      {"f32x4.mul", TokenType::Binary, Opcode::F32X4Mul},
+#line 57 "src/lexer-keywords.txt"
+      {"f32.demote_f64", TokenType::Convert, Opcode::F32DemoteF64},
+#line 97 "src/lexer-keywords.txt"
+      {"f32x4.sub", TokenType::Binary, Opcode::F32X4Sub},
+      {""}, {""}, {""}, {""},
+#line 296 "src/lexer-keywords.txt"
+      {"i32x4.mul", TokenType::Binary, Opcode::I32X4Mul},
+      {""},
+#line 304 "src/lexer-keywords.txt"
+      {"i32x4.sub", TokenType::Binary, Opcode::I32X4Sub},
+#line 337 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8SubU},
+#line 214 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8SubU},
+      {""}, {""},
+#line 393 "src/lexer-keywords.txt"
+      {"i64.store8", TokenType::Store, Opcode::I64Store8},
+#line 263 "src/lexer-keywords.txt"
+      {"i32.store8", TokenType::Store, Opcode::I32Store8},
+      {""}, {""},
+#line 93 "src/lexer-keywords.txt"
+      {"f32x4.ne", TokenType::Compare, Opcode::F32X4Ne},
+      {""}, {""}, {""},
+#line 318 "src/lexer-keywords.txt"
+      {"i64.atomic.load", TokenType::AtomicLoad, Opcode::I64AtomicLoad},
+#line 202 "src/lexer-keywords.txt"
+      {"i32.atomic.load", TokenType::AtomicLoad, Opcode::I32AtomicLoad},
+      {""},
+#line 298 "src/lexer-keywords.txt"
+      {"i32x4.ne", TokenType::Compare, Opcode::I32X4Ne},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 374 "src/lexer-keywords.txt"
+      {"i64.load8_s", TokenType::Load, Opcode::I64Load8S},
+#line 245 "src/lexer-keywords.txt"
+      {"i32.load8_s", TokenType::Load, Opcode::I32Load8S},
+#line 294 "src/lexer-keywords.txt"
+      {"i32x4.min_s", TokenType::Binary, Opcode::I32X4MinS},
+      {""}, {""},
+#line 512 "src/lexer-keywords.txt"
+      {"v128.store", TokenType::Store, Opcode::V128Store},
+#line 375 "src/lexer-keywords.txt"
+      {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
+#line 246 "src/lexer-keywords.txt"
+      {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
+#line 295 "src/lexer-keywords.txt"
+      {"i32x4.min_u", TokenType::Binary, Opcode::I32X4MinU},
+#line 330 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32SubU},
       {""}, {""}, {""},
 #line 39 "src/lexer-keywords.txt"
       {"declare", TokenType::Declare},
       {""}, {""},
-#line 135 "src/lexer-keywords.txt"
-      {"f64x2.le", TokenType::Compare, Opcode::F64X2Le},
-      {""}, {""}, {""}, {""}, {""},
-#line 138 "src/lexer-keywords.txt"
-      {"f64x2.min", TokenType::Binary, Opcode::F64X2Min},
-      {""}, {""}, {""}, {""},
-#line 350 "src/lexer-keywords.txt"
-      {"i64.atomic.wait", TokenType::AtomicWait, Opcode::I64AtomicWait},
-#line 226 "src/lexer-keywords.txt"
-      {"i32.atomic.wait", TokenType::AtomicWait, Opcode::I32AtomicWait},
-      {""}, {""},
-#line 511 "src/lexer-keywords.txt"
-      {"v128.store", TokenType::Store, Opcode::V128Store},
-      {""}, {""},
-#line 504 "src/lexer-keywords.txt"
-      {"v128.andnot", TokenType::Binary, Opcode::V128Andnot},
-#line 118 "src/lexer-keywords.txt"
-      {"f64.nearest", TokenType::Unary, Opcode::F64Nearest},
-#line 68 "src/lexer-keywords.txt"
-      {"f32.nearest", TokenType::Unary, Opcode::F32Nearest},
+#line 78 "src/lexer-keywords.txt"
+      {"f32x4.abs", TokenType::Unary, Opcode::F32X4Abs},
+#line 527 "src/lexer-keywords.txt"
+      {"f32.demote/f64", TokenType::Convert, Opcode::F32DemoteF64},
       {""},
-#line 349 "src/lexer-keywords.txt"
-      {"i64.atomic.store", TokenType::AtomicStore, Opcode::I64AtomicStore},
-#line 225 "src/lexer-keywords.txt"
-      {"i32.atomic.store", TokenType::AtomicStore, Opcode::I32AtomicStore},
-#line 480 "src/lexer-keywords.txt"
-      {"ref.null", TokenType::RefNull, Opcode::RefNull},
-#line 128 "src/lexer-keywords.txt"
-      {"f64x2.abs", TokenType::Unary, Opcode::F64X2Abs},
-      {""}, {""}, {""}, {""}, {""},
-#line 139 "src/lexer-keywords.txt"
-      {"f64x2.mul", TokenType::Binary, Opcode::F64X2Mul},
-#line 479 "src/lexer-keywords.txt"
-      {"ref.is_null", TokenType::RefIsNull, Opcode::RefIsNull},
-      {""},
-#line 408 "src/lexer-keywords.txt"
-      {"i64x2.mul", TokenType::Binary, Opcode::I64X2Mul},
-      {""},
-#line 510 "src/lexer-keywords.txt"
-      {"v128.or", TokenType::Binary, Opcode::V128Or},
-      {""},
-#line 347 "src/lexer-keywords.txt"
-      {"i64.atomic.store32", TokenType::AtomicStore, Opcode::I64AtomicStore32},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 130 "src/lexer-keywords.txt"
+#line 131 "src/lexer-keywords.txt"
       {"f64x2.div", TokenType::Binary, Opcode::F64X2Div},
-      {""}, {""}, {""},
-#line 336 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8SubU},
-#line 213 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8SubU},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 129 "src/lexer-keywords.txt"
-      {"f64x2.add", TokenType::Binary, Opcode::F64X2Add},
+#line 370 "src/lexer-keywords.txt"
+      {"i64.load16_s", TokenType::Load, Opcode::I64Load16S},
+#line 243 "src/lexer-keywords.txt"
+      {"i32.load16_s", TokenType::Load, Opcode::I32Load16S},
       {""},
-#line 23 "src/lexer-keywords.txt"
-      {"assert_return", TokenType::AssertReturn},
-#line 404 "src/lexer-keywords.txt"
-      {"i64x2.add", TokenType::Binary, Opcode::I64X2Add},
-      {""},
-#line 56 "src/lexer-keywords.txt"
-      {"f32.demote_f64", TokenType::Convert, Opcode::F32DemoteF64},
-      {""},
+#line 276 "src/lexer-keywords.txt"
+      {"i32x4.abs", TokenType::Unary, Opcode::I32X4Abs},
 #line 21 "src/lexer-keywords.txt"
       {"assert_invalid", TokenType::AssertInvalid},
-      {""},
-#line 508 "src/lexer-keywords.txt"
-      {"v128.load", TokenType::Load, Opcode::V128Load},
-#line 343 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I64AtomicRmwSub},
-#line 220 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I32AtomicRmwSub},
-#line 512 "src/lexer-keywords.txt"
-      {"v128", Type::V128},
-      {""}, {""},
-#line 332 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AddU},
-#line 209 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AddU},
-      {""},
-#line 507 "src/lexer-keywords.txt"
-      {"v128.const", TokenType::Const, Opcode::V128Const},
-#line 333 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AndU},
-#line 210 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AndU},
-      {""}, {""},
-#line 329 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32SubU},
-      {""}, {""}, {""},
-#line 369 "src/lexer-keywords.txt"
-      {"i64.load16_s", TokenType::Load, Opcode::I64Load16S},
-#line 242 "src/lexer-keywords.txt"
-      {"i32.load16_s", TokenType::Load, Opcode::I32Load16S},
-#line 506 "src/lexer-keywords.txt"
-      {"v128.bitselect", TokenType::Ternary, Opcode::V128BitSelect},
-      {""},
-#line 370 "src/lexer-keywords.txt"
-      {"i64.load16_u", TokenType::Load, Opcode::I64Load16U},
-#line 243 "src/lexer-keywords.txt"
-      {"i32.load16_u", TokenType::Load, Opcode::I32Load16U},
 #line 25 "src/lexer-keywords.txt"
       {"assert_unlinkable", TokenType::AssertUnlinkable},
-      {""}, {""},
-#line 317 "src/lexer-keywords.txt"
-      {"i64.atomic.load", TokenType::AtomicLoad, Opcode::I64AtomicLoad},
-#line 201 "src/lexer-keywords.txt"
-      {"i32.atomic.load", TokenType::AtomicLoad, Opcode::I32AtomicLoad},
-#line 526 "src/lexer-keywords.txt"
-      {"f32.demote/f64", TokenType::Convert, Opcode::F32DemoteF64},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 497 "src/lexer-keywords.txt"
-      {"table.size", TokenType::TableSize, Opcode::TableSize},
-      {""}, {""},
-#line 558 "src/lexer-keywords.txt"
-      {"set_local", TokenType::LocalSet, Opcode::LocalSet},
-#line 126 "src/lexer-keywords.txt"
-      {"f64.trunc", TokenType::Unary, Opcode::F64Trunc},
-#line 75 "src/lexer-keywords.txt"
-      {"f32.trunc", TokenType::Unary, Opcode::F32Trunc},
-      {""},
 #line 371 "src/lexer-keywords.txt"
-      {"i64.load32_s", TokenType::Load, Opcode::I64Load32S},
-      {""},
-#line 559 "src/lexer-keywords.txt"
-      {"tee_local", TokenType::LocalTee, Opcode::LocalTee},
-      {""},
-#line 372 "src/lexer-keywords.txt"
-      {"i64.load32_u", TokenType::Load, Opcode::I64Load32U},
-#line 339 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I64AtomicRmwAdd},
-#line 216 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I32AtomicRmwAdd},
-#line 502 "src/lexer-keywords.txt"
-      {"type", TokenType::Type},
-      {""}, {""}, {""},
-#line 342 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I64AtomicRmwOr},
-#line 219 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I32AtomicRmwOr},
-      {""}, {""}, {""},
-#line 22 "src/lexer-keywords.txt"
-      {"assert_malformed", TokenType::AssertMalformed},
-#line 485 "src/lexer-keywords.txt"
-      {"return_call", TokenType::ReturnCall, Opcode::ReturnCall},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 454 "src/lexer-keywords.txt"
-      {"import", TokenType::Import},
-      {""}, {""},
-#line 46 "src/lexer-keywords.txt"
-      {"export", TokenType::Export},
-      {""}, {""},
-#line 104 "src/lexer-keywords.txt"
-      {"f64.convert_i64_s", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 53 "src/lexer-keywords.txt"
-      {"f32.convert_i64_s", TokenType::Convert, Opcode::F32ConvertI64S},
-      {""}, {""}, {""},
-#line 325 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AddU},
-      {""}, {""}, {""},
-#line 326 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AndU},
-      {""},
-#line 102 "src/lexer-keywords.txt"
-      {"f64.convert_i32_s", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 51 "src/lexer-keywords.txt"
-      {"f32.convert_i32_s", TokenType::Convert, Opcode::F32ConvertI32S},
-      {""}, {""}, {""}, {""}, {""},
-#line 500 "src/lexer-keywords.txt"
-      {"throw", TokenType::Throw, Opcode::Throw},
-      {""}, {""},
-#line 33 "src/lexer-keywords.txt"
-      {"call_indirect", TokenType::CallIndirect, Opcode::CallIndirect},
-      {""},
-#line 340 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I64AtomicRmwAnd},
-#line 217 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I32AtomicRmwAnd},
-      {""}, {""}, {""},
-#line 397 "src/lexer-keywords.txt"
-      {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
-#line 267 "src/lexer-keywords.txt"
-      {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
-#line 398 "src/lexer-keywords.txt"
-      {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
-#line 268 "src/lexer-keywords.txt"
-      {"i32.trunc_f64_u", TokenType::Convert, Opcode::I32TruncF64U},
-      {""},
-#line 97 "src/lexer-keywords.txt"
-      {"f32x4", TokenType::F32X4},
-#line 105 "src/lexer-keywords.txt"
-      {"f64.convert_i64_u", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 54 "src/lexer-keywords.txt"
-      {"f32.convert_i64_u", TokenType::Convert, Opcode::F32ConvertI64U},
-#line 304 "src/lexer-keywords.txt"
-      {"i32x4", TokenType::I32X4},
-#line 150 "src/lexer-keywords.txt"
-      {"get", TokenType::Get},
-#line 40 "src/lexer-keywords.txt"
-      {"drop", TokenType::Drop, Opcode::Drop},
-#line 328 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32OrU},
-#line 395 "src/lexer-keywords.txt"
-      {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
-#line 265 "src/lexer-keywords.txt"
-      {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
-#line 396 "src/lexer-keywords.txt"
-      {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
-#line 266 "src/lexer-keywords.txt"
-      {"i32.trunc_f32_u", TokenType::Convert, Opcode::I32TruncF32U},
-#line 327 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw32CmpxchgU},
-#line 103 "src/lexer-keywords.txt"
-      {"f64.convert_i32_u", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 52 "src/lexer-keywords.txt"
-      {"f32.convert_i32_u", TokenType::Convert, Opcode::F32ConvertI32U},
-#line 475 "src/lexer-keywords.txt"
-      {"param", TokenType::Param},
-      {""}, {""}, {""},
-#line 29 "src/lexer-keywords.txt"
-      {"br_if", TokenType::BrIf, Opcode::BrIf},
-#line 390 "src/lexer-keywords.txt"
-      {"i64.store16", TokenType::Store, Opcode::I64Store16},
-#line 261 "src/lexer-keywords.txt"
-      {"i32.store16", TokenType::Store, Opcode::I32Store16},
-      {""},
-#line 461 "src/lexer-keywords.txt"
-      {"loop", TokenType::Loop, Opcode::Loop},
-#line 322 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16SubU},
-#line 206 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16SubU},
-#line 392 "src/lexer-keywords.txt"
-      {"i64.store8", TokenType::Store, Opcode::I64Store8},
-#line 262 "src/lexer-keywords.txt"
-      {"i32.store8", TokenType::Store, Opcode::I32Store8},
-      {""},
-#line 550 "src/lexer-keywords.txt"
-      {"i64.trunc_s/f64", TokenType::Convert, Opcode::I64TruncF64S},
-#line 538 "src/lexer-keywords.txt"
-      {"i32.trunc_s/f64", TokenType::Convert, Opcode::I32TruncF64S},
-#line 554 "src/lexer-keywords.txt"
-      {"i64.trunc_u/f64", TokenType::Convert, Opcode::I64TruncF64U},
-#line 542 "src/lexer-keywords.txt"
-      {"i32.trunc_u/f64", TokenType::Convert, Opcode::I32TruncF64U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 549 "src/lexer-keywords.txt"
-      {"i64.trunc_s/f32", TokenType::Convert, Opcode::I64TruncF32S},
-#line 537 "src/lexer-keywords.txt"
-      {"i32.trunc_s/f32", TokenType::Convert, Opcode::I32TruncF32S},
-#line 553 "src/lexer-keywords.txt"
-      {"i64.trunc_u/f32", TokenType::Convert, Opcode::I64TruncF32U},
-#line 541 "src/lexer-keywords.txt"
-      {"i32.trunc_u/f32", TokenType::Convert, Opcode::I32TruncF32U},
-      {""}, {""}, {""}, {""},
-#line 96 "src/lexer-keywords.txt"
-      {"f32x4.sub", TokenType::Binary, Opcode::F32X4Sub},
-#line 373 "src/lexer-keywords.txt"
-      {"i64.load8_s", TokenType::Load, Opcode::I64Load8S},
+      {"i64.load16_u", TokenType::Load, Opcode::I64Load16U},
 #line 244 "src/lexer-keywords.txt"
-      {"i32.load8_s", TokenType::Load, Opcode::I32Load8S},
-#line 303 "src/lexer-keywords.txt"
-      {"i32x4.sub", TokenType::Binary, Opcode::I32X4Sub},
-      {""},
-#line 374 "src/lexer-keywords.txt"
-      {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
-#line 245 "src/lexer-keywords.txt"
-      {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
-      {""}, {""},
-#line 380 "src/lexer-keywords.txt"
-      {"i64.or", TokenType::Binary, Opcode::I64Or},
-#line 251 "src/lexer-keywords.txt"
-      {"i32.or", TokenType::Binary, Opcode::I32Or},
-#line 92 "src/lexer-keywords.txt"
-      {"f32x4.ne", TokenType::Compare, Opcode::F32X4Ne},
-#line 87 "src/lexer-keywords.txt"
-      {"f32x4.lt", TokenType::Compare, Opcode::F32X4Lt},
-      {""},
-#line 297 "src/lexer-keywords.txt"
-      {"i32x4.ne", TokenType::Compare, Opcode::I32X4Ne},
-      {""},
-#line 493 "src/lexer-keywords.txt"
-      {"table.get", TokenType::TableGet, Opcode::TableGet},
-      {""},
-#line 30 "src/lexer-keywords.txt"
-      {"br_on_exn", TokenType::BrOnExn, Opcode::BrOnExn},
-      {""}, {""}, {""}, {""}, {""},
-#line 86 "src/lexer-keywords.txt"
-      {"f32x4.le", TokenType::Compare, Opcode::F32X4Le},
-      {""},
-#line 289 "src/lexer-keywords.txt"
-      {"i32x4.lt_s", TokenType::Compare, Opcode::I32X4LtS},
-#line 293 "src/lexer-keywords.txt"
-      {"i32x4.min_s", TokenType::Binary, Opcode::I32X4MinS},
-#line 290 "src/lexer-keywords.txt"
-      {"i32x4.lt_u", TokenType::Compare, Opcode::I32X4LtU},
-      {""},
-#line 89 "src/lexer-keywords.txt"
-      {"f32x4.min", TokenType::Binary, Opcode::F32X4Min},
-#line 294 "src/lexer-keywords.txt"
-      {"i32x4.min_u", TokenType::Binary, Opcode::I32X4MinU},
-#line 285 "src/lexer-keywords.txt"
-      {"i32x4.le_s", TokenType::Compare, Opcode::I32X4LeS},
-      {""},
-#line 286 "src/lexer-keywords.txt"
-      {"i32x4.le_u", TokenType::Compare, Opcode::I32X4LeU},
-      {""}, {""},
-#line 546 "src/lexer-keywords.txt"
-      {"i64.extend_s/i32", TokenType::Convert, Opcode::I64ExtendI32S},
-      {""},
-#line 547 "src/lexer-keywords.txt"
-      {"i64.extend_u/i32", TokenType::Convert, Opcode::I64ExtendI32U},
-#line 318 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AddU},
-#line 202 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AddU},
-      {""}, {""},
-#line 319 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AndU},
-#line 203 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AndU},
-#line 346 "src/lexer-keywords.txt"
-      {"i64.atomic.store16", TokenType::AtomicStore, Opcode::I64AtomicStore16},
-#line 223 "src/lexer-keywords.txt"
-      {"i32.atomic.store16", TokenType::AtomicStore, Opcode::I32AtomicStore16},
-      {""},
-#line 77 "src/lexer-keywords.txt"
-      {"f32x4.abs", TokenType::Unary, Opcode::F32X4Abs},
-#line 471 "src/lexer-keywords.txt"
-      {"nan:canonical", TokenType::NanCanonical},
-      {""},
-#line 275 "src/lexer-keywords.txt"
-      {"i32x4.abs", TokenType::Unary, Opcode::I32X4Abs},
+      {"i32.load16_u", TokenType::Load, Opcode::I32Load16U},
+#line 559 "src/lexer-keywords.txt"
+      {"set_local", TokenType::LocalSet, Opcode::LocalSet},
+      {""}, {""}, {""},
+#line 560 "src/lexer-keywords.txt"
+      {"tee_local", TokenType::LocalTee, Opcode::LocalTee},
+#line 333 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AddU},
+#line 210 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AddU},
       {""}, {""},
 #line 90 "src/lexer-keywords.txt"
-      {"f32x4.mul", TokenType::Binary, Opcode::F32X4Mul},
-      {""}, {""},
-#line 295 "src/lexer-keywords.txt"
-      {"i32x4.mul", TokenType::Binary, Opcode::I32X4Mul},
-      {""}, {""},
-#line 18 "src/lexer-keywords.txt"
-      {"anyref", Type::Anyref},
+      {"f32x4.min", TokenType::Binary, Opcode::F32X4Min},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 103 "src/lexer-keywords.txt"
+      {"f64.convert_i32_s", TokenType::Convert, Opcode::F64ConvertI32S},
+#line 52 "src/lexer-keywords.txt"
+      {"f32.convert_i32_s", TokenType::Convert, Opcode::F32ConvertI32S},
+      {""},
+#line 506 "src/lexer-keywords.txt"
+      {"v128.and", TokenType::Binary, Opcode::V128And},
+      {""},
+#line 334 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AndU},
+#line 211 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AndU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 509 "src/lexer-keywords.txt"
+      {"v128.load", TokenType::Load, Opcode::V128Load},
+#line 343 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I64AtomicRmwOr},
+#line 220 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I32AtomicRmwOr},
       {""}, {""}, {""},
-#line 466 "src/lexer-keywords.txt"
-      {"memory.size", TokenType::MemorySize, Opcode::MemorySize},
-      {""}, {""}, {""}, {""},
-#line 465 "src/lexer-keywords.txt"
-      {"memory.init", TokenType::MemoryInit, Opcode::MemoryInit},
+#line 344 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I64AtomicRmwSub},
+#line 221 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I32AtomicRmwSub},
       {""},
-#line 81 "src/lexer-keywords.txt"
-      {"f32x4.div", TokenType::Binary, Opcode::F32X4Div},
+#line 511 "src/lexer-keywords.txt"
+      {"v128.or", TokenType::Binary, Opcode::V128Or},
+#line 503 "src/lexer-keywords.txt"
+      {"type", TokenType::Type},
       {""},
-#line 321 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16OrU},
-#line 205 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16OrU},
+#line 505 "src/lexer-keywords.txt"
+      {"v128.andnot", TokenType::Binary, Opcode::V128Andnot},
+#line 23 "src/lexer-keywords.txt"
+      {"assert_return", TokenType::AssertReturn},
+#line 340 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I64AtomicRmwAdd},
+#line 217 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I32AtomicRmwAdd},
+      {""},
+#line 22 "src/lexer-keywords.txt"
+      {"assert_malformed", TokenType::AssertMalformed},
+#line 47 "src/lexer-keywords.txt"
+      {"export", TokenType::Export},
       {""}, {""},
-#line 484 "src/lexer-keywords.txt"
-      {"return_call_indirect", TokenType::ReturnCallIndirect, Opcode::ReturnCallIndirect},
-#line 320 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw16CmpxchgU},
-#line 204 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw16CmpxchgU},
+#line 151 "src/lexer-keywords.txt"
+      {"get", TokenType::Get},
+#line 455 "src/lexer-keywords.txt"
+      {"import", TokenType::Import},
       {""}, {""}, {""}, {""},
-#line 78 "src/lexer-keywords.txt"
+#line 507 "src/lexer-keywords.txt"
+      {"v128.bitselect", TokenType::Ternary, Opcode::V128BitSelect},
+#line 79 "src/lexer-keywords.txt"
       {"f32x4.add", TokenType::Binary, Opcode::F32X4Add},
       {""}, {""},
-#line 276 "src/lexer-keywords.txt"
+#line 317 "src/lexer-keywords.txt"
+      {"i64.atomic.load8_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad8U},
+#line 201 "src/lexer-keywords.txt"
+      {"i32.atomic.load8_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad8U},
+      {""}, {""},
+#line 277 "src/lexer-keywords.txt"
       {"i32x4.add", TokenType::Binary, Opcode::I32X4Add},
-#line 528 "src/lexer-keywords.txt"
+#line 316 "src/lexer-keywords.txt"
+      {"i64.atomic.load32_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad32U},
+      {""}, {""}, {""}, {""},
+#line 326 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AddU},
+      {""},
+#line 29 "src/lexer-keywords.txt"
+      {"br_if", TokenType::BrIf, Opcode::BrIf},
+      {""},
+#line 396 "src/lexer-keywords.txt"
+      {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
+#line 266 "src/lexer-keywords.txt"
+      {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
+      {""},
+#line 397 "src/lexer-keywords.txt"
+      {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
+#line 267 "src/lexer-keywords.txt"
+      {"i32.trunc_f32_u", TokenType::Convert, Opcode::I32TruncF32U},
+      {""}, {""},
+#line 486 "src/lexer-keywords.txt"
+      {"return_call", TokenType::ReturnCall, Opcode::ReturnCall},
+#line 341 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I64AtomicRmwAnd},
+#line 218 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I32AtomicRmwAnd},
+      {""}, {""}, {""},
+#line 327 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AndU},
+#line 508 "src/lexer-keywords.txt"
+      {"v128.const", TokenType::Const, Opcode::V128Const},
+      {""}, {""}, {""},
+#line 462 "src/lexer-keywords.txt"
+      {"loop", TokenType::Loop, Opcode::Loop},
+      {""},
+#line 329 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32OrU},
+#line 494 "src/lexer-keywords.txt"
+      {"table.get", TokenType::TableGet, Opcode::TableGet},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 104 "src/lexer-keywords.txt"
+      {"f64.convert_i32_u", TokenType::Convert, Opcode::F64ConvertI32U},
+#line 53 "src/lexer-keywords.txt"
+      {"f32.convert_i32_u", TokenType::Convert, Opcode::F32ConvertI32U},
+#line 40 "src/lexer-keywords.txt"
+      {"drop", TokenType::Drop, Opcode::Drop},
+#line 278 "src/lexer-keywords.txt"
+      {"i32x4.all_true", TokenType::Unary, Opcode::I32X4AllTrue},
+      {""},
+#line 105 "src/lexer-keywords.txt"
+      {"f64.convert_i64_s", TokenType::Convert, Opcode::F64ConvertI64S},
+#line 54 "src/lexer-keywords.txt"
+      {"f32.convert_i64_s", TokenType::Convert, Opcode::F32ConvertI64S},
+      {""},
+#line 529 "src/lexer-keywords.txt"
       {"f64.convert_s/i32", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 522 "src/lexer-keywords.txt"
+#line 523 "src/lexer-keywords.txt"
       {"f32.convert_s/i32", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 530 "src/lexer-keywords.txt"
+      {""},
+#line 531 "src/lexer-keywords.txt"
       {"f64.convert_u/i32", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 524 "src/lexer-keywords.txt"
+#line 525 "src/lexer-keywords.txt"
       {"f32.convert_u/i32", TokenType::Convert, Opcode::F32ConvertI32U},
       {""},
-#line 153 "src/lexer-keywords.txt"
-      {"global", TokenType::Global},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 152 "src/lexer-keywords.txt"
-      {"global.set", TokenType::GlobalSet, Opcode::GlobalSet},
+#line 82 "src/lexer-keywords.txt"
+      {"f32x4.div", TokenType::Binary, Opcode::F32X4Div},
       {""}, {""}, {""},
-#line 476 "src/lexer-keywords.txt"
-      {"quote", TokenType::Quote},
-      {""}, {""}, {""},
-#line 143 "src/lexer-keywords.txt"
-      {"f64x2.splat", TokenType::Unary, Opcode::F64X2Splat},
-      {""}, {""},
-#line 414 "src/lexer-keywords.txt"
-      {"i64x2.splat", TokenType::Unary, Opcode::I64X2Splat},
-#line 463 "src/lexer-keywords.txt"
-      {"memory.fill", TokenType::MemoryFill, Opcode::MemoryFill},
-      {""}, {""}, {""},
-#line 359 "src/lexer-keywords.txt"
-      {"i64.extend32_s", TokenType::Unary, Opcode::I64Extend32S},
+#line 550 "src/lexer-keywords.txt"
+      {"i64.trunc_s/f32", TokenType::Convert, Opcode::I64TruncF32S},
+#line 538 "src/lexer-keywords.txt"
+      {"i32.trunc_s/f32", TokenType::Convert, Opcode::I32TruncF32S},
       {""},
-#line 353 "src/lexer-keywords.txt"
-      {"i64.ctz", TokenType::Unary, Opcode::I64Ctz},
-#line 229 "src/lexer-keywords.txt"
-      {"i32.ctz", TokenType::Unary, Opcode::I32Ctz},
-#line 494 "src/lexer-keywords.txt"
-      {"table.grow", TokenType::TableGrow, Opcode::TableGrow},
+#line 554 "src/lexer-keywords.txt"
+      {"i64.trunc_u/f32", TokenType::Convert, Opcode::I64TruncF32U},
+#line 542 "src/lexer-keywords.txt"
+      {"i32.trunc_u/f32", TokenType::Convert, Opcode::I32TruncF32U},
       {""},
-#line 123 "src/lexer-keywords.txt"
-      {"f64.sqrt", TokenType::Unary, Opcode::F64Sqrt},
-#line 72 "src/lexer-keywords.txt"
-      {"f32.sqrt", TokenType::Unary, Opcode::F32Sqrt},
-#line 134 "src/lexer-keywords.txt"
+#line 135 "src/lexer-keywords.txt"
       {"f64x2.gt", TokenType::Compare, Opcode::F64X2Gt},
+#line 328 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw32CmpxchgU},
+#line 501 "src/lexer-keywords.txt"
+      {"throw", TokenType::Throw, Opcode::Throw},
+#line 323 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16SubU},
+#line 207 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16SubU},
+      {""}, {""},
+#line 144 "src/lexer-keywords.txt"
+      {"f64x2.splat", TokenType::Unary, Opcode::F64X2Splat},
+#line 134 "src/lexer-keywords.txt"
+      {"f64x2.ge", TokenType::Compare, Opcode::F64X2Ge},
+#line 33 "src/lexer-keywords.txt"
+      {"call_indirect", TokenType::CallIndirect, Opcode::CallIndirect},
+#line 127 "src/lexer-keywords.txt"
+      {"f64.trunc", TokenType::Unary, Opcode::F64Trunc},
+#line 76 "src/lexer-keywords.txt"
+      {"f32.trunc", TokenType::Unary, Opcode::F32Trunc},
+      {""}, {""},
+#line 415 "src/lexer-keywords.txt"
+      {"i64x2.splat", TokenType::Unary, Opcode::I64X2Splat},
       {""},
-#line 513 "src/lexer-keywords.txt"
-      {"v128.xor", TokenType::Binary, Opcode::V128Xor},
-#line 111 "src/lexer-keywords.txt"
-      {"f64.gt", TokenType::Compare, Opcode::F64Gt},
-#line 61 "src/lexer-keywords.txt"
-      {"f32.gt", TokenType::Compare, Opcode::F32Gt},
+#line 154 "src/lexer-keywords.txt"
+      {"global", TokenType::Global},
+      {""}, {""}, {""}, {""}, {""},
+#line 153 "src/lexer-keywords.txt"
+      {"global.set", TokenType::GlobalSet, Opcode::GlobalSet},
+      {""}, {""}, {""}, {""}, {""},
+#line 391 "src/lexer-keywords.txt"
+      {"i64.store16", TokenType::Store, Opcode::I64Store16},
+#line 262 "src/lexer-keywords.txt"
+      {"i32.store16", TokenType::Store, Opcode::I32Store16},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 476 "src/lexer-keywords.txt"
+      {"param", TokenType::Param},
+      {""}, {""}, {""}, {""},
+#line 398 "src/lexer-keywords.txt"
+      {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
+#line 268 "src/lexer-keywords.txt"
+      {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
       {""},
-#line 361 "src/lexer-keywords.txt"
+#line 399 "src/lexer-keywords.txt"
+      {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
+#line 269 "src/lexer-keywords.txt"
+      {"i32.trunc_f64_u", TokenType::Convert, Opcode::I32TruncF64U},
+#line 347 "src/lexer-keywords.txt"
+      {"i64.atomic.store16", TokenType::AtomicStore, Opcode::I64AtomicStore16},
+#line 224 "src/lexer-keywords.txt"
+      {"i32.atomic.store16", TokenType::AtomicStore, Opcode::I32AtomicStore16},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 360 "src/lexer-keywords.txt"
+      {"i64.extend32_s", TokenType::Unary, Opcode::I64Extend32S},
+      {""}, {""}, {""}, {""},
+#line 547 "src/lexer-keywords.txt"
+      {"i64.extend_s/i32", TokenType::Convert, Opcode::I64ExtendI32S},
+      {""}, {""},
+#line 548 "src/lexer-keywords.txt"
+      {"i64.extend_u/i32", TokenType::Convert, Opcode::I64ExtendI32U},
+      {""}, {""}, {""}, {""},
+#line 362 "src/lexer-keywords.txt"
       {"i64.extend_i32_s", TokenType::Convert, Opcode::I64ExtendI32S},
       {""}, {""}, {""},
-#line 362 "src/lexer-keywords.txt"
-      {"i64.extend_i32_u", TokenType::Convert, Opcode::I64ExtendI32U},
-      {""},
-#line 133 "src/lexer-keywords.txt"
-      {"f64x2.ge", TokenType::Compare, Opcode::F64X2Ge},
-      {""}, {""},
-#line 110 "src/lexer-keywords.txt"
-      {"f64.ge", TokenType::Compare, Opcode::F64Ge},
-#line 60 "src/lexer-keywords.txt"
-      {"f32.ge", TokenType::Compare, Opcode::F32Ge},
-      {""}, {""}, {""},
-#line 457 "src/lexer-keywords.txt"
-      {"local.get", TokenType::LocalGet, Opcode::LocalGet},
-      {""},
-#line 481 "src/lexer-keywords.txt"
-      {"register", TokenType::Register},
-      {""},
-#line 351 "src/lexer-keywords.txt"
-      {"i64.clz", TokenType::Unary, Opcode::I64Clz},
-#line 227 "src/lexer-keywords.txt"
-      {"i32.clz", TokenType::Unary, Opcode::I32Clz},
-#line 365 "src/lexer-keywords.txt"
-      {"i64.gt_s", TokenType::Compare, Opcode::I64GtS},
-#line 238 "src/lexer-keywords.txt"
-      {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
-      {""}, {""},
-#line 366 "src/lexer-keywords.txt"
-      {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
-#line 239 "src/lexer-keywords.txt"
-      {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
+#line 106 "src/lexer-keywords.txt"
+      {"f64.convert_i64_u", TokenType::Convert, Opcode::F64ConvertI64U},
+#line 55 "src/lexer-keywords.txt"
+      {"f32.convert_i64_u", TokenType::Convert, Opcode::F32ConvertI64U},
 #line 363 "src/lexer-keywords.txt"
-      {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
+      {"i64.extend_i32_u", TokenType::Convert, Opcode::I64ExtendI32U},
+#line 30 "src/lexer-keywords.txt"
+      {"br_on_exn", TokenType::BrOnExn, Opcode::BrOnExn},
+#line 381 "src/lexer-keywords.txt"
+      {"i64.or", TokenType::Binary, Opcode::I64Or},
+#line 252 "src/lexer-keywords.txt"
+      {"i32.or", TokenType::Binary, Opcode::I32Or},
+      {""}, {""}, {""},
+#line 400 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f32_s", TokenType::Convert, Opcode::I64TruncSatF32S},
+#line 270 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f32_s", TokenType::Convert, Opcode::I32TruncSatF32S},
+      {""}, {""}, {""}, {""},
+#line 401 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f32_u", TokenType::Convert, Opcode::I64TruncSatF32U},
+#line 271 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f32_u", TokenType::Convert, Opcode::I32TruncSatF32U},
+#line 551 "src/lexer-keywords.txt"
+      {"i64.trunc_s/f64", TokenType::Convert, Opcode::I64TruncF64S},
+#line 539 "src/lexer-keywords.txt"
+      {"i32.trunc_s/f64", TokenType::Convert, Opcode::I32TruncF64S},
+      {""},
+#line 555 "src/lexer-keywords.txt"
+      {"i64.trunc_u/f64", TokenType::Convert, Opcode::I64TruncF64U},
+#line 543 "src/lexer-keywords.txt"
+      {"i32.trunc_u/f64", TokenType::Convert, Opcode::I32TruncF64U},
+#line 319 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AddU},
+#line 203 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AddU},
+      {""}, {""}, {""},
+#line 495 "src/lexer-keywords.txt"
+      {"table.grow", TokenType::TableGrow, Opcode::TableGrow},
+#line 361 "src/lexer-keywords.txt"
+      {"i64.extend8_s", TokenType::Unary, Opcode::I64Extend8S},
 #line 236 "src/lexer-keywords.txt"
-      {"i32.ge_s", TokenType::Compare, Opcode::I32GeS},
+      {"i32.extend8_s", TokenType::Unary, Opcode::I32Extend8S},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 320 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AndU},
+#line 204 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AndU},
+#line 458 "src/lexer-keywords.txt"
+      {"local.get", TokenType::LocalGet, Opcode::LocalGet},
+      {""}, {""},
 #line 315 "src/lexer-keywords.txt"
-      {"i64.atomic.load32_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad32U},
+      {"i64.atomic.load16_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad16U},
+#line 200 "src/lexer-keywords.txt"
+      {"i32.atomic.load16_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad16U},
+#line 322 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16OrU},
+#line 206 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16OrU},
+      {""},
+#line 435 "src/lexer-keywords.txt"
+      {"i8x16.lt_s", TokenType::Compare, Opcode::I8X16LtS},
+      {""}, {""},
+#line 436 "src/lexer-keywords.txt"
+      {"i8x16.lt_u", TokenType::Compare, Opcode::I8X16LtU},
+#line 433 "src/lexer-keywords.txt"
+      {"i8x16.le_s", TokenType::Compare, Opcode::I8X16LeS},
+      {""}, {""},
+#line 434 "src/lexer-keywords.txt"
+      {"i8x16.le_u", TokenType::Compare, Opcode::I8X16LeU},
+      {""}, {""},
+#line 86 "src/lexer-keywords.txt"
+      {"f32x4.gt", TokenType::Compare, Opcode::F32X4Gt},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 95 "src/lexer-keywords.txt"
+      {"f32x4.splat", TokenType::Unary, Opcode::F32X4Splat},
+#line 85 "src/lexer-keywords.txt"
+      {"f32x4.ge", TokenType::Compare, Opcode::F32X4Ge},
+      {""},
+#line 452 "src/lexer-keywords.txt"
+      {"i8x16.sub", TokenType::Binary, Opcode::I8X16Sub},
+      {""},
+#line 284 "src/lexer-keywords.txt"
+      {"i32x4.gt_s", TokenType::Compare, Opcode::I32X4GtS},
+      {""},
+#line 303 "src/lexer-keywords.txt"
+      {"i32x4.splat", TokenType::Unary, Opcode::I32X4Splat},
+#line 285 "src/lexer-keywords.txt"
+      {"i32x4.gt_u", TokenType::Compare, Opcode::I32X4GtU},
+#line 282 "src/lexer-keywords.txt"
+      {"i32x4.ge_s", TokenType::Compare, Opcode::I32X4GeS},
+#line 477 "src/lexer-keywords.txt"
+      {"quote", TokenType::Quote},
+      {""},
+#line 283 "src/lexer-keywords.txt"
+      {"i32x4.ge_u", TokenType::Compare, Opcode::I32X4GeU},
+#line 112 "src/lexer-keywords.txt"
+      {"f64.gt", TokenType::Compare, Opcode::F64Gt},
+#line 62 "src/lexer-keywords.txt"
+      {"f32.gt", TokenType::Compare, Opcode::F32Gt},
+      {""}, {""},
+#line 321 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw16CmpxchgU},
+#line 205 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw16CmpxchgU},
+#line 444 "src/lexer-keywords.txt"
+      {"i8x16.ne", TokenType::Compare, Opcode::I8X16Ne},
+#line 472 "src/lexer-keywords.txt"
+      {"nan:canonical", TokenType::NanCanonical},
+#line 111 "src/lexer-keywords.txt"
+      {"f64.ge", TokenType::Compare, Opcode::F64Ge},
+#line 61 "src/lexer-keywords.txt"
+      {"f32.ge", TokenType::Compare, Opcode::F32Ge},
+      {""}, {""}, {""}, {""}, {""},
+#line 366 "src/lexer-keywords.txt"
+      {"i64.gt_s", TokenType::Compare, Opcode::I64GtS},
+#line 239 "src/lexer-keywords.txt"
+      {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
+#line 439 "src/lexer-keywords.txt"
+      {"i8x16.min_s", TokenType::Binary, Opcode::I8X16MinS},
       {""},
 #line 364 "src/lexer-keywords.txt"
-      {"i64.ge_u", TokenType::Compare, Opcode::I64GeU},
+      {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
 #line 237 "src/lexer-keywords.txt"
+      {"i32.ge_s", TokenType::Compare, Opcode::I32GeS},
+#line 367 "src/lexer-keywords.txt"
+      {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
+#line 240 "src/lexer-keywords.txt"
+      {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
+#line 440 "src/lexer-keywords.txt"
+      {"i8x16.min_u", TokenType::Binary, Opcode::I8X16MinU},
+#line 482 "src/lexer-keywords.txt"
+      {"register", TokenType::Register},
+#line 365 "src/lexer-keywords.txt"
+      {"i64.ge_u", TokenType::Compare, Opcode::I64GeU},
+#line 238 "src/lexer-keywords.txt"
       {"i32.ge_u", TokenType::Compare, Opcode::I32GeU},
-#line 316 "src/lexer-keywords.txt"
-      {"i64.atomic.load8_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad8U},
-#line 200 "src/lexer-keywords.txt"
-      {"i32.atomic.load8_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad8U},
-#line 334 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw8CmpxchgU},
-#line 211 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw8CmpxchgU},
-      {""}, {""}, {""},
-#line 417 "src/lexer-keywords.txt"
-      {"i64.xor", TokenType::Binary, Opcode::I64Xor},
-#line 311 "src/lexer-keywords.txt"
-      {"i32.xor", TokenType::Binary, Opcode::I32Xor},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 399 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f32_s", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 269 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f32_s", TokenType::Convert, Opcode::I32TruncSatF32S},
-      {""}, {""},
-#line 400 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f32_u", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 270 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f32_u", TokenType::Convert, Opcode::I32TruncSatF32U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 335 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8OrU},
-#line 212 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8OrU},
-      {""}, {""}, {""}, {""}, {""},
-#line 387 "src/lexer-keywords.txt"
-      {"i64.shl", TokenType::Binary, Opcode::I64Shl},
-#line 258 "src/lexer-keywords.txt"
-      {"i32.shl", TokenType::Binary, Opcode::I32Shl},
-      {""}, {""}, {""}, {""},
-#line 358 "src/lexer-keywords.txt"
-      {"i64.extend16_s", TokenType::Unary, Opcode::I64Extend16S},
-#line 234 "src/lexer-keywords.txt"
-      {"i32.extend16_s", TokenType::Unary, Opcode::I32Extend16S},
-#line 388 "src/lexer-keywords.txt"
-      {"i64.shr_s", TokenType::Binary, Opcode::I64ShrS},
-#line 259 "src/lexer-keywords.txt"
-      {"i32.shr_s", TokenType::Binary, Opcode::I32ShrS},
       {""},
-#line 277 "src/lexer-keywords.txt"
-      {"i32x4.all_true", TokenType::Unary, Opcode::I32X4AllTrue},
-#line 389 "src/lexer-keywords.txt"
-      {"i64.shr_u", TokenType::Binary, Opcode::I64ShrU},
-#line 260 "src/lexer-keywords.txt"
-      {"i32.shr_u", TokenType::Binary, Opcode::I32ShrU},
+#line 335 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw8CmpxchgU},
+#line 212 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw8CmpxchgU},
       {""}, {""},
-#line 331 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XorU},
+#line 485 "src/lexer-keywords.txt"
+      {"return_call_indirect", TokenType::ReturnCallIndirect, Opcode::ReturnCallIndirect},
+      {""}, {""}, {""}, {""}, {""},
+#line 419 "src/lexer-keywords.txt"
+      {"i8x16.abs", TokenType::Unary, Opcode::I8X16Abs},
+#line 388 "src/lexer-keywords.txt"
+      {"i64.shl", TokenType::Binary, Opcode::I64Shl},
+#line 259 "src/lexer-keywords.txt"
+      {"i32.shl", TokenType::Binary, Opcode::I32Shl},
+#line 124 "src/lexer-keywords.txt"
+      {"f64.sqrt", TokenType::Unary, Opcode::F64Sqrt},
+#line 73 "src/lexer-keywords.txt"
+      {"f32.sqrt", TokenType::Unary, Opcode::F32Sqrt},
+      {""},
+#line 407 "src/lexer-keywords.txt"
+      {"i64x2.load32x2_s", TokenType::Load, Opcode::I64X2Load32X2S},
+#line 292 "src/lexer-keywords.txt"
+      {"i32x4.max_s", TokenType::Binary, Opcode::I32X4MaxS},
+#line 110 "src/lexer-keywords.txt"
+      {"f64.floor", TokenType::Unary, Opcode::F64Floor},
+#line 60 "src/lexer-keywords.txt"
+      {"f32.floor", TokenType::Unary, Opcode::F32Floor},
+      {""}, {""},
+#line 408 "src/lexer-keywords.txt"
+      {"i64x2.load32x2_u", TokenType::Load, Opcode::I64X2Load32X2U},
+#line 293 "src/lexer-keywords.txt"
+      {"i32x4.max_u", TokenType::Binary, Opcode::I32X4MaxU},
       {""}, {""}, {""}, {""},
-#line 35 "src/lexer-keywords.txt"
-      {"catch", TokenType::Catch, Opcode::Catch},
+#line 467 "src/lexer-keywords.txt"
+      {"memory.size", TokenType::MemorySize, Opcode::MemorySize},
+      {""}, {""}, {""}, {""},
+#line 530 "src/lexer-keywords.txt"
+      {"f64.convert_s/i64", TokenType::Convert, Opcode::F64ConvertI64S},
+#line 524 "src/lexer-keywords.txt"
+      {"f32.convert_s/i64", TokenType::Convert, Opcode::F32ConvertI64S},
+      {""},
+#line 532 "src/lexer-keywords.txt"
+      {"f64.convert_u/i64", TokenType::Convert, Opcode::F64ConvertI64U},
+#line 526 "src/lexer-keywords.txt"
+      {"f32.convert_u/i64", TokenType::Convert, Opcode::F32ConvertI64U},
       {""},
 #line 20 "src/lexer-keywords.txt"
       {"assert_exhaustion", TokenType::AssertExhaustion},
-      {""}, {""}, {""},
-#line 360 "src/lexer-keywords.txt"
-      {"i64.extend8_s", TokenType::Unary, Opcode::I64Extend8S},
-#line 235 "src/lexer-keywords.txt"
-      {"i32.extend8_s", TokenType::Unary, Opcode::I32Extend8S},
-      {""},
-#line 472 "src/lexer-keywords.txt"
-      {"nop", TokenType::Nop, Opcode::Nop},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 109 "src/lexer-keywords.txt"
-      {"f64.floor", TokenType::Unary, Opcode::F64Floor},
-#line 59 "src/lexer-keywords.txt"
-      {"f32.floor", TokenType::Unary, Opcode::F32Floor},
-      {""},
-#line 451 "src/lexer-keywords.txt"
-      {"i8x16.sub", TokenType::Binary, Opcode::I8X16Sub},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""},
-#line 443 "src/lexer-keywords.txt"
-      {"i8x16.ne", TokenType::Compare, Opcode::I8X16Ne},
-      {""}, {""}, {""},
-#line 191 "src/lexer-keywords.txt"
-      {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
       {""}, {""},
-#line 144 "src/lexer-keywords.txt"
-      {"f64x2.sqrt", TokenType::Unary, Opcode::F64X2Sqrt},
-      {""}, {""},
-#line 330 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XchgU},
-#line 477 "src/lexer-keywords.txt"
-      {"ref.func", TokenType::RefFunc, Opcode::RefFunc},
-#line 434 "src/lexer-keywords.txt"
-      {"i8x16.lt_s", TokenType::Compare, Opcode::I8X16LtS},
-#line 438 "src/lexer-keywords.txt"
-      {"i8x16.min_s", TokenType::Binary, Opcode::I8X16MinS},
-#line 435 "src/lexer-keywords.txt"
-      {"i8x16.lt_u", TokenType::Compare, Opcode::I8X16LtU},
-#line 183 "src/lexer-keywords.txt"
-      {"i16x8.ne", TokenType::Compare, Opcode::I16X8Ne},
-      {""},
-#line 439 "src/lexer-keywords.txt"
-      {"i8x16.min_u", TokenType::Binary, Opcode::I8X16MinU},
-#line 432 "src/lexer-keywords.txt"
-      {"i8x16.le_s", TokenType::Compare, Opcode::I8X16LeS},
-      {""},
-#line 433 "src/lexer-keywords.txt"
-      {"i8x16.le_u", TokenType::Compare, Opcode::I8X16LeU},
-      {""},
-#line 535 "src/lexer-keywords.txt"
-      {"get_local", TokenType::LocalGet, Opcode::LocalGet},
-#line 115 "src/lexer-keywords.txt"
-      {"f64.max", TokenType::Binary, Opcode::F64Max},
-#line 65 "src/lexer-keywords.txt"
-      {"f32.max", TokenType::Binary, Opcode::F32Max},
-      {""}, {""},
-#line 173 "src/lexer-keywords.txt"
-      {"i16x8.lt_s", TokenType::Compare, Opcode::I16X8LtS},
-#line 177 "src/lexer-keywords.txt"
-      {"i16x8.min_s", TokenType::Binary, Opcode::I16X8MinS},
-#line 174 "src/lexer-keywords.txt"
-      {"i16x8.lt_u", TokenType::Compare, Opcode::I16X8LtU},
-      {""}, {""},
-#line 178 "src/lexer-keywords.txt"
-      {"i16x8.min_u", TokenType::Binary, Opcode::I16X8MinU},
-#line 169 "src/lexer-keywords.txt"
-      {"i16x8.le_s", TokenType::Compare, Opcode::I16X8LeS},
-      {""},
-#line 170 "src/lexer-keywords.txt"
-      {"i16x8.le_u", TokenType::Compare, Opcode::I16X8LeU},
-      {""}, {""},
-#line 418 "src/lexer-keywords.txt"
-      {"i8x16.abs", TokenType::Unary, Opcode::I8X16Abs},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 336 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8OrU},
+#line 213 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8OrU},
       {""}, {""}, {""}, {""}, {""},
-#line 155 "src/lexer-keywords.txt"
-      {"i16x8.abs", TokenType::Unary, Opcode::I16X8Abs},
-      {""}, {""}, {""}, {""},
-#line 452 "src/lexer-keywords.txt"
-      {"i8x16", TokenType::I8X16},
-#line 179 "src/lexer-keywords.txt"
-      {"i16x8.mul", TokenType::Binary, Opcode::I16X8Mul},
-      {""}, {""},
-#line 314 "src/lexer-keywords.txt"
-      {"i64.atomic.load16_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad16U},
-#line 199 "src/lexer-keywords.txt"
-      {"i32.atomic.load16_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad16U},
+#line 464 "src/lexer-keywords.txt"
+      {"memory.fill", TokenType::MemoryFill, Opcode::MemoryFill},
       {""},
-#line 516 "src/lexer-keywords.txt"
+#line 536 "src/lexer-keywords.txt"
+      {"get_local", TokenType::LocalGet, Opcode::LocalGet},
+#line 332 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XorU},
+      {""}, {""}, {""},
+#line 517 "src/lexer-keywords.txt"
       {"v64x2.load_splat", TokenType::Load, Opcode::V64X2LoadSplat},
-#line 122 "src/lexer-keywords.txt"
-      {"f64.reinterpret_i64", TokenType::Convert, Opcode::F64ReinterpretI64},
-#line 521 "src/lexer-keywords.txt"
-      {"anyfunc", Type::Funcref},
-      {""}, {""},
-#line 529 "src/lexer-keywords.txt"
-      {"f64.convert_s/i64", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 523 "src/lexer-keywords.txt"
-      {"f32.convert_s/i64", TokenType::Convert, Opcode::F32ConvertI64S},
-#line 531 "src/lexer-keywords.txt"
-      {"f64.convert_u/i64", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 525 "src/lexer-keywords.txt"
-      {"f32.convert_u/i64", TokenType::Convert, Opcode::F32ConvertI64U},
-#line 421 "src/lexer-keywords.txt"
-      {"i8x16.add", TokenType::Binary, Opcode::I8X16Add},
-#line 557 "src/lexer-keywords.txt"
-      {"set_global", TokenType::GlobalSet, Opcode::GlobalSet},
-      {""}, {""},
-#line 324 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XorU},
-#line 208 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XorU},
-#line 71 "src/lexer-keywords.txt"
-      {"f32.reinterpret_i32", TokenType::Convert, Opcode::F32ReinterpretI32},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 158 "src/lexer-keywords.txt"
-      {"i16x8.add", TokenType::Binary, Opcode::I16X8Add},
       {""},
-#line 338 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XorU},
-#line 215 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XorU},
+#line 18 "src/lexer-keywords.txt"
+      {"anyref", Type::Anyref},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 453 "src/lexer-keywords.txt"
+      {"i8x16", TokenType::I8X16},
+#line 466 "src/lexer-keywords.txt"
+      {"memory.init", TokenType::MemoryInit, Opcode::MemoryInit},
+      {""}, {""},
+#line 389 "src/lexer-keywords.txt"
+      {"i64.shr_s", TokenType::Binary, Opcode::I64ShrS},
+#line 260 "src/lexer-keywords.txt"
+      {"i32.shr_s", TokenType::Binary, Opcode::I32ShrS},
+      {""}, {""}, {""}, {""},
+#line 390 "src/lexer-keywords.txt"
+      {"i64.shr_u", TokenType::Binary, Opcode::I64ShrU},
+#line 261 "src/lexer-keywords.txt"
+      {"i32.shr_u", TokenType::Binary, Opcode::I32ShrU},
+#line 514 "src/lexer-keywords.txt"
+      {"v128.xor", TokenType::Binary, Opcode::V128Xor},
+      {""},
+#line 145 "src/lexer-keywords.txt"
+      {"f64x2.sqrt", TokenType::Unary, Opcode::F64X2Sqrt},
 #line 412 "src/lexer-keywords.txt"
-      {"i64x2.shr_s", TokenType::Binary, Opcode::I64X2ShrS},
-#line 411 "src/lexer-keywords.txt"
       {"i64x2.shl", TokenType::Binary, Opcode::I64X2Shl},
       {""}, {""},
-#line 413 "src/lexer-keywords.txt"
-      {"i64x2.shr_u", TokenType::Binary, Opcode::I64X2ShrU},
-#line 19 "src/lexer-keywords.txt"
-      {"array", TokenType::Array},
-#line 533 "src/lexer-keywords.txt"
-      {"f64.reinterpret/i64", TokenType::Convert, Opcode::F64ReinterpretI64},
-      {""}, {""}, {""},
-#line 94 "src/lexer-keywords.txt"
-      {"f32x4.splat", TokenType::Unary, Opcode::F32X4Splat},
-      {""}, {""},
-#line 302 "src/lexer-keywords.txt"
-      {"i32x4.splat", TokenType::Unary, Opcode::I32X4Splat},
-      {""}, {""}, {""}, {""}, {""},
-#line 291 "src/lexer-keywords.txt"
-      {"i32x4.max_s", TokenType::Binary, Opcode::I32X4MaxS},
-#line 527 "src/lexer-keywords.txt"
-      {"f32.reinterpret/i32", TokenType::Convert, Opcode::F32ReinterpretI32},
-      {""}, {""},
-#line 292 "src/lexer-keywords.txt"
-      {"i32x4.max_u", TokenType::Binary, Opcode::I32X4MaxU},
-#line 406 "src/lexer-keywords.txt"
-      {"i64x2.load32x2_s", TokenType::Load, Opcode::I64X2Load32X2S},
-      {""},
-#line 85 "src/lexer-keywords.txt"
-      {"f32x4.gt", TokenType::Compare, Opcode::F32X4Gt},
-      {""},
-#line 407 "src/lexer-keywords.txt"
-      {"i64x2.load32x2_u", TokenType::Load, Opcode::I64X2Load32X2U},
-      {""},
-#line 24 "src/lexer-keywords.txt"
-      {"assert_trap", TokenType::AssertTrap},
-      {""}, {""},
-#line 323 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XchgU},
-#line 207 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XchgU},
-      {""}, {""}, {""},
-#line 84 "src/lexer-keywords.txt"
-      {"f32x4.ge", TokenType::Compare, Opcode::F32X4Ge},
-      {""},
-#line 283 "src/lexer-keywords.txt"
-      {"i32x4.gt_s", TokenType::Compare, Opcode::I32X4GtS},
-      {""},
-#line 284 "src/lexer-keywords.txt"
-      {"i32x4.gt_u", TokenType::Compare, Opcode::I32X4GtU},
-      {""},
-#line 503 "src/lexer-keywords.txt"
-      {"unreachable", TokenType::Unreachable, Opcode::Unreachable},
-      {""},
-#line 281 "src/lexer-keywords.txt"
-      {"i32x4.ge_s", TokenType::Compare, Opcode::I32X4GeS},
-      {""},
-#line 282 "src/lexer-keywords.txt"
-      {"i32x4.ge_u", TokenType::Compare, Opcode::I32X4GeU},
-      {""}, {""}, {""}, {""}, {""},
-#line 132 "src/lexer-keywords.txt"
-      {"f64x2.extract_lane", TokenType::SimdLaneOp, Opcode::F64X2ExtractLane},
-      {""}, {""},
-#line 405 "src/lexer-keywords.txt"
-      {"i64x2.extract_lane", TokenType::SimdLaneOp, Opcode::I64X2ExtractLane},
-      {""}, {""},
-#line 501 "src/lexer-keywords.txt"
-      {"try", TokenType::Try, Opcode::Try},
-      {""},
-#line 137 "src/lexer-keywords.txt"
-      {"f64x2.max", TokenType::Binary, Opcode::F64X2Max},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 401 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f64_s", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 271 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f64_s", TokenType::Convert, Opcode::I32TruncSatF64S},
-#line 121 "src/lexer-keywords.txt"
-      {"f64.promote_f32", TokenType::Convert, Opcode::F64PromoteF32},
-      {""},
-#line 402 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f64_u", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 272 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f64_u", TokenType::Convert, Opcode::I32TruncSatF64U},
-      {""}, {""},
-#line 41 "src/lexer-keywords.txt"
-      {"elem.drop", TokenType::ElemDrop, Opcode::ElemDrop},
-#line 37 "src/lexer-keywords.txt"
-      {"data.drop", TokenType::DataDrop, Opcode::DataDrop},
-      {""}, {""}, {""}, {""},
-#line 467 "src/lexer-keywords.txt"
-      {"memory", TokenType::Memory},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 119 "src/lexer-keywords.txt"
-      {"f64.neg", TokenType::Unary, Opcode::F64Neg},
-#line 69 "src/lexer-keywords.txt"
-      {"f32.neg", TokenType::Unary, Opcode::F32Neg},
-      {""},
-#line 449 "src/lexer-keywords.txt"
-      {"i8x16.sub_saturate_s", TokenType::Binary, Opcode::I8X16SubSaturateS},
-      {""},
-#line 450 "src/lexer-keywords.txt"
-      {"i8x16.sub_saturate_u", TokenType::Binary, Opcode::I8X16SubSaturateU},
-      {""}, {""}, {""}, {""},
-#line 27 "src/lexer-keywords.txt"
-      {"binary", TokenType::Bin},
-      {""}, {""},
-#line 532 "src/lexer-keywords.txt"
-      {"f64.promote/f32", TokenType::Convert, Opcode::F64PromoteF32},
 #line 422 "src/lexer-keywords.txt"
-      {"i8x16.all_true", TokenType::Unary, Opcode::I8X16AllTrue},
-      {""}, {""}, {""},
-#line 189 "src/lexer-keywords.txt"
-      {"i16x8.sub_saturate_s", TokenType::Binary, Opcode::I16X8SubSaturateS},
+      {"i8x16.add", TokenType::Binary, Opcode::I8X16Add},
       {""},
-#line 190 "src/lexer-keywords.txt"
-      {"i16x8.sub_saturate_u", TokenType::Binary, Opcode::I16X8SubSaturateU},
+#line 174 "src/lexer-keywords.txt"
+      {"i16x8.lt_s", TokenType::Compare, Opcode::I16X8LtS},
+      {""}, {""},
+#line 175 "src/lexer-keywords.txt"
+      {"i16x8.lt_u", TokenType::Compare, Opcode::I16X8LtU},
+#line 170 "src/lexer-keywords.txt"
+      {"i16x8.le_s", TokenType::Compare, Opcode::I16X8LeS},
+      {""}, {""},
+#line 171 "src/lexer-keywords.txt"
+      {"i16x8.le_u", TokenType::Compare, Opcode::I16X8LeU},
+      {""}, {""},
+#line 72 "src/lexer-keywords.txt"
+      {"f32.reinterpret_i32", TokenType::Convert, Opcode::F32ReinterpretI32},
+      {""}, {""},
+#line 359 "src/lexer-keywords.txt"
+      {"i64.extend16_s", TokenType::Unary, Opcode::I64Extend16S},
+#line 235 "src/lexer-keywords.txt"
+      {"i32.extend16_s", TokenType::Unary, Opcode::I32Extend16S},
+      {""},
+#line 358 "src/lexer-keywords.txt"
+      {"i64.eqz", TokenType::Convert, Opcode::I64Eqz},
+#line 234 "src/lexer-keywords.txt"
+      {"i32.eqz", TokenType::Convert, Opcode::I32Eqz},
+#line 180 "src/lexer-keywords.txt"
+      {"i16x8.mul", TokenType::Binary, Opcode::I16X8Mul},
       {""},
 #line 192 "src/lexer-keywords.txt"
-      {"i16x8", TokenType::I16X8},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 159 "src/lexer-keywords.txt"
-      {"i16x8.all_true", TokenType::Unary, Opcode::I16X8AllTrue},
-#line 552 "src/lexer-keywords.txt"
-      {"i64.trunc_s:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 540 "src/lexer-keywords.txt"
-      {"i32.trunc_s:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64S},
-#line 556 "src/lexer-keywords.txt"
-      {"i64.trunc_u:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 544 "src/lexer-keywords.txt"
-      {"i32.trunc_u:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64U},
-      {""}, {""},
-#line 142 "src/lexer-keywords.txt"
-      {"f64x2.replace_lane", TokenType::SimdLaneOp, Opcode::F64X2ReplaceLane},
-      {""}, {""},
-#line 410 "src/lexer-keywords.txt"
-      {"i64x2.replace_lane", TokenType::SimdLaneOp, Opcode::I64X2ReplaceLane},
-#line 309 "src/lexer-keywords.txt"
-      {"i32x4.widen_low_i16x8_s", TokenType::Unary, Opcode::I32X4WidenLowI16X8S},
-      {""},
+      {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
+      {""}, {""}, {""}, {""},
 #line 310 "src/lexer-keywords.txt"
-      {"i32x4.widen_low_i16x8_u", TokenType::Unary, Opcode::I32X4WidenLowI16X8U},
-#line 551 "src/lexer-keywords.txt"
-      {"i64.trunc_s:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 539 "src/lexer-keywords.txt"
-      {"i32.trunc_s:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32S},
-#line 555 "src/lexer-keywords.txt"
-      {"i64.trunc_u:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 543 "src/lexer-keywords.txt"
-      {"i32.trunc_u:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32U},
-      {""}, {""}, {""}, {""},
-#line 274 "src/lexer-keywords.txt"
-      {"i32.wrap_i64", TokenType::Convert, Opcode::I32WrapI64},
+      {"i32x4.widen_low_i16x8_s", TokenType::Unary, Opcode::I32X4WidenLowI16X8S},
       {""}, {""},
-#line 151 "src/lexer-keywords.txt"
-      {"global.get", TokenType::GlobalGet, Opcode::GlobalGet},
-      {""}, {""}, {""}, {""},
-#line 470 "src/lexer-keywords.txt"
-      {"nan:arithmetic", TokenType::NanArithmetic},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 464 "src/lexer-keywords.txt"
-      {"memory.grow", TokenType::MemoryGrow, Opcode::MemoryGrow},
-      {""}, {""}, {""}, {""},
-#line 95 "src/lexer-keywords.txt"
-      {"f32x4.sqrt", TokenType::Unary, Opcode::F32X4Sqrt},
-      {""}, {""}, {""}, {""}, {""},
-#line 419 "src/lexer-keywords.txt"
-      {"i8x16.add_saturate_s", TokenType::Binary, Opcode::I8X16AddSaturateS},
+#line 311 "src/lexer-keywords.txt"
+      {"i32x4.widen_low_i16x8_u", TokenType::Unary, Opcode::I32X4WidenLowI16X8U},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 473 "src/lexer-keywords.txt"
+      {"nop", TokenType::Nop, Opcode::Nop},
+#line 184 "src/lexer-keywords.txt"
+      {"i16x8.ne", TokenType::Compare, Opcode::I16X8Ne},
+      {""}, {""},
+#line 450 "src/lexer-keywords.txt"
+      {"i8x16.sub_saturate_s", TokenType::Binary, Opcode::I8X16SubSaturateS},
       {""},
+#line 35 "src/lexer-keywords.txt"
+      {"catch", TokenType::Catch, Opcode::Catch},
+#line 451 "src/lexer-keywords.txt"
+      {"i8x16.sub_saturate_u", TokenType::Binary, Opcode::I8X16SubSaturateU},
+#line 423 "src/lexer-keywords.txt"
+      {"i8x16.all_true", TokenType::Unary, Opcode::I8X16AllTrue},
+      {""}, {""}, {""},
+#line 178 "src/lexer-keywords.txt"
+      {"i16x8.min_s", TokenType::Binary, Opcode::I16X8MinS},
+#line 402 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f64_s", TokenType::Convert, Opcode::I64TruncSatF64S},
+#line 272 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f64_s", TokenType::Convert, Opcode::I32TruncSatF64S},
+      {""},
+#line 413 "src/lexer-keywords.txt"
+      {"i64x2.shr_s", TokenType::Binary, Opcode::I64X2ShrS},
+#line 558 "src/lexer-keywords.txt"
+      {"set_global", TokenType::GlobalSet, Opcode::GlobalSet},
+#line 179 "src/lexer-keywords.txt"
+      {"i16x8.min_u", TokenType::Binary, Opcode::I16X8MinU},
+#line 403 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f64_u", TokenType::Convert, Opcode::I64TruncSatF64U},
+#line 273 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f64_u", TokenType::Convert, Opcode::I32TruncSatF64U},
+      {""},
+#line 414 "src/lexer-keywords.txt"
+      {"i64x2.shr_u", TokenType::Binary, Opcode::I64X2ShrU},
+      {""}, {""},
+#line 528 "src/lexer-keywords.txt"
+      {"f32.reinterpret/i32", TokenType::Convert, Opcode::F32ReinterpretI32},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 520 "src/lexer-keywords.txt"
+      {"v8x16.swizzle", TokenType::Binary, Opcode::V8X16Swizzle},
+#line 156 "src/lexer-keywords.txt"
+      {"i16x8.abs", TokenType::Unary, Opcode::I16X8Abs},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 193 "src/lexer-keywords.txt"
+      {"i16x8", TokenType::I16X8},
+#line 331 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XchgU},
+      {""},
+#line 349 "src/lexer-keywords.txt"
+      {"i64.atomic.store8", TokenType::AtomicStore, Opcode::I64AtomicStore8},
+#line 225 "src/lexer-keywords.txt"
+      {"i32.atomic.store8", TokenType::AtomicStore, Opcode::I32AtomicStore8},
+      {""},
+#line 120 "src/lexer-keywords.txt"
+      {"f64.neg", TokenType::Unary, Opcode::F64Neg},
+#line 70 "src/lexer-keywords.txt"
+      {"f32.neg", TokenType::Unary, Opcode::F32Neg},
+      {""}, {""}, {""}, {""},
+#line 133 "src/lexer-keywords.txt"
+      {"f64x2.extract_lane", TokenType::SimdLaneOp, Opcode::F64X2ExtractLane},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 406 "src/lexer-keywords.txt"
+      {"i64x2.extract_lane", TokenType::SimdLaneOp, Opcode::I64X2ExtractLane},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 122 "src/lexer-keywords.txt"
+      {"f64.promote_f32", TokenType::Convert, Opcode::F64PromoteF32},
+#line 478 "src/lexer-keywords.txt"
+      {"ref.func", TokenType::RefFunc, Opcode::RefFunc},
+#line 516 "src/lexer-keywords.txt"
+      {"v32x4.load_splat", TokenType::Load, Opcode::V32X4LoadSplat},
+      {""},
+#line 123 "src/lexer-keywords.txt"
+      {"f64.reinterpret_i64", TokenType::Convert, Opcode::F64ReinterpretI64},
+      {""},
+#line 116 "src/lexer-keywords.txt"
+      {"f64.max", TokenType::Binary, Opcode::F64Max},
+#line 66 "src/lexer-keywords.txt"
+      {"f32.max", TokenType::Binary, Opcode::F32Max},
+      {""}, {""}, {""}, {""}, {""},
+#line 418 "src/lexer-keywords.txt"
+      {"i64.xor", TokenType::Binary, Opcode::I64Xor},
+#line 312 "src/lexer-keywords.txt"
+      {"i32.xor", TokenType::Binary, Opcode::I32Xor},
+      {""}, {""}, {""}, {""}, {""},
+#line 152 "src/lexer-keywords.txt"
+      {"global.get", TokenType::GlobalGet, Opcode::GlobalGet},
+#line 325 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XorU},
+#line 209 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XorU},
+      {""},
+#line 19 "src/lexer-keywords.txt"
+      {"array", TokenType::Array},
+      {""},
+#line 96 "src/lexer-keywords.txt"
+      {"f32x4.sqrt", TokenType::Unary, Opcode::F32X4Sqrt},
+#line 300 "src/lexer-keywords.txt"
+      {"i32x4.shl", TokenType::Binary, Opcode::I32X4Shl},
+      {""}, {""}, {""},
+#line 138 "src/lexer-keywords.txt"
+      {"f64x2.max", TokenType::Binary, Opcode::F64X2Max},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 159 "src/lexer-keywords.txt"
+      {"i16x8.add", TokenType::Binary, Opcode::I16X8Add},
+      {""}, {""}, {""}, {""},
 #line 420 "src/lexer-keywords.txt"
+      {"i8x16.add_saturate_s", TokenType::Binary, Opcode::I8X16AddSaturateS},
+      {""}, {""},
+#line 421 "src/lexer-keywords.txt"
       {"i8x16.add_saturate_u", TokenType::Binary, Opcode::I8X16AddSaturateU},
       {""},
-#line 491 "src/lexer-keywords.txt"
-      {"table.copy", TokenType::TableCopy, Opcode::TableCopy},
-      {""},
-#line 545 "src/lexer-keywords.txt"
-      {"i32.wrap/i64", TokenType::Convert, Opcode::I32WrapI64},
-      {""},
-#line 108 "src/lexer-keywords.txt"
-      {"f64.eq", TokenType::Compare, Opcode::F64Eq},
-#line 58 "src/lexer-keywords.txt"
-      {"f32.eq", TokenType::Compare, Opcode::F32Eq},
-      {""},
-#line 356 "src/lexer-keywords.txt"
-      {"i64.eq", TokenType::Compare, Opcode::I64Eq},
-#line 232 "src/lexer-keywords.txt"
-      {"i32.eq", TokenType::Compare, Opcode::I32Eq},
+#line 533 "src/lexer-keywords.txt"
+      {"f64.promote/f32", TokenType::Convert, Opcode::F64PromoteF32},
       {""}, {""},
-#line 156 "src/lexer-keywords.txt"
-      {"i16x8.add_saturate_s", TokenType::Binary, Opcode::I16X8AddSaturateS},
-      {""},
-#line 157 "src/lexer-keywords.txt"
-      {"i16x8.add_saturate_u", TokenType::Binary, Opcode::I16X8AddSaturateU},
-#line 345 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I64AtomicRmwXor},
-#line 222 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I32AtomicRmwXor},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""},
-#line 140 "src/lexer-keywords.txt"
+#line 141 "src/lexer-keywords.txt"
       {"f64x2.neg", TokenType::Unary, Opcode::F64X2Neg},
-      {""}, {""},
-#line 409 "src/lexer-keywords.txt"
+#line 534 "src/lexer-keywords.txt"
+      {"f64.reinterpret/i64", TokenType::Convert, Opcode::F64ReinterpretI64},
+      {""}, {""}, {""},
+#line 24 "src/lexer-keywords.txt"
+      {"assert_trap", TokenType::AssertTrap},
+      {""},
+#line 410 "src/lexer-keywords.txt"
       {"i64x2.neg", TokenType::Unary, Opcode::I64X2Neg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""},
-#line 348 "src/lexer-keywords.txt"
-      {"i64.atomic.store8", TokenType::AtomicStore, Opcode::I64AtomicStore8},
-#line 224 "src/lexer-keywords.txt"
-      {"i32.atomic.store8", TokenType::AtomicStore, Opcode::I32AtomicStore8},
-#line 515 "src/lexer-keywords.txt"
-      {"v32x4.load_splat", TokenType::Load, Opcode::V32X4LoadSplat},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 357 "src/lexer-keywords.txt"
-      {"i64.eqz", TokenType::Convert, Opcode::I64Eqz},
-#line 233 "src/lexer-keywords.txt"
-      {"i32.eqz", TokenType::Convert, Opcode::I32Eqz},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 381 "src/lexer-keywords.txt"
-      {"i64.popcnt", TokenType::Unary, Opcode::I64Popcnt},
-#line 252 "src/lexer-keywords.txt"
-      {"i32.popcnt", TokenType::Unary, Opcode::I32Popcnt},
-      {""}, {""}, {""},
-#line 278 "src/lexer-keywords.txt"
-      {"i32x4.any_true", TokenType::Unary, Opcode::I32X4AnyTrue},
-      {""}, {""}, {""}, {""}, {""},
-#line 300 "src/lexer-keywords.txt"
-      {"i32x4.shr_s", TokenType::Binary, Opcode::I32X4ShrS},
-#line 299 "src/lexer-keywords.txt"
-      {"i32x4.shl", TokenType::Binary, Opcode::I32X4Shl},
       {""}, {""},
-#line 301 "src/lexer-keywords.txt"
-      {"i32x4.shr_u", TokenType::Binary, Opcode::I32X4ShrU},
-#line 448 "src/lexer-keywords.txt"
-      {"i8x16.splat", TokenType::Unary, Opcode::I8X16Splat},
-#line 519 "src/lexer-keywords.txt"
-      {"v8x16.swizzle", TokenType::Binary, Opcode::V8X16Swizzle},
-      {""}, {""}, {""}, {""},
-#line 436 "src/lexer-keywords.txt"
-      {"i8x16.max_s", TokenType::Binary, Opcode::I8X16MaxS},
-      {""}, {""}, {""},
-#line 437 "src/lexer-keywords.txt"
-      {"i8x16.max_u", TokenType::Binary, Opcode::I8X16MaxU},
-      {""}, {""}, {""}, {""},
-#line 188 "src/lexer-keywords.txt"
-      {"i16x8.splat", TokenType::Unary, Opcode::I16X8Splat},
-      {""}, {""}, {""}, {""}, {""},
-#line 175 "src/lexer-keywords.txt"
-      {"i16x8.max_s", TokenType::Binary, Opcode::I16X8MaxS},
-      {""}, {""}, {""},
-#line 176 "src/lexer-keywords.txt"
-      {"i16x8.max_u", TokenType::Binary, Opcode::I16X8MaxU},
+#line 143 "src/lexer-keywords.txt"
+      {"f64x2.replace_lane", TokenType::SimdLaneOp, Opcode::F64X2ReplaceLane},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 411 "src/lexer-keywords.txt"
+      {"i64x2.replace_lane", TokenType::SimdLaneOp, Opcode::I64X2ReplaceLane},
       {""},
-#line 430 "src/lexer-keywords.txt"
+#line 190 "src/lexer-keywords.txt"
+      {"i16x8.sub_saturate_s", TokenType::Binary, Opcode::I16X8SubSaturateS},
+      {""},
+#line 301 "src/lexer-keywords.txt"
+      {"i32x4.shr_s", TokenType::Binary, Opcode::I32X4ShrS},
+#line 191 "src/lexer-keywords.txt"
+      {"i16x8.sub_saturate_u", TokenType::Binary, Opcode::I16X8SubSaturateU},
+#line 160 "src/lexer-keywords.txt"
+      {"i16x8.all_true", TokenType::Unary, Opcode::I16X8AllTrue},
+      {""}, {""}, {""},
+#line 302 "src/lexer-keywords.txt"
+      {"i32x4.shr_u", TokenType::Binary, Opcode::I32X4ShrU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 552 "src/lexer-keywords.txt"
+      {"i64.trunc_s:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32S},
+#line 540 "src/lexer-keywords.txt"
+      {"i32.trunc_s:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32S},
+      {""},
+#line 556 "src/lexer-keywords.txt"
+      {"i64.trunc_u:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32U},
+#line 544 "src/lexer-keywords.txt"
+      {"i32.trunc_u:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32U},
+      {""}, {""}, {""}, {""}, {""},
+#line 431 "src/lexer-keywords.txt"
       {"i8x16.gt_s", TokenType::Compare, Opcode::I8X16GtS},
       {""},
-#line 431 "src/lexer-keywords.txt"
+#line 449 "src/lexer-keywords.txt"
+      {"i8x16.splat", TokenType::Unary, Opcode::I8X16Splat},
+#line 432 "src/lexer-keywords.txt"
       {"i8x16.gt_u", TokenType::Compare, Opcode::I8X16GtU},
-      {""}, {""}, {""},
-#line 428 "src/lexer-keywords.txt"
-      {"i8x16.ge_s", TokenType::Compare, Opcode::I8X16GeS},
-      {""},
 #line 429 "src/lexer-keywords.txt"
+      {"i8x16.ge_s", TokenType::Compare, Opcode::I8X16GeS},
+      {""}, {""},
+#line 430 "src/lexer-keywords.txt"
       {"i8x16.ge_u", TokenType::Compare, Opcode::I8X16GeU},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 167 "src/lexer-keywords.txt"
-      {"i16x8.gt_s", TokenType::Compare, Opcode::I16X8GtS},
       {""},
-#line 168 "src/lexer-keywords.txt"
-      {"i16x8.gt_u", TokenType::Compare, Opcode::I16X8GtU},
-      {""}, {""}, {""},
-#line 165 "src/lexer-keywords.txt"
-      {"i16x8.ge_s", TokenType::Compare, Opcode::I16X8GeS},
-#line 83 "src/lexer-keywords.txt"
+#line 41 "src/lexer-keywords.txt"
+      {"elem.drop", TokenType::ElemDrop, Opcode::ElemDrop},
+      {""},
+#line 84 "src/lexer-keywords.txt"
       {"f32x4.extract_lane", TokenType::SimdLaneOp, Opcode::F32X4ExtractLane},
-#line 166 "src/lexer-keywords.txt"
-      {"i16x8.ge_u", TokenType::Compare, Opcode::I16X8GeU},
-      {""},
-#line 280 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 281 "src/lexer-keywords.txt"
       {"i32x4.extract_lane", TokenType::SimdLaneOp, Opcode::I32X4ExtractLane},
       {""}, {""}, {""}, {""},
-#line 88 "src/lexer-keywords.txt"
-      {"f32x4.max", TokenType::Binary, Opcode::F32X4Max},
-      {""}, {""},
-#line 382 "src/lexer-keywords.txt"
-      {"i64.reinterpret_f64", TokenType::Convert, Opcode::I64ReinterpretF64},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""},
-#line 253 "src/lexer-keywords.txt"
-      {"i32.reinterpret_f32", TokenType::Convert, Opcode::I32ReinterpretF32},
-      {""}, {""},
-#line 131 "src/lexer-keywords.txt"
-      {"f64x2.eq", TokenType::Compare, Opcode::F64X2Eq},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 324 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XchgU},
+#line 208 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XchgU},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 548 "src/lexer-keywords.txt"
-      {"i64.reinterpret/f64", TokenType::Convert, Opcode::I64ReinterpretF64},
+#line 37 "src/lexer-keywords.txt"
+      {"data.drop", TokenType::DataDrop, Opcode::DataDrop},
+      {""},
+#line 504 "src/lexer-keywords.txt"
+      {"unreachable", TokenType::Unreachable, Opcode::Unreachable},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 536 "src/lexer-keywords.txt"
-      {"i32.reinterpret/f32", TokenType::Convert, Opcode::I32ReinterpretF32},
-#line 287 "src/lexer-keywords.txt"
-      {"i32x4.load16x4_s", TokenType::Load, Opcode::I32X4Load16X4S},
+#line 339 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XorU},
+#line 216 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XorU},
+      {""}, {""}, {""}, {""},
+#line 437 "src/lexer-keywords.txt"
+      {"i8x16.max_s", TokenType::Binary, Opcode::I8X16MaxS},
       {""}, {""}, {""},
-#line 288 "src/lexer-keywords.txt"
-      {"i32x4.load16x4_u", TokenType::Load, Opcode::I32X4Load16X4U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 534 "src/lexer-keywords.txt"
-      {"get_global", TokenType::GlobalGet, Opcode::GlobalGet},
+#line 89 "src/lexer-keywords.txt"
+      {"f32x4.max", TokenType::Binary, Opcode::F32X4Max},
       {""},
-#line 93 "src/lexer-keywords.txt"
-      {"f32x4.replace_lane", TokenType::SimdLaneOp, Opcode::F32X4ReplaceLane},
+#line 438 "src/lexer-keywords.txt"
+      {"i8x16.max_u", TokenType::Binary, Opcode::I8X16MaxU},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 306 "src/lexer-keywords.txt"
+      {"i32x4.trunc_sat_f32x4_s", TokenType::Unary, Opcode::I32X4TruncSatF32X4S},
       {""}, {""},
-#line 298 "src/lexer-keywords.txt"
+#line 307 "src/lexer-keywords.txt"
+      {"i32x4.trunc_sat_f32x4_u", TokenType::Unary, Opcode::I32X4TruncSatF32X4U},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 288 "src/lexer-keywords.txt"
+      {"i32x4.load16x4_s", TokenType::Load, Opcode::I32X4Load16X4S},
+      {""}, {""},
+#line 92 "src/lexer-keywords.txt"
+      {"f32x4.neg", TokenType::Unary, Opcode::F32X4Neg},
+      {""},
+#line 157 "src/lexer-keywords.txt"
+      {"i16x8.add_saturate_s", TokenType::Binary, Opcode::I16X8AddSaturateS},
+#line 289 "src/lexer-keywords.txt"
+      {"i32x4.load16x4_u", TokenType::Load, Opcode::I32X4Load16X4U},
+      {""},
+#line 158 "src/lexer-keywords.txt"
+      {"i16x8.add_saturate_u", TokenType::Binary, Opcode::I16X8AddSaturateU},
+      {""},
+#line 297 "src/lexer-keywords.txt"
+      {"i32x4.neg", TokenType::Unary, Opcode::I32X4Neg},
+#line 553 "src/lexer-keywords.txt"
+      {"i64.trunc_s:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64S},
+#line 541 "src/lexer-keywords.txt"
+      {"i32.trunc_s:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64S},
+      {""},
+#line 557 "src/lexer-keywords.txt"
+      {"i64.trunc_u:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64U},
+#line 545 "src/lexer-keywords.txt"
+      {"i32.trunc_u:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64U},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 94 "src/lexer-keywords.txt"
+      {"f32x4.replace_lane", TokenType::SimdLaneOp, Opcode::F32X4ReplaceLane},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 299 "src/lexer-keywords.txt"
       {"i32x4.replace_lane", TokenType::SimdLaneOp, Opcode::I32X4ReplaceLane},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 424 "src/lexer-keywords.txt"
-      {"i8x16.avgr_u", TokenType::Binary, Opcode::I8X16AvgrU},
+#line 275 "src/lexer-keywords.txt"
+      {"i32.wrap_i64", TokenType::Convert, Opcode::I32WrapI64},
+      {""},
+#line 80 "src/lexer-keywords.txt"
+      {"f32x4.convert_i32x4_s", TokenType::Unary, Opcode::F32X4ConvertI32X4S},
+      {""}, {""},
+#line 81 "src/lexer-keywords.txt"
+      {"f32x4.convert_i32x4_u", TokenType::Unary, Opcode::F32X4ConvertI32X4U},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 279 "src/lexer-keywords.txt"
+      {"i32x4.any_true", TokenType::Unary, Opcode::I32X4AnyTrue},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 254 "src/lexer-keywords.txt"
+      {"i32.reinterpret_f32", TokenType::Convert, Opcode::I32ReinterpretF32},
+      {""}, {""}, {""},
+#line 168 "src/lexer-keywords.txt"
+      {"i16x8.gt_s", TokenType::Compare, Opcode::I16X8GtS},
+      {""},
+#line 189 "src/lexer-keywords.txt"
+      {"i16x8.splat", TokenType::Unary, Opcode::I16X8Splat},
+#line 169 "src/lexer-keywords.txt"
+      {"i16x8.gt_u", TokenType::Compare, Opcode::I16X8GtU},
+#line 166 "src/lexer-keywords.txt"
+      {"i16x8.ge_s", TokenType::Compare, Opcode::I16X8GeS},
+      {""}, {""},
+#line 167 "src/lexer-keywords.txt"
+      {"i16x8.ge_u", TokenType::Compare, Opcode::I16X8GeU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 346 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I64AtomicRmwXor},
+#line 223 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I32AtomicRmwXor},
+      {""}, {""}, {""},
+#line 546 "src/lexer-keywords.txt"
+      {"i32.wrap/i64", TokenType::Convert, Opcode::I32WrapI64},
+      {""}, {""}, {""}, {""},
+#line 425 "src/lexer-keywords.txt"
+      {"i8x16.avgr_u", TokenType::Binary, Opcode::I8X16AvgrU},
+      {""}, {""}, {""}, {""},
+#line 109 "src/lexer-keywords.txt"
+      {"f64.eq", TokenType::Compare, Opcode::F64Eq},
+#line 59 "src/lexer-keywords.txt"
+      {"f32.eq", TokenType::Compare, Opcode::F32Eq},
       {""}, {""}, {""}, {""}, {""},
-#line 161 "src/lexer-keywords.txt"
+#line 357 "src/lexer-keywords.txt"
+      {"i64.eq", TokenType::Compare, Opcode::I64Eq},
+#line 233 "src/lexer-keywords.txt"
+      {"i32.eq", TokenType::Compare, Opcode::I32Eq},
+      {""}, {""}, {""}, {""},
+#line 537 "src/lexer-keywords.txt"
+      {"i32.reinterpret/f32", TokenType::Convert, Opcode::I32ReinterpretF32},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 176 "src/lexer-keywords.txt"
+      {"i16x8.max_s", TokenType::Binary, Opcode::I16X8MaxS},
+      {""},
+#line 465 "src/lexer-keywords.txt"
+      {"memory.grow", TokenType::MemoryGrow, Opcode::MemoryGrow},
+      {""}, {""}, {""},
+#line 177 "src/lexer-keywords.txt"
+      {"i16x8.max_u", TokenType::Binary, Opcode::I16X8MaxU},
+      {""},
+#line 522 "src/lexer-keywords.txt"
+      {"anyfunc", Type::Funcref},
+      {""}, {""}, {""}, {""},
+#line 535 "src/lexer-keywords.txt"
+      {"get_global", TokenType::GlobalGet, Opcode::GlobalGet},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 471 "src/lexer-keywords.txt"
+      {"nan:arithmetic", TokenType::NanArithmetic},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 518 "src/lexer-keywords.txt"
+      {"v8x16.load_splat", TokenType::Load, Opcode::V8X16LoadSplat},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 383 "src/lexer-keywords.txt"
+      {"i64.reinterpret_f64", TokenType::Convert, Opcode::I64ReinterpretF64},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 382 "src/lexer-keywords.txt"
+      {"i64.popcnt", TokenType::Unary, Opcode::I64Popcnt},
+#line 253 "src/lexer-keywords.txt"
+      {"i32.popcnt", TokenType::Unary, Opcode::I32Popcnt},
+      {""}, {""}, {""}, {""},
+#line 132 "src/lexer-keywords.txt"
+      {"f64x2.eq", TokenType::Compare, Opcode::F64X2Eq},
+#line 446 "src/lexer-keywords.txt"
+      {"i8x16.shl", TokenType::Binary, Opcode::I8X16Shl},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 492 "src/lexer-keywords.txt"
+      {"table.copy", TokenType::TableCopy, Opcode::TableCopy},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 549 "src/lexer-keywords.txt"
+      {"i64.reinterpret/f64", TokenType::Convert, Opcode::I64ReinterpretF64},
+      {""}, {""}, {""}, {""}, {""},
+#line 502 "src/lexer-keywords.txt"
+      {"try", TokenType::Try, Opcode::Try},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""},
+#line 468 "src/lexer-keywords.txt"
+      {"memory", TokenType::Memory},
+      {""},
+#line 447 "src/lexer-keywords.txt"
+      {"i8x16.shr_s", TokenType::Binary, Opcode::I8X16ShrS},
+      {""}, {""}, {""}, {""}, {""},
+#line 448 "src/lexer-keywords.txt"
+      {"i8x16.shr_u", TokenType::Binary, Opcode::I8X16ShrU},
+      {""}, {""},
+#line 162 "src/lexer-keywords.txt"
       {"i16x8.avgr_u", TokenType::Binary, Opcode::I16X8AvgrU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 519 "src/lexer-keywords.txt"
+      {"v8x16.shuffle", TokenType::SimdShuffleOp, Opcode::V8X16Shuffle},
+      {""}, {""}, {""}, {""}, {""},
+#line 427 "src/lexer-keywords.txt"
+      {"i8x16.extract_lane_s", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneS},
+      {""}, {""},
+#line 428 "src/lexer-keywords.txt"
+      {"i8x16.extract_lane_u", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 27 "src/lexer-keywords.txt"
+      {"binary", TokenType::Bin},
+      {""}, {""}, {""}, {""}, {""},
+#line 515 "src/lexer-keywords.txt"
+      {"v16x8.load_splat", TokenType::Load, Opcode::V16X8LoadSplat},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 83 "src/lexer-keywords.txt"
+      {"f32x4.eq", TokenType::Compare, Opcode::F32X4Eq},
       {""}, {""}, {""}, {""}, {""}, {""},
+#line 280 "src/lexer-keywords.txt"
+      {"i32x4.eq", TokenType::Compare, Opcode::I32X4Eq},
+      {""}, {""}, {""},
+#line 186 "src/lexer-keywords.txt"
+      {"i16x8.shl", TokenType::Binary, Opcode::I16X8Shl},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 443 "src/lexer-keywords.txt"
+      {"i8x16.neg", TokenType::Unary, Opcode::I8X16Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 445 "src/lexer-keywords.txt"
+      {"i8x16.replace_lane", TokenType::SimdLaneOp, Opcode::I8X16ReplaceLane},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 187 "src/lexer-keywords.txt"
+      {"i16x8.shr_s", TokenType::Binary, Opcode::I16X8ShrS},
+      {""}, {""}, {""}, {""}, {""},
+#line 188 "src/lexer-keywords.txt"
+      {"i16x8.shr_u", TokenType::Binary, Opcode::I16X8ShrU},
+      {""}, {""}, {""},
+#line 424 "src/lexer-keywords.txt"
+      {"i8x16.any_true", TokenType::Unary, Opcode::I8X16AnyTrue},
+      {""}, {""}, {""},
+#line 196 "src/lexer-keywords.txt"
+      {"i16x8.widen_low_i8x16_s", TokenType::Unary, Opcode::I16X8WidenLowI8X16S},
+      {""}, {""},
+#line 197 "src/lexer-keywords.txt"
+      {"i16x8.widen_low_i8x16_u", TokenType::Unary, Opcode::I16X8WidenLowI8X16U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 172 "src/lexer-keywords.txt"
+      {"i16x8.load8x8_s", TokenType::Load, Opcode::I16X8Load8X8S},
+      {""}, {""},
+#line 173 "src/lexer-keywords.txt"
+      {"i16x8.load8x8_u", TokenType::Load, Opcode::I16X8Load8X8U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 164 "src/lexer-keywords.txt"
+      {"i16x8.extract_lane_s", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneS},
+      {""}, {""},
+#line 165 "src/lexer-keywords.txt"
+      {"i16x8.extract_lane_u", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 183 "src/lexer-keywords.txt"
+      {"i16x8.neg", TokenType::Unary, Opcode::I16X8Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 342 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmwCmpxchg},
+#line 219 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmwCmpxchg},
+      {""},
+#line 185 "src/lexer-keywords.txt"
+      {"i16x8.replace_lane", TokenType::SimdLaneOp, Opcode::I16X8ReplaceLane},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 107 "src/lexer-keywords.txt"
+      {"f64.copysign", TokenType::Binary, Opcode::F64Copysign},
+#line 56 "src/lexer-keywords.txt"
+      {"f32.copysign", TokenType::Binary, Opcode::F32Copysign},
+      {""}, {""},
+#line 161 "src/lexer-keywords.txt"
+      {"i16x8.any_true", TokenType::Unary, Opcode::I16X8AnyTrue},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 338 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XchgU},
+#line 215 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XchgU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 181 "src/lexer-keywords.txt"
+      {"i16x8.narrow_i32x4_s", TokenType::Binary, Opcode::I16X8NarrowI32X4S},
+      {""}, {""},
+#line 182 "src/lexer-keywords.txt"
+      {"i16x8.narrow_i32x4_u", TokenType::Binary, Opcode::I16X8NarrowI32X4U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 426 "src/lexer-keywords.txt"
+      {"i8x16.eq", TokenType::Compare, Opcode::I8X16Eq},
+      {""},
+#line 26 "src/lexer-keywords.txt"
+      {"atomic.notify", TokenType::AtomicNotify, Opcode::AtomicNotify},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
 #line 36 "src/lexer-keywords.txt"
       {"current_memory", TokenType::MemorySize, Opcode::MemorySize},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""},
-#line 91 "src/lexer-keywords.txt"
-      {"f32x4.neg", TokenType::Unary, Opcode::F32X4Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 296 "src/lexer-keywords.txt"
-      {"i32x4.neg", TokenType::Unary, Opcode::I32X4Neg},
-      {""}, {""}, {""}, {""},
-#line 305 "src/lexer-keywords.txt"
-      {"i32x4.trunc_sat_f32x4_s", TokenType::Unary, Opcode::I32X4TruncSatF32X4S},
-      {""},
-#line 306 "src/lexer-keywords.txt"
-      {"i32x4.trunc_sat_f32x4_u", TokenType::Unary, Opcode::I32X4TruncSatF32X4U},
-#line 517 "src/lexer-keywords.txt"
-      {"v8x16.load_splat", TokenType::Load, Opcode::V8X16LoadSplat},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""},
-#line 514 "src/lexer-keywords.txt"
-      {"v16x8.load_splat", TokenType::Load, Opcode::V16X8LoadSplat},
-      {""},
-#line 26 "src/lexer-keywords.txt"
-      {"atomic.notify", TokenType::AtomicNotify, Opcode::AtomicNotify},
-      {""}, {""}, {""}, {""},
-#line 423 "src/lexer-keywords.txt"
-      {"i8x16.any_true", TokenType::Unary, Opcode::I8X16AnyTrue},
-      {""}, {""}, {""}, {""}, {""},
-#line 446 "src/lexer-keywords.txt"
-      {"i8x16.shr_s", TokenType::Binary, Opcode::I8X16ShrS},
-#line 445 "src/lexer-keywords.txt"
-      {"i8x16.shl", TokenType::Binary, Opcode::I8X16Shl},
+#line 308 "src/lexer-keywords.txt"
+      {"i32x4.widen_high_i16x8_s", TokenType::Unary, Opcode::I32X4WidenHighI16X8S},
       {""}, {""},
-#line 447 "src/lexer-keywords.txt"
-      {"i8x16.shr_u", TokenType::Binary, Opcode::I8X16ShrU},
-      {""}, {""}, {""}, {""},
-#line 160 "src/lexer-keywords.txt"
-      {"i16x8.any_true", TokenType::Unary, Opcode::I16X8AnyTrue},
-      {""}, {""}, {""}, {""}, {""},
-#line 186 "src/lexer-keywords.txt"
-      {"i16x8.shr_s", TokenType::Binary, Opcode::I16X8ShrS},
-#line 185 "src/lexer-keywords.txt"
-      {"i16x8.shl", TokenType::Binary, Opcode::I16X8Shl},
-      {""}, {""},
-#line 187 "src/lexer-keywords.txt"
-      {"i16x8.shr_u", TokenType::Binary, Opcode::I16X8ShrU},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 79 "src/lexer-keywords.txt"
-      {"f32x4.convert_i32x4_s", TokenType::Unary, Opcode::F32X4ConvertI32X4S},
-      {""},
-#line 80 "src/lexer-keywords.txt"
-      {"f32x4.convert_i32x4_u", TokenType::Unary, Opcode::F32X4ConvertI32X4U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 106 "src/lexer-keywords.txt"
-      {"f64.copysign", TokenType::Binary, Opcode::F64Copysign},
-#line 55 "src/lexer-keywords.txt"
-      {"f32.copysign", TokenType::Binary, Opcode::F32Copysign},
-      {""}, {""}, {""}, {""}, {""},
-#line 518 "src/lexer-keywords.txt"
-      {"v8x16.shuffle", TokenType::SimdShuffleOp, Opcode::V8X16Shuffle},
-      {""}, {""}, {""}, {""}, {""},
-#line 337 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XchgU},
-#line 214 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XchgU},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 426 "src/lexer-keywords.txt"
-      {"i8x16.extract_lane_s", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneS},
-      {""},
-#line 427 "src/lexer-keywords.txt"
-      {"i8x16.extract_lane_u", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneU},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""},
-#line 163 "src/lexer-keywords.txt"
-      {"i16x8.extract_lane_s", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneS},
-      {""},
-#line 164 "src/lexer-keywords.txt"
-      {"i16x8.extract_lane_u", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneU},
+#line 309 "src/lexer-keywords.txt"
+      {"i32x4.widen_high_i16x8_u", TokenType::Unary, Opcode::I32X4WidenHighI16X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 82 "src/lexer-keywords.txt"
-      {"f32x4.eq", TokenType::Compare, Opcode::F32X4Eq},
-      {""}, {""},
-#line 279 "src/lexer-keywords.txt"
-      {"i32x4.eq", TokenType::Compare, Opcode::I32X4Eq},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 180 "src/lexer-keywords.txt"
-      {"i16x8.narrow_i32x4_s", TokenType::Binary, Opcode::I16X8NarrowI32X4S},
-      {""},
-#line 181 "src/lexer-keywords.txt"
-      {"i16x8.narrow_i32x4_u", TokenType::Binary, Opcode::I16X8NarrowI32X4U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 341 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmwCmpxchg},
-#line 218 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmwCmpxchg},
-      {""}, {""}, {""}, {""},
-#line 444 "src/lexer-keywords.txt"
-      {"i8x16.replace_lane", TokenType::SimdLaneOp, Opcode::I8X16ReplaceLane},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""},
-#line 184 "src/lexer-keywords.txt"
-      {"i16x8.replace_lane", TokenType::SimdLaneOp, Opcode::I16X8ReplaceLane},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""},
-#line 154 "src/lexer-keywords.txt"
+#line 155 "src/lexer-keywords.txt"
       {"grow_memory", TokenType::MemoryGrow, Opcode::MemoryGrow},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 441 "src/lexer-keywords.txt"
+      {"i8x16.narrow_i16x8_s", TokenType::Binary, Opcode::I8X16NarrowI16X8S},
+      {""}, {""},
 #line 442 "src/lexer-keywords.txt"
-      {"i8x16.neg", TokenType::Unary, Opcode::I8X16Neg},
-      {""}, {""}, {""}, {""}, {""},
-#line 462 "src/lexer-keywords.txt"
-      {"memory.copy", TokenType::MemoryCopy, Opcode::MemoryCopy},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 182 "src/lexer-keywords.txt"
-      {"i16x8.neg", TokenType::Unary, Opcode::I16X8Neg},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""},
-#line 195 "src/lexer-keywords.txt"
-      {"i16x8.widen_low_i8x16_s", TokenType::Unary, Opcode::I16X8WidenLowI8X16S},
-      {""},
-#line 196 "src/lexer-keywords.txt"
-      {"i16x8.widen_low_i8x16_u", TokenType::Unary, Opcode::I16X8WidenLowI8X16U},
+      {"i8x16.narrow_i16x8_u", TokenType::Binary, Opcode::I8X16NarrowI16X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 425 "src/lexer-keywords.txt"
-      {"i8x16.eq", TokenType::Compare, Opcode::I8X16Eq},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 162 "src/lexer-keywords.txt"
+#line 163 "src/lexer-keywords.txt"
       {"i16x8.eq", TokenType::Compare, Opcode::I16X8Eq},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""},
-#line 171 "src/lexer-keywords.txt"
-      {"i16x8.load8x8_s", TokenType::Load, Opcode::I16X8Load8X8S},
-      {""},
-#line 172 "src/lexer-keywords.txt"
-      {"i16x8.load8x8_u", TokenType::Load, Opcode::I16X8Load8X8U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 440 "src/lexer-keywords.txt"
-      {"i8x16.narrow_i16x8_s", TokenType::Binary, Opcode::I8X16NarrowI16X8S},
-      {""},
-#line 441 "src/lexer-keywords.txt"
-      {"i8x16.narrow_i16x8_u", TokenType::Binary, Opcode::I8X16NarrowI16X8U},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""},
-#line 307 "src/lexer-keywords.txt"
-      {"i32x4.widen_high_i16x8_s", TokenType::Unary, Opcode::I32X4WidenHighI16X8S},
-      {""},
-#line 308 "src/lexer-keywords.txt"
-      {"i32x4.widen_high_i16x8_u", TokenType::Unary, Opcode::I32X4WidenHighI16X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1586,12 +1583,10 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 344 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 345 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I64AtomicRmwXchg},
-#line 221 "src/lexer-keywords.txt"
+#line 222 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I32AtomicRmwXchg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1605,13 +1600,9 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 463 "src/lexer-keywords.txt"
+      {"memory.copy", TokenType::MemoryCopy, Opcode::MemoryCopy},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1624,10 +1615,10 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 193 "src/lexer-keywords.txt"
-      {"i16x8.widen_high_i8x16_s", TokenType::Unary, Opcode::I16X8WidenHighI8X16S},
-      {""},
 #line 194 "src/lexer-keywords.txt"
+      {"i16x8.widen_high_i8x16_s", TokenType::Unary, Opcode::I16X8WidenHighI8X16S},
+      {""}, {""},
+#line 195 "src/lexer-keywords.txt"
       {"i16x8.widen_high_i8x16_u", TokenType::Unary, Opcode::I16X8WidenHighI8X16U}
     };
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -780,8 +780,10 @@ Result WastParser::ParseValueType(Type* out_type) {
     case Type::Anyref:
     case Type::Funcref:
     case Type::Hostref:
-    case Type::Exnref:
       is_enabled = options_->features.reference_types_enabled();
+      break;
+    case Type::Exnref:
+      is_enabled = options_->features.exceptions_enabled();
       break;
     default:
       is_enabled = true;

--- a/test/dump/br_on_exn.txt
+++ b/test/dump/br_on_exn.txt
@@ -43,30 +43,37 @@
 0000019: 00                                        ; event attribute
 000001a: 00                                        ; event signature index
 0000017: 03                                        ; FIXUP section size
-; section "Code" (10)
-000001b: 0a                                        ; section code
+; section "DataCount" (12)
+000001b: 0c                                        ; section code
 000001c: 00                                        ; section size (guess)
-000001d: 01                                        ; num functions
+000001d: 00                                        ; data count
+000001c: 01                                        ; FIXUP section size
+; section "Code" (10)
+000001e: 0a                                        ; section code
+000001f: 00                                        ; section size (guess)
+0000020: 01                                        ; num functions
 ; function body 0
-000001e: 00                                        ; func body size (guess)
-000001f: 00                                        ; local decl count
-0000020: 02                                        ; block
-0000021: 7f                                        ; i32
-0000022: 06                                        ; try
-0000023: 40                                        ; void
-0000024: 07                                        ; catch
-0000025: 0a                                        ; br_on_exn
-0000026: 01                                        ; break depth
-0000027: 00                                        ; event index
-0000028: 1a                                        ; drop
-0000029: 0b                                        ; end
-000002a: 41                                        ; i32.const
-000002b: 00                                        ; i32 literal
+0000021: 00                                        ; func body size (guess)
+0000022: 00                                        ; local decl count
+0000023: 02                                        ; block
+0000024: 7f                                        ; i32
+0000025: 06                                        ; try
+0000026: 40                                        ; void
+0000027: 07                                        ; catch
+0000028: 0a                                        ; br_on_exn
+0000029: 01                                        ; break depth
+000002a: 00                                        ; event index
+000002b: 1a                                        ; drop
 000002c: 0b                                        ; end
-000002d: 1a                                        ; drop
-000002e: 0b                                        ; end
-000001e: 10                                        ; FIXUP func body size
-000001c: 12                                        ; FIXUP section size
+000002d: 41                                        ; i32.const
+000002e: 00                                        ; i32 literal
+000002f: 0b                                        ; end
+0000030: 1a                                        ; drop
+0000031: 0b                                        ; end
+0000021: 10                                        ; FIXUP func body size
+000001f: 12                                        ; FIXUP section size
+; move data: [1e, 32) -> [1b, 2f)
+; truncate to 47 (0x2f)
 
 br_on_exn.wasm:	file format wasm 0x1
 

--- a/test/dump/rethrow.txt
+++ b/test/dump/rethrow.txt
@@ -33,21 +33,28 @@
 0000015: 00                                        ; event attribute
 0000016: 00                                        ; event signature index
 0000013: 03                                        ; FIXUP section size
-; section "Code" (10)
-0000017: 0a                                        ; section code
+; section "DataCount" (12)
+0000017: 0c                                        ; section code
 0000018: 00                                        ; section size (guess)
-0000019: 01                                        ; num functions
+0000019: 00                                        ; data count
+0000018: 01                                        ; FIXUP section size
+; section "Code" (10)
+000001a: 0a                                        ; section code
+000001b: 00                                        ; section size (guess)
+000001c: 01                                        ; num functions
 ; function body 0
-000001a: 00                                        ; func body size (guess)
-000001b: 00                                        ; local decl count
-000001c: 06                                        ; try
-000001d: 40                                        ; void
-000001e: 07                                        ; catch
-000001f: 09                                        ; rethrow
-0000020: 0b                                        ; end
-0000021: 0b                                        ; end
-000001a: 07                                        ; FIXUP func body size
-0000018: 09                                        ; FIXUP section size
+000001d: 00                                        ; func body size (guess)
+000001e: 00                                        ; local decl count
+000001f: 06                                        ; try
+0000020: 40                                        ; void
+0000021: 07                                        ; catch
+0000022: 09                                        ; rethrow
+0000023: 0b                                        ; end
+0000024: 0b                                        ; end
+000001d: 07                                        ; FIXUP func body size
+000001b: 09                                        ; FIXUP section size
+; move data: [1a, 25) -> [17, 22)
+; truncate to 34 (0x22)
 
 rethrow.wasm:	file format wasm 0x1
 

--- a/test/dump/throw.txt
+++ b/test/dump/throw.txt
@@ -36,20 +36,27 @@
 0000019: 00                                        ; event attribute
 000001a: 00                                        ; event signature index
 0000017: 03                                        ; FIXUP section size
-; section "Code" (10)
-000001b: 0a                                        ; section code
+; section "DataCount" (12)
+000001b: 0c                                        ; section code
 000001c: 00                                        ; section size (guess)
-000001d: 01                                        ; num functions
+000001d: 00                                        ; data count
+000001c: 01                                        ; FIXUP section size
+; section "Code" (10)
+000001e: 0a                                        ; section code
+000001f: 00                                        ; section size (guess)
+0000020: 01                                        ; num functions
 ; function body 0
-000001e: 00                                        ; func body size (guess)
-000001f: 00                                        ; local decl count
-0000020: 41                                        ; i32.const
-0000021: 01                                        ; i32 literal
-0000022: 08                                        ; throw
-0000023: 00                                        ; throw event
-0000024: 0b                                        ; end
-000001e: 06                                        ; FIXUP func body size
-000001c: 08                                        ; FIXUP section size
+0000021: 00                                        ; func body size (guess)
+0000022: 00                                        ; local decl count
+0000023: 41                                        ; i32.const
+0000024: 01                                        ; i32 literal
+0000025: 08                                        ; throw
+0000026: 00                                        ; throw event
+0000027: 0b                                        ; end
+0000021: 06                                        ; FIXUP func body size
+000001f: 08                                        ; FIXUP section size
+; move data: [1e, 28) -> [1b, 25)
+; truncate to 37 (0x25)
 
 throw.wasm:	file format wasm 0x1
 

--- a/test/dump/try-multi.txt
+++ b/test/dump/try-multi.txt
@@ -49,43 +49,50 @@
 000001a: 00                                        ; function 0 signature index
 000001b: 00                                        ; function 1 signature index
 0000018: 03                                        ; FIXUP section size
-; section "Code" (10)
-000001c: 0a                                        ; section code
+; section "DataCount" (12)
+000001c: 0c                                        ; section code
 000001d: 00                                        ; section size (guess)
-000001e: 02                                        ; num functions
+000001e: 00                                        ; data count
+000001d: 01                                        ; FIXUP section size
+; section "Code" (10)
+000001f: 0a                                        ; section code
+0000020: 00                                        ; section size (guess)
+0000021: 02                                        ; num functions
 ; function body 0
-000001f: 00                                        ; func body size (guess)
-0000020: 00                                        ; local decl count
-0000021: 06                                        ; try
-0000022: 01                                        ; block type function index
-0000023: 41                                        ; i32.const
-0000024: 01                                        ; i32 literal
-0000025: 41                                        ; i32.const
-0000026: 02                                        ; i32 literal
-0000027: 07                                        ; catch
-0000028: 1a                                        ; drop
-0000029: 41                                        ; i32.const
-000002a: 03                                        ; i32 literal
-000002b: 41                                        ; i32.const
-000002c: 04                                        ; i32 literal
-000002d: 0b                                        ; end
-000002e: 0f                                        ; return
-000002f: 0b                                        ; end
-000001f: 10                                        ; FIXUP func body size
+0000022: 00                                        ; func body size (guess)
+0000023: 00                                        ; local decl count
+0000024: 06                                        ; try
+0000025: 01                                        ; block type function index
+0000026: 41                                        ; i32.const
+0000027: 01                                        ; i32 literal
+0000028: 41                                        ; i32.const
+0000029: 02                                        ; i32 literal
+000002a: 07                                        ; catch
+000002b: 1a                                        ; drop
+000002c: 41                                        ; i32.const
+000002d: 03                                        ; i32 literal
+000002e: 41                                        ; i32.const
+000002f: 04                                        ; i32 literal
+0000030: 0b                                        ; end
+0000031: 0f                                        ; return
+0000032: 0b                                        ; end
+0000022: 10                                        ; FIXUP func body size
 ; function body 1
-0000030: 00                                        ; func body size (guess)
-0000031: 00                                        ; local decl count
-0000032: 41                                        ; i32.const
-0000033: 00                                        ; i32 literal
-0000034: 06                                        ; try
-0000035: 02                                        ; block type function index
-0000036: 1a                                        ; drop
-0000037: 07                                        ; catch
-0000038: 1a                                        ; drop
-0000039: 0b                                        ; end
-000003a: 0b                                        ; end
-0000030: 0a                                        ; FIXUP func body size
-000001d: 1d                                        ; FIXUP section size
+0000033: 00                                        ; func body size (guess)
+0000034: 00                                        ; local decl count
+0000035: 41                                        ; i32.const
+0000036: 00                                        ; i32 literal
+0000037: 06                                        ; try
+0000038: 02                                        ; block type function index
+0000039: 1a                                        ; drop
+000003a: 07                                        ; catch
+000003b: 1a                                        ; drop
+000003c: 0b                                        ; end
+000003d: 0b                                        ; end
+0000033: 0a                                        ; FIXUP func body size
+0000020: 1d                                        ; FIXUP section size
+; move data: [1f, 3e) -> [1c, 3b)
+; truncate to 59 (0x3b)
 
 try-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/try.txt
+++ b/test/dump/try.txt
@@ -28,27 +28,34 @@
 0000010: 01                                        ; num functions
 0000011: 00                                        ; function 0 signature index
 000000f: 02                                        ; FIXUP section size
-; section "Code" (10)
-0000012: 0a                                        ; section code
+; section "DataCount" (12)
+0000012: 0c                                        ; section code
 0000013: 00                                        ; section size (guess)
-0000014: 01                                        ; num functions
+0000014: 00                                        ; data count
+0000013: 01                                        ; FIXUP section size
+; section "Code" (10)
+0000015: 0a                                        ; section code
+0000016: 00                                        ; section size (guess)
+0000017: 01                                        ; num functions
 ; function body 0
-0000015: 00                                        ; func body size (guess)
-0000016: 00                                        ; local decl count
-0000017: 06                                        ; try
-0000018: 7f                                        ; i32
-0000019: 01                                        ; nop
-000001a: 41                                        ; i32.const
-000001b: 07                                        ; i32 literal
-000001c: 07                                        ; catch
-000001d: 1a                                        ; drop
-000001e: 41                                        ; i32.const
-000001f: 08                                        ; i32 literal
-0000020: 0b                                        ; end
-0000021: 1a                                        ; drop
-0000022: 0b                                        ; end
-0000015: 0d                                        ; FIXUP func body size
-0000013: 0f                                        ; FIXUP section size
+0000018: 00                                        ; func body size (guess)
+0000019: 00                                        ; local decl count
+000001a: 06                                        ; try
+000001b: 7f                                        ; i32
+000001c: 01                                        ; nop
+000001d: 41                                        ; i32.const
+000001e: 07                                        ; i32 literal
+000001f: 07                                        ; catch
+0000020: 1a                                        ; drop
+0000021: 41                                        ; i32.const
+0000022: 08                                        ; i32 literal
+0000023: 0b                                        ; end
+0000024: 1a                                        ; drop
+0000025: 0b                                        ; end
+0000018: 0d                                        ; FIXUP func body size
+0000016: 0f                                        ; FIXUP section size
+; move data: [15, 26) -> [12, 23)
+; truncate to 35 (0x23)
 
 try.wasm:	file format wasm 0x1
 

--- a/test/parse/func/local-exnref.txt
+++ b/test/parse/func/local-exnref.txt
@@ -1,0 +1,3 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-exceptions
+(module (func (local exnref)))

--- a/test/parse/func/param-exnref.txt
+++ b/test/parse/func/param-exnref.txt
@@ -1,0 +1,3 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-exceptions
+(module (func (param exnref)))

--- a/test/parse/func/result-exnref.txt
+++ b/test/parse/func/result-exnref.txt
@@ -1,0 +1,3 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-exceptions
+(module (func (result exnref) ref.null))

--- a/test/parse/module/global-exnref.txt
+++ b/test/parse/module/global-exnref.txt
@@ -1,0 +1,3 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-exceptions
+(module (global exnref (ref.null)))


### PR DESCRIPTION
The exnref type was already supported in the type checker, and other
parts of the code, but there was no way to name the type in the text
format.

This PR also fixes makes binary-reader.cc check for just the
exceptions_enabled flag to enable exnref. The exception-handling
proposal depends on the reference types proposal, but that is now
handled at a higher level, in the `UpdateDependencies` function.

Fixes issue #1388.