### PR TITLE
Avoid writing DataCount section when it is not needed.

### DIFF
--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1519,7 +1519,8 @@ Result BinaryWriter::WriteModule() {
     EndSection();
   }
 
-  if (options_.features.bulk_memory_enabled()) {
+  if (options_.features.bulk_memory_enabled() &&
+      module_->data_segments.size()) {
     // Keep track of the data count section offset so it can be removed if
     // it isn't needed.
     data_count_start_ = stream_->offset();
@@ -1560,7 +1561,7 @@ Result BinaryWriter::WriteModule() {
 
   // Remove the DataCount section if there are no instructions that require it.
   if (options_.features.bulk_memory_enabled() &&
-      !has_data_segment_instruction_) {
+      module_->data_segments.size() && !has_data_segment_instruction_) {
     Offset size = stream_->offset() - data_count_end_;
     if (size) {
       // If the DataCount section was followed by anything, assert that it's

--- a/test/binary/bad-data-without-memory.txt
+++ b/test/binary/bad-data-without-memory.txt
@@ -12,5 +12,3 @@ section(DATACOUNT) { count[1] }
 000000c: error: no memory to copy data to
 000000c: error: no memory to copy data to
 ;;; STDERR ;;)
-
-

--- a/test/dump/call_ref.txt
+++ b/test/dump/call_ref.txt
@@ -59,38 +59,31 @@
 0000028: 01                                        ; num elems
 0000029: 01                                        ; elem function index
 0000024: 05                                        ; FIXUP section size
-; section "DataCount" (12)
-000002a: 0c                                        ; section code
-000002b: 00                                        ; section size (guess)
-000002c: 00                                        ; data count
-000002b: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000002d: 0a                                        ; section code
-000002e: 00                                        ; section size (guess)
-000002f: 02                                        ; num functions
+000002a: 0a                                        ; section code
+000002b: 00                                        ; section size (guess)
+000002c: 02                                        ; num functions
 ; function body 0
-0000030: 00                                        ; func body size (guess)
-0000031: 00                                        ; local decl count
-0000032: 41                                        ; i32.const
-0000033: 0a                                        ; i32 literal
-0000034: d2                                        ; ref.func
-0000035: 01                                        ; function index
-0000036: 14                                        ; call_ref
-0000037: 0b                                        ; end
-0000030: 07                                        ; FIXUP func body size
+000002d: 00                                        ; func body size (guess)
+000002e: 00                                        ; local decl count
+000002f: 41                                        ; i32.const
+0000030: 0a                                        ; i32 literal
+0000031: d2                                        ; ref.func
+0000032: 01                                        ; function index
+0000033: 14                                        ; call_ref
+0000034: 0b                                        ; end
+000002d: 07                                        ; FIXUP func body size
 ; function body 1
-0000038: 00                                        ; func body size (guess)
-0000039: 00                                        ; local decl count
-000003a: 20                                        ; local.get
-000003b: 00                                        ; local index
-000003c: 41                                        ; i32.const
-000003d: 13                                        ; i32 literal
-000003e: 6a                                        ; i32.add
-000003f: 0b                                        ; end
-0000038: 07                                        ; FIXUP func body size
-000002e: 11                                        ; FIXUP section size
-; move data: [2d, 40) -> [2a, 3d)
-; truncate to 61 (0x3d)
+0000035: 00                                        ; func body size (guess)
+0000036: 00                                        ; local decl count
+0000037: 20                                        ; local.get
+0000038: 00                                        ; local index
+0000039: 41                                        ; i32.const
+000003a: 13                                        ; i32 literal
+000003b: 6a                                        ; i32.add
+000003c: 0b                                        ; end
+0000035: 07                                        ; FIXUP func body size
+000002b: 11                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/elem-mvp-compat.txt
+++ b/test/dump/elem-mvp-compat.txt
@@ -27,12 +27,6 @@
 0000014: 0b                                        ; end
 0000015: 00                                        ; num elems
 000000f: 06                                        ; FIXUP section size
-; section "DataCount" (12)
-0000016: 0c                                        ; section code
-0000017: 00                                        ; section size (guess)
-0000018: 00                                        ; data count
-0000017: 01                                        ; FIXUP section size
-; truncate to 22 (0x16)
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/rethrow.txt
+++ b/test/dump/rethrow.txt
@@ -33,30 +33,23 @@
 0000015: 00                                        ; tag attribute
 0000016: 00                                        ; tag signature index
 0000013: 03                                        ; FIXUP section size
-; section "DataCount" (12)
-0000017: 0c                                        ; section code
-0000018: 00                                        ; section size (guess)
-0000019: 00                                        ; data count
-0000018: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000001a: 0a                                        ; section code
-000001b: 00                                        ; section size (guess)
-000001c: 01                                        ; num functions
+0000017: 0a                                        ; section code
+0000018: 00                                        ; section size (guess)
+0000019: 01                                        ; num functions
 ; function body 0
-000001d: 00                                        ; func body size (guess)
-000001e: 00                                        ; local decl count
-000001f: 06                                        ; try
-0000020: 40                                        ; void
-0000021: 07                                        ; catch
-0000022: 00                                        ; catch tag
-0000023: 09                                        ; rethrow
-0000024: 00                                        ; rethrow depth
-0000025: 0b                                        ; end
-0000026: 0b                                        ; end
-000001d: 09                                        ; FIXUP func body size
-000001b: 0b                                        ; FIXUP section size
-; move data: [1a, 27) -> [17, 24)
-; truncate to 36 (0x24)
+000001a: 00                                        ; func body size (guess)
+000001b: 00                                        ; local decl count
+000001c: 06                                        ; try
+000001d: 40                                        ; void
+000001e: 07                                        ; catch
+000001f: 00                                        ; catch tag
+0000020: 09                                        ; rethrow
+0000021: 00                                        ; rethrow depth
+0000022: 0b                                        ; end
+0000023: 0b                                        ; end
+000001a: 09                                        ; FIXUP func body size
+0000018: 0b                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -60,23 +60,16 @@
 000002d: 01                                        ; num elems
 000002e: 00                                        ; elem function index
 000001f: 0f                                        ; FIXUP section size
-; section "DataCount" (12)
-000002f: 0c                                        ; section code
-0000030: 00                                        ; section size (guess)
-0000031: 00                                        ; data count
-0000030: 01                                        ; FIXUP section size
 ; section "Code" (10)
-0000032: 0a                                        ; section code
-0000033: 00                                        ; section size (guess)
-0000034: 01                                        ; num functions
+000002f: 0a                                        ; section code
+0000030: 00                                        ; section size (guess)
+0000031: 01                                        ; num functions
 ; function body 0
-0000035: 00                                        ; func body size (guess)
-0000036: 00                                        ; local decl count
-0000037: 0b                                        ; end
-0000035: 02                                        ; FIXUP func body size
-0000033: 04                                        ; FIXUP section size
-; move data: [32, 38) -> [2f, 35)
-; truncate to 53 (0x35)
+0000032: 00                                        ; func body size (guess)
+0000033: 00                                        ; local decl count
+0000034: 0b                                        ; end
+0000032: 02                                        ; FIXUP func body size
+0000030: 04                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/throw.txt
+++ b/test/dump/throw.txt
@@ -36,27 +36,20 @@
 0000019: 00                                        ; tag attribute
 000001a: 00                                        ; tag signature index
 0000017: 03                                        ; FIXUP section size
-; section "DataCount" (12)
-000001b: 0c                                        ; section code
-000001c: 00                                        ; section size (guess)
-000001d: 00                                        ; data count
-000001c: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000001e: 0a                                        ; section code
-000001f: 00                                        ; section size (guess)
-0000020: 01                                        ; num functions
+000001b: 0a                                        ; section code
+000001c: 00                                        ; section size (guess)
+000001d: 01                                        ; num functions
 ; function body 0
-0000021: 00                                        ; func body size (guess)
-0000022: 00                                        ; local decl count
-0000023: 41                                        ; i32.const
-0000024: 01                                        ; i32 literal
-0000025: 08                                        ; throw
-0000026: 00                                        ; throw tag
-0000027: 0b                                        ; end
-0000021: 06                                        ; FIXUP func body size
-000001f: 08                                        ; FIXUP section size
-; move data: [1e, 28) -> [1b, 25)
-; truncate to 37 (0x25)
+000001e: 00                                        ; func body size (guess)
+000001f: 00                                        ; local decl count
+0000020: 41                                        ; i32.const
+0000021: 01                                        ; i32 literal
+0000022: 08                                        ; throw
+0000023: 00                                        ; throw tag
+0000024: 0b                                        ; end
+000001e: 06                                        ; FIXUP func body size
+000001c: 08                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/try-catch-all.txt
+++ b/test/dump/try-catch-all.txt
@@ -41,33 +41,26 @@
 0000019: 00                                        ; tag attribute
 000001a: 00                                        ; tag signature index
 0000017: 03                                        ; FIXUP section size
-; section "DataCount" (12)
-000001b: 0c                                        ; section code
-000001c: 00                                        ; section size (guess)
-000001d: 00                                        ; data count
-000001c: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000001e: 0a                                        ; section code
-000001f: 00                                        ; section size (guess)
-0000020: 01                                        ; num functions
+000001b: 0a                                        ; section code
+000001c: 00                                        ; section size (guess)
+000001d: 01                                        ; num functions
 ; function body 0
-0000021: 00                                        ; func body size (guess)
-0000022: 00                                        ; local decl count
-0000023: 06                                        ; try
-0000024: 7f                                        ; i32
-0000025: 01                                        ; nop
+000001e: 00                                        ; func body size (guess)
+000001f: 00                                        ; local decl count
+0000020: 06                                        ; try
+0000021: 7f                                        ; i32
+0000022: 01                                        ; nop
+0000023: 41                                        ; i32.const
+0000024: 07                                        ; i32 literal
+0000025: 19                                        ; catch_all
 0000026: 41                                        ; i32.const
-0000027: 07                                        ; i32 literal
-0000028: 19                                        ; catch_all
-0000029: 41                                        ; i32.const
-000002a: 08                                        ; i32 literal
-000002b: 0b                                        ; end
-000002c: 1a                                        ; drop
-000002d: 0b                                        ; end
-0000021: 0c                                        ; FIXUP func body size
-000001f: 0e                                        ; FIXUP section size
-; move data: [1e, 2e) -> [1b, 2b)
-; truncate to 43 (0x2b)
+0000027: 08                                        ; i32 literal
+0000028: 0b                                        ; end
+0000029: 1a                                        ; drop
+000002a: 0b                                        ; end
+000001e: 0c                                        ; FIXUP func body size
+000001c: 0e                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/try-delegate.txt
+++ b/test/dump/try-delegate.txt
@@ -47,44 +47,37 @@
 0000019: 00                                        ; tag attribute
 000001a: 00                                        ; tag signature index
 0000017: 03                                        ; FIXUP section size
-; section "DataCount" (12)
-000001b: 0c                                        ; section code
-000001c: 00                                        ; section size (guess)
-000001d: 00                                        ; data count
-000001c: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000001e: 0a                                        ; section code
-000001f: 00                                        ; section size (guess)
-0000020: 01                                        ; num functions
+000001b: 0a                                        ; section code
+000001c: 00                                        ; section size (guess)
+000001d: 01                                        ; num functions
 ; function body 0
-0000021: 00                                        ; func body size (guess)
-0000022: 00                                        ; local decl count
-0000023: 06                                        ; try
-0000024: 7f                                        ; i32
-0000025: 06                                        ; try
-0000026: 40                                        ; void
-0000027: 01                                        ; nop
-0000028: 18                                        ; delegate
-0000029: 01                                        ; delegate depth
-000002a: 06                                        ; try
-000002b: 40                                        ; void
-000002c: 01                                        ; nop
-000002d: 18                                        ; delegate
-000002e: 00                                        ; delegate depth
-000002f: 41                                        ; i32.const
-0000030: 07                                        ; i32 literal
-0000031: 07                                        ; catch
-0000032: 00                                        ; catch tag
-0000033: 1a                                        ; drop
-0000034: 41                                        ; i32.const
-0000035: 08                                        ; i32 literal
-0000036: 0b                                        ; end
-0000037: 1a                                        ; drop
-0000038: 0b                                        ; end
-0000021: 17                                        ; FIXUP func body size
-000001f: 19                                        ; FIXUP section size
-; move data: [1e, 39) -> [1b, 36)
-; truncate to 54 (0x36)
+000001e: 00                                        ; func body size (guess)
+000001f: 00                                        ; local decl count
+0000020: 06                                        ; try
+0000021: 7f                                        ; i32
+0000022: 06                                        ; try
+0000023: 40                                        ; void
+0000024: 01                                        ; nop
+0000025: 18                                        ; delegate
+0000026: 01                                        ; delegate depth
+0000027: 06                                        ; try
+0000028: 40                                        ; void
+0000029: 01                                        ; nop
+000002a: 18                                        ; delegate
+000002b: 00                                        ; delegate depth
+000002c: 41                                        ; i32.const
+000002d: 07                                        ; i32 literal
+000002e: 07                                        ; catch
+000002f: 00                                        ; catch tag
+0000030: 1a                                        ; drop
+0000031: 41                                        ; i32.const
+0000032: 08                                        ; i32 literal
+0000033: 0b                                        ; end
+0000034: 1a                                        ; drop
+0000035: 0b                                        ; end
+000001e: 17                                        ; FIXUP func body size
+000001c: 19                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/try-multi.txt
+++ b/test/dump/try-multi.txt
@@ -58,52 +58,45 @@
 000001f: 00                                        ; tag attribute
 0000020: 00                                        ; tag signature index
 000001d: 03                                        ; FIXUP section size
-; section "DataCount" (12)
-0000021: 0c                                        ; section code
-0000022: 00                                        ; section size (guess)
-0000023: 00                                        ; data count
-0000022: 01                                        ; FIXUP section size
 ; section "Code" (10)
-0000024: 0a                                        ; section code
-0000025: 00                                        ; section size (guess)
-0000026: 02                                        ; num functions
+0000021: 0a                                        ; section code
+0000022: 00                                        ; section size (guess)
+0000023: 02                                        ; num functions
 ; function body 0
-0000027: 00                                        ; func body size (guess)
-0000028: 00                                        ; local decl count
-0000029: 06                                        ; try
-000002a: 02                                        ; block type function index
-000002b: 41                                        ; i32.const
-000002c: 01                                        ; i32 literal
-000002d: 41                                        ; i32.const
-000002e: 02                                        ; i32 literal
-000002f: 07                                        ; catch
-0000030: 00                                        ; catch tag
-0000031: 1a                                        ; drop
-0000032: 41                                        ; i32.const
-0000033: 03                                        ; i32 literal
-0000034: 41                                        ; i32.const
-0000035: 04                                        ; i32 literal
-0000036: 0b                                        ; end
-0000037: 0f                                        ; return
-0000038: 0b                                        ; end
-0000027: 11                                        ; FIXUP func body size
+0000024: 00                                        ; func body size (guess)
+0000025: 00                                        ; local decl count
+0000026: 06                                        ; try
+0000027: 02                                        ; block type function index
+0000028: 41                                        ; i32.const
+0000029: 01                                        ; i32 literal
+000002a: 41                                        ; i32.const
+000002b: 02                                        ; i32 literal
+000002c: 07                                        ; catch
+000002d: 00                                        ; catch tag
+000002e: 1a                                        ; drop
+000002f: 41                                        ; i32.const
+0000030: 03                                        ; i32 literal
+0000031: 41                                        ; i32.const
+0000032: 04                                        ; i32 literal
+0000033: 0b                                        ; end
+0000034: 0f                                        ; return
+0000035: 0b                                        ; end
+0000024: 11                                        ; FIXUP func body size
 ; function body 1
-0000039: 00                                        ; func body size (guess)
-000003a: 00                                        ; local decl count
-000003b: 41                                        ; i32.const
-000003c: 00                                        ; i32 literal
-000003d: 06                                        ; try
-000003e: 00                                        ; block type function index
+0000036: 00                                        ; func body size (guess)
+0000037: 00                                        ; local decl count
+0000038: 41                                        ; i32.const
+0000039: 00                                        ; i32 literal
+000003a: 06                                        ; try
+000003b: 00                                        ; block type function index
+000003c: 1a                                        ; drop
+000003d: 07                                        ; catch
+000003e: 00                                        ; catch tag
 000003f: 1a                                        ; drop
-0000040: 07                                        ; catch
-0000041: 00                                        ; catch tag
-0000042: 1a                                        ; drop
-0000043: 0b                                        ; end
-0000044: 0b                                        ; end
-0000039: 0b                                        ; FIXUP func body size
-0000025: 1f                                        ; FIXUP section size
-; move data: [24, 45) -> [21, 42)
-; truncate to 66 (0x42)
+0000040: 0b                                        ; end
+0000041: 0b                                        ; end
+0000036: 0b                                        ; FIXUP func body size
+0000022: 1f                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/dump/try.txt
+++ b/test/dump/try.txt
@@ -45,39 +45,32 @@
 0000019: 00                                        ; tag attribute
 000001a: 00                                        ; tag signature index
 0000017: 03                                        ; FIXUP section size
-; section "DataCount" (12)
-000001b: 0c                                        ; section code
-000001c: 00                                        ; section size (guess)
-000001d: 00                                        ; data count
-000001c: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000001e: 0a                                        ; section code
-000001f: 00                                        ; section size (guess)
-0000020: 01                                        ; num functions
+000001b: 0a                                        ; section code
+000001c: 00                                        ; section size (guess)
+000001d: 01                                        ; num functions
 ; function body 0
-0000021: 00                                        ; func body size (guess)
-0000022: 00                                        ; local decl count
-0000023: 06                                        ; try
-0000024: 40                                        ; void
-0000025: 01                                        ; nop
-0000026: 0b                                        ; end
-0000027: 06                                        ; try
-0000028: 7f                                        ; i32
-0000029: 01                                        ; nop
-000002a: 41                                        ; i32.const
-000002b: 07                                        ; i32 literal
-000002c: 07                                        ; catch
-000002d: 00                                        ; catch tag
-000002e: 1a                                        ; drop
-000002f: 41                                        ; i32.const
-0000030: 08                                        ; i32 literal
-0000031: 0b                                        ; end
-0000032: 1a                                        ; drop
-0000033: 0b                                        ; end
-0000021: 12                                        ; FIXUP func body size
-000001f: 14                                        ; FIXUP section size
-; move data: [1e, 34) -> [1b, 31)
-; truncate to 49 (0x31)
+000001e: 00                                        ; func body size (guess)
+000001f: 00                                        ; local decl count
+0000020: 06                                        ; try
+0000021: 40                                        ; void
+0000022: 01                                        ; nop
+0000023: 0b                                        ; end
+0000024: 06                                        ; try
+0000025: 7f                                        ; i32
+0000026: 01                                        ; nop
+0000027: 41                                        ; i32.const
+0000028: 07                                        ; i32 literal
+0000029: 07                                        ; catch
+000002a: 00                                        ; catch tag
+000002b: 1a                                        ; drop
+000002c: 41                                        ; i32.const
+000002d: 08                                        ; i32 literal
+000002e: 0b                                        ; end
+000002f: 1a                                        ; drop
+0000030: 0b                                        ; end
+000001e: 12                                        ; FIXUP func body size
+000001c: 14                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 

--- a/test/spec/bulk-memory-operations/memory_init.txt
+++ b/test/spec/bulk-memory-operations/memory_init.txt
@@ -7,8 +7,7 @@ test() =>
 test() =>
 test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:189: assert_invalid passed:
-  0000000: error: data_segment variable out of range: 0 (max 0)
-  0000027: error: OnDataDropExpr callback failed
+  0000023: error: data.drop requires data count section
 out/test/spec/bulk-memory-operations/memory_init.wast:195: assert_invalid passed:
   0000000: error: data_segment variable out of range: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
@@ -16,9 +15,7 @@ test() =>
 out/test/spec/bulk-memory-operations/memory_init.wast:216: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/bulk-memory-operations/memory_init.wast:223: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/bulk-memory-operations/memory_init.wast:226: assert_invalid passed:
-  error: memory variable out of range: 0 (max 0)
-  0000000: error: data_segment variable out of range: 1 (max 0)
-  000002f: error: OnMemoryInitExpr callback failed
+  000002a: error: memory.init requires data count section
 out/test/spec/bulk-memory-operations/memory_init.wast:232: assert_invalid passed:
   0000000: error: data_segment variable out of range: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed

--- a/test/spec/reference-types/memory_init.txt
+++ b/test/spec/reference-types/memory_init.txt
@@ -7,8 +7,7 @@ test() =>
 test() =>
 test() =>
 out/test/spec/reference-types/memory_init.wast:190: assert_invalid passed:
-  0000000: error: data_segment variable out of range: 0 (max 0)
-  0000027: error: OnDataDropExpr callback failed
+  0000023: error: data.drop requires data count section
 out/test/spec/reference-types/memory_init.wast:196: assert_invalid passed:
   0000000: error: data_segment variable out of range: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
@@ -16,9 +15,7 @@ test() =>
 out/test/spec/reference-types/memory_init.wast:217: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/reference-types/memory_init.wast:224: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/reference-types/memory_init.wast:227: assert_invalid passed:
-  error: memory variable out of range: 0 (max 0)
-  0000000: error: data_segment variable out of range: 1 (max 0)
-  000002f: error: OnMemoryInitExpr callback failed
+  000002a: error: memory.init requires data count section
 out/test/spec/reference-types/memory_init.wast:233: assert_invalid passed:
   0000000: error: data_segment variable out of range: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed


### PR DESCRIPTION
Without this change, when bulk memory is enabled, the DataCount is
always written when then removed if it proves that its not needed by any
instruction.

However, if we know there are no data segments we can avoid writing it
altogether. This happens to be more compact but I'm hoping to land this
now in anticipation of enabled bulk memory by default.  Once we do that
we don't want all the `dump` tests to include the writing and truncating
of the DataCount section in cases when there is no data.