### PR TITLE
[wasm2wat] Fix a few more roundtripping issues

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -464,6 +464,7 @@ Result BinaryReaderIR::OnImportTable(Index import_index,
   import->module_name = module_name.to_string();
   import->field_name = field_name.to_string();
   import->table.elem_limits = *elem_limits;
+  import->table.elem_type = elem_type;
   module_->AppendField(
       MakeUnique<ImportModuleField>(std::move(import), GetLocation()));
   return Result::Ok;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1304,7 +1304,7 @@ void WatWriter::WriteElemSegment(const ElemSegment& segment) {
     WriteInitExpr(segment.offset);
   }
 
-  if (flags == SegDeclared) {
+  if ((flags & SegDeclared) == SegDeclared) {
     WritePuts("declare", NextChar::Space);
   }
 

--- a/test/roundtrip/elem-declare.txt
+++ b/test/roundtrip/elem-declare.txt
@@ -1,0 +1,14 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-reference-types
+(module
+  (table 2 funcref)
+  (elem declare funcref (ref.func $f) (ref.null func))
+  (func $f)
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0))
+  (table (;0;) 2 funcref)
+  (elem (;0;) declare funcref (ref.func 0) (ref.null func)))
+;;; STDOUT ;;)

--- a/test/roundtrip/table-import-externref.txt
+++ b/test/roundtrip/table-import-externref.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-reference-types
+(module
+  (table (import "m" "func") 1 funcref)
+  (table (import "m" "extern") 1 externref)
+)
+(;; STDOUT ;;;
+(module
+  (import "m" "func" (table (;0;) 1 funcref))
+  (import "m" "extern" (table (;1;) 1 externref)))
+;;; STDOUT ;;)


### PR DESCRIPTION
* The `declare` keyword should be printed when using element expressions
  or element indexes (i.e. flags == 3 or flags == 7).
* An imported table was not properly setting the element type in the IR

Fixes #1448 and #1449.