### PR TITLE
Add support for inline export/import of exception tags

### DIFF
--- a/test/parse/module/export-tag.txt
+++ b/test/parse/module/export-tag.txt
@@ -2,4 +2,5 @@
 ;;; ARGS: --enable-exceptions
 (module
   (tag (param i32 i32))
-  (export "my_tag" (tag 0)))
+  (export "my_tag" (tag 0))
+  (tag (export "my_tag_2") (param i32)))

--- a/test/parse/module/import-tag.txt
+++ b/test/parse/module/import-tag.txt
@@ -1,4 +1,5 @@
 ;;; TOOL: wat2wasm
 ;;; ARGS: --enable-exceptions
 (module
-  (import "foo" "1" (tag (param f64 f32))))
+  (import "foo" "1" (tag (param f64 f32)))
+  (tag $t2 (import "foo" "2") (param i32 i64)))

--- a/test/typecheck/bad-tag-results.txt
+++ b/test/typecheck/bad-tag-results.txt
@@ -3,7 +3,7 @@
 ;;; ERROR: 1
 (module (tag (result i32)))
 (;; STDERR ;;;
-out/test/typecheck/bad-tag-results.txt:4:10: error: Tag signature must have 0 results.
+out/test/typecheck/bad-tag-results.txt:4:14: error: Tag signature must have 0 results.
 (module (tag (result i32)))
-         ^^^
+             ^
 ;;; STDERR ;;)


### PR DESCRIPTION
This PR adds support for inline export/import of tags in modules. e.g.,

```
(tag (import "foo" "bar") (param i32))
```

This is used in the spec tests for the exception handling proposal already:

  https://github.com/WebAssembly/exception-handling/blob/main/test/core/tag.wast

so it would be useful to support in wabt, so that the test suite can be imported in the future.