### PR TITLE
Fix crash when function counts mismatch

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -644,7 +644,13 @@ Result BinaryReaderIR::OnStartFunction(Index func_index) {
 }
 
 Result BinaryReaderIR::OnFunctionBodyCount(Index count) {
-  assert(module_->num_func_imports + count == module_->funcs.size());
+  // Can hit this case on a malformed module if we don't stop on first error.
+  if (module_->num_func_imports + count != module_->funcs.size()) {
+    PrintError(
+        "number of imported func + func count in code section does not match "
+        "actual number of funcs in module");
+    return Result::Error;
+  }
   return Result::Ok;
 }
 


### PR DESCRIPTION
This can happen if we don't stop on first error, and we get a malformed
module where the func counts don't match.

It's hard to write a test for this, since the kStopOnFirstError is fixed
(not set by command line), but this case is quite easy for fuzzers to
catch.