### PR TITLE
Avoid warning when building with -Wsign-compare

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -59,7 +59,7 @@ void wasm_rt_trap(wasm_rt_trap_t code) {
 static bool func_types_are_equal(FuncType* a, FuncType* b) {
   if (a->param_count != b->param_count || a->result_count != b->result_count)
     return 0;
-  int i;
+  unsigned int i;
   for (i = 0; i < a->param_count; ++i)
     if (a->params[i] != b->params[i])
       return 0;


### PR DESCRIPTION
Just a trivial warning fix.