### PR TITLE
[wat2wasm] Write table indexes in text format

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1275,6 +1275,12 @@ void WatWriter::WriteElemSegment(const ElemSegment& segment) {
 
   uint8_t flags = segment.GetFlags(&module);
 
+  if ((flags & (SegPassive | SegExplicitIndex)) == SegExplicitIndex) {
+    WriteOpenSpace("table");
+    WriteVar(segment.table_var, NextChar::Space);
+    WriteCloseSpace();
+  }
+
   if (!(flags & SegPassive)) {
     WriteInitExpr(segment.offset);
   }

--- a/test/roundtrip/elem-nonzero-table.txt
+++ b/test/roundtrip/elem-nonzero-table.txt
@@ -1,0 +1,16 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-reference-types
+(module
+  (table 1 funcref)
+  (table 1 funcref)
+  (elem (table 1) (i32.const 0) 0)
+  (func)
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0))
+  (table (;0;) 1 funcref)
+  (table (;1;) 1 funcref)
+  (elem (;0;) (table 1) (i32.const 0) func 0))
+;;; STDOUT ;;)

--- a/test/roundtrip/generate-bulk-memory-names.txt
+++ b/test/roundtrip/generate-bulk-memory-names.txt
@@ -29,7 +29,7 @@
     i32.const 0
     i32.const 0
     i32.const 0
-    table.init $e0
+    table.init $T0 $e0
     elem.drop $e0)
   (table $T0 1 funcref)
   (memory $M0 1)

--- a/test/roundtrip/table-copy-index.txt
+++ b/test/roundtrip/table-copy-index.txt
@@ -1,0 +1,23 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-reference-types
+(module
+  (table $t 0 funcref)
+  (table $u 0 funcref)
+
+  (func
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.copy $t $u)
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.copy 0 1)
+  (table (;0;) 0 funcref)
+  (table (;1;) 0 funcref))
+;;; STDOUT ;;)

--- a/test/roundtrip/table-init-index.txt
+++ b/test/roundtrip/table-init-index.txt
@@ -1,0 +1,24 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-reference-types
+(module
+  (table $t 0 funcref)
+  (table $u 0 funcref)
+  (elem $e 0)
+  (func
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.init $u $e)
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    i32.const 0
+    i32.const 0
+    i32.const 0
+    table.init 1 0)
+  (table (;0;) 0 funcref)
+  (table (;1;) 0 funcref)
+  (elem (;0;) func))
+;;; STDOUT ;;)


### PR DESCRIPTION
See #1445 and #1443. This writes non-zero table indexes for `table.init`, `table.copy`, and for element segments.