### PR TITLE
Code Annotations

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -657,6 +657,22 @@ Result BinaryReaderLogging::OnComdatEntry(ComdatType kind, Index index) {
   return reader_->OnComdatEntry(kind, index);
 }
 
+Result BinaryReaderLogging::BeginCodeAnnotationSection(string_view name,
+                                                       Offset size) {
+  LOGF("BeginCodeAnnotationSection('" PRIstringview "', size:%" PRIzd ")\n",
+       WABT_PRINTF_STRING_VIEW_ARG(name), size);
+  Indent();
+  return reader_->BeginCodeAnnotationSection(name, size);
+}
+Result BinaryReaderLogging::OnCodeAnnotation(Offset code_offset,
+                                             const void* data,
+                                             Address size) {
+  string_view content(static_cast<const char*>(data), size);
+  LOGF("OnCodeAnnotation(offset: %" PRIzd ", data: \"" PRIstringview "\")\n",
+       code_offset, WABT_PRINTF_STRING_VIEW_ARG(content));
+  return reader_->OnCodeAnnotation(code_offset, data, size);
+}
+
 #define DEFINE_BEGIN(name)                        \
   Result BinaryReaderLogging::name(Offset size) { \
     LOGF(#name "(%" PRIzd ")\n", size);           \
@@ -895,6 +911,10 @@ DEFINE_BEGIN(BeginTagSection);
 DEFINE_INDEX(OnTagCount);
 DEFINE_INDEX_INDEX(OnTagType, "index", "sig_index")
 DEFINE_END(EndTagSection);
+
+DEFINE_INDEX(OnCodeAnnotationFuncCount);
+DEFINE_INDEX_INDEX(OnCodeAnnotationCount, "func_index", "count");
+DEFINE_END(EndCodeAnnotationSection);
 
 // We don't need to log these (the individual opcodes are logged instead), but
 // we still need to forward the calls.

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -370,6 +370,15 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnTagType(Index index, Index sig_index) override;
   Result EndTagSection() override;
 
+  /* Code Annotation sections */
+  Result BeginCodeAnnotationSection(string_view name, Offset size) override;
+  Result OnCodeAnnotationFuncCount(Index count) override;
+  Result OnCodeAnnotationCount(Index function_index, Index count) override;
+  Result OnCodeAnnotation(Offset offset,
+                          const void* data,
+                          Address size) override;
+  Result EndCodeAnnotationSection() override;
+
   Result OnInitExprF32ConstExpr(Index index, uint32_t value) override;
   Result OnInitExprF64ConstExpr(Index index, uint64_t value) override;
   Result OnInitExprV128ConstExpr(Index index, v128 value) override;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -455,6 +455,21 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnTagType(Index index, Index sig_index) override { return Result::Ok; }
   Result EndTagSection() override { return Result::Ok; }
 
+  /* Code Annotation sections */
+  Result BeginCodeAnnotationSection(string_view name, Offset size) override {
+    return Result::Ok;
+  }
+  Result OnCodeAnnotationFuncCount(Index count) override { return Result::Ok; }
+  Result OnCodeAnnotationCount(Index function_index, Index count) override {
+    return Result::Ok;
+  }
+  Result OnCodeAnnotation(Offset offset,
+                          const void* data,
+                          Address size) override {
+    return Result::Ok;
+  }
+  Result EndCodeAnnotationSection() override { return Result::Ok; }
+
   /* Dylink section */
   Result BeginDylinkSection(Offset size) override { return Result::Ok; }
   Result OnDylinkInfo(uint32_t mem_size,

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1021,6 +1021,11 @@ class BinaryReaderObjdump : public BinaryReaderObjdumpBase {
   Result OnTagCount(Index count) override;
   Result OnTagType(Index index, Index sig_index) override;
 
+  Result OnCodeAnnotationCount(Index function_index, Index count) override;
+  Result OnCodeAnnotation(Offset code_offset,
+                          const void* data,
+                          Address size) override;
+
  private:
   Result InitExprToConstOffset(const InitExpr& expr, uint32_t* out_offset);
   Result HandleInitExpr(const InitExpr& expr);
@@ -2038,6 +2043,32 @@ Result BinaryReaderObjdump::OnTagType(Index index, Index sig_index) {
     return Result::Ok;
   }
   printf(" - tag[%" PRIindex "] sig=%" PRIindex "\n", index, sig_index);
+  return Result::Ok;
+}
+
+Result BinaryReaderObjdump::OnCodeAnnotationCount(Index function_index,
+                                                  Index count) {
+  if (!ShouldPrintDetails()) {
+    return Result::Ok;
+  }
+  printf("   - func[%" PRIindex "]", function_index);
+  auto name = GetFunctionName(function_index);
+  if (!name.empty()) {
+    printf(" <" PRIstringview ">", WABT_PRINTF_STRING_VIEW_ARG(name));
+  }
+  printf(":\n");
+  return Result::Ok;
+}
+Result BinaryReaderObjdump::OnCodeAnnotation(Offset code_offset,
+                                             const void* data,
+                                             Address size) {
+  if (!ShouldPrintDetails()) {
+    return Result::Ok;
+  }
+  printf("    - ann[%" PRIzx "]:\n", code_offset);
+
+  out_stream_->WriteMemoryDump(data, size, 0, PrintChars::Yes,
+                               "     - ");
   return Result::Ok;
 }
 

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -447,6 +447,15 @@ class BinaryReaderDelegate {
   virtual Result OnTagType(Index index, Index sig_index) = 0;
   virtual Result EndTagSection() = 0;
 
+  /* Code Annotation sections */
+  virtual Result BeginCodeAnnotationSection(string_view name, Offset size) = 0;
+  virtual Result OnCodeAnnotationFuncCount(Index count) = 0;
+  virtual Result OnCodeAnnotationCount(Index function_index, Index count) = 0;
+  virtual Result OnCodeAnnotation(Offset offset,
+                                  const void* data,
+                                  Address size) = 0;
+  virtual Result EndCodeAnnotationSection() = 0;
+
   /* InitExpr - used by elem, data and global sections; these functions are
    * only called between calls to Begin*InitExpr and End*InitExpr */
   virtual Result OnInitExprF32ConstExpr(Index index, uint32_t value) = 0;

--- a/src/binary.h
+++ b/src/binary.h
@@ -33,6 +33,7 @@
 #define WABT_BINARY_SECTION_LINKING "linking"
 #define WABT_BINARY_SECTION_DYLINK "dylink"
 #define WABT_BINARY_SECTION_DYLINK0 "dylink.0"
+#define WABT_BINARY_SECTION_CODE_ANNOTATION "code_annotation."
 
 #define WABT_FOREACH_BINARY_SECTION(V) \
   V(Custom, custom, 0)                 \

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1492,6 +1492,9 @@ void CWriter::Write(const ExprList& exprs) {
         break;
       }
 
+      case ExprType::CodeAnnotation:
+        break;
+
       case ExprType::Compare:
         Write(*cast<CompareExpr>(&expr));
         break;

--- a/src/common.h
+++ b/src/common.h
@@ -380,6 +380,12 @@ enum class SymbolBinding {
 };
 
 /* matches binary format, do not change */
+enum class BranchHintKind : uint32_t {
+  LikelyNotTaken = 0,
+  LikelyTaken = 1,
+};
+
+/* matches binary format, do not change */
 enum class ExternalKind {
   Func = 0,
   Table = 1,

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -585,6 +585,12 @@ struct Decompiler {
         ts += "](";
         return WrapChild(args[0], ts, ")", Precedence::Atomic);
       }
+      case ExprType::CodeAnnotation: {
+        auto cae = cast<CodeAnnotationExpr>(n.e);
+        std::string c = "// @code_annotation." + cae->name + " ";
+        c += BinaryToString(cae->data);
+        return Value{{std::move(c)}, Precedence::None};
+      }
       default: {
         // Everything that looks like a function call.
         std::string name;

--- a/src/expr-visitor.cc
+++ b/src/expr-visitor.cc
@@ -219,6 +219,11 @@ Result ExprVisitor::HandleDefaultState(Expr* expr) {
       CHECK_RESULT(delegate_->OnCallRefExpr(cast<CallRefExpr>(expr)));
       break;
 
+    case ExprType::CodeAnnotation:
+      CHECK_RESULT(
+          delegate_->OnCodeAnnotationExpr(cast<CodeAnnotationExpr>(expr)));
+      break;
+
     case ExprType::Compare:
       CHECK_RESULT(delegate_->OnCompareExpr(cast<CompareExpr>(expr)));
       break;

--- a/src/expr-visitor.h
+++ b/src/expr-visitor.h
@@ -76,6 +76,7 @@ class ExprVisitor::Delegate {
   virtual Result OnCallExpr(CallExpr*) = 0;
   virtual Result OnCallIndirectExpr(CallIndirectExpr*) = 0;
   virtual Result OnCallRefExpr(CallRefExpr*) = 0;
+  virtual Result OnCodeAnnotationExpr(CodeAnnotationExpr*) = 0;
   virtual Result OnCompareExpr(CompareExpr*) = 0;
   virtual Result OnConstExpr(ConstExpr*) = 0;
   virtual Result OnConvertExpr(ConvertExpr*) = 0;
@@ -149,6 +150,9 @@ class ExprVisitor::DelegateNop : public ExprVisitor::Delegate {
   Result OnCallExpr(CallExpr*) override { return Result::Ok; }
   Result OnCallIndirectExpr(CallIndirectExpr*) override { return Result::Ok; }
   Result OnCallRefExpr(CallRefExpr*) override { return Result::Ok; }
+  Result OnCodeAnnotationExpr(CodeAnnotationExpr*) override {
+    return Result::Ok;
+  }
   Result OnCompareExpr(CompareExpr*) override { return Result::Ok; }
   Result OnConstExpr(ConstExpr*) override { return Result::Ok; }
   Result OnConvertExpr(ConvertExpr*) override { return Result::Ok; }

--- a/src/feature.def
+++ b/src/feature.def
@@ -34,5 +34,6 @@ WABT_FEATURE(tail_call,           "tail-call",               false,   "Tail-call
 WABT_FEATURE(bulk_memory,         "bulk-memory",             false,   "Bulk-memory operations")
 WABT_FEATURE(reference_types,     "reference-types",         false,   "Reference types (externref)")
 WABT_FEATURE(annotations,         "annotations",             false,   "Custom annotation syntax")
+WABT_FEATURE(code_annotations,    "code-annotations",        false,   "Code annotations")
 WABT_FEATURE(gc,                  "gc",                      false,   "Garbage collection")
 WABT_FEATURE(memory64,            "memory64",                false,   "64-bit memory")

--- a/src/ir-util.cc
+++ b/src/ir-util.cc
@@ -166,6 +166,7 @@ ModuleContext::Arities ModuleContext::GetExprArity(const Expr& expr) const {
     case ExprType::DataDrop:
     case ExprType::ElemDrop:
     case ExprType::AtomicFence:
+    case ExprType::CodeAnnotation:
       return { 0, 0 };
 
     case ExprType::MemoryInit:

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -40,6 +40,7 @@ const char* ExprTypeName[] = {
   "Call",
   "CallIndirect",
   "CallRef",
+  "CodeAnnotation",
   "Compare",
   "Const",
   "Convert",

--- a/src/ir.h
+++ b/src/ir.h
@@ -296,6 +296,7 @@ enum class ExprType {
   Call,
   CallIndirect,
   CallRef,
+  CodeAnnotation,
   Compare,
   Const,
   Convert,
@@ -570,6 +571,19 @@ class CallIndirectExpr : public ExprMixin<ExprType::CallIndirect> {
   Var table;
 };
 
+class CodeAnnotationExpr : public ExprMixin<ExprType::CodeAnnotation> {
+ public:
+  explicit CodeAnnotationExpr(std::string name,
+                              std::vector<uint8_t> data,
+                              const Location& loc = Location())
+      : ExprMixin<ExprType::CodeAnnotation>(loc),
+        name(std::move(name)),
+        data(std::move(data)) {}
+
+  std::string name;
+  std::vector<uint8_t> data;
+};
+
 class ReturnCallIndirectExpr : public ExprMixin<ExprType::ReturnCallIndirect> {
  public:
   explicit ReturnCallIndirectExpr(const Location &loc = Location())
@@ -766,6 +780,7 @@ struct Func {
   LocalTypes local_types;
   BindingHash bindings;
   ExprList exprs;
+  Location loc;
 };
 
 struct Global {

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -94,6 +94,7 @@ class Validator : public ExprVisitor::Delegate {
   Result OnCallExpr(CallExpr*) override;
   Result OnCallIndirectExpr(CallIndirectExpr*) override;
   Result OnCallRefExpr(CallRefExpr*) override;
+  Result OnCodeAnnotationExpr(CodeAnnotationExpr*) override;
   Result OnCompareExpr(CompareExpr*) override;
   Result OnConstExpr(ConstExpr*) override;
   Result OnConvertExpr(ConvertExpr*) override;
@@ -283,6 +284,10 @@ Result Validator::OnCallRefExpr(CallRefExpr* expr) {
   }
 
   return Result::Error;
+}
+
+Result Validator::OnCodeAnnotationExpr(CodeAnnotationExpr* expr) {
+  return Result::Ok;
 }
 
 Result Validator::OnCompareExpr(CompareExpr* expr) {

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -194,6 +194,10 @@ bool IsInstr(TokenTypePair pair) {
   return IsPlainOrBlockInstr(pair[0]) || IsExpr(pair);
 }
 
+bool IsLparAnn(TokenTypePair pair) {
+  return pair[0] == TokenType::LparAnn;
+}
+
 bool IsCatch(TokenType token_type) {
   return token_type == TokenType::Catch || token_type == TokenType::CatchAll;
 }
@@ -508,10 +512,15 @@ TokenType WastParser::Peek(size_t n) {
     if (cur.token_type() != TokenType::LparAnn) {
       tokens_.push_back(cur);
     } else {
-      // Custom annotation. For now, discard until matching Rpar.
+      // Custom annotation. For now, discard until matching Rpar, unless it is
+      // a code annotation. In that case, we know how to parse it.
       if (!options_->features.annotations_enabled()) {
         Error(cur.loc, "annotations not enabled: %s", cur.to_string().c_str());
         tokens_.push_back(Token(cur.loc, TokenType::Invalid));
+        continue;
+      }
+      if (options_->features.code_annotations_enabled() && cur.text().find("code_annotation.") == 0) {
+        tokens_.push_back(cur);
         continue;
       }
       int indent = 1;
@@ -1704,11 +1713,22 @@ Result WastParser::ParseResultList(TypeVector* result_types) {
 Result WastParser::ParseInstrList(ExprList* exprs) {
   WABT_TRACE(ParseInstrList);
   ExprList new_exprs;
-  while (IsInstr(PeekPair())) {
-    if (Succeeded(ParseInstr(&new_exprs))) {
-      exprs->splice(exprs->end(), new_exprs);
+  while (true) {
+    auto pair = PeekPair();
+    if (IsInstr(pair)) {
+      if (Succeeded(ParseInstr(&new_exprs))) {
+        exprs->splice(exprs->end(), new_exprs);
+      } else {
+        CHECK_RESULT(Synchronize(IsInstr));
+      }
+    } else if (IsLparAnn(pair)) {
+      if (Succeeded(ParseCodeAnn(&new_exprs))) {
+        exprs->splice(exprs->end(), new_exprs);
+      } else {
+        CHECK_RESULT(Synchronize(IsLparAnn));
+      }
     } else {
-      CHECK_RESULT(Synchronize(IsInstr));
+      break;
     }
   }
   return Result::Ok;
@@ -1742,6 +1762,22 @@ Result WastParser::ParseInstr(ExprList* exprs) {
     assert(!"ParseInstr should only be called when IsInstr() is true");
     return Result::Error;
   }
+}
+
+Result WastParser::ParseCodeAnn(ExprList* exprs) {
+  WABT_TRACE(ParseCodeAnn);
+  Token tk = Consume();
+  string_view name = tk.text();
+  name.remove_prefix(sizeof("code_annotation.") - 1);
+  std::string data_text;
+  CHECK_RESULT(ParseQuotedText(&data_text));
+  std::vector<uint8_t> data(data_text.begin(), data_text.end());
+  exprs->push_back(
+      MakeUnique<CodeAnnotationExpr>(name.to_string(), std::move(data)));
+  TokenType rpar = Peek();
+  assert(rpar == TokenType::Rpar);
+  Consume();
+  return Result::Ok;
 }
 
 template <typename T>

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -170,6 +170,7 @@ class WastParser {
   Result ParseInstrList(ExprList*);
   Result ParseTerminatingInstrList(ExprList*);
   Result ParseInstr(ExprList*);
+  Result ParseCodeAnn(ExprList*);
   Result ParsePlainInstr(std::unique_ptr<Expr>*);
   Result ParseF32(Const*, ConstType type);
   Result ParseF64(Const*, ConstType type);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -517,6 +517,7 @@ class WatWriter::ExprVisitorDelegate : public ExprVisitor::Delegate {
   Result OnCallExpr(CallExpr*) override;
   Result OnCallIndirectExpr(CallIndirectExpr*) override;
   Result OnCallRefExpr(CallRefExpr*) override;
+  Result OnCodeAnnotationExpr(CodeAnnotationExpr*) override;
   Result OnCompareExpr(CompareExpr*) override;
   Result OnConstExpr(ConstExpr*) override;
   Result OnConvertExpr(ConvertExpr*) override;
@@ -638,6 +639,15 @@ Result WatWriter::ExprVisitorDelegate::OnCallIndirectExpr(
 Result WatWriter::ExprVisitorDelegate::OnCallRefExpr(
     CallRefExpr* expr) {
   writer_->WritePutsSpace(Opcode::CallRef_Opcode.GetName());
+  return Result::Ok;
+}
+
+Result WatWriter::ExprVisitorDelegate::OnCodeAnnotationExpr(
+    CodeAnnotationExpr* expr) {
+  writer_->WriteOpen("@code_annotation.", NextChar::None);
+  writer_->WritePutsSpace(expr->name.c_str());
+  writer_->WriteQuotedData(expr->data.data(), expr->data.size());
+  writer_->WriteCloseSpace();
   return Result::Ok;
 }
 

--- a/test/binary/bad-code-annotation-annotation-count.txt
+++ b/test/binary/bad-code-annotation-annotation-count.txt
@@ -1,0 +1,61 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[1]
+  function_index[0]
+  ann_count[2]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000035: warning: unable to read u32 leb128: code offset
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-annotation-count.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[1]:
+     - 0000000: 01                                       .
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+000039 func[0]:
+ 00003a: 41 01                      | i32.const 1
+ 00003c: 0f                         | return
+ 00003d: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/bad-code-annotation-annotation-duplicate.txt
+++ b/test/binary/bad-code-annotation-annotation-duplicate.txt
@@ -1,0 +1,64 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[1]
+  function_index[0]
+  ann_count[2]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000036: warning: duplicate code offset: 1
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-annotation-duplicate.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[1]:
+     - 0000000: 01                                       .
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+00003c func[0]:
+ 00003d: 41 01                      | i32.const 1
+ 00003f: 0f                         | return
+ 000040: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/bad-code-annotation-annotation-out-of-order.txt
+++ b/test/binary/bad-code-annotation-annotation-out-of-order.txt
@@ -1,0 +1,64 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[1]
+  function_index[0]
+  ann_count[2]
+  ann_offset[3]
+  ann_data_size[1]
+  ann_data[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000036: warning: code offset out of order: 1
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-annotation-out-of-order.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[3]:
+     - 0000000: 01                                       .
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+00003c func[0]:
+ 00003d: 41 01                      | i32.const 1
+ 00003f: 0f                         | return
+ 000040: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/bad-code-annotation-function-count.txt
+++ b/test/binary/bad-code-annotation-function-count.txt
@@ -1,0 +1,61 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[2]
+  function_index[0]
+  ann_count[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000035: warning: unable to read u32 leb128: function index
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-function-count.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[1]:
+     - 0000000: 01                                       .
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+000039 func[0]:
+ 00003a: 41 01                      | i32.const 1
+ 00003c: 0f                         | return
+ 00003d: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/bad-code-annotation-function-duplicate.txt
+++ b/test/binary/bad-code-annotation-function-duplicate.txt
@@ -1,0 +1,63 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[2]
+  function_index[0]
+  ann_count[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+  function_index[0]
+  ann_count[0]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000036: warning: duplicate function index: 0
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-function-duplicate.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[1]:
+     - 0000000: 01                                       .
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+00003b func[0]:
+ 00003c: 41 01                      | i32.const 1
+ 00003e: 0f                         | return
+ 00003f: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/bad-code-annotation-function-index.txt
+++ b/test/binary/bad-code-annotation-function-index.txt
@@ -1,0 +1,58 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[1]
+  function_index[2]
+  ann_count[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000031: warning: invalid function index: 2
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-function-index.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+000039 func[0]:
+ 00003a: 41 01                      | i32.const 1
+ 00003c: 0f                         | return
+ 00003d: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/bad-code-annotation-function-out-of-order.txt
+++ b/test/binary/bad-code-annotation-function-out-of-order.txt
@@ -1,0 +1,78 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS1: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[2]
+  type[0]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[2]
+  function_index[1]
+  ann_count[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+  function_index[0]
+  ann_count[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[2]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+
+(;; STDERR ;;;
+0000037: warning: function index out of order: 0
+;;; STDERR ;;)
+
+(;; STDOUT ;;;
+bad-code-annotation-function-out-of-order.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[2]:
+ - func[0] sig=0
+ - func[1] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[1]:
+    - ann[1]:
+     - 0000000: 01                                       .
+Code[2]:
+ - func[0] size=5
+ - func[1] size=5
+Code Disassembly:
+00003f func[0]:
+ 000040: 41 01                      | i32.const 1
+ 000042: 0f                         | return
+ 000043: 0b                         | end
+000045 func[1]:
+ 000046: 41 01                      | i32.const 1
+ 000048: 0f                         | return
+ 000049: 0b                         | end
+;;; STDOUT ;;)

--- a/test/binary/code-annotation-section.txt
+++ b/test/binary/code-annotation-section.txt
@@ -1,0 +1,56 @@
+;;; TOOL: run-objdump-gen-wasm
+;;; ARGS: -x
+magic
+version
+section(TYPE) {
+  count[1]
+  function params[0] results[1] i32
+}
+section(FUNCTION) {
+  count[1]
+  type[0]
+}
+section(MEMORY) {
+  count[1]
+  has_max[0]
+  initial[0]
+}
+section("code_annotation.test") {
+  function_count[1]
+  function_index[0]
+  ann_count[1]
+  ann_offset[1]
+  ann_data_size[1]
+  ann_data[1]
+}
+
+section(CODE) {
+  count[1]
+  func {
+    local_decls[0]
+    i32.const 1
+    return
+  }
+}
+(;; STDOUT ;;;
+code-annotation-section.wasm:	file format wasm 0x1
+Section Details:
+Type[1]:
+ - type[0] () -> i32
+Function[1]:
+ - func[0] sig=0
+Memory[1]:
+ - memory[0] pages: initial=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[1]:
+     - 0000000: 01                                       .
+Code[1]:
+ - func[0] size=5
+Code Disassembly:
+000039 func[0]:
+ 00003a: 41 01                      | i32.const 1
+ 00003c: 0f                         | return
+ 00003d: 0b                         | end
+;;; STDOUT ;;)

--- a/test/decompile/code-annotations.txt
+++ b/test/decompile/code-annotations.txt
@@ -1,0 +1,16 @@
+;;; TOOL: run-wasm-decompile
+
+(module
+  (func $f (param i32) (result i32)
+    i32.const 1234
+    local.get 0
+    (@code_annotation.test "aa\01a") i32.add
+    return))
+
+(;; STDOUT ;;;
+function f_a(a:int):int {
+  let t0 = a;
+  // @code_annotation.test "aa\01a";
+  return 1234 + t0;
+}
+;;; STDOUT ;;)

--- a/test/dump/code-annotations.txt
+++ b/test/dump/code-annotations.txt
@@ -1,0 +1,36 @@
+;;; TOOL: run-objdump
+;;; ARGS0: --enable-annotations --enable-code-annotations
+;;; ARGS1: --headers --details
+(module
+  (func $f (param i32) (result i32)
+    i32.const 1234
+    local.get 0
+    (@code_annotation.test "aa\01a") i32.add
+    return))
+(;; STDOUT ;;;
+code-annotations.wasm:	file format wasm 0x1
+Sections:
+     Type start=0x0000000a end=0x00000010 (size=0x00000006) count: 1
+ Function start=0x00000012 end=0x00000014 (size=0x00000002) count: 1
+   Custom start=0x00000016 end=0x00000034 (size=0x0000001e) "code_annotation.test"
+     Code start=0x00000036 end=0x00000041 (size=0x0000000b) count: 1
+Section Details:
+Type[1]:
+ - type[0] (i32) -> i32
+Function[1]:
+ - func[0] sig=0
+Custom:
+ - name: "code_annotation.test"
+   - func[0]:
+    - ann[6]:
+     - 0000000: 6161 0161                                aa.a
+Code[1]:
+ - func[0] size=9
+Code Disassembly:
+000038 func[0]:
+ 000039: 41 d2 09                   | i32.const 1234
+ 00003c: 20 00                      | local.get 0
+ 00003e: 6a                         | i32.add
+ 00003f: 0f                         | return
+ 000040: 0b                         | end
+;;; STDOUT ;;)

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -25,6 +25,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -36,6 +36,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -26,6 +26,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -25,6 +25,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -31,6 +31,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -28,6 +28,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -35,6 +35,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -35,6 +35,7 @@ options:
       --enable-bulk-memory                     Enable Bulk-memory operations
       --enable-reference-types                 Enable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
+      --enable-code-annotations                Enable Code annotations
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-all                             Enable all features

--- a/test/roundtrip/code-annotations.txt
+++ b/test/roundtrip/code-annotations.txt
@@ -1,0 +1,8 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --enable-annotations --enable-code-annotations
+(module
+  (func $f (param i32) (result i32)
+    i32.const 1234
+    local.get 0
+    (@code_annotation.test "aa\01a") i32.add
+    return))

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -124,6 +124,8 @@ def main(args):
     parser.add_argument('--enable-tail-call', action='store_true')
     parser.add_argument('--enable-reference-types', action='store_true')
     parser.add_argument('--enable-memory64', action='store_true')
+    parser.add_argument('--enable-annotations', action='store_true')
+    parser.add_argument('--enable-code-annotations', action='store_true')
     parser.add_argument('--inline-exports', action='store_true')
     parser.add_argument('--inline-imports', action='store_true')
     parser.add_argument('--reloc', action='store_true')
@@ -146,6 +148,8 @@ def main(args):
         '--enable-tail-call': options.enable_tail_call,
         '--enable-reference-types': options.enable_reference_types,
         '--enable-memory64': options.enable_memory64,
+        '--enable-annotations': options.enable_annotations,
+        '--enable-code-annotations': options.enable_code_annotations,
         '--reloc': options.reloc,
         '--no-check': options.no_check,
     })
@@ -166,6 +170,8 @@ def main(args):
         '--enable-reference-types': options.enable_reference_types,
         '--enable-threads': options.enable_threads,
         '--enable-memory64': options.enable_memory64,
+        '--enable-annotations': options.enable_annotations,
+        '--enable-code-annotations': options.enable_code_annotations,
         '--inline-exports': options.inline_exports,
         '--inline-imports': options.inline_imports,
         '--no-debug-names': not options.debug_names,


### PR DESCRIPTION
This PR adds support for Code Annotations.

See https://github.com/WebAssembly/tool-conventions/issues/167 for context and https://github.com/WebAssembly/tool-conventions/pull/173 for the specification.

In particular this pr implements the following:

- Parsing code annotation sections in BinaryReader, providing appropriate callbacks that a BinaryReaderDelegate can implement:
    - BinaryReaderObjdump: show the sections in a human-readable form
    - BinaryReaderIr: add code annotations in the IR as expressions
- Parsing code annotations in text format, adding them in the IR like the BinaryReaderIR does
- Writing  the code annotations present in the IR in the proper sections when converting IR to binary
- Support in wasm-decompiler for showing the annotations as comments in the pseudo-code

All the features have corresponding tests.

Support for code annotations is gated through the `--enable-code-annotations` feature. For reading/writing in the text format, `--enable-annotations` is also required.

Missing features:
- Support for function-level code annotations (offset 0)
- Extensive validation in validator.cc (like making sure that all annotations are at the same code offset of an instruction)