### PR TITLE
Move flake8 CI from travis to github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,7 @@ jobs:
         python-version: '3.x'
     - uses: actions/checkout@v1
     - name: install tools
-      run: |
-        sudo pip3 install flake8==3.7.8
+      run: pip3 install flake8==3.7.8
     - run: flake8
   build:
     name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,6 +9,18 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - uses: actions/checkout@v1
+    - name: install tools
+      run: |
+        sudo pip3 install flake8==3.7.8
+    - run: flake8
   build:
     name: Build
     runs-on: ${{ matrix.os }}

--- a/scripts/travis-before-install.sh
+++ b/scripts/travis-before-install.sh
@@ -15,11 +15,6 @@
 # limitations under the License.
 #
 
-if [[ ${TRAVIS_OS_NAME} = "linux" ]]; then
-  pip install --user flake8
-elif [[ ${TRAVIS_OS_NAME} = "osx" ]]; then
+if [[ ${TRAVIS_OS_NAME} = "osx" ]]; then
   brew update
-else
-  echo "unknown TRAVIS_OS_NAME: ${TRAVIS_OS_NAME}"
-  exit 1
 fi

--- a/scripts/travis-build.sh
+++ b/scripts/travis-build.sh
@@ -21,10 +21,6 @@ set -o errexit
 SCRIPT_DIR="$(cd "$(dirname "$0")"; pwd -P)"
 source "${SCRIPT_DIR}/travis-common.sh"
 
-if [[ ${TRAVIS_OS_NAME} = "linux" ]]; then
-  flake8
-fi
-
 if [[ ${COMPILER} = "clang" && -z ${SANITIZER:-} ]]; then
   # Test building without GTest submodule
   make clang-debug-no-tests


### PR DESCRIPTION
Also, pin to a specific version.   We were broken today by the flake8 upgrade to 3.8.0.