### PR TITLE
[simd] Shift alignment_log2 before validation

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1086,7 +1086,7 @@ Result BinaryReaderIR::OnSimdLoadLaneExpr(Opcode opcode,
                                           Address offset,
                                           uint64_t value) {
   return AppendExpr(
-      MakeUnique<SimdLoadLaneExpr>(opcode, alignment_log2, offset, value));
+      MakeUnique<SimdLoadLaneExpr>(opcode, 1 << alignment_log2, offset, value));
 }
 
 Result BinaryReaderIR::OnSimdStoreLaneExpr(Opcode opcode,
@@ -1094,7 +1094,7 @@ Result BinaryReaderIR::OnSimdStoreLaneExpr(Opcode opcode,
                                           Address offset,
                                           uint64_t value) {
   return AppendExpr(
-      MakeUnique<SimdStoreLaneExpr>(opcode, alignment_log2, offset, value));
+      MakeUnique<SimdStoreLaneExpr>(opcode, 1 << alignment_log2, offset, value));
 }
 
 Result BinaryReaderIR::OnSimdShuffleOpExpr(Opcode opcode, v128 value) {

--- a/test/regress/regress-1674.txt
+++ b/test/regress/regress-1674.txt
@@ -1,0 +1,11 @@
+;;; TOOL: wat2wasm
+;;; ARGS: --enable-simd
+(module
+  (memory 1)
+  (func
+      i32.const 0
+      v128.const i32x4 0 0 0 0
+      v128.load32_lane align=1 0
+      drop
+  )
+)


### PR DESCRIPTION
The alignment value in binary format is log2, so we need to shift it in
binary-reader-ir before it is validated (since validation requires that
it is shifted to be the number of bytes). We correctly did that for some
Simd instructions (like load splat) but did not do it for load/store
lane.

Fixes #1674.