### PR TITLE
Let cmake add "-g" flag when it is needed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,8 +139,7 @@ else ()
   #   interfaces, etc.
   # disable -Wpointer-arith: this is a GCC extension, and doesn't work in MSVC.
   add_definitions(
-    -Wall -Wextra -Wno-unused-parameter -Wpointer-arith -g
-    -Wuninitialized
+    -Wall -Wextra -Wno-unused-parameter -Wpointer-arith -Wuninitialized
   )
 
   set(CMAKE_CXX_EXTENSIONS OFF)


### PR DESCRIPTION
Reference: [Issue#1571](https://github.com/WebAssembly/wabt/issues/1571)
Problem: 
It used to add the debug info in the binary even if below command was used.

```
$ cmake .. -DCMAKE_BUILD_TYPE=Release
$ cmake --build .

```
Solution :
Let the cmake add `-g` flag when it is needed.

Test 1: run below command 
```
$ cmake .. -DCMAKE_BUILD_TYPE=Release
$ cmake --build .

```
It will generate binary without debug info

Test 2: 
```
$ cmake .. -DCMAKE_BUILD_TYPE=Debug
$ cmake --build .
```
It will generate binary with debug info