### PR TITLE
Fix gcc warning in GetExprArity

### DIFF
--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -223,7 +223,6 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
 
     case ExprType::Try:
       return { 0, cast<TryExpr>(&expr)->block.decl.sig.GetNumResults() };
-      break;
 
     case ExprType::Ternary:
       return { 3, 1 };
@@ -260,4 +259,8 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
     case ExprType::SimdShuffleOp:
       return { 2, 1 };
   }
+
+  fprintf(stderr, "bad expr type: %s\n", GetExprTypeName(expr));
+  assert(0);
+  return {0, 0};
 }

--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -260,7 +260,5 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
       return { 2, 1 };
   }
 
-  fprintf(stderr, "bad expr type: %s\n", GetExprTypeName(expr));
-  assert(0);
-  return {0, 0};
+  WABT_UNREACHABLE;
 }


### PR DESCRIPTION
All enumeration values are handled in the switch, but it's still
possible to produce an invalid value, which would not return.