### PR TITLE
Update testsuite

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -926,7 +926,8 @@ Result WastParser::ParseNat(uint64_t* out_nat) {
 
   Token token = Consume();
   string_view sv = token.literal().text;
-  if (Failed(ParseUint64(sv.begin(), sv.end(), out_nat))) {
+  if (Failed(ParseUint64(sv.begin(), sv.end(), out_nat)) ||
+      *out_nat > 0xffffffffu) {
     Error(token.loc, "invalid int \"" PRIstringview "\"",
           WABT_PRINTF_STRING_VIEW_ARG(sv));
   }

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -1,394 +1,533 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/block.wast
 (;; STDOUT ;;;
-out/test/spec/block.wast:306: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:310: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:314: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:318: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/block.wast:323: assert_invalid passed:
+out/test/spec/block.wast:422: assert_malformed passed:
+  out/test/spec/block/block.1.wat:1:96: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (type $sig) (result i32) (param i32)))
+                                                                     ^
+out/test/spec/block.wast:429: assert_malformed passed:
+  out/test/spec/block/block.2.wat:1:83: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (param i32) (type $sig) (result i32)))
+                                                        ^
+out/test/spec/block.wast:436: assert_malformed passed:
+  out/test/spec/block/block.3.wat:1:96: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (param i32) (result i32) (type $sig)))
+                                                                     ^
+out/test/spec/block.wast:443: assert_malformed passed:
+  out/test/spec/block/block.4.wat:1:84: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (result i32) (type $sig) (param i32)))
+                                                         ^
+out/test/spec/block.wast:450: assert_malformed passed:
+  out/test/spec/block/block.5.wat:1:84: error: unexpected token (, expected ).
+  ...esult i32)))(func (i32.const 0) (block (result i32) (param i32) (type $sig)))
+                                                         ^
+out/test/spec/block.wast:457: assert_malformed passed:
+  out/test/spec/block/block.6.wat:1:41: error: unexpected token (, expected ).
+  (func (i32.const 0) (block (result i32) (param i32)))
+                                          ^
+out/test/spec/block.wast:464: assert_malformed passed:
+  out/test/spec/block/block.7.wat:1:35: error: unexpected token $x, expected ).
+  (func (i32.const 0) (block (param $x i32) (drop)))
+                                    ^^
+  out/test/spec/block/block.7.wat:1:50: error: unexpected token ), expected EOF.
+  (func (i32.const 0) (block (param $x i32) (drop)))
+                                                   ^
+out/test/spec/block.wast:468: assert_malformed passed:
+  out/test/spec/block/block.8.wat:1:25: error: expected 0 results, got 1
+  (type $sig (func))(func (block (type $sig) (result i32) (i32.const 0)) (unrea...
+                          ^
+out/test/spec/block.wast:475: assert_malformed passed:
+  out/test/spec/block/block.9.wat:1:50: error: expected 1 arguments, got 0
+  ...func (param i32) (result i32)))(func (block (type $sig) (result i32) (i32....
+                                          ^
+out/test/spec/block.wast:482: assert_malformed passed:
+  out/test/spec/block/block.10.wat:1:64: error: expected 1 results, got 0
+  ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (drop)...
+                                          ^
+out/test/spec/block.wast:489: assert_malformed passed:
+  out/test/spec/block/block.11.wat:1:68: error: expected 2 arguments, got 1
+  ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (resul...
+                                          ^
+out/test/spec/block.wast:497: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:329: assert_invalid passed:
+out/test/spec/block.wast:505: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/block.wast:509: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/block.wast:513: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/block.wast:517: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/block.wast:522: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/block.wast:528: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i64]
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:335: assert_invalid passed:
+out/test/spec/block.wast:534: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f32]
   000001f: error: OnEndExpr callback failed
-out/test/spec/block.wast:341: assert_invalid passed:
+out/test/spec/block.wast:540: assert_invalid passed:
   error: type mismatch in block, expected [] but got [f64]
   0000023: error: OnEndExpr callback failed
-out/test/spec/block.wast:348: assert_invalid passed:
+out/test/spec/block.wast:546: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32, i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/block.wast:552: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:354: assert_invalid passed:
+out/test/spec/block.wast:558: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:360: assert_invalid passed:
+out/test/spec/block.wast:564: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:366: assert_invalid passed:
+out/test/spec/block.wast:570: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/block.wast:373: assert_invalid passed:
+out/test/spec/block.wast:576: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/block.wast:583: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
-out/test/spec/block.wast:382: assert_invalid passed:
+out/test/spec/block.wast:592: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
-out/test/spec/block.wast:391: assert_invalid passed:
+out/test/spec/block.wast:601: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:401: assert_invalid passed:
+out/test/spec/block.wast:611: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:407: assert_invalid passed:
+out/test/spec/block.wast:617: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:413: assert_invalid passed:
+out/test/spec/block.wast:623: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:419: assert_invalid passed:
+out/test/spec/block.wast:629: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/block.wast:426: assert_invalid passed:
+out/test/spec/block.wast:635: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got []
+  000001d: error: OnEndExpr callback failed
+out/test/spec/block.wast:641: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:432: assert_invalid passed:
+out/test/spec/block.wast:647: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:438: assert_invalid passed:
+out/test/spec/block.wast:653: assert_invalid passed:
   error: type mismatch in block, expected [i32] but got [f64]
   0000024: error: OnEndExpr callback failed
-out/test/spec/block.wast:444: assert_invalid passed:
+out/test/spec/block.wast:659: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:450: assert_invalid passed:
+out/test/spec/block.wast:665: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:456: assert_invalid passed:
+out/test/spec/block.wast:671: assert_invalid passed:
   error: type mismatch in block, expected [i64] but got [f64]
   0000024: error: OnEndExpr callback failed
-out/test/spec/block.wast:462: assert_invalid passed:
+out/test/spec/block.wast:677: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:468: assert_invalid passed:
+out/test/spec/block.wast:683: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:474: assert_invalid passed:
+out/test/spec/block.wast:689: assert_invalid passed:
   error: type mismatch in block, expected [f32] but got [f64]
   0000024: error: OnEndExpr callback failed
-out/test/spec/block.wast:480: assert_invalid passed:
+out/test/spec/block.wast:695: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got [i32]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:486: assert_invalid passed:
+out/test/spec/block.wast:701: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got [i64]
   000001d: error: OnEndExpr callback failed
-out/test/spec/block.wast:492: assert_invalid passed:
+out/test/spec/block.wast:707: assert_invalid passed:
   error: type mismatch in block, expected [f64] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/block.wast:499: assert_invalid passed:
+out/test/spec/block.wast:713: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/block.wast:719: assert_invalid passed:
+  error: type mismatch in block, expected [i32, i32] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/block.wast:725: assert_invalid passed:
+  error: type mismatch in block, expected [] but got [i32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/block.wast:732: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:505: assert_invalid passed:
+out/test/spec/block.wast:738: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:511: assert_invalid passed:
+out/test/spec/block.wast:744: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:517: assert_invalid passed:
+out/test/spec/block.wast:750: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:523: assert_invalid passed:
+out/test/spec/block.wast:756: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [f32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:529: assert_invalid passed:
+out/test/spec/block.wast:762: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [f64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:535: assert_invalid passed:
+out/test/spec/block.wast:768: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:541: assert_invalid passed:
+out/test/spec/block.wast:774: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:547: assert_invalid passed:
+out/test/spec/block.wast:780: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got [f64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:553: assert_invalid passed:
+out/test/spec/block.wast:786: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got [i32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:559: assert_invalid passed:
+out/test/spec/block.wast:792: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:565: assert_invalid passed:
+out/test/spec/block.wast:798: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got [f32]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/block.wast:572: assert_invalid passed:
+out/test/spec/block.wast:805: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:578: assert_invalid passed:
+out/test/spec/block.wast:811: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:584: assert_invalid passed:
+out/test/spec/block.wast:817: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:590: assert_invalid passed:
+out/test/spec/block.wast:823: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:597: assert_invalid passed:
+out/test/spec/block.wast:829: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:836: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:603: assert_invalid passed:
+out/test/spec/block.wast:842: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:609: assert_invalid passed:
+out/test/spec/block.wast:848: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:615: assert_invalid passed:
+out/test/spec/block.wast:854: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/block.wast:622: assert_invalid passed:
+out/test/spec/block.wast:860: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/block.wast:867: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:628: assert_invalid passed:
+out/test/spec/block.wast:873: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:634: assert_invalid passed:
+out/test/spec/block.wast:879: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:640: assert_invalid passed:
+out/test/spec/block.wast:885: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:647: assert_invalid passed:
+out/test/spec/block.wast:892: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:653: assert_invalid passed:
+out/test/spec/block.wast:898: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:659: assert_invalid passed:
+out/test/spec/block.wast:904: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:665: assert_invalid passed:
+out/test/spec/block.wast:910: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:671: assert_invalid passed:
+out/test/spec/block.wast:916: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:677: assert_invalid passed:
+out/test/spec/block.wast:922: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:683: assert_invalid passed:
+out/test/spec/block.wast:928: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:689: assert_invalid passed:
+out/test/spec/block.wast:934: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:695: assert_invalid passed:
+out/test/spec/block.wast:940: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:701: assert_invalid passed:
+out/test/spec/block.wast:946: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:707: assert_invalid passed:
+out/test/spec/block.wast:952: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:713: assert_invalid passed:
+out/test/spec/block.wast:958: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:720: assert_invalid passed:
+out/test/spec/block.wast:964: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/block.wast:970: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:977: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:726: assert_invalid passed:
+out/test/spec/block.wast:983: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:732: assert_invalid passed:
+out/test/spec/block.wast:989: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:738: assert_invalid passed:
+out/test/spec/block.wast:995: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/block.wast:745: assert_invalid passed:
+out/test/spec/block.wast:1001: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/block.wast:1008: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:751: assert_invalid passed:
+out/test/spec/block.wast:1014: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:757: assert_invalid passed:
+out/test/spec/block.wast:1020: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:763: assert_invalid passed:
+out/test/spec/block.wast:1026: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:769: assert_invalid passed:
+out/test/spec/block.wast:1032: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:775: assert_invalid passed:
+out/test/spec/block.wast:1038: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:781: assert_invalid passed:
+out/test/spec/block.wast:1044: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:787: assert_invalid passed:
+out/test/spec/block.wast:1050: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:793: assert_invalid passed:
+out/test/spec/block.wast:1056: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [f64]
   0000025: error: OnBrExpr callback failed
-out/test/spec/block.wast:799: assert_invalid passed:
+out/test/spec/block.wast:1062: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i32]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:805: assert_invalid passed:
+out/test/spec/block.wast:1068: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:811: assert_invalid passed:
+out/test/spec/block.wast:1074: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [f32]
   0000021: error: OnBrExpr callback failed
-out/test/spec/block.wast:818: assert_invalid passed:
+out/test/spec/block.wast:1080: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/block.wast:1087: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
-out/test/spec/block.wast:824: assert_invalid passed:
+out/test/spec/block.wast:1093: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i64]
   0000024: error: EndFunctionBody callback failed
-out/test/spec/block.wast:830: assert_invalid passed:
+out/test/spec/block.wast:1099: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f32]
   0000027: error: EndFunctionBody callback failed
-out/test/spec/block.wast:836: assert_invalid passed:
+out/test/spec/block.wast:1105: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64]
   000002b: error: EndFunctionBody callback failed
-out/test/spec/block.wast:843: assert_invalid passed:
+out/test/spec/block.wast:1111: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32, i32]
+  000002b: error: EndFunctionBody callback failed
+out/test/spec/block.wast:1118: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:849: assert_invalid passed:
+out/test/spec/block.wast:1124: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:855: assert_invalid passed:
+out/test/spec/block.wast:1130: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:861: assert_invalid passed:
+out/test/spec/block.wast:1136: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/block.wast:868: assert_invalid passed:
+out/test/spec/block.wast:1142: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/block.wast:1149: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:874: assert_invalid passed:
+out/test/spec/block.wast:1155: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:880: assert_invalid passed:
+out/test/spec/block.wast:1161: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:886: assert_invalid passed:
+out/test/spec/block.wast:1167: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/block.wast:893: assert_invalid passed:
+out/test/spec/block.wast:1173: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/block.wast:1180: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:901: assert_invalid passed:
+out/test/spec/block.wast:1188: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   0000023: error: OnBrExpr callback failed
-out/test/spec/block.wast:909: assert_invalid passed:
+out/test/spec/block.wast:1196: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f64]
   0000027: error: OnBrExpr callback failed
-out/test/spec/block.wast:917: assert_invalid passed:
+out/test/spec/block.wast:1204: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [i32]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:925: assert_invalid passed:
+out/test/spec/block.wast:1212: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f32]
   0000023: error: OnBrExpr callback failed
-out/test/spec/block.wast:933: assert_invalid passed:
+out/test/spec/block.wast:1220: assert_invalid passed:
   error: type mismatch in br, expected [i64] but got [f64]
   0000027: error: OnBrExpr callback failed
-out/test/spec/block.wast:941: assert_invalid passed:
+out/test/spec/block.wast:1228: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i32]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:949: assert_invalid passed:
+out/test/spec/block.wast:1236: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:957: assert_invalid passed:
+out/test/spec/block.wast:1244: assert_invalid passed:
   error: type mismatch in br, expected [f32] but got [f64]
   0000027: error: OnBrExpr callback failed
-out/test/spec/block.wast:965: assert_invalid passed:
+out/test/spec/block.wast:1252: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i32]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:973: assert_invalid passed:
+out/test/spec/block.wast:1260: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/block.wast:981: assert_invalid passed:
+out/test/spec/block.wast:1268: assert_invalid passed:
   error: type mismatch in br, expected [f64] but got [f32]
   0000023: error: OnBrExpr callback failed
-out/test/spec/block.wast:990: assert_invalid passed:
+out/test/spec/block.wast:1276: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/block.wast:1285: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:996: assert_invalid passed:
+out/test/spec/block.wast:1291: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1002: assert_invalid passed:
+out/test/spec/block.wast:1297: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1008: assert_invalid passed:
+out/test/spec/block.wast:1303: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1015: assert_invalid passed:
+out/test/spec/block.wast:1309: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/block.wast:1316: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1021: assert_invalid passed:
+out/test/spec/block.wast:1322: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1027: assert_invalid passed:
+out/test/spec/block.wast:1328: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1033: assert_invalid passed:
+out/test/spec/block.wast:1334: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   000001f: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1040: assert_invalid passed:
+out/test/spec/block.wast:1340: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/block.wast:1347: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1046: assert_invalid passed:
+out/test/spec/block.wast:1353: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1052: assert_invalid passed:
+out/test/spec/block.wast:1359: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1058: assert_invalid passed:
+out/test/spec/block.wast:1365: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1064: assert_invalid passed:
+out/test/spec/block.wast:1371: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1070: assert_invalid passed:
+out/test/spec/block.wast:1377: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1076: assert_invalid passed:
+out/test/spec/block.wast:1383: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1082: assert_invalid passed:
+out/test/spec/block.wast:1389: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1088: assert_invalid passed:
+out/test/spec/block.wast:1395: assert_invalid passed:
   error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1094: assert_invalid passed:
+out/test/spec/block.wast:1401: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1100: assert_invalid passed:
+out/test/spec/block.wast:1407: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1106: assert_invalid passed:
+out/test/spec/block.wast:1413: assert_invalid passed:
   error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
-out/test/spec/block.wast:1114: assert_malformed passed:
-  out/test/spec/block/block.128.wat:1:17: error: unexpected label "$l"
+out/test/spec/block.wast:1419: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000022: error: OnBinaryExpr callback failed
+out/test/spec/block.wast:1426: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001d: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1432: assert_invalid passed:
+  error: type mismatch in block, expected [i32, f64] but got []
+  000001e: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1438: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000022: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1444: assert_invalid passed:
+  error: type mismatch in block, expected [f32, i32] but got [f32]
+  0000023: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1450: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got []
+  000001f: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1456: assert_invalid passed:
+  error: type mismatch in block, expected [i32, f64] but got []
+  0000020: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1462: assert_invalid passed:
+  error: type mismatch in block, expected [i32] but got [f32]
+  0000024: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1468: assert_invalid passed:
+  error: type mismatch in block, expected [f32, i32] but got [f32]
+  0000025: error: OnBlockExpr callback failed
+out/test/spec/block.wast:1475: assert_malformed passed:
+  out/test/spec/block/block.167.wat:1:45: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) block (param $x i32) end)
+                                              ^^
+out/test/spec/block.wast:1479: assert_malformed passed:
+  out/test/spec/block/block.168.wat:1:46: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) (block (param $x i32)))
+                                               ^^
+out/test/spec/block.wast:1485: assert_malformed passed:
+  out/test/spec/block/block.169.wat:1:17: error: unexpected label "$l"
   (func block end $l)
                   ^^
-out/test/spec/block.wast:1118: assert_malformed passed:
-  out/test/spec/block/block.129.wat:1:20: error: mismatching label "$a" != "$l"
+out/test/spec/block.wast:1489: assert_malformed passed:
+  out/test/spec/block/block.170.wat:1:20: error: mismatching label "$a" != "$l"
   (func block $a end $l)
                      ^^
-170/170 tests passed.
+222/222 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -1,65 +1,65 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
-out/test/spec/br.wast:420: assert_invalid passed:
+out/test/spec/br.wast:471: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/br.wast:427: assert_invalid passed:
+out/test/spec/br.wast:478: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:433: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  0000020: error: OnBrExpr callback failed
-out/test/spec/br.wast:439: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
-  000001e: error: OnBrExpr callback failed
-out/test/spec/br.wast:446: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:455: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:464: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:473: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  000001b: error: OnBrExpr callback failed
 out/test/spec/br.wast:484: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
-  000001b: error: OnBrExpr callback failed
-out/test/spec/br.wast:495: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  0000021: error: OnBrExpr callback failed
-out/test/spec/br.wast:507: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
-  0000036: error: OnBrExpr callback failed
-out/test/spec/br.wast:523: assert_invalid passed:
+  0000020: error: OnBrExpr callback failed
+out/test/spec/br.wast:490: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got [i64]
+  000001e: error: OnBrExpr callback failed
+out/test/spec/br.wast:497: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
+out/test/spec/br.wast:506: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/br.wast:515: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/br.wast:524: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001b: error: OnBrExpr callback failed
 out/test/spec/br.wast:535: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/br.wast:546: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000021: error: OnBrExpr callback failed
+out/test/spec/br.wast:558: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  0000036: error: OnBrExpr callback failed
+out/test/spec/br.wast:574: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:547: assert_invalid passed:
+out/test/spec/br.wast:586: assert_invalid passed:
+  error: type mismatch in br, expected [i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/br.wast:598: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000023: error: OnBrExpr callback failed
-out/test/spec/br.wast:559: assert_invalid passed:
+out/test/spec/br.wast:610: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
-out/test/spec/br.wast:571: assert_invalid passed:
+out/test/spec/br.wast:622: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
-out/test/spec/br.wast:583: assert_invalid passed:
+out/test/spec/br.wast:634: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
-out/test/spec/br.wast:596: assert_invalid passed:
+out/test/spec/br.wast:647: assert_invalid passed:
   error: invalid depth: 1 (max 0)
   0000019: error: OnBrExpr callback failed
-out/test/spec/br.wast:600: assert_invalid passed:
+out/test/spec/br.wast:651: assert_invalid passed:
   error: invalid depth: 5 (max 2)
   000001d: error: OnBrExpr callback failed
-out/test/spec/br.wast:604: assert_invalid passed:
+out/test/spec/br.wast:655: assert_invalid passed:
   error: invalid depth: 268435457 (max 0)
   000001d: error: OnBrExpr callback failed
-83/83 tests passed.
+96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -1,60 +1,60 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call.wast
 (;; STDOUT ;;;
-out/test/spec/call.wast:299: assert_trap passed: undefined table index
-out/test/spec/call.wast:326: assert_invalid passed:
+out/test/spec/call.wast:354: assert_trap passed: undefined table index
+out/test/spec/call.wast:381: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001b: error: OnConvertExpr callback failed
-out/test/spec/call.wast:333: assert_invalid passed:
+out/test/spec/call.wast:388: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001f: error: OnConvertExpr callback failed
-out/test/spec/call.wast:341: assert_invalid passed:
+out/test/spec/call.wast:396: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   000001e: error: OnCallExpr callback failed
-out/test/spec/call.wast:348: assert_invalid passed:
+out/test/spec/call.wast:403: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
-out/test/spec/call.wast:355: assert_invalid passed:
+out/test/spec/call.wast:410: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/test/spec/call.wast:362: assert_invalid passed:
+out/test/spec/call.wast:417: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
-out/test/spec/call.wast:370: assert_invalid passed:
+out/test/spec/call.wast:425: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/test/spec/call.wast:377: assert_invalid passed:
+out/test/spec/call.wast:432: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
-out/test/spec/call.wast:384: assert_invalid passed:
+out/test/spec/call.wast:439: assert_invalid passed:
   error: type mismatch in call, expected [i32, f64] but got [f64, i32]
   000002a: error: OnCallExpr callback failed
-out/test/spec/call.wast:391: assert_invalid passed:
+out/test/spec/call.wast:446: assert_invalid passed:
   error: type mismatch in call, expected [f64, i32] but got [i32, f64]
   000002a: error: OnCallExpr callback failed
-out/test/spec/call.wast:399: assert_invalid passed:
+out/test/spec/call.wast:454: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   0000020: error: OnCallExpr callback failed
-out/test/spec/call.wast:408: assert_invalid passed:
+out/test/spec/call.wast:463: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000023: error: OnCallExpr callback failed
-out/test/spec/call.wast:417: assert_invalid passed:
+out/test/spec/call.wast:472: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   0000020: error: OnCallExpr callback failed
-out/test/spec/call.wast:426: assert_invalid passed:
+out/test/spec/call.wast:481: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000023: error: OnCallExpr callback failed
-out/test/spec/call.wast:435: assert_invalid passed:
+out/test/spec/call.wast:490: assert_invalid passed:
   error: type mismatch in call, expected [i32] but got []
   0000022: error: OnCallExpr callback failed
-out/test/spec/call.wast:444: assert_invalid passed:
+out/test/spec/call.wast:499: assert_invalid passed:
   error: type mismatch in call, expected [i32, i32] but got [i32]
   0000025: error: OnCallExpr callback failed
-out/test/spec/call.wast:457: assert_invalid passed:
+out/test/spec/call.wast:512: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)
   0000019: error: OnCallExpr callback failed
-out/test/spec/call.wast:461: assert_invalid passed:
+out/test/spec/call.wast:516: assert_invalid passed:
   0000000: error: function variable out of range: 1012321300 (max 1)
   000001d: error: OnCallExpr callback failed
-82/82 tests passed.
+90/90 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -1,149 +1,149 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/call_indirect.wast
 (;; STDOUT ;;;
-out/test/spec/call_indirect.wast:469: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:470: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:471: assert_trap passed: undefined table index
-out/test/spec/call_indirect.wast:472: assert_trap passed: undefined table index
-out/test/spec/call_indirect.wast:473: assert_trap passed: undefined table index
-out/test/spec/call_indirect.wast:479: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:480: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:486: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:487: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:493: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:494: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:500: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:501: assert_trap passed: indirect call signature mismatch
-out/test/spec/call_indirect.wast:594: assert_malformed passed:
+out/test/spec/call_indirect.wast:498: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:499: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:500: assert_trap passed: undefined table index
+out/test/spec/call_indirect.wast:501: assert_trap passed: undefined table index
+out/test/spec/call_indirect.wast:502: assert_trap passed: undefined table index
+out/test/spec/call_indirect.wast:508: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:509: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:515: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:516: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:522: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:523: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:529: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:530: assert_trap passed: indirect call signature mismatch
+out/test/spec/call_indirect.wast:623: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.1.wat:1:122: error: unexpected token "param", expected an expr.
   ...indirect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const ...
                                         ^^^^^
   out/test/spec/call_indirect/call_indirect.1.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (type $sig) (result i32) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:606: assert_malformed passed:
+out/test/spec/call_indirect.wast:635: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.2.wat:1:109: error: unexpected token "type", expected an expr.
   ... i32)  (call_indirect (param i32) (type $sig) (result i32)    (i32.const 0...
                                         ^^^^
   out/test/spec/call_indirect/call_indirect.2.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (type $sig) (result i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:618: assert_malformed passed:
+out/test/spec/call_indirect.wast:647: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.3.wat:1:122: error: unexpected token "type", expected an expr.
   ...indirect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const ...
                                         ^^^^
   out/test/spec/call_indirect/call_indirect.3.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (param i32) (result i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:630: assert_malformed passed:
+out/test/spec/call_indirect.wast:659: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.4.wat:1:110: error: unexpected token "type", expected an expr.
   ...i32)  (call_indirect (result i32) (type $sig) (param i32)    (i32.const 0)...
                                         ^^^^
   out/test/spec/call_indirect/call_indirect.4.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (type $sig) (param i32)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:642: assert_malformed passed:
+out/test/spec/call_indirect.wast:671: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.5.wat:1:110: error: unexpected token "param", expected an expr.
   ...i32)  (call_indirect (result i32) (param i32) (type $sig)    (i32.const 0)...
                                         ^^^^^
   out/test/spec/call_indirect/call_indirect.5.wat:1:166: error: unexpected token ), expected EOF.
   ...irect (result i32) (param i32) (type $sig)    (i32.const 0) (i32.const 0)  ))
                                                                                  ^
-out/test/spec/call_indirect.wast:654: assert_malformed passed:
+out/test/spec/call_indirect.wast:683: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.6.wat:1:67: error: unexpected token "param", expected an expr.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                           ^^^^^
   out/test/spec/call_indirect/call_indirect.6.wat:1:106: error: unexpected token ), expected EOF.
   ...t i32)  (call_indirect (result i32) (param i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/test/spec/call_indirect.wast:664: assert_malformed passed:
+out/test/spec/call_indirect.wast:693: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.7.wat:1:46: error: unexpected token $x, expected ).
   ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                              ^^
   out/test/spec/call_indirect/call_indirect.7.wat:1:82: error: unexpected token ), expected EOF.
   ...e 0 funcref)(func (call_indirect (param $x i32) (i32.const 0) (i32.const 0)))
                                                                                  ^
-out/test/spec/call_indirect.wast:671: assert_malformed passed:
+out/test/spec/call_indirect.wast:700: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.8.wat:1:57: error: expected 0 results, got 1
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:681: assert_malformed passed:
+out/test/spec/call_indirect.wast:710: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.9.wat:1:82: error: expected 1 arguments, got 0
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (result i32) (i32...
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:691: assert_malformed passed:
+out/test/spec/call_indirect.wast:720: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.10.wat:1:69: error: expected 1 results, got 0
   ...i32)))(table 0 funcref)(func  (call_indirect (type $sig) (param i32) (i32....
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:701: assert_malformed passed:
+out/test/spec/call_indirect.wast:730: assert_malformed passed:
   out/test/spec/call_indirect/call_indirect.11.wat:1:86: error: expected 2 arguments, got 1
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
-out/test/spec/call_indirect.wast:716: assert_invalid passed:
+out/test/spec/call_indirect.wast:745: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   000001c: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:724: assert_invalid passed:
+out/test/spec/call_indirect.wast:753: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
-out/test/spec/call_indirect.wast:732: assert_invalid passed:
+out/test/spec/call_indirect.wast:761: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
-out/test/spec/call_indirect.wast:741: assert_invalid passed:
+out/test/spec/call_indirect.wast:770: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:749: assert_invalid passed:
+out/test/spec/call_indirect.wast:778: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:757: assert_invalid passed:
+out/test/spec/call_indirect.wast:786: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/call_indirect.wast:765: assert_invalid passed:
+out/test/spec/call_indirect.wast:794: assert_invalid passed:
   error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
-out/test/spec/call_indirect.wast:776: assert_invalid passed:
+out/test/spec/call_indirect.wast:805: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:784: assert_invalid passed:
+out/test/spec/call_indirect.wast:813: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:793: assert_invalid passed:
+out/test/spec/call_indirect.wast:822: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:803: assert_invalid passed:
+out/test/spec/call_indirect.wast:832: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:813: assert_invalid passed:
+out/test/spec/call_indirect.wast:842: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:823: assert_invalid passed:
+out/test/spec/call_indirect.wast:852: assert_invalid passed:
   error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:834: assert_invalid passed:
+out/test/spec/call_indirect.wast:863: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000036: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:847: assert_invalid passed:
+out/test/spec/call_indirect.wast:876: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   0000039: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:860: assert_invalid passed:
+out/test/spec/call_indirect.wast:889: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32] but got []
   0000036: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:873: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
-  0000039: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:886: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got []
-  000003a: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:902: assert_invalid passed:
   error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  0000039: error: OnCallIndirectExpr callback failed
+out/test/spec/call_indirect.wast:915: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32] but got []
+  000003a: error: OnCallIndirectExpr callback failed
+out/test/spec/call_indirect.wast:931: assert_invalid passed:
+  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000003d: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:922: assert_invalid passed:
+out/test/spec/call_indirect.wast:951: assert_invalid passed:
   0000000: error: function type variable out of range: 1 (max 1)
   0000022: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:929: assert_invalid passed:
+out/test/spec/call_indirect.wast:958: assert_invalid passed:
   0000000: error: function type variable out of range: 1012321300 (max 1)
   0000026: error: OnCallIndirectExpr callback failed
-out/test/spec/call_indirect.wast:940: assert_invalid passed:
+out/test/spec/call_indirect.wast:969: assert_invalid passed:
   0000000: error: function variable out of range: 0 (max 0)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed
-151/151 tests passed.
+155/155 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/conversions.txt
+++ b/test/spec/conversions.txt
@@ -1,147 +1,147 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/conversions.wast
 (;; STDOUT ;;;
-out/test/spec/conversions.wast:70: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:71: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:72: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:73: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:74: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:75: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:76: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:77: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:92: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:93: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:94: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:95: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:96: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:97: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:98: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:99: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:115: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:116: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:117: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:118: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:119: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:120: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:121: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:122: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:138: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:139: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:140: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:141: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:142: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:143: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:144: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:145: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:146: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:147: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:148: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:166: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:167: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:168: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:169: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:170: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:171: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:172: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:173: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:186: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:187: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:188: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:189: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:190: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:191: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:192: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:193: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:211: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:212: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:213: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:214: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:215: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:216: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:217: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:218: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:235: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:236: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:237: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:238: assert_trap passed: integer overflow
-out/test/spec/conversions.wast:239: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:240: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:241: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:242: assert_trap passed: invalid conversion to integer
-out/test/spec/conversions.wast:475: assert_invalid passed:
+out/test/spec/conversions.wast:78: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:79: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:80: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:81: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:82: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:83: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:84: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:85: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:100: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:101: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:102: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:103: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:104: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:105: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:106: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:107: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:123: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:124: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:125: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:126: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:127: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:128: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:129: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:130: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:146: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:147: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:148: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:149: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:150: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:151: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:152: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:153: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:154: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:155: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:156: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:174: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:175: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:176: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:177: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:178: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:179: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:180: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:181: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:194: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:195: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:196: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:197: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:198: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:199: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:200: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:201: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:219: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:220: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:221: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:222: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:223: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:224: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:225: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:226: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:243: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:244: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:245: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:246: assert_trap passed: integer overflow
+out/test/spec/conversions.wast:247: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:248: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:249: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:250: assert_trap passed: invalid conversion to integer
+out/test/spec/conversions.wast:674: assert_invalid passed:
   error: type mismatch in i32.wrap_i64, expected [i64] but got [f32]
   000001e: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:476: assert_invalid passed:
+out/test/spec/conversions.wast:675: assert_invalid passed:
   error: type mismatch in i32.trunc_f32_s, expected [f32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:477: assert_invalid passed:
+out/test/spec/conversions.wast:676: assert_invalid passed:
   error: type mismatch in i32.trunc_f32_u, expected [f32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:478: assert_invalid passed:
+out/test/spec/conversions.wast:677: assert_invalid passed:
   error: type mismatch in i32.trunc_f64_s, expected [f64] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:479: assert_invalid passed:
+out/test/spec/conversions.wast:678: assert_invalid passed:
   error: type mismatch in i32.trunc_f64_u, expected [f64] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:480: assert_invalid passed:
+out/test/spec/conversions.wast:679: assert_invalid passed:
   error: type mismatch in i32.reinterpret_f32, expected [f32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:481: assert_invalid passed:
+out/test/spec/conversions.wast:680: assert_invalid passed:
   error: type mismatch in i64.extend_i32_s, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:482: assert_invalid passed:
+out/test/spec/conversions.wast:681: assert_invalid passed:
   error: type mismatch in i64.extend_i32_u, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:483: assert_invalid passed:
+out/test/spec/conversions.wast:682: assert_invalid passed:
   error: type mismatch in i64.trunc_f32_s, expected [f32] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:484: assert_invalid passed:
+out/test/spec/conversions.wast:683: assert_invalid passed:
   error: type mismatch in i64.trunc_f32_u, expected [f32] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:485: assert_invalid passed:
+out/test/spec/conversions.wast:684: assert_invalid passed:
   error: type mismatch in i64.trunc_f64_s, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:486: assert_invalid passed:
+out/test/spec/conversions.wast:685: assert_invalid passed:
   error: type mismatch in i64.trunc_f64_u, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:487: assert_invalid passed:
+out/test/spec/conversions.wast:686: assert_invalid passed:
   error: type mismatch in i64.reinterpret_f64, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:488: assert_invalid passed:
+out/test/spec/conversions.wast:687: assert_invalid passed:
   error: type mismatch in f32.convert_i32_s, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:489: assert_invalid passed:
+out/test/spec/conversions.wast:688: assert_invalid passed:
   error: type mismatch in f32.convert_i32_u, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:490: assert_invalid passed:
+out/test/spec/conversions.wast:689: assert_invalid passed:
   error: type mismatch in f32.convert_i64_s, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:491: assert_invalid passed:
+out/test/spec/conversions.wast:690: assert_invalid passed:
   error: type mismatch in f32.convert_i64_u, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:492: assert_invalid passed:
+out/test/spec/conversions.wast:691: assert_invalid passed:
   error: type mismatch in f32.demote_f64, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:493: assert_invalid passed:
+out/test/spec/conversions.wast:692: assert_invalid passed:
   error: type mismatch in f32.reinterpret_i32, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:494: assert_invalid passed:
+out/test/spec/conversions.wast:693: assert_invalid passed:
   error: type mismatch in f64.convert_i32_s, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:495: assert_invalid passed:
+out/test/spec/conversions.wast:694: assert_invalid passed:
   error: type mismatch in f64.convert_i32_u, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:496: assert_invalid passed:
+out/test/spec/conversions.wast:695: assert_invalid passed:
   error: type mismatch in f64.convert_i64_s, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:497: assert_invalid passed:
+out/test/spec/conversions.wast:696: assert_invalid passed:
   error: type mismatch in f64.convert_i64_u, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:498: assert_invalid passed:
+out/test/spec/conversions.wast:697: assert_invalid passed:
   error: type mismatch in f64.promote_f32, expected [f32] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/conversions.wast:499: assert_invalid passed:
+out/test/spec/conversions.wast:698: assert_invalid passed:
   error: type mismatch in f64.reinterpret_i64, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-434/434 tests passed.
+614/614 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/fac.txt
+++ b/test/spec/fac.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/fac.wast
 (;; STDOUT ;;;
-6/6 tests passed.
+7/7 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -1,190 +1,243 @@
 ;;; TOOL: run-interp-spec
-;;; ARGS: --disable-multi-value
 ;;; STDIN_FILE: third_party/testsuite/func.wast
 (;; STDOUT ;;;
-out/test/spec/func.wast:303: assert_invalid passed:
+out/test/spec/func.wast:436: assert_invalid passed:
   0000000: error: function type variable out of range: 2 (max 2)
   000001a: error: OnFunction callback failed
-out/test/spec/func.wast:387: assert_malformed passed:
+out/test/spec/func.wast:520: assert_malformed passed:
   out/test/spec/func/func.4.wat:1:76: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (type $sig) (result i32) (param i32) (i32.const 0))
                                                          ^^^^^
-out/test/spec/func.wast:394: assert_malformed passed:
+out/test/spec/func.wast:527: assert_malformed passed:
   out/test/spec/func/func.5.wat:1:63: error: unexpected token "type", expected an instr.
   ... i32) (result i32)))(func (param i32) (type $sig) (result i32) (i32.const 0))
                                             ^^^^
-out/test/spec/func.wast:401: assert_malformed passed:
+out/test/spec/func.wast:534: assert_malformed passed:
   out/test/spec/func/func.6.wat:1:76: error: unexpected token "type", expected an instr.
   ... i32) (result i32)))(func (param i32) (result i32) (type $sig) (i32.const 0))
                                                          ^^^^
-out/test/spec/func.wast:408: assert_malformed passed:
+out/test/spec/func.wast:541: assert_malformed passed:
   out/test/spec/func/func.7.wat:1:64: error: unexpected token "type", expected an instr.
   ... i32) (result i32)))(func (result i32) (type $sig) (param i32) (i32.const 0))
                                              ^^^^
-out/test/spec/func.wast:415: assert_malformed passed:
+out/test/spec/func.wast:548: assert_malformed passed:
   out/test/spec/func/func.8.wat:1:64: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (result i32) (param i32) (type $sig) (i32.const 0))
                                              ^^^^^
   out/test/spec/func/func.8.wat:1:85: error: unexpected token ), expected (.
   ... i32) (result i32)))(func (result i32) (param i32) (type $sig) (i32.const 0))
                                                                   ^
-out/test/spec/func.wast:422: assert_malformed passed:
+out/test/spec/func.wast:555: assert_malformed passed:
   out/test/spec/func/func.9.wat:1:21: error: unexpected token "param", expected an instr.
   (func (result i32) (param i32) (i32.const 0))
                       ^^^^^
-out/test/spec/func.wast:429: assert_malformed passed:
+out/test/spec/func.wast:562: assert_malformed passed:
   out/test/spec/func/func.10.wat:1:20: error: expected 0 results, got 1
   (type $sig (func))(func (type $sig) (result i32) (i32.const 0))
                      ^^^^
-out/test/spec/func.wast:436: assert_malformed passed:
+out/test/spec/func.wast:569: assert_malformed passed:
   out/test/spec/func/func.11.wat:1:45: error: expected 1 arguments, got 0
   ...g (func (param i32) (result i32)))(func (type $sig) (result i32) (i32.cons...
                                         ^^^^
-out/test/spec/func.wast:443: assert_malformed passed:
+out/test/spec/func.wast:576: assert_malformed passed:
   out/test/spec/func/func.12.wat:1:45: error: expected 1 results, got 0
   ...g (func (param i32) (result i32)))(func (type $sig) (param i32) (i32.const...
                                         ^^^^
-out/test/spec/func.wast:450: assert_malformed passed:
+out/test/spec/func.wast:583: assert_malformed passed:
   out/test/spec/func/func.13.wat:1:49: error: expected 2 arguments, got 1
   ...unc (param i32 i32) (result i32)))(func (type $sig) (param i32) (result i3...
                                         ^^^^
-out/test/spec/func.wast:461: assert_invalid passed:
+out/test/spec/func.wast:594: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
-out/test/spec/func.wast:465: assert_invalid passed:
+out/test/spec/func.wast:598: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
-out/test/spec/func.wast:469: assert_invalid passed:
+out/test/spec/func.wast:602: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
-out/test/spec/func.wast:477: assert_invalid passed:
+out/test/spec/func.wast:610: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
-out/test/spec/func.wast:481: assert_invalid passed:
+out/test/spec/func.wast:614: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/func.wast:485: assert_invalid passed:
+out/test/spec/func.wast:618: assert_invalid passed:
   error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
-out/test/spec/func.wast:493: assert_invalid passed:
-  error: multiple result values not currently supported.
-  0000010: error: OnFuncType callback failed
-out/test/spec/func.wast:497: assert_invalid passed:
-  error: multiple result values not currently supported.
-  0000010: error: OnFuncType callback failed
-out/test/spec/func.wast:506: assert_invalid passed:
+out/test/spec/func.wast:626: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   0000019: error: EndFunctionBody callback failed
-out/test/spec/func.wast:510: assert_invalid passed:
+out/test/spec/func.wast:630: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   0000019: error: EndFunctionBody callback failed
-out/test/spec/func.wast:514: assert_invalid passed:
+out/test/spec/func.wast:634: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   0000019: error: EndFunctionBody callback failed
-out/test/spec/func.wast:518: assert_invalid passed:
+out/test/spec/func.wast:638: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   0000019: error: EndFunctionBody callback failed
-out/test/spec/func.wast:523: assert_invalid passed:
+out/test/spec/func.wast:642: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64, i32] but got []
+  000001a: error: EndFunctionBody callback failed
+out/test/spec/func.wast:647: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
-out/test/spec/func.wast:529: assert_invalid passed:
+out/test/spec/func.wast:653: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32, i32] but got []
+  000001b: error: EndFunctionBody callback failed
+out/test/spec/func.wast:659: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
-out/test/spec/func.wast:535: assert_invalid passed:
+out/test/spec/func.wast:665: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32, i64]
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/func.wast:671: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [f32]
   000001e: error: EndFunctionBody callback failed
-out/test/spec/func.wast:542: assert_invalid passed:
+out/test/spec/func.wast:677: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32, f32] but got [f32]
+  000001f: error: EndFunctionBody callback failed
+out/test/spec/func.wast:683: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [f32]
+  0000023: error: EndFunctionBody callback failed
+out/test/spec/func.wast:690: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
-out/test/spec/func.wast:548: assert_invalid passed:
+out/test/spec/func.wast:696: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got []
+  000001a: error: OnReturnExpr callback failed
+out/test/spec/func.wast:702: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
-out/test/spec/func.wast:554: assert_invalid passed:
+out/test/spec/func.wast:708: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i64] but got []
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/func.wast:714: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
-out/test/spec/func.wast:561: assert_invalid passed:
+out/test/spec/func.wast:720: assert_invalid passed:
+  error: type mismatch in return, expected [i64, i64] but got [i64]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/func.wast:727: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
-out/test/spec/func.wast:567: assert_invalid passed:
+out/test/spec/func.wast:733: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got []
+  000001a: error: OnReturnExpr callback failed
+out/test/spec/func.wast:739: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got [i32]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/func.wast:745: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
-out/test/spec/func.wast:573: assert_invalid passed:
+out/test/spec/func.wast:751: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got []
+  000001b: error: OnReturnExpr callback failed
+out/test/spec/func.wast:757: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
-out/test/spec/func.wast:579: assert_invalid passed:
+out/test/spec/func.wast:763: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got [i64]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/func.wast:769: assert_invalid passed:
   error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
-out/test/spec/func.wast:586: assert_invalid passed:
+out/test/spec/func.wast:775: assert_invalid passed:
+  error: type mismatch in return, expected [i32, i32] but got [i32]
+  000001c: error: OnReturnExpr callback failed
+out/test/spec/func.wast:782: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
-out/test/spec/func.wast:592: assert_invalid passed:
+out/test/spec/func.wast:788: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/func.wast:794: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [f32]
   000001f: error: OnBrExpr callback failed
-out/test/spec/func.wast:598: assert_invalid passed:
+out/test/spec/func.wast:800: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001d: error: OnBrExpr callback failed
+out/test/spec/func.wast:806: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
-out/test/spec/func.wast:604: assert_invalid passed:
+out/test/spec/func.wast:812: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001b: error: OnBrExpr callback failed
+out/test/spec/func.wast:818: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
-out/test/spec/func.wast:610: assert_invalid passed:
+out/test/spec/func.wast:824: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001d: error: OnBrExpr callback failed
+out/test/spec/func.wast:830: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
-out/test/spec/func.wast:617: assert_invalid passed:
+out/test/spec/func.wast:837: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
-out/test/spec/func.wast:623: assert_invalid passed:
+out/test/spec/func.wast:843: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001d: error: OnBrExpr callback failed
+out/test/spec/func.wast:849: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
-out/test/spec/func.wast:629: assert_invalid passed:
+out/test/spec/func.wast:855: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001e: error: OnBrExpr callback failed
+out/test/spec/func.wast:861: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
-out/test/spec/func.wast:639: assert_malformed passed:
-  out/test/spec/func/func.44.wat:1:14: error: unexpected token "local", expected an instr.
+out/test/spec/func.wast:867: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i32]
+  000001f: error: OnBrExpr callback failed
+out/test/spec/func.wast:877: assert_malformed passed:
+  out/test/spec/func/func.62.wat:1:14: error: unexpected token "local", expected an instr.
   (func (nop) (local i32))
                ^^^^^
-out/test/spec/func.wast:643: assert_malformed passed:
-  out/test/spec/func/func.45.wat:1:14: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:881: assert_malformed passed:
+  out/test/spec/func/func.63.wat:1:14: error: unexpected token "param", expected an instr.
   (func (nop) (param i32))
                ^^^^^
-out/test/spec/func.wast:647: assert_malformed passed:
-  out/test/spec/func/func.46.wat:1:14: error: unexpected token "result", expected an instr.
+out/test/spec/func.wast:885: assert_malformed passed:
+  out/test/spec/func/func.64.wat:1:14: error: unexpected token "result", expected an instr.
   (func (nop) (result i32))
                ^^^^^^
-out/test/spec/func.wast:651: assert_malformed passed:
-  out/test/spec/func/func.47.wat:1:20: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:889: assert_malformed passed:
+  out/test/spec/func/func.65.wat:1:20: error: unexpected token "param", expected an instr.
   (func (local i32) (param i32))
                      ^^^^^
-out/test/spec/func.wast:655: assert_malformed passed:
-  out/test/spec/func/func.48.wat:1:20: error: unexpected token "result", expected an instr.
+out/test/spec/func.wast:893: assert_malformed passed:
+  out/test/spec/func/func.66.wat:1:20: error: unexpected token "result", expected an instr.
   (func (local i32) (result i32) (local.get 0))
                      ^^^^^^
-out/test/spec/func.wast:659: assert_malformed passed:
-  out/test/spec/func/func.49.wat:1:21: error: unexpected token "param", expected an instr.
+out/test/spec/func.wast:897: assert_malformed passed:
+  out/test/spec/func/func.67.wat:1:21: error: unexpected token "param", expected an instr.
   (func (result i32) (param i32) (local.get 0))
                       ^^^^^
-out/test/spec/func.wast:665: assert_malformed passed:
-  out/test/spec/func/func.50.wat:1:13: error: redefinition of function "$foo"
+out/test/spec/func.wast:903: assert_malformed passed:
+  out/test/spec/func/func.68.wat:1:13: error: redefinition of function "$foo"
   (func $foo)(func $foo)
               ^^^^
-out/test/spec/func.wast:669: assert_malformed passed:
-  out/test/spec/func/func.51.wat:1:28: error: redefinition of function "$foo"
+out/test/spec/func.wast:907: assert_malformed passed:
+  out/test/spec/func/func.69.wat:1:28: error: redefinition of function "$foo"
   (import "" "" (func $foo))(func $foo)
                              ^^^^
-out/test/spec/func.wast:673: assert_malformed passed:
-  out/test/spec/func/func.52.wat:1:28: error: redefinition of function "$foo"
+out/test/spec/func.wast:911: assert_malformed passed:
+  out/test/spec/func/func.70.wat:1:28: error: redefinition of function "$foo"
   (import "" "" (func $foo))(import "" "" (func $foo))
                              ^^^^^^
-out/test/spec/func.wast:678: assert_malformed passed:
-  out/test/spec/func/func.53.wat:1:31: error: redefinition of parameter "$foo"
+out/test/spec/func.wast:916: assert_malformed passed:
+  out/test/spec/func/func.71.wat:1:31: error: redefinition of parameter "$foo"
   (func (param $foo i32) (param $foo i32))
                                 ^^^^
-out/test/spec/func.wast:680: assert_malformed passed:
-  out/test/spec/func/func.54.wat:1:31: error: redefinition of parameter "$foo"
+out/test/spec/func.wast:918: assert_malformed passed:
+  out/test/spec/func/func.72.wat:1:31: error: redefinition of parameter "$foo"
   (func (param $foo i32) (local $foo i32))
                                 ^^^^
-out/test/spec/func.wast:682: assert_malformed passed:
-  out/test/spec/func/func.55.wat:1:31: error: redefinition of local "$foo"
+out/test/spec/func.wast:920: assert_malformed passed:
+  out/test/spec/func/func.73.wat:1:31: error: redefinition of local "$foo"
   (func (local $foo i32) (local $foo i32))
                                 ^^^^
-126/126 tests passed.
+164/164 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/i32.txt
+++ b/test/spec/i32.txt
@@ -1,82 +1,76 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i32.wast
 (;; STDOUT ;;;
-out/test/spec/i32.wast:62: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:63: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:64: assert_trap passed: integer overflow
+out/test/spec/i32.wast:64: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:65: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:83: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:84: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:100: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:101: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:121: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:122: assert_trap passed: integer divide by zero
-out/test/spec/i32.wast:426: assert_invalid passed:
+out/test/spec/i32.wast:66: assert_trap passed: integer overflow
+out/test/spec/i32.wast:67: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:85: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:86: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:102: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:103: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:123: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:124: assert_trap passed: integer divide by zero
+out/test/spec/i32.wast:444: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:434: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
-  000001c: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:443: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
-  000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:452: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001e: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:461: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000021: error: OnConvertExpr callback failed
+  000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:470: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001c: error: OnConvertExpr callback failed
+  000001e: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:479: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001c: error: OnConvertExpr callback failed
+  0000021: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:488: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:497: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000018: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:505: assert_invalid passed:
+  000001c: error: OnConvertExpr callback failed
+out/test/spec/i32.wast:506: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got []
+  000001c: error: OnConvertExpr callback failed
+out/test/spec/i32.wast:515: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:513: assert_invalid passed:
+out/test/spec/i32.wast:523: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got []
+  0000018: error: OnConvertExpr callback failed
+out/test/spec/i32.wast:531: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:522: assert_invalid passed:
+out/test/spec/i32.wast:540: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   0000035: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:538: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
-  000001a: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:547: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
-  000001a: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:556: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  0000020: error: OnConvertExpr callback failed
+  000001a: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:565: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001d: error: OnConvertExpr callback failed
+  000001a: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:574: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
-  000001d: error: OnConvertExpr callback failed
+  0000020: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:583: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:593: assert_invalid passed:
+out/test/spec/i32.wast:592: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got []
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/i32.wast:601: assert_invalid passed:
+  error: type mismatch in i32.eqz, expected [i32] but got []
+  000001d: error: OnConvertExpr callback failed
+out/test/spec/i32.wast:611: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:601: assert_invalid passed:
+out/test/spec/i32.wast:619: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:609: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:618: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:627: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
@@ -84,23 +78,23 @@ out/test/spec/i32.wast:636: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:645: assert_invalid passed:
-  error: type mismatch in drop, expected [any] but got []
-  0000021: error: OnDropExpr callback failed
-out/test/spec/i32.wast:654: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:663: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000023: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:673: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000021: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:683: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:692: assert_invalid passed:
+out/test/spec/i32.wast:654: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:663: assert_invalid passed:
+  error: type mismatch in drop, expected [any] but got []
+  0000021: error: OnDropExpr callback failed
+out/test/spec/i32.wast:672: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000020: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:681: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000023: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:691: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  0000021: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:701: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
@@ -115,34 +109,34 @@ out/test/spec/i32.wast:728: assert_invalid passed:
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:737: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000018: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:745: assert_invalid passed:
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:746: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:753: assert_invalid passed:
+  000001e: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:755: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:761: assert_invalid passed:
+out/test/spec/i32.wast:763: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:769: assert_invalid passed:
+out/test/spec/i32.wast:771: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
-  000001f: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:778: assert_invalid passed:
+  0000018: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:779: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  0000021: error: OnBinaryExpr callback failed
+  000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:787: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:796: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  0000021: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:805: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
   0000035: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:803: assert_invalid passed:
+out/test/spec/i32.wast:821: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000037: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:819: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
-  000001a: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:828: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  000001c: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:837: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001a: error: OnBinaryExpr callback failed
@@ -151,16 +145,16 @@ out/test/spec/i32.wast:846: assert_invalid passed:
   000001c: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:855: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
-  0000020: error: OnBinaryExpr callback failed
+  000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:864: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  0000022: error: OnBinaryExpr callback failed
+  000001c: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:873: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
-  000001d: error: OnBinaryExpr callback failed
+  0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:882: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
-  000001f: error: OnBinaryExpr callback failed
+  0000022: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:891: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
@@ -173,92 +167,98 @@ out/test/spec/i32.wast:909: assert_invalid passed:
 out/test/spec/i32.wast:918: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:930: assert_invalid passed:
+out/test/spec/i32.wast:927: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got []
+  000001d: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:936: assert_invalid passed:
+  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  000001f: error: OnBinaryExpr callback failed
+out/test/spec/i32.wast:948: assert_invalid passed:
   error: type mismatch in i32.add, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:931: assert_invalid passed:
+out/test/spec/i32.wast:949: assert_invalid passed:
   error: type mismatch in i32.and, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:932: assert_invalid passed:
+out/test/spec/i32.wast:950: assert_invalid passed:
   error: type mismatch in i32.div_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:933: assert_invalid passed:
+out/test/spec/i32.wast:951: assert_invalid passed:
   error: type mismatch in i32.div_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:934: assert_invalid passed:
+out/test/spec/i32.wast:952: assert_invalid passed:
   error: type mismatch in i32.mul, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:935: assert_invalid passed:
+out/test/spec/i32.wast:953: assert_invalid passed:
   error: type mismatch in i32.or, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:936: assert_invalid passed:
+out/test/spec/i32.wast:954: assert_invalid passed:
   error: type mismatch in i32.rem_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:937: assert_invalid passed:
+out/test/spec/i32.wast:955: assert_invalid passed:
   error: type mismatch in i32.rem_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:938: assert_invalid passed:
+out/test/spec/i32.wast:956: assert_invalid passed:
   error: type mismatch in i32.rotl, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:939: assert_invalid passed:
+out/test/spec/i32.wast:957: assert_invalid passed:
   error: type mismatch in i32.rotr, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:940: assert_invalid passed:
+out/test/spec/i32.wast:958: assert_invalid passed:
   error: type mismatch in i32.shl, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:941: assert_invalid passed:
+out/test/spec/i32.wast:959: assert_invalid passed:
   error: type mismatch in i32.shr_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:942: assert_invalid passed:
+out/test/spec/i32.wast:960: assert_invalid passed:
   error: type mismatch in i32.shr_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:943: assert_invalid passed:
+out/test/spec/i32.wast:961: assert_invalid passed:
   error: type mismatch in i32.sub, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:944: assert_invalid passed:
+out/test/spec/i32.wast:962: assert_invalid passed:
   error: type mismatch in i32.xor, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i32.wast:945: assert_invalid passed:
+out/test/spec/i32.wast:963: assert_invalid passed:
   error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/i32.wast:946: assert_invalid passed:
+out/test/spec/i32.wast:964: assert_invalid passed:
   error: type mismatch in i32.clz, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i32.wast:947: assert_invalid passed:
+out/test/spec/i32.wast:965: assert_invalid passed:
   error: type mismatch in i32.ctz, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i32.wast:948: assert_invalid passed:
+out/test/spec/i32.wast:966: assert_invalid passed:
   error: type mismatch in i32.popcnt, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i32.wast:949: assert_invalid passed:
+out/test/spec/i32.wast:967: assert_invalid passed:
   error: type mismatch in i32.eq, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:950: assert_invalid passed:
+out/test/spec/i32.wast:968: assert_invalid passed:
   error: type mismatch in i32.ge_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:951: assert_invalid passed:
+out/test/spec/i32.wast:969: assert_invalid passed:
   error: type mismatch in i32.ge_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:952: assert_invalid passed:
+out/test/spec/i32.wast:970: assert_invalid passed:
   error: type mismatch in i32.gt_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:953: assert_invalid passed:
+out/test/spec/i32.wast:971: assert_invalid passed:
   error: type mismatch in i32.gt_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:954: assert_invalid passed:
+out/test/spec/i32.wast:972: assert_invalid passed:
   error: type mismatch in i32.le_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:955: assert_invalid passed:
+out/test/spec/i32.wast:973: assert_invalid passed:
   error: type mismatch in i32.le_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:956: assert_invalid passed:
+out/test/spec/i32.wast:974: assert_invalid passed:
   error: type mismatch in i32.lt_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:957: assert_invalid passed:
+out/test/spec/i32.wast:975: assert_invalid passed:
   error: type mismatch in i32.lt_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i32.wast:958: assert_invalid passed:
+out/test/spec/i32.wast:976: assert_invalid passed:
   error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
-443/443 tests passed.
+457/457 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/i64.txt
+++ b/test/spec/i64.txt
@@ -1,102 +1,102 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/i64.wast
 (;; STDOUT ;;;
-out/test/spec/i64.wast:62: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:63: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:64: assert_trap passed: integer overflow
 out/test/spec/i64.wast:65: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:83: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:84: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:100: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:101: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:121: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:122: assert_trap passed: integer divide by zero
-out/test/spec/i64.wast:427: assert_invalid passed:
+out/test/spec/i64.wast:66: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:67: assert_trap passed: integer overflow
+out/test/spec/i64.wast:68: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:86: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:87: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:103: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:104: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:124: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:125: assert_trap passed: integer divide by zero
+out/test/spec/i64.wast:457: assert_invalid passed:
   error: type mismatch in i64.add, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:428: assert_invalid passed:
+out/test/spec/i64.wast:458: assert_invalid passed:
   error: type mismatch in i64.and, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:429: assert_invalid passed:
+out/test/spec/i64.wast:459: assert_invalid passed:
   error: type mismatch in i64.div_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:430: assert_invalid passed:
+out/test/spec/i64.wast:460: assert_invalid passed:
   error: type mismatch in i64.div_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:431: assert_invalid passed:
+out/test/spec/i64.wast:461: assert_invalid passed:
   error: type mismatch in i64.mul, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:432: assert_invalid passed:
+out/test/spec/i64.wast:462: assert_invalid passed:
   error: type mismatch in i64.or, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:433: assert_invalid passed:
+out/test/spec/i64.wast:463: assert_invalid passed:
   error: type mismatch in i64.rem_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:434: assert_invalid passed:
+out/test/spec/i64.wast:464: assert_invalid passed:
   error: type mismatch in i64.rem_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:435: assert_invalid passed:
+out/test/spec/i64.wast:465: assert_invalid passed:
   error: type mismatch in i64.rotl, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:436: assert_invalid passed:
+out/test/spec/i64.wast:466: assert_invalid passed:
   error: type mismatch in i64.rotr, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:437: assert_invalid passed:
+out/test/spec/i64.wast:467: assert_invalid passed:
   error: type mismatch in i64.shl, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:438: assert_invalid passed:
+out/test/spec/i64.wast:468: assert_invalid passed:
   error: type mismatch in i64.shr_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:439: assert_invalid passed:
+out/test/spec/i64.wast:469: assert_invalid passed:
   error: type mismatch in i64.shr_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:440: assert_invalid passed:
+out/test/spec/i64.wast:470: assert_invalid passed:
   error: type mismatch in i64.sub, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:441: assert_invalid passed:
+out/test/spec/i64.wast:471: assert_invalid passed:
   error: type mismatch in i64.xor, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
-out/test/spec/i64.wast:442: assert_invalid passed:
+out/test/spec/i64.wast:472: assert_invalid passed:
   error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
-out/test/spec/i64.wast:443: assert_invalid passed:
+out/test/spec/i64.wast:473: assert_invalid passed:
   error: type mismatch in i64.clz, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i64.wast:444: assert_invalid passed:
+out/test/spec/i64.wast:474: assert_invalid passed:
   error: type mismatch in i64.ctz, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i64.wast:445: assert_invalid passed:
+out/test/spec/i64.wast:475: assert_invalid passed:
   error: type mismatch in i64.popcnt, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
-out/test/spec/i64.wast:446: assert_invalid passed:
+out/test/spec/i64.wast:476: assert_invalid passed:
   error: type mismatch in i64.eq, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:447: assert_invalid passed:
+out/test/spec/i64.wast:477: assert_invalid passed:
   error: type mismatch in i64.ge_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:448: assert_invalid passed:
+out/test/spec/i64.wast:478: assert_invalid passed:
   error: type mismatch in i64.ge_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:449: assert_invalid passed:
+out/test/spec/i64.wast:479: assert_invalid passed:
   error: type mismatch in i64.gt_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:450: assert_invalid passed:
+out/test/spec/i64.wast:480: assert_invalid passed:
   error: type mismatch in i64.gt_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:451: assert_invalid passed:
+out/test/spec/i64.wast:481: assert_invalid passed:
   error: type mismatch in i64.le_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:452: assert_invalid passed:
+out/test/spec/i64.wast:482: assert_invalid passed:
   error: type mismatch in i64.le_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:453: assert_invalid passed:
+out/test/spec/i64.wast:483: assert_invalid passed:
   error: type mismatch in i64.lt_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:454: assert_invalid passed:
+out/test/spec/i64.wast:484: assert_invalid passed:
   error: type mismatch in i64.lt_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-out/test/spec/i64.wast:455: assert_invalid passed:
+out/test/spec/i64.wast:485: assert_invalid passed:
   error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
-389/389 tests passed.
+413/413 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -1,211 +1,404 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/if.wast
 (;; STDOUT ;;;
-out/test/spec/if.wast:440: assert_trap passed: undefined table index
-out/test/spec/if.wast:499: assert_invalid passed:
+out/test/spec/if.wast:585: assert_trap passed: undefined table index
+out/test/spec/if.wast:726: assert_malformed passed:
+  out/test/spec/if/if.1.wat:1:95: error: unexpected token "param", expected then block (e.g. (then ...)).
+  ...i32.const 0)  (if (type $sig) (result i32) (param i32) (i32.const 1) (then)))
+                                                 ^^^^^
+  out/test/spec/if/if.1.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (type $sig) (result i32) (param i32) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/if.wast:735: assert_malformed passed:
+  out/test/spec/if/if.2.wat:1:82: error: unexpected token "type", expected then block (e.g. (then ...)).
+  ...nc (i32.const 0)  (if (param i32) (type $sig) (result i32) (i32.const 1) (...
+                                        ^^^^
+  out/test/spec/if/if.2.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (param i32) (type $sig) (result i32) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/if.wast:744: assert_malformed passed:
+  out/test/spec/if/if.3.wat:1:95: error: unexpected token "type", expected then block (e.g. (then ...)).
+  ...i32.const 0)  (if (param i32) (result i32) (type $sig) (i32.const 1) (then)))
+                                                 ^^^^
+  out/test/spec/if/if.3.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (param i32) (result i32) (type $sig) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/if.wast:753: assert_malformed passed:
+  out/test/spec/if/if.4.wat:1:83: error: unexpected token "type", expected then block (e.g. (then ...)).
+  ...c (i32.const 0)  (if (result i32) (type $sig) (param i32) (i32.const 1) (t...
+                                        ^^^^
+  out/test/spec/if/if.4.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (result i32) (type $sig) (param i32) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/if.wast:762: assert_malformed passed:
+  out/test/spec/if/if.5.wat:1:83: error: unexpected token "param", expected then block (e.g. (then ...)).
+  ...c (i32.const 0)  (if (result i32) (param i32) (type $sig) (i32.const 1) (t...
+                                        ^^^^^
+  out/test/spec/if/if.5.wat:1:121: error: unexpected token "then", expected an instr.
+  ...i32.const 0)  (if (result i32) (param i32) (type $sig) (i32.const 1) (then)))
+                                                                           ^^^^
+out/test/spec/if.wast:771: assert_malformed passed:
+  out/test/spec/if/if.6.wat:1:39: error: unexpected token "param", expected then block (e.g. (then ...)).
+  (func (i32.const 0) (if (result i32) (param i32) (i32.const 1) (then)))
+                                        ^^^^^
+  out/test/spec/if/if.6.wat:1:65: error: unexpected token "then", expected an instr.
+  (func (i32.const 0) (if (result i32) (param i32) (i32.const 1) (then)))
+                                                                  ^^^^
+out/test/spec/if.wast:778: assert_malformed passed:
+  out/test/spec/if/if.7.wat:1:47: error: unexpected token $x, expected ).
+  ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
+                                             ^^
+  out/test/spec/if/if.7.wat:1:69: error: unexpected token (, expected EOF.
+  ...(i32.const 0) (i32.const 1)  (if (param $x i32) (then (drop)) (else (drop))))
+                                                                   ^
+out/test/spec/if.wast:786: assert_malformed passed:
+  out/test/spec/if/if.8.wat:1:40: error: expected 0 results, got 1
+  (type $sig (func))(func (i32.const 1)  (if (type $sig) (result i32) (then (i3...
+                                         ^
+out/test/spec/if.wast:796: assert_malformed passed:
+  out/test/spec/if/if.9.wat:1:65: error: expected 1 arguments, got 0
+  ...) (result i32)))(func (i32.const 1)  (if (type $sig) (result i32) (then (i...
+                                          ^
+out/test/spec/if.wast:806: assert_malformed passed:
+  out/test/spec/if/if.10.wat:1:79: error: expected 1 results, got 0
+  ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (then (dr...
+                                          ^
+out/test/spec/if.wast:816: assert_malformed passed:
+  out/test/spec/if/if.11.wat:1:83: error: expected 2 arguments, got 1
+  ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (result i...
+                                          ^
+out/test/spec/if.wast:826: assert_invalid passed:
+  error: type mismatch in function, expected [] but got [i32]
+  000001f: error: EndFunctionBody callback failed
+out/test/spec/if.wast:834: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:503: assert_invalid passed:
+out/test/spec/if.wast:838: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:507: assert_invalid passed:
+out/test/spec/if.wast:842: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:511: assert_invalid passed:
+out/test/spec/if.wast:846: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:516: assert_invalid passed:
+out/test/spec/if.wast:851: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:520: assert_invalid passed:
+out/test/spec/if.wast:855: assert_invalid passed:
   error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:524: assert_invalid passed:
+out/test/spec/if.wast:859: assert_invalid passed:
   error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:528: assert_invalid passed:
+out/test/spec/if.wast:863: assert_invalid passed:
   error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
-out/test/spec/if.wast:533: assert_invalid passed:
+out/test/spec/if.wast:868: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/if.wast:539: assert_invalid passed:
+out/test/spec/if.wast:874: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
-out/test/spec/if.wast:545: assert_invalid passed:
+out/test/spec/if.wast:880: assert_invalid passed:
   error: type mismatch in if false branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
-out/test/spec/if.wast:551: assert_invalid passed:
+out/test/spec/if.wast:886: assert_invalid passed:
   error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
-out/test/spec/if.wast:558: assert_invalid passed:
+out/test/spec/if.wast:893: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/if.wast:899: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/if.wast:905: assert_invalid passed:
+  error: type mismatch in if false branch, expected [] but got [i32, i32]
+  0000021: error: OnEndExpr callback failed
+out/test/spec/if.wast:911: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  0000020: error: OnElseExpr callback failed
+out/test/spec/if.wast:918: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
-out/test/spec/if.wast:564: assert_invalid passed:
+out/test/spec/if.wast:924: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
-out/test/spec/if.wast:570: assert_invalid passed:
+out/test/spec/if.wast:930: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
-out/test/spec/if.wast:576: assert_invalid passed:
+out/test/spec/if.wast:937: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001e: error: OnElseExpr callback failed
+out/test/spec/if.wast:943: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got []
+  0000022: error: OnEndExpr callback failed
+out/test/spec/if.wast:949: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001e: error: OnEndExpr callback failed
+out/test/spec/if.wast:956: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
-out/test/spec/if.wast:583: assert_invalid passed:
+out/test/spec/if.wast:962: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got []
+  0000022: error: OnEndExpr callback failed
+out/test/spec/if.wast:969: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/if.wast:589: assert_invalid passed:
+out/test/spec/if.wast:975: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
-out/test/spec/if.wast:595: assert_invalid passed:
+out/test/spec/if.wast:981: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
-out/test/spec/if.wast:602: assert_invalid passed:
+out/test/spec/if.wast:988: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001f: error: OnElseExpr callback failed
+out/test/spec/if.wast:994: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got []
+  0000024: error: OnEndExpr callback failed
+out/test/spec/if.wast:1000: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got []
+  000001f: error: OnElseExpr callback failed
+out/test/spec/if.wast:1007: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/if.wast:608: assert_invalid passed:
+out/test/spec/if.wast:1013: assert_invalid passed:
   error: type mismatch in if false branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
-out/test/spec/if.wast:614: assert_invalid passed:
+out/test/spec/if.wast:1019: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/if.wast:620: assert_invalid passed:
+out/test/spec/if.wast:1026: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000020: error: OnElseExpr callback failed
+out/test/spec/if.wast:1032: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  0000025: error: OnEndExpr callback failed
+out/test/spec/if.wast:1038: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000020: error: OnElseExpr callback failed
+out/test/spec/if.wast:1045: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000022: error: OnElseExpr callback failed
+out/test/spec/if.wast:1052: assert_invalid passed:
+  error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  0000027: error: OnEndExpr callback failed
+out/test/spec/if.wast:1059: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000022: error: OnElseExpr callback failed
+out/test/spec/if.wast:1067: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  0000021: error: OnElseExpr callback failed
+out/test/spec/if.wast:1073: assert_invalid passed:
+  error: type mismatch in if false branch, expected [] but got [i32]
+  0000024: error: OnEndExpr callback failed
+out/test/spec/if.wast:1079: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  0000021: error: OnElseExpr callback failed
+out/test/spec/if.wast:1086: assert_invalid passed:
   error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
-out/test/spec/if.wast:627: assert_invalid passed:
+out/test/spec/if.wast:1092: assert_invalid passed:
+  error: type mismatch in if true branch, expected [] but got [i32]
+  0000024: error: OnElseExpr callback failed
+out/test/spec/if.wast:1099: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/if.wast:637: assert_invalid passed:
+out/test/spec/if.wast:1109: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
-out/test/spec/if.wast:647: assert_invalid passed:
+out/test/spec/if.wast:1119: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
-out/test/spec/if.wast:658: assert_invalid passed:
+out/test/spec/if.wast:1130: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/if.wast:664: assert_invalid passed:
+out/test/spec/if.wast:1136: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/test/spec/if.wast:670: assert_invalid passed:
+out/test/spec/if.wast:1142: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/if.wast:1148: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000024: error: OnBrExpr callback failed
+out/test/spec/if.wast:1155: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
-out/test/spec/if.wast:679: assert_invalid passed:
+out/test/spec/if.wast:1164: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
-out/test/spec/if.wast:688: assert_invalid passed:
+out/test/spec/if.wast:1173: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  000001f: error: OnBrExpr callback failed
+out/test/spec/if.wast:1182: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000024: error: OnBrExpr callback failed
+out/test/spec/if.wast:1192: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
-out/test/spec/if.wast:697: assert_invalid passed:
+out/test/spec/if.wast:1201: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
-out/test/spec/if.wast:707: assert_invalid passed:
+out/test/spec/if.wast:1210: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000020: error: OnBrExpr callback failed
+out/test/spec/if.wast:1219: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got []
+  0000025: error: OnBrExpr callback failed
+out/test/spec/if.wast:1229: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
-out/test/spec/if.wast:716: assert_invalid passed:
+out/test/spec/if.wast:1238: assert_invalid passed:
   error: type mismatch in br, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
-out/test/spec/if.wast:726: assert_invalid passed:
+out/test/spec/if.wast:1247: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i64]
+  0000021: error: OnBrExpr callback failed
+out/test/spec/if.wast:1256: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i64]
+  0000026: error: OnBrExpr callback failed
+out/test/spec/if.wast:1265: assert_invalid passed:
+  error: type mismatch in br, expected [i32, i32] but got [i64]
+  0000023: error: OnBrExpr callback failed
+out/test/spec/if.wast:1275: assert_invalid passed:
+  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  0000022: error: OnElseExpr callback failed
+out/test/spec/if.wast:1286: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
-out/test/spec/if.wast:734: assert_invalid passed:
+out/test/spec/if.wast:1294: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/test/spec/if.wast:743: assert_invalid passed:
+out/test/spec/if.wast:1303: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/test/spec/if.wast:752: assert_invalid passed:
+out/test/spec/if.wast:1312: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
-out/test/spec/if.wast:761: assert_invalid passed:
+out/test/spec/if.wast:1321: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000022: error: OnIfExpr callback failed
-out/test/spec/if.wast:771: assert_invalid passed:
+out/test/spec/if.wast:1331: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/test/spec/if.wast:780: assert_invalid passed:
+out/test/spec/if.wast:1340: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/test/spec/if.wast:789: assert_invalid passed:
+out/test/spec/if.wast:1349: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
-out/test/spec/if.wast:798: assert_invalid passed:
+out/test/spec/if.wast:1358: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
-out/test/spec/if.wast:806: assert_invalid passed:
+out/test/spec/if.wast:1366: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
-out/test/spec/if.wast:814: assert_invalid passed:
+out/test/spec/if.wast:1374: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
-out/test/spec/if.wast:823: assert_invalid passed:
+out/test/spec/if.wast:1383: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000036: error: OnIfExpr callback failed
-out/test/spec/if.wast:839: assert_invalid passed:
+out/test/spec/if.wast:1399: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001b: error: OnIfExpr callback failed
-out/test/spec/if.wast:848: assert_invalid passed:
+out/test/spec/if.wast:1408: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001b: error: OnIfExpr callback failed
-out/test/spec/if.wast:857: assert_invalid passed:
+out/test/spec/if.wast:1417: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   0000021: error: OnIfExpr callback failed
-out/test/spec/if.wast:866: assert_invalid passed:
+out/test/spec/if.wast:1426: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
-out/test/spec/if.wast:875: assert_invalid passed:
+out/test/spec/if.wast:1435: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
-out/test/spec/if.wast:884: assert_invalid passed:
+out/test/spec/if.wast:1444: assert_invalid passed:
   error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
-out/test/spec/if.wast:895: assert_malformed passed:
-  out/test/spec/if/if.53.wat:1:26: error: unexpected label "$l"
+out/test/spec/if.wast:1454: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  000001f: error: OnIfExpr callback failed
+out/test/spec/if.wast:1460: assert_invalid passed:
+  error: type mismatch in if, expected [i32, f64] but got []
+  0000020: error: OnIfExpr callback failed
+out/test/spec/if.wast:1466: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got [f32]
+  0000024: error: OnIfExpr callback failed
+out/test/spec/if.wast:1472: assert_invalid passed:
+  error: type mismatch in if, expected [f32, i32] but got [f32]
+  0000025: error: OnIfExpr callback failed
+out/test/spec/if.wast:1478: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got []
+  0000021: error: OnIfExpr callback failed
+out/test/spec/if.wast:1484: assert_invalid passed:
+  error: type mismatch in if, expected [i32, f64] but got []
+  0000022: error: OnIfExpr callback failed
+out/test/spec/if.wast:1490: assert_invalid passed:
+  error: type mismatch in if, expected [i32] but got [f32]
+  0000026: error: OnIfExpr callback failed
+out/test/spec/if.wast:1496: assert_invalid passed:
+  error: type mismatch in if, expected [f32, i32] but got [f32]
+  0000027: error: OnIfExpr callback failed
+out/test/spec/if.wast:1503: assert_malformed passed:
+  out/test/spec/if/if.104.wat:1:42: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) if (param $x i32) end)
+                                           ^^
+out/test/spec/if.wast:1507: assert_malformed passed:
+  out/test/spec/if/if.105.wat:1:43: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) (if (param $x i32) (then)))
+                                            ^^
+out/test/spec/if.wast:1512: assert_malformed passed:
+  out/test/spec/if/if.106.wat:1:26: error: unexpected label "$l"
   (func i32.const 0 if end $l)
                            ^^
-out/test/spec/if.wast:899: assert_malformed passed:
-  out/test/spec/if/if.54.wat:1:29: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:1516: assert_malformed passed:
+  out/test/spec/if/if.107.wat:1:29: error: mismatching label "$a" != "$l"
   (func i32.const 0 if $a end $l)
                               ^^
-out/test/spec/if.wast:903: assert_malformed passed:
-  out/test/spec/if/if.55.wat:1:27: error: unexpected label "$l"
+out/test/spec/if.wast:1520: assert_malformed passed:
+  out/test/spec/if/if.108.wat:1:27: error: unexpected label "$l"
   (func i32.const 0 if else $l end)
                             ^^
-out/test/spec/if.wast:907: assert_malformed passed:
-  out/test/spec/if/if.56.wat:1:30: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:1524: assert_malformed passed:
+  out/test/spec/if/if.109.wat:1:30: error: mismatching label "$a" != "$l"
   (func i32.const 0 if $a else $l end)
                                ^^
-out/test/spec/if.wast:911: assert_malformed passed:
-  out/test/spec/if/if.57.wat:1:31: error: unexpected label "$l"
+out/test/spec/if.wast:1528: assert_malformed passed:
+  out/test/spec/if/if.110.wat:1:31: error: unexpected label "$l"
   (func i32.const 0 if else end $l)
                                 ^^
-out/test/spec/if.wast:915: assert_malformed passed:
-  out/test/spec/if/if.58.wat:1:27: error: unexpected label "$l"
+out/test/spec/if.wast:1532: assert_malformed passed:
+  out/test/spec/if/if.111.wat:1:27: error: unexpected label "$l"
   (func i32.const 0 if else $l end $l)
                             ^^
-  out/test/spec/if/if.58.wat:1:34: error: unexpected label "$l"
+  out/test/spec/if/if.111.wat:1:34: error: unexpected label "$l"
   (func i32.const 0 if else $l end $l)
                                    ^^
-out/test/spec/if.wast:919: assert_malformed passed:
-  out/test/spec/if/if.59.wat:1:27: error: unexpected label "$l1"
+out/test/spec/if.wast:1536: assert_malformed passed:
+  out/test/spec/if/if.112.wat:1:27: error: unexpected label "$l1"
   (func i32.const 0 if else $l1 end $l2)
                             ^^^
-  out/test/spec/if/if.59.wat:1:35: error: unexpected label "$l2"
+  out/test/spec/if/if.112.wat:1:35: error: unexpected label "$l2"
   (func i32.const 0 if else $l1 end $l2)
                                     ^^^
-out/test/spec/if.wast:923: assert_malformed passed:
-  out/test/spec/if/if.60.wat:1:34: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:1540: assert_malformed passed:
+  out/test/spec/if/if.113.wat:1:34: error: mismatching label "$a" != "$l"
   (func i32.const 0 if $a else end $l)
                                    ^^
-out/test/spec/if.wast:927: assert_malformed passed:
-  out/test/spec/if/if.61.wat:1:37: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:1544: assert_malformed passed:
+  out/test/spec/if/if.114.wat:1:37: error: mismatching label "$a" != "$l"
   (func i32.const 0 if $a else $a end $l)
                                       ^^
-out/test/spec/if.wast:931: assert_malformed passed:
-  out/test/spec/if/if.62.wat:1:30: error: mismatching label "$a" != "$l"
+out/test/spec/if.wast:1548: assert_malformed passed:
+  out/test/spec/if/if.115.wat:1:30: error: mismatching label "$a" != "$l"
   (func i32.const 0 if $a else $l end $l)
                                ^^
-  out/test/spec/if/if.62.wat:1:37: error: mismatching label "$a" != "$l"
+  out/test/spec/if/if.115.wat:1:37: error: mismatching label "$a" != "$l"
   (func i32.const 0 if $a else $l end $l)
                                       ^^
-150/150 tests passed.
+238/238 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -1,49 +1,149 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/loop.wast
 (;; STDOUT ;;;
-out/test/spec/loop.wast:386: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:390: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:394: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:398: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
-  000001c: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:403: assert_invalid passed:
+out/test/spec/loop.wast:526: assert_malformed passed:
+  out/test/spec/loop/loop.1.wat:1:95: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (type $sig) (result i32) (param i32)))
+                                                                     ^
+out/test/spec/loop.wast:533: assert_malformed passed:
+  out/test/spec/loop/loop.2.wat:1:82: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (param i32) (type $sig) (result i32)))
+                                                        ^
+out/test/spec/loop.wast:540: assert_malformed passed:
+  out/test/spec/loop/loop.3.wat:1:95: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (param i32) (result i32) (type $sig)))
+                                                                     ^
+out/test/spec/loop.wast:547: assert_malformed passed:
+  out/test/spec/loop/loop.4.wat:1:83: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (result i32) (type $sig) (param i32)))
+                                                         ^
+out/test/spec/loop.wast:554: assert_malformed passed:
+  out/test/spec/loop/loop.5.wat:1:83: error: unexpected token (, expected ).
+  ...result i32)))(func (i32.const 0) (loop (result i32) (param i32) (type $sig)))
+                                                         ^
+out/test/spec/loop.wast:561: assert_malformed passed:
+  out/test/spec/loop/loop.6.wat:1:40: error: unexpected token (, expected ).
+  (func (i32.const 0) (loop (result i32) (param i32)))
+                                         ^
+out/test/spec/loop.wast:568: assert_malformed passed:
+  out/test/spec/loop/loop.7.wat:1:34: error: unexpected token $x, expected ).
+  (func (i32.const 0) (loop (param $x i32) (drop)))
+                                   ^^
+  out/test/spec/loop/loop.7.wat:1:49: error: unexpected token ), expected EOF.
+  (func (i32.const 0) (loop (param $x i32) (drop)))
+                                                  ^
+out/test/spec/loop.wast:572: assert_malformed passed:
+  out/test/spec/loop/loop.8.wat:1:25: error: expected 0 results, got 1
+  (type $sig (func))(func (loop (type $sig) (result i32) (i32.const 0)) (unreac...
+                          ^
+out/test/spec/loop.wast:579: assert_malformed passed:
+  out/test/spec/loop/loop.9.wat:1:50: error: expected 1 arguments, got 0
+  ...func (param i32) (result i32)))(func (loop (type $sig) (result i32) (i32.c...
+                                          ^
+out/test/spec/loop.wast:586: assert_malformed passed:
+  out/test/spec/loop/loop.10.wat:1:64: error: expected 1 results, got 0
+  ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (drop))...
+                                          ^
+out/test/spec/loop.wast:593: assert_malformed passed:
+  out/test/spec/loop/loop.11.wat:1:68: error: expected 2 arguments, got 1
+  ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (result...
+                                          ^
+out/test/spec/loop.wast:601: assert_invalid passed:
   error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
-out/test/spec/loop.wast:409: assert_invalid passed:
+out/test/spec/loop.wast:609: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/loop.wast:613: assert_invalid passed:
+  error: type mismatch in implicit return, expected [i64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/loop.wast:617: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f32] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/loop.wast:621: assert_invalid passed:
+  error: type mismatch in implicit return, expected [f64] but got []
+  000001c: error: EndFunctionBody callback failed
+out/test/spec/loop.wast:626: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32]
+  000001c: error: OnEndExpr callback failed
+out/test/spec/loop.wast:632: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32, i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/loop.wast:638: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
-out/test/spec/loop.wast:415: assert_invalid passed:
+out/test/spec/loop.wast:644: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got []
+  000001c: error: OnEndExpr callback failed
+out/test/spec/loop.wast:650: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
-out/test/spec/loop.wast:421: assert_invalid passed:
+out/test/spec/loop.wast:656: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got []
+  000001d: error: OnEndExpr callback failed
+out/test/spec/loop.wast:662: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
-out/test/spec/loop.wast:427: assert_invalid passed:
+out/test/spec/loop.wast:668: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got [i32]
+  000001e: error: OnEndExpr callback failed
+out/test/spec/loop.wast:674: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, i32] but got [i32]
+  0000020: error: OnEndExpr callback failed
+out/test/spec/loop.wast:680: assert_invalid passed:
+  error: type mismatch in loop, expected [] but got [i32]
+  000001f: error: OnEndExpr callback failed
+out/test/spec/loop.wast:686: assert_invalid passed:
   error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
-out/test/spec/loop.wast:434: assert_invalid passed:
+out/test/spec/loop.wast:693: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
-out/test/spec/loop.wast:443: assert_invalid passed:
+out/test/spec/loop.wast:702: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
-out/test/spec/loop.wast:452: assert_invalid passed:
+out/test/spec/loop.wast:711: assert_invalid passed:
   error: type mismatch in loop, expected [i32] but got []
   0000020: error: OnEndExpr callback failed
-out/test/spec/loop.wast:463: assert_malformed passed:
-  out/test/spec/loop/loop.13.wat:1:16: error: unexpected label "$l"
+out/test/spec/loop.wast:721: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001d: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:727: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, f64] but got []
+  000001e: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:733: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got [f32]
+  0000022: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:739: assert_invalid passed:
+  error: type mismatch in loop, expected [f32, i32] but got [f32]
+  0000023: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:745: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got []
+  000001f: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:751: assert_invalid passed:
+  error: type mismatch in loop, expected [i32, f64] but got []
+  0000020: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:757: assert_invalid passed:
+  error: type mismatch in loop, expected [i32] but got [f32]
+  0000024: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:763: assert_invalid passed:
+  error: type mismatch in loop, expected [f32, i32] but got [f32]
+  0000025: error: OnLoopExpr callback failed
+out/test/spec/loop.wast:770: assert_malformed passed:
+  out/test/spec/loop/loop.39.wat:1:44: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) loop (param $x i32) end)
+                                             ^^
+out/test/spec/loop.wast:774: assert_malformed passed:
+  out/test/spec/loop/loop.40.wat:1:45: error: unexpected token $x, expected ).
+  (func (param i32) (result i32) (loop (param $x i32)))
+                                              ^^
+out/test/spec/loop.wast:779: assert_malformed passed:
+  out/test/spec/loop/loop.41.wat:1:16: error: unexpected label "$l"
   (func loop end $l)
                  ^^
-out/test/spec/loop.wast:467: assert_malformed passed:
-  out/test/spec/loop/loop.14.wat:1:19: error: mismatching label "$a" != "$l"
+out/test/spec/loop.wast:783: assert_malformed passed:
+  out/test/spec/loop/loop.42.wat:1:19: error: mismatching label "$a" != "$l"
   (func loop $a end $l)
                     ^^
-80/80 tests passed.
+119/119 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -1,71 +1,86 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/memory.wast
 (;; STDOUT ;;;
-out/test/spec/memory.wast:8: assert_invalid passed:
+out/test/spec/memory.wast:10: assert_invalid passed:
   error: only one memory block allowed
   000000f: error: OnMemory callback failed
-out/test/spec/memory.wast:9: assert_invalid passed:
+out/test/spec/memory.wast:11: assert_invalid passed:
   error: only one memory block allowed
   0000023: error: OnMemory callback failed
-out/test/spec/memory.wast:18: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
-  000000c: error: BeginDataSegment callback failed
-out/test/spec/memory.wast:19: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
-  000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:20: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
-out/test/spec/memory.wast:23: assert_invalid passed:
+out/test/spec/memory.wast:21: assert_invalid passed:
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
+out/test/spec/memory.wast:22: assert_invalid passed:
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
+out/test/spec/memory.wast:25: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   000001c: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:27: assert_invalid passed:
+out/test/spec/memory.wast:29: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   0000021: error: OnStoreExpr callback failed
-out/test/spec/memory.wast:31: assert_invalid passed:
+out/test/spec/memory.wast:33: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   000001c: error: OnLoadExpr callback failed
-out/test/spec/memory.wast:35: assert_invalid passed:
+out/test/spec/memory.wast:37: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   000001e: error: OnStoreExpr callback failed
-out/test/spec/memory.wast:39: assert_invalid passed:
+out/test/spec/memory.wast:41: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed
-out/test/spec/memory.wast:43: assert_invalid passed:
+out/test/spec/memory.wast:45: assert_invalid passed:
   error: memory variable out of range: 0 (max 0)
   000001b: error: OnMemoryGrowExpr callback failed
-out/test/spec/memory.wast:49: assert_invalid passed:
+out/test/spec/memory.wast:51: assert_invalid passed:
   error: max pages (0) must be >= initial pages (1)
   000000e: error: OnMemory callback failed
-out/test/spec/memory.wast:53: assert_invalid passed:
+out/test/spec/memory.wast:55: assert_invalid passed:
   error: initial pages (65537) must be <= (65536)
   000000f: error: OnMemory callback failed
-out/test/spec/memory.wast:57: assert_invalid passed:
+out/test/spec/memory.wast:59: assert_invalid passed:
   error: initial pages (2147483648) must be <= (65536)
   0000011: error: OnMemory callback failed
-out/test/spec/memory.wast:61: assert_invalid passed:
+out/test/spec/memory.wast:63: assert_invalid passed:
   error: initial pages (4294967295) must be <= (65536)
   0000011: error: OnMemory callback failed
-out/test/spec/memory.wast:65: assert_invalid passed:
+out/test/spec/memory.wast:67: assert_invalid passed:
   error: max pages (65537) must be <= (65536)
   0000010: error: OnMemory callback failed
-out/test/spec/memory.wast:69: assert_invalid passed:
+out/test/spec/memory.wast:71: assert_invalid passed:
   error: max pages (2147483648) must be <= (65536)
   0000012: error: OnMemory callback failed
-out/test/spec/memory.wast:73: assert_invalid passed:
+out/test/spec/memory.wast:75: assert_invalid passed:
   error: max pages (4294967295) must be <= (65536)
   0000012: error: OnMemory callback failed
-out/test/spec/memory.wast:216: assert_malformed passed:
-  out/test/spec/memory/memory.26.wat:1:17: error: redefinition of memory "$foo"
+out/test/spec/memory.wast:80: assert_malformed passed:
+  out/test/spec/memory/memory.27.wat:1:9: error: invalid int "0x1_0000_0000"
+  (memory 0x1_0000_0000)
+          ^^^^^^^^^^^^^
+out/test/spec/memory.wast:84: assert_malformed passed:
+  out/test/spec/memory/memory.28.wat:1:9: error: invalid int "0x1_0000_0000"
+  (memory 0x1_0000_0000 0x1_0000_0000)
+          ^^^^^^^^^^^^^
+  out/test/spec/memory/memory.28.wat:1:23: error: invalid int "0x1_0000_0000"
+  (memory 0x1_0000_0000 0x1_0000_0000)
+                        ^^^^^^^^^^^^^
+out/test/spec/memory.wast:88: assert_malformed passed:
+  out/test/spec/memory/memory.29.wat:1:11: error: invalid int "0x1_0000_0000"
+  (memory 0 0x1_0000_0000)
+            ^^^^^^^^^^^^^
+out/test/spec/memory.wast:231: assert_malformed passed:
+  out/test/spec/memory/memory.31.wat:1:17: error: redefinition of memory "$foo"
   (memory $foo 1)(memory $foo 1)
                   ^^^^^^
-out/test/spec/memory.wast:220: assert_malformed passed:
-  out/test/spec/memory/memory.27.wat:1:32: error: redefinition of memory "$foo"
+out/test/spec/memory.wast:235: assert_malformed passed:
+  out/test/spec/memory/memory.32.wat:1:32: error: redefinition of memory "$foo"
   (import "" "" (memory $foo 1))(memory $foo 1)
                                  ^^^^^^
-out/test/spec/memory.wast:224: assert_malformed passed:
-  out/test/spec/memory/memory.28.wat:1:32: error: redefinition of memory "$foo"
+out/test/spec/memory.wast:239: assert_malformed passed:
+  out/test/spec/memory/memory.33.wat:1:32: error: redefinition of memory "$foo"
   (import "" "" (memory $foo 1))(import "" "" (memory $foo 1))
                                  ^^^^^^
-66/66 tests passed.
+69/69 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table.txt
+++ b/test/spec/table.txt
@@ -1,17 +1,50 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/table.wast
 (;; STDOUT ;;;
-out/test/spec/table.wast:3: assert_malformed passed:
-  out/test/spec/table/table.0.wat:1:24: error: redefinition of table "$foo"
+out/test/spec/table.wast:11: assert_invalid passed:
+  error: only one table allowed
+  0000011: error: OnTable callback failed
+out/test/spec/table.wast:12: assert_invalid passed:
+  error: only one table allowed
+  0000024: error: OnTable callback failed
+out/test/spec/table.wast:14: assert_invalid passed:
+  0000000: error: table variable out of range: 0 (max 0)
+  000000c: error: BeginElemSegment callback failed
+out/test/spec/table.wast:15: assert_invalid passed:
+  0000000: error: table variable out of range: 0 (max 0)
+  0000016: error: BeginElemSegment callback failed
+out/test/spec/table.wast:19: assert_invalid passed:
+  error: max elems (0) must be >= initial elems (1)
+  000000f: error: OnTable callback failed
+out/test/spec/table.wast:23: assert_invalid passed:
+  error: max elems (0) must be >= initial elems (4294967295)
+  0000013: error: OnTable callback failed
+out/test/spec/table.wast:28: assert_malformed passed:
+  out/test/spec/table/table.13.wat:1:8: error: invalid int "0x1_0000_0000"
+  (table 0x1_0000_0000 funcref)
+         ^^^^^^^^^^^^^
+out/test/spec/table.wast:32: assert_malformed passed:
+  out/test/spec/table/table.14.wat:1:8: error: invalid int "0x1_0000_0000"
+  (table 0x1_0000_0000 0x1_0000_0000 funcref)
+         ^^^^^^^^^^^^^
+  out/test/spec/table/table.14.wat:1:22: error: invalid int "0x1_0000_0000"
+  (table 0x1_0000_0000 0x1_0000_0000 funcref)
+                       ^^^^^^^^^^^^^
+out/test/spec/table.wast:36: assert_malformed passed:
+  out/test/spec/table/table.15.wat:1:10: error: invalid int "0x1_0000_0000"
+  (table 0 0x1_0000_0000 funcref)
+           ^^^^^^^^^^^^^
+out/test/spec/table.wast:43: assert_malformed passed:
+  out/test/spec/table/table.16.wat:1:24: error: redefinition of table "$foo"
   (table $foo 1 funcref)(table $foo 1 funcref)
                          ^^^^^
-out/test/spec/table.wast:7: assert_malformed passed:
-  out/test/spec/table/table.1.wat:1:39: error: redefinition of table "$foo"
+out/test/spec/table.wast:47: assert_malformed passed:
+  out/test/spec/table/table.17.wat:1:39: error: redefinition of table "$foo"
   (import "" "" (table $foo 1 funcref))(table $foo 1 funcref)
                                         ^^^^^
-out/test/spec/table.wast:11: assert_malformed passed:
-  out/test/spec/table/table.2.wat:1:39: error: redefinition of table "$foo"
+out/test/spec/table.wast:51: assert_malformed passed:
+  out/test/spec/table/table.18.wat:1:39: error: redefinition of table "$foo"
   (import "" "" (table $foo 1 funcref))(import "" "" (table $foo 1 funcref))
                                         ^^^^^^
-3/3 tests passed.
+12/12 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/type.txt
+++ b/test/spec/type.txt
@@ -1,7 +1,5 @@
 ;;; TOOL: run-interp-spec
-;;; ARGS: --disable-multi-value
 ;;; STDIN_FILE: third_party/testsuite/type.wast
-;;; NOTE: Two tests don't pass because they use quoted modules with assert_invalid, which isn't currently supported by wabt.
 (;; STDOUT ;;;
 out/test/spec/type.wast:44: assert_malformed passed:
   out/test/spec/type/type.1.wat:1:27: error: unexpected token "param", expected param or result.
@@ -11,11 +9,5 @@ out/test/spec/type.wast:48: assert_malformed passed:
   out/test/spec/type/type.2.wat:1:21: error: unexpected token $x, expected ).
   (type (func (result $x i32)))
                       ^^
-out/test/spec/type.wast:53: assert_invalid passed:
-  error: multiple result values not currently supported.
-  0000010: error: OnFuncType callback failed
-out/test/spec/type.wast:57: assert_invalid passed:
-  error: multiple result values not currently supported.
-  0000010: error: OnFuncType callback failed
-4/4 tests passed.
+2/2 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/block.txt
+++ b/test/wasm2c/spec/block.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/block.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 41/41 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/br.txt
+++ b/test/wasm2c/spec/br.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/br.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 63/63 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/call.txt
+++ b/test/wasm2c/spec/call.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/call.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 64/64 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/call_indirect.txt
+++ b/test/wasm2c/spec/call_indirect.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/call_indirect.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 118/118 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/conversions.txt
+++ b/test/wasm2c/spec/conversions.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/conversions.wast
+;;; SKIP: non-trapping float-to-int, multi-value not supported yet
 (;; STDOUT ;;;
 409/409 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/fac.txt
+++ b/test/wasm2c/spec/fac.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/fac.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 6/6 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/func.txt
+++ b/test/wasm2c/spec/func.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/func.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 73/73 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/i32.txt
+++ b/test/wasm2c/spec/i32.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/i32.wast
+;;; SKIP: sign-extend, multi-value not supported yet
 (;; STDOUT ;;;
 360/360 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/i64.txt
+++ b/test/wasm2c/spec/i64.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/i64.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 360/360 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/if.txt
+++ b/test/wasm2c/spec/if.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/if.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 88/88 tests passed.
 ;;; STDOUT ;;)

--- a/test/wasm2c/spec/loop.txt
+++ b/test/wasm2c/spec/loop.txt
@@ -1,5 +1,6 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; STDIN_FILE: third_party/testsuite/loop.wast
+;;; SKIP: multi-value not supported yet
 (;; STDOUT ;;;
 66/66 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
Includes the three merged proposals (nontrapping-float-to-int,
sign-extension, multi-value).

It also has one bug fix when parsing table limits (when the min or max
size does not fit in a 32-bit int).