### PR TITLE
Fix assert when function has struct type

### DIFF
--- a/src/ir.cc
+++ b/src/ir.cc
@@ -315,7 +315,7 @@ FuncType* Module::GetFuncType(const Var& var) {
   if (index >= types.size()) {
     return nullptr;
   }
-  return cast<FuncType>(types[index]);
+  return dyn_cast<FuncType>(types[index]);
 }
 
 Index Module::GetFuncTypeIndex(const FuncSignature& sig) const {

--- a/test/binary/bad-func-with-struct-type.txt
+++ b/test/binary/bad-func-with-struct-type.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-gc
+;;; ARGS2: --enable-gc
+magic
+version
+section(TYPE) { count[1] struct field_count[0] }
+section(FUNCTION) { count[1] type[0] }
+section(CODE) { count[1] func { locals[0] } }
+(;; STDERR ;;;
+out/test/binary/bad-func-with-struct-type/bad-func-with-struct-type.wasm:0000011: error: type 0 is not a function
+out/test/binary/bad-func-with-struct-type/bad-func-with-struct-type.wasm:0000011: error: type 0 is not a function
+;;; STDERR ;;)

--- a/test/gen-wasm.py
+++ b/test/gen-wasm.py
@@ -44,6 +44,8 @@ NAMED_VALUES = {
     'v128': 0x7b,    # -5
     'anyfunc': 0x70,    # -0x10
     'function': 0x60,    # -0x20
+    'struct': 0x5f,    # -0x21
+    'array': 0x5e,    # -0x22
     'void': 0x40,    # -0x40
     'magic': (0, 0x61, 0x73, 0x6d),
     'version': (1, 0, 0, 0),


### PR DESCRIPTION
Function types and struct types share an index space, but a function can
only be defined using a function type.

Since `Module::GetFuncType` already returns `nullptr` for an OOB index,
it makes sense to return `nullptr` for an invalid type too.