### PR TITLE
Improve error message when python 3 not available - Fix for  #1385

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -464,6 +464,13 @@ if (NOT EMSCRIPTEN)
     )
   endif ()
 
+  # Python 3.5 is the version shipped in Ubuntu Xenial
+  find_package(PythonInterp 3.5)
+  if(NOT PYTHONINTERP_FOUND)
+    set(BUILD_TESTS OFF) 
+    message(WARNING "Skipping tests. Python 3 is required for wabt testing. Please install python3 to run tests.")
+  endif()
+
   find_package(Threads)
   if (BUILD_TESTS)
     if (NOT USE_SYSTEM_GTEST)
@@ -520,11 +527,6 @@ if (NOT EMSCRIPTEN)
       set(USES_TERMINAL USES_TERMINAL)
     endif ()
 
-    # Python 3.5 is the version shipped in Ubuntu Xenial
-    find_package(PythonInterp 3.5)
-    if(NOT PYTHONINTERP_FOUND)
-      message(FATAL_ERROR "Python 3 is required for wabt testing. Please install it. \nIf you want to proceed without installing python 3, either add -no-tests to make target (example: make clang-debug-no-tests) or run cmake with -DBUILD_TESTS=OFF.")
-    endif()
     # test running
     set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -466,7 +466,7 @@ if (NOT EMSCRIPTEN)
 
   # Python 3.5 is the version shipped in Ubuntu Xenial
   find_package(PythonInterp 3.5)
-  if(NOT PYTHONINTERP_FOUND)
+  if(BUILD_TESTS AND (NOT PYTHONINTERP_FOUND))
     set(BUILD_TESTS OFF) 
     message(WARNING "Skipping tests. Python 3 is required for wabt testing. Please install python3 to run tests.")
   endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,68 +520,72 @@ if (NOT EMSCRIPTEN)
       set(USES_TERMINAL USES_TERMINAL)
     endif ()
 
-    # Python 3.5 is the version shipped in Ubuntu Xenial
-    find_package(PythonInterp 3.5 REQUIRED)
-    # test running
-    set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
-
-    add_custom_target(run-tests
-      COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
-      DEPENDS ${WABT_EXECUTABLES}
-      WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-      ${USES_TERMINAL}
-    )
-
+    add_custom_target(check)
     add_custom_target(run-unittests
       COMMAND $<TARGET_FILE:wabt-unittests>
       DEPENDS wabt-unittests
       WORKING_DIRECTORY ${WABT_SOURCE_DIR}
       ${USES_TERMINAL}
     )
+    # Python 3.5 is the version shipped in Ubuntu Xenial
+    find_package(PythonInterp 3.5)
+    if(PYTHONINTERP_FOUND)
+      # test running
+      set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
 
-    add_custom_target(run-c-api-tests
-      COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
-      WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-      ${USES_TERMINAL}
-    )
-
-    add_custom_target(check DEPENDS run-unittests run-tests run-c-api-tests)
-
-    function(c_api_example NAME)
-      set(EXENAME wasm-c-api-${NAME})
-      add_executable(${EXENAME} third_party/wasm-c-api/example/${NAME}.c)
-      if (NOT COMPILER_IS_MSVC)
-        set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wno-pointer-to-int-cast")
-      endif ()
-      target_link_libraries(${EXENAME} wasm Threads::Threads)
-      add_custom_target(${EXENAME}-copy-to-bin ALL
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
-        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${EXENAME}> ${WABT_SOURCE_DIR}/bin/
-        COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm $<TARGET_FILE_DIR:${EXENAME}>/
-        COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm ${WABT_SOURCE_DIR}/bin/
-        DEPENDS ${EXENAME}
+      add_custom_target(run-tests
+        COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
+        DEPENDS ${WABT_EXECUTABLES}
+        WORKING_DIRECTORY ${WABT_SOURCE_DIR}
+        ${USES_TERMINAL}
       )
-      add_dependencies(run-c-api-tests ${EXENAME})
-    endfunction()
 
-    c_api_example(callback)
-    c_api_example(finalize)
-    c_api_example(global)
-    c_api_example(hello)
-    c_api_example(hostref)
-    c_api_example(multi)
-    c_api_example(memory)
-    c_api_example(reflect)
-    c_api_example(serialize)
-    c_api_example(start)
-    c_api_example(table)
-    c_api_example(trap)
-    if (NOT WIN32)
-      # depends on pthreads
-      set(THREADS_PREFER_PTHREAD_FLAG ON)
-      find_package(Threads REQUIRED)
-      c_api_example(threads)
-    endif ()
+      add_custom_target(run-c-api-tests
+        COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
+        WORKING_DIRECTORY ${WABT_SOURCE_DIR}
+        ${USES_TERMINAL}
+      )
+
+      add_dependencies(check run-unittests run-tests  run-c-api-tests)
+
+      function(c_api_example NAME)
+        set(EXENAME wasm-c-api-${NAME})
+        add_executable(${EXENAME} third_party/wasm-c-api/example/${NAME}.c)
+        if (NOT COMPILER_IS_MSVC)
+          set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wno-pointer-to-int-cast")
+        endif ()
+        target_link_libraries(${EXENAME} wasm Threads::Threads)
+        add_custom_target(${EXENAME}-copy-to-bin ALL
+          COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
+          COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${EXENAME}> ${WABT_SOURCE_DIR}/bin/
+          COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm $<TARGET_FILE_DIR:${EXENAME}>/
+          COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm ${WABT_SOURCE_DIR}/bin/
+          DEPENDS ${EXENAME}
+        )
+        add_dependencies(run-c-api-tests ${EXENAME})
+      endfunction()
+
+      c_api_example(callback)
+      c_api_example(finalize)
+      c_api_example(global)
+      c_api_example(hello)
+      c_api_example(hostref)
+      c_api_example(multi)
+      c_api_example(memory)
+      c_api_example(reflect)
+      c_api_example(serialize)
+      c_api_example(start)
+      c_api_example(table)
+      c_api_example(trap)
+      if (NOT WIN32)
+        # depends on pthreads
+        set(THREADS_PREFER_PTHREAD_FLAG ON)
+        find_package(Threads REQUIRED)
+        c_api_example(threads)
+      endif ()
+    else()
+      add_dependencies(check run-unittests)
+    endif(PYTHONINTERP_FOUND)
   endif ()
 
   # install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -522,70 +522,69 @@ if (NOT EMSCRIPTEN)
 
     # Python 3.5 is the version shipped in Ubuntu Xenial
     find_package(PythonInterp 3.5)
-    if(PYTHONINTERP_FOUND)
-      # test running
-      set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
-
-      add_custom_target(run-tests
-        COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
-        DEPENDS ${WABT_EXECUTABLES}
-        WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-        ${USES_TERMINAL}
-      )
-
-      add_custom_target(run-unittests
-        COMMAND $<TARGET_FILE:wabt-unittests>
-        DEPENDS wabt-unittests
-        WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-        ${USES_TERMINAL}
-      )
-
-      add_custom_target(run-c-api-tests
-        COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
-        WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-        ${USES_TERMINAL}
-      )
-
-      add_custom_target(check DEPENDS run-unittests run-tests run-c-api-tests)
-
-      function(c_api_example NAME)
-        set(EXENAME wasm-c-api-${NAME})
-        add_executable(${EXENAME} third_party/wasm-c-api/example/${NAME}.c)
-        if (NOT COMPILER_IS_MSVC)
-          set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wno-pointer-to-int-cast")
-        endif ()
-        target_link_libraries(${EXENAME} wasm Threads::Threads)
-        add_custom_target(${EXENAME}-copy-to-bin ALL
-          COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
-          COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${EXENAME}> ${WABT_SOURCE_DIR}/bin/
-          COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm $<TARGET_FILE_DIR:${EXENAME}>/
-          COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm ${WABT_SOURCE_DIR}/bin/
-          DEPENDS ${EXENAME}
-        )
-        add_dependencies(run-c-api-tests ${EXENAME})
-      endfunction()
-
-      c_api_example(callback)
-      c_api_example(finalize)
-      c_api_example(global)
-      c_api_example(hello)
-      c_api_example(hostref)
-      c_api_example(multi)
-      c_api_example(memory)
-      c_api_example(reflect)
-      c_api_example(serialize)
-      c_api_example(start)
-      c_api_example(table)
-      c_api_example(trap)
-      if (NOT WIN32)
-        # depends on pthreads
-        set(THREADS_PREFER_PTHREAD_FLAG ON)
-        find_package(Threads REQUIRED)
-        c_api_example(threads)
-      endif ()
-    else()
+    if(NOT PYTHONINTERP_FOUND)
       message(FATAL_ERROR "Python 3 is required for wabt testing. Please install it. \nIf you want to proceed without installing python 3, either add -no-tests to make target (example: make clang-debug-no-tests) or run cmake with -DBUILD_TESTS=OFF.")
-    endif(PYTHONINTERP_FOUND)
+    endif()
+    # test running
+    set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
+
+    add_custom_target(run-tests
+      COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
+      DEPENDS ${WABT_EXECUTABLES}
+      WORKING_DIRECTORY ${WABT_SOURCE_DIR}
+      ${USES_TERMINAL}
+    )
+
+    add_custom_target(run-unittests
+      COMMAND $<TARGET_FILE:wabt-unittests>
+      DEPENDS wabt-unittests
+      WORKING_DIRECTORY ${WABT_SOURCE_DIR}
+      ${USES_TERMINAL}
+    )
+
+    add_custom_target(run-c-api-tests
+      COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
+      WORKING_DIRECTORY ${WABT_SOURCE_DIR}
+      ${USES_TERMINAL}
+    )
+
+    add_custom_target(check DEPENDS run-unittests run-tests run-c-api-tests)
+
+    function(c_api_example NAME)
+      set(EXENAME wasm-c-api-${NAME})
+      add_executable(${EXENAME} third_party/wasm-c-api/example/${NAME}.c)
+      if (NOT COMPILER_IS_MSVC)
+        set_target_properties(${EXENAME} PROPERTIES COMPILE_FLAGS "-std=gnu11 -Wno-pointer-to-int-cast")
+      endif ()
+      target_link_libraries(${EXENAME} wasm Threads::Threads)
+      add_custom_target(${EXENAME}-copy-to-bin ALL
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${WABT_SOURCE_DIR}/bin
+        COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${EXENAME}> ${WABT_SOURCE_DIR}/bin/
+        COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm $<TARGET_FILE_DIR:${EXENAME}>/
+        COMMAND ${CMAKE_COMMAND} -E copy ${WABT_SOURCE_DIR}/third_party/wasm-c-api/example/${NAME}.wasm ${WABT_SOURCE_DIR}/bin/
+        DEPENDS ${EXENAME}
+      )
+      add_dependencies(run-c-api-tests ${EXENAME})
+    endfunction()
+
+    c_api_example(callback)
+    c_api_example(finalize)
+    c_api_example(global)
+    c_api_example(hello)
+    c_api_example(hostref)
+    c_api_example(multi)
+    c_api_example(memory)
+    c_api_example(reflect)
+    c_api_example(serialize)
+    c_api_example(start)
+    c_api_example(table)
+    c_api_example(trap)
+    if (NOT WIN32)
+      # depends on pthreads
+      set(THREADS_PREFER_PTHREAD_FLAG ON)
+      find_package(Threads REQUIRED)
+      c_api_example(threads)
+    endif ()
   endif ()
 
   # install

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -545,7 +545,7 @@ if (NOT EMSCRIPTEN)
         WORKING_DIRECTORY ${WABT_SOURCE_DIR}
         ${USES_TERMINAL}
       )
-      
+
       add_custom_target(check DEPENDS run-tests run-unittests run-c-api-tests)
 
       function(c_api_example NAME)
@@ -584,7 +584,7 @@ if (NOT EMSCRIPTEN)
         c_api_example(threads)
       endif ()
     else()
-      message(FATAL_ERROR "Python 3 is required for wabt testing. Please install it. \nIf you want to proceed without installing python 3, either add -no-tests to make target (example: make clang-debug-no-tests) or run cmake with -DBUILD_TESTS=OFF.").
+      message(FATAL_ERROR "Python 3 is required for wabt testing. Please install it. \nIf you want to proceed without installing python 3, either add -no-tests to make target (example: make clang-debug-no-tests) or run cmake with -DBUILD_TESTS=OFF.")
     endif(PYTHONINTERP_FOUND)
   endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -546,7 +546,7 @@ if (NOT EMSCRIPTEN)
         ${USES_TERMINAL}
       )
 
-      add_custom_target(check DEPENDS run-tests run-unittests run-c-api-tests)
+      add_custom_target(check DEPENDS run-unittests run-tests run-c-api-tests)
 
       function(c_api_example NAME)
         set(EXENAME wasm-c-api-${NAME})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -520,13 +520,6 @@ if (NOT EMSCRIPTEN)
       set(USES_TERMINAL USES_TERMINAL)
     endif ()
 
-    add_custom_target(check)
-    add_custom_target(run-unittests
-      COMMAND $<TARGET_FILE:wabt-unittests>
-      DEPENDS wabt-unittests
-      WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-      ${USES_TERMINAL}
-    )
     # Python 3.5 is the version shipped in Ubuntu Xenial
     find_package(PythonInterp 3.5)
     if(PYTHONINTERP_FOUND)
@@ -540,13 +533,20 @@ if (NOT EMSCRIPTEN)
         ${USES_TERMINAL}
       )
 
+      add_custom_target(run-unittests
+        COMMAND $<TARGET_FILE:wabt-unittests>
+        DEPENDS wabt-unittests
+        WORKING_DIRECTORY ${WABT_SOURCE_DIR}
+        ${USES_TERMINAL}
+      )
+
       add_custom_target(run-c-api-tests
         COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
         WORKING_DIRECTORY ${WABT_SOURCE_DIR}
         ${USES_TERMINAL}
       )
-
-      add_dependencies(check run-unittests run-tests  run-c-api-tests)
+      
+      add_custom_target(check DEPENDS run-tests run-unittests run-c-api-tests)
 
       function(c_api_example NAME)
         set(EXENAME wasm-c-api-${NAME})
@@ -584,7 +584,7 @@ if (NOT EMSCRIPTEN)
         c_api_example(threads)
       endif ()
     else()
-      add_dependencies(check run-unittests)
+      message(FATAL_ERROR "Python 3 is required for wabt testing. Please install it. \nIf you want to proceed without installing python 3, either add -no-tests to make target (example: make clang-debug-no-tests) or run cmake with -DBUILD_TESTS=OFF.").
     endif(PYTHONINTERP_FOUND)
   endif ()
 


### PR DESCRIPTION
https://github.com/WebAssembly/wabt/issues/1385

In this PR, I have made python optional in CMakeLists.txt . I have tested locally by bumping the required version to 3.8 which is not existing on my Mac.

I have noticed that the below tests are run from python file - test/run-c-api-examples.py. 
-  c_api_example(callback)
-   c_api_example(finalize)
-   c_api_example(global)
-   c_api_example(hello)
-   c_api_example(hostref)
-   c_api_example(multi)
-   c_api_example(memory)
-   c_api_example(reflect)
-   c_api_example(serialize)
-   c_api_example(start)
-   c_api_example(table)
-   c_api_example(trap)

Do we need to port run-c-api-examples.py to gtest file or cpp file?