### PR TITLE
Handle invalid func type identifier in parser

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -342,9 +342,15 @@ Result CheckFuncTypeVarMatchesExplicit(const Location& loc,
       // ResolveFuncTypeWithEmptySignature), but if they are provided then we
       // have to check. If we get here then the type var is invalid, so we
       // can't check whether they match.
-      errors->emplace_back(ErrorLevel::Error, loc,
-                           StringPrintf("invalid func type index %" PRIindex,
-                                        decl.type_var.index()));
+      if (decl.type_var.is_index()) {
+        errors->emplace_back(ErrorLevel::Error, loc,
+                             StringPrintf("invalid func type index %" PRIindex,
+                                          decl.type_var.index()));
+      } else {
+        errors->emplace_back(ErrorLevel::Error, loc,
+                             StringPrintf("expected func type identifier %s",
+                                          decl.type_var.name().c_str()));
+      }
       result = Result::Error;
     }
   }


### PR DESCRIPTION
When checking for func type matching, we didn't handle the case where
the type use is an identifier.