### PR TITLE
[simd] Fix load/store lanes on BE systems

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -2186,7 +2186,7 @@ RunResult Thread::DoSimdLoadLane(Instr instr, Trap::Ptr* out_trap) {
   if (Load<T>(instr, &val, out_trap) != RunResult::Ok) {
     return RunResult::Trap;
   }
-  result.v[instr.imm_u32x2_u8.idx] = val;
+  result[instr.imm_u32x2_u8.idx] = val;
   Push(result);
   return RunResult::Ok;
 }
@@ -2196,7 +2196,7 @@ RunResult Thread::DoSimdStoreLane(Instr instr, Trap::Ptr* out_trap) {
   using T = typename S::LaneType;
   Memory::Ptr memory{store_, inst_->memories()[instr.imm_u32x2_u8.fst]};
   auto result = Pop<S>();
-  T val = result.v[instr.imm_u32x2_u8.idx];
+  T val = result[instr.imm_u32x2_u8.idx];
   u64 offset = PopPtr(memory);
   TRAP_IF(Failed(memory->Store(offset, instr.imm_u32x2_u8.snd, val)),
           StringPrintf("out of bounds memory access: access at %" PRIu64


### PR DESCRIPTION
The use of `.v` is incorrect, we should simply use array subscript
operator on the Simd type, which takes care of BE systems.

For #1670. (Not using fix as I don't have a BE system to verify.)