### PR TITLE
Detect malformed import kind in binary reader

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2086,6 +2086,10 @@ Result BinaryReader::ReadImportSection(Offset section_size) {
         num_event_imports_++;
         break;
       }
+
+      default:
+        PrintError("malformed import kind: %d", kind);
+        return Result::Error;
     }
   }
 

--- a/test/binary/bad-import-kind.txt
+++ b/test/binary/bad-import-kind.txt
@@ -1,0 +1,8 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(IMPORT) { count[1] str("module") str("func") dummy[5] }
+(;; STDERR ;;;
+0000018: error: malformed import kind: 5
+0000018: error: malformed import kind: 5
+;;; STDERR ;;)


### PR DESCRIPTION
Detected by fuzzing against [Fizzy](https://github.com/wasmx/fizzy).

Spectests submission: https://github.com/WebAssembly/spec/pull/1233