### PR TITLE
Avoid changing directory in run-spec-wasm2c.py and honor --print-cmd. NFC

### DIFF
--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -20,10 +20,11 @@
 #include <cstdlib>
 
 #include "src/apply-names.h"
-#include "src/binary-reader.h"
 #include "src/binary-reader-ir.h"
+#include "src/binary-reader.h"
 #include "src/error-formatter.h"
 #include "src/feature.h"
+#include "src/filenames.h"
 #include "src/generate-names.h"
 #include "src/ir.h"
 #include "src/option-parser.h"
@@ -139,12 +140,13 @@ int ProgramMain(int argc, char** argv) {
 
       if (Succeeded(result)) {
         if (!s_outfile.empty()) {
-          std::string header_name =
+          std::string header_name_full =
               strip_extension(s_outfile).to_string() + ".h";
           FileStream c_stream(s_outfile.c_str());
-          FileStream h_stream(header_name);
-          result = WriteC(&c_stream, &h_stream, header_name.c_str(), &module,
-                          s_write_c_options);
+          FileStream h_stream(header_name_full);
+          string_view header_name = GetBasename(header_name_full);
+          result = WriteC(&c_stream, &h_stream, header_name.to_string().c_str(),
+                          &module, s_write_c_options);
         } else {
           FileStream stream(stdout);
           result =


### PR DESCRIPTION
With this change once can run `test/run-spec-wasm2c.py -p` and
any failing commands can be re-run directly from the root without
needing to figure out in which directory to run the command.