### PR TITLE
Rename atomic.notify, *.atomic.wait

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -1373,7 +1373,7 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         CALLBACK0(OnOpcodeBare);
         break;
 
-      case Opcode::AtomicNotify: {
+      case Opcode::MemoryAtomicNotify: {
         Address alignment_log2;
         CHECK_RESULT(ReadAlignment(&alignment_log2, "load alignment"));
         Address offset;
@@ -1384,8 +1384,8 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         break;
       }
 
-      case Opcode::I32AtomicWait:
-      case Opcode::I64AtomicWait: {
+      case Opcode::MemoryAtomicWait32:
+      case Opcode::MemoryAtomicWait64: {
         Address alignment_log2;
         CHECK_RESULT(ReadAlignment(&alignment_log2, "load alignment"));
         Address offset;

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1635,9 +1635,9 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
     case O::I32X4Abs: return DoSimdUnop(IntAbs<u32>);
 
     case O::AtomicFence:
-    case O::AtomicNotify:
-    case O::I32AtomicWait:
-    case O::I64AtomicWait:
+    case O::MemoryAtomicNotify:
+    case O::MemoryAtomicWait32:
+    case O::MemoryAtomicWait64:
       return TRAP("not implemented");
 
     case O::I32AtomicLoad:       return DoAtomicLoad<u32>(instr, out_trap);

--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -541,7 +541,7 @@ Instr Istream::Read(Offset* offset) const {
       instr.imm_u32x2.snd = ReadAt<u32>(offset);
       break;
 
-    case Opcode::AtomicNotify:
+    case Opcode::MemoryAtomicNotify:
     case Opcode::F32Store:
     case Opcode::F64Store:
     case Opcode::I32AtomicRmw16AddU:
@@ -610,12 +610,12 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::I32AtomicRmw16CmpxchgU:
     case Opcode::I32AtomicRmw8CmpxchgU:
     case Opcode::I32AtomicRmwCmpxchg:
-    case Opcode::I32AtomicWait:
     case Opcode::I64AtomicRmw16CmpxchgU:
     case Opcode::I64AtomicRmw32CmpxchgU:
     case Opcode::I64AtomicRmw8CmpxchgU:
     case Opcode::I64AtomicRmwCmpxchg:
-    case Opcode::I64AtomicWait:
+    case Opcode::MemoryAtomicWait32:
+    case Opcode::MemoryAtomicWait64:
       // Index and memory offset immediates, 3 operands.
       instr.kind = InstrKind::Imm_Index_Offset_Op_3;
       instr.imm_u32x2.fst = ReadAt<u32>(offset);

--- a/src/lexer-keywords.txt
+++ b/src/lexer-keywords.txt
@@ -25,7 +25,6 @@ assert_return, TokenType::AssertReturn
 assert_trap, TokenType::AssertTrap
 assert_unlinkable, TokenType::AssertUnlinkable
 atomic.fence, TokenType::AtomicFence, Opcode::AtomicFence
-atomic.notify, TokenType::AtomicNotify, Opcode::AtomicNotify
 binary, TokenType::Bin
 block, TokenType::Block, Opcode::Block
 br_if, TokenType::BrIf, Opcode::BrIf
@@ -243,7 +242,6 @@ i32.atomic.rmw.xor, TokenType::AtomicRmw, Opcode::I32AtomicRmwXor
 i32.atomic.store16, TokenType::AtomicStore, Opcode::I32AtomicStore16
 i32.atomic.store8, TokenType::AtomicStore, Opcode::I32AtomicStore8
 i32.atomic.store, TokenType::AtomicStore, Opcode::I32AtomicStore
-i32.atomic.wait, TokenType::AtomicWait, Opcode::I32AtomicWait
 i32.clz, TokenType::Unary, Opcode::I32Clz
 i32.const, TokenType::Const, Opcode::I32Const
 i32.ctz, TokenType::Unary, Opcode::I32Ctz
@@ -368,7 +366,6 @@ i64.atomic.store16, TokenType::AtomicStore, Opcode::I64AtomicStore16
 i64.atomic.store32, TokenType::AtomicStore, Opcode::I64AtomicStore32
 i64.atomic.store8, TokenType::AtomicStore, Opcode::I64AtomicStore8
 i64.atomic.store, TokenType::AtomicStore, Opcode::I64AtomicStore
-i64.atomic.wait, TokenType::AtomicWait, Opcode::I64AtomicWait
 i64.clz, TokenType::Unary, Opcode::I64Clz
 i64.const, TokenType::Const, Opcode::I64Const
 i64.ctz, TokenType::Unary, Opcode::I64Ctz
@@ -482,6 +479,9 @@ local.set, TokenType::LocalSet, Opcode::LocalSet
 local.tee, TokenType::LocalTee, Opcode::LocalTee
 local, TokenType::Local
 loop, TokenType::Loop, Opcode::Loop
+memory.atomic.notify, TokenType::AtomicNotify, Opcode::MemoryAtomicNotify
+memory.atomic.wait32, TokenType::AtomicWait, Opcode::MemoryAtomicWait32
+memory.atomic.wait64, TokenType::AtomicWait, Opcode::MemoryAtomicWait64
 memory.copy, TokenType::MemoryCopy, Opcode::MemoryCopy
 memory.fill, TokenType::MemoryFill, Opcode::MemoryFill
 memory.grow, TokenType::MemoryGrow, Opcode::MemoryGrow
@@ -541,6 +541,9 @@ v128.load8_splat, TokenType::Load, Opcode::V128Load8Splat
 i8x16.shuffle, TokenType::SimdShuffleOp, Opcode::I8X16Shuffle
 i8x16.swizzle, TokenType::Binary, Opcode::I8X16Swizzle
 # Deprecated names.
+atomic.notify, TokenType::AtomicNotify, Opcode::MemoryAtomicNotify
+i32.atomic.wait, TokenType::AtomicWait, Opcode::MemoryAtomicWait32
+i64.atomic.wait, TokenType::AtomicWait, Opcode::MemoryAtomicWait64
 anyfunc, Type::FuncRef
 f32.convert_s/i32, TokenType::Convert, Opcode::F32ConvertI32S
 f32.convert_s/i64, TokenType::Convert, Opcode::F32ConvertI64S

--- a/src/opcode.cc
+++ b/src/opcode.cc
@@ -91,9 +91,9 @@ bool Opcode::IsEnabled(const Features& features) const {
     case Opcode::I64Extend32S:
       return features.sign_extension_enabled();
 
-    case Opcode::AtomicNotify:
-    case Opcode::I32AtomicWait:
-    case Opcode::I64AtomicWait:
+    case Opcode::MemoryAtomicNotify:
+    case Opcode::MemoryAtomicWait32:
+    case Opcode::MemoryAtomicWait64:
     case Opcode::AtomicFence:
     case Opcode::I32AtomicLoad:
     case Opcode::I64AtomicLoad:

--- a/src/opcode.def
+++ b/src/opcode.def
@@ -452,9 +452,9 @@ WABT_OPCODE(V128, V128, ___,  ___,  0,  0xfd, 0xfa, F32X4ConvertI32X4S, "f32x4.c
 WABT_OPCODE(V128, V128, ___,  ___,  0,  0xfd, 0xfb, F32X4ConvertI32X4U, "f32x4.convert_i32x4_u", "")
 
 /* Thread opcodes (--enable-threads) */
-WABT_OPCODE(I32,  I32,  I32,  ___,  4,  0xfe, 0x00, AtomicNotify, "atomic.notify", "")
-WABT_OPCODE(I32,  I32,  I32,  I64,  4,  0xfe, 0x01, I32AtomicWait, "i32.atomic.wait", "")
-WABT_OPCODE(I32,  I32,  I64,  I64,  8,  0xfe, 0x02, I64AtomicWait, "i64.atomic.wait", "")
+WABT_OPCODE(I32,  I32,  I32,  ___,  4,  0xfe, 0x00, MemoryAtomicNotify, "memory.atomic.notify", "")
+WABT_OPCODE(I32,  I32,  I32,  I64,  4,  0xfe, 0x01, MemoryAtomicWait32, "memory.atomic.wait32", "")
+WABT_OPCODE(I32,  I32,  I64,  I64,  8,  0xfe, 0x02, MemoryAtomicWait64, "memory.atomic.wait64", "")
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0xfe, 0x03, AtomicFence, "atomic.fence", "")
 WABT_OPCODE(I32,  I32,  ___,  ___,  4,  0xfe, 0x10, I32AtomicLoad, "i32.atomic.load", "")
 WABT_OPCODE(I64,  I32,  ___,  ___,  8,  0xfe, 0x11, I64AtomicLoad, "i64.atomic.load", "")

--- a/src/prebuilt/lexer-keywords.cc
+++ b/src/prebuilt/lexer-keywords.cc
@@ -152,7 +152,7 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 {
   enum
     {
-      TOTAL_KEYWORDS = 562,
+      TOTAL_KEYWORDS = 565,
       MIN_WORD_LENGTH = 2,
       MAX_WORD_LENGTH = 26,
       MIN_HASH_VALUE = 23,
@@ -164,150 +164,150 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 475 "src/lexer-keywords.txt"
+#line 472 "src/lexer-keywords.txt"
       {"if", TokenType::If, Opcode::If},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 140 "src/lexer-keywords.txt"
+#line 139 "src/lexer-keywords.txt"
       {"f64", Type::F64},
 #line 492 "src/lexer-keywords.txt"
       {"mut", TokenType::Mut},
-#line 83 "src/lexer-keywords.txt"
+#line 82 "src/lexer-keywords.txt"
       {"f32", Type::F32},
-#line 424 "src/lexer-keywords.txt"
+#line 421 "src/lexer-keywords.txt"
       {"i64", Type::I64},
       {""},
-#line 293 "src/lexer-keywords.txt"
+#line 291 "src/lexer-keywords.txt"
       {"i32", Type::I32},
       {""}, {""}, {""},
 #line 522 "src/lexer-keywords.txt"
       {"then", TokenType::Then},
-#line 49 "src/lexer-keywords.txt"
+#line 48 "src/lexer-keywords.txt"
       {"exn", Type::ExnRef, TokenType::Exn},
-#line 479 "src/lexer-keywords.txt"
+#line 476 "src/lexer-keywords.txt"
       {"item", TokenType::Item},
-#line 110 "src/lexer-keywords.txt"
+#line 109 "src/lexer-keywords.txt"
       {"f32x4", TokenType::F32X4},
-#line 46 "src/lexer-keywords.txt"
-      {"else", TokenType::Else, Opcode::Else},
 #line 45 "src/lexer-keywords.txt"
+      {"else", TokenType::Else, Opcode::Else},
+#line 44 "src/lexer-keywords.txt"
       {"elem", TokenType::Elem},
-#line 325 "src/lexer-keywords.txt"
+#line 323 "src/lexer-keywords.txt"
       {"i32x4", TokenType::I32X4},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 127 "src/lexer-keywords.txt"
+#line 126 "src/lexer-keywords.txt"
       {"f64.lt", TokenType::Compare, Opcode::F64Lt},
-#line 71 "src/lexer-keywords.txt"
+#line 70 "src/lexer-keywords.txt"
       {"f32.lt", TokenType::Compare, Opcode::F32Lt},
       {""},
-#line 48 "src/lexer-keywords.txt"
+#line 47 "src/lexer-keywords.txt"
       {"event", TokenType::Event},
       {""}, {""}, {""},
-#line 50 "src/lexer-keywords.txt"
+#line 49 "src/lexer-keywords.txt"
       {"exnref", Type::ExnRef},
       {""},
-#line 51 "src/lexer-keywords.txt"
+#line 50 "src/lexer-keywords.txt"
       {"extern", Type::ExternRef, TokenType::Extern},
       {""}, {""},
-#line 125 "src/lexer-keywords.txt"
+#line 124 "src/lexer-keywords.txt"
       {"f64.le", TokenType::Compare, Opcode::F64Le},
-#line 69 "src/lexer-keywords.txt"
+#line 68 "src/lexer-keywords.txt"
       {"f32.le", TokenType::Compare, Opcode::F32Le},
       {""}, {""}, {""},
-#line 167 "src/lexer-keywords.txt"
+#line 166 "src/lexer-keywords.txt"
       {"funcref", Type::FuncRef},
-#line 129 "src/lexer-keywords.txt"
+#line 128 "src/lexer-keywords.txt"
       {"f64.min", TokenType::Binary, Opcode::F64Min},
-#line 73 "src/lexer-keywords.txt"
+#line 72 "src/lexer-keywords.txt"
       {"f32.min", TokenType::Binary, Opcode::F32Min},
       {""},
 #line 512 "src/lexer-keywords.txt"
       {"start", TokenType::Start},
       {""},
-#line 397 "src/lexer-keywords.txt"
+#line 394 "src/lexer-keywords.txt"
       {"i64.lt_s", TokenType::Compare, Opcode::I64LtS},
-#line 267 "src/lexer-keywords.txt"
+#line 265 "src/lexer-keywords.txt"
       {"i32.lt_s", TokenType::Compare, Opcode::I32LtS},
       {""}, {""},
-#line 398 "src/lexer-keywords.txt"
+#line 395 "src/lexer-keywords.txt"
       {"i64.lt_u", TokenType::Compare, Opcode::I64LtU},
-#line 268 "src/lexer-keywords.txt"
+#line 266 "src/lexer-keywords.txt"
       {"i32.lt_u", TokenType::Compare, Opcode::I32LtU},
-#line 388 "src/lexer-keywords.txt"
+#line 385 "src/lexer-keywords.txt"
       {"i64.le_s", TokenType::Compare, Opcode::I64LeS},
-#line 260 "src/lexer-keywords.txt"
+#line 258 "src/lexer-keywords.txt"
       {"i32.le_s", TokenType::Compare, Opcode::I32LeS},
       {""}, {""},
-#line 389 "src/lexer-keywords.txt"
+#line 386 "src/lexer-keywords.txt"
       {"i64.le_u", TokenType::Compare, Opcode::I64LeU},
-#line 261 "src/lexer-keywords.txt"
+#line 259 "src/lexer-keywords.txt"
       {"i32.le_u", TokenType::Compare, Opcode::I32LeU},
 #line 521 "src/lexer-keywords.txt"
       {"table", TokenType::Table},
       {""}, {""}, {""},
-#line 404 "src/lexer-keywords.txt"
+#line 401 "src/lexer-keywords.txt"
       {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
-#line 274 "src/lexer-keywords.txt"
+#line 272 "src/lexer-keywords.txt"
       {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
       {""},
-#line 102 "src/lexer-keywords.txt"
+#line 101 "src/lexer-keywords.txt"
       {"f32x4.ne", TokenType::Compare, Opcode::F32X4Ne},
-#line 405 "src/lexer-keywords.txt"
+#line 402 "src/lexer-keywords.txt"
       {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
-#line 275 "src/lexer-keywords.txt"
+#line 273 "src/lexer-keywords.txt"
       {"i32.rem_u", TokenType::Binary, Opcode::I32RemU},
-#line 318 "src/lexer-keywords.txt"
+#line 316 "src/lexer-keywords.txt"
       {"i32x4.ne", TokenType::Compare, Opcode::I32X4Ne},
-#line 98 "src/lexer-keywords.txt"
+#line 97 "src/lexer-keywords.txt"
       {"f32x4.min", TokenType::Binary, Opcode::F32X4Min},
-#line 96 "src/lexer-keywords.txt"
+#line 95 "src/lexer-keywords.txt"
       {"f32x4.lt", TokenType::Compare, Opcode::F32X4Lt},
       {""}, {""}, {""},
-#line 130 "src/lexer-keywords.txt"
+#line 129 "src/lexer-keywords.txt"
       {"f64.mul", TokenType::Binary, Opcode::F64Mul},
-#line 74 "src/lexer-keywords.txt"
+#line 73 "src/lexer-keywords.txt"
       {"f32.mul", TokenType::Binary, Opcode::F32Mul},
       {""},
-#line 399 "src/lexer-keywords.txt"
+#line 396 "src/lexer-keywords.txt"
       {"i64.mul", TokenType::Binary, Opcode::I64Mul},
-#line 269 "src/lexer-keywords.txt"
+#line 267 "src/lexer-keywords.txt"
       {"i32.mul", TokenType::Binary, Opcode::I32Mul},
       {""}, {""},
-#line 314 "src/lexer-keywords.txt"
+#line 312 "src/lexer-keywords.txt"
       {"i32x4.min_s", TokenType::Binary, Opcode::I32X4MinS},
-#line 95 "src/lexer-keywords.txt"
+#line 94 "src/lexer-keywords.txt"
       {"f32x4.le", TokenType::Compare, Opcode::F32X4Le},
-#line 166 "src/lexer-keywords.txt"
+#line 165 "src/lexer-keywords.txt"
       {"field", TokenType::Field},
-#line 310 "src/lexer-keywords.txt"
+#line 308 "src/lexer-keywords.txt"
       {"i32x4.lt_s", TokenType::Compare, Opcode::I32X4LtS},
-#line 315 "src/lexer-keywords.txt"
+#line 313 "src/lexer-keywords.txt"
       {"i32x4.min_u", TokenType::Binary, Opcode::I32X4MinU},
-#line 311 "src/lexer-keywords.txt"
+#line 309 "src/lexer-keywords.txt"
       {"i32x4.lt_u", TokenType::Compare, Opcode::I32X4LtU},
       {""}, {""}, {""},
-#line 306 "src/lexer-keywords.txt"
+#line 304 "src/lexer-keywords.txt"
       {"i32x4.le_s", TokenType::Compare, Opcode::I32X4LeS},
-#line 40 "src/lexer-keywords.txt"
+#line 39 "src/lexer-keywords.txt"
       {"data", TokenType::Data},
-#line 307 "src/lexer-keywords.txt"
+#line 305 "src/lexer-keywords.txt"
       {"i32x4.le_u", TokenType::Compare, Opcode::I32X4LeU},
       {""}, {""},
 #line 491 "src/lexer-keywords.txt"
       {"module", TokenType::Module},
-#line 165 "src/lexer-keywords.txt"
+#line 164 "src/lexer-keywords.txt"
       {"f64x2", TokenType::F64X2},
-#line 168 "src/lexer-keywords.txt"
+#line 167 "src/lexer-keywords.txt"
       {"func", Type::FuncRef, TokenType::Func},
       {""},
-#line 437 "src/lexer-keywords.txt"
+#line 434 "src/lexer-keywords.txt"
       {"i64x2", TokenType::I64X2},
 #line 510 "src/lexer-keywords.txt"
       {"select", TokenType::Select, Opcode::Select},
       {""},
-#line 99 "src/lexer-keywords.txt"
+#line 98 "src/lexer-keywords.txt"
       {"f32x4.mul", TokenType::Binary, Opcode::F32X4Mul},
       {""}, {""},
-#line 316 "src/lexer-keywords.txt"
+#line 314 "src/lexer-keywords.txt"
       {"i32x4.mul", TokenType::Binary, Opcode::I32X4Mul},
 #line 519 "src/lexer-keywords.txt"
       {"table.set", TokenType::TableSet, Opcode::TableSet},
@@ -317,131 +317,131 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 #line 518 "src/lexer-keywords.txt"
       {"table.init", TokenType::TableInit, Opcode::TableInit},
       {""}, {""},
-#line 111 "src/lexer-keywords.txt"
+#line 110 "src/lexer-keywords.txt"
       {"f64.abs", TokenType::Unary, Opcode::F64Abs},
-#line 54 "src/lexer-keywords.txt"
+#line 53 "src/lexer-keywords.txt"
       {"f32.abs", TokenType::Unary, Opcode::F32Abs},
-#line 138 "src/lexer-keywords.txt"
+#line 137 "src/lexer-keywords.txt"
       {"f64.sub", TokenType::Binary, Opcode::F64Sub},
-#line 81 "src/lexer-keywords.txt"
+#line 80 "src/lexer-keywords.txt"
       {"f32.sub", TokenType::Binary, Opcode::F32Sub},
       {""},
-#line 415 "src/lexer-keywords.txt"
+#line 412 "src/lexer-keywords.txt"
       {"i64.sub", TokenType::Binary, Opcode::I64Sub},
-#line 284 "src/lexer-keywords.txt"
+#line 282 "src/lexer-keywords.txt"
       {"i32.sub", TokenType::Binary, Opcode::I32Sub},
-#line 133 "src/lexer-keywords.txt"
+#line 132 "src/lexer-keywords.txt"
       {"f64.ne", TokenType::Compare, Opcode::F64Ne},
-#line 77 "src/lexer-keywords.txt"
+#line 76 "src/lexer-keywords.txt"
       {"f32.ne", TokenType::Compare, Opcode::F32Ne},
       {""},
-#line 400 "src/lexer-keywords.txt"
+#line 397 "src/lexer-keywords.txt"
       {"i64.ne", TokenType::Compare, Opcode::I64Ne},
-#line 270 "src/lexer-keywords.txt"
+#line 268 "src/lexer-keywords.txt"
       {"i32.ne", TokenType::Compare, Opcode::I32Ne},
       {""},
-#line 47 "src/lexer-keywords.txt"
+#line 46 "src/lexer-keywords.txt"
       {"end", TokenType::End, Opcode::End},
       {""}, {""}, {""}, {""}, {""},
-#line 84 "src/lexer-keywords.txt"
+#line 83 "src/lexer-keywords.txt"
       {"f32x4.abs", TokenType::Unary, Opcode::F32X4Abs},
       {""},
-#line 36 "src/lexer-keywords.txt"
+#line 35 "src/lexer-keywords.txt"
       {"call", TokenType::Call, Opcode::Call},
-#line 295 "src/lexer-keywords.txt"
+#line 293 "src/lexer-keywords.txt"
       {"i32x4.abs", TokenType::Unary, Opcode::I32X4Abs},
-#line 42 "src/lexer-keywords.txt"
+#line 41 "src/lexer-keywords.txt"
       {"do", TokenType::Do},
-#line 100 "src/lexer-keywords.txt"
+#line 99 "src/lexer-keywords.txt"
       {"f32x4.nearest", TokenType::Unary, Opcode::F32X4Nearest},
       {""}, {""}, {""}, {""}, {""},
 #line 515 "src/lexer-keywords.txt"
       {"table.fill", TokenType::TableFill, Opcode::TableFill},
-#line 108 "src/lexer-keywords.txt"
+#line 107 "src/lexer-keywords.txt"
       {"f32x4.sub", TokenType::Binary, Opcode::F32X4Sub},
-#line 483 "src/lexer-keywords.txt"
+#line 480 "src/lexer-keywords.txt"
       {"local", TokenType::Local},
       {""},
-#line 324 "src/lexer-keywords.txt"
+#line 322 "src/lexer-keywords.txt"
       {"i32x4.sub", TokenType::Binary, Opcode::I32X4Sub},
-#line 157 "src/lexer-keywords.txt"
+#line 156 "src/lexer-keywords.txt"
       {"f64x2.ne", TokenType::Compare, Opcode::F64X2Ne},
-#line 113 "src/lexer-keywords.txt"
+#line 112 "src/lexer-keywords.txt"
       {"f64.ceil", TokenType::Unary, Opcode::F64Ceil},
-#line 56 "src/lexer-keywords.txt"
+#line 55 "src/lexer-keywords.txt"
       {"f32.ceil", TokenType::Unary, Opcode::F32Ceil},
       {""},
-#line 153 "src/lexer-keywords.txt"
+#line 152 "src/lexer-keywords.txt"
       {"f64x2.min", TokenType::Binary, Opcode::F64X2Min},
-#line 151 "src/lexer-keywords.txt"
+#line 150 "src/lexer-keywords.txt"
       {"f64x2.lt", TokenType::Compare, Opcode::F64X2Lt},
       {""},
-#line 478 "src/lexer-keywords.txt"
+#line 475 "src/lexer-keywords.txt"
       {"invoke", TokenType::Invoke},
       {""}, {""},
 #line 505 "src/lexer-keywords.txt"
       {"result", TokenType::Result},
-#line 30 "src/lexer-keywords.txt"
+#line 29 "src/lexer-keywords.txt"
       {"block", TokenType::Block, Opcode::Block},
       {""},
 #line 509 "src/lexer-keywords.txt"
       {"return", TokenType::Return, Opcode::Return},
       {""},
-#line 375 "src/lexer-keywords.txt"
+#line 372 "src/lexer-keywords.txt"
       {"i64.div_s", TokenType::Binary, Opcode::I64DivS},
-#line 250 "src/lexer-keywords.txt"
+#line 248 "src/lexer-keywords.txt"
       {"i32.div_s", TokenType::Binary, Opcode::I32DivS},
-#line 150 "src/lexer-keywords.txt"
+#line 149 "src/lexer-keywords.txt"
       {"f64x2.le", TokenType::Compare, Opcode::F64X2Le},
-#line 34 "src/lexer-keywords.txt"
+#line 33 "src/lexer-keywords.txt"
       {"br", TokenType::Br, Opcode::Br},
-#line 376 "src/lexer-keywords.txt"
+#line 373 "src/lexer-keywords.txt"
       {"i64.div_u", TokenType::Binary, Opcode::I64DivU},
-#line 251 "src/lexer-keywords.txt"
+#line 249 "src/lexer-keywords.txt"
       {"i32.div_u", TokenType::Binary, Opcode::I32DivU},
-#line 406 "src/lexer-keywords.txt"
+#line 403 "src/lexer-keywords.txt"
       {"i64.rotl", TokenType::Binary, Opcode::I64Rotl},
-#line 276 "src/lexer-keywords.txt"
+#line 274 "src/lexer-keywords.txt"
       {"i32.rotl", TokenType::Binary, Opcode::I32Rotl},
 #line 511 "src/lexer-keywords.txt"
       {"shared", TokenType::Shared},
       {""},
-#line 299 "src/lexer-keywords.txt"
+#line 297 "src/lexer-keywords.txt"
       {"i32x4.bitmask", TokenType::Unary, Opcode::I32X4Bitmask},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 481 "src/lexer-keywords.txt"
+#line 478 "src/lexer-keywords.txt"
       {"local.set", TokenType::LocalSet, Opcode::LocalSet},
       {""}, {""}, {""},
-#line 86 "src/lexer-keywords.txt"
+#line 85 "src/lexer-keywords.txt"
       {"f32x4.ceil", TokenType::Unary, Opcode::F32X4Ceil},
-#line 154 "src/lexer-keywords.txt"
+#line 153 "src/lexer-keywords.txt"
       {"f64x2.mul", TokenType::Binary, Opcode::F64X2Mul},
       {""}, {""},
-#line 429 "src/lexer-keywords.txt"
+#line 426 "src/lexer-keywords.txt"
       {"i64x2.mul", TokenType::Binary, Opcode::I64X2Mul},
 #line 535 "src/lexer-keywords.txt"
       {"v128", Type::V128},
       {""}, {""},
-#line 482 "src/lexer-keywords.txt"
+#line 479 "src/lexer-keywords.txt"
       {"local.tee", TokenType::LocalTee, Opcode::LocalTee},
       {""},
-#line 33 "src/lexer-keywords.txt"
+#line 32 "src/lexer-keywords.txt"
       {"br_table", TokenType::BrTable, Opcode::BrTable},
       {""},
-#line 334 "src/lexer-keywords.txt"
+#line 332 "src/lexer-keywords.txt"
       {"i64.and", TokenType::Binary, Opcode::I64And},
-#line 218 "src/lexer-keywords.txt"
+#line 217 "src/lexer-keywords.txt"
       {"i32.and", TokenType::Binary, Opcode::I32And},
       {""},
-#line 114 "src/lexer-keywords.txt"
+#line 113 "src/lexer-keywords.txt"
       {"f64.const", TokenType::Const, Opcode::F64Const},
-#line 57 "src/lexer-keywords.txt"
+#line 56 "src/lexer-keywords.txt"
       {"f32.const", TokenType::Const, Opcode::F32Const},
-#line 52 "src/lexer-keywords.txt"
+#line 51 "src/lexer-keywords.txt"
       {"externref", Type::ExternRef},
-#line 373 "src/lexer-keywords.txt"
+#line 370 "src/lexer-keywords.txt"
       {"i64.const", TokenType::Const, Opcode::I64Const},
-#line 248 "src/lexer-keywords.txt"
+#line 246 "src/lexer-keywords.txt"
       {"i32.const", TokenType::Const, Opcode::I32Const},
       {""}, {""},
 #line 497 "src/lexer-keywords.txt"
@@ -453,93 +453,93 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 #line 26 "src/lexer-keywords.txt"
       {"assert_unlinkable", TokenType::AssertUnlinkable},
       {""}, {""},
-#line 141 "src/lexer-keywords.txt"
+#line 140 "src/lexer-keywords.txt"
       {"f64x2.abs", TokenType::Unary, Opcode::F64X2Abs},
       {""},
 #line 513 "src/lexer-keywords.txt"
       {"struct", Type::Struct, TokenType::Struct},
       {""}, {""},
-#line 155 "src/lexer-keywords.txt"
+#line 154 "src/lexer-keywords.txt"
       {"f64x2.nearest", TokenType::Unary, Opcode::F64X2Nearest},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 163 "src/lexer-keywords.txt"
+#line 162 "src/lexer-keywords.txt"
       {"f64x2.sub", TokenType::Binary, Opcode::F64X2Sub},
       {""}, {""},
-#line 436 "src/lexer-keywords.txt"
+#line 433 "src/lexer-keywords.txt"
       {"i64x2.sub", TokenType::Binary, Opcode::I64X2Sub},
       {""}, {""}, {""},
-#line 121 "src/lexer-keywords.txt"
+#line 120 "src/lexer-keywords.txt"
       {"f64.eq", TokenType::Compare, Opcode::F64Eq},
-#line 65 "src/lexer-keywords.txt"
+#line 64 "src/lexer-keywords.txt"
       {"f32.eq", TokenType::Compare, Opcode::F32Eq},
       {""},
-#line 377 "src/lexer-keywords.txt"
+#line 374 "src/lexer-keywords.txt"
       {"i64.eq", TokenType::Compare, Opcode::I64Eq},
-#line 252 "src/lexer-keywords.txt"
+#line 250 "src/lexer-keywords.txt"
       {"i32.eq", TokenType::Compare, Opcode::I32Eq},
-#line 120 "src/lexer-keywords.txt"
+#line 119 "src/lexer-keywords.txt"
       {"f64.div", TokenType::Binary, Opcode::F64Div},
-#line 64 "src/lexer-keywords.txt"
+#line 63 "src/lexer-keywords.txt"
       {"f32.div", TokenType::Binary, Opcode::F32Div},
       {""}, {""}, {""}, {""}, {""},
 #line 502 "src/lexer-keywords.txt"
       {"ref.is_null", TokenType::RefIsNull, Opcode::RefIsNull},
       {""}, {""}, {""},
-#line 63 "src/lexer-keywords.txt"
+#line 62 "src/lexer-keywords.txt"
       {"f32.demote_f64", TokenType::Convert, Opcode::F32DemoteF64},
-#line 112 "src/lexer-keywords.txt"
+#line 111 "src/lexer-keywords.txt"
       {"f64.add", TokenType::Binary, Opcode::F64Add},
-#line 55 "src/lexer-keywords.txt"
+#line 54 "src/lexer-keywords.txt"
       {"f32.add", TokenType::Binary, Opcode::F32Add},
       {""},
-#line 333 "src/lexer-keywords.txt"
+#line 331 "src/lexer-keywords.txt"
       {"i64.add", TokenType::Binary, Opcode::I64Add},
-#line 217 "src/lexer-keywords.txt"
+#line 216 "src/lexer-keywords.txt"
       {"i32.add", TokenType::Binary, Opcode::I32Add},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 143 "src/lexer-keywords.txt"
+#line 142 "src/lexer-keywords.txt"
       {"f64x2.ceil", TokenType::Unary, Opcode::F64X2Ceil},
       {""},
-#line 90 "src/lexer-keywords.txt"
+#line 89 "src/lexer-keywords.txt"
       {"f32x4.eq", TokenType::Compare, Opcode::F32X4Eq},
-#line 85 "src/lexer-keywords.txt"
+#line 84 "src/lexer-keywords.txt"
       {"f32x4.add", TokenType::Binary, Opcode::F32X4Add},
       {""},
-#line 300 "src/lexer-keywords.txt"
+#line 298 "src/lexer-keywords.txt"
       {"i32x4.eq", TokenType::Compare, Opcode::I32X4Eq},
-#line 296 "src/lexer-keywords.txt"
+#line 294 "src/lexer-keywords.txt"
       {"i32x4.add", TokenType::Binary, Opcode::I32X4Add},
       {""}, {""}, {""}, {""},
-#line 126 "src/lexer-keywords.txt"
+#line 125 "src/lexer-keywords.txt"
       {"f64.load", TokenType::Load, Opcode::F64Load},
-#line 70 "src/lexer-keywords.txt"
+#line 69 "src/lexer-keywords.txt"
       {"f32.load", TokenType::Load, Opcode::F32Load},
       {""},
-#line 396 "src/lexer-keywords.txt"
+#line 393 "src/lexer-keywords.txt"
       {"i64.load", TokenType::Load, Opcode::I64Load},
-#line 266 "src/lexer-keywords.txt"
+#line 264 "src/lexer-keywords.txt"
       {"i32.load", TokenType::Load, Opcode::I32Load},
-#line 136 "src/lexer-keywords.txt"
+#line 135 "src/lexer-keywords.txt"
       {"f64.sqrt", TokenType::Unary, Opcode::F64Sqrt},
-#line 79 "src/lexer-keywords.txt"
+#line 78 "src/lexer-keywords.txt"
       {"f32.sqrt", TokenType::Unary, Opcode::F32Sqrt},
-#line 137 "src/lexer-keywords.txt"
+#line 136 "src/lexer-keywords.txt"
       {"f64.store", TokenType::Store, Opcode::F64Store},
-#line 80 "src/lexer-keywords.txt"
+#line 79 "src/lexer-keywords.txt"
       {"f32.store", TokenType::Store, Opcode::F32Store},
       {""},
-#line 414 "src/lexer-keywords.txt"
+#line 411 "src/lexer-keywords.txt"
       {"i64.store", TokenType::Store, Opcode::I64Store},
-#line 283 "src/lexer-keywords.txt"
+#line 281 "src/lexer-keywords.txt"
       {"i32.store", TokenType::Store, Opcode::I32Store},
       {""},
-#line 371 "src/lexer-keywords.txt"
-      {"i64.atomic.wait", TokenType::AtomicWait, Opcode::I64AtomicWait},
-#line 246 "src/lexer-keywords.txt"
-      {"i32.atomic.wait", TokenType::AtomicWait, Opcode::I32AtomicWait},
+#line 546 "src/lexer-keywords.txt"
+      {"i64.atomic.wait", TokenType::AtomicWait, Opcode::MemoryAtomicWait64},
+#line 545 "src/lexer-keywords.txt"
+      {"i32.atomic.wait", TokenType::AtomicWait, Opcode::MemoryAtomicWait32},
       {""}, {""},
-#line 412 "src/lexer-keywords.txt"
+#line 409 "src/lexer-keywords.txt"
       {"i64.store32", TokenType::Store, Opcode::I64Store32},
       {""},
 #line 506 "src/lexer-keywords.txt"
@@ -547,257 +547,257 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""},
 #line 22 "src/lexer-keywords.txt"
       {"assert_invalid", TokenType::AssertInvalid},
-#line 581 "src/lexer-keywords.txt"
+#line 584 "src/lexer-keywords.txt"
       {"set_local", TokenType::LocalSet, Opcode::LocalSet},
       {""},
-#line 107 "src/lexer-keywords.txt"
+#line 106 "src/lexer-keywords.txt"
       {"f32x4.sqrt", TokenType::Unary, Opcode::F32X4Sqrt},
       {""}, {""}, {""},
-#line 582 "src/lexer-keywords.txt"
+#line 585 "src/lexer-keywords.txt"
       {"tee_local", TokenType::LocalTee, Opcode::LocalTee},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 89 "src/lexer-keywords.txt"
+#line 88 "src/lexer-keywords.txt"
       {"f32x4.div", TokenType::Binary, Opcode::F32X4Div},
 #line 503 "src/lexer-keywords.txt"
       {"ref.null", TokenType::RefNull, Opcode::RefNull},
-#line 297 "src/lexer-keywords.txt"
+#line 295 "src/lexer-keywords.txt"
       {"i32x4.all_true", TokenType::Unary, Opcode::I32X4AllTrue},
       {""}, {""},
-#line 131 "src/lexer-keywords.txt"
+#line 130 "src/lexer-keywords.txt"
       {"f64.nearest", TokenType::Unary, Opcode::F64Nearest},
-#line 75 "src/lexer-keywords.txt"
+#line 74 "src/lexer-keywords.txt"
       {"f32.nearest", TokenType::Unary, Opcode::F32Nearest},
       {""}, {""},
-#line 394 "src/lexer-keywords.txt"
+#line 391 "src/lexer-keywords.txt"
       {"i64.load8_s", TokenType::Load, Opcode::I64Load8S},
-#line 264 "src/lexer-keywords.txt"
+#line 262 "src/lexer-keywords.txt"
       {"i32.load8_s", TokenType::Load, Opcode::I32Load8S},
       {""}, {""},
-#line 395 "src/lexer-keywords.txt"
-      {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
-#line 265 "src/lexer-keywords.txt"
-      {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
 #line 392 "src/lexer-keywords.txt"
+      {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
+#line 263 "src/lexer-keywords.txt"
+      {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
+#line 389 "src/lexer-keywords.txt"
       {"i64.load32_s", TokenType::Load, Opcode::I64Load32S},
       {""}, {""}, {""},
-#line 393 "src/lexer-keywords.txt"
+#line 390 "src/lexer-keywords.txt"
       {"i64.load32_u", TokenType::Load, Opcode::I64Load32U},
       {""}, {""},
-#line 370 "src/lexer-keywords.txt"
+#line 368 "src/lexer-keywords.txt"
       {"i64.atomic.store", TokenType::AtomicStore, Opcode::I64AtomicStore},
-#line 245 "src/lexer-keywords.txt"
+#line 244 "src/lexer-keywords.txt"
       {"i32.atomic.store", TokenType::AtomicStore, Opcode::I32AtomicStore},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 145 "src/lexer-keywords.txt"
+#line 144 "src/lexer-keywords.txt"
       {"f64x2.eq", TokenType::Compare, Opcode::F64X2Eq},
-#line 142 "src/lexer-keywords.txt"
+#line 141 "src/lexer-keywords.txt"
       {"f64x2.add", TokenType::Binary, Opcode::F64X2Add},
       {""}, {""},
-#line 425 "src/lexer-keywords.txt"
+#line 422 "src/lexer-keywords.txt"
       {"i64x2.add", TokenType::Binary, Opcode::I64X2Add},
       {""}, {""}, {""},
-#line 368 "src/lexer-keywords.txt"
+#line 366 "src/lexer-keywords.txt"
       {"i64.atomic.store32", TokenType::AtomicStore, Opcode::I64AtomicStore32},
       {""}, {""},
 #line 508 "src/lexer-keywords.txt"
       {"return_call", TokenType::ReturnCall, Opcode::ReturnCall},
-#line 35 "src/lexer-keywords.txt"
+#line 34 "src/lexer-keywords.txt"
       {"call_indirect", TokenType::CallIndirect, Opcode::CallIndirect},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 413 "src/lexer-keywords.txt"
+#line 410 "src/lexer-keywords.txt"
       {"i64.store8", TokenType::Store, Opcode::I64Store8},
-#line 282 "src/lexer-keywords.txt"
+#line 280 "src/lexer-keywords.txt"
       {"i32.store8", TokenType::Store, Opcode::I32Store8},
-#line 41 "src/lexer-keywords.txt"
+#line 40 "src/lexer-keywords.txt"
       {"declare", TokenType::Declare},
       {""}, {""}, {""},
 #line 520 "src/lexer-keywords.txt"
       {"table.size", TokenType::TableSize, Opcode::TableSize},
       {""}, {""}, {""},
-#line 139 "src/lexer-keywords.txt"
+#line 138 "src/lexer-keywords.txt"
       {"f64.trunc", TokenType::Unary, Opcode::F64Trunc},
-#line 82 "src/lexer-keywords.txt"
+#line 81 "src/lexer-keywords.txt"
       {"f32.trunc", TokenType::Unary, Opcode::F32Trunc},
       {""}, {""}, {""},
-#line 162 "src/lexer-keywords.txt"
+#line 161 "src/lexer-keywords.txt"
       {"f64x2.sqrt", TokenType::Unary, Opcode::F64X2Sqrt},
       {""}, {""},
-#line 418 "src/lexer-keywords.txt"
+#line 415 "src/lexer-keywords.txt"
       {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
-#line 287 "src/lexer-keywords.txt"
+#line 285 "src/lexer-keywords.txt"
       {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
-#line 419 "src/lexer-keywords.txt"
+#line 416 "src/lexer-keywords.txt"
       {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
-#line 288 "src/lexer-keywords.txt"
+#line 286 "src/lexer-keywords.txt"
       {"i32.trunc_f64_u", TokenType::Convert, Opcode::I32TruncF64U},
       {""},
-#line 312 "src/lexer-keywords.txt"
+#line 310 "src/lexer-keywords.txt"
       {"i32x4.max_s", TokenType::Binary, Opcode::I32X4MaxS},
       {""},
 #line 24 "src/lexer-keywords.txt"
       {"assert_return", TokenType::AssertReturn},
-#line 109 "src/lexer-keywords.txt"
+#line 108 "src/lexer-keywords.txt"
       {"f32x4.trunc", TokenType::Unary, Opcode::F32X4Trunc},
-#line 313 "src/lexer-keywords.txt"
+#line 311 "src/lexer-keywords.txt"
       {"i32x4.max_u", TokenType::Binary, Opcode::I32X4MaxU},
       {""}, {""},
-#line 407 "src/lexer-keywords.txt"
+#line 404 "src/lexer-keywords.txt"
       {"i64.rotr", TokenType::Binary, Opcode::I64Rotr},
-#line 277 "src/lexer-keywords.txt"
+#line 275 "src/lexer-keywords.txt"
       {"i32.rotr", TokenType::Binary, Opcode::I32Rotr},
       {""},
-#line 144 "src/lexer-keywords.txt"
+#line 143 "src/lexer-keywords.txt"
       {"f64x2.div", TokenType::Binary, Opcode::F64X2Div},
       {""},
-#line 411 "src/lexer-keywords.txt"
+#line 408 "src/lexer-keywords.txt"
       {"i64.store16", TokenType::Store, Opcode::I64Store16},
-#line 281 "src/lexer-keywords.txt"
+#line 279 "src/lexer-keywords.txt"
       {"i32.store16", TokenType::Store, Opcode::I32Store16},
 #line 27 "src/lexer-keywords.txt"
       {"atomic.fence", TokenType::AtomicFence, Opcode::AtomicFence},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 416 "src/lexer-keywords.txt"
+#line 413 "src/lexer-keywords.txt"
       {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
-#line 285 "src/lexer-keywords.txt"
+#line 283 "src/lexer-keywords.txt"
       {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
-#line 417 "src/lexer-keywords.txt"
+#line 414 "src/lexer-keywords.txt"
       {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
-#line 286 "src/lexer-keywords.txt"
+#line 284 "src/lexer-keywords.txt"
       {"i32.trunc_f32_u", TokenType::Convert, Opcode::I32TruncF32U},
       {""}, {""}, {""},
 #line 525 "src/lexer-keywords.txt"
       {"type", TokenType::Type},
       {""},
-#line 117 "src/lexer-keywords.txt"
+#line 116 "src/lexer-keywords.txt"
       {"f64.convert_i64_s", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 60 "src/lexer-keywords.txt"
+#line 59 "src/lexer-keywords.txt"
       {"f32.convert_i64_s", TokenType::Convert, Opcode::F32ConvertI64S},
       {""},
 #line 494 "src/lexer-keywords.txt"
       {"nan:canonical", TokenType::NanCanonical},
-#line 338 "src/lexer-keywords.txt"
+#line 336 "src/lexer-keywords.txt"
       {"i64.atomic.load", TokenType::AtomicLoad, Opcode::I64AtomicLoad},
-#line 221 "src/lexer-keywords.txt"
+#line 220 "src/lexer-keywords.txt"
       {"i32.atomic.load", TokenType::AtomicLoad, Opcode::I32AtomicLoad},
       {""},
-#line 477 "src/lexer-keywords.txt"
+#line 474 "src/lexer-keywords.txt"
       {"input", TokenType::Input},
       {""},
 #line 532 "src/lexer-keywords.txt"
       {"v128.not", TokenType::Unary, Opcode::V128Not},
       {""}, {""}, {""}, {""}, {""},
-#line 476 "src/lexer-keywords.txt"
+#line 473 "src/lexer-keywords.txt"
       {"import", TokenType::Import},
       {""}, {""},
-#line 53 "src/lexer-keywords.txt"
+#line 52 "src/lexer-keywords.txt"
       {"export", TokenType::Export},
       {""}, {""},
-#line 92 "src/lexer-keywords.txt"
+#line 91 "src/lexer-keywords.txt"
       {"f32x4.floor", TokenType::Unary, Opcode::F32X4Floor},
       {""}, {""}, {""}, {""}, {""},
-#line 115 "src/lexer-keywords.txt"
+#line 114 "src/lexer-keywords.txt"
       {"f64.convert_i32_s", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 58 "src/lexer-keywords.txt"
+#line 57 "src/lexer-keywords.txt"
       {"f32.convert_i32_s", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 549 "src/lexer-keywords.txt"
+#line 552 "src/lexer-keywords.txt"
       {"f32.demote/f64", TokenType::Convert, Opcode::F32DemoteF64},
 #line 523 "src/lexer-keywords.txt"
       {"throw", TokenType::Throw, Opcode::Throw},
       {""}, {""},
-#line 422 "src/lexer-keywords.txt"
+#line 419 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f64_s", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 291 "src/lexer-keywords.txt"
+#line 289 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f64_s", TokenType::Convert, Opcode::I32TruncSatF64S},
       {""},
 #line 527 "src/lexer-keywords.txt"
       {"v128.andnot", TokenType::Binary, Opcode::V128Andnot},
-#line 423 "src/lexer-keywords.txt"
+#line 420 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f64_u", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 292 "src/lexer-keywords.txt"
+#line 290 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f64_u", TokenType::Convert, Opcode::I32TruncSatF64U},
       {""}, {""}, {""}, {""},
-#line 381 "src/lexer-keywords.txt"
+#line 378 "src/lexer-keywords.txt"
       {"i64.extend8_s", TokenType::Unary, Opcode::I64Extend8S},
-#line 255 "src/lexer-keywords.txt"
+#line 253 "src/lexer-keywords.txt"
       {"i32.extend8_s", TokenType::Unary, Opcode::I32Extend8S},
-#line 367 "src/lexer-keywords.txt"
+#line 365 "src/lexer-keywords.txt"
       {"i64.atomic.store16", TokenType::AtomicStore, Opcode::I64AtomicStore16},
-#line 243 "src/lexer-keywords.txt"
+#line 242 "src/lexer-keywords.txt"
       {"i32.atomic.store16", TokenType::AtomicStore, Opcode::I32AtomicStore16},
       {""}, {""},
-#line 32 "src/lexer-keywords.txt"
+#line 31 "src/lexer-keywords.txt"
       {"br_on_exn", TokenType::BrOnExn, Opcode::BrOnExn},
-#line 380 "src/lexer-keywords.txt"
+#line 377 "src/lexer-keywords.txt"
       {"i64.extend32_s", TokenType::Unary, Opcode::I64Extend32S},
       {""}, {""},
-#line 164 "src/lexer-keywords.txt"
+#line 163 "src/lexer-keywords.txt"
       {"f64x2.trunc", TokenType::Unary, Opcode::F64X2Trunc},
       {""}, {""}, {""}, {""},
-#line 104 "src/lexer-keywords.txt"
+#line 103 "src/lexer-keywords.txt"
       {"f32x4.pmin", TokenType::Binary, Opcode::F32X4PMin},
       {""}, {""}, {""},
-#line 357 "src/lexer-keywords.txt"
+#line 355 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8SubU},
-#line 233 "src/lexer-keywords.txt"
+#line 232 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8SubU},
-#line 382 "src/lexer-keywords.txt"
+#line 379 "src/lexer-keywords.txt"
       {"i64.extend_i32_s", TokenType::Convert, Opcode::I64ExtendI32S},
       {""},
-#line 337 "src/lexer-keywords.txt"
+#line 335 "src/lexer-keywords.txt"
       {"i64.atomic.load8_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad8U},
-#line 220 "src/lexer-keywords.txt"
+#line 219 "src/lexer-keywords.txt"
       {"i32.atomic.load8_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad8U},
-#line 383 "src/lexer-keywords.txt"
+#line 380 "src/lexer-keywords.txt"
       {"i64.extend_i32_u", TokenType::Convert, Opcode::I64ExtendI32U},
       {""}, {""}, {""},
 #line 528 "src/lexer-keywords.txt"
       {"v128.and", TokenType::Binary, Opcode::V128And},
-#line 390 "src/lexer-keywords.txt"
+#line 387 "src/lexer-keywords.txt"
       {"i64.load16_s", TokenType::Load, Opcode::I64Load16S},
-#line 262 "src/lexer-keywords.txt"
+#line 260 "src/lexer-keywords.txt"
       {"i32.load16_s", TokenType::Load, Opcode::I32Load16S},
       {""}, {""},
-#line 391 "src/lexer-keywords.txt"
+#line 388 "src/lexer-keywords.txt"
       {"i64.load16_u", TokenType::Load, Opcode::I64Load16U},
-#line 263 "src/lexer-keywords.txt"
+#line 261 "src/lexer-keywords.txt"
       {"i32.load16_u", TokenType::Load, Opcode::I32Load16U},
       {""},
 #line 23 "src/lexer-keywords.txt"
       {"assert_malformed", TokenType::AssertMalformed},
-#line 106 "src/lexer-keywords.txt"
+#line 105 "src/lexer-keywords.txt"
       {"f32x4.splat", TokenType::Unary, Opcode::F32X4Splat},
       {""}, {""},
-#line 323 "src/lexer-keywords.txt"
+#line 321 "src/lexer-keywords.txt"
       {"i32x4.splat", TokenType::Unary, Opcode::I32X4Splat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 484 "src/lexer-keywords.txt"
+#line 481 "src/lexer-keywords.txt"
       {"loop", TokenType::Loop, Opcode::Loop},
 #line 507 "src/lexer-keywords.txt"
       {"return_call_indirect", TokenType::ReturnCallIndirect, Opcode::ReturnCallIndirect},
       {""}, {""},
-#line 118 "src/lexer-keywords.txt"
+#line 117 "src/lexer-keywords.txt"
       {"f64.convert_i64_u", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 61 "src/lexer-keywords.txt"
+#line 60 "src/lexer-keywords.txt"
       {"f32.convert_i64_u", TokenType::Convert, Opcode::F32ConvertI64U},
       {""},
-#line 147 "src/lexer-keywords.txt"
+#line 146 "src/lexer-keywords.txt"
       {"f64x2.floor", TokenType::Unary, Opcode::F64X2Floor},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
 #line 530 "src/lexer-keywords.txt"
       {"v128.const", TokenType::Const, Opcode::V128Const},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 354 "src/lexer-keywords.txt"
+#line 352 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AndU},
-#line 230 "src/lexer-keywords.txt"
+#line 229 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AndU},
 #line 488 "src/lexer-keywords.txt"
       {"memory.init", TokenType::MemoryInit, Opcode::MemoryInit},
       {""}, {""}, {""},
-#line 116 "src/lexer-keywords.txt"
+#line 115 "src/lexer-keywords.txt"
       {"f64.convert_i32_u", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 59 "src/lexer-keywords.txt"
+#line 58 "src/lexer-keywords.txt"
       {"f32.convert_i32_u", TokenType::Convert, Opcode::F32ConvertI32U},
       {""}, {""}, {""}, {""},
 #line 489 "src/lexer-keywords.txt"
@@ -805,30 +805,30 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 #line 529 "src/lexer-keywords.txt"
       {"v128.bitselect", TokenType::Ternary, Opcode::V128BitSelect},
       {""},
-#line 43 "src/lexer-keywords.txt"
+#line 42 "src/lexer-keywords.txt"
       {"drop", TokenType::Drop, Opcode::Drop},
       {""}, {""},
 #line 498 "src/lexer-keywords.txt"
       {"param", TokenType::Param},
-#line 159 "src/lexer-keywords.txt"
+#line 158 "src/lexer-keywords.txt"
       {"f64x2.pmin", TokenType::Binary, Opcode::F64X2PMin},
       {""}, {""},
-#line 420 "src/lexer-keywords.txt"
+#line 417 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f32_s", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 289 "src/lexer-keywords.txt"
+#line 287 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f32_s", TokenType::Convert, Opcode::I32TruncSatF32S},
       {""}, {""},
-#line 421 "src/lexer-keywords.txt"
+#line 418 "src/lexer-keywords.txt"
       {"i64.trunc_sat_f32_u", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 290 "src/lexer-keywords.txt"
+#line 288 "src/lexer-keywords.txt"
       {"i32.trunc_sat_f32_u", TokenType::Convert, Opcode::I32TruncSatF32U},
       {""}, {""}, {""},
-#line 360 "src/lexer-keywords.txt"
+#line 358 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I64AtomicRmwAdd},
-#line 236 "src/lexer-keywords.txt"
+#line 235 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I32AtomicRmwAdd},
       {""},
-#line 336 "src/lexer-keywords.txt"
+#line 334 "src/lexer-keywords.txt"
       {"i64.atomic.load32_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad32U},
       {""}, {""},
 #line 534 "src/lexer-keywords.txt"
@@ -836,452 +836,456 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 #line 486 "src/lexer-keywords.txt"
       {"memory.fill", TokenType::MemoryFill, Opcode::MemoryFill},
       {""}, {""}, {""},
-#line 161 "src/lexer-keywords.txt"
+#line 160 "src/lexer-keywords.txt"
       {"f64x2.splat", TokenType::Unary, Opcode::F64X2Splat},
-#line 169 "src/lexer-keywords.txt"
+#line 168 "src/lexer-keywords.txt"
       {"get", TokenType::Get},
       {""},
-#line 435 "src/lexer-keywords.txt"
+#line 432 "src/lexer-keywords.txt"
       {"i64x2.splat", TokenType::Unary, Opcode::I64X2Splat},
-#line 573 "src/lexer-keywords.txt"
+#line 576 "src/lexer-keywords.txt"
       {"i64.trunc_s/f64", TokenType::Convert, Opcode::I64TruncF64S},
-#line 561 "src/lexer-keywords.txt"
+#line 564 "src/lexer-keywords.txt"
       {"i32.trunc_s/f64", TokenType::Convert, Opcode::I32TruncF64S},
-#line 577 "src/lexer-keywords.txt"
+#line 580 "src/lexer-keywords.txt"
       {"i64.trunc_u/f64", TokenType::Convert, Opcode::I64TruncF64U},
-#line 565 "src/lexer-keywords.txt"
+#line 568 "src/lexer-keywords.txt"
       {"i32.trunc_u/f64", TokenType::Convert, Opcode::I32TruncF64U},
-#line 134 "src/lexer-keywords.txt"
+#line 133 "src/lexer-keywords.txt"
       {"f64.promote_f32", TokenType::Convert, Opcode::F64PromoteF32},
       {""}, {""}, {""}, {""},
-#line 364 "src/lexer-keywords.txt"
+#line 362 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I64AtomicRmwSub},
-#line 240 "src/lexer-keywords.txt"
+#line 239 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I32AtomicRmwSub},
-#line 353 "src/lexer-keywords.txt"
+#line 351 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AddU},
-#line 229 "src/lexer-keywords.txt"
+#line 228 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AddU},
       {""}, {""}, {""}, {""},
 #line 531 "src/lexer-keywords.txt"
       {"v128.load", TokenType::Load, Opcode::V128Load},
       {""},
-#line 569 "src/lexer-keywords.txt"
+#line 572 "src/lexer-keywords.txt"
       {"i64.extend_s/i32", TokenType::Convert, Opcode::I64ExtendI32S},
       {""},
-#line 570 "src/lexer-keywords.txt"
+#line 573 "src/lexer-keywords.txt"
       {"i64.extend_u/i32", TokenType::Convert, Opcode::I64ExtendI32U},
       {""}, {""},
 #line 500 "src/lexer-keywords.txt"
       {"ref.extern", TokenType::RefExtern},
       {""}, {""}, {""},
-#line 572 "src/lexer-keywords.txt"
+#line 575 "src/lexer-keywords.txt"
       {"i64.trunc_s/f32", TokenType::Convert, Opcode::I64TruncF32S},
-#line 560 "src/lexer-keywords.txt"
+#line 563 "src/lexer-keywords.txt"
       {"i32.trunc_s/f32", TokenType::Convert, Opcode::I32TruncF32S},
-#line 576 "src/lexer-keywords.txt"
+#line 579 "src/lexer-keywords.txt"
       {"i64.trunc_u/f32", TokenType::Convert, Opcode::I64TruncF32U},
-#line 564 "src/lexer-keywords.txt"
+#line 567 "src/lexer-keywords.txt"
       {"i32.trunc_u/f32", TokenType::Convert, Opcode::I32TruncF32U},
-#line 374 "src/lexer-keywords.txt"
+#line 371 "src/lexer-keywords.txt"
       {"i64.ctz", TokenType::Unary, Opcode::I64Ctz},
-#line 249 "src/lexer-keywords.txt"
+#line 247 "src/lexer-keywords.txt"
       {"i32.ctz", TokenType::Unary, Opcode::I32Ctz},
-#line 552 "src/lexer-keywords.txt"
+#line 555 "src/lexer-keywords.txt"
       {"f64.convert_s/i64", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 546 "src/lexer-keywords.txt"
+#line 549 "src/lexer-keywords.txt"
       {"f32.convert_s/i64", TokenType::Convert, Opcode::F32ConvertI64S},
-#line 554 "src/lexer-keywords.txt"
+#line 557 "src/lexer-keywords.txt"
       {"f64.convert_u/i64", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 548 "src/lexer-keywords.txt"
+#line 551 "src/lexer-keywords.txt"
       {"f32.convert_u/i64", TokenType::Convert, Opcode::F32ConvertI64U},
       {""}, {""},
-#line 363 "src/lexer-keywords.txt"
+#line 361 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I64AtomicRmwOr},
-#line 239 "src/lexer-keywords.txt"
+#line 238 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I32AtomicRmwOr},
       {""}, {""},
-#line 128 "src/lexer-keywords.txt"
+#line 127 "src/lexer-keywords.txt"
       {"f64.max", TokenType::Binary, Opcode::F64Max},
-#line 72 "src/lexer-keywords.txt"
+#line 71 "src/lexer-keywords.txt"
       {"f32.max", TokenType::Binary, Opcode::F32Max},
       {""},
-#line 94 "src/lexer-keywords.txt"
+#line 93 "src/lexer-keywords.txt"
       {"f32x4.gt", TokenType::Compare, Opcode::F32X4Gt},
-#line 31 "src/lexer-keywords.txt"
+#line 30 "src/lexer-keywords.txt"
       {"br_if", TokenType::BrIf, Opcode::BrIf},
 #line 21 "src/lexer-keywords.txt"
       {"assert_exhaustion", TokenType::AssertExhaustion},
       {""},
-#line 372 "src/lexer-keywords.txt"
+#line 369 "src/lexer-keywords.txt"
       {"i64.clz", TokenType::Unary, Opcode::I64Clz},
-#line 247 "src/lexer-keywords.txt"
+#line 245 "src/lexer-keywords.txt"
       {"i32.clz", TokenType::Unary, Opcode::I32Clz},
-#line 350 "src/lexer-keywords.txt"
+#line 348 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32SubU},
       {""}, {""},
-#line 330 "src/lexer-keywords.txt"
+#line 328 "src/lexer-keywords.txt"
       {"i32x4.widen_low_i16x8_s", TokenType::Unary, Opcode::I32X4WidenLowI16X8S},
       {""},
-#line 331 "src/lexer-keywords.txt"
+#line 329 "src/lexer-keywords.txt"
       {"i32x4.widen_low_i16x8_u", TokenType::Unary, Opcode::I32X4WidenLowI16X8U},
-#line 93 "src/lexer-keywords.txt"
+#line 92 "src/lexer-keywords.txt"
       {"f32x4.ge", TokenType::Compare, Opcode::F32X4Ge},
       {""},
-#line 304 "src/lexer-keywords.txt"
+#line 302 "src/lexer-keywords.txt"
       {"i32x4.gt_s", TokenType::Compare, Opcode::I32X4GtS},
       {""},
-#line 305 "src/lexer-keywords.txt"
+#line 303 "src/lexer-keywords.txt"
       {"i32x4.gt_u", TokenType::Compare, Opcode::I32X4GtU},
-#line 361 "src/lexer-keywords.txt"
+#line 359 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I64AtomicRmwAnd},
-#line 237 "src/lexer-keywords.txt"
+#line 236 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I32AtomicRmwAnd},
       {""},
-#line 302 "src/lexer-keywords.txt"
+#line 300 "src/lexer-keywords.txt"
       {"i32x4.ge_s", TokenType::Compare, Opcode::I32X4GeS},
       {""},
-#line 303 "src/lexer-keywords.txt"
+#line 301 "src/lexer-keywords.txt"
       {"i32x4.ge_u", TokenType::Compare, Opcode::I32X4GeU},
       {""}, {""},
-#line 97 "src/lexer-keywords.txt"
+#line 96 "src/lexer-keywords.txt"
       {"f32x4.max", TokenType::Binary, Opcode::F32X4Max},
       {""}, {""}, {""}, {""}, {""},
-#line 378 "src/lexer-keywords.txt"
+#line 375 "src/lexer-keywords.txt"
       {"i64.eqz", TokenType::Convert, Opcode::I64Eqz},
-#line 253 "src/lexer-keywords.txt"
+#line 251 "src/lexer-keywords.txt"
       {"i32.eqz", TokenType::Convert, Opcode::I32Eqz},
       {""}, {""}, {""},
-#line 347 "src/lexer-keywords.txt"
+#line 345 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AndU},
-#line 91 "src/lexer-keywords.txt"
+#line 90 "src/lexer-keywords.txt"
       {"f32x4.extract_lane", TokenType::SimdLaneOp, Opcode::F32X4ExtractLane},
       {""}, {""},
-#line 301 "src/lexer-keywords.txt"
+#line 299 "src/lexer-keywords.txt"
       {"i32x4.extract_lane", TokenType::SimdLaneOp, Opcode::I32X4ExtractLane},
       {""}, {""}, {""},
-#line 124 "src/lexer-keywords.txt"
+#line 123 "src/lexer-keywords.txt"
       {"f64.gt", TokenType::Compare, Opcode::F64Gt},
-#line 68 "src/lexer-keywords.txt"
+#line 67 "src/lexer-keywords.txt"
       {"f32.gt", TokenType::Compare, Opcode::F32Gt},
       {""}, {""}, {""}, {""}, {""},
 #line 533 "src/lexer-keywords.txt"
       {"v128.or", TokenType::Binary, Opcode::V128Or},
       {""},
-#line 379 "src/lexer-keywords.txt"
+#line 376 "src/lexer-keywords.txt"
       {"i64.extend16_s", TokenType::Unary, Opcode::I64Extend16S},
-#line 254 "src/lexer-keywords.txt"
+#line 252 "src/lexer-keywords.txt"
       {"i32.extend16_s", TokenType::Unary, Opcode::I32Extend16S},
 #line 516 "src/lexer-keywords.txt"
       {"table.get", TokenType::TableGet, Opcode::TableGet},
-#line 123 "src/lexer-keywords.txt"
+#line 122 "src/lexer-keywords.txt"
       {"f64.ge", TokenType::Compare, Opcode::F64Ge},
-#line 67 "src/lexer-keywords.txt"
+#line 66 "src/lexer-keywords.txt"
       {"f32.ge", TokenType::Compare, Opcode::F32Ge},
       {""}, {""}, {""},
-#line 343 "src/lexer-keywords.txt"
+#line 341 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16SubU},
-#line 226 "src/lexer-keywords.txt"
+#line 225 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16SubU},
       {""}, {""}, {""}, {""},
-#line 386 "src/lexer-keywords.txt"
+#line 383 "src/lexer-keywords.txt"
       {"i64.gt_s", TokenType::Compare, Opcode::I64GtS},
-#line 258 "src/lexer-keywords.txt"
-      {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
-#line 401 "src/lexer-keywords.txt"
-      {"i64.or", TokenType::Binary, Opcode::I64Or},
-#line 271 "src/lexer-keywords.txt"
-      {"i32.or", TokenType::Binary, Opcode::I32Or},
-#line 387 "src/lexer-keywords.txt"
-      {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
-#line 259 "src/lexer-keywords.txt"
-      {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
-#line 384 "src/lexer-keywords.txt"
-      {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
 #line 256 "src/lexer-keywords.txt"
+      {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
+#line 398 "src/lexer-keywords.txt"
+      {"i64.or", TokenType::Binary, Opcode::I64Or},
+#line 269 "src/lexer-keywords.txt"
+      {"i32.or", TokenType::Binary, Opcode::I32Or},
+#line 384 "src/lexer-keywords.txt"
+      {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
+#line 257 "src/lexer-keywords.txt"
+      {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
+#line 381 "src/lexer-keywords.txt"
+      {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
+#line 254 "src/lexer-keywords.txt"
       {"i32.ge_s", TokenType::Compare, Opcode::I32GeS},
       {""}, {""},
-#line 385 "src/lexer-keywords.txt"
+#line 382 "src/lexer-keywords.txt"
       {"i64.ge_u", TokenType::Compare, Opcode::I64GeU},
-#line 257 "src/lexer-keywords.txt"
+#line 255 "src/lexer-keywords.txt"
       {"i32.ge_u", TokenType::Compare, Opcode::I32GeU},
       {""}, {""}, {""},
-#line 149 "src/lexer-keywords.txt"
+#line 148 "src/lexer-keywords.txt"
       {"f64x2.gt", TokenType::Compare, Opcode::F64X2Gt},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 340 "src/lexer-keywords.txt"
+#line 338 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AndU},
-#line 223 "src/lexer-keywords.txt"
+#line 222 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AndU},
-#line 346 "src/lexer-keywords.txt"
+#line 344 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AddU},
-#line 148 "src/lexer-keywords.txt"
+#line 147 "src/lexer-keywords.txt"
       {"f64x2.ge", TokenType::Compare, Opcode::F64X2Ge},
-#line 408 "src/lexer-keywords.txt"
+#line 405 "src/lexer-keywords.txt"
       {"i64.shl", TokenType::Binary, Opcode::I64Shl},
-#line 278 "src/lexer-keywords.txt"
+#line 276 "src/lexer-keywords.txt"
       {"i32.shl", TokenType::Binary, Opcode::I32Shl},
       {""},
-#line 551 "src/lexer-keywords.txt"
+#line 554 "src/lexer-keywords.txt"
       {"f64.convert_s/i32", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 545 "src/lexer-keywords.txt"
+#line 548 "src/lexer-keywords.txt"
       {"f32.convert_s/i32", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 553 "src/lexer-keywords.txt"
+#line 556 "src/lexer-keywords.txt"
       {"f64.convert_u/i32", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 547 "src/lexer-keywords.txt"
+#line 550 "src/lexer-keywords.txt"
       {"f32.convert_u/i32", TokenType::Convert, Opcode::F32ConvertI32U},
-#line 348 "src/lexer-keywords.txt"
+#line 346 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw32CmpxchgU},
       {""}, {""}, {""}, {""},
-#line 152 "src/lexer-keywords.txt"
+#line 151 "src/lexer-keywords.txt"
       {"f64x2.max", TokenType::Binary, Opcode::F64X2Max},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 298 "src/lexer-keywords.txt"
+#line 296 "src/lexer-keywords.txt"
       {"i32x4.any_true", TokenType::Unary, Opcode::I32X4AnyTrue},
-#line 402 "src/lexer-keywords.txt"
+#line 399 "src/lexer-keywords.txt"
       {"i64.popcnt", TokenType::Unary, Opcode::I64Popcnt},
-#line 272 "src/lexer-keywords.txt"
+#line 270 "src/lexer-keywords.txt"
       {"i32.popcnt", TokenType::Unary, Opcode::I32Popcnt},
-#line 146 "src/lexer-keywords.txt"
+#line 145 "src/lexer-keywords.txt"
       {"f64x2.extract_lane", TokenType::SimdLaneOp, Opcode::F64X2ExtractLane},
       {""}, {""},
-#line 426 "src/lexer-keywords.txt"
+#line 423 "src/lexer-keywords.txt"
       {"i64x2.extract_lane", TokenType::SimdLaneOp, Opcode::I64X2ExtractLane},
       {""},
-#line 320 "src/lexer-keywords.txt"
+#line 318 "src/lexer-keywords.txt"
       {"i32x4.shl", TokenType::Binary, Opcode::I32X4Shl},
       {""}, {""}, {""},
-#line 480 "src/lexer-keywords.txt"
+#line 477 "src/lexer-keywords.txt"
       {"local.get", TokenType::LocalGet, Opcode::LocalGet},
-#line 465 "src/lexer-keywords.txt"
+#line 462 "src/lexer-keywords.txt"
       {"i8x16.ne", TokenType::Compare, Opcode::I8X16Ne},
-#line 37 "src/lexer-keywords.txt"
+#line 36 "src/lexer-keywords.txt"
       {"catch", TokenType::Catch, Opcode::Catch},
       {""}, {""},
-#line 474 "src/lexer-keywords.txt"
+#line 471 "src/lexer-keywords.txt"
       {"i8x16", TokenType::I8X16},
-#line 172 "src/lexer-keywords.txt"
+#line 171 "src/lexer-keywords.txt"
       {"global", TokenType::Global},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 460 "src/lexer-keywords.txt"
+#line 457 "src/lexer-keywords.txt"
       {"i8x16.min_s", TokenType::Binary, Opcode::I8X16MinS},
       {""}, {""},
-#line 456 "src/lexer-keywords.txt"
+#line 453 "src/lexer-keywords.txt"
       {"i8x16.lt_s", TokenType::Compare, Opcode::I8X16LtS},
-#line 461 "src/lexer-keywords.txt"
+#line 458 "src/lexer-keywords.txt"
       {"i8x16.min_u", TokenType::Binary, Opcode::I8X16MinU},
-#line 457 "src/lexer-keywords.txt"
+#line 454 "src/lexer-keywords.txt"
       {"i8x16.lt_u", TokenType::Compare, Opcode::I8X16LtU},
-#line 339 "src/lexer-keywords.txt"
+#line 337 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AddU},
-#line 222 "src/lexer-keywords.txt"
+#line 221 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AddU},
       {""},
-#line 454 "src/lexer-keywords.txt"
+#line 451 "src/lexer-keywords.txt"
       {"i8x16.le_s", TokenType::Compare, Opcode::I8X16LeS},
       {""},
-#line 455 "src/lexer-keywords.txt"
+#line 452 "src/lexer-keywords.txt"
       {"i8x16.le_u", TokenType::Compare, Opcode::I8X16LeU},
-#line 103 "src/lexer-keywords.txt"
+#line 102 "src/lexer-keywords.txt"
       {"f32x4.pmax", TokenType::Binary, Opcode::F32X4PMax},
       {""}, {""},
-#line 341 "src/lexer-keywords.txt"
+#line 339 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw16CmpxchgU},
-#line 224 "src/lexer-keywords.txt"
+#line 223 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw16CmpxchgU},
       {""},
-#line 171 "src/lexer-keywords.txt"
+#line 170 "src/lexer-keywords.txt"
       {"global.set", TokenType::GlobalSet, Opcode::GlobalSet},
-#line 555 "src/lexer-keywords.txt"
+#line 558 "src/lexer-keywords.txt"
       {"f64.promote/f32", TokenType::Convert, Opcode::F64PromoteF32},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 544 "src/lexer-keywords.txt"
+#line 547 "src/lexer-keywords.txt"
       {"anyfunc", Type::FuncRef},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
 #line 495 "src/lexer-keywords.txt"
       {"nop", TokenType::Nop, Opcode::Nop},
       {""}, {""},
-#line 439 "src/lexer-keywords.txt"
+#line 436 "src/lexer-keywords.txt"
       {"i8x16.abs", TokenType::Unary, Opcode::I8X16Abs},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""},
-#line 432 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 484 "src/lexer-keywords.txt"
+      {"memory.atomic.wait64", TokenType::AtomicWait, Opcode::MemoryAtomicWait64},
+      {""}, {""}, {""},
+#line 429 "src/lexer-keywords.txt"
       {"i64x2.shl", TokenType::Binary, Opcode::I64X2Shl},
-#line 473 "src/lexer-keywords.txt"
+#line 470 "src/lexer-keywords.txt"
       {"i8x16.sub", TokenType::Binary, Opcode::I8X16Sub},
       {""}, {""},
-#line 203 "src/lexer-keywords.txt"
+#line 202 "src/lexer-keywords.txt"
       {"i16x8.ne", TokenType::Compare, Opcode::I16X8Ne},
-#line 409 "src/lexer-keywords.txt"
+#line 406 "src/lexer-keywords.txt"
       {"i64.shr_s", TokenType::Binary, Opcode::I64ShrS},
-#line 279 "src/lexer-keywords.txt"
+#line 277 "src/lexer-keywords.txt"
       {"i32.shr_s", TokenType::Binary, Opcode::I32ShrS},
       {""}, {""},
-#line 410 "src/lexer-keywords.txt"
+#line 407 "src/lexer-keywords.txt"
       {"i64.shr_u", TokenType::Binary, Opcode::I64ShrU},
-#line 280 "src/lexer-keywords.txt"
+#line 278 "src/lexer-keywords.txt"
       {"i32.shr_u", TokenType::Binary, Opcode::I32ShrU},
       {""}, {""},
-#line 438 "src/lexer-keywords.txt"
+#line 435 "src/lexer-keywords.txt"
       {"i64.xor", TokenType::Binary, Opcode::I64Xor},
-#line 332 "src/lexer-keywords.txt"
+#line 330 "src/lexer-keywords.txt"
       {"i32.xor", TokenType::Binary, Opcode::I32Xor},
       {""},
-#line 349 "src/lexer-keywords.txt"
+#line 347 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32OrU},
-#line 197 "src/lexer-keywords.txt"
+#line 196 "src/lexer-keywords.txt"
       {"i16x8.min_s", TokenType::Binary, Opcode::I16X8MinS},
       {""}, {""},
-#line 193 "src/lexer-keywords.txt"
+#line 192 "src/lexer-keywords.txt"
       {"i16x8.lt_s", TokenType::Compare, Opcode::I16X8LtS},
-#line 198 "src/lexer-keywords.txt"
+#line 197 "src/lexer-keywords.txt"
       {"i16x8.min_u", TokenType::Binary, Opcode::I16X8MinU},
-#line 194 "src/lexer-keywords.txt"
+#line 193 "src/lexer-keywords.txt"
       {"i16x8.lt_u", TokenType::Compare, Opcode::I16X8LtU},
-      {""}, {""},
-#line 321 "src/lexer-keywords.txt"
+      {""},
+#line 483 "src/lexer-keywords.txt"
+      {"memory.atomic.wait32", TokenType::AtomicWait, Opcode::MemoryAtomicWait32},
+#line 319 "src/lexer-keywords.txt"
       {"i32x4.shr_s", TokenType::Binary, Opcode::I32X4ShrS},
-#line 189 "src/lexer-keywords.txt"
+#line 188 "src/lexer-keywords.txt"
       {"i16x8.le_s", TokenType::Compare, Opcode::I16X8LeS},
-#line 446 "src/lexer-keywords.txt"
+#line 443 "src/lexer-keywords.txt"
       {"i8x16.bitmask", TokenType::Unary, Opcode::I8X16Bitmask},
-#line 190 "src/lexer-keywords.txt"
+#line 189 "src/lexer-keywords.txt"
       {"i16x8.le_u", TokenType::Compare, Opcode::I16X8LeU},
-#line 322 "src/lexer-keywords.txt"
+#line 320 "src/lexer-keywords.txt"
       {"i32x4.shr_u", TokenType::Binary, Opcode::I32X4ShrU},
-#line 158 "src/lexer-keywords.txt"
+#line 157 "src/lexer-keywords.txt"
       {"f64x2.pmax", TokenType::Binary, Opcode::F64X2PMax},
       {""}, {""},
-#line 471 "src/lexer-keywords.txt"
+#line 468 "src/lexer-keywords.txt"
       {"i8x16.sub_sat_s", TokenType::Binary, Opcode::I8X16SubSatS},
-#line 427 "src/lexer-keywords.txt"
+#line 424 "src/lexer-keywords.txt"
       {"v128.load32x2_s", TokenType::Load, Opcode::V128Load32X2S},
-#line 472 "src/lexer-keywords.txt"
+#line 469 "src/lexer-keywords.txt"
       {"i8x16.sub_sat_u", TokenType::Binary, Opcode::I8X16SubSatU},
-#line 428 "src/lexer-keywords.txt"
+#line 425 "src/lexer-keywords.txt"
       {"v128.load32x2_u", TokenType::Load, Opcode::V128Load32X2U},
       {""}, {""},
-#line 212 "src/lexer-keywords.txt"
+#line 211 "src/lexer-keywords.txt"
       {"i16x8", TokenType::I16X8},
       {""},
-#line 199 "src/lexer-keywords.txt"
+#line 198 "src/lexer-keywords.txt"
       {"i16x8.mul", TokenType::Binary, Opcode::I16X8Mul},
-#line 558 "src/lexer-keywords.txt"
+#line 561 "src/lexer-keywords.txt"
       {"get_local", TokenType::LocalGet, Opcode::LocalGet},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 135 "src/lexer-keywords.txt"
+#line 134 "src/lexer-keywords.txt"
       {"f64.reinterpret_i64", TokenType::Convert, Opcode::F64ReinterpretI64},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 580 "src/lexer-keywords.txt"
+#line 583 "src/lexer-keywords.txt"
       {"set_global", TokenType::GlobalSet, Opcode::GlobalSet},
       {""}, {""},
 #line 20 "src/lexer-keywords.txt"
       {"array", Type::Array, TokenType::Array},
       {""}, {""}, {""}, {""},
-#line 174 "src/lexer-keywords.txt"
+#line 173 "src/lexer-keywords.txt"
       {"i16x8.abs", TokenType::Unary, Opcode::I16X8Abs},
-#line 342 "src/lexer-keywords.txt"
+#line 340 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16OrU},
-#line 225 "src/lexer-keywords.txt"
+#line 224 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16OrU},
-#line 87 "src/lexer-keywords.txt"
+#line 86 "src/lexer-keywords.txt"
       {"f32x4.convert_i32x4_s", TokenType::Unary, Opcode::F32X4ConvertI32X4S},
       {""},
-#line 88 "src/lexer-keywords.txt"
+#line 87 "src/lexer-keywords.txt"
       {"f32x4.convert_i32x4_u", TokenType::Unary, Opcode::F32X4ConvertI32X4U},
       {""},
-#line 355 "src/lexer-keywords.txt"
+#line 353 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw8CmpxchgU},
-#line 231 "src/lexer-keywords.txt"
+#line 230 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw8CmpxchgU},
       {""},
-#line 78 "src/lexer-keywords.txt"
+#line 77 "src/lexer-keywords.txt"
       {"f32.reinterpret_i32", TokenType::Convert, Opcode::F32ReinterpretI32},
       {""},
-#line 211 "src/lexer-keywords.txt"
+#line 210 "src/lexer-keywords.txt"
       {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
       {""}, {""},
 #line 517 "src/lexer-keywords.txt"
       {"table.grow", TokenType::TableGrow, Opcode::TableGrow},
       {""}, {""},
-#line 308 "src/lexer-keywords.txt"
+#line 306 "src/lexer-keywords.txt"
       {"v128.load16x4_s", TokenType::Load, Opcode::V128Load16X4S},
       {""},
-#line 309 "src/lexer-keywords.txt"
+#line 307 "src/lexer-keywords.txt"
       {"v128.load16x4_u", TokenType::Load, Opcode::V128Load16X4U},
       {""}, {""}, {""},
 #line 524 "src/lexer-keywords.txt"
       {"try", TokenType::Try, Opcode::Try},
       {""}, {""}, {""}, {""},
-#line 105 "src/lexer-keywords.txt"
+#line 104 "src/lexer-keywords.txt"
       {"f32x4.replace_lane", TokenType::SimdLaneOp, Opcode::F32X4ReplaceLane},
       {""}, {""},
-#line 319 "src/lexer-keywords.txt"
+#line 317 "src/lexer-keywords.txt"
       {"i32x4.replace_lane", TokenType::SimdLaneOp, Opcode::I32X4ReplaceLane},
       {""}, {""}, {""}, {""},
-#line 433 "src/lexer-keywords.txt"
+#line 430 "src/lexer-keywords.txt"
       {"i64x2.shr_s", TokenType::Binary, Opcode::I64X2ShrS},
-#line 181 "src/lexer-keywords.txt"
+#line 180 "src/lexer-keywords.txt"
       {"i16x8.bitmask", TokenType::Unary, Opcode::I16X8Bitmask},
 #line 501 "src/lexer-keywords.txt"
       {"ref.func", TokenType::RefFunc, Opcode::RefFunc},
       {""},
-#line 434 "src/lexer-keywords.txt"
+#line 431 "src/lexer-keywords.txt"
       {"i64x2.shr_u", TokenType::Binary, Opcode::I64X2ShrU},
       {""}, {""},
-#line 209 "src/lexer-keywords.txt"
+#line 208 "src/lexer-keywords.txt"
       {"i16x8.sub_sat_s", TokenType::Binary, Opcode::I16X8SubSatS},
       {""},
-#line 210 "src/lexer-keywords.txt"
+#line 209 "src/lexer-keywords.txt"
       {"i16x8.sub_sat_u", TokenType::Binary, Opcode::I16X8SubSatU},
 #line 490 "src/lexer-keywords.txt"
       {"memory", TokenType::Memory},
-#line 191 "src/lexer-keywords.txt"
+#line 190 "src/lexer-keywords.txt"
       {"v128.load8x8_s", TokenType::Load, Opcode::V128Load8X8S},
       {""}, {""}, {""},
-#line 192 "src/lexer-keywords.txt"
+#line 191 "src/lexer-keywords.txt"
       {"v128.load8x8_u", TokenType::Load, Opcode::V128Load8X8U},
       {""}, {""},
-#line 447 "src/lexer-keywords.txt"
+#line 444 "src/lexer-keywords.txt"
       {"i8x16.eq", TokenType::Compare, Opcode::I8X16Eq},
-#line 442 "src/lexer-keywords.txt"
+#line 439 "src/lexer-keywords.txt"
       {"i8x16.add", TokenType::Binary, Opcode::I8X16Add},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 440 "src/lexer-keywords.txt"
+#line 437 "src/lexer-keywords.txt"
       {"i8x16.add_sat_s", TokenType::Binary, Opcode::I8X16AddSatS},
 #line 536 "src/lexer-keywords.txt"
       {"v128.xor", TokenType::Binary, Opcode::V128Xor},
-#line 441 "src/lexer-keywords.txt"
+#line 438 "src/lexer-keywords.txt"
       {"i8x16.add_sat_u", TokenType::Binary, Opcode::I8X16AddSatU},
       {""}, {""}, {""}, {""},
-#line 356 "src/lexer-keywords.txt"
+#line 354 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8OrU},
-#line 232 "src/lexer-keywords.txt"
+#line 231 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8OrU},
       {""}, {""}, {""}, {""},
-#line 294 "src/lexer-keywords.txt"
+#line 292 "src/lexer-keywords.txt"
       {"i32.wrap_i64", TokenType::Convert, Opcode::I32WrapI64},
       {""}, {""}, {""}, {""},
-#line 29 "src/lexer-keywords.txt"
+#line 28 "src/lexer-keywords.txt"
       {"binary", TokenType::Bin},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 352 "src/lexer-keywords.txt"
+#line 350 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XorU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 443 "src/lexer-keywords.txt"
+#line 440 "src/lexer-keywords.txt"
       {"i8x16.all_true", TokenType::Unary, Opcode::I8X16AllTrue},
-#line 351 "src/lexer-keywords.txt"
+#line 349 "src/lexer-keywords.txt"
       {"i64.atomic.rmw32.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XchgU},
       {""}, {""}, {""},
-#line 160 "src/lexer-keywords.txt"
+#line 159 "src/lexer-keywords.txt"
       {"f64x2.replace_lane", TokenType::SimdLaneOp, Opcode::F64X2ReplaceLane},
       {""}, {""},
-#line 431 "src/lexer-keywords.txt"
+#line 428 "src/lexer-keywords.txt"
       {"i64x2.replace_lane", TokenType::SimdLaneOp, Opcode::I64X2ReplaceLane},
       {""}, {""}, {""}, {""},
 #line 540 "src/lexer-keywords.txt"
@@ -1291,9 +1295,9 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {"register", TokenType::Register},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 182 "src/lexer-keywords.txt"
+#line 181 "src/lexer-keywords.txt"
       {"i16x8.eq", TokenType::Compare, Opcode::I16X8Eq},
-#line 177 "src/lexer-keywords.txt"
+#line 176 "src/lexer-keywords.txt"
       {"i16x8.add", TokenType::Binary, Opcode::I16X8Add},
       {""}, {""},
 #line 25 "src/lexer-keywords.txt"
@@ -1304,48 +1308,48 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
 #line 538 "src/lexer-keywords.txt"
       {"v128.load32_splat", TokenType::Load, Opcode::V128Load32Splat},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 175 "src/lexer-keywords.txt"
+#line 174 "src/lexer-keywords.txt"
       {"i16x8.add_sat_s", TokenType::Binary, Opcode::I16X8AddSatS},
       {""},
-#line 176 "src/lexer-keywords.txt"
+#line 175 "src/lexer-keywords.txt"
       {"i16x8.add_sat_u", TokenType::Binary, Opcode::I16X8AddSatU},
-#line 345 "src/lexer-keywords.txt"
+#line 343 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XorU},
-#line 228 "src/lexer-keywords.txt"
+#line 227 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XorU},
       {""}, {""}, {""},
-#line 335 "src/lexer-keywords.txt"
+#line 333 "src/lexer-keywords.txt"
       {"i64.atomic.load16_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad16U},
-#line 219 "src/lexer-keywords.txt"
+#line 218 "src/lexer-keywords.txt"
       {"i32.atomic.load16_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad16U},
 #line 526 "src/lexer-keywords.txt"
       {"unreachable", TokenType::Unreachable, Opcode::Unreachable},
       {""},
-#line 344 "src/lexer-keywords.txt"
+#line 342 "src/lexer-keywords.txt"
       {"i64.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XchgU},
-#line 227 "src/lexer-keywords.txt"
+#line 226 "src/lexer-keywords.txt"
       {"i32.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XchgU},
       {""}, {""},
-#line 326 "src/lexer-keywords.txt"
+#line 324 "src/lexer-keywords.txt"
       {"i32x4.trunc_sat_f32x4_s", TokenType::Unary, Opcode::I32X4TruncSatF32X4S},
       {""},
-#line 327 "src/lexer-keywords.txt"
+#line 325 "src/lexer-keywords.txt"
       {"i32x4.trunc_sat_f32x4_u", TokenType::Unary, Opcode::I32X4TruncSatF32X4U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 458 "src/lexer-keywords.txt"
+#line 455 "src/lexer-keywords.txt"
       {"i8x16.max_s", TokenType::Binary, Opcode::I8X16MaxS},
       {""}, {""}, {""},
-#line 459 "src/lexer-keywords.txt"
+#line 456 "src/lexer-keywords.txt"
       {"i8x16.max_u", TokenType::Binary, Opcode::I8X16MaxU},
       {""},
-#line 122 "src/lexer-keywords.txt"
+#line 121 "src/lexer-keywords.txt"
       {"f64.floor", TokenType::Unary, Opcode::F64Floor},
-#line 66 "src/lexer-keywords.txt"
+#line 65 "src/lexer-keywords.txt"
       {"f32.floor", TokenType::Unary, Opcode::F32Floor},
-#line 556 "src/lexer-keywords.txt"
+#line 559 "src/lexer-keywords.txt"
       {"f64.reinterpret/i64", TokenType::Convert, Opcode::F64ReinterpretI64},
       {""}, {""},
-#line 178 "src/lexer-keywords.txt"
+#line 177 "src/lexer-keywords.txt"
       {"i16x8.all_true", TokenType::Unary, Opcode::I16X8AllTrue},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
@@ -1356,195 +1360,197 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {"i8x16.swizzle", TokenType::Binary, Opcode::I8X16Swizzle},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 550 "src/lexer-keywords.txt"
+#line 553 "src/lexer-keywords.txt"
       {"f32.reinterpret/i32", TokenType::Convert, Opcode::F32ReinterpretI32},
 #line 493 "src/lexer-keywords.txt"
       {"nan:arithmetic", TokenType::NanArithmetic},
       {""},
-#line 359 "src/lexer-keywords.txt"
+#line 357 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XorU},
-#line 235 "src/lexer-keywords.txt"
+#line 234 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XorU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 369 "src/lexer-keywords.txt"
+#line 367 "src/lexer-keywords.txt"
       {"i64.atomic.store8", TokenType::AtomicStore, Opcode::I64AtomicStore8},
-#line 244 "src/lexer-keywords.txt"
+#line 243 "src/lexer-keywords.txt"
       {"i32.atomic.store8", TokenType::AtomicStore, Opcode::I32AtomicStore8},
       {""}, {""},
 #line 514 "src/lexer-keywords.txt"
       {"table.copy", TokenType::TableCopy, Opcode::TableCopy},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 195 "src/lexer-keywords.txt"
+#line 194 "src/lexer-keywords.txt"
       {"i16x8.max_s", TokenType::Binary, Opcode::I16X8MaxS},
       {""}, {""}, {""},
-#line 196 "src/lexer-keywords.txt"
+#line 195 "src/lexer-keywords.txt"
       {"i16x8.max_u", TokenType::Binary, Opcode::I16X8MaxU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 568 "src/lexer-keywords.txt"
+#line 571 "src/lexer-keywords.txt"
       {"i32.wrap/i64", TokenType::Convert, Opcode::I32WrapI64},
       {""}, {""}, {""}, {""}, {""},
-#line 470 "src/lexer-keywords.txt"
+#line 467 "src/lexer-keywords.txt"
       {"i8x16.splat", TokenType::Unary, Opcode::I8X16Splat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 101 "src/lexer-keywords.txt"
+#line 100 "src/lexer-keywords.txt"
       {"f32x4.neg", TokenType::Unary, Opcode::F32X4Neg},
       {""}, {""},
-#line 317 "src/lexer-keywords.txt"
+#line 315 "src/lexer-keywords.txt"
       {"i32x4.neg", TokenType::Unary, Opcode::I32X4Neg},
       {""},
-#line 575 "src/lexer-keywords.txt"
+#line 578 "src/lexer-keywords.txt"
       {"i64.trunc_s:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 563 "src/lexer-keywords.txt"
+#line 566 "src/lexer-keywords.txt"
       {"i32.trunc_s:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64S},
-#line 579 "src/lexer-keywords.txt"
+#line 582 "src/lexer-keywords.txt"
       {"i64.trunc_u:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 567 "src/lexer-keywords.txt"
+#line 570 "src/lexer-keywords.txt"
       {"i32.trunc_u:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 574 "src/lexer-keywords.txt"
+#line 577 "src/lexer-keywords.txt"
       {"i64.trunc_s:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 562 "src/lexer-keywords.txt"
+#line 565 "src/lexer-keywords.txt"
       {"i32.trunc_s:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32S},
-#line 578 "src/lexer-keywords.txt"
+#line 581 "src/lexer-keywords.txt"
       {"i64.trunc_u:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 566 "src/lexer-keywords.txt"
+#line 569 "src/lexer-keywords.txt"
       {"i32.trunc_u:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 208 "src/lexer-keywords.txt"
+#line 207 "src/lexer-keywords.txt"
       {"i16x8.splat", TokenType::Unary, Opcode::I16X8Splat},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 132 "src/lexer-keywords.txt"
+#line 131 "src/lexer-keywords.txt"
       {"f64.neg", TokenType::Unary, Opcode::F64Neg},
-#line 76 "src/lexer-keywords.txt"
+#line 75 "src/lexer-keywords.txt"
       {"f32.neg", TokenType::Unary, Opcode::F32Neg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
 #line 487 "src/lexer-keywords.txt"
       {"memory.grow", TokenType::MemoryGrow, Opcode::MemoryGrow},
+#line 482 "src/lexer-keywords.txt"
+      {"memory.atomic.notify", TokenType::AtomicNotify, Opcode::MemoryAtomicNotify},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 156 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 155 "src/lexer-keywords.txt"
       {"f64x2.neg", TokenType::Unary, Opcode::F64X2Neg},
       {""}, {""},
-#line 430 "src/lexer-keywords.txt"
+#line 427 "src/lexer-keywords.txt"
       {"i64x2.neg", TokenType::Unary, Opcode::I64X2Neg},
       {""}, {""}, {""},
-#line 28 "src/lexer-keywords.txt"
-      {"atomic.notify", TokenType::AtomicNotify, Opcode::AtomicNotify},
+#line 544 "src/lexer-keywords.txt"
+      {"atomic.notify", TokenType::AtomicNotify, Opcode::MemoryAtomicNotify},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 452 "src/lexer-keywords.txt"
+#line 449 "src/lexer-keywords.txt"
       {"i8x16.gt_s", TokenType::Compare, Opcode::I8X16GtS},
       {""},
-#line 453 "src/lexer-keywords.txt"
+#line 450 "src/lexer-keywords.txt"
       {"i8x16.gt_u", TokenType::Compare, Opcode::I8X16GtU},
       {""}, {""}, {""},
-#line 450 "src/lexer-keywords.txt"
+#line 447 "src/lexer-keywords.txt"
       {"i8x16.ge_s", TokenType::Compare, Opcode::I8X16GeS},
       {""},
-#line 451 "src/lexer-keywords.txt"
+#line 448 "src/lexer-keywords.txt"
       {"i8x16.ge_u", TokenType::Compare, Opcode::I8X16GeU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 44 "src/lexer-keywords.txt"
+#line 43 "src/lexer-keywords.txt"
       {"elem.drop", TokenType::ElemDrop, Opcode::ElemDrop},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 448 "src/lexer-keywords.txt"
+#line 445 "src/lexer-keywords.txt"
       {"i8x16.extract_lane_s", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneS},
       {""},
-#line 449 "src/lexer-keywords.txt"
+#line 446 "src/lexer-keywords.txt"
       {"i8x16.extract_lane_u", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneU},
-#line 170 "src/lexer-keywords.txt"
+#line 169 "src/lexer-keywords.txt"
       {"global.get", TokenType::GlobalGet, Opcode::GlobalGet},
       {""}, {""}, {""},
-#line 366 "src/lexer-keywords.txt"
+#line 364 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I64AtomicRmwXor},
-#line 242 "src/lexer-keywords.txt"
+#line 241 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I32AtomicRmwXor},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 39 "src/lexer-keywords.txt"
+#line 38 "src/lexer-keywords.txt"
       {"data.drop", TokenType::DataDrop, Opcode::DataDrop},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 187 "src/lexer-keywords.txt"
+#line 186 "src/lexer-keywords.txt"
       {"i16x8.gt_s", TokenType::Compare, Opcode::I16X8GtS},
       {""},
-#line 188 "src/lexer-keywords.txt"
+#line 187 "src/lexer-keywords.txt"
       {"i16x8.gt_u", TokenType::Compare, Opcode::I16X8GtU},
       {""}, {""}, {""},
-#line 185 "src/lexer-keywords.txt"
+#line 184 "src/lexer-keywords.txt"
       {"i16x8.ge_s", TokenType::Compare, Opcode::I16X8GeS},
       {""},
-#line 186 "src/lexer-keywords.txt"
+#line 185 "src/lexer-keywords.txt"
       {"i16x8.ge_u", TokenType::Compare, Opcode::I16X8GeU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 444 "src/lexer-keywords.txt"
+#line 441 "src/lexer-keywords.txt"
       {"i8x16.any_true", TokenType::Unary, Opcode::I8X16AnyTrue},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 467 "src/lexer-keywords.txt"
+#line 464 "src/lexer-keywords.txt"
       {"i8x16.shl", TokenType::Binary, Opcode::I8X16Shl},
       {""},
-#line 183 "src/lexer-keywords.txt"
+#line 182 "src/lexer-keywords.txt"
       {"i16x8.extract_lane_s", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneS},
       {""},
-#line 184 "src/lexer-keywords.txt"
+#line 183 "src/lexer-keywords.txt"
       {"i16x8.extract_lane_u", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""},
-#line 403 "src/lexer-keywords.txt"
+#line 400 "src/lexer-keywords.txt"
       {"i64.reinterpret_f64", TokenType::Convert, Opcode::I64ReinterpretF64},
       {""},
-#line 38 "src/lexer-keywords.txt"
+#line 37 "src/lexer-keywords.txt"
       {"current_memory", TokenType::MemorySize, Opcode::MemorySize},
       {""}, {""}, {""}, {""}, {""},
 #line 541 "src/lexer-keywords.txt"
       {"i8x16.shuffle", TokenType::SimdShuffleOp, Opcode::I8X16Shuffle},
       {""}, {""}, {""}, {""}, {""},
-#line 557 "src/lexer-keywords.txt"
+#line 560 "src/lexer-keywords.txt"
       {"get_global", TokenType::GlobalGet, Opcode::GlobalGet},
       {""}, {""}, {""}, {""},
-#line 215 "src/lexer-keywords.txt"
+#line 214 "src/lexer-keywords.txt"
       {"i16x8.widen_low_i8x16_s", TokenType::Unary, Opcode::I16X8WidenLowI8X16S},
       {""},
-#line 216 "src/lexer-keywords.txt"
+#line 215 "src/lexer-keywords.txt"
       {"i16x8.widen_low_i8x16_u", TokenType::Unary, Opcode::I16X8WidenLowI8X16U},
       {""}, {""},
-#line 445 "src/lexer-keywords.txt"
+#line 442 "src/lexer-keywords.txt"
       {"i8x16.avgr_u", TokenType::Binary, Opcode::I8X16AvgrU},
       {""}, {""}, {""}, {""}, {""},
-#line 273 "src/lexer-keywords.txt"
+#line 271 "src/lexer-keywords.txt"
       {"i32.reinterpret_f32", TokenType::Convert, Opcode::I32ReinterpretF32},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 179 "src/lexer-keywords.txt"
+#line 178 "src/lexer-keywords.txt"
       {"i16x8.any_true", TokenType::Unary, Opcode::I16X8AnyTrue},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 205 "src/lexer-keywords.txt"
+#line 204 "src/lexer-keywords.txt"
       {"i16x8.shl", TokenType::Binary, Opcode::I16X8Shl},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 468 "src/lexer-keywords.txt"
+#line 465 "src/lexer-keywords.txt"
       {"i8x16.shr_s", TokenType::Binary, Opcode::I8X16ShrS},
       {""}, {""}, {""},
-#line 469 "src/lexer-keywords.txt"
+#line 466 "src/lexer-keywords.txt"
       {"i8x16.shr_u", TokenType::Binary, Opcode::I8X16ShrU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""},
-#line 180 "src/lexer-keywords.txt"
+#line 179 "src/lexer-keywords.txt"
       {"i16x8.avgr_u", TokenType::Binary, Opcode::I16X8AvgrU},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1553,71 +1559,71 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 466 "src/lexer-keywords.txt"
+#line 463 "src/lexer-keywords.txt"
       {"i8x16.replace_lane", TokenType::SimdLaneOp, Opcode::I8X16ReplaceLane},
       {""}, {""}, {""},
-#line 206 "src/lexer-keywords.txt"
+#line 205 "src/lexer-keywords.txt"
       {"i16x8.shr_s", TokenType::Binary, Opcode::I16X8ShrS},
       {""}, {""}, {""},
-#line 207 "src/lexer-keywords.txt"
+#line 206 "src/lexer-keywords.txt"
       {"i16x8.shr_u", TokenType::Binary, Opcode::I16X8ShrU},
       {""}, {""}, {""},
 #line 485 "src/lexer-keywords.txt"
       {"memory.copy", TokenType::MemoryCopy, Opcode::MemoryCopy},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 358 "src/lexer-keywords.txt"
+#line 356 "src/lexer-keywords.txt"
       {"i64.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XchgU},
-#line 234 "src/lexer-keywords.txt"
+#line 233 "src/lexer-keywords.txt"
       {"i32.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XchgU},
       {""}, {""}, {""}, {""}, {""},
-#line 200 "src/lexer-keywords.txt"
+#line 199 "src/lexer-keywords.txt"
       {"i16x8.narrow_i32x4_s", TokenType::Binary, Opcode::I16X8NarrowI32X4S},
       {""},
-#line 201 "src/lexer-keywords.txt"
+#line 200 "src/lexer-keywords.txt"
       {"i16x8.narrow_i32x4_u", TokenType::Binary, Opcode::I16X8NarrowI32X4U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 571 "src/lexer-keywords.txt"
+#line 574 "src/lexer-keywords.txt"
       {"i64.reinterpret/f64", TokenType::Convert, Opcode::I64ReinterpretF64},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 119 "src/lexer-keywords.txt"
+#line 118 "src/lexer-keywords.txt"
       {"f64.copysign", TokenType::Binary, Opcode::F64Copysign},
-#line 62 "src/lexer-keywords.txt"
+#line 61 "src/lexer-keywords.txt"
       {"f32.copysign", TokenType::Binary, Opcode::F32Copysign},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 559 "src/lexer-keywords.txt"
+#line 562 "src/lexer-keywords.txt"
       {"i32.reinterpret/f32", TokenType::Convert, Opcode::I32ReinterpretF32},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""},
-#line 204 "src/lexer-keywords.txt"
+#line 203 "src/lexer-keywords.txt"
       {"i16x8.replace_lane", TokenType::SimdLaneOp, Opcode::I16X8ReplaceLane},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 462 "src/lexer-keywords.txt"
+#line 459 "src/lexer-keywords.txt"
       {"i8x16.narrow_i16x8_s", TokenType::Binary, Opcode::I8X16NarrowI16X8S},
       {""},
-#line 463 "src/lexer-keywords.txt"
+#line 460 "src/lexer-keywords.txt"
       {"i8x16.narrow_i16x8_u", TokenType::Binary, Opcode::I8X16NarrowI16X8U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 173 "src/lexer-keywords.txt"
+#line 172 "src/lexer-keywords.txt"
       {"grow_memory", TokenType::MemoryGrow, Opcode::MemoryGrow},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""},
-#line 328 "src/lexer-keywords.txt"
+#line 326 "src/lexer-keywords.txt"
       {"i32x4.widen_high_i16x8_s", TokenType::Unary, Opcode::I32X4WidenHighI16X8S},
       {""},
-#line 329 "src/lexer-keywords.txt"
+#line 327 "src/lexer-keywords.txt"
       {"i32x4.widen_high_i16x8_u", TokenType::Unary, Opcode::I32X4WidenHighI16X8U},
       {""}, {""}, {""}, {""},
-#line 362 "src/lexer-keywords.txt"
+#line 360 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmwCmpxchg},
-#line 238 "src/lexer-keywords.txt"
+#line 237 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmwCmpxchg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1634,7 +1640,7 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-#line 464 "src/lexer-keywords.txt"
+#line 461 "src/lexer-keywords.txt"
       {"i8x16.neg", TokenType::Unary, Opcode::I8X16Neg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1645,7 +1651,7 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 202 "src/lexer-keywords.txt"
+#line 201 "src/lexer-keywords.txt"
       {"i16x8.neg", TokenType::Unary, Opcode::I16X8Neg},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1692,10 +1698,10 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""},
-#line 213 "src/lexer-keywords.txt"
+#line 212 "src/lexer-keywords.txt"
       {"i16x8.widen_high_i8x16_s", TokenType::Unary, Opcode::I16X8WidenHighI8X16S},
       {""},
-#line 214 "src/lexer-keywords.txt"
+#line 213 "src/lexer-keywords.txt"
       {"i16x8.widen_high_i8x16_u", TokenType::Unary, Opcode::I16X8WidenHighI8X16U},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
@@ -1717,9 +1723,9 @@ Perfect_Hash::InWordSet (const char *str, size_t len)
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""}, {""}, {""}, {""}, {""},
-#line 365 "src/lexer-keywords.txt"
+#line 363 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I64AtomicRmwXchg},
-#line 241 "src/lexer-keywords.txt"
+#line 240 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I32AtomicRmwXchg}
     };
 

--- a/test/dump/atomic.txt
+++ b/test/dump/atomic.txt
@@ -90,17 +90,17 @@ Code Disassembly:
 00001e func[0]:
  00001f: 41 00                      | i32.const 0
  000021: 41 00                      | i32.const 0
- 000023: fe 00 02 00                | atomic.notify 2 0
+ 000023: fe 00 02 00                | memory.atomic.notify 2 0
  000027: 1a                         | drop
  000028: 41 00                      | i32.const 0
  00002a: 41 00                      | i32.const 0
  00002c: 42 00                      | i64.const 0
- 00002e: fe 01 02 00                | i32.atomic.wait 2 0
+ 00002e: fe 01 02 00                | memory.atomic.wait32 2 0
  000032: 1a                         | drop
  000033: 41 00                      | i32.const 0
  000035: 42 00                      | i64.const 0
  000037: 42 00                      | i64.const 0
- 000039: fe 02 03 00                | i64.atomic.wait 3 0
+ 000039: fe 02 03 00                | memory.atomic.wait64 3 0
  00003d: 1a                         | drop
  00003e: 41 00                      | i32.const 0
  000040: fe 10 02 00                | i32.atomic.load 2 0

--- a/test/parse/expr/atomic-disabled.txt
+++ b/test/parse/expr/atomic-disabled.txt
@@ -82,13 +82,13 @@
 
 ))
 (;; STDERR ;;;
-out/test/parse/expr/atomic-disabled.txt:7:29: error: opcode not allowed: atomic.notify
+out/test/parse/expr/atomic-disabled.txt:7:29: error: opcode not allowed: memory.atomic.notify
     i32.const 0 i32.const 0 atomic.notify drop
                             ^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:8:41: error: opcode not allowed: i32.atomic.wait
+out/test/parse/expr/atomic-disabled.txt:8:41: error: opcode not allowed: memory.atomic.wait32
     i32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop
                                         ^^^^^^^^^^^^^^^
-out/test/parse/expr/atomic-disabled.txt:9:41: error: opcode not allowed: i64.atomic.wait
+out/test/parse/expr/atomic-disabled.txt:9:41: error: opcode not allowed: memory.atomic.wait64
     i32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop
                                         ^^^^^^^^^^^^^^^
 out/test/parse/expr/atomic-disabled.txt:11:17: error: opcode not allowed: i32.atomic.load

--- a/test/roundtrip/fold-atomic.txt
+++ b/test/roundtrip/fold-atomic.txt
@@ -86,16 +86,16 @@
   (type (;0;) (func))
   (func (;0;) (type 0)
     (drop
-      (atomic.notify
+      (memory.atomic.notify
         (i32.const 0)
         (i32.const 0)))
     (drop
-      (i32.atomic.wait
+      (memory.atomic.wait32
         (i32.const 0)
         (i32.const 0)
         (i64.const 0)))
     (drop
-      (i64.atomic.wait
+      (memory.atomic.wait64
         (i32.const 0)
         (i64.const 0)
         (i64.const 0)))

--- a/test/typecheck/bad-atomic-type-mismatch.txt
+++ b/test/typecheck/bad-atomic-type-mismatch.txt
@@ -208,13 +208,13 @@
 
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-atomic-type-mismatch.txt:9:33: error: type mismatch in atomic.notify, expected [i32, i32] but got [f32, i32]
+out/test/typecheck/bad-atomic-type-mismatch.txt:9:33: error: type mismatch in memory.atomic.notify, expected [i32, i32] but got [f32, i32]
   (func f32.const 0 i32.const 0 atomic.notify drop)
                                 ^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:10:45: error: type mismatch in i32.atomic.wait, expected [i32, i32, i64] but got [f32, i32, i64]
+out/test/typecheck/bad-atomic-type-mismatch.txt:10:45: error: type mismatch in memory.atomic.wait32, expected [i32, i32, i64] but got [f32, i32, i64]
   (func f32.const 0 i32.const 0 i64.const 0 i32.atomic.wait drop)
                                             ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:11:45: error: type mismatch in i64.atomic.wait, expected [i32, i64, i64] but got [f32, i64, i64]
+out/test/typecheck/bad-atomic-type-mismatch.txt:11:45: error: type mismatch in memory.atomic.wait64, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.wait drop)
                                             ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:12:21: error: type mismatch in i32.atomic.load, expected [i32] but got [f32]
@@ -406,13 +406,13 @@ out/test/typecheck/bad-atomic-type-mismatch.txt:73:45: error: type mismatch in i
 out/test/typecheck/bad-atomic-type-mismatch.txt:74:45: error: type mismatch in i64.atomic.rmw32.cmpxchg_u, expected [i32, i64, i64] but got [f32, i64, i64]
   (func f32.const 0 i64.const 0 i64.const 0 i64.atomic.rmw32.cmpxchg_u drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:77:33: error: type mismatch in atomic.notify, expected [i32, i32] but got [i32, f32]
+out/test/typecheck/bad-atomic-type-mismatch.txt:77:33: error: type mismatch in memory.atomic.notify, expected [i32, i32] but got [i32, f32]
   (func i32.const 0 f32.const 0 atomic.notify drop)
                                 ^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:78:45: error: type mismatch in i32.atomic.wait, expected [i32, i32, i64] but got [i32, f32, i64]
+out/test/typecheck/bad-atomic-type-mismatch.txt:78:45: error: type mismatch in memory.atomic.wait32, expected [i32, i32, i64] but got [i32, f32, i64]
   (func i32.const 0 f32.const 0 i64.const 0 i32.atomic.wait drop)
                                             ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:79:45: error: type mismatch in i64.atomic.wait, expected [i32, i64, i64] but got [i32, f64, i64]
+out/test/typecheck/bad-atomic-type-mismatch.txt:79:45: error: type mismatch in memory.atomic.wait64, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.wait drop)
                                             ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:80:33: error: type mismatch in i32.atomic.store, expected [i32, i32] but got [i32, f32]
@@ -583,10 +583,10 @@ out/test/typecheck/bad-atomic-type-mismatch.txt:134:45: error: type mismatch in 
 out/test/typecheck/bad-atomic-type-mismatch.txt:135:45: error: type mismatch in i64.atomic.rmw32.cmpxchg_u, expected [i32, i64, i64] but got [i32, f64, i64]
   (func i32.const 0 f64.const 0 i64.const 0 i64.atomic.rmw32.cmpxchg_u drop)
                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:138:45: error: type mismatch in i32.atomic.wait, expected [i32, i32, i64] but got [i32, i32, f64]
+out/test/typecheck/bad-atomic-type-mismatch.txt:138:45: error: type mismatch in memory.atomic.wait32, expected [i32, i32, i64] but got [i32, i32, f64]
   (func i32.const 0 i32.const 0 f64.const 0 i32.atomic.wait drop)
                                             ^^^^^^^^^^^^^^^
-out/test/typecheck/bad-atomic-type-mismatch.txt:139:45: error: type mismatch in i64.atomic.wait, expected [i32, i64, i64] but got [i32, i64, f64]
+out/test/typecheck/bad-atomic-type-mismatch.txt:139:45: error: type mismatch in memory.atomic.wait64, expected [i32, i64, i64] but got [i32, i64, f64]
   (func i32.const 0 i64.const 0 f64.const 0 i64.atomic.wait drop)
                                             ^^^^^^^^^^^^^^^
 out/test/typecheck/bad-atomic-type-mismatch.txt:140:45: error: type mismatch in i32.atomic.rmw.cmpxchg, expected [i32, i32, i32] but got [i32, i32, f32]


### PR DESCRIPTION
atomic.notify   -> memory.atomic.notify
i32.atomic.wait -> memory.atomic.wait32
i64.atomic.wait -> memory.atomic.wait64

These were renamed upstream a while ago, but the new names were not
added to wabt.