### PR TITLE
wasm-objdump: Report data segment names

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -250,6 +250,9 @@ class BinaryReaderObjdumpPrepass : public BinaryReaderObjdumpBase {
       case NameSectionSubsection::Table:
         SetTableName(index, name);
         break;
+      case NameSectionSubsection::DataSegment:
+        SetSegmentName(index, name);
+        break;
       default:
         break;
     }
@@ -650,14 +653,28 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeIndexIndex(Index value,
 
 Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32(uint32_t value) {
   Offset immediate_len = state->offset - current_opcode_offset;
-  LogOpcode(immediate_len, "%u", value);
+  string_view name;
+  if (current_opcode == Opcode::DataDrop &&
+      !(name = GetSegmentName(value)).empty()) {
+    LogOpcode(immediate_len, "%d <" PRIstringview ">", value,
+              WABT_PRINTF_STRING_VIEW_ARG(name));
+  } else {
+    LogOpcode(immediate_len, "%u", value);
+  }
   return Result::Ok;
 }
 
 Result BinaryReaderObjdumpDisassemble::OnOpcodeUint32Uint32(uint32_t value,
                                                             uint32_t value2) {
   Offset immediate_len = state->offset - current_opcode_offset;
-  LogOpcode(immediate_len, "%u %u", value, value2);
+  string_view name;
+  if (current_opcode == Opcode::MemoryInit &&
+      !(name = GetSegmentName(value)).empty()) {
+    LogOpcode(immediate_len, "%u %u <" PRIstringview ">", value, value2,
+              WABT_PRINTF_STRING_VIEW_ARG(name));
+  } else {
+    LogOpcode(immediate_len, "%u %u", value, value2);
+  }
   return Result::Ok;
 }
 

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1596,10 +1596,10 @@ Result BinaryWriter::WriteModule() {
     WriteNames<Table>(module_->tables, NameSectionSubsection::Table);
     WriteNames<Memory>(module_->memories, NameSectionSubsection::Memory);
     WriteNames<Global>(module_->globals, NameSectionSubsection::Global);
-    WriteNames<DataSegment>(module_->data_segments,
-                            NameSectionSubsection::DataSegment);
     WriteNames<ElemSegment>(module_->elem_segments,
                             NameSectionSubsection::ElemSegment);
+    WriteNames<DataSegment>(module_->data_segments,
+                            NameSectionSubsection::DataSegment);
 
     EndSection();
   }

--- a/test/dump/bulk-memory.txt
+++ b/test/dump/bulk-memory.txt
@@ -1,9 +1,9 @@
 ;;; TOOL: run-objdump
-;;; ARGS0: --enable-bulk-memory
+;;; ARGS0: --debug-names --enable-bulk-memory
 
 (module
   (memory 1)
-  (data "a")
+  (data $mydata "a")
   (func
     i32.const 0 i32.const 0 i32.const 0 memory.init 0
     data.drop 0
@@ -29,8 +29,8 @@ Code Disassembly:
  00002d: 41 00                      | i32.const 0
  00002f: 41 00                      | i32.const 0
  000031: 41 00                      | i32.const 0
- 000033: fc 08 00 00                | memory.init 0 0
- 000037: fc 09 00                   | data.drop 0
+ 000033: fc 08 00 00                | memory.init 0 0 <mydata>
+ 000037: fc 09 00                   | data.drop 0 <mydata>
  00003a: 41 00                      | i32.const 0
  00003c: 41 00                      | i32.const 0
  00003e: 41 00                      | i32.const 0

--- a/test/dump/extended-names.txt
+++ b/test/dump/extended-names.txt
@@ -6,7 +6,9 @@
 (table $t2 1 funcref)
 (memory $mem2 1 1)
 (data $data1 "hello")
-(func)
+(func
+  data.drop 0
+)
 (elem $elem1 func 0)
 (global $g1 (mut i32) (i32.const 1))
 (global $g2 i32 (i32.const 2))
@@ -92,82 +94,82 @@
 ; function body 0
 000003f: 00                                        ; func body size (guess)
 0000040: 00                                        ; local decl count
-0000041: 0b                                        ; end
-000003f: 02                                        ; FIXUP func body size
-000003d: 04                                        ; FIXUP section size
-; move data: [3c, 42) -> [39, 3f)
-; truncate to 63 (0x3f)
+0000041: fc                                        ; prefix
+0000042: 09                                        ; data.drop
+0000043: 00                                        ; data.drop segment
+0000044: 0b                                        ; end
+000003f: 05                                        ; FIXUP func body size
+000003d: 07                                        ; FIXUP section size
 ; section "Data" (11)
-000003f: 0b                                        ; section code
-0000040: 00                                        ; section size (guess)
-0000041: 01                                        ; num data segments
+0000045: 0b                                        ; section code
+0000046: 00                                        ; section size (guess)
+0000047: 01                                        ; num data segments
 ; data segment header 0
-0000042: 01                                        ; segment flags
-0000043: 05                                        ; data segment size
+0000048: 01                                        ; segment flags
+0000049: 05                                        ; data segment size
 ; data segment data 0
-0000044: 6865 6c6c 6f                              ; data segment data
-0000040: 08                                        ; FIXUP section size
+000004a: 6865 6c6c 6f                              ; data segment data
+0000046: 08                                        ; FIXUP section size
 ; section "name"
-0000049: 00                                        ; section code
-000004a: 00                                        ; section size (guess)
-000004b: 04                                        ; string length
-000004c: 6e61 6d65                                name  ; custom section name
-0000050: 02                                        ; local name type
-0000051: 00                                        ; subsection size (guess)
-0000052: 01                                        ; num functions
-0000053: 00                                        ; function index
-0000054: 00                                        ; num locals
-0000051: 03                                        ; FIXUP subsection size
-0000055: 04                                        ; name subsection type
-0000056: 00                                        ; subsection size (guess)
-0000057: 01                                        ; num names
-0000058: 00                                        ; elem index
-0000059: 05                                        ; string length
-000005a: 7479 7065 31                             type1  ; elem name 0
-0000056: 08                                        ; FIXUP subsection size
-000005f: 05                                        ; name subsection type
-0000060: 00                                        ; subsection size (guess)
-0000061: 02                                        ; num names
-0000062: 00                                        ; elem index
-0000063: 02                                        ; string length
-0000064: 7431                                     t1  ; elem name 0
-0000066: 01                                        ; elem index
-0000067: 02                                        ; string length
-0000068: 7432                                     t2  ; elem name 1
-0000060: 09                                        ; FIXUP subsection size
-000006a: 06                                        ; name subsection type
-000006b: 00                                        ; subsection size (guess)
-000006c: 01                                        ; num names
-000006d: 00                                        ; elem index
-000006e: 04                                        ; string length
-000006f: 6d65 6d32                                mem2  ; elem name 0
-000006b: 07                                        ; FIXUP subsection size
-0000073: 07                                        ; name subsection type
-0000074: 00                                        ; subsection size (guess)
-0000075: 02                                        ; num names
-0000076: 00                                        ; elem index
-0000077: 02                                        ; string length
-0000078: 6731                                     g1  ; elem name 0
-000007a: 01                                        ; elem index
-000007b: 02                                        ; string length
-000007c: 6732                                     g2  ; elem name 1
-0000074: 09                                        ; FIXUP subsection size
-000007e: 09                                        ; name subsection type
-000007f: 00                                        ; subsection size (guess)
-0000080: 01                                        ; num names
-0000081: 00                                        ; elem index
-0000082: 05                                        ; string length
-0000083: 6461 7461 31                             data1  ; elem name 0
-000007f: 08                                        ; FIXUP subsection size
-0000088: 08                                        ; name subsection type
-0000089: 00                                        ; subsection size (guess)
-000008a: 01                                        ; num names
-000008b: 00                                        ; elem index
-000008c: 05                                        ; string length
-000008d: 656c 656d 31                             elem1  ; elem name 0
-0000089: 08                                        ; FIXUP subsection size
-000004a: 47                                        ; FIXUP section size
-0000089: warning: out-of-order sub-section
+000004f: 00                                        ; section code
+0000050: 00                                        ; section size (guess)
+0000051: 04                                        ; string length
+0000052: 6e61 6d65                                name  ; custom section name
+0000056: 02                                        ; local name type
+0000057: 00                                        ; subsection size (guess)
+0000058: 01                                        ; num functions
+0000059: 00                                        ; function index
+000005a: 00                                        ; num locals
+0000057: 03                                        ; FIXUP subsection size
+000005b: 04                                        ; name subsection type
+000005c: 00                                        ; subsection size (guess)
+000005d: 01                                        ; num names
+000005e: 00                                        ; elem index
+000005f: 05                                        ; string length
+0000060: 7479 7065 31                             type1  ; elem name 0
+000005c: 08                                        ; FIXUP subsection size
+0000065: 05                                        ; name subsection type
+0000066: 00                                        ; subsection size (guess)
+0000067: 02                                        ; num names
+0000068: 00                                        ; elem index
+0000069: 02                                        ; string length
+000006a: 7431                                     t1  ; elem name 0
+000006c: 01                                        ; elem index
+000006d: 02                                        ; string length
+000006e: 7432                                     t2  ; elem name 1
+0000066: 09                                        ; FIXUP subsection size
+0000070: 06                                        ; name subsection type
+0000071: 00                                        ; subsection size (guess)
+0000072: 01                                        ; num names
+0000073: 00                                        ; elem index
+0000074: 04                                        ; string length
+0000075: 6d65 6d32                                mem2  ; elem name 0
+0000071: 07                                        ; FIXUP subsection size
+0000079: 07                                        ; name subsection type
+000007a: 00                                        ; subsection size (guess)
+000007b: 02                                        ; num names
+000007c: 00                                        ; elem index
+000007d: 02                                        ; string length
+000007e: 6731                                     g1  ; elem name 0
+0000080: 01                                        ; elem index
+0000081: 02                                        ; string length
+0000082: 6732                                     g2  ; elem name 1
+000007a: 09                                        ; FIXUP subsection size
+0000084: 08                                        ; name subsection type
+0000085: 00                                        ; subsection size (guess)
+0000086: 01                                        ; num names
+0000087: 00                                        ; elem index
+0000088: 05                                        ; string length
+0000089: 656c 656d 31                             elem1  ; elem name 0
+0000085: 08                                        ; FIXUP subsection size
+000008e: 09                                        ; name subsection type
+000008f: 00                                        ; subsection size (guess)
+0000090: 01                                        ; num names
+0000091: 00                                        ; elem index
+0000092: 05                                        ; string length
+0000093: 6461 7461 31                             data1  ; elem name 0
+000008f: 08                                        ; FIXUP subsection size
+0000050: 47                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
@@ -191,10 +193,12 @@ Global[2]:
 Elem[1]:
  - segment[0] flags=1 table=0 count=1
   - elem[0] = func[0]
+DataCount:
+ - data count: 1
 Code[1]:
- - func[0] size=2
+ - func[0] size=5
 Data[1]:
- - segment[0] passive size=5
+ - segment[0] <data1> passive size=5
   - 0000000: 6865 6c6c 6f                             hello
 Custom:
  - name: "name"
@@ -204,10 +208,12 @@ Custom:
  - memory[0] <mem2>
  - global[0] <g1>
  - global[1] <g2>
+ - elemseg[0] <elem1>
  - dataseg[0] <data1>
 
 Code Disassembly:
 
-00003d func[0]:
- 00003e: 0b                         | end
+000040 func[0]:
+ 000041: fc 09 00                   | data.drop 0 <data1>
+ 000044: 0b                         | end
 ;;; STDOUT ;;)


### PR DESCRIPTION
Also fix ordering of data names and table segment names.