### PR TITLE
Add missing includes to type.h

### DIFF
--- a/src/type.h
+++ b/src/type.h
@@ -17,8 +17,11 @@
 #ifndef WABT_TYPE_H_
 #define WABT_TYPE_H_
 
+#include <cassert>
 #include <cstdint>
 #include <vector>
+
+#include "config.h"
 
 namespace wabt {
 


### PR DESCRIPTION
- cassert for assert
- confing.h for WABT_UNREACHABLE

I think it was working because type.h was only included in common.h,
both cassert and config.h was included prior to including type.h.