### PR TITLE
[simd] Unskip more tests

### DIFF
--- a/test/spec/simd/simd_const.txt
+++ b/test/spec/simd/simd_const.txt
@@ -2,7 +2,6 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_const.wast
 ;;; ARGS*: --enable-simd --enable-reference-types
 ;;; NOTE: reference types is only required because the test uses two tables
-;;; SKIP: unskip when spec test is updated
 (;; STDOUT ;;;
 out/test/spec/simd/simd_const.wast:130: assert_malformed passed:
   out/test/spec/simd/simd_const/simd_const.113.wat:1:25: error: invalid literal "0x100"
@@ -1762,5 +1761,5 @@ out/test/spec/simd/simd_const.wast:1560: assert_malformed passed:
   out/test/spec/simd/simd_const/simd_const.485.wat:1:42: error: unexpected token 0x1.0p_+1.
   (global v128 (v128.const f64x2 0x1.0p_+1 0x1.0p_+1))
                                            ^^^^^^^^^
-444/444 tests passed.
+445/445 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd/simd_load16_lane.txt
+++ b/test/spec/simd/simd_load16_lane.txt
@@ -1,4 +1,15 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_load16_lane.wast
 ;;; ARGS*: --enable-simd
-;;; SKIP:
+(;; STDOUT ;;;
+out/test/spec/simd/simd_load16_lane.wast:195: assert_invalid passed:
+  error: type mismatch in v128.load16_lane, expected [i32, v128] but got [v128, i32]
+  0000027: error: OnSimdLoadLaneExpr callback failed
+out/test/spec/simd/simd_load16_lane.wast:201: assert_invalid passed:
+  error: lane index must be less than 8 (got 8)
+  0000027: error: OnSimdLoadLaneExpr callback failed
+out/test/spec/simd/simd_load16_lane.wast:208: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (2)
+  0000027: error: OnSimdLoadLaneExpr callback failed
+35/35 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_load32_lane.txt
+++ b/test/spec/simd/simd_load32_lane.txt
@@ -1,4 +1,15 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_load32_lane.wast
 ;;; ARGS*: --enable-simd
-;;; SKIP:
+(;; STDOUT ;;;
+out/test/spec/simd/simd_load32_lane.wast:127: assert_invalid passed:
+  error: type mismatch in v128.load32_lane, expected [i32, v128] but got [v128, i32]
+  0000027: error: OnSimdLoadLaneExpr callback failed
+out/test/spec/simd/simd_load32_lane.wast:133: assert_invalid passed:
+  error: lane index must be less than 4 (got 4)
+  0000027: error: OnSimdLoadLaneExpr callback failed
+out/test/spec/simd/simd_load32_lane.wast:140: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (4)
+  0000027: error: OnSimdLoadLaneExpr callback failed
+23/23 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/simd/simd_store64_lane.txt
+++ b/test/spec/simd/simd_store64_lane.txt
@@ -1,4 +1,15 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/simd/simd_store64_lane.wast
 ;;; ARGS*: --enable-simd
-;;; SKIP:
+(;; STDOUT ;;;
+out/test/spec/simd/simd_store64_lane.wast:115: assert_invalid passed:
+  error: type mismatch in v128.store64_lane, expected [i32, v128] but got [v128, i32]
+  0000027: error: OnSimdStoreLaneExpr callback failed
+out/test/spec/simd/simd_store64_lane.wast:121: assert_invalid passed:
+  error: lane index must be less than 2 (got 2)
+  0000027: error: OnSimdStoreLaneExpr callback failed
+out/test/spec/simd/simd_store64_lane.wast:128: assert_invalid passed:
+  error: alignment must not be larger than natural alignment (8)
+  0000027: error: OnSimdStoreLaneExpr callback failed
+15/15 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
Missed unskipping these in prior implementations. With this, all simd
tests are now running.