### PR TITLE
Disallow non-zero table idx if reference types disabled

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2277,6 +2277,9 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
   for (Index i = 0; i < num_elem_segments; ++i) {
     uint32_t flags;
     CHECK_RESULT(ReadU32Leb128(&flags, "elem segment flags"));
+    ERROR_IF(flags != 0 && !options_.features.reference_types_enabled(),
+             "invalid elem segment flags: %#x: reference types not allowed",
+             flags);
     ERROR_IF(flags > SegFlagMax, "invalid elem segment flags: %#x", flags);
     Index table_index(0);
     if ((flags & (SegPassive | SegExplicitIndex)) == SegExplicitIndex) {

--- a/test/binary/bad-elem-flags-no-reftype.txt
+++ b/test/binary/bad-elem-flags-no-reftype.txt
@@ -1,0 +1,19 @@
+;;; TOOL: run-gen-wasm-bad
+magic
+version
+section(TABLE) {
+  count[1]
+  anyfunc
+  has_max[0]
+  initial[0]
+}
+section(ELEM) {
+  count[1]
+  flags[1]
+  kind[0]
+  count[0]
+}
+(;; STDERR ;;;
+0000012: error: invalid elem segment flags: 0x1: reference types not allowed
+0000012: error: invalid elem segment flags: 0x1: reference types not allowed
+;;; STDERR ;;)

--- a/test/binary/bad-elem-flags.txt
+++ b/test/binary/bad-elem-flags.txt
@@ -1,4 +1,6 @@
 ;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-reference-types
+;;; ARGS2: --enable-reference-types
 magic
 version
 section(TABLE) {

--- a/test/parse/expr/bulk-memory-named.txt
+++ b/test/parse/expr/bulk-memory-named.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-bulk-memory
+;;; ARGS: --enable-bulk-memory --enable-reference-types
 
 (module
   (memory 1)

--- a/test/parse/expr/bulk-memory-named64.txt
+++ b/test/parse/expr/bulk-memory-named64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-bulk-memory --enable-memory64
+;;; ARGS: --enable-bulk-memory --enable-memory64 --enable-reference-types
 
 (module
   (memory 1 i64)

--- a/test/parse/expr/table-drop.txt
+++ b/test/parse/expr/table-drop.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-bulk-memory
+;;; ARGS: --enable-bulk-memory --enable-reference-types
 (module
   (memory 0)
 

--- a/test/parse/expr/table-init.txt
+++ b/test/parse/expr/table-init.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-bulk-memory
+;;; ARGS: --enable-bulk-memory --enable-reference-types
 (module
   (memory 0)
 

--- a/test/roundtrip/bulk-memory.txt
+++ b/test/roundtrip/bulk-memory.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-bulk-memory
+;;; ARGS: --stdout --enable-bulk-memory --enable-reference-types
 (module
   (memory 0)
   (table 0 anyfunc)

--- a/test/roundtrip/bulk-memory64.txt
+++ b/test/roundtrip/bulk-memory64.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-bulk-memory --enable-memory64
+;;; ARGS: --stdout --enable-bulk-memory --enable-memory64 --enable-reference-types
 (module
   (memory 0 i64)
   (table 0 anyfunc)

--- a/test/roundtrip/fold-bulk-memory.txt
+++ b/test/roundtrip/fold-bulk-memory.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --fold-exprs --enable-bulk-memory
+;;; ARGS: --stdout --fold-exprs --enable-bulk-memory --enable-reference-types
 
 (module
   (memory 1)

--- a/test/roundtrip/generate-bulk-memory-names.txt
+++ b/test/roundtrip/generate-bulk-memory-names.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --generate-names --enable-bulk-memory
+;;; ARGS: --stdout --generate-names --enable-bulk-memory --enable-reference-types
 
 (module
   (memory 1)

--- a/test/spec/bulk-memory-operations/binary.txt
+++ b/test/spec/bulk-memory-operations/binary.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/binary.wast
-;;; ARGS*: --enable-bulk-memory
+;;; ARGS*: --enable-bulk-memory --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/bulk-memory-operations/binary.wast:6: assert_malformed passed:
   0000000: error: unable to read uint32_t: magic
@@ -89,15 +89,16 @@ out/test/spec/bulk-memory-operations/binary.wast:272: assert_malformed passed:
 out/test/spec/bulk-memory-operations/binary.wast:282: assert_malformed passed:
   000000e: error: unable to read i64 leb128: init_expr i64.const value
 out/test/spec/bulk-memory-operations/binary.wast:295: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
+  0000000: error: table variable out of range: 1 (max 1)
+  0000022: error: OnCallIndirectExpr callback failed
 out/test/spec/bulk-memory-operations/binary.wast:314: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
+  0000023: error: function body must end with END opcode
 out/test/spec/bulk-memory-operations/binary.wast:333: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
+  0000024: error: function body must end with END opcode
 out/test/spec/bulk-memory-operations/binary.wast:351: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
+  0000025: error: function body must end with END opcode
 out/test/spec/bulk-memory-operations/binary.wast:369: assert_malformed passed:
-  0000022: error: call_indirect reserved value must be 0
+  0000026: error: function body must end with END opcode
 out/test/spec/bulk-memory-operations/binary.wast:388: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
 out/test/spec/bulk-memory-operations/binary.wast:408: assert_malformed passed:

--- a/test/spec/bulk-memory-operations/bulk.txt
+++ b/test/spec/bulk-memory-operations/bulk.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/bulk.wast
-;;; ARGS*: --enable-bulk-memory
+;;; ARGS*: --enable-bulk-memory --enable-reference-types
 (;; STDOUT ;;;
 fill(i32:1, i32:255, i32:3) =>
 fill(i32:0, i32:48042, i32:2) =>

--- a/test/spec/bulk-memory-operations/elem.txt
+++ b/test/spec/bulk-memory-operations/elem.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/elem.wast
-;;; ARGS*: --enable-bulk-memory
+;;; ARGS*: --enable-bulk-memory --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/bulk-memory-operations/elem.wast:300: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)

--- a/test/spec/bulk-memory-operations/table_copy.txt
+++ b/test/spec/bulk-memory-operations/table_copy.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/table_copy.wast
-;;; ARGS*: --enable-bulk-memory
+;;; ARGS*: --enable-bulk-memory --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 out/test/spec/bulk-memory-operations/table_copy.wast:40: assert_trap passed: uninitialized table element

--- a/test/spec/bulk-memory-operations/table_init.txt
+++ b/test/spec/bulk-memory-operations/table_init.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/table_init.wast
-;;; ARGS*: --enable-bulk-memory
+;;; ARGS*: --enable-bulk-memory --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 out/test/spec/bulk-memory-operations/table_init.wast:40: assert_trap passed: uninitialized table element


### PR DESCRIPTION
If the reference types extension is disabled, do not allow table index
in the element segment other than zero.

Here I'm not 100% sure I identified the extension right.
And considering the complexity of the `ReadElemSection`, I decided to just check `flags !=0` at the beginning, so the error message is less precise than it could be.