### PR TITLE
Enable CMake policy CMP0077

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,10 @@
 cmake_minimum_required(VERSION 3.0.0)
 project(WABT VERSION 1.0.13)
 
+if (POLICY CMP0077)
+  cmake_policy(SET CMP0077 NEW)
+endif (POLICY CMP0077)
+
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Check if wabt is being used directly or via add_subdirectory, FetchContent, etc


### PR DESCRIPTION
TL;DR: this makes it simpler and safer for projects including WABT via FetchContent to configure options via the CMAKE_ARGS argument.

Importing projects may want to set (e.g.) BUILD_TESTS to "no". However, this doesn't work without creating an identical option() in the importing in the importing project. Enabling CMP0077 in supported versions of CMake allows importing projects to set default values for the variables without touching the cache.