### PR TITLE
Set features of the Store used in wasm-interp

### DIFF
--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -461,6 +461,7 @@ class Store {
   ObjectList::Index object_count() const;
 
   const Features& features() const;
+  void setFeatures(const Features& features) { features_ = features; }
 
  private:
   template <typename T>

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -325,6 +325,7 @@ int ProgramMain(int argc, char** argv) {
   s_stderr_stream = FileStream::CreateStderr();
 
   ParseOptions(argc, argv);
+  s_store.setFeatures(s_features);
 
   wabt::Result result = ReadAndRunModule(s_infile);
   return result != wabt::Result::Ok;


### PR DESCRIPTION
Without this change wasm-interp always runs with default
features.

These features seem to be used in just a single location:
```src/interp/interp.cc:  int pass = store.features().bulk_memory_enabled() ? Init : Check;```

I noticed this when trying to enable bulk memory but run
the interpreter with `--disable-bulk-memory` and it was
not effecting this line of code.