### PR TITLE
Fix reading of section code

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2360,9 +2360,9 @@ Result BinaryReader::ReadSections() {
   bool seen_section_code[static_cast<int>(BinarySection::Last) + 1] = {false};
 
   for (; state_.offset < state_.size; ++section_index) {
-    uint32_t section_code;
+    uint8_t section_code;
     Offset section_size;
-    CHECK_RESULT(ReadU32Leb128(&section_code, "section code"));
+    CHECK_RESULT(ReadU8(&section_code, "section code"));
     CHECK_RESULT(ReadOffset(&section_size, "section size"));
     ReadEndRestoreGuard guard(this);
     read_end_ = state_.offset + section_size;

--- a/test/binary/bad-section-code-leb128.txt
+++ b/test/binary/bad-section-code-leb128.txt
@@ -1,0 +1,10 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section_code[0x81 0]  ;; Section code is not LEB128 encoded
+section_size[1]
+type_count[0]
+(;; STDERR ;;;
+000000a: error: invalid section code: 129
+000000a: error: invalid section code: 129
+;;; STDERR ;;)


### PR DESCRIPTION
The section code is just a single byte, not a LEB128-encoded value.
With this fix the section code is now read correctly with ReadU8().

The issue has been found by fuzzing wabt wasm validation against [Fizzy](https://github.com/wasmx/fizzy).

The wasm spectests reproducing the issue have been submitted to https://github.com/WebAssembly/spec/pull/1230.