### PR TITLE
Remove ununsed onSymbol callback. NFC

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -568,13 +568,6 @@ Result BinaryReaderLogging::OnReloc(RelocType type,
   return reader_->OnReloc(type, offset, index, addend);
 }
 
-Result BinaryReaderLogging::OnSymbol(Index symbol_index,
-                                     SymbolType type,
-                                     uint32_t flags) {
-  LOGF("OnSymbol(type: %s flags: 0x%x)\n", GetSymbolTypeName(type), flags);
-  return reader_->OnSymbol(symbol_index, type, flags);
-}
-
 Result BinaryReaderLogging::OnDataSymbol(Index index,
                                          uint32_t flags,
                                          string_view name,

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -328,7 +328,6 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
 
   Result BeginLinkingSection(Offset size) override;
   Result OnSymbolCount(Index count) override;
-  Result OnSymbol(Index sybmol_index, SymbolType type, uint32_t flags) override;
   Result OnDataSymbol(Index index,
                       uint32_t flags,
                       string_view name,

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -470,11 +470,6 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   /* Linking section */
   Result BeginLinkingSection(Offset size) override { return Result::Ok; }
   Result OnSymbolCount(Index count) override { return Result::Ok; }
-  Result OnSymbol(Index sybmol_index,
-                  SymbolType type,
-                  uint32_t flags) override {
-    return Result::Ok;
-  }
   Result OnDataSymbol(Index index,
                       uint32_t flags,
                       string_view name,

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2008,7 +2008,6 @@ Result BinaryReader::ReadLinkingSection(Offset section_size) {
           CHECK_RESULT(ReadU32Leb128(&kind, "sym type"));
           CHECK_RESULT(ReadU32Leb128(&flags, "sym flags"));
           SymbolType sym_type = static_cast<SymbolType>(kind);
-          CALLBACK(OnSymbol, i, sym_type, flags);
           switch (sym_type) {
             case SymbolType::Function:
             case SymbolType::Global:

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -402,7 +402,6 @@ class BinaryReaderDelegate {
   /* Linking section */
   virtual Result BeginLinkingSection(Offset size) = 0;
   virtual Result OnSymbolCount(Index count) = 0;
-  virtual Result OnSymbol(Index index, SymbolType type, uint32_t flags) = 0;
   virtual Result OnDataSymbol(Index index,
                               uint32_t flags,
                               string_view name,


### PR DESCRIPTION
We have the more specific OnFunctionSymbol, OnGlobalSymbol family
of callbacks that is used by objdump.