### PR TITLE
Delay validation of elem init expressions until validation time

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -20,6 +20,7 @@
 #include <cstdio>
 #include <vector>
 
+#include "src/cast.h"
 #include "src/expr-visitor.h"
 #include "src/ir.h"
 #include "src/string-view.h"
@@ -460,9 +461,10 @@ Result NameApplier::VisitElemSegment(Index elem_segment_index,
                                      ElemSegment* segment) {
   CHECK_RESULT(UseNameForTableVar(&segment->table_var));
   CHECK_RESULT(visitor_.VisitExprList(segment->offset));
-  for (ElemExpr& elem_expr : segment->elem_exprs) {
-    if (elem_expr.kind == ElemExprKind::RefFunc) {
-      CHECK_RESULT(UseNameForFuncVar(&elem_expr.var));
+  for (ExprList& elem_expr : segment->elem_exprs) {
+    Expr* expr = &elem_expr.front();
+    if (expr->type() == ExprType::RefFunc) {
+      CHECK_RESULT(UseNameForFuncVar(&cast<RefFuncExpr>(expr)->var));
     }
   }
   return Result::Ok;

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1171,7 +1171,10 @@ Result BinaryReaderIR::OnElemSegmentElemExpr_RefNull(Index segment_index,
                                                      Type type) {
   assert(segment_index == module_->elem_segments.size() - 1);
   ElemSegment* segment = module_->elem_segments[segment_index];
-  segment->elem_exprs.emplace_back(type);
+  Location loc = GetLocation();
+  ExprList init_expr;
+  init_expr.push_back(MakeUnique<RefNullExpr>(type, loc));
+  segment->elem_exprs.push_back(std::move(init_expr));
   return Result::Ok;
 }
 
@@ -1179,7 +1182,10 @@ Result BinaryReaderIR::OnElemSegmentElemExpr_RefFunc(Index segment_index,
                                                      Index func_index) {
   assert(segment_index == module_->elem_segments.size() - 1);
   ElemSegment* segment = module_->elem_segments[segment_index];
-  segment->elem_exprs.emplace_back(Var(func_index, GetLocation()));
+  Location loc = GetLocation();
+  ExprList init_expr;
+  init_expr.push_back(MakeUnique<RefFuncExpr>(Var(func_index, loc), loc));
+  segment->elem_exprs.push_back(std::move(init_expr));
   return Result::Ok;
 }
 

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1105,11 +1105,13 @@ void CWriter::WriteElemInitializers() {
     Write(";", Newline());
 
     size_t i = 0;
-    for (const ElemExpr& elem_expr : elem_segment->elem_exprs) {
+    for (const ExprList& elem_expr : elem_segment->elem_exprs) {
       // We don't support the bulk-memory proposal here, so we know that we
       // don't have any passive segments (where ref.null can be used).
-      assert(elem_expr.kind == ElemExprKind::RefFunc);
-      const Func* func = module_->GetFunc(elem_expr.var);
+      assert(elem_expr.size() == 1);
+      const Expr* expr = &elem_expr.front();
+      assert(expr->type() == ExprType::RefFunc);
+      const Func* func = module_->GetFunc(cast<RefFuncExpr>(expr)->var);
       Index func_type_index = module_->GetFuncTypeIndex(func->decl.type_var);
 
       Write(ExternalRef(table->name), ".data[offset + ", i,

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -664,11 +664,12 @@ uint8_t ElemSegment::GetFlags(const Module* module) const {
       break;
   }
 
-  all_ref_func = all_ref_func &&
-                 std::all_of(elem_exprs.begin(), elem_exprs.end(),
-                             [](const ElemExpr& elem_expr) {
-                               return elem_expr.kind == ElemExprKind::RefFunc;
-                             });
+  all_ref_func =
+      all_ref_func &&
+      std::all_of(elem_exprs.begin(), elem_exprs.end(),
+                  [](const ExprList& elem_expr) {
+                    return elem_expr.front().type() == ExprType::RefFunc;
+                  });
   if (!all_ref_func) {
     flags |= SegUseElemExprs;
   }

--- a/src/ir.h
+++ b/src/ir.h
@@ -786,22 +786,7 @@ struct Table {
   Type elem_type;
 };
 
-enum class ElemExprKind {
-  RefNull,
-  RefFunc,
-};
-
-struct ElemExpr {
-  ElemExpr() : kind(ElemExprKind::RefNull), type(Type::FuncRef) {}
-  explicit ElemExpr(Var var) : kind(ElemExprKind::RefFunc), var(var) {}
-  explicit ElemExpr(Type type) : kind(ElemExprKind::RefNull), type(type) {}
-
-  ElemExprKind kind;
-  Var var;    // Only used when kind == RefFunc.
-  Type type;  // Only used when kind == RefNull
-};
-
-typedef std::vector<ElemExpr> ElemExprVector;
+typedef std::vector<ExprList> ExprListVector;
 
 struct ElemSegment {
   explicit ElemSegment(string_view name) : name(name.to_string()) {}
@@ -812,7 +797,7 @@ struct ElemSegment {
   Var table_var;
   Type elem_type;
   ExprList offset;
-  ElemExprVector elem_exprs;
+  ExprListVector elem_exprs;
 };
 
 struct Memory {

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -488,9 +488,10 @@ void NameResolver::VisitTag(Tag* tag) {
 void NameResolver::VisitElemSegment(ElemSegment* segment) {
   ResolveTableVar(&segment->table_var);
   visitor_.VisitExprList(segment->offset);
-  for (ElemExpr& elem_expr : segment->elem_exprs) {
-    if (elem_expr.kind == ElemExprKind::RefFunc) {
-      ResolveFuncVar(&elem_expr.var);
+  for (ExprList& elem_expr : segment->elem_exprs) {
+    if (elem_expr.size() == 1 &&
+        elem_expr.front().type() == ExprType::RefFunc) {
+      ResolveFuncVar(&cast<RefFuncExpr>(&elem_expr.front())->var);
     }
   }
 }

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -126,9 +126,9 @@ class WastParser {
   Result ParseTextList(std::vector<uint8_t>* out_data);
   bool ParseTextListOpt(std::vector<uint8_t>* out_data);
   Result ParseVarList(VarVector* out_var_list);
-  bool ParseElemExprOpt(ElemExpr* out_elem_expr);
-  bool ParseElemExprListOpt(ElemExprVector* out_list);
-  bool ParseElemExprVarListOpt(ElemExprVector* out_list);
+  bool ParseElemExprOpt(ExprList* out_elem_expr);
+  bool ParseElemExprListOpt(ExprListVector* out_list);
+  bool ParseElemExprVarListOpt(ExprListVector* out_list);
   Result ParseValueType(Type* out_type);
   Result ParseValueTypeList(TypeVector* out_type_list);
   Result ParseRefKind(Type* out_type);

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1396,20 +1396,13 @@ void WatWriter::WriteElemSegment(const ElemSegment& segment) {
     WritePuts("func", NextChar::Space);
   }
 
-  for (const ElemExpr& expr : segment.elem_exprs) {
+  for (const ExprList& expr : segment.elem_exprs) {
     if (flags & SegUseElemExprs) {
-      if (expr.kind == ElemExprKind::RefNull) {
-        WriteOpenSpace("ref.null");
-        WriteRefKind(expr.type, NextChar::Space);
-        WriteCloseSpace();
-      } else {
-        WriteOpenSpace("ref.func");
-        WriteVar(expr.var, NextChar::Space);
-        WriteCloseSpace();
-      }
+      WriteInitExpr(expr);
     } else {
-      assert(expr.kind == ElemExprKind::RefFunc);
-      WriteVar(expr.var, NextChar::Space);
+      assert(expr.size() == 1);
+      assert(expr.front().type() == ExprType::RefFunc);
+      WriteVar(cast<const RefFuncExpr>(&expr.front())->var, NextChar::Space);
     }
   }
   WriteCloseNewline();


### PR DESCRIPTION
Doing validation at parse time means we cannot run tests which
included invalid instruction in the elem init expressions.

For example. the updated test suite repo contains tests such as this:

```
(assert_invalid
  (module
    (table 1 funcref)
    (elem (i32.const 0) funcref (item (i32.add (i32.const 0) (i32.const 1))))
  )
  "constant expression required"
)
```

There we have an illegal instruction sequence in the init expresssion.
However, in order to run this test we need to be able to process it with
wast2json first which means it at least has to parse correctly.

This change removes the `ElemExpr` and `ElemExprKind` types from the IR
and instead just stores elem init expressions as `ExprList` like we do
for global init expressions.  This expression list can then be validated
but crucially can also be invalid.

This technique matches the existing `OnDataSegmentInitExpr_Other` and
`OnGlobalInitExpr_Other` and indeed it seem that it was indented to
work this way since the `OnElemSegmentElemExpr_Other` already existed
(unused) in the codebase.