### PR TITLE
Pass current Thread to host function callbacks

### DIFF
--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -730,8 +730,8 @@ own wasm_func_t* wasm_func_new(wasm_store_t* store,
                                const wasm_functype_t* type,
                                wasm_func_callback_t callback) {
   FuncType wabt_type = *type->As<FuncType>();
-  auto lambda = [=](const Values& wabt_params, Values& wabt_results,
-                    Trap::Ptr* out_trap) -> Result {
+  auto lambda = [=](Thread& thread, const Values& wabt_params,
+                    Values& wabt_results, Trap::Ptr* out_trap) -> Result {
     wasm_val_vec_t params, results;
     wasm_val_vec_new_uninitialized(&params, wabt_params.size());
     wasm_val_vec_new_uninitialized(&results, wabt_results.size());
@@ -759,8 +759,8 @@ own wasm_func_t* wasm_func_new_with_env(wasm_store_t* store,
                                         void* env,
                                         void (*finalizer)(void*)) {
   FuncType wabt_type = *type->As<FuncType>();
-  auto lambda = [=](const Values& wabt_params, Values& wabt_results,
-                    Trap::Ptr* out_trap) -> Result {
+  auto lambda = [=](Thread& thread, const Values& wabt_params,
+                    Values& wabt_results, Trap::Ptr* out_trap) -> Result {
     wasm_val_vec_t params, results;
     wasm_val_vec_new_uninitialized(&params, wabt_params.size());
     wasm_val_vec_new_uninitialized(&results, wabt_results.size());

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -421,7 +421,7 @@ Result HostFunc::DoCall(Thread& thread,
                         const Values& params,
                         Values& results,
                         Trap::Ptr* out_trap) {
-  return callback_(params, results, out_trap);
+  return callback_(thread, params, results, out_trap);
 }
 
 //// Table ////

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -701,8 +701,10 @@ class HostFunc : public Func {
   static const char* GetTypeName() { return "HostFunc"; }
   using Ptr = RefPtr<HostFunc>;
 
-  using Callback = std::function<
-      Result(const Values& params, Values& results, Trap::Ptr* out_trap)>;
+  using Callback = std::function<Result(Thread& thread,
+                                        const Values& params,
+                                        Values& results,
+                                        Trap::Ptr* out_trap)>;
 
   static HostFunc::Ptr New(Store&, FuncType, Callback);
 

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1224,7 +1224,8 @@ CommandRunner::CommandRunner() : store_(s_features) {
     auto import_name = StringPrintf("spectest.%s", print.name);
     spectest[print.name] = HostFunc::New(
         store_, print.type,
-        [=](const Values& params, Values& results, Trap::Ptr* trap) -> wabt::Result {
+        [=](Thread& inst, const Values& params, Values& results,
+            Trap::Ptr* trap) -> wabt::Result {
           printf("called host ");
           WriteCall(s_stdout_stream.get(), import_name, print.type, params,
                     results, *trap);

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -171,8 +171,8 @@ Result ReadAndInstantiateModule(const char* module_filename,
 
       auto host_func =
           HostFunc::New(s_store, func_type,
-                        [=](const Values& params, Values& results,
-                            Trap::Ptr* trap) -> Result {
+                        [=](Thread& thread, const Values& params,
+                            Values& results, Trap::Ptr* trap) -> Result {
                           printf("called host ");
                           WriteCall(stream, import_name, func_type, params,
                                     results, *trap);


### PR DESCRIPTION
The for experimental WASI implementation I'm working on the WASI
callbacks (implemented as HostFuncs) need to know which module a call is
coming from.  This is because the implicitly operate on the memory of
the calling instance.

This approach seems the match the current convention of passing in the
Thread in `Func::DoCall`.

The purpose here is to allow the HostCall callback to determine from
which instance it is being called.  An alternative approach that I
considered was created different set of WASI HostCall object for
each instance so that instance and its memory we bound to the WASI
functions.