### PR TITLE
Element offset expr is required when bulk disabled

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1154,9 +1154,14 @@ Result WastParser::ParseElemModuleField(Module* module) {
     }
   }
 
-  if ((field->elem_segment.kind != SegmentKind::Declared) &&
-      !ParseOffsetExprOpt(&field->elem_segment.offset)) {
-    field->elem_segment.kind = SegmentKind::Passive;
+  // Parse offset expression, if not declared/passive segment.
+  if (options_->features.bulk_memory_enabled()) {
+    if (field->elem_segment.kind != SegmentKind::Declared &&
+        !ParseOffsetExprOpt(&field->elem_segment.offset)) {
+      field->elem_segment.kind = SegmentKind::Passive;
+    }
+  } else {
+    CHECK_RESULT(ParseOffsetExpr(&field->elem_segment.offset));
   }
 
   if (ParseRefTypeOpt(&field->elem_segment.elem_type)) {

--- a/test/parse/expr/bulk-memory-disabled.txt
+++ b/test/parse/expr/bulk-memory-disabled.txt
@@ -36,12 +36,12 @@ out/test/parse/expr/bulk-memory-disabled.txt:10:41: error: opcode not allowed: m
 out/test/parse/expr/bulk-memory-disabled.txt:11:41: error: opcode not allowed: memory.fill
     i32.const 0 i32.const 0 i32.const 0 memory.fill
                                         ^^^^^^^^^^^
-out/test/parse/expr/bulk-memory-disabled.txt:15:23: error: unexpected token 0, expected ).
+out/test/parse/expr/bulk-memory-disabled.txt:15:15: error: unexpected token "funcref", expected an offset expr (e.g. (i32.const 123)).
   (elem $elem funcref 0)
-                      ^
-out/test/parse/expr/bulk-memory-disabled.txt:16:17: error: ref.null not allowed
+              ^^^^^^^
+out/test/parse/expr/bulk-memory-disabled.txt:16:9: error: unexpected token "funcref", expected an offset expr (e.g. (i32.const 123)).
   (elem funcref (ref.null func))
-                ^
+        ^^^^^^^
 out/test/parse/expr/bulk-memory-disabled.txt:18:41: error: opcode not allowed: table.init
     i32.const 0 i32.const 0 i32.const 0 table.init 0
                                         ^^^^^^^^^^

--- a/test/parse/module/bad-table-no-offset.txt
+++ b/test/parse/module/bad-table-no-offset.txt
@@ -1,0 +1,11 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module
+  (table 1 anyfunc)
+  (func)
+  (elem 0))
+(;; STDERR ;;;
+out/test/parse/module/bad-table-no-offset.txt:6:10: error: unexpected token ")", expected an offset expr (e.g. (i32.const 123)).
+  (elem 0))
+         ^
+;;; STDERR ;;)


### PR DESCRIPTION
Text parsing was allowing element segments without an offset expression
even when the bulk memory flag was disabled.

Fixes #1566.