### PR TITLE
Remove range assertions in BinaryReader

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -722,7 +722,6 @@ Result BinaryReaderIR::OnCallExpr(Index func_index) {
 }
 
 Result BinaryReaderIR::OnCallIndirectExpr(Index sig_index, Index table_index) {
-  assert(sig_index < module_->types.size());
   auto expr = MakeUnique<CallIndirectExpr>();
   SetFuncDeclaration(&expr->decl, Var(sig_index, GetLocation()));
   expr->table = Var(table_index);
@@ -734,7 +733,6 @@ Result BinaryReaderIR::OnReturnCallExpr(Index func_index) {
 }
 
 Result BinaryReaderIR::OnReturnCallIndirectExpr(Index sig_index, Index table_index) {
-  assert(sig_index < module_->types.size());
   auto expr = MakeUnique<ReturnCallIndirectExpr>();
   SetFuncDeclaration(&expr->decl, Var(sig_index, GetLocation()));
   expr->table = Var(table_index);

--- a/test/binary/bad-callindirect-invalid-sig.txt
+++ b/test/binary/bad-callindirect-invalid-sig.txt
@@ -1,0 +1,18 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(TABLE) { count[1] anyfunc flags[0] min[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    i32.const 0
+    call_indirect leb_i32(100) 0
+  }
+}
+(;; STDERR ;;;
+out/test/binary/bad-callindirect-invalid-sig/bad-callindirect-invalid-sig.wasm:0000023: error: function type variable out of range: 100 (max 1)
+out/test/binary/bad-callindirect-invalid-sig/bad-callindirect-invalid-sig.wasm:0000023: error: function type variable out of range: 100 (max 1)
+;;; STDERR ;;)

--- a/test/binary/bad-returncallindirect-invalid-sig.txt
+++ b/test/binary/bad-returncallindirect-invalid-sig.txt
@@ -1,0 +1,20 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-tail-call
+;;; ARGS2: --enable-tail-call
+magic
+version
+section(TYPE) { count[1] function params[0] results[0] }
+section(FUNCTION) { count[1] type[0] }
+section(TABLE) { count[1] anyfunc flags[0] min[0] }
+section(CODE) {
+  count[1]
+  func {
+    locals[0]
+    i32.const 0
+    return_call_indirect leb_i32(100) 0
+  }
+}
+(;; STDERR ;;;
+out/test/binary/bad-returncallindirect-invalid-sig/bad-returncallindirect-invalid-sig.wasm:0000023: error: function type variable out of range: 100 (max 1)
+out/test/binary/bad-returncallindirect-invalid-sig/bad-returncallindirect-invalid-sig.wasm:0000023: error: function type variable out of range: 100 (max 1)
+;;; STDERR ;;)


### PR DESCRIPTION
These assertions check to see whether the `sig_index` (i.e. the function
type) are in bounds. But this is the responsibility of the validator,
not the binary reader.

Fixes issues #1413 and #1414.