### PR TITLE
Update local bindings on function with type use

### DIFF
--- a/test/desugar/locals.txt
+++ b/test/desugar/locals.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat-desugar
+(module
+  (type (func (param i32) (result i32)))
+  (func (type 0) (local $var i32)
+        (local.get 0)
+        (local.tee $var)))
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func (param i32) (result i32)))
+  (func (;0;) (type 0) (param i32) (result i32)
+    (local $var i32)
+    local.get 0
+    local.tee 0))
+;;; STDOUT ;;)


### PR DESCRIPTION
When a function is specified like this:

    (func (type $t) ...)

the type can have any sequence of params and results, but it is not
known what that signature is until it is resolved. However, locals that
are parsed will be given a binding index under the assumption that the
signature is empty, e.g.

    (func (type $t)
      (local $v0 i32)
      (local $v1 i32)
      ...
    )

So `$v0` will have index 0, and `$v1` will have index 1. If it turns out
later that type `$t` has any parameters, then these indexes need to be
updated.