### PR TITLE
Prevent large allocation in br_table instruction

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -656,7 +656,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
 
       case Opcode::BrTable: {
         Index num_targets;
-        CHECK_RESULT(ReadIndex(&num_targets, "br_table target count"));
+        CHECK_RESULT(ReadCount(&num_targets, "br_table target count"));
         target_depths_.resize(num_targets);
 
         for (Index i = 0; i < num_targets; ++i) {

--- a/test/binary/bad-brtable-too-big.txt
+++ b/test/binary/bad-brtable-too-big.txt
@@ -1,0 +1,17 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    br_table leb_i32(0xffffffff)  ;; invalid target count
+    0 0 0 ;; first few targets
+  }
+}
+(;; STDERR ;;;
+000001d: error: invalid br_table target count 4294967295, only 4 bytes left in section
+000001d: error: invalid br_table target count 4294967295, only 4 bytes left in section
+;;; STDERR ;;)


### PR DESCRIPTION
The binary reader tries to allocate a vector for all of the branch
targets, but wasn't checking whether the length was excessively long.
There's already a function to do this: `ReadCount`, which errors out if
the count is longer than the section (this assumes each element requires
at least one byte).

Fixes issue #1386.