### PR TITLE
Fix up reloc-related tests after #1537

### DIFF
--- a/test/dump/relocations-long-func-bodies.txt
+++ b/test/dump/relocations-long-func-bodies.txt
@@ -22,14 +22,14 @@ relocations-long-func-bodies.wasm:	file format wasm 0x1
 
 Code Disassembly:
 
-00002e func[0]:
- 00002f: 23 80 80 80 80 00          | global.get 0 <$g>
-           000030: R_WASM_GLOBAL_INDEX_LEB 0 <$g>
+00002e func[0] <previous_func>:
+ 00002f: 23 80 80 80 80 00          | global.get 0 <g>
+           000030: R_WASM_GLOBAL_INDEX_LEB 2 <g>
  000035: 1a                         | drop
  000036: 0b                         | end
 000038 func[1] <long_func>:
- 000039: 23 80 80 80 80 00          | global.get 0 <$g>
-           00003a: R_WASM_GLOBAL_INDEX_LEB 0 <$g>
+ 000039: 23 80 80 80 80 00          | global.get 0 <g>
+           00003a: R_WASM_GLOBAL_INDEX_LEB 2 <g>
  00003f: 1a                         | drop
  000040: 41 00                      | i32.const 0
  000042: 1a                         | drop

--- a/test/dump/relocations-long-func-section.txt
+++ b/test/dump/relocations-long-func-section.txt
@@ -55,9 +55,9 @@ relocations-long-func-section.wasm:	file format wasm 0x1
 
 Code Disassembly:
 
-000020 func[0]:
- 000021: 23 80 80 80 80 00          | global.get 0 <$a>
-           000022: R_WASM_GLOBAL_INDEX_LEB 0 <$a>
+000020 func[0] <0>:
+ 000021: 23 80 80 80 80 00          | global.get 0 <a>
+           000022: R_WASM_GLOBAL_INDEX_LEB 2 <a>
  000027: 1a                         | drop
  000028: 41 00                      | i32.const 0
  00002a: 1a                         | drop
@@ -102,9 +102,9 @@ Code Disassembly:
  000064: 41 00                      | i32.const 0
  000066: 1a                         | drop
  000067: 0b                         | end
-000069 func[1]:
- 00006a: 23 80 80 80 80 00          | global.get 0 <$a>
-           00006b: R_WASM_GLOBAL_INDEX_LEB 0 <$a>
+000069 func[1] <1>:
+ 00006a: 23 80 80 80 80 00          | global.get 0 <a>
+           00006b: R_WASM_GLOBAL_INDEX_LEB 2 <a>
  000070: 1a                         | drop
  000071: 41 00                      | i32.const 0
  000073: 1a                         | drop

--- a/test/dump/relocations-section-target.txt
+++ b/test/dump/relocations-section-target.txt
@@ -25,8 +25,9 @@ Code[1]:
  - func[1] size=8 <a>
 Custom:
  - name: "linking"
-  - symbol table [count=1]
+  - symbol table [count=2]
    - 0: F <env.b> func=0 undefined binding=global vis=default
+   - 1: F <a> func=1 exported no_strip binding=global vis=hidden
 Custom:
  - name: "reloc.Code"
   - relocations for section: 4 (Code) [1]
@@ -38,4 +39,5 @@ Code Disassembly:
  000029: 10 80 80 80 80 00          | call 0 <env.b>
            00002a: R_WASM_FUNCTION_INDEX_LEB 0 <env.b>
  00002f: 0b                         | end
+
 ;;; STDOUT ;;)

--- a/test/dump/relocations-section-target.txt
+++ b/test/dump/relocations-section-target.txt
@@ -9,7 +9,7 @@
   (export "a" (func $a)))
 (;; STDOUT ;;;
 
-relocs-section-target.wasm:	file format wasm 0x1
+relocations-section-target.wasm:	file format wasm 0x1
 
 Section Details:
 


### PR DESCRIPTION
PRs #1527 and #1539 needed their test expectations updated after #1537
was merged; this patch does that.  It also renames a test for
consistency.