### PR TITLE
Update output from type to func type in binary writer and reader

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -144,8 +144,7 @@ Result BinaryReaderLogging::OnFuncType(Index index,
                                        Type* param_types,
                                        Index result_count,
                                        Type* result_types) {
-  // TODO: switch to "OnFuncType"?
-  LOGF("OnType(index: %" PRIindex ", params: ", index);
+  LOGF("OnFuncType(index: %" PRIindex ", params: ", index);
   LogTypes(param_count, param_types);
   LOGF_NOINDENT(", results: ");
   LogTypes(result_count, result_types);

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1214,7 +1214,7 @@ Result BinaryWriter::WriteModule() {
         case TypeEntryKind::Func: {
           const FuncType* func_type = cast<FuncType>(type);
           const FuncSignature* sig = &func_type->sig;
-          WriteHeader("type", i);  // TODO: switch to "func type"?
+          WriteHeader("func type", i);
           WriteType(stream_, Type::Func);
 
           Index num_params = sig->param_types.size();

--- a/test/binary/bad-logging-basic.txt
+++ b/test/binary/bad-logging-basic.txt
@@ -18,7 +18,7 @@ section(CODE) {
 BeginModule(version: 1)
   BeginTypeSection(4)
     OnTypeCount(1)
-    OnType(index: 0, params: [], results: [])
+    OnFuncType(index: 0, params: [], results: [])
   EndTypeSection
   BeginFunctionSection(2)
     OnFunctionCount(1)

--- a/test/binary/user-section.txt
+++ b/test/binary/user-section.txt
@@ -12,7 +12,7 @@ BeginModule(version: 1)
   EndCustomSection
   BeginTypeSection(5)
     OnTypeCount(1)
-    OnType(index: 0, params: [], results: [i32])
+    OnFuncType(index: 0, params: [], results: [i32])
   EndTypeSection
   BeginCustomSection('bar', size: 5)
   EndCustomSection

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -21,7 +21,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 02                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -108,7 +108,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -54,7 +54,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -53,7 +53,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/block-multi.txt
+++ b/test/dump/block-multi.txt
@@ -20,17 +20,17 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results
-; type 1
+; func type 1
 000000e: 60                                        ; func
 000000f: 00                                        ; num params
 0000010: 02                                        ; num results
 0000011: 7f                                        ; i32
 0000012: 7f                                        ; i32
-; type 2
+; func type 2
 0000013: 60                                        ; func
 0000014: 01                                        ; num params
 0000015: 7f                                        ; i32

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -19,11 +19,11 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results
-; type 1
+; func type 1
 000000e: 60                                        ; func
 000000f: 00                                        ; num params
 0000010: 01                                        ; num results

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -21,7 +21,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -23,7 +23,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -23,7 +23,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -14,7 +14,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -15,7 +15,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/br_on_exn.txt
+++ b/test/dump/br_on_exn.txt
@@ -19,12 +19,12 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 00                                        ; num results
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 00                                        ; num params
 0000011: 00                                        ; num results

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -27,7 +27,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -17,14 +17,14 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 02                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 7d                                        ; f32
 000000f: 01                                        ; num results
 0000010: 7f                                        ; i32
-; type 1
+; func type 1
 0000011: 60                                        ; func
 0000012: 00                                        ; num params
 0000013: 01                                        ; num results

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -14,7 +14,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -21,7 +21,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -122,7 +122,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -85,7 +85,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/convert-sat.txt
+++ b/test/dump/convert-sat.txt
@@ -40,7 +40,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -38,7 +38,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -10,7 +10,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -21,12 +21,12 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 00                                        ; num results
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 01                                        ; num params
 0000011: 7d                                        ; f32

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -12,7 +12,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/drop.txt
+++ b/test/dump/drop.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/event.txt
+++ b/test/dump/event.txt
@@ -12,16 +12,16 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results
-; type 1
+; func type 1
 000000e: 60                                        ; func
 000000f: 01                                        ; num params
 0000010: 7f                                        ; i32
 0000011: 00                                        ; num results
-; type 2
+; func type 2
 0000012: 60                                        ; func
 0000013: 02                                        ; num params
 0000014: 7d                                        ; f32

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -14,7 +14,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -16,7 +16,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results

--- a/test/dump/extended-names.txt
+++ b/test/dump/extended-names.txt
@@ -20,12 +20,12 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 00                                        ; num results
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 00                                        ; num params
 0000011: 00                                        ; num results

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -10,7 +10,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -9,7 +9,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/func-result-multi.txt
+++ b/test/dump/func-result-multi.txt
@@ -12,7 +12,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 02                                        ; num results

--- a/test/dump/getglobal.txt
+++ b/test/dump/getglobal.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -22,7 +22,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 02                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -26,7 +26,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/hexfloat_f32.txt
+++ b/test/dump/hexfloat_f32.txt
@@ -45,7 +45,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/hexfloat_f64.txt
+++ b/test/dump/hexfloat_f64.txt
@@ -45,7 +45,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/if-multi.txt
+++ b/test/dump/if-multi.txt
@@ -27,17 +27,17 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results
-; type 1
+; func type 1
 000000e: 60                                        ; func
 000000f: 00                                        ; num params
 0000010: 02                                        ; num results
 0000011: 7f                                        ; i32
 0000012: 7d                                        ; f32
-; type 2
+; func type 2
 0000013: 60                                        ; func
 0000014: 01                                        ; num params
 0000015: 7d                                        ; f32

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -21,7 +21,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -14,7 +14,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -27,7 +27,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -15,7 +15,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 04                                        ; num params
 000000d: 7f                                        ; i32
@@ -23,13 +23,13 @@
 000000f: 7d                                        ; f32
 0000010: 7c                                        ; f64
 0000011: 00                                        ; num results
-; type 1
+; func type 1
 0000012: 60                                        ; func
 0000013: 01                                        ; num params
 0000014: 7f                                        ; i32
 0000015: 01                                        ; num results
 0000016: 7f                                        ; i32
-; type 2
+; func type 2
 0000017: 60                                        ; func
 0000018: 01                                        ; num params
 0000019: 7f                                        ; i32

--- a/test/dump/invalid-elem-segment-no-table.txt
+++ b/test/dump/invalid-elem-segment-no-table.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/invalid-elem-segment-offset.txt
+++ b/test/dump/invalid-elem-segment-offset.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -58,7 +58,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -52,7 +52,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/load64.txt
+++ b/test/dump/load64.txt
@@ -52,7 +52,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -9,7 +9,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -60,7 +60,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -53,7 +53,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/loop-multi.txt
+++ b/test/dump/loop-multi.txt
@@ -20,17 +20,17 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results
-; type 1
+; func type 1
 000000e: 60                                        ; func
 000000f: 00                                        ; num params
 0000010: 02                                        ; num results
 0000011: 7f                                        ; i32
 0000012: 7f                                        ; i32
-; type 2
+; func type 2
 0000013: 60                                        ; func
 0000014: 01                                        ; num params
 0000015: 7f                                        ; i32

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -28,18 +28,18 @@
 0000008: 01                                        ; section code
 0000009: 0000 0000 00                              ; section size (guess)
 000000e: 03                                        ; num types
-; type 0
+; func type 0
 000000f: 60                                        ; func
 0000010: 01                                        ; num params
 0000011: 7f                                        ; i32
 0000012: 01                                        ; num results
 0000013: 7f                                        ; i32
-; type 1
+; func type 1
 0000014: 60                                        ; func
 0000015: 01                                        ; num params
 0000016: 7f                                        ; i32
 0000017: 00                                        ; num results
-; type 2
+; func type 2
 0000018: 60                                        ; func
 0000019: 02                                        ; num params
 000001a: 7f                                        ; i32

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -10,7 +10,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -9,7 +9,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 04                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -16,22 +16,22 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 04                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results
 000000e: 7f                                        ; i32
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 00                                        ; num params
 0000011: 01                                        ; num results
 0000012: 7e                                        ; i64
-; type 2
+; func type 2
 0000013: 60                                        ; func
 0000014: 00                                        ; num params
 0000015: 01                                        ; num results
 0000016: 7d                                        ; f32
-; type 3
+; func type 3
 0000017: 60                                        ; func
 0000018: 00                                        ; num params
 0000019: 01                                        ; num results

--- a/test/dump/rethrow.txt
+++ b/test/dump/rethrow.txt
@@ -14,7 +14,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -13,12 +13,12 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results
 000000e: 7f                                        ; i32
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 00                                        ; num params
 0000011: 00                                        ; num results

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -29,7 +29,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -12,7 +12,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -26,7 +26,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 02                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -30,7 +30,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/signatures.txt
+++ b/test/dump/signatures.txt
@@ -19,47 +19,47 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 09                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 00                                        ; num results
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 01                                        ; num params
 0000011: 7e                                        ; i64
 0000012: 00                                        ; num results
-; type 2
+; func type 2
 0000013: 60                                        ; func
 0000014: 01                                        ; num params
 0000015: 7d                                        ; f32
 0000016: 00                                        ; num results
-; type 3
+; func type 3
 0000017: 60                                        ; func
 0000018: 01                                        ; num params
 0000019: 7c                                        ; f64
 000001a: 00                                        ; num results
-; type 4
+; func type 4
 000001b: 60                                        ; func
 000001c: 00                                        ; num params
 000001d: 01                                        ; num results
 000001e: 7f                                        ; i32
-; type 5
+; func type 5
 000001f: 60                                        ; func
 0000020: 00                                        ; num params
 0000021: 01                                        ; num results
 0000022: 7e                                        ; i64
-; type 6
+; func type 6
 0000023: 60                                        ; func
 0000024: 00                                        ; num params
 0000025: 01                                        ; num results
 0000026: 7d                                        ; f32
-; type 7
+; func type 7
 0000027: 60                                        ; func
 0000028: 00                                        ; num params
 0000029: 01                                        ; num results
 000002a: 7c                                        ; f64
-; type 8
+; func type 8
 000002b: 60                                        ; func
 000002c: 01                                        ; num params
 000002d: 7f                                        ; i32

--- a/test/dump/start.txt
+++ b/test/dump/start.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -58,7 +58,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -37,7 +37,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/store64.txt
+++ b/test/dump/store64.txt
@@ -37,7 +37,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/string-escape.txt
+++ b/test/dump/string-escape.txt
@@ -8,7 +8,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/string-hex.txt
+++ b/test/dump/string-hex.txt
@@ -8,7 +8,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -12,7 +12,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -17,18 +17,18 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 00                                        ; num results
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 02                                        ; num params
 0000011: 7f                                        ; i32
 0000012: 7e                                        ; i64
 0000013: 00                                        ; num results
-; type 2
+; func type 2
 0000014: 60                                        ; func
 0000015: 00                                        ; num params
 0000016: 01                                        ; num results

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -13,7 +13,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/throw.txt
+++ b/test/dump/throw.txt
@@ -12,12 +12,12 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 02                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 01                                        ; num params
 000000d: 7f                                        ; i32
 000000e: 00                                        ; num results
-; type 1
+; func type 1
 000000f: 60                                        ; func
 0000010: 00                                        ; num params
 0000011: 00                                        ; num results

--- a/test/dump/try-multi.txt
+++ b/test/dump/try-multi.txt
@@ -26,17 +26,17 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 03                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results
-; type 1
+; func type 1
 000000e: 60                                        ; func
 000000f: 00                                        ; num params
 0000010: 02                                        ; num results
 0000011: 7f                                        ; i32
 0000012: 7f                                        ; i32
-; type 2
+; func type 2
 0000013: 60                                        ; func
 0000014: 01                                        ; num params
 0000015: 7f                                        ; i32

--- a/test/dump/try.txt
+++ b/test/dump/try.txt
@@ -17,7 +17,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/unary-extend.txt
+++ b/test/dump/unary-extend.txt
@@ -28,7 +28,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -41,7 +41,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -10,7 +10,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 00                                        ; num results

--- a/test/interp/basic-logging.txt
+++ b/test/interp/basic-logging.txt
@@ -11,7 +11,7 @@
 0000008: 01                                        ; section code
 0000009: 00                                        ; section size (guess)
 000000a: 01                                        ; num types
-; type 0
+; func type 0
 000000b: 60                                        ; func
 000000c: 00                                        ; num params
 000000d: 01                                        ; num results
@@ -48,7 +48,7 @@
 BeginModule(version: 1)
   BeginTypeSection(5)
     OnTypeCount(1)
-    OnType(index: 0, params: [], results: [i32])
+    OnFuncType(index: 0, params: [], results: [i32])
   EndTypeSection
   BeginFunctionSection(2)
     OnFunctionCount(1)


### PR DESCRIPTION
This commit addresses the first item of #1375 - specifically, it changes the output from `type` to `func type` in the binary writer, and updates the tests.

There are also changes in the third party test suite - what is the procedure for updating the upstream test suite repository? Should there be a PR to its repo first with these changes?

```
$ cd third_party/testsuite && git status
HEAD detached at 18f8340
        modified:   binary.wast
        modified:   proposals/bulk-memory-operations/binary.wast
        modified:   proposals/exception-handling/binary.wast
        modified:   proposals/function-references/binary.wast
        modified:   proposals/reference-types/binary.wast
        modified:   proposals/simd/simd_const.wast
```