### PR TITLE
Enable reference types by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Wabt has been compiled to JavaScript via emscripten. Some of the functionality i
 | [multi-value][] | `--disable-multi-value` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [tail-call][] | `--enable-tail-call` | | ✓ | ✓ | ✓ | ✓ |
 | [bulk memory][] | `--disable-bulk-memory` | ✓ | ✓ | ✓ | ✓ | ✓ |
-| [reference types][] | `--enable-reference-types` | | ✓ | ✓ | ✓ | ✓ |
+| [reference types][] | `--disable-reference-types` | ✓ | ✓ | ✓ | ✓ | ✓ |
 | [annotations][] | `--enable-annotations` | | | ✓ | | |
 | [memory64][] | `--enable-memory64` | | | | | |
 

--- a/scripts/fuzz-wasm2wat.sh
+++ b/scripts/fuzz-wasm2wat.sh
@@ -21,6 +21,6 @@ set -o errexit
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 ROOT_DIR="$(dirname "${SCRIPT_DIR}")"
 
-ENABLE="--enable-except --enable-sat --enable-sign --enable-thread --enable-multi --enable-tail --enable-ref"
+ENABLE="--enable-except --enable-sat --enable-sign --enable-thread --enable-multi --enable-tail"
 
 ${FUZZ_BIN_DIR}/afl-fuzz -i fuzz-in/wasm/ -o fuzz-out -- out/gcc-fuzz/Debug/wasm2wat @@ ${ENABLE}

--- a/scripts/fuzz-wat2wasm.sh
+++ b/scripts/fuzz-wat2wasm.sh
@@ -21,6 +21,6 @@ set -o errexit
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 ROOT_DIR="$(dirname "${SCRIPT_DIR}")"
 
-ENABLE="--enable-except --enable-sat --enable-sign --enable-thread --enable-multi --enable-tail --enable-ref"
+ENABLE="--enable-except --enable-sat --enable-sign --enable-thread --enable-multi --enable-tail"
 
 ${FUZZ_BIN_DIR}/afl-fuzz -x fuzz-in/wast.dict -i fuzz-in/wast/ -o fuzz-out -- out/gcc-fuzz/Debug/wat2wasm @@ ${ENABLE}

--- a/src/feature.cc
+++ b/src/feature.cc
@@ -48,8 +48,8 @@ void Features::UpdateDependencies() {
   }
 
   // Reference types requires bulk memory.
-  if (reference_types_enabled_) {
-    bulk_memory_enabled_ = true;
+  if (!bulk_memory_enabled_) {
+    reference_types_enabled_ = false;
   }
 }
 

--- a/src/feature.def
+++ b/src/feature.def
@@ -32,7 +32,7 @@ WABT_FEATURE(function_references, "function-references",     false,   "Typed fun
 WABT_FEATURE(multi_value,         "multi-value",             true,    "Multi-value")
 WABT_FEATURE(tail_call,           "tail-call",               false,   "Tail-call support")
 WABT_FEATURE(bulk_memory,         "bulk-memory",             true,    "Bulk-memory operations")
-WABT_FEATURE(reference_types,     "reference-types",         false,   "Reference types (externref)")
+WABT_FEATURE(reference_types,     "reference-types",         true,    "Reference types (externref)")
 WABT_FEATURE(annotations,         "annotations",             false,   "Custom annotation syntax")
 WABT_FEATURE(gc,                  "gc",                      false,   "Garbage collection")
 WABT_FEATURE(memory64,            "memory64",                false,   "64-bit memory")

--- a/src/opcode.def
+++ b/src/opcode.def
@@ -251,7 +251,7 @@ WABT_OPCODE(___, I32,  I32,  I32,  0,  0xfc, 0x0c, TableInit, "table.init", "")
 WABT_OPCODE(___, ___,  ___,  ___,  0,  0xfc, 0x0d, ElemDrop, "elem.drop", "")
 WABT_OPCODE(___, I32,  I32,  I32,  0,  0xfc, 0x0e, TableCopy, "table.copy", "")
 
-/* Reference types (--enable-reference-types) */
+/* Reference types */
 WABT_OPCODE(___,  I32,  ___,  ___,  0,  0,    0x25, TableGet, "table.get", "")
 WABT_OPCODE(___,  I32,  ___,  ___,  0,  0,    0x26, TableSet, "table.set", "")
 WABT_OPCODE(___,  ___,  I32,  ___,  0,  0xfc, 0x0f, TableGrow, "table.grow", "")

--- a/test/binary/bad-call-indirect-reserved.txt
+++ b/test/binary/bad-call-indirect-reserved.txt
@@ -1,4 +1,6 @@
 ;;; TOOL: run-gen-wasm-bad
+;;; ARGS1: --disable-reference-types
+;;; ARGS2: --disable-reference-types
 magic
 version
 section(TYPE) { count[1] function params[0] results[0]}

--- a/test/binary/bad-returncallindirect-reserved.txt
+++ b/test/binary/bad-returncallindirect-reserved.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-gen-wasm-bad
-;;; ARGS1: --enable-tail-call
-;;; ARGS2: --enable-tail-call
+;;; ARGS1: --disable-reference-types --enable-tail-call
+;;; ARGS2: --disable-reference-types --enable-tail-call
 magic
 version
 section(TYPE) { count[1] function params[0] results[0]}

--- a/test/dump/reference-types.txt
+++ b/test/dump/reference-types.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: run-objdump
-;;; ARGS0: --enable-reference-types
 ;;; ARGS1: -x
 
 (module

--- a/test/dump/relocations.txt
+++ b/test/dump/relocations.txt
@@ -28,9 +28,9 @@ Sections:
    Global start=0x00000048 end=0x0000004e (size=0x00000006) count: 1
    Export start=0x00000050 end=0x00000055 (size=0x00000005) count: 1
      Elem start=0x00000057 end=0x0000005e (size=0x00000007) count: 1
-     Code start=0x00000060 end=0x00000082 (size=0x00000022) count: 1
-   Custom start=0x00000084 end=0x000000a5 (size=0x00000021) "linking"
-   Custom start=0x000000a7 end=0x000000c0 (size=0x00000019) "reloc.Code"
+     Code start=0x00000060 end=0x00000086 (size=0x00000026) count: 1
+   Custom start=0x00000088 end=0x000000a9 (size=0x00000021) "linking"
+   Custom start=0x000000ab end=0x000000c7 (size=0x0000001c) "reloc.Code"
 
 Section Details:
 
@@ -53,7 +53,7 @@ Elem[1]:
  - segment[0] flags=0 table=0 count=1 - init i32=0
   - elem[0] = func[1] <__extern.bar>
 Code[1]:
- - func[2] size=32 <f>
+ - func[2] size=36 <f>
 Custom:
  - name: "linking"
   - symbol table [count=5]
@@ -64,11 +64,12 @@ Custom:
    - 4: G <g> global=0 [ binding=global vis=default ]
 Custom:
  - name: "reloc.Code"
-  - relocations for section: 7 (Code) [4]
+  - relocations for section: 7 (Code) [5]
    - R_WASM_GLOBAL_INDEX_LEB offset=0x000004(file=0x000064) symbol=4 <g>
    - R_WASM_FUNCTION_INDEX_LEB offset=0x00000a(file=0x00006a) symbol=2 <f>
    - R_WASM_FUNCTION_INDEX_LEB offset=0x000010(file=0x000070) symbol=0 <__extern.foo>
    - R_WASM_TYPE_INDEX_LEB offset=0x00001b(file=0x00007b) type=2
+   - R_WASM_TABLE_NUMBER_LEB offset=0x000020(file=0x000080) symbol=3 <>
 
 Code Disassembly:
 
@@ -81,7 +82,9 @@ Code Disassembly:
            000070: R_WASM_FUNCTION_INDEX_LEB 0 <__extern.foo>
  000075: 41 d2 09                   | i32.const 1234
  000078: 41 00                      | i32.const 0
- 00007a: 11 82 80 80 80 00 00       | call_indirect 2 0
+ 00007a: 11 82 80 80 80 00 80 80 80 | call_indirect 2 0
+ 000083: 80 00                      | 
            00007b: R_WASM_TYPE_INDEX_LEB 2
- 000081: 0b                         | end
+ 000085: 0b                         | end
+           000080: R_WASM_TABLE_NUMBER_LEB 3 <>
 ;;; STDOUT ;;)

--- a/test/dump/table-multi.txt
+++ b/test/dump/table-multi.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-objdump
-;;; ARGS0: --enable-reference-types -v
+;;; ARGS0: -v
 ;;; ARGS1: -x
 (module
   (func (param i32))

--- a/test/gen-spec-wast.py
+++ b/test/gen-spec-wast.py
@@ -246,7 +246,7 @@ def main(args):
     parser.add_argument('--enable-sign-extension', action='store_true')
     parser.add_argument('--enable-multi-value', action='store_true')
     parser.add_argument('--enable-tail-call', action='store_true')
-    parser.add_argument('--enable-reference-types', action='store_true')
+    parser.add_argument('--disable-reference-types', action='store_true')
     parser.add_argument('--enable-memory64', action='store_true')
     options = parser.parse_args(args)
 
@@ -262,7 +262,7 @@ def main(args):
         '--enable-sign-extension': options.enable_sign_extension,
         '--enable-threads': options.enable_threads,
         '--enable-tail-call': options.enable_tail_call,
-        '--enable-reference-types': options.enable_reference_types,
+        '--disable-reference-types': options.disable_reference_types,
         '--enable-memory64': options.enable_memory64,
     })
 

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -23,7 +23,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -34,7 +34,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -24,7 +24,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -23,7 +23,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -29,7 +29,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -26,7 +26,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -33,7 +33,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -33,7 +33,7 @@ options:
       --disable-multi-value                    Disable Multi-value
       --enable-tail-call                       Enable Tail-call support
       --disable-bulk-memory                    Disable Bulk-memory operations
-      --enable-reference-types                 Enable Reference types (externref)
+      --disable-reference-types                Disable Reference types (externref)
       --enable-annotations                     Enable Custom annotation syntax
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory

--- a/test/interp/reference-types.txt
+++ b/test/interp/reference-types.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: run-interp
-;;; ARGS*: --enable-reference-types
 
 (module
   (table $t_func 1 funcref)

--- a/test/parse/expr/bad-select-multi.txt
+++ b/test/parse/expr/bad-select-multi.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS*: --enable-reference-types
 ;;; ERROR: 1
 (module
   (func
@@ -12,10 +11,10 @@
     unreachable
     ))
 (;; STDERR ;;;
-out/test/parse/expr/bad-select-multi.txt:11:5: error: invalid arity in select instruction: 2.
+out/test/parse/expr/bad-select-multi.txt:10:5: error: invalid arity in select instruction: 2.
     select (result i32 i32)
     ^^^^^^
-out/test/parse/expr/bad-select-multi.txt:11:5: error: type mismatch in function, expected [] but got [... i32, i32, i32, i32]
+out/test/parse/expr/bad-select-multi.txt:10:5: error: type mismatch in function, expected [] but got [... i32, i32, i32, i32]
     select (result i32 i32)
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bulk-memory-disabled.txt
+++ b/test/parse/expr/bulk-memory-disabled.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS*: --disable-bulk-memory
+;;; ARGS*: --disable-reference-types --disable-bulk-memory
 ;;; ERROR: 1
 
 (module

--- a/test/parse/expr/reference-types-call-indirect.txt
+++ b/test/parse/expr/reference-types-call-indirect.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 
 (module
   (table $foo 1 anyfunc)

--- a/test/parse/expr/reference-types-named.txt
+++ b/test/parse/expr/reference-types-named.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 
 (module
   (table $foo 1 externref)

--- a/test/parse/expr/reference-types.txt
+++ b/test/parse/expr/reference-types.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 
 (module
   (table $foo 1 externref)

--- a/test/parse/expr/table-get.txt
+++ b/test/parse/expr/table-get.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 (module
   (func (result externref)
     i32.const 0

--- a/test/parse/expr/table-grow.txt
+++ b/test/parse/expr/table-grow.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 (module
   (func (result i32)
     ref.null extern

--- a/test/parse/expr/table-set.txt
+++ b/test/parse/expr/table-set.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 (module
   (func (param externref)
     i32.const 0

--- a/test/parse/module/bad-table-no-offset.txt
+++ b/test/parse/module/bad-table-no-offset.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --disable-bulk-memory
+;;; ARGS: --disable-reference-types --disable-bulk-memory
 ;;; ERROR: 1
 (module
   (table 1 anyfunc)

--- a/test/parse/module/bad-table-too-many.txt
+++ b/test/parse/module/bad-table-too-many.txt
@@ -1,11 +1,12 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --disable-reference-types
 ;;; ERROR: 1
 (module
   (func (param i32))
   (table anyfunc (elem 0))
   (table anyfunc (elem 0)))
 (;; STDERR ;;;
-out/test/parse/module/bad-table-too-many.txt:6:4: error: only one table allowed
+out/test/parse/module/bad-table-too-many.txt:7:4: error: only one table allowed
   (table anyfunc (elem 0)))
    ^^^^^
 ;;; STDERR ;;)

--- a/test/parse/module/global.txt
+++ b/test/parse/module/global.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 (module
   (import "foo" "i32_global" (global i32))
   (import "foo" "i64_global" (global i64))

--- a/test/parse/module/reference-types-disabled.txt
+++ b/test/parse/module/reference-types-disabled.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: wat2wasm
+;;; ARGS: --disable-reference-types
 ;;; ERROR: 1
 
 (module
@@ -11,19 +12,19 @@
   )
 )
 (;; STDERR ;;;
-out/test/parse/module/reference-types-disabled.txt:5:15: error: value type not allowed: externref
+out/test/parse/module/reference-types-disabled.txt:6:15: error: value type not allowed: externref
   (table $t 1 externref)
               ^^^^^^^^^
-out/test/parse/module/reference-types-disabled.txt:9:5: error: opcode not allowed: table.get
+out/test/parse/module/reference-types-disabled.txt:10:5: error: opcode not allowed: table.get
     table.get $t
     ^^^^^^^^^
-out/test/parse/module/reference-types-disabled.txt:10:5: error: opcode not allowed: table.set
+out/test/parse/module/reference-types-disabled.txt:11:5: error: opcode not allowed: table.set
     table.set $t
     ^^^^^^^^^
-out/test/parse/module/reference-types-disabled.txt:9:15: error: undefined table variable "$t"
+out/test/parse/module/reference-types-disabled.txt:10:15: error: undefined table variable "$t"
     table.get $t
               ^^
-out/test/parse/module/reference-types-disabled.txt:10:15: error: undefined table variable "$t"
+out/test/parse/module/reference-types-disabled.txt:11:15: error: undefined table variable "$t"
     table.set $t
               ^^
 ;;; STDERR ;;)

--- a/test/roundtrip/elem-declare.txt
+++ b/test/roundtrip/elem-declare.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-reference-types
+;;; ARGS: --stdout
 (module
   (table 2 funcref)
   (elem declare funcref (ref.func $f) (ref.null func))

--- a/test/roundtrip/elem-nonzero-table.txt
+++ b/test/roundtrip/elem-nonzero-table.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-reference-types
+;;; ARGS: --stdout
 (module
   (table 1 funcref)
   (table 1 funcref)

--- a/test/roundtrip/fold-reference-types.txt
+++ b/test/roundtrip/fold-reference-types.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --fold-exprs --enable-reference-types
+;;; ARGS: --stdout --fold-exprs
 
 (module
   (table $t 1 externref)

--- a/test/roundtrip/select-type.txt
+++ b/test/roundtrip/select-type.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-reference-types
+;;; ARGS: --stdout
 (module
   (func
     unreachable

--- a/test/roundtrip/table-copy-index.txt
+++ b/test/roundtrip/table-copy-index.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-reference-types
+;;; ARGS: --stdout
 (module
   (table $t 0 funcref)
   (table $u 0 funcref)

--- a/test/roundtrip/table-import-externref.txt
+++ b/test/roundtrip/table-import-externref.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-reference-types
+;;; ARGS: --stdout
 (module
   (table (import "m" "func") 1 funcref)
   (table (import "m" "extern") 1 externref)

--- a/test/roundtrip/table-init-index.txt
+++ b/test/roundtrip/table-init-index.txt
@@ -1,5 +1,5 @@
 ;;; TOOL: run-roundtrip
-;;; ARGS: --stdout --enable-reference-types
+;;; ARGS: --stdout
 (module
   (table $t 0 funcref)
   (table $u 0 funcref)

--- a/test/run-roundtrip.py
+++ b/test/run-roundtrip.py
@@ -121,7 +121,7 @@ def main(args):
     parser.add_argument('--enable-sign-extension', action='store_true')
     parser.add_argument('--enable-multi-value', action='store_true')
     parser.add_argument('--enable-tail-call', action='store_true')
-    parser.add_argument('--enable-reference-types', action='store_true')
+    parser.add_argument('--disable-reference-types', action='store_true')
     parser.add_argument('--enable-memory64', action='store_true')
     parser.add_argument('--inline-exports', action='store_true')
     parser.add_argument('--inline-imports', action='store_true')
@@ -142,7 +142,7 @@ def main(args):
         '--enable-function-references': options.enable_function_references,
         '--enable-threads': options.enable_threads,
         '--enable-tail-call': options.enable_tail_call,
-        '--enable-reference-types': options.enable_reference_types,
+        '--disable-reference-types': options.disable_reference_types,
         '--enable-memory64': options.enable_memory64,
         '--reloc': options.reloc,
         '--no-check': options.no_check,
@@ -160,7 +160,7 @@ def main(args):
         '--enable-sign-extension': options.enable_sign_extension,
         '--enable-tail-call': options.enable_tail_call,
         '--enable-function-references': options.enable_function_references,
-        '--enable-reference-types': options.enable_reference_types,
+        '--disable-reference-types': options.disable_reference_types,
         '--enable-threads': options.enable_threads,
         '--enable-memory64': options.enable_memory64,
         '--inline-exports': options.inline_exports,

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -379,6 +379,7 @@ def main(args):
             find_exe.GetWast2JsonExecutable(options.bindir),
             error_cmdline=options.error_cmdline)
         wast2json.AppendOptionalArgs({'-v': options.verbose})
+        wast2json.AppendArg('--disable-reference-types')
         wast2json.AppendArg('--disable-bulk-memory')
 
         json_file_path = utils.ChangeDir(

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp-spec
+;;; ARGS*: --disable-reference-types
 ;;; STDIN_FILE: third_party/testsuite/binary.wast
 (;; STDOUT ;;;
 out/test/spec/binary.wast:6: assert_malformed passed:

--- a/test/spec/bulk-memory-operations/binary.txt
+++ b/test/spec/bulk-memory-operations/binary.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp-spec
+;;; ARGS*: --disable-reference-types
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/binary.wast
 (;; STDOUT ;;;
 out/test/spec/bulk-memory-operations/binary.wast:6: assert_malformed passed:

--- a/test/spec/bulk-memory-operations/imports.txt
+++ b/test/spec/bulk-memory-operations/imports.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp-spec
+;;; ARGS*: --disable-reference-types
 ;;; STDIN_FILE: third_party/testsuite/proposals/bulk-memory-operations/imports.wast
 (;; STDOUT ;;;
 called host spectest.print_i32(i32:13) =>

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp-spec
+;;; ARGS*: --disable-reference-types
 ;;; STDIN_FILE: third_party/testsuite/imports.wast
 (;; STDOUT ;;;
 called host spectest.print_i32(i32:13) =>

--- a/test/spec/memory64/binary.txt
+++ b/test/spec/memory64/binary.txt
@@ -1,6 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/memory64/binary.wast
-;;; ARGS*: --enable-memory64
+;;; ARGS*: --enable-memory64 --disable-reference-types
 (;; STDOUT ;;;
 out/test/spec/memory64/binary.wast:6: assert_malformed passed:
   0000000: error: unable to read uint32_t: magic

--- a/test/spec/reference-types/binary-leb128.txt
+++ b/test/spec/reference-types/binary-leb128.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/binary-leb128.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/binary-leb128.wast:218: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count

--- a/test/spec/reference-types/binary.txt
+++ b/test/spec/reference-types/binary.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/binary.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/binary.wast:6: assert_malformed passed:
   0000000: error: unable to read uint32_t: magic

--- a/test/spec/reference-types/br_table.txt
+++ b/test/spec/reference-types/br_table.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/br_table.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/br_table.wast:1441: assert_invalid passed:
   error: type mismatch in block, expected [] but got [i32]

--- a/test/spec/reference-types/bulk.txt
+++ b/test/spec/reference-types/bulk.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/bulk.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 fill(i32:1, i32:255, i32:3) =>
 fill(i32:0, i32:48042, i32:2) =>

--- a/test/spec/reference-types/call_indirect.txt
+++ b/test/spec/reference-types/call_indirect.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/call_indirect.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/call_indirect.wast:498: assert_trap passed: indirect call signature mismatch
 out/test/spec/reference-types/call_indirect.wast:499: assert_trap passed: indirect call signature mismatch

--- a/test/spec/reference-types/custom.txt
+++ b/test/spec/reference-types/custom.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/custom.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/custom.wast:61: assert_malformed passed:
   0000009: error: unable to read u32 leb128: section size

--- a/test/spec/reference-types/data.txt
+++ b/test/spec/reference-types/data.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/data.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/data.wast:293: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)

--- a/test/spec/reference-types/elem.txt
+++ b/test/spec/reference-types/elem.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/elem.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/elem.wast:320: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/reference-types/elem.wast:330: assert_trap passed: out of bounds table access: table.init out of bounds

--- a/test/spec/reference-types/exports.txt
+++ b/test/spec/reference-types/exports.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/exports.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/exports.wast:29: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)

--- a/test/spec/reference-types/global.txt
+++ b/test/spec/reference-types/global.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/global.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/global.wast:232: assert_trap passed: undefined table index
 out/test/spec/reference-types/global.wast:254: assert_invalid passed:

--- a/test/spec/reference-types/imports.txt
+++ b/test/spec/reference-types/imports.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/imports.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 called host spectest.print_i32(i32:13) =>
 called host spectest.print_i32_f32(i32:14, f32:42.000000) =>

--- a/test/spec/reference-types/linking.txt
+++ b/test/spec/reference-types/linking.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/linking.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/linking.wast:28: assert_unlinkable passed:
   error: import signature mismatch

--- a/test/spec/reference-types/memory_copy.txt
+++ b/test/spec/reference-types/memory_copy.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/memory_copy.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 test() =>

--- a/test/spec/reference-types/memory_fill.txt
+++ b/test/spec/reference-types/memory_fill.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/memory_fill.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 out/test/spec/reference-types/memory_fill.wast:44: assert_trap passed: out of bounds memory access: memory.fill out of bounds

--- a/test/spec/reference-types/memory_grow.txt
+++ b/test/spec/reference-types/memory_grow.txt
@@ -1,7 +1,6 @@
 ;;; SLOW:
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/memory_grow.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/memory_grow.wast:15: assert_trap passed: out of bounds memory access: access at 0+4 >= max value 0
 out/test/spec/reference-types/memory_grow.wast:16: assert_trap passed: out of bounds memory access: access at 0+4 >= max value 0

--- a/test/spec/reference-types/memory_init.txt
+++ b/test/spec/reference-types/memory_init.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/memory_init.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 test() =>

--- a/test/spec/reference-types/ref_func.txt
+++ b/test/spec/reference-types/ref_func.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/ref_func.wast
-;;; ARGS*: --enable-reference-types
 (;; STDERR ;;;
 out/test/spec/reference-types/ref_func.wast:98:15: error: function is not declared in any elem sections
     (ref.func $f1)

--- a/test/spec/reference-types/ref_is_null.txt
+++ b/test/spec/reference-types/ref_is_null.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/ref_is_null.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 init(externref:1) =>
 deinit() =>

--- a/test/spec/reference-types/ref_null.txt
+++ b/test/spec/reference-types/ref_null.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/ref_null.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 2/2 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/reference-types/select.txt
+++ b/test/spec/reference-types/select.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/select.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/select.wast:260: assert_trap passed: unreachable executed
 out/test/spec/reference-types/select.wast:261: assert_trap passed: unreachable executed

--- a/test/spec/reference-types/table-sub.txt
+++ b/test/spec/reference-types/table-sub.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table-sub.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/table-sub.wast:2: assert_invalid passed:
   error: type mismatch at table.copy. got externref, expected funcref

--- a/test/spec/reference-types/table.txt
+++ b/test/spec/reference-types/table.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/table.wast:14: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)

--- a/test/spec/reference-types/table_copy.txt
+++ b/test/spec/reference-types/table_copy.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_copy.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 out/test/spec/reference-types/table_copy.wast:46: assert_trap passed: uninitialized table element

--- a/test/spec/reference-types/table_fill.txt
+++ b/test/spec/reference-types/table_fill.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_fill.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/table_fill.wast:50: assert_trap passed: out of bounds table access: table.fill out of bounds
 out/test/spec/reference-types/table_fill.wast:58: assert_trap passed: out of bounds table access: table.fill out of bounds

--- a/test/spec/reference-types/table_get.txt
+++ b/test/spec/reference-types/table_get.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_get.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 init(externref:2) =>
 out/test/spec/reference-types/table_get.wast:33: assert_trap passed: out of bounds table access: table.get at 2 >= max value 2

--- a/test/spec/reference-types/table_grow.txt
+++ b/test/spec/reference-types/table_grow.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_grow.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/table_grow.wast:14: assert_trap passed: out of bounds table access: table.set at 0 >= max value 0
 out/test/spec/reference-types/table_grow.wast:15: assert_trap passed: out of bounds table access: table.get at 0 >= max value 0

--- a/test/spec/reference-types/table_init.txt
+++ b/test/spec/reference-types/table_init.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_init.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 test() =>
 out/test/spec/reference-types/table_init.wast:42: assert_trap passed: uninitialized table element

--- a/test/spec/reference-types/table_set.txt
+++ b/test/spec/reference-types/table_set.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_set.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/table_set.wast:41: assert_trap passed: out of bounds table access: table.set at 2 >= max value 1
 out/test/spec/reference-types/table_set.wast:42: assert_trap passed: out of bounds table access: table.set at 3 >= max value 2

--- a/test/spec/reference-types/table_size.txt
+++ b/test/spec/reference-types/table_size.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/table_size.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/table_size.wast:70: assert_invalid passed:
   error: type mismatch in function, expected [] but got [i32]

--- a/test/spec/reference-types/unreached-invalid.txt
+++ b/test/spec/reference-types/unreached-invalid.txt
@@ -1,6 +1,5 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/proposals/reference-types/unreached-invalid.wast
-;;; ARGS*: --enable-reference-types
 (;; STDOUT ;;;
 out/test/spec/reference-types/unreached-invalid.wast:4: assert_invalid passed:
   0000000: error: local variable out of range (max 0)

--- a/test/spec/table.txt
+++ b/test/spec/table.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: run-interp-spec
+;;; ARGS*: --disable-reference-types
 ;;; STDIN_FILE: third_party/testsuite/table.wast
 (;; STDOUT ;;;
 out/test/spec/table.wast:11: assert_invalid passed:

--- a/test/typecheck/bad-reference-types-no-table.txt
+++ b/test/typecheck/bad-reference-types-no-table.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 ;;; ERROR: 1
 
 (module
@@ -11,10 +10,10 @@
   )
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-reference-types-no-table.txt:9:15: error: undefined table variable "$t"
+out/test/typecheck/bad-reference-types-no-table.txt:8:15: error: undefined table variable "$t"
     table.get $t
               ^^
-out/test/typecheck/bad-reference-types-no-table.txt:10:15: error: undefined table variable "$t"
+out/test/typecheck/bad-reference-types-no-table.txt:9:15: error: undefined table variable "$t"
     table.set $t
               ^^
 ;;; STDERR ;;)

--- a/test/typecheck/if-anyref.txt
+++ b/test/typecheck/if-anyref.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: wat2wasm
-;;; ARGS: --enable-reference-types
 (module
   (func (param externref) (result externref)
     i32.const 0

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -90,7 +90,6 @@ def main(args):
     ProcessProposalDir('nontrapping-float-to-int-conversions',
                        '--enable-saturating-float-to-int')
     ProcessProposalDir('sign-extension-ops', '--enable-sign-extension')
-    ProcessProposalDir('reference-types', '--enable-reference-types')
     ProcessProposalDir('memory64', '--enable-memory64')
 
     return 0


### PR DESCRIPTION
This features was finished earlier this year:
https://github.com/WebAssembly/proposals/blob/master/finished-proposals.md

One thing to note is that the version of the spec tests we currently
have in third_party/testsuite doesn't have ref types merged yet so
this change disables ref types when running some of those tests.  This
can be removed in a followup when we update the testsuite.