### PR TITLE
Fix printing of try-delegate labels

### DIFF
--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -904,6 +904,7 @@ Result WatWriter::ExprVisitorDelegate::OnUnwindExpr(TryExpr* expr) {
 
 Result WatWriter::ExprVisitorDelegate::OnDelegateExpr(TryExpr* expr) {
   writer_->Dedent();
+  writer_->EndBlock();
   writer_->WritePutsSpace(Opcode::Delegate_Opcode.GetName());
   writer_->WriteVar(expr->delegate_target, NextChar::Newline);
   return Result::Ok;

--- a/test/roundtrip/try-delegate.txt
+++ b/test/roundtrip/try-delegate.txt
@@ -1,0 +1,29 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout --enable-exceptions --debug-names
+(module
+  (func
+    try
+      try
+        nop
+      delegate 0
+      try
+        nop
+      delegate 0
+    catch_all
+    end
+  )
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0)
+    try  ;; label = @1
+      try  ;; label = @2
+        nop
+      delegate 0
+      try  ;; label = @2
+        nop
+      delegate 0
+    catch_all
+    end))
+;;; STDOUT ;;)


### PR DESCRIPTION
This is similar to a previous bug (#1609) for other kinds of block labels.

The tests check that 2+ adjacent try-delegate blocks will have labels that print correctly.

(split from #1675)