### PR TITLE
Enable multi value by default

### DIFF
--- a/docs/demo/wat2wasm/index.html
+++ b/docs/demo/wat2wasm/index.html
@@ -46,7 +46,7 @@
     <div>
       <input type="checkbox" id="simd"><label for="simd">simd</label>
       <input type="checkbox" id="threads"><label for="threads">threads</label>
-      <input type="checkbox" id="multi_value"><label for="multi_value">multi value</label>
+      <input type="checkbox" id="multi_value" checked><label for="multi_value">multi value</label>
       <input type="checkbox" id="tail_call"><label for="tail_call">tail call</label>
       <input type="checkbox" id="bulk_memory"><label for="bulk_memory">bulk memory</label>
       <input type="checkbox" id="reference_types"><label for="reference_types">reference types</label>


### PR DESCRIPTION
[Multi value](https://github.com/WebAssembly/multi-value) was merged into the spec almost a year ago, and all browsers support it. I think it is time to check the multi value checkbox by default.

Reference types were merged recently but support among browsers is limited at the moment, so I don't think it is time to check it by default yet.

Node stable does not support multi value, but this is a web based tool.