### PR TITLE
Add submodule init to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Clone as normal, but don't forget to get the submodules as well:
 ```console
 $ git clone --recursive https://github.com/WebAssembly/wabt
 $ cd wabt
+$ git submodule update --init
 ```
 
 This will fetch the testsuite and gtest repos, which are needed for some tests.


### PR DESCRIPTION
Add submodule init before CMake commands. gtest and others will fail when running cmake without this.