### PR TITLE
Fix resolving local names w/ empty func signatures

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -320,8 +320,6 @@ Result CheckFuncTypeVarMatchesExplicit(const Location& loc,
                                        Errors* errors) {
   Result result = Result::Ok;
   if (decl.has_func_type) {
-    // This should only be run after resolving names.
-    assert(decl.type_var.is_index());
     const FuncType* func_type = module.GetFuncType(decl.type_var);
     if (func_type) {
       result |=
@@ -1040,8 +1038,8 @@ Result WastParser::ParseModuleFieldList(Module* module) {
       CHECK_RESULT(Synchronize(IsModuleField));
     }
   }
-  CHECK_RESULT(ResolveNamesModule(module, errors_));
   CHECK_RESULT(ResolveFuncTypes(module, errors_));
+  CHECK_RESULT(ResolveNamesModule(module, errors_));
   return Result::Ok;
 }
 

--- a/test/desugar/locals.txt
+++ b/test/desugar/locals.txt
@@ -10,5 +10,5 @@
   (func (;0;) (type 0) (param i32) (result i32)
     (local $var i32)
     local.get 0
-    local.tee 0))
+    local.tee $var))
 ;;; STDOUT ;;)


### PR DESCRIPTION
This was originally landed in 6bff9f0, but was incorrect (the test
didn't even do the right thing!)

The problem was that the local index was correctly being updated, but it
happened _after_ the names had already been resolved. To fix it,
`ResolveFuncTypes` and `ResolveNamesModule` needed be called in that
order. There was an erroneous assertion that fired as a result ("This
should only be run after resolving names"), but that's incorrect -- the
code works properly before resolving names too, since
`Module::GetFuncType` can properly look up function types by name.

Thanks to @alexcrichton for pointing this out.