### PR TITLE
Fix crashes in parser when f32.const is given a nan expression

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -2363,7 +2363,13 @@ Result WastParser::ParseF32(Const* const_, ConstType const_type) {
     const_->set_f32(expected);
     return Result::Ok;
   }
-  auto literal = Consume().literal();
+
+  auto token = Consume();
+  if (!token.HasLiteral()) {
+    return Result::Error;
+  }
+
+  auto literal = token.literal();
   uint32_t f32_bits;
   Result result = ParseFloat(literal.type, literal.text.begin(),
                              literal.text.end(), &f32_bits);
@@ -2378,7 +2384,13 @@ Result WastParser::ParseF64(Const* const_, ConstType const_type) {
     const_->set_f64(expected);
     return Result::Ok;
   }
-  auto literal = Consume().literal();
+
+  auto token = Consume();
+  if (!token.HasLiteral()) {
+    return Result::Error;
+  }
+
+  auto literal = token.literal();
   uint64_t f64_bits;
   Result result = ParseDouble(literal.type, literal.text.begin(),
                               literal.text.end(), &f64_bits);

--- a/test/parse/expr/bad-const-f32-nan-arith.txt
+++ b/test/parse/expr/bad-const-f32-nan-arith.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(func f32.const nan:arithmetic)
+(;; STDERR ;;;
+out/test/parse/expr/bad-const-f32-nan-arith.txt:3:17: error: invalid literal "nan:arithmetic"
+(func f32.const nan:arithmetic)
+                ^^^^^^^^^^^^^^
+;;; STDERR ;;)

--- a/test/parse/expr/bad-const-f64-nan-arith.txt
+++ b/test/parse/expr/bad-const-f64-nan-arith.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(func f64.const nan:arithmetic)
+(;; STDERR ;;;
+out/test/parse/expr/bad-const-f64-nan-arith.txt:3:17: error: invalid literal "nan:arithmetic"
+(func f64.const nan:arithmetic)
+                ^^^^^^^^^^^^^^
+;;; STDERR ;;)


### PR DESCRIPTION
The parser assumes that f32.const will always be followed by a literal,
and crashes if it is followed by a nan expression when it is not
allowed.