### PR TITLE
Made the interpreter "type-safe" in debug mode

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -607,7 +607,7 @@ Result BinaryReaderLogging::OnSegmentInfo(Index index,
                                           Address alignment,
                                           uint32_t flags) {
   LOGF("OnSegmentInfo(%d name: " PRIstringview
-       ", alignment: %d, flags: 0x%x)\n",
+       ", alignment: %lu, flags: 0x%x)\n",
        index, WABT_PRINTF_STRING_VIEW_ARG(name), alignment, flags);
   return reader_->OnSegmentInfo(index, name, alignment, flags);
 }
@@ -695,7 +695,7 @@ Result BinaryReaderLogging::OnComdatEntry(ComdatType kind, Index index) {
 #define DEFINE_LOAD_STORE_OPCODE(name)                                      \
   Result BinaryReaderLogging::name(Opcode opcode, Address alignment_log2,   \
                                    Address offset) {                        \
-    LOGF(#name "(opcode: \"%s\" (%u), align log2: %u, offset: %" PRIaddress \
+    LOGF(#name "(opcode: \"%s\" (%u), align log2: %lu, offset: %" PRIaddress\
                ")\n",                                                       \
          opcode.GetName(), opcode.GetCode(), alignment_log2, offset);       \
     return reader_->name(opcode, alignment_log2, offset);                   \

--- a/src/interp/interp-inl.h
+++ b/src/interp/interp-inl.h
@@ -371,53 +371,54 @@ inline bool TypesMatch(ValueType expected, ValueType actual) {
 }
 
 //// Value ////
-inline Value WABT_VECTORCALL Value::Make(s32 val) { Value res; res.i32_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(u32 val) { Value res; res.i32_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(s64 val) { Value res; res.i64_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(u64 val) { Value res; res.i64_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(f32 val) { Value res; res.f32_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(f64 val) { Value res; res.f64_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(v128 val) { Value res; res.v128_ = val; return res; }
-inline Value WABT_VECTORCALL Value::Make(Ref val) { Value res; res.ref_ = val; return res; }
+inline Value WABT_VECTORCALL Value::Make(s32 val) { Value res; res.i32_ = val; res.SetType(ValueType::I32); return res; }
+inline Value WABT_VECTORCALL Value::Make(u32 val) { Value res; res.i32_ = val; res.SetType(ValueType::I32); return res; }
+inline Value WABT_VECTORCALL Value::Make(s64 val) { Value res; res.i64_ = val; res.SetType(ValueType::I64); return res; }
+inline Value WABT_VECTORCALL Value::Make(u64 val) { Value res; res.i64_ = val; res.SetType(ValueType::I64); return res; }
+inline Value WABT_VECTORCALL Value::Make(f32 val) { Value res; res.f32_ = val; res.SetType(ValueType::F32); return res; }
+inline Value WABT_VECTORCALL Value::Make(f64 val) { Value res; res.f64_ = val; res.SetType(ValueType::F64); return res; }
+inline Value WABT_VECTORCALL Value::Make(v128 val) { Value res; res.v128_ = val; res.SetType(ValueType::V128); return res; }
+inline Value WABT_VECTORCALL Value::Make(Ref val) { Value res; res.ref_ = val; res.SetType(ValueType::ExternRef); return res; }
 template <typename T, u8 L>
 Value WABT_VECTORCALL Value::Make(Simd<T, L> val) {
   Value res;
   res.v128_ = Bitcast<v128>(val);
+  res.SetType(ValueType::V128);
   return res;
 }
 
-template <> inline s8 WABT_VECTORCALL Value::Get<s8>() const { return i32_; }
-template <> inline u8 WABT_VECTORCALL Value::Get<u8>() const { return i32_; }
-template <> inline s16 WABT_VECTORCALL Value::Get<s16>() const { return i32_; }
-template <> inline u16 WABT_VECTORCALL Value::Get<u16>() const { return i32_; }
-template <> inline s32 WABT_VECTORCALL Value::Get<s32>() const { return i32_; }
-template <> inline u32 WABT_VECTORCALL Value::Get<u32>() const { return i32_; }
-template <> inline s64 WABT_VECTORCALL Value::Get<s64>() const { return i64_; }
-template <> inline u64 WABT_VECTORCALL Value::Get<u64>() const { return i64_; }
-template <> inline f32 WABT_VECTORCALL Value::Get<f32>() const { return f32_; }
-template <> inline f64 WABT_VECTORCALL Value::Get<f64>() const { return f64_; }
-template <> inline v128 WABT_VECTORCALL Value::Get<v128>() const { return v128_; }
-template <> inline Ref WABT_VECTORCALL Value::Get<Ref>() const { return ref_; }
+template <> inline s8 WABT_VECTORCALL Value::Get<s8>() const { CheckType(ValueType::I32); return i32_; }
+template <> inline u8 WABT_VECTORCALL Value::Get<u8>() const { CheckType(ValueType::I32); return i32_; }
+template <> inline s16 WABT_VECTORCALL Value::Get<s16>() const { CheckType(ValueType::I32); return i32_; }
+template <> inline u16 WABT_VECTORCALL Value::Get<u16>() const { CheckType(ValueType::I32); return i32_; }
+template <> inline s32 WABT_VECTORCALL Value::Get<s32>() const { CheckType(ValueType::I32); return i32_; }
+template <> inline u32 WABT_VECTORCALL Value::Get<u32>() const { CheckType(ValueType::I32); return i32_; }
+template <> inline s64 WABT_VECTORCALL Value::Get<s64>() const { CheckType(ValueType::I64); return i64_; }
+template <> inline u64 WABT_VECTORCALL Value::Get<u64>() const { CheckType(ValueType::I64); return i64_; }
+template <> inline f32 WABT_VECTORCALL Value::Get<f32>() const { CheckType(ValueType::F32); return f32_; }
+template <> inline f64 WABT_VECTORCALL Value::Get<f64>() const { CheckType(ValueType::F64); return f64_; }
+template <> inline v128 WABT_VECTORCALL Value::Get<v128>() const { CheckType(ValueType::V128); return v128_; }
+template <> inline Ref WABT_VECTORCALL Value::Get<Ref>() const { CheckType(ValueType::ExternRef); return ref_; }
 
-template <> inline s8x16 WABT_VECTORCALL Value::Get<s8x16>() const { return Bitcast<s8x16>(v128_); }
-template <> inline u8x16 WABT_VECTORCALL Value::Get<u8x16>() const { return Bitcast<u8x16>(v128_); }
-template <> inline s16x8 WABT_VECTORCALL Value::Get<s16x8>() const { return Bitcast<s16x8>(v128_); }
-template <> inline u16x8 WABT_VECTORCALL Value::Get<u16x8>() const { return Bitcast<u16x8>(v128_); }
-template <> inline s32x4 WABT_VECTORCALL Value::Get<s32x4>() const { return Bitcast<s32x4>(v128_); }
-template <> inline u32x4 WABT_VECTORCALL Value::Get<u32x4>() const { return Bitcast<u32x4>(v128_); }
-template <> inline s64x2 WABT_VECTORCALL Value::Get<s64x2>() const { return Bitcast<s64x2>(v128_); }
-template <> inline u64x2 WABT_VECTORCALL Value::Get<u64x2>() const { return Bitcast<u64x2>(v128_); }
-template <> inline f32x4 WABT_VECTORCALL Value::Get<f32x4>() const { return Bitcast<f32x4>(v128_); }
-template <> inline f64x2 WABT_VECTORCALL Value::Get<f64x2>() const { return Bitcast<f64x2>(v128_); }
+template <> inline s8x16 WABT_VECTORCALL Value::Get<s8x16>() const { CheckType(ValueType::V128); return Bitcast<s8x16>(v128_); }
+template <> inline u8x16 WABT_VECTORCALL Value::Get<u8x16>() const { CheckType(ValueType::V128); return Bitcast<u8x16>(v128_); }
+template <> inline s16x8 WABT_VECTORCALL Value::Get<s16x8>() const { CheckType(ValueType::V128); return Bitcast<s16x8>(v128_); }
+template <> inline u16x8 WABT_VECTORCALL Value::Get<u16x8>() const { CheckType(ValueType::V128); return Bitcast<u16x8>(v128_); }
+template <> inline s32x4 WABT_VECTORCALL Value::Get<s32x4>() const { CheckType(ValueType::V128); return Bitcast<s32x4>(v128_); }
+template <> inline u32x4 WABT_VECTORCALL Value::Get<u32x4>() const { CheckType(ValueType::V128); return Bitcast<u32x4>(v128_); }
+template <> inline s64x2 WABT_VECTORCALL Value::Get<s64x2>() const { CheckType(ValueType::V128); return Bitcast<s64x2>(v128_); }
+template <> inline u64x2 WABT_VECTORCALL Value::Get<u64x2>() const { CheckType(ValueType::V128); return Bitcast<u64x2>(v128_); }
+template <> inline f32x4 WABT_VECTORCALL Value::Get<f32x4>() const { CheckType(ValueType::V128); return Bitcast<f32x4>(v128_); }
+template <> inline f64x2 WABT_VECTORCALL Value::Get<f64x2>() const { CheckType(ValueType::V128); return Bitcast<f64x2>(v128_); }
 
-template <> inline void WABT_VECTORCALL Value::Set<s32>(s32 val) { i32_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<u32>(u32 val) { i32_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<s64>(s64 val) { i64_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<u64>(u64 val) { i64_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<f32>(f32 val) { f32_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<f64>(f64 val) { f64_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<v128>(v128 val) { v128_ = val; }
-template <> inline void WABT_VECTORCALL Value::Set<Ref>(Ref val) { ref_ = val; }
+template <> inline void WABT_VECTORCALL Value::Set<s32>(s32 val) { i32_ = val; SetType(ValueType::I32); }
+template <> inline void WABT_VECTORCALL Value::Set<u32>(u32 val) { i32_ = val; SetType(ValueType::I32); }
+template <> inline void WABT_VECTORCALL Value::Set<s64>(s64 val) { i64_ = val; SetType(ValueType::I64); }
+template <> inline void WABT_VECTORCALL Value::Set<u64>(u64 val) { i64_ = val; SetType(ValueType::I64); }
+template <> inline void WABT_VECTORCALL Value::Set<f32>(f32 val) { f32_ = val; SetType(ValueType::F32); }
+template <> inline void WABT_VECTORCALL Value::Set<f64>(f64 val) { f64_ = val; SetType(ValueType::F64); }
+template <> inline void WABT_VECTORCALL Value::Set<v128>(v128 val) { v128_ = val; SetType(ValueType::V128); }
+template <> inline void WABT_VECTORCALL Value::Set<Ref>(Ref val) { ref_ = val; SetType(ValueType::ExternRef); }
 
 //// Store ////
 inline bool Store::IsValid(Ref ref) const {

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -570,11 +570,11 @@ Result SharedValidator::CheckAlign(const Location& loc,
                                    Address alignment,
                                    Address natural_alignment) {
   if (!is_power_of_two(alignment)) {
-    PrintError(loc, "alignment (%u) must be a power of 2", alignment);
+    PrintError(loc, "alignment (%lu) must be a power of 2", alignment);
     return Result::Error;
   }
   if (alignment > natural_alignment) {
-    PrintError(loc, "alignment must not be larger than natural alignment (%u)",
+    PrintError(loc, "alignment must not be larger than natural alignment (%lu)",
                natural_alignment);
     return Result::Error;
   }
@@ -585,11 +585,11 @@ Result SharedValidator::CheckAtomicAlign(const Location& loc,
                                          Address alignment,
                                          Address natural_alignment) {
   if (!is_power_of_two(alignment)) {
-    PrintError(loc, "alignment (%u) must be a power of 2", alignment);
+    PrintError(loc, "alignment (%lu) must be a power of 2", alignment);
     return Result::Error;
   }
   if (alignment != natural_alignment) {
-    PrintError(loc, "alignment must be equal to natural alignment (%u)",
+    PrintError(loc, "alignment must be equal to natural alignment (%lu)",
                natural_alignment);
     return Result::Error;
   }

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -703,7 +703,7 @@ wabt::Result JSONParser::ParseLaneConstValue(Type lane_type,
                                              ExpectedValue* out_value,
                                              string_view value_str,
                                              AllowExpected allow_expected) {
-  v128& v = out_value->value.value.v128_;
+  v128 v = out_value->value.value.Get<v128>();
 
   switch (lane_type) {
     case Type::I8: {
@@ -758,6 +758,8 @@ wabt::Result JSONParser::ParseLaneConstValue(Type lane_type,
       PrintError("unknown concrete type: \"%s\"", lane_type.GetName());
       return wabt::Result::Error;
   }
+
+  out_value->value.value.Set<v128>(v);
   return wabt::Result::Ok;
 }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -496,10 +496,10 @@ void WatWriter::WriteLoadStoreExpr(const Expr* expr) {
   auto typed_expr = cast<T>(expr);
   WritePutsSpace(typed_expr->opcode.GetName());
   if (typed_expr->offset) {
-    Writef("offset=%u", typed_expr->offset);
+    Writef("offset=%lu", typed_expr->offset);
   }
   if (!typed_expr->opcode.IsNaturallyAligned(typed_expr->align)) {
-    Writef("align=%u", typed_expr->align);
+    Writef("align=%lu", typed_expr->align);
   }
   WriteNewline(NO_FORCE_NEWLINE);
 }


### PR DESCRIPTION
Adds a type field to `Value` to verify the right union member is being read.
A Wasm module that has been validated shouldn't need this, but any code reading the wrong value would trigger UB, but still often work (like a uint32_t read from a uint64_t on little endian machine), and mask bugs.
Turning this on found bugs in the PR I just landed (as I suspected) but also in older code.