### PR TITLE
Use stderr for reporting errors in wasm-interp

### DIFF
--- a/src/interp/interp-wasi.h
+++ b/src/interp/interp-wasi.h
@@ -30,7 +30,7 @@ namespace interp {
 
 Result WasiBindImports(const Module::Ptr& module,
                        RefVec& imports,
-                       Stream* stream,
+                       Stream* err_stream,
                        Stream* trace_stream);
 
 Result WasiRunStart(const Instance::Ptr& instance,

--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -13,6 +13,6 @@ section(DATA) {
   offset[i32.const 0 end]
   data[str("overflow")]
 }
-(;; STDOUT ;;;
+(;; STDERR ;;;
 error initializing module: out of bounds memory access: data segment is out of bounds: [0, 8) >= max value 0
-;;; STDOUT ;;)
+;;; STDERR ;;)

--- a/test/interp/start-failure.txt
+++ b/test/interp/start-failure.txt
@@ -4,6 +4,6 @@
   (func $start unreachable)
   (start $start)
 )
-(;; STDOUT ;;;
+(;; STDERR ;;;
 error initializing module: unreachable executed
-;;; STDOUT ;;)
+;;; STDERR ;;)

--- a/test/wasi/oob_trap.txt
+++ b/test/wasi/oob_trap.txt
@@ -18,6 +18,9 @@
   (call $fd_write (i32.const 1) (i32.const 12) (i32.const 1) (i32.const 20))
   drop
 )
+(;; STDERR ;;;
+error: out of bounds memory access: [65535, 65541) >= max value 65536
+;;; STDERR ;;)
 (;; STDOUT ;;;
 #0.    0: V:0  | i32.const 1
 #0.    8: V:1  | i32.const 12
@@ -25,5 +28,4 @@
 #0.   24: V:3  | i32.const 20
 #0.   32: V:4  | call_import $0
 >>> running wasi function "fd_write":
- error: out of bounds memory access: [65535, 65541) >= max value 65536
 ;;; STDOUT ;;)


### PR DESCRIPTION
We should probably send traving to stderr too but thats a bigger
change.