### PR TITLE
Add objdump flag to print section offsets instead of file offsets

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -540,7 +540,7 @@ Result BinaryReaderObjdumpDisassemble::OnLocalDecl(Index decl_index,
   Offset offset = current_opcode_offset;
   size_t data_size = state->offset - offset;
 
-  printf(" %06" PRIzx ":", offset);
+  printf(" %06" PRIzx " (%06" PRIzx "):", offset, offset - GetSectionStart(BinarySection::Code));
   for (size_t i = 0; i < data_size && i < IMMEDIATE_OCTET_COUNT;
        i++, offset++) {
     printf(" %02x", data_[offset]);
@@ -577,7 +577,7 @@ void BinaryReaderObjdumpDisassemble::LogOpcode(size_t data_size,
   while (offset < offset_end) {
     // Print bytes, but only display a maximum of IMMEDIATE_OCTET_COUNT on each
     // line.
-    printf(" %06" PRIzx ":", offset);
+    printf(" %06" PRIzx " (%06" PRIzx "):", offset, offset - GetSectionStart(BinarySection::Code));
     size_t i;
     for (i = 0; offset < offset_end && i < IMMEDIATE_OCTET_COUNT;
          ++i, ++offset) {
@@ -777,7 +777,8 @@ Result BinaryReaderObjdumpDisassemble::OnEndExpr() {
 
 Result BinaryReaderObjdumpDisassemble::BeginFunctionBody(Index index,
                                                          Offset size) {
-  printf("%06" PRIzx " func[%" PRIindex "]", state->offset, index);
+  printf("%06" PRIzx " (%06" PRIzx ") func[%" PRIindex "]", state->offset,
+         state->offset - GetSectionStart(BinarySection::Code), index);
   auto name = GetFunctionName(index);
   if (!name.empty()) {
     printf(" <" PRIstringview ">", WABT_PRINTF_STRING_VIEW_ARG(name));

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -197,9 +197,9 @@ void BinaryReaderObjdumpBase::PrintRelocation(const Reloc& reloc,
 }
 
 Offset BinaryReaderObjdumpBase::GetPrintOffset(Offset offset) const {
-  return
-      options_->section_offsets ?
-      offset - GetSectionStart(BinarySection::Code) : offset;
+  return options_->section_offsets
+             ? offset - GetSectionStart(BinarySection::Code)
+             : offset;
 }
 
 Result BinaryReaderObjdumpBase::OnRelocCount(Index count, Index section_index) {

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -45,6 +45,7 @@ struct ObjdumpOptions {
   bool disassemble;
   bool debug;
   bool relocs;
+  bool section_offsets;
   ObjdumpMode mode;
   const char* filename;
   const char* section_name;

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -60,6 +60,9 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_objdump_options.details = true; });
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",
                    []() { s_objdump_options.relocs = true; });
+  parser.AddOption(0, "section-offsets",
+                   "Print section offsets instead of file offsets",
+                   []() { s_objdump_options.section_offsets = true; });
   parser.AddArgument(
       "filename", OptionParser::ArgumentCount::OneOrMore,
       [](const char* argument) { s_infiles.push_back(argument); });

--- a/src/tools/wasm-objdump.cc
+++ b/src/tools/wasm-objdump.cc
@@ -61,7 +61,8 @@ static void ParseOptions(int argc, char** argv) {
   parser.AddOption('r', "reloc", "Show relocations inline with disassembly",
                    []() { s_objdump_options.relocs = true; });
   parser.AddOption(0, "section-offsets",
-                   "Print section offsets instead of file offsets",
+                   "Print section offsets instead of file offsets "
+                   "in code disassembly",
                    []() { s_objdump_options.section_offsets = true; });
   parser.AddArgument(
       "filename", OptionParser::ArgumentCount::OneOrMore,

--- a/test/dump/section-offsets.txt
+++ b/test/dump/section-offsets.txt
@@ -1,0 +1,61 @@
+;;; TOOL: run-objdump
+;;; ARGS0: -v
+;;; ARGS1: --section-offsets
+(module
+  (func)
+  (func)
+  (func))
+(;; STDERR ;;;
+0000000: 0061 736d                                 ; WASM_BINARY_MAGIC
+0000004: 0100 0000                                 ; WASM_BINARY_VERSION
+; section "Type" (1)
+0000008: 01                                        ; section code
+0000009: 00                                        ; section size (guess)
+000000a: 01                                        ; num types
+; func type 0
+000000b: 60                                        ; func
+000000c: 00                                        ; num params
+000000d: 00                                        ; num results
+0000009: 04                                        ; FIXUP section size
+; section "Function" (3)
+000000e: 03                                        ; section code
+000000f: 00                                        ; section size (guess)
+0000010: 03                                        ; num functions
+0000011: 00                                        ; function 0 signature index
+0000012: 00                                        ; function 1 signature index
+0000013: 00                                        ; function 2 signature index
+000000f: 04                                        ; FIXUP section size
+; section "Code" (10)
+0000014: 0a                                        ; section code
+0000015: 00                                        ; section size (guess)
+0000016: 03                                        ; num functions
+; function body 0
+0000017: 00                                        ; func body size (guess)
+0000018: 00                                        ; local decl count
+0000019: 0b                                        ; end
+0000017: 02                                        ; FIXUP func body size
+; function body 1
+000001a: 00                                        ; func body size (guess)
+000001b: 00                                        ; local decl count
+000001c: 0b                                        ; end
+000001a: 02                                        ; FIXUP func body size
+; function body 2
+000001d: 00                                        ; func body size (guess)
+000001e: 00                                        ; local decl count
+000001f: 0b                                        ; end
+000001d: 02                                        ; FIXUP func body size
+0000015: 0a                                        ; FIXUP section size
+;;; STDERR ;;)
+(;; STDOUT ;;;
+
+section-offsets.wasm:	file format wasm 0x1
+
+Code Disassembly:
+
+000002 func[0]:
+ 000003: 0b                         | end
+000005 func[1]:
+ 000006: 0b                         | end
+000008 func[2]:
+ 000009: 0b                         | end
+;;; STDOUT ;;)

--- a/test/help/wasm-objdump.txt
+++ b/test/help/wasm-objdump.txt
@@ -18,4 +18,5 @@ options:
       --debug                  Print extra debug information
   -x, --details                Show section details
   -r, --reloc                  Show relocations inline with disassembly
+      --section-offsets        Print section offsets instead of file offsets in code disassembly
 ;;; STDOUT ;;)


### PR DESCRIPTION
This is useful for working with debug info, which uses section offsets