### PR TITLE
Branch hinting

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -664,6 +664,12 @@ Result BinaryReaderLogging::OnComdatEntry(ComdatType kind, Index index) {
   return reader_->OnComdatEntry(kind, index);
 }
 
+Result BinaryReaderLogging::OnBranchHint(BranchHintKind kind, Offset code_offset) {
+  LOGF("OnBranchHint(kind: %d, offset: %" PRIzd ")\n",
+       static_cast<int>(kind), code_offset);
+  return reader_->OnBranchHint(kind, code_offset);
+}
+
 #define DEFINE_BEGIN(name)                        \
   Result BinaryReaderLogging::name(Offset size) { \
     LOGF(#name "(%" PRIzd ")\n", size);           \
@@ -901,6 +907,11 @@ DEFINE_BEGIN(BeginTagSection);
 DEFINE_INDEX(OnTagCount);
 DEFINE_INDEX_INDEX(OnTagType, "index", "sig_index")
 DEFINE_END(EndTagSection);
+
+DEFINE_BEGIN(BeginBranchHintsSection);
+DEFINE_INDEX(OnBranchHintsFuncCount);
+DEFINE_INDEX_INDEX(OnBranchHintsCount, "func_index", "count");
+DEFINE_END(EndBranchHintsSection);
 
 // We don't need to log these (the individual opcodes are logged instead), but
 // we still need to forward the calls.

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -370,6 +370,13 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnTagType(Index index, Index sig_index) override;
   Result EndTagSection() override;
 
+  /* Branch Hints section */
+  Result BeginBranchHintsSection(Offset size) override;
+  Result OnBranchHintsFuncCount(Index count) override;
+  Result OnBranchHintsCount(Index function_index, Index count) override;
+  Result OnBranchHint(BranchHintKind kind, Offset code_offset) override;
+  Result EndBranchHintsSection() override;
+
   Result OnInitExprF32ConstExpr(Index index, uint32_t value) override;
   Result OnInitExprF64ConstExpr(Index index, uint64_t value) override;
   Result OnInitExprV128ConstExpr(Index index, v128 value) override;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -454,6 +454,13 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnTagType(Index index, Index sig_index) override { return Result::Ok; }
   Result EndTagSection() override { return Result::Ok; }
 
+  /* Branch Hints section */
+  Result BeginBranchHintsSection(Offset size) override { return Result::Ok; }
+  Result OnBranchHintsFuncCount(Index count) override { return Result::Ok; }
+  Result OnBranchHintsCount(Index function_index, Index count) override { return Result::Ok; }
+  Result OnBranchHint(BranchHintKind kind, Offset code_offset) override { return Result::Ok; }
+  Result EndBranchHintsSection() override { return Result::Ok; }
+
   /* Dylink section */
   Result BeginDylinkSection(Offset size) override { return Result::Ok; }
   Result OnDylinkInfo(uint32_t mem_size,

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1013,6 +1013,10 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnTagCount(Index count) override;
   Result OnTagType(Index index, Index sig_index) override;
 
+  Result OnBranchHintsFuncCount(Index count) override;
+  Result OnBranchHintsCount(Index function_index, Index count) override;
+  Result OnBranchHint(BranchHintKind kind, Offset code_offset) override;
+
  private:
   Result InitExprToConstOffset(const InitExpr& expr, uint32_t* out_offset);
   Result HandleInitExpr(const InitExpr& expr);
@@ -2026,6 +2030,31 @@ Result BinaryReaderObjdump::OnTagType(Index index, Index sig_index) {
     return Result::Ok;
   }
   printf(" - tag[%" PRIindex "] sig=%" PRIindex "\n", index, sig_index);
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdump::OnBranchHintsFuncCount(Index count) {
+  printf("  - hinted functions [count=%d]\n", count);
+  return Result::Ok;
+}
+Result BinaryReaderObjdump::OnBranchHintsCount(Index function_index, Index count) {
+  printf("   - branch hints [function_index=%" PRIindex " count=%d]\n", function_index, count);
+  return Result::Ok;
+}
+Result BinaryReaderObjdump::OnBranchHint(BranchHintKind kind, Offset code_offset) {
+  const char* kind_str;
+  switch(kind) {
+    case BranchHintKind::LikelyNotTaken:
+      kind_str = "likely_not_taken";
+      break;
+    case BranchHintKind::LikelyTaken:
+      kind_str = "likely_taken";
+      break;
+    default:
+      err_stream_->Writef("invalid branch hint kind: %d\n", static_cast<int>(kind));
+      return Result::Error;
+  }
+  printf("    - branch hint [kind=%s code_offset=%" PRIzx "]\n", kind_str, code_offset);
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2212,7 +2212,7 @@ Result BinaryReader::ReadCustomSection(Index section_index,
     CHECK_RESULT(ReadRelocSection(section_size));
   } else if (section_name == WABT_BINARY_SECTION_LINKING) {
     CHECK_RESULT(ReadLinkingSection(section_size));
-  } else if (section_name == WABT_BINARY_SECTION_BRANCH_HINTS) {
+  } else if (options_.features.branch_hinting_enabled() && section_name == WABT_BINARY_SECTION_BRANCH_HINTS) {
     CHECK_RESULT(ReadBranchHintsSection(section_size));
   } else {
     // This is an unknown custom section, skip it.

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -447,6 +447,13 @@ class BinaryReaderDelegate {
   virtual Result OnTagType(Index index, Index sig_index) = 0;
   virtual Result EndTagSection() = 0;
 
+  /* Branch Hints section */
+  virtual Result BeginBranchHintsSection(Offset size) = 0;
+  virtual Result OnBranchHintsFuncCount(Index count) = 0;
+  virtual Result OnBranchHintsCount(Index function_index, Index count) = 0;
+  virtual Result OnBranchHint(BranchHintKind kind, Offset code_offset) = 0;
+  virtual Result EndBranchHintsSection() = 0;
+
   /* InitExpr - used by elem, data and global sections; these functions are
    * only called between calls to Begin*InitExpr and End*InitExpr */
   virtual Result OnInitExprF32ConstExpr(Index index, uint32_t value) = 0;

--- a/src/binary.h
+++ b/src/binary.h
@@ -32,6 +32,7 @@
 #define WABT_BINARY_SECTION_RELOC "reloc"
 #define WABT_BINARY_SECTION_LINKING "linking"
 #define WABT_BINARY_SECTION_DYLINK "dylink"
+#define WABT_BINARY_SECTION_BRANCH_HINTS "branchHints"
 
 #define WABT_FOREACH_BINARY_SECTION(V) \
   V(Custom, custom, 0)                 \

--- a/src/common.h
+++ b/src/common.h
@@ -374,6 +374,12 @@ enum class SymbolBinding {
 };
 
 /* matches binary format, do not change */
+enum class BranchHintKind: uint32_t {
+  LikelyNotTaken = 0,
+  LikelyTaken = 1,
+};
+
+/* matches binary format, do not change */
 enum class ExternalKind {
   Func = 0,
   Table = 1,

--- a/src/feature.def
+++ b/src/feature.def
@@ -35,3 +35,4 @@ WABT_FEATURE(reference_types,  "reference-types",         false,   "Reference ty
 WABT_FEATURE(annotations,      "annotations",             false,   "Custom annotation syntax")
 WABT_FEATURE(gc,               "gc",                      false,   "Garbage collection")
 WABT_FEATURE(memory64,         "memory64",                false,   "64-bit memory")
+WABT_FEATURE(branch_hinting,   "branch-hinting",          false,   "Branch hinting")

--- a/test/binary/bad-branch-hinting-function-count.txt
+++ b/test/binary/bad-branch-hinting-function-count.txt
@@ -1,0 +1,48 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[2]
+  function_index[0]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+000002e: error: unable to read u32 leb128: function index
+000002e: error: unable to read u32 leb128: function index
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-function-duplicate.txt
+++ b/test/binary/bad-branch-hinting-function-duplicate.txt
@@ -1,0 +1,53 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[2]
+  function_index[0]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+  function_index[0]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+000002f: error: duplicate function name: 0
+000002f: error: duplicate function name: 0
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-function-index.txt
+++ b/test/binary/bad-branch-hinting-function-index.txt
@@ -1,0 +1,48 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[1]
+  function_index[2]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+000002a: error: invalid function index: 2
+000002a: error: invalid function index: 2
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-function-out-of-order.txt
+++ b/test/binary/bad-branch-hinting-function-out-of-order.txt
@@ -1,0 +1,68 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[2]
+  type[0]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[2]
+  function_index[1]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+  function_index[0]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[2]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+0000030: error: function index out of order: 0
+0000030: error: function index out of order: 0
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-hint-count.txt
+++ b/test/binary/bad-branch-hinting-hint-count.txt
@@ -1,0 +1,48 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[1]
+  function_index[0]
+  reserved[0]
+  hint_count[2]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+000002e: error: unable to read u32 leb128: kind
+000002e: error: unable to read u32 leb128: kind
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-hint-duplicate.txt
+++ b/test/binary/bad-branch-hinting-hint-duplicate.txt
@@ -1,0 +1,50 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[1]
+  function_index[0]
+  reserved[0]
+  hint_count[2]
+  hint_kind[1]
+  hint_offset[8]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+0000030: error: duplicate code offset: 8
+0000030: error: duplicate code offset: 8
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-hint-kind.txt
+++ b/test/binary/bad-branch-hinting-hint-kind.txt
@@ -1,0 +1,48 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[1]
+  function_index[0]
+  reserved[0]
+  hint_count[1]
+  hint_kind[3]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+000002d: error: unexpected hint kind (got 3)
+000002d: error: unexpected hint kind (got 3)
+;;; STDERR ;;)

--- a/test/binary/bad-branch-hinting-hint-out-of-order.txt
+++ b/test/binary/bad-branch-hinting-hint-out-of-order.txt
@@ -1,0 +1,50 @@
+;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --enable-branch-hinting
+;;; ARGS2: --enable-branch-hinting
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[1]
+  function_index[0]
+  reserved[0]
+  hint_count[2]
+  hint_kind[1]
+  hint_offset[8]
+  hint_kind[1]
+  hint_offset[4]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDERR ;;;
+0000030: error: code offset out of order: 4
+0000030: error: code offset out of order: 4
+;;; STDERR ;;)

--- a/test/binary/branch-hinting-section.txt
+++ b/test/binary/branch-hinting-section.txt
@@ -1,0 +1,80 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[2] i32 i32 results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("branchHints") {
+  function_count[1]
+  function_index[0]
+  reserved[0]
+  hint_count[1]
+  hint_kind[1]
+  hint_offset[8]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    locals[decl_count[1] i32_count[2] i32]
+    get_local 1
+    get_local 0
+    i32.sub
+    i32.const 0
+    i32.eq
+    if void
+      i32.const 100
+      return
+    end
+    i32.const 1
+    return
+  }
+}
+(;; STDOUT ;;;
+
+branch-hints-section.wasm:	file format wasm 0x1
+
+Section Details:
+
+Type[1]:
+ - type[0] (i32, i32) -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "branchHints"
+  - hinted functions [count=1]
+   - branch hints [function_index=0 count=1]
+    - branch hint [kind=likely_taken code_offset=8]
+Code[1]:
+ - func[0] size=21
+
+Code Disassembly:
+
+000032 func[0]:
+ 000033: 02 7f                      | local[0..1] type=i32
+ 000035: 20 01                      | local.get 1
+ 000037: 20 00                      | local.get 0
+ 000039: 6b                         | i32.sub
+ 00003a: 41 00                      | i32.const 0
+ 00003c: 46                         | i32.eq
+ 00003d: 04 40                      | if
+ 00003f: 41 64                      |   i32.const 4294967268
+ 000041: 0f                         |   return
+ 000042: 0b                         | end
+ 000043: 41 01                      | i32.const 1
+ 000045: 0f                         | return
+ 000046: 0b                         | end
+;;; STDOUT ;;)


### PR DESCRIPTION
This PR adds basic support for handling the custom section "branchHints" (see Branch Hinting proposal).


I added code to parse the section in the binary reader, and call new appropriate visitor methods with the parsed information.

I also Implemented the new visitor methods for the binary reader logger and the binary reader objdump.

So now it is possible to use wasm-objdump to output the contents of the section in a readable format, and wasm-validate will complain if the section is malformed.

The branchHints section parsing is done conditionally with a feature flag `--enable-branch-hinting`.

I also added some tests.

A possible further improvement would be to mark the hinted branches as such  in the code output of wasm-objdump/wasm-decompile.