### PR TITLE
Fix func.wast spec test

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -328,6 +328,18 @@ Result CheckFuncTypeVarMatchesExplicit(const Location& loc,
       result |=
           CheckTypes(loc, decl.sig.param_types, func_type->sig.param_types,
                      "function", "argument", errors);
+    } else if (!(decl.sig.param_types.empty() &&
+                 decl.sig.result_types.empty())) {
+      // We want to check whether the function type at the explicit index
+      // matches the given param and result types. If they were omitted then
+      // they'll be resolved automatically (see
+      // ResolveFuncTypeWithEmptySignature), but if they are provided then we
+      // have to check. If we get here then the type var is invalid, so we
+      // can't check whether they match.
+      errors->emplace_back(ErrorLevel::Error, loc,
+                           StringPrintf("invalid func type index %" PRIindex,
+                                        decl.type_var.index()));
+      result = Result::Error;
     }
   }
   return result;

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -1,11 +1,13 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/func.wast
-;;; ERROR: 1
 (;; STDOUT ;;;
 out/test/spec/func.wast:436: assert_invalid passed:
   0000000: error: function type variable out of range: 2 (max 2)
   000001a: error: OnFunction callback failed
-out/test/spec/func.wast:448: expected module to be malformed: "out/test/spec/func/func.3.wat"
+out/test/spec/func.wast:448: assert_malformed passed:
+  out/test/spec/func/func.3.wat:1:123: error: invalid func type index 2
+  ...lt f64) (f64.const 1))(type $t (func (param i32)))(func (type 2) (param i32))
+                                                        ^^^^
 out/test/spec/func.wast:560: assert_malformed passed:
   out/test/spec/func/func.6.wat:1:76: error: unexpected token "param", expected an instr.
   ... i32) (result i32)))(func (type $sig) (result i32) (param i32) (i32.const 0))
@@ -241,5 +243,5 @@ out/test/spec/func.wast:960: assert_malformed passed:
   out/test/spec/func/func.75.wat:1:31: error: redefinition of local "$foo"
   (func (local $foo i32) (local $foo i32))
                                 ^^^^
-167/168 tests passed.
+168/168 tests passed.
 ;;; STDOUT ;;)


### PR DESCRIPTION
Fix spec test failure in func.wast

The wasm text format allows the use of a function type to be specified
one of three ways:

```
;; 1. As an explicit type index or symbol
(type 0)

;; 2. As params and results
(param i32) (result i64)

;; 3. Both; an explicit type index, params and results
(type 0) (param i32) (result i64)
```

Options 2 and 3 are text format sugar, since the binary format always
encodes these as an explicit type index.

Option 3 needs to check that the type at that index matches the
explicitly given params and results. Normally checking whether an index
is in bounds is a validation step, not a syntax checking step. However,
in this case if the index is out of bounds, then the types cannot be
checked, so it must be a syntax error.