### PR TITLE
Fix checking of delegate target block kind.

### DIFF
--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -550,6 +550,10 @@ Result TypeChecker::OnDelegate(Index depth) {
   // Delegate starts counting after the current try, as the delegate
   // instruction is not actually in the try block.
   CHECK_RESULT(GetLabel(depth + 1, &label));
+  if (Failed(Check2LabelTypes(label, LabelType::Try, LabelType::Func))) {
+    PrintError("try-delegate must target a try block or function label");
+    result = Result::Error;
+  }
 
   Label* try_label;
   CHECK_RESULT(TopLabel(&try_label));

--- a/test/typecheck/bad-delegate-target.txt
+++ b/test/typecheck/bad-delegate-target.txt
@@ -1,0 +1,36 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+;;; ARGS: --enable-exceptions
+(module
+  (event $e)
+  (func
+    try
+      block
+        try
+          throw $e
+        delegate 0
+      end
+    catch $e
+    loop
+      try
+        throw $e
+      delegate 0
+    end
+    try
+    catch $e
+      try
+      delegate 0
+    catch_all
+    end
+    end))
+(;; STDERR ;;;
+out/test/typecheck/bad-delegate-target.txt:9:9: error: try-delegate must target a try block or function label
+        try
+        ^^^
+out/test/typecheck/bad-delegate-target.txt:15:7: error: try-delegate must target a try block or function label
+      try
+      ^^^
+out/test/typecheck/bad-delegate-target.txt:21:7: error: try-delegate must target a try block or function label
+      try
+      ^^^
+;;; STDERR ;;)

--- a/test/typecheck/delegate.txt
+++ b/test/typecheck/delegate.txt
@@ -4,10 +4,11 @@
   (event $e)
   (func
     try
-      block
+      try
         try
           throw $e
         delegate 0
+      catch $e
       end
     catch $e
     end)


### PR DESCRIPTION
This PR fixes an issue with the validation of the `delegate` exception instruction: it was failing to check that the delegate target block was a valid kind of block. It should now follow the clarified behavior of `delegate` from this issue: https://github.com/WebAssembly/exception-handling/issues/146