### PR TITLE
Fix warnings generated in my system clang (9.0.1-12)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ option(USE_LSAN "Use leak sanitizer" OFF)
 option(USE_UBSAN "Use undefined behavior sanitizer" OFF)
 option(CODE_COVERAGE "Build with code coverage enabled" OFF)
 option(WITH_EXCEPTIONS "Build with exceptions enabled" OFF)
-option(WERROR "Build with warnings as errors" OFF)
+option(WERROR "Build with warnings as errors" ON)
 # WASI support is still a work in progress.
 # Only a handful of syscalls are supported at this point.
 option(WITH_WASI "Build WASI support via uvwasi" OFF)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ option(USE_LSAN "Use leak sanitizer" OFF)
 option(USE_UBSAN "Use undefined behavior sanitizer" OFF)
 option(CODE_COVERAGE "Build with code coverage enabled" OFF)
 option(WITH_EXCEPTIONS "Build with exceptions enabled" OFF)
-option(WERROR "Build with warnings as errors" ON)
+option(WERROR "Build with warnings as errors" OFF)
 # WASI support is still a work in progress.
 # Only a handful of syscalls are supported at this point.
 option(WITH_WASI "Build WASI support via uvwasi" OFF)

--- a/src/decompiler-ast.h
+++ b/src/decompiler-ast.h
@@ -219,7 +219,7 @@ struct AST {
     cur_block_id = blocks_closed.size();
     blocks_closed.push_back(false);
     auto start = exp_stack.size();
-    auto value_stack_depth_start = value_stack_depth - nparams;
+    int value_stack_depth_start = value_stack_depth - nparams;
     auto value_stack_in_variables = value_stack_depth;
     bool unreachable = false;
     for (auto& e : es) {

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1740,7 +1740,7 @@ RunResult Thread::Load(Instr instr, T* out, Trap::Ptr* out_trap) {
   u64 offset = memory->type().limits.is_64 ? Pop<u64>() : Pop<u32>();
   TRAP_IF(Failed(memory->Load(offset, instr.imm_u32x2.snd, out)),
           StringPrintf("out of bounds memory access: access at %" PRIu64
-                       "+%" PRIzd " >= max value %u",
+                       "+%" PRIzd " >= max value %" PRIu64,
                        offset + instr.imm_u32x2.snd, sizeof(T),
                        memory->ByteSize()));
   return RunResult::Ok;
@@ -1763,7 +1763,7 @@ RunResult Thread::DoStore(Instr instr, Trap::Ptr* out_trap) {
   u64 offset = memory->type().limits.is_64 ? Pop<u64>() : Pop<u32>();
   TRAP_IF(Failed(memory->Store(offset, instr.imm_u32x2.snd, val)),
           StringPrintf("out of bounds memory access: access at %" PRIu64
-                       "+%" PRIzd " >= max value %u",
+                       "+%" PRIzd " >= max value %" PRIu64,
                        offset + instr.imm_u32x2.snd, sizeof(V),
                        memory->ByteSize()));
   return RunResult::Ok;


### PR DESCRIPTION
I guess maybe we don't do CI with `-Werror` enabled?  We probably
should.