### PR TITLE
Use stderr for all logging and error output

### DIFF
--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -490,7 +490,7 @@ static ReadBinaryOptions GetOptions() {
   const bool kFailOnCustomSectionError = true;
   s_features.EnableAll();
   if (getenv("WASM_API_DEBUG") != nullptr) {
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   }
   return ReadBinaryOptions(s_features, s_log_stream.get(), kReadDebugNames,
                            kStopOnFirstError, kFailOnCustomSectionError);

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -69,7 +69,7 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   s_features.AddOptions(&parser);
   parser.AddOption('V', "value-stack-size", "SIZE",

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -82,7 +82,7 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   s_features.AddOptions(&parser);
   parser.AddOption('V', "value-stack-size", "SIZE",

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -53,7 +53,7 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_objdump_options.disassemble = true; });
   parser.AddOption("debug", "Print extra debug information", []() {
     s_objdump_options.debug = true;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
     s_objdump_options.log_stream = s_log_stream.get();
   });
   parser.AddOption('x', "details", "Show section details",

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -57,7 +57,7 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
     s_read_binary_options.log_stream = s_log_stream.get();
   });
   s_features.AddOptions(&parser);

--- a/src/tools/wasm-validate.cc
+++ b/src/tools/wasm-validate.cc
@@ -50,7 +50,7 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   s_features.AddOptions(&parser);
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -60,7 +60,7 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   parser.AddOption(
       'o', "output", "FILENAME",

--- a/src/tools/wasm2wat.cc
+++ b/src/tools/wasm2wat.cc
@@ -62,7 +62,7 @@ static void ParseOptions(int argc, char** argv) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   parser.AddOption(
       'o', "output", "FILENAME",

--- a/src/tools/wast2json.cc
+++ b/src/tools/wast2json.cc
@@ -63,7 +63,7 @@ static void ParseOptions(int argc, char* argv[]) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   parser.AddOption("debug-parser", "Turn on debugging the parser of wast files",
                    []() { s_debug_parsing = true; });

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -69,7 +69,7 @@ static void ParseOptions(int argc, char* argv[]) {
 
   parser.AddOption('v', "verbose", "Use multiple times for more info", []() {
     s_verbose++;
-    s_log_stream = FileStream::CreateStdout();
+    s_log_stream = FileStream::CreateStderr();
   });
   parser.AddOption("debug-parser", "Turn on debugging the parser of wat files",
                    []() { s_debug_parsing = true; });

--- a/test/binary/bad-logging-basic.txt
+++ b/test/binary/bad-logging-basic.txt
@@ -12,9 +12,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-0000015: error: function signature count != function body count
-;;; STDERR ;;)
-(;; STDOUT ;;;
 BeginModule(version: 1)
   BeginTypeSection(4)
     OnTypeCount(1)
@@ -25,4 +22,5 @@ BeginModule(version: 1)
     OnFunction(index: 0, sig_index: 0)
   EndFunctionSection
   BeginCodeSection(4)
-;;; STDOUT ;;)
+0000015: error: function signature count != function body count
+;;; STDERR ;;)

--- a/test/binary/user-section.txt
+++ b/test/binary/user-section.txt
@@ -6,7 +6,7 @@ section("foo") { count[4] }
 section(TYPE) { count[1] function params[0] results[1] i32 }
 section("bar") { count[5] }
 section("foo") { count[6] }
-(;; STDOUT ;;;
+(;; STDERR ;;;
 BeginModule(version: 1)
   BeginCustomSection('foo', size: 5)
   EndCustomSection
@@ -19,6 +19,8 @@ BeginModule(version: 1)
   BeginCustomSection('foo', size: 5)
   EndCustomSection
 EndModule
+;;; STDERR ;;)
+(;; STDOUT ;;;
 (module
   (type (;0;) (func (result i32))))
 ;;; STDOUT ;;)

--- a/test/dump/basic.txt
+++ b/test/dump/basic.txt
@@ -14,7 +14,7 @@
     get_local 1
     i32.add)
   (export "f" (func $f)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -80,6 +80,8 @@
 0000038: 0b                                        ; end
 0000024: 14                                        ; FIXUP func body size
 0000022: 16                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 basic.wasm:	file format wasm 0x1
 

--- a/test/dump/binary.txt
+++ b/test/dump/binary.txt
@@ -101,7 +101,7 @@
 
 ))
 
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -275,6 +275,8 @@
 0000015: e201                                      ; FIXUP func body size
 ; move data: [14, f9) -> [15, fa)
 0000013: e501                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 binary.wasm:	file format wasm 0x1
 

--- a/test/dump/block-257-exprs-br.txt
+++ b/test/dump/block-257-exprs-br.txt
@@ -47,7 +47,7 @@
       br $foo  ;; should be depth 1
       br 0     ;; also depth 1
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -340,6 +340,8 @@
 0000015: 8902                                      ; FIXUP func body size
 ; move data: [14, 120) -> [15, 121)
 0000013: 8c02                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 block-257-exprs-br.wasm:	file format wasm 0x1
 

--- a/test/dump/block-257-exprs.txt
+++ b/test/dump/block-257-exprs.txt
@@ -46,7 +46,7 @@
       ;; 257
       nop
    end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -336,6 +336,8 @@
 0000015: 8602                                      ; FIXUP func body size
 ; move data: [14, 11d) -> [15, 11e)
 0000013: 8902                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 block-257-exprs.wasm:	file format wasm 0x1
 

--- a/test/dump/block-multi.txt
+++ b/test/dump/block-multi.txt
@@ -13,7 +13,7 @@
     block (param i32)
       drop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -72,6 +72,8 @@
 0000032: 0b                                        ; end
 000002a: 08                                        ; FIXUP func body size
 000001d: 15                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 block-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/block.txt
+++ b/test/dump/block.txt
@@ -12,7 +12,7 @@
     block (result i32)
       i32.const 1
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -62,6 +62,8 @@
 000002a: 0b                                        ; end
 0000023: 07                                        ; FIXUP func body size
 0000018: 12                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 block.wasm:	file format wasm 0x1
 

--- a/test/dump/br-block-named.txt
+++ b/test/dump/br-block-named.txt
@@ -14,7 +14,7 @@
         end
       end
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -61,6 +61,8 @@
 000002a: 0b                                        ; end
 0000015: 15                                        ; FIXUP func body size
 0000013: 17                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 br-block-named.wasm:	file format wasm 0x1
 

--- a/test/dump/br-block.txt
+++ b/test/dump/br-block.txt
@@ -16,7 +16,7 @@
         end
       end
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -67,6 +67,8 @@
 000002e: 0b                                        ; end
 0000015: 19                                        ; FIXUP func body size
 0000013: 1b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 br-block.wasm:	file format wasm 0x1
 

--- a/test/dump/br-loop-inner-expr.txt
+++ b/test/dump/br-loop-inner-expr.txt
@@ -16,7 +16,7 @@
         i32.const 5
       end
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -69,6 +69,8 @@
 0000030: 0b                                        ; end
 0000016: 1a                                        ; FIXUP func body size
 0000014: 1c                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 br-loop-inner-expr.wasm:	file format wasm 0x1
 

--- a/test/dump/br-loop-inner.txt
+++ b/test/dump/br-loop-inner.txt
@@ -7,7 +7,7 @@
         (br $exit))
       (if (i32.const 2)
         (br $cont))))))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -55,6 +55,8 @@
 000002b: 0b                                        ; end
 0000015: 16                                        ; FIXUP func body size
 0000013: 18                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 br-loop-inner.wasm:	file format wasm 0x1
 

--- a/test/dump/br-loop.txt
+++ b/test/dump/br-loop.txt
@@ -8,7 +8,7 @@
         br $cont
       end
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -46,6 +46,8 @@
 0000021: 0b                                        ; end
 0000015: 0c                                        ; FIXUP func body size
 0000013: 0e                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 br-loop.wasm:	file format wasm 0x1
 

--- a/test/dump/br_on_exn.txt
+++ b/test/dump/br_on_exn.txt
@@ -12,7 +12,7 @@
       i32.const 0
     end
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -74,6 +74,8 @@
 000001f: 12                                        ; FIXUP section size
 ; move data: [1e, 32) -> [1b, 2f)
 ; truncate to 47 (0x2f)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 br_on_exn.wasm:	file format wasm 0x1
 

--- a/test/dump/brif-loop.txt
+++ b/test/dump/brif-loop.txt
@@ -6,7 +6,7 @@
       i32.const 0
       br_if $cont
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -41,6 +41,8 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 brif-loop.wasm:	file format wasm 0x1
 

--- a/test/dump/brif.txt
+++ b/test/dump/brif.txt
@@ -6,7 +6,7 @@
       i32.const 1
       br_if $foo
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -41,6 +41,8 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 brif.wasm:	file format wasm 0x1
 

--- a/test/dump/brtable-empty.txt
+++ b/test/dump/brtable-empty.txt
@@ -6,7 +6,7 @@
       i32.const 0  
       br_table 0 
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -42,6 +42,8 @@
 000001f: 0b                                        ; end
 0000015: 0a                                        ; FIXUP func body size
 0000013: 0c                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 brtable-empty.wasm:	file format wasm 0x1
 

--- a/test/dump/brtable.txt
+++ b/test/dump/brtable.txt
@@ -20,7 +20,7 @@
     end
     i32.const 3
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -75,6 +75,8 @@
 0000032: 0b                                        ; end
 0000015: 1d                                        ; FIXUP func body size
 0000013: 1f                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 brtable.wasm:	file format wasm 0x1
 

--- a/test/dump/call.txt
+++ b/test/dump/call.txt
@@ -4,7 +4,7 @@
   (func (param i32)
      i32.const 1
      call 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -37,6 +37,8 @@
 000001c: 0b                                        ; end
 0000016: 06                                        ; FIXUP func body size
 0000014: 08                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 call.wasm:	file format wasm 0x1
 

--- a/test/dump/callimport.txt
+++ b/test/dump/callimport.txt
@@ -10,7 +10,7 @@
     drop
     ;; call local func
     call 1))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -67,6 +67,8 @@
 0000037: 0b                                        ; end
 0000029: 0e                                        ; FIXUP func body size
 0000027: 10                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 callimport.wasm:	file format wasm 0x1
 

--- a/test/dump/callindirect.txt
+++ b/test/dump/callindirect.txt
@@ -7,7 +7,7 @@
     i32.const 0
     call_indirect (type $t))
   (table anyfunc (elem $f)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -65,6 +65,8 @@
 000002f: 0b                                        ; end
 0000026: 09                                        ; FIXUP func body size
 0000024: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 callindirect.wasm:	file format wasm 0x1
 

--- a/test/dump/cast.txt
+++ b/test/dump/cast.txt
@@ -14,7 +14,7 @@
     f64.const 0
     i64.reinterpret/f64
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -58,6 +58,8 @@
 0000031: 0b                                        ; end
 0000015: 1c                                        ; FIXUP func body size
 0000013: 1e                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 cast.wasm:	file format wasm 0x1
 

--- a/test/dump/compare.txt
+++ b/test/dump/compare.txt
@@ -115,7 +115,7 @@
     f64.const 0
     f64.ge
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -310,6 +310,8 @@
 0000015: 9f02                                      ; FIXUP func body size
 ; move data: [14, 136) -> [15, 137)
 0000013: a202                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 compare.wasm:	file format wasm 0x1
 

--- a/test/dump/const.txt
+++ b/test/dump/const.txt
@@ -78,7 +78,7 @@
     drop
     f64.const 0x1.921fb54442d18p+2
     drop ))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -222,6 +222,8 @@
 0000015: 9a02                                      ; FIXUP func body size
 ; move data: [14, 131) -> [15, 132)
 0000013: 9d02                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 const.wasm:	file format wasm 0x1
 

--- a/test/dump/convert-sat.txt
+++ b/test/dump/convert-sat.txt
@@ -33,7 +33,7 @@
     f64.const 0
     i64.trunc_u:sat/f64
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -101,6 +101,8 @@
 0000067: 0b                                        ; end
 0000015: 52                                        ; FIXUP func body size
 0000013: 54                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 convert-sat.wasm:	file format wasm 0x1
 

--- a/test/dump/convert.txt
+++ b/test/dump/convert.txt
@@ -31,7 +31,7 @@
     f64.promote/f32
     f32.demote/f64
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -89,6 +89,8 @@
 0000038: 0b                                        ; end
 0000015: 23                                        ; FIXUP func body size
 0000013: 25                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 convert.wasm:	file format wasm 0x1
 

--- a/test/dump/current-memory.txt
+++ b/test/dump/current-memory.txt
@@ -4,7 +4,7 @@
   (memory 1)
   (func (result i32)
     current_memory))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -43,6 +43,8 @@
 000001f: 0b                                        ; end
 000001b: 04                                        ; FIXUP func body size
 0000019: 06                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 current-memory.wasm:	file format wasm 0x1
 

--- a/test/dump/debug-import-names.txt
+++ b/test/dump/debug-import-names.txt
@@ -3,7 +3,7 @@
 ;;; ARGS1: --headers -x
 (module
   (import "bar" "foo" (func $foo)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -46,6 +46,8 @@
 000002e: 00                                        ; num locals
 000002b: 03                                        ; FIXUP subsection size
 000001c: 12                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 debug-import-names.wasm:	file format wasm 0x1
 

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -14,7 +14,7 @@
     (local $F3L1 f64)
     (local i64)
     (local $F3L3 i64)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -119,6 +119,8 @@
 0000072: 4633 4c33                                F3L3  ; local name 3
 0000040: 35                                        ; FIXUP subsection size
 000002e: 47                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 debug-names.wasm:	file format wasm 0x1
 

--- a/test/dump/dedupe-sig.txt
+++ b/test/dump/dedupe-sig.txt
@@ -5,7 +5,7 @@
   (import "foo" "bar" (func (param i32) (result i64)))
   (func (param i32) (result i64) 
     i64.const 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -49,6 +49,8 @@
 0000028: 0b                                        ; end
 0000024: 04                                        ; FIXUP func body size
 0000022: 06                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 dedupe-sig.wasm:	file format wasm 0x1
 

--- a/test/dump/drop.txt
+++ b/test/dump/drop.txt
@@ -4,7 +4,7 @@
   (func
     i32.const 0
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -35,6 +35,8 @@
 000001a: 0b                                        ; end
 0000015: 05                                        ; FIXUP func body size
 0000013: 07                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 drop.wasm:	file format wasm 0x1
 

--- a/test/dump/elem-mvp-compat-named.txt
+++ b/test/dump/elem-mvp-compat-named.txt
@@ -4,7 +4,7 @@
 (module
   (table $t 1 funcref)
   (elem $t (i32.const 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Table" (4)
@@ -27,6 +27,8 @@
 0000014: 0b                                        ; end
 0000015: 00                                        ; num elems
 000000f: 06                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 elem-mvp-compat-named.wasm:	file format wasm 0x1
 

--- a/test/dump/elem-mvp-compat.txt
+++ b/test/dump/elem-mvp-compat.txt
@@ -4,7 +4,7 @@
 (module
   (table 1 funcref)
   (elem (table 0) (i32.const 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Table" (4)
@@ -33,6 +33,8 @@
 0000018: 00                                        ; data count
 0000017: 01                                        ; FIXUP section size
 ; truncate to 22 (0x16)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 elem-mvp-compat.wasm:	file format wasm 0x1
 

--- a/test/dump/event.txt
+++ b/test/dump/event.txt
@@ -5,7 +5,7 @@
   (event)
   (event (param i32))
   (event (param f32 f64)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -42,6 +42,8 @@
 000001e: 00                                        ; event attribute
 000001f: 02                                        ; event signature index
 0000018: 07                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 event.wasm:	file format wasm 0x1
 

--- a/test/dump/export-multi.txt
+++ b/test/dump/export-multi.txt
@@ -4,7 +4,7 @@
   (func (nop))
   (export "a" (func 0))
   (export "b" (func 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -46,6 +46,8 @@
 0000023: 0b                                        ; end
 0000020: 03                                        ; FIXUP func body size
 000001e: 05                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 export-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/expr-br.txt
+++ b/test/dump/expr-br.txt
@@ -7,7 +7,7 @@
       br 0 
     end))
 
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -43,6 +43,8 @@
 000001f: 0b                                        ; end
 0000016: 09                                        ; FIXUP func body size
 0000014: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 expr-br.wasm:	file format wasm 0x1
 

--- a/test/dump/expr-brif.txt
+++ b/test/dump/expr-brif.txt
@@ -9,7 +9,7 @@
       drop
       i32.const 29
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -50,6 +50,8 @@
 0000024: 0b                                        ; end
 0000016: 0e                                        ; FIXUP func body size
 0000014: 10                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 expr-brif.wasm:	file format wasm 0x1
 

--- a/test/dump/extended-names.txt
+++ b/test/dump/extended-names.txt
@@ -11,9 +11,6 @@
 (global $g1 (mut i32) (i32.const 1))
 (global $g2 i32 (i32.const 2))
 (;; STDERR ;;;
-0000089: warning: out-of-order sub-section
-;;; STDERR ;;)
-(;; STDOUT ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -170,6 +167,9 @@
 000008d: 656c 656d 31                             elem1  ; elem name 0
 0000089: 08                                        ; FIXUP subsection size
 000004a: 47                                        ; FIXUP section size
+0000089: warning: out-of-order sub-section
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 extended-names.wasm:	file format wasm 0x1
 

--- a/test/dump/func-exported.txt
+++ b/test/dump/func-exported.txt
@@ -3,7 +3,7 @@
 (module
   (func)
   (export "foo" (func 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -40,6 +40,8 @@
 0000020: 0b                                        ; end
 000001e: 02                                        ; FIXUP func body size
 000001c: 04                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 func-exported.wasm:	file format wasm 0x1
 

--- a/test/dump/func-multi.txt
+++ b/test/dump/func-multi.txt
@@ -4,7 +4,7 @@
   (func)
   (func)
   (func))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -44,6 +44,8 @@
 000001f: 0b                                        ; end
 000001d: 02                                        ; FIXUP func body size
 0000015: 0a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 func-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/func-named.txt
+++ b/test/dump/func-named.txt
@@ -2,7 +2,7 @@
 ;;; ARGS0: -v
 (module
   (func $my-func))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -30,6 +30,8 @@
 0000017: 0b                                        ; end
 0000015: 02                                        ; FIXUP func body size
 0000013: 04                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 func-named.wasm:	file format wasm 0x1
 

--- a/test/dump/func-result-multi.txt
+++ b/test/dump/func-result-multi.txt
@@ -5,7 +5,7 @@
   (func (result i32 i64)
     i32.const 0
     i64.const 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -39,6 +39,8 @@
 000001d: 0b                                        ; end
 0000017: 06                                        ; FIXUP func body size
 0000015: 08                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 func-result-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/getglobal.txt
+++ b/test/dump/getglobal.txt
@@ -4,7 +4,7 @@
   (global i32 (i32.const 0))
   (func (result i32)
     get_global 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -45,6 +45,8 @@
 0000022: 0b                                        ; end
 000001e: 04                                        ; FIXUP func body size
 000001c: 06                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 getglobal.wasm:	file format wasm 0x1
 

--- a/test/dump/getlocal-param.txt
+++ b/test/dump/getlocal-param.txt
@@ -15,7 +15,7 @@
     drop
     get_local 5
     drop ))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -71,6 +71,8 @@
 0000033: 0b                                        ; end
 0000017: 1c                                        ; FIXUP func body size
 0000015: 1e                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 getlocal-param.wasm:	file format wasm 0x1
 

--- a/test/dump/getlocal.txt
+++ b/test/dump/getlocal.txt
@@ -19,7 +19,7 @@
     drop
     get_local 7
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -85,6 +85,8 @@
 000003d: 0b                                        ; end
 0000015: 28                                        ; FIXUP func body size
 0000013: 2a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 getlocal.wasm:	file format wasm 0x1
 

--- a/test/dump/global.txt
+++ b/test/dump/global.txt
@@ -16,7 +16,7 @@
   (global i64 (get_global 1))
   (global f32 (get_global 2))
   (global f64 (get_global 3)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Import" (2)
@@ -101,6 +101,8 @@
 0000086: 03                                        ; global index
 0000087: 0b                                        ; end
 0000054: 33                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 global.wasm:	file format wasm 0x1
 

--- a/test/dump/grow-memory.txt
+++ b/test/dump/grow-memory.txt
@@ -6,7 +6,7 @@
     get_local 0
     grow_memory
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -49,6 +49,8 @@
 0000023: 0b                                        ; end
 000001c: 07                                        ; FIXUP func body size
 000001a: 09                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 grow-memory.wasm:	file format wasm 0x1
 

--- a/test/dump/hexfloat_f32.txt
+++ b/test/dump/hexfloat_f32.txt
@@ -38,7 +38,7 @@
     drop
   )
 )
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -117,6 +117,8 @@
 000007d: 0b                                        ; end
 0000015: 68                                        ; FIXUP func body size
 0000013: 6a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 hexfloat_f32.wasm:	file format wasm 0x1
 

--- a/test/dump/hexfloat_f64.txt
+++ b/test/dump/hexfloat_f64.txt
@@ -38,7 +38,7 @@
     drop
   )
 )
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -119,6 +119,8 @@
 0000015: ac01                                      ; FIXUP func body size
 ; move data: [14, c3) -> [15, c4)
 0000013: af01                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 hexfloat_f64.wasm:	file format wasm 0x1
 

--- a/test/dump/if-multi.txt
+++ b/test/dump/if-multi.txt
@@ -20,7 +20,7 @@
     else
       drop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -90,6 +90,8 @@
 0000046: 0b                                        ; end
 0000037: 0f                                        ; FIXUP func body size
 000001d: 29                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 if-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/if-then-else-list.txt
+++ b/test/dump/if-then-else-list.txt
@@ -14,7 +14,7 @@
       i32.const 5
       drop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -60,6 +60,8 @@
 0000029: 0b                                        ; end
 0000015: 14                                        ; FIXUP func body size
 0000013: 16                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 if-then-else-list.wasm:	file format wasm 0x1
 

--- a/test/dump/if-then-list.txt
+++ b/test/dump/if-then-list.txt
@@ -7,7 +7,7 @@
       nop 
       nop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -42,6 +42,8 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 if-then-list.wasm:	file format wasm 0x1
 

--- a/test/dump/if.txt
+++ b/test/dump/if.txt
@@ -20,7 +20,7 @@
     else
       return
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -79,6 +79,8 @@
 000003a: 0b                                        ; end
 0000030: 0a                                        ; FIXUP func body size
 0000014: 26                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 if.wasm:	file format wasm 0x1
 

--- a/test/dump/import.txt
+++ b/test/dump/import.txt
@@ -8,7 +8,7 @@
   (import "ignored" "testtable" (table 0 anyfunc))
   (import "ignored" "testevent" (event (param i32)))
 )
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -79,6 +79,8 @@
 0000079: 00                                        ; event attribute
 000007a: 02                                        ; event signature index
 000001c: 5e                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 import.wasm:	file format wasm 0x1
 

--- a/test/dump/invalid-data-segment-no-memory.txt
+++ b/test/dump/invalid-data-segment-no-memory.txt
@@ -2,7 +2,7 @@
 ;;; ARGS: -v --no-check
 (module
   (data (i32.const 0) "hello"))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Data" (11)
@@ -18,4 +18,4 @@
 ; data segment data 0
 0000010: 6865 6c6c 6f                              ; data segment data
 0000009: 0b                                        ; FIXUP section size
-;;; STDOUT ;;)
+;;; STDERR ;;)

--- a/test/dump/invalid-data-segment-offset.txt
+++ b/test/dump/invalid-data-segment-offset.txt
@@ -3,7 +3,7 @@
 (module
   (memory 1)
   (data (i32.add (i32.const 1) (i32.const 2)) "foo"))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Memory" (5)
@@ -30,4 +30,4 @@
 ; data segment data 0
 0000018: 666f 6f                                   ; data segment data
 000000e: 0c                                        ; FIXUP section size
-;;; STDOUT ;;)
+;;; STDERR ;;)

--- a/test/dump/invalid-elem-segment-no-table.txt
+++ b/test/dump/invalid-elem-segment-no-table.txt
@@ -4,7 +4,7 @@
   (func)
   (func)
   (elem (i32.const 0) 0 1))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -51,4 +51,4 @@
 0000025: 0b                                        ; end
 0000023: 02                                        ; FIXUP func body size
 000001e: 07                                        ; FIXUP section size
-;;; STDOUT ;;)
+;;; STDERR ;;)

--- a/test/dump/invalid-elem-segment-offset.txt
+++ b/test/dump/invalid-elem-segment-offset.txt
@@ -4,7 +4,7 @@
   (table 1 anyfunc)
   (func)
   (elem (i32.eqz (i32.const 1)) 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -54,4 +54,4 @@
 0000027: 0b                                        ; end
 0000025: 02                                        ; FIXUP func body size
 0000023: 04                                        ; FIXUP section size
-;;; STDOUT ;;)
+;;; STDERR ;;)

--- a/test/dump/load-aligned.txt
+++ b/test/dump/load-aligned.txt
@@ -51,7 +51,7 @@
     i32.const 0
     i64.load align=8
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -183,6 +183,8 @@
 000007c: 0b                                        ; end
 000001a: 62                                        ; FIXUP func body size
 0000018: 64                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 load-aligned.wasm:	file format wasm 0x1
 

--- a/test/dump/load.txt
+++ b/test/dump/load.txt
@@ -45,7 +45,7 @@
     i32.const 0
     f64.load
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -165,6 +165,8 @@
 0000070: 0b                                        ; end
 000001a: 56                                        ; FIXUP func body size
 0000018: 58                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 load.wasm:	file format wasm 0x1
 

--- a/test/dump/load64.txt
+++ b/test/dump/load64.txt
@@ -45,7 +45,7 @@
     i64.const 0
     f64.load
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -165,6 +165,8 @@
 0000070: 0b                                        ; end
 000001a: 56                                        ; FIXUP func body size
 0000018: 58                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 load64.wasm:	file format wasm 0x1
 

--- a/test/dump/locals.txt
+++ b/test/dump/locals.txt
@@ -2,7 +2,7 @@
 ;;; ARGS0: -v
 (module
   (func (local i32 i64 i64 f32 f32 f32 f64 f64 f64 f64)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -38,6 +38,8 @@
 000001f: 0b                                        ; end
 0000015: 0a                                        ; FIXUP func body size
 0000013: 0c                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 locals.wasm:	file format wasm 0x1
 

--- a/test/dump/loop-257-exprs-br.txt
+++ b/test/dump/loop-257-exprs-br.txt
@@ -53,7 +53,7 @@
       br 0       ;; depth 1 (due to implicit block)
       end
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -353,6 +353,8 @@
 0000015: 9002                                      ; FIXUP func body size
 ; move data: [14, 127) -> [15, 128)
 0000013: 9302                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 loop-257-exprs-br.wasm:	file format wasm 0x1
 

--- a/test/dump/loop-257-exprs.txt
+++ b/test/dump/loop-257-exprs.txt
@@ -46,7 +46,7 @@
       ;; 257
       nop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -336,6 +336,8 @@
 0000015: 8602                                      ; FIXUP func body size
 ; move data: [14, 11d) -> [15, 11e)
 0000013: 8902                                      ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 loop-257-exprs.wasm:	file format wasm 0x1
 

--- a/test/dump/loop-multi.txt
+++ b/test/dump/loop-multi.txt
@@ -13,7 +13,7 @@
     loop (param i32)
       drop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -72,6 +72,8 @@
 0000032: 0b                                        ; end
 000002a: 08                                        ; FIXUP func body size
 000001d: 15                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 loop-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/loop.txt
+++ b/test/dump/loop.txt
@@ -6,7 +6,7 @@
       nop
       nop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -39,6 +39,8 @@
 000001c: 0b                                        ; end
 0000015: 07                                        ; FIXUP func body size
 0000013: 09                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 loop.wasm:	file format wasm 0x1
 

--- a/test/dump/memory-1-byte.txt
+++ b/test/dump/memory-1-byte.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-objdump
 ;;; ARGS0: -v
 (module (memory 1))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Memory" (5)
@@ -12,6 +12,8 @@
 000000b: 00                                        ; limits: flags
 000000c: 01                                        ; limits: initial
 0000009: 03                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 memory-1-byte.wasm:	file format wasm 0x1
 

--- a/test/dump/memory-data-size.txt
+++ b/test/dump/memory-data-size.txt
@@ -5,7 +5,7 @@
 (module (memory 2))
 (module (memory 4))
 (module (memory 5))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Memory" (5)
@@ -46,6 +46,8 @@
 000000b: 00                                        ; limits: flags
 000000c: 05                                        ; limits: initial
 0000009: 03                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 memory-data-size.0.wasm:	file format wasm 0x1
 

--- a/test/dump/memory-hex.txt
+++ b/test/dump/memory-hex.txt
@@ -3,7 +3,7 @@
 (module
   (memory
     (data "\00\01\02\03\04\05\06\07\08\09\0a")))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Memory" (5)
@@ -28,6 +28,8 @@
 ; data segment data 0
 0000016: 0001 0203 0405 0607 0809 0a               ; data segment data
 000000f: 11                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 memory-hex.wasm:	file format wasm 0x1
 

--- a/test/dump/memory.txt
+++ b/test/dump/memory.txt
@@ -5,7 +5,7 @@
   (memory 1)
   (data (i32.const 10) "hello")
   (data (i32.const 20) "goodbye, Lorem ipsum dolor sit amet, consectetur"))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Memory" (5)
@@ -39,6 +39,8 @@
 000002f: 7073 756d 2064 6f6c 6f72 2073 6974 2061 
 000003f: 6d65 742c 2063 6f6e 7365 6374 6574 7572   ; data segment data
 000000e: 40                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 memory.wasm:	file format wasm 0x1
 

--- a/test/dump/module-name.txt
+++ b/test/dump/module-name.txt
@@ -2,7 +2,7 @@
 ;;; ARGS0: -v --debug-names
 ;;; ARGS1: -x
 (module $my_module)
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "name"
@@ -20,6 +20,8 @@
 000001d: 00                                        ; num functions
 000001c: 01                                        ; FIXUP subsection size
 0000009: 14                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 module-name.wasm:	file format wasm 0x1
 module name: <my_module>

--- a/test/dump/mutable-global.txt
+++ b/test/dump/mutable-global.txt
@@ -4,7 +4,7 @@
 (module
   (import "foo" "imported" (global (mut i32)))
   (global (export "exported") (mut i32) (i32.const 1)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Import" (2)
@@ -39,6 +39,8 @@
 000002f: 03                                        ; export kind
 0000030: 01                                        ; export global index
 0000024: 0c                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 mutable-global.wasm:	file format wasm 0x1
 

--- a/test/dump/no-canonicalize.txt
+++ b/test/dump/no-canonicalize.txt
@@ -21,7 +21,7 @@
     i32.const 2
     i32.mul
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -146,6 +146,8 @@
 0000099: 0b                                        ; end
 000008d: 8880 8080 00                              ; FIXUP func body size
 000006b: aa80 8080 00                              ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 no-canonicalize.wasm:	file format wasm 0x1
 

--- a/test/dump/nocheck.txt
+++ b/test/dump/nocheck.txt
@@ -6,7 +6,7 @@
     f64.const 2
     i32.add)
   (export "foo" (func 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -49,6 +49,8 @@
 0000030: 0b                                        ; end
 000001f: 11                                        ; FIXUP func body size
 000001d: 13                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 nocheck.wasm:	file format wasm 0x1
 

--- a/test/dump/nop.txt
+++ b/test/dump/nop.txt
@@ -3,7 +3,7 @@
 (module
   (func 
     nop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -32,6 +32,8 @@
 0000018: 0b                                        ; end
 0000015: 03                                        ; FIXUP func body size
 0000013: 05                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 nop.wasm:	file format wasm 0x1
 

--- a/test/dump/param-multi.txt
+++ b/test/dump/param-multi.txt
@@ -2,7 +2,7 @@
 ;;; ARGS0: -v
 (module
   (func (param i32 i64 f32 f64)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -34,6 +34,8 @@
 000001b: 0b                                        ; end
 0000019: 02                                        ; FIXUP func body size
 0000017: 04                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 param-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/result.txt
+++ b/test/dump/result.txt
@@ -9,7 +9,7 @@
     f32.const 0)
   (func (result f64) 
     f64.const 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -79,6 +79,8 @@
 0000042: 0b                                        ; end
 0000037: 0b                                        ; FIXUP func body size
 0000023: 1f                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 result.wasm:	file format wasm 0x1
 

--- a/test/dump/rethrow.txt
+++ b/test/dump/rethrow.txt
@@ -7,7 +7,7 @@
     catch
       rethrow
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -55,6 +55,8 @@
 000001b: 09                                        ; FIXUP section size
 ; move data: [1a, 25) -> [17, 22)
 ; truncate to 34 (0x22)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 rethrow.wasm:	file format wasm 0x1
 

--- a/test/dump/return.txt
+++ b/test/dump/return.txt
@@ -6,7 +6,7 @@
     return)
   (func 
     return))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -49,6 +49,8 @@
 0000023: 0b                                        ; end
 0000020: 03                                        ; FIXUP func body size
 0000018: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 return.wasm:	file format wasm 0x1
 

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -22,7 +22,7 @@
     i32.const 1
     select
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -82,6 +82,8 @@
 000004b: 0b                                        ; end
 0000015: 36                                        ; FIXUP func body size
 0000013: 38                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 select.wasm:	file format wasm 0x1
 

--- a/test/dump/setglobal.txt
+++ b/test/dump/setglobal.txt
@@ -5,7 +5,7 @@
   (func
     f32.const 2
     set_global 0))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -47,6 +47,8 @@
 0000029: 0b                                        ; end
 0000020: 09                                        ; FIXUP func body size
 000001e: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 setglobal.wasm:	file format wasm 0x1
 

--- a/test/dump/setlocal-param.txt
+++ b/test/dump/setlocal-param.txt
@@ -19,7 +19,7 @@
     set_local 4
     f32.const 0
     set_local 5))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -81,6 +81,8 @@
 0000042: 0b                                        ; end
 0000017: 2b                                        ; FIXUP func body size
 0000015: 2d                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 setlocal-param.wasm:	file format wasm 0x1
 

--- a/test/dump/setlocal.txt
+++ b/test/dump/setlocal.txt
@@ -23,7 +23,7 @@
     set_local 6
     i64.const 0
     set_local 7))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -97,6 +97,8 @@
 0000059: 0b                                        ; end
 0000015: 44                                        ; FIXUP func body size
 0000013: 46                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 setlocal.wasm:	file format wasm 0x1
 

--- a/test/dump/signatures.txt
+++ b/test/dump/signatures.txt
@@ -12,7 +12,7 @@
   (type (func (result f64)))
 
   (type (func (param i32) (result f64))))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -66,6 +66,8 @@
 000002e: 01                                        ; num results
 000002f: 7c                                        ; f64
 0000009: 26                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 signatures.wasm:	file format wasm 0x1
 

--- a/test/dump/start.txt
+++ b/test/dump/start.txt
@@ -6,7 +6,7 @@
   (func $b)
   (func $start)
   (start $start))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -51,6 +51,8 @@
 0000022: 0b                                        ; end
 0000020: 02                                        ; FIXUP func body size
 0000018: 0a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 start.wasm:	file format wasm 0x1
 

--- a/test/dump/store-aligned.txt
+++ b/test/dump/store-aligned.txt
@@ -51,7 +51,7 @@
     i32.const 0
     i64.const 0
     i64.store align=8))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -199,6 +199,8 @@
 000008c: 0b                                        ; end
 000001a: 72                                        ; FIXUP func body size
 0000018: 74                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 store-aligned.wasm:	file format wasm 0x1
 

--- a/test/dump/store.txt
+++ b/test/dump/store.txt
@@ -30,7 +30,7 @@
     i32.const 0
     f64.const 0
     f64.store))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -129,6 +129,8 @@
 0000065: 0b                                        ; end
 000001a: 4b                                        ; FIXUP func body size
 0000018: 4d                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 store.wasm:	file format wasm 0x1
 

--- a/test/dump/store64.txt
+++ b/test/dump/store64.txt
@@ -30,7 +30,7 @@
     i64.const 0
     f64.const 0
     f64.store))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -129,6 +129,8 @@
 0000065: 0b                                        ; end
 000001a: 4b                                        ; FIXUP func body size
 0000018: 4d                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 store64.wasm:	file format wasm 0x1
 

--- a/test/dump/string-escape.txt
+++ b/test/dump/string-escape.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-objdump
 ;;; ARGS0: -v
 (module (func) (export "tab:\t newline:\n slash:\\ quote:\' double:\"" (func 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -40,6 +40,8 @@
 0000045: 0b                                        ; end
 0000043: 02                                        ; FIXUP func body size
 0000041: 04                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 string-escape.wasm:	file format wasm 0x1
 

--- a/test/dump/string-hex.txt
+++ b/test/dump/string-hex.txt
@@ -1,7 +1,7 @@
 ;;; TOOL: run-objdump
 ;;; ARGS0: -v
 (module (func) (export "foo\de\ad\ca\bb" (func 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -38,6 +38,8 @@
 0000024: 0b                                        ; end
 0000022: 02                                        ; FIXUP func body size
 0000020: 04                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 string-hex.wasm:	file format wasm 0x1
 

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -5,7 +5,7 @@
   (func (param i32))
   (table anyfunc (elem 0))
   (table anyfunc (elem 0)))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -77,6 +77,8 @@
 0000033: 04                                        ; FIXUP section size
 ; move data: [32, 38) -> [2f, 35)
 ; truncate to 53 (0x35)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 table-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/table.txt
+++ b/test/dump/table.txt
@@ -10,7 +10,7 @@
   (table 6 6 anyfunc)
   (elem (i32.const 0) 1 1)
   (elem (i32.const 2) 0 0 1 2))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -97,6 +97,8 @@
 000004c: 0b                                        ; end
 0000041: 0b                                        ; FIXUP func body size
 0000039: 13                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 table.wasm:	file format wasm 0x1
 

--- a/test/dump/tee_local.txt
+++ b/test/dump/tee_local.txt
@@ -6,7 +6,7 @@
     i32.const 0
     tee_local 0
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -41,6 +41,8 @@
 000001e: 0b                                        ; end
 0000015: 09                                        ; FIXUP func body size
 0000013: 0b                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 tee_local.wasm:	file format wasm 0x1
 

--- a/test/dump/throw.txt
+++ b/test/dump/throw.txt
@@ -5,7 +5,7 @@
   (func
     i32.const 1
     throw $e))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -57,6 +57,8 @@
 000001f: 08                                        ; FIXUP section size
 ; move data: [1e, 28) -> [1b, 25)
 ; truncate to 37 (0x25)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 throw.wasm:	file format wasm 0x1
 

--- a/test/dump/try-multi.txt
+++ b/test/dump/try-multi.txt
@@ -19,7 +19,7 @@
     catch
       drop
     end))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -93,6 +93,8 @@
 0000020: 1d                                        ; FIXUP section size
 ; move data: [1f, 3e) -> [1c, 3b)
 ; truncate to 59 (0x3b)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 try-multi.wasm:	file format wasm 0x1
 

--- a/test/dump/try.txt
+++ b/test/dump/try.txt
@@ -10,7 +10,7 @@
       i32.const 8
     end
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -56,6 +56,8 @@
 0000016: 0f                                        ; FIXUP section size
 ; move data: [15, 26) -> [12, 23)
 ; truncate to 35 (0x23)
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 try.wasm:	file format wasm 0x1
 

--- a/test/dump/unary-extend.txt
+++ b/test/dump/unary-extend.txt
@@ -21,7 +21,7 @@
     i64.const 0
     i64.extend32_s
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -69,6 +69,8 @@
 000002b: 0b                                        ; end
 0000015: 16                                        ; FIXUP func body size
 0000013: 18                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 unary-extend.wasm:	file format wasm 0x1
 

--- a/test/dump/unary.txt
+++ b/test/dump/unary.txt
@@ -34,7 +34,7 @@
     f64.abs
     f64.neg
     drop))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -95,6 +95,8 @@
 0000042: 0b                                        ; end
 0000015: 2d                                        ; FIXUP func body size
 0000013: 2f                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 unary.wasm:	file format wasm 0x1
 

--- a/test/dump/unreachable.txt
+++ b/test/dump/unreachable.txt
@@ -3,7 +3,7 @@
 (module
   (func
     unreachable))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -32,6 +32,8 @@
 0000018: 0b                                        ; end
 0000015: 03                                        ; FIXUP func body size
 0000013: 05                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
 
 unreachable.wasm:	file format wasm 0x1
 

--- a/test/interp/basic-logging.txt
+++ b/test/interp/basic-logging.txt
@@ -4,7 +4,7 @@
   (func (export "main") (result i32)
     i32.const 42
     return))
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 ; section "Type" (1)
@@ -67,6 +67,8 @@ BeginModule(version: 1)
     EndFunctionBody(0)
   EndCodeSection
 EndModule
+;;; STDERR ;;)
+(;; STDOUT ;;;
    0| i32.const 42
    8| return
   12| return

--- a/test/two-commands.txt
+++ b/test/two-commands.txt
@@ -3,9 +3,9 @@
 ;;; TOOL: wat2wasm
 ;;; ARGS: -v
 (module)
-(;; STDOUT ;;;
+(;; STDERR ;;;
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
 0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
 0000004: 0100 0000                                 ; WASM_BINARY_VERSION
-;;; STDOUT ;;)
+;;; STDERR ;;)


### PR DESCRIPTION
I'm not sure why we were using stdout but the convention is normally to
write all logging and error message to stderr.