### PR TITLE
[decompiler] fixed blocks with params.

### DIFF
--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -661,7 +661,7 @@ struct Decompiler {
   std::string InitExp(const ExprList &el) {
     assert(!el.empty());
     AST ast(mc, nullptr);
-    ast.Construct(el, 1, false);
+    ast.Construct(el, 1, 0, false);
     auto val = DecompileExpr(ast.exp_stack[0], nullptr);
     assert(ast.exp_stack.size() == 1 && val.v.size() == 1);
     return std::move(val.v[0]);
@@ -764,7 +764,7 @@ struct Decompiler {
       AST ast(mc, f);
       cur_ast = &ast;
       if (!is_import) {
-        ast.Construct(f->exprs, f->GetNumResults(), true);
+        ast.Construct(f->exprs, f->GetNumResults(), 0, true);
         lst.Track(ast.exp_stack[0]);
         lst.CheckLayouts();
       }

--- a/src/tools/wasm-decompile.cc
+++ b/src/tools/wasm-decompile.cc
@@ -83,15 +83,17 @@ int ProgramMain(int argc, char** argv) {
     result = ReadBinaryIr(infile.c_str(), file_data.data(), file_data.size(),
                           options, &errors, &module);
     if (Succeeded(result)) {
+      ValidateOptions options(features);
+      result = ValidateModule(&module, &errors, options);
       if (Succeeded(result)) {
-        ValidateOptions options(features);
-        result = ValidateModule(&module, &errors, options);
+        result = GenerateNames(&module,
+                               static_cast<NameOpts>(NameOpts::AlphaNames));
       }
-      result = GenerateNames(&module,
-                             static_cast<NameOpts>(NameOpts::AlphaNames));
-      // Must be called after ReadBinaryIr & GenerateNames, and before
-      // ApplyNames, see comments at definition.
-      RenameAll(module);
+      if (Succeeded(result)) {
+        // Must be called after ReadBinaryIr & GenerateNames, and before
+        // ApplyNames, see comments at definition.
+        RenameAll(module);
+      }
       if (Succeeded(result)) {
         /* TODO(binji): This shouldn't fail; if a name can't be applied
          * (because the index is invalid, say) it should just be skipped. */

--- a/test/decompile/basic.txt
+++ b/test/decompile/basic.txt
@@ -86,6 +86,10 @@
     end
     i32.const 104
     drop
+    i32.const 1
+    block (param i32)   ;; block with input
+      br_if 0
+    end
     block (result i32)  ;; block as an exp.
     i32.const 2
     i32.const 0
@@ -168,11 +172,13 @@ export function f(a:int, b:int):int {
   return 103;
   label B_e:
   104;
+  if (1) goto B_j;
+  label B_j:
   a = {
         2;
-        if (0) goto B_j;
+        if (0) goto B_k;
         3;
-        label B_j:
+        label B_k:
       }
   nop;
   is_null(null);


### PR DESCRIPTION
It would previously assume the blocktype is "simple" (at most a single result value), but now also supports function signatures.
Also fixed it ignoring the validator result.