### PR TITLE
Fix compile failed on Ubuntu 18.04 aarch64 cmake3.10.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
   endif ()
 endif ()
 
+if (NOT "${CMAKE_PROJECT_VERSION}")
+  set(CMAKE_PROJECT_VERSION ${PROJECT_VERSION})
+endif()
+
 option(BUILD_TESTS "Build GTest-based tests" ON)
 option(USE_SYSTEM_GTEST "Use system GTest, instead of building" OFF)
 option(BUILD_TOOLS "Build wabt commandline tools" ON)


### PR DESCRIPTION
I try to compile wabt on Ubuntu 18.04 aarch64 with gcc 7.5.0 and cmake 3.10.2, failed with the error below:
![image](https://user-images.githubusercontent.com/15418097/95938509-9b219d80-0e0c-11eb-9e2c-54187944f137.png)

the wabt source code is downloaded from release page v1.0.19 tar package which without the .git dir.

I made a tiny modify to fix this