### PR TITLE
Adjust label printing for blocks in folded form

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1080,6 +1080,7 @@ void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
       WriteFoldedExprList(cast<BlockExpr>(expr_tree.expr)->block.exprs);
       FlushExprTreeStack();
       WriteCloseNewline();
+      EndBlock();
       break;
 
     case ExprType::Loop:
@@ -1089,6 +1090,7 @@ void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
       WriteFoldedExprList(cast<LoopExpr>(expr_tree.expr)->block.exprs);
       FlushExprTreeStack();
       WriteCloseNewline();
+      EndBlock();
       break;
 
     case ExprType::If: {
@@ -1108,6 +1110,7 @@ void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
         WriteCloseNewline();
       }
       WriteCloseNewline();
+      EndBlock();
       break;
     }
 
@@ -1156,6 +1159,7 @@ void WatWriter::FlushExprTree(const ExprTree& expr_tree) {
           break;
       }
       WriteCloseNewline();
+      EndBlock();
       break;
     }
 

--- a/test/roundtrip/fold-block-labels.txt
+++ b/test/roundtrip/fold-block-labels.txt
@@ -1,0 +1,89 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --fold-exprs --enable-exceptions --debug-names
+(module
+  (func
+    block
+      br 0
+    end
+    block
+      br 0
+    end)
+
+  (func
+    block
+      br 0
+      block
+        br 0
+      end
+    end
+    block
+      br 0
+    end)
+
+  (func
+    (i32.const 0)
+    if
+      br 0
+    end
+    (i32.const 0)
+    if
+      br 0
+    end)
+
+  (func
+    loop
+      br 0
+    end
+    loop
+      br 0
+    end)
+
+  (func
+    try
+      br 0
+    catch_all
+    end
+    try
+      br 0
+    catch_all
+    end)
+  )
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    (block  ;; label = @1
+      (br 0 (;@1;)))
+    (block  ;; label = @1
+      (br 0 (;@1;))))
+  (func (;1;) (type 0)
+    (block  ;; label = @1
+      (br 0 (;@1;))
+      (block  ;; label = @2
+        (br 0 (;@2;))))
+    (block  ;; label = @1
+      (br 0 (;@1;))))
+  (func (;2;) (type 0)
+    (if  ;; label = @1
+      (i32.const 0)
+      (then
+        (br 0 (;@1;))))
+    (if  ;; label = @1
+      (i32.const 0)
+      (then
+        (br 0 (;@1;)))))
+  (func (;3;) (type 0)
+    (loop  ;; label = @1
+      (br 0 (;@1;)))
+    (loop  ;; label = @1
+      (br 0 (;@1;))))
+  (func (;4;) (type 0)
+    (try  ;; label = @1
+      (do
+        (br 0 (;@1;)))
+      (catch_all))
+    (try  ;; label = @1
+      (do
+        (br 0 (;@1;)))
+      (catch_all))))
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR makes label printing for blocks in folded form more consistent with non-folded forms.

For example, given the following input wat file:

```
(module
  (func
    block
      br 0
    end
    block
      br 0
    end))
```

If you do a roundtrip with `wat2wasm` and `wasm2wat` currently, you get different labels depending on if you supplied `--fold-exprs` or not:

Non-folded:
```
(module
  (type (;0;) (func))
  (func (;0;) (type 0)
    block  ;; label = @1
      br 0 (;@1;)
    end
    block  ;; label = @1
      br 0 (;@1;)
    end))
```

Folded:
```
(module
  (type (;0;) (func))
  (func (;0;) (type 0)
    (block  ;; label = @1
      (br 0 (;@1;)))
    (block  ;; label = @2    <<---- this is different
      (br 0 (;@2;)))))
```

This PR should make both use the same label depths.