### PR TITLE
Report missing section features in wasm2wat (#1197)

### DIFF
--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -59,6 +59,8 @@ out/test/spec/binary.wast:45: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
 out/test/spec/binary.wast:48: assert_malformed passed:
   000000a: error: invalid section code: 12
+  000000a: error: encountered sections that are not feature-enabled; try enabling with:
+  000000a: error:     --enable-bulk-memory
 out/test/spec/binary.wast:49: assert_malformed passed:
   000000a: error: invalid section code: 127
 out/test/spec/binary.wast:50: assert_malformed passed:

--- a/test/spec/bulk-memory-operations/binary.txt
+++ b/test/spec/bulk-memory-operations/binary.txt
@@ -60,6 +60,8 @@ out/test/spec/bulk-memory-operations/binary.wast:45: assert_malformed passed:
   0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
 out/test/spec/bulk-memory-operations/binary.wast:48: assert_malformed passed:
   000000a: error: invalid section code: 13
+  000000a: error: encountered sections that are not feature-enabled; try enabling with:
+  000000a: error:     --enable-exceptions
 out/test/spec/bulk-memory-operations/binary.wast:49: assert_malformed passed:
   000000a: error: invalid section code: 127
 out/test/spec/bulk-memory-operations/binary.wast:50: assert_malformed passed:


### PR DESCRIPTION
Ran into https://github.com/WebAssembly/wabt/issues/1197 when using `wasm2wat` so I took a stab at adding hints for missing features like `--enable-bulk-memory`. 

Previously, it seems like looping through WASM sections would return early for these errors (ignoring [`stop_on_first_error`](https://github.com/WebAssembly/wabt/blob/0b80b37c5f99102c5b1c669191ff7b48436875d9/src/binary-reader.cc#L2531)) since the `ERROR_UNLESS` macro will cause `ReadSections` to return Error for missing section features. 

With this PR, we accumulate a list of the missing features in `missing_section_features` and print them out with a helpful error message when returning from `ReadSections` - this makes it easy to extend in the future. Took some inspiration from [the thread on this un-merged PR](https://github.com/WebAssembly/wabt/pull/1540#issuecomment-690535601) tackling the same issue. We shouldn't run into any cases of reporting the same feature missing multiple times because there's already [a guard for multiple section definitions](https://github.com/WebAssembly/wabt/blob/0b80b37c5f99102c5b1c669191ff7b48436875d9/src/binary-reader.cc#L2508-L2514). 

See the updated test cases for what this looks like - happy to update the messaging if there are any suggestions