### PR TITLE
Fix bug when writing grouped named parameters

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1125,26 +1125,27 @@ void WatWriter::WriteTypeBindings(const char* prefix,
    *   (param $foo i32)
    *   (param i32 i64 f32)
    */
-  bool is_open = false;
+  bool first = true;
+  bool prev_has_name = false;
   size_t index = 0;
   for (Type type : types) {
-    if (!is_open) {
-      WriteOpenSpace(prefix);
-      is_open = true;
-    }
-
     const std::string& name = index_to_name[binding_index_offset + index];
-    if (!name.empty()) {
+    bool has_name = !name.empty();
+    if ((has_name || prev_has_name) && !first) {
+      WriteCloseSpace();
+    }
+    if (has_name || prev_has_name || first) {
+      WriteOpenSpace(prefix);
+    }
+    if (has_name) {
       WriteString(name, NextChar::Space);
     }
     WriteType(type, NextChar::Space);
-    if (!name.empty()) {
-      WriteCloseSpace();
-      is_open = false;
-    }
+    prev_has_name = has_name;
+    first = false;
     ++index;
   }
-  if (is_open) {
+  if (types.size() != 0) {
     WriteCloseSpace();
   }
 }

--- a/test/roundtrip/named-locals.txt
+++ b/test/roundtrip/named-locals.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --debug-names
+(module (func (local i32 i32) (local $b i32) (local i32)))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (local i32 i32) (local $b i32) (local i32)))
+;;; STDOUT ;;)

--- a/test/roundtrip/named-params.txt
+++ b/test/roundtrip/named-params.txt
@@ -1,0 +1,8 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --debug-names
+(module (func (param i32) (param $b i32)))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (param i32 i32)))
+  (func (;0;) (type 0) (param i32) (param $b i32)))
+;;; STDOUT ;;)


### PR DESCRIPTION
A named parameter (or local) must always be in its own `param` block, so
this syntax is not allowed:

`(param i32 $b i32)`

And must instead be converted to:

`(param i32) (param $b i32)`