### PR TITLE
wast2json does not check all file errors

### DIFF
--- a/src/tools/wast2json.cc
+++ b/src/tools/wast2json.cc
@@ -134,11 +134,18 @@ int ProgramMain(int argc, char** argv) {
                                    output_basename, s_write_binary_options,
                                    &module_streams, s_log_stream.get());
 
-    json_stream.WriteToFile(s_outfile);
+    if (Succeeded(result)) {
+      result = json_stream.WriteToFile(s_outfile);
+    }
 
-    for (auto iter = module_streams.begin(); iter != module_streams.end();
-         ++iter) {
-      iter->stream->WriteToFile(iter->filename);
+    if (Succeeded(result)) {
+      for (auto iter = module_streams.begin(); iter != module_streams.end();
+           ++iter) {
+        result = iter->stream->WriteToFile(iter->filename);
+        if (!Succeeded(result)) {
+          break;
+        }
+      }
     }
   }
 


### PR DESCRIPTION
`wast2json` ignores some file errors and returns an exit code of `0` even if an error has occurred.

For example:

```
$ wast2json binary.wast -o /nonexistent/binary.json` 
stream.cc:139: unable to open /nonexistent/binary.json for writing
stream.cc:139: unable to open /nonexistent/binary.0.wasm for writing
...
```

reports many errors, but returns with an exit code of `0`.

The reason is that the result values ​​of the `WriteToFile` calls for `json_stream` and `module_streams` are ignored.
