### PR TITLE
[EH] Make tag attribute's encoding uint8

### DIFF
--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2119,8 +2119,8 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
 }
 
 Result BinaryReader::ReadTagType(Index* out_sig_index) {
-  uint32_t attribute;
-  CHECK_RESULT(ReadU32Leb128(&attribute, "tag attribute"));
+  uint8_t attribute;
+  CHECK_RESULT(ReadU8(&attribute, "tag attribute"));
   ERROR_UNLESS(attribute == 0, "tag attribute must be 0");
   CHECK_RESULT(ReadIndex(out_sig_index, "tag signature index"));
   return Result::Ok;

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1110,7 +1110,7 @@ void BinaryWriter::WriteGlobalHeader(const Global* global) {
 }
 
 void BinaryWriter::WriteTagType(const Tag* tag) {
-  WriteU32Leb128(stream_, 0, "tag attribute");
+  stream_->WriteU8(0, "tag attribute");
   WriteU32Leb128(stream_, module_->GetFuncTypeIndex(tag->decl),
                  "tag signature index");
 }


### PR DESCRIPTION
This changes the encoding of the `attribute` field, which currently only
contains the value `0` denoting this tag is for an exception, from
`varuint32` to `uint8`. This field is effectively unused at the moment
and reserved for future use, and it is not likely to need `varuint32`
even in future.
See https://github.com/WebAssembly/exception-handling/pull/162.

This does not change any encoded binaries because `0` is encoded in the
same way both in `varuint32` and `uint8`.