### PR TITLE
Revert br_table in reference types proposal

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -420,21 +420,11 @@ Result TypeChecker::OnBrTableTarget(Index depth) {
   if (br_table_sig_ == nullptr) {
     br_table_sig_ = &label_sig;
   } else {
-    if (features_.reference_types_enabled()) {
-      if (br_table_sig_->size() != label_sig.size()) {
-        result |= Result::Error;
-        PrintError("br_table labels have inconsistent arity: expected %" PRIzd
-                   " got %" PRIzd,
-                   br_table_sig_->size(), label_sig.size());
-      }
-    } else {
-      if (*br_table_sig_ != label_sig) {
-        result |= Result::Error;
-        PrintError(
-            "br_table labels have inconsistent types: expected %s, got %s",
-            TypesToString(*br_table_sig_).c_str(),
-            TypesToString(label_sig).c_str());
-      }
+    if (*br_table_sig_ != label_sig) {
+      result |= Result::Error;
+      PrintError("br_table labels have inconsistent types: expected %s, got %s",
+                 TypesToString(*br_table_sig_).c_str(),
+                 TypesToString(label_sig).c_str());
     }
   }
 

--- a/test/spec/reference-types/br_table.txt
+++ b/test/spec/reference-types/br_table.txt
@@ -15,7 +15,7 @@ out/test/spec/reference-types/br_table.wast:1461: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1469: assert_invalid passed:
-  error: br_table labels have inconsistent arity: expected 1 got 0
+  error: br_table labels have inconsistent types: expected [f32], got []
   0000026: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/br_table.wast:1481: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got []

--- a/test/spec/reference-types/unreached-invalid.txt
+++ b/test/spec/reference-types/unreached-invalid.txt
@@ -263,7 +263,7 @@ out/test/spec/reference-types/unreached-invalid.wast:521: assert_invalid passed:
   error: type mismatch in br_table, expected [i32] but got [f32]
   0000025: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:527: assert_invalid passed:
-  error: br_table labels have inconsistent arity: expected 1 got 0
+  error: br_table labels have inconsistent types: expected [f32], got []
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/reference-types/unreached-invalid.wast:540: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]


### PR DESCRIPTION
The reference types proposal originally modified the `br_table` behavior
to only check arity, not the specific types. This was to remove a
subtyping check, but now that subtyping has been removed, we can revert
back to the original (MVP) br_table behavior.