### PR TITLE
Add _free to list of exports

### DIFF
--- a/src/emscripten-exported.json
+++ b/src/emscripten-exported.json
@@ -1,4 +1,5 @@
 [
+"_free",
 "_malloc",
 "_wabt_apply_names_module",
 "_wabt_bulk_memory_enabled",


### PR DESCRIPTION
_free is used in src/wabt.post.js.