### PR TITLE
update uvwasi repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -12,4 +12,4 @@
 	url = https://github.com/WebAssembly/wasm-c-api
 [submodule "third_party/uvwasi"]
 	path = third_party/uvwasi
-	url = https://github.com/cjihrig/uvwasi
+	url = https://github.com/nodejs/uvwasi


### PR DESCRIPTION
uvwasi was transferred into the Node.js GitHub org.
This commit updates the project's source repo.