### PR TITLE
Fix resolution of delegate labels

### DIFF
--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -412,21 +412,13 @@ Result NameResolver::OnCatchExpr(TryExpr*, Catch* catch_) {
 }
 
 Result NameResolver::OnDelegateExpr(TryExpr* expr) {
-  Var* delegate_target = &expr->delegate_target;
-  bool was_name = delegate_target->is_name();
-  ResolveLabelVar(delegate_target);
-  if (was_name) {
-    // Invalid label (of the immediate try-delegate block) used.
-    if (delegate_target->index() == 0) {
-      PrintError(&delegate_target->loc, "invalid label variable for try-delegate");
-      return Result::Ok;
-    }
-    // Adjust label by one, because a delegate instruction cannot target its
-    // immediately enclosing try block.
-    delegate_target->set_index(delegate_target->index() - 1);
-  }
   // Pop the label here as a try-delegate has no `end` instruction.
   PopLabel();
+
+  // We resolve *after* popping the label in order to ensure that the
+  // delegate label starts counting after the current try-delegate.
+  ResolveLabelVar(&expr->delegate_target);
+
   return Result::Ok;
 }
 

--- a/test/dump/try-delegate.txt
+++ b/test/dump/try-delegate.txt
@@ -7,6 +7,9 @@
       try
         nop
       delegate 1
+      try
+        nop
+      delegate $try1
       i32.const 7
     catch $e
       drop
@@ -63,20 +66,25 @@
 0000027: 01                                        ; nop
 0000028: 18                                        ; delegate
 0000029: 01                                        ; delegate depth
-000002a: 41                                        ; i32.const
-000002b: 07                                        ; i32 literal
-000002c: 07                                        ; catch
-000002d: 00                                        ; catch tag
-000002e: 1a                                        ; drop
+000002a: 06                                        ; try
+000002b: 40                                        ; void
+000002c: 01                                        ; nop
+000002d: 18                                        ; delegate
+000002e: 00                                        ; delegate depth
 000002f: 41                                        ; i32.const
-0000030: 08                                        ; i32 literal
-0000031: 0b                                        ; end
-0000032: 1a                                        ; drop
-0000033: 0b                                        ; end
-0000021: 12                                        ; FIXUP func body size
-000001f: 14                                        ; FIXUP section size
-; move data: [1e, 34) -> [1b, 31)
-; truncate to 49 (0x31)
+0000030: 07                                        ; i32 literal
+0000031: 07                                        ; catch
+0000032: 00                                        ; catch tag
+0000033: 1a                                        ; drop
+0000034: 41                                        ; i32.const
+0000035: 08                                        ; i32 literal
+0000036: 0b                                        ; end
+0000037: 1a                                        ; drop
+0000038: 0b                                        ; end
+0000021: 17                                        ; FIXUP func body size
+000001f: 19                                        ; FIXUP section size
+; move data: [1e, 39) -> [1b, 36)
+; truncate to 54 (0x36)
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
@@ -89,11 +97,14 @@ Code Disassembly:
  000022: 06 40                      |   try
  000024: 01                         |     nop
  000025: 18 01                      |   delegate 1
- 000027: 41 07                      |   i32.const 7
- 000029: 07 00                      | catch 0
- 00002b: 1a                         |   drop
- 00002c: 41 08                      |   i32.const 8
- 00002e: 0b                         | end
- 00002f: 1a                         | drop
- 000030: 0b                         | end
+ 000027: 06 40                      |   try
+ 000029: 01                         |     nop
+ 00002a: 18 00                      |   delegate 0
+ 00002c: 41 07                      |   i32.const 7
+ 00002e: 07 00                      | catch 0
+ 000030: 1a                         |   drop
+ 000031: 41 08                      |   i32.const 8
+ 000033: 0b                         | end
+ 000034: 1a                         | drop
+ 000035: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/parse/bad-delegate-label.txt
+++ b/test/parse/bad-delegate-label.txt
@@ -9,7 +9,7 @@
   )
 )
 (;; STDERR ;;;
-out/test/parse/bad-delegate-label.txt:8:14: error: invalid label variable for try-delegate
+out/test/parse/bad-delegate-label.txt:8:14: error: undefined label variable "$t"
     delegate $t
              ^^
 ;;; STDERR ;;)

--- a/test/parse/bad-delegate-label.txt
+++ b/test/parse/bad-delegate-label.txt
@@ -1,0 +1,15 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-exceptions
+;;; ERROR: 1
+(module
+  (func
+    try $t
+      nop
+    delegate $t
+  )
+)
+(;; STDERR ;;;
+out/test/parse/bad-delegate-label.txt:8:14: error: invalid label variable for try-delegate
+    delegate $t
+             ^^
+;;; STDERR ;;)


### PR DESCRIPTION
This PR has two commits for fixing bugs related to try-delegate labels.

One fixes the printing in certain cases (similar to #1609).

The other fixes the label resolution code. Example from the spec (https://github.com/WebAssembly/exception-handling/blob/master/proposals/exception-handling/Exceptions.md):

```
try $l1
  try
    call $foo
  delegate $l1  ;; (= delegate 0)
catch
  ...
catch_all
  ...
end
```

The label `$l1` should resolve to `0` in the delegate target, which is 1 less than how typical block constructs work. The current code mis-resolves this to `1`. It should also error in cases like the following:

```
try $l1
  nop
delegate $l1
```

Because it's not possible to represent the label `$l1` in the binary format, as a `try-delegate` cannot target itself.