### PR TITLE
Disallow "64-bit" flag if memory64 is disabled

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -587,6 +587,8 @@ Result BinaryReader::ReadMemory(Limits* out_page_limits) {
   ERROR_UNLESS(unknown_flags == 0, "malformed memory limits flag: %d", flags);
   ERROR_IF(is_shared && !options_.features.threads_enabled(),
            "memory may not be shared: threads not allowed");
+  ERROR_IF(is_64 && !options_.features.memory64_enabled(),
+           "memory64 not allowed");
   CHECK_RESULT(ReadU32Leb128(&initial, "memory initial page count"));
   if (has_max) {
     CHECK_RESULT(ReadU32Leb128(&max, "memory max page count"));

--- a/test/binary/bad-memory-limits-flag-is64.txt
+++ b/test/binary/bad-memory-limits-flag-is64.txt
@@ -1,0 +1,11 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(MEMORY) {
+  count[1]
+  flags[4]
+}
+(;; STDERR ;;;
+000000c: error: memory64 not allowed
+000000c: error: memory64 not allowed
+;;; STDERR ;;)

--- a/test/binary/bad-table-limits-flag-is64.txt
+++ b/test/binary/bad-table-limits-flag-is64.txt
@@ -1,0 +1,12 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TABLE) {
+  count[1]
+  anyfunc
+  flags[4]
+}
+(;; STDERR ;;;
+000000d: error: tables may not be 64-bit
+000000d: error: tables may not be 64-bit
+;;; STDERR ;;)

--- a/test/interp/load64.txt
+++ b/test/interp/load64.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp
+;;; ARGS: --enable-memory64
 (module
   (memory 1 i64)
   (data (i32.const 0) "\ff\ff\ff\ff")

--- a/test/interp/store64.txt
+++ b/test/interp/store64.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp
+;;; ARGS: --enable-memory64
 (module
   (memory 1 i64)
 

--- a/test/parse/expr/atomic64.txt
+++ b/test/parse/expr/atomic64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-threads
+;;; ARGS: --enable-threads --enable-memory64
 (module
   (memory 1 1 shared i64)
   (func

--- a/test/parse/expr/bulk-memory-named64.txt
+++ b/test/parse/expr/bulk-memory-named64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-bulk-memory
+;;; ARGS: --enable-bulk-memory --enable-memory64
 
 (module
   (memory 1 i64)

--- a/test/parse/expr/load64.txt
+++ b/test/parse/expr/load64.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --enable-memory64
 (module
   (memory 1 i64)
   (func

--- a/test/parse/expr/store64.txt
+++ b/test/parse/expr/store64.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --enable-memory64
 (module
   (memory 1 i64)
   (func

--- a/test/roundtrip/bulk-memory64.txt
+++ b/test/roundtrip/bulk-memory64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-bulk-memory
+;;; ARGS: --stdout --enable-bulk-memory --enable-memory64
 (module
   (memory 0 i64)
   (table 0 anyfunc)

--- a/test/roundtrip/memory-index64.txt
+++ b/test/roundtrip/memory-index64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout
+;;; ARGS: --stdout --enable-memory64
 (module
   (import "a" "b" (memory 1 i64)))
 (;; STDOUT ;;;


### PR DESCRIPTION
Fixes regressions in binary reader introduced by the implementation of
the memory64 extension: https://github.com/WebAssembly/wabt/pull/1500.