### PR TITLE
Disallow non-zero memidx when bulk memory disabled

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2387,6 +2387,8 @@ Result BinaryReader::ReadDataSection(Offset section_size) {
   for (Index i = 0; i < num_data_segments; ++i) {
     uint32_t flags;
     CHECK_RESULT(ReadU32Leb128(&flags, "data segment flags"));
+    ERROR_IF(flags != 0 && !options_.features.bulk_memory_enabled(),
+             "invalid memory index %d: bulk memory not allowed", flags);
     ERROR_IF(flags > SegFlagMax, "invalid data segment flags: %#x", flags);
     Index memory_index(0);
     if (flags & SegExplicitIndex) {

--- a/test/binary/bad-data-invalid-memidx.txt
+++ b/test/binary/bad-data-invalid-memidx.txt
@@ -1,0 +1,18 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section(DATA) {
+  count[1]
+  memory_index[1]
+  offset[i32.const 0 end]
+  data[str("")]
+}
+(;; STDERR ;;;
+0000011: error: invalid memory index 1: bulk memory not allowed
+0000011: error: invalid memory index 1: bulk memory not allowed
+;;; STDERR ;;)

--- a/test/binary/bad-segment-no-memory.txt
+++ b/test/binary/bad-segment-no-memory.txt
@@ -1,4 +1,6 @@
 ;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-bulk-memory
+;;; ARGS2: --enable-bulk-memory
 magic
 version
 section(DATA) {


### PR DESCRIPTION
If bulk memory extension is disabled, do not allow memory index in the
data segment other than zero.