### PR TITLE
Add interpreter support for the exception handling proposal

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1555,8 +1555,9 @@ Result BinaryReaderInterp::OnCatchExpr(Index tag_index) {
     desc.try_end_offset = istream_.end();
   }
   // The label kind is switched to Block from Try in order to distinguish
-  // catch blocks from try blocks. This is needed for operations like
-  // GetNearestTryLabel, where we need to only find try blocks.
+  // catch blocks from try blocks. This is used to ensure that a try-delegate
+  // inside this catch will not delegate to the catch, and instead find outer
+  // try blocks to use as a delegate target.
   label->kind = LabelKind::Block;
   desc.catches.push_back(CatchDesc{tag_index, istream_.end()});
   return Result::Ok;

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1540,10 +1540,11 @@ Result BinaryReaderInterp::OnCatchExpr(Index tag_index) {
   Label* label = TopLabel();
   HandlerDesc& desc = func_->handlers[label->handler_desc_index];
   desc.kind = HandlerKind::Catch;
-  // Jump to the end of the block at the end of the previous try or catch.
+  // Drop the previous block's exception if it was a catch.
   if (label->kind == LabelKind::Block) {
     istream_.EmitCatchDrop(1);
   }
+  // Jump to the end of the block at the end of the previous try or catch.
   Istream::Offset offset = label->offset;
   istream_.Emit(Opcode::Br);
   assert(offset == Istream::kInvalidOffset);

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1516,7 +1516,7 @@ Result BinaryReaderInterp::OnRethrowExpr(Index depth) {
 Result BinaryReaderInterp::OnTryExpr(Type sig_type) {
   u32 exn_stack_height;
   CHECK_RESULT(
-    validator_.GetCatchCount(label_stack_.size() - 1, &exn_stack_height));
+      validator_.GetCatchCount(label_stack_.size() - 1, &exn_stack_height));
   u32 value_stack_height = validator_.type_stack_size();
   CHECK_RESULT(validator_.OnTry(loc, sig_type));
   // Push a label that tracks mapping of exn -> catch

--- a/src/interp/interp-inl.h
+++ b/src/interp/interp-inl.h
@@ -127,14 +127,14 @@ inline ExportType& ExportType::operator=(const ExportType& other) {
 //// Frame ////
 inline Frame::Frame(Ref func,
                     u32 values,
-                    u32 offset,
                     u32 exceptions,
+                    u32 offset,
                     Instance* inst,
                     Module* mod)
     : func(func),
       values(values),
-      offset(offset),
       exceptions(exceptions),
+      offset(offset),
       inst(inst),
       mod(mod) {}
 

--- a/src/interp/interp-inl.h
+++ b/src/interp/interp-inl.h
@@ -128,9 +128,15 @@ inline ExportType& ExportType::operator=(const ExportType& other) {
 inline Frame::Frame(Ref func,
                     u32 values,
                     u32 offset,
+                    u32 exceptions,
                     Instance* inst,
                     Module* mod)
-    : func(func), values(values), offset(offset), inst(inst), mod(mod) {}
+    : func(func),
+      values(values),
+      offset(offset),
+      exceptions(exceptions),
+      inst(inst),
+      mod(mod) {}
 
 //// FreeList ////
 template <typename T>
@@ -522,6 +528,25 @@ inline Trap::Ptr Trap::New(Store& store,
 
 inline std::string Trap::message() const {
   return message_;
+}
+
+//// Exception ////
+// static
+inline bool Exception::classof(const Object* obj) {
+  return obj->kind() == skind;
+}
+
+// static
+inline Exception::Ptr Exception::New(Store& store, Ref tag, Values& args) {
+  return store.Alloc<Exception>(store, tag, args);
+}
+
+inline Ref Exception::tag() const {
+  return tag_;
+}
+
+inline Values& Exception::args() {
+  return args_;
 }
 
 //// Extern ////

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -999,6 +999,9 @@ RunResult Thread::PushCall(const HostFunc& func, Trap::Ptr* out_trap) {
 }
 
 RunResult Thread::PopCall() {
+  // Sanity check that the exception stack was popped correctly.
+  assert(frames_.back().exceptions == exceptions_.size());
+
   frames_.pop_back();
   if (frames_.empty()) {
     return RunResult::Return;

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1837,7 +1837,8 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
     }
     case O::Rethrow: {
       u32 exn_index = instr.imm_u32;
-      Exception::Ptr exn{store_, exceptions_[exceptions_.size() - exn_index - 1]};
+      Exception::Ptr exn{store_,
+                         exceptions_[exceptions_.size() - exn_index - 1]};
       return DoThrow(exn);
     }
 

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -948,6 +948,7 @@ void Thread::Mark(Store& store) {
   for (auto index: refs_) {
     store.Mark(values_[index].Get<Ref>());
   }
+  store.Mark(exceptions_);
 }
 
 void Thread::PushValues(const ValueTypes& types, const Values& values) {

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -314,8 +314,8 @@ struct CatchDesc {
   u32 offset;
 };
 
-// The Try kind is for catch-less try blocks, which have a HandlerDesc that
-// is ignored as the block cannot ever catch an exception.
+// Handlers for a catch-less `try` or `try-catch` block are included in the
+// Catch kind. `try-delegate` instructions create a Delegate handler.
 enum class HandlerKind { Catch, Delegate };
 
 struct HandlerDesc {

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -418,7 +418,7 @@ struct Frame {
   Ref func;
   u32 values;  // Height of the value stack at this activation.
   u32 exceptions;  // Height of the exception stack at this activation.
-  u32 offset;  // Istream offset; either the return PC, or the current PC.
+  u32 offset;      // Istream offset; either the return PC, or the current PC.
 
   // Cached for convenience. Both are null if func is a HostFunc.
   Instance* inst;

--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -86,6 +86,12 @@ void Istream::EmitDropKeep(u32 drop, u32 keep) {
   }
 }
 
+void Istream::EmitCatchDrop(u32 drop) {
+  if (drop > 0) {
+    Emit(Opcode::InterpCatchDrop, drop);
+  }
+}
+
 Istream::Offset Istream::EmitFixupU32() {
   auto result = end();
   EmitInternal(kInvalidOffset);
@@ -493,6 +499,8 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::DataDrop:
     case Opcode::ElemDrop:
     case Opcode::RefFunc:
+    case Opcode::Throw:
+    case Opcode::Rethrow:
       // Index immediate, 0 operands.
       instr.kind = InstrKind::Imm_Index_Op_0;
       instr.imm_u32 = ReadAt<u32>(offset);
@@ -685,6 +693,8 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::AtomicFence:
     case Opcode::I32Const:
     case Opcode::InterpAlloca:
+    case Opcode::InterpCatchDrop:
+    case Opcode::InterpAdjustFrameForReturnCall:
       // i32/f32 immediate, 0 operands.
       instr.kind = InstrKind::Imm_I32_Op_0;
       instr.imm_u32 = ReadAt<u32>(offset);
@@ -762,8 +772,6 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::InterpData:
     case Opcode::Invalid:
     case Opcode::Loop:
-    case Opcode::Rethrow:
-    case Opcode::Throw:
     case Opcode::Try:
     case Opcode::ReturnCall:
       // Not used.

--- a/src/interp/istream.h
+++ b/src/interp/istream.h
@@ -91,9 +91,10 @@ class Istream {
   using SerializedOpcode = u32;  // TODO: change to u16
   using Offset = u32;
   static const Offset kInvalidOffset = ~0;
-  // Each br_table entry is made up of two instructions:
+  // Each br_table entry is made up of three instructions:
   //
   //   interp_drop_keep $drop $keep
+  //   interp_catch_drop $catches
   //   br $label
   //
   // Each opcode is a SerializedOpcode, and each immediate is a u32.

--- a/src/interp/istream.h
+++ b/src/interp/istream.h
@@ -98,7 +98,7 @@ class Istream {
   //
   // Each opcode is a SerializedOpcode, and each immediate is a u32.
   static const Offset kBrTableEntrySize =
-      sizeof(SerializedOpcode) * 2 + 3 * sizeof(u32);
+      sizeof(SerializedOpcode) * 3 + 4 * sizeof(u32);
 
   // Emit API.
   void Emit(u32);
@@ -110,6 +110,7 @@ class Istream {
   void Emit(Opcode::Enum, u32, u32);
   void Emit(Opcode::Enum, u32, u32, u8);
   void EmitDropKeep(u32 drop, u32 keep);
+  void EmitCatchDrop(u32 drop);
 
   Offset EmitFixupU32();
   void ResolveFixupU32(Offset);

--- a/src/opcode.def
+++ b/src/opcode.def
@@ -231,6 +231,8 @@ WABT_OPCODE(___,  I32,  ___,  ___,  0,  0,    0xe1, InterpBrUnless, "br_unless",
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe2, InterpCallImport, "call_import", "")
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe3, InterpData, "data", "")
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe4, InterpDropKeep, "drop_keep", "")
+WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe5, InterpCatchDrop, "catch_drop", "")
+WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe6, InterpAdjustFrameForReturnCall, "adjust_frame_for_return_call", "")
 
 /* Saturating float-to-int opcodes (--enable-saturating-float-to-int) */
 WABT_OPCODE(I32,  F32,  ___,  ___,  0,  0xfc, 0x00, I32TruncSatF32S, "i32.trunc_sat_f32_s", "")

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -51,8 +51,8 @@ class SharedValidator {
   Result GetLabel(Index depth, Label** out_label) {
     return typechecker_.GetLabel(depth, out_label);
   }
-  Result GetCatchDepth(Index depth, Index* out_depth) {
-    return typechecker_.GetCatchDepth(depth, out_depth);
+  Result GetCatchCount(Index depth, Index* out_count) {
+    return typechecker_.GetCatchCount(depth, out_count);
   }
 
   Result WABT_PRINTF_FORMAT(3, 4)

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -51,6 +51,9 @@ class SharedValidator {
   Result GetLabel(Index depth, Label** out_label) {
     return typechecker_.GetLabel(depth, out_label);
   }
+  Result GetCatchDepth(Index depth, Index* out_depth) {
+    return typechecker_.GetCatchDepth(depth, out_depth);
+  }
 
   Result WABT_PRINTF_FORMAT(3, 4)
       PrintError(const Location& loc, const char* fmt, ...);

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -100,20 +100,20 @@ Result TypeChecker::GetRethrowLabel(Index depth, Label** out_label) {
   return Result::Error;
 }
 
-Result TypeChecker::GetCatchDepth(Index depth, Index* out_depth) {
+Result TypeChecker::GetCatchCount(Index depth, Index* out_count) {
   Label* unused;
   if (Failed(GetLabel(depth, &unused))) {
     return Result::Error;
   }
 
-  Index catch_depth = 0;
+  Index catch_count = 0;
   for (Index idx = 0; idx <= depth; idx++) {
     LabelType type = label_stack_[label_stack_.size() - idx - 1].label_type;
     if (type == LabelType::Catch) {
-      catch_depth++;
+      catch_count++;
     }
   }
-  *out_depth = catch_depth;
+  *out_count = catch_count;
 
   return Result::Ok;
 }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -100,6 +100,24 @@ Result TypeChecker::GetRethrowLabel(Index depth, Label** out_label) {
   return Result::Error;
 }
 
+Result TypeChecker::GetCatchDepth(Index depth, Index* out_depth) {
+  Label* unused;
+  if (Failed(GetLabel(depth, &unused))) {
+    return Result::Error;
+  }
+
+  Index catch_depth = 0;
+  for (Index idx = 0; idx <= depth; idx++) {
+    LabelType type = label_stack_[label_stack_.size() - idx - 1].label_type;
+    if (type == LabelType::Catch) {
+      catch_depth++;
+    }
+  }
+  *out_depth = catch_depth;
+
+  return Result::Ok;
+}
+
 Result TypeChecker::TopLabel(Label** out_label) {
   return GetLabel(0, out_label);
 }

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -58,7 +58,7 @@ class TypeChecker {
   bool IsUnreachable();
   Result GetLabel(Index depth, Label** out_label);
   Result GetRethrowLabel(Index depth, Label** out_label);
-  Result GetCatchDepth(Index depth, Index* out_depth);
+  Result GetCatchCount(Index depth, Index* out_depth);
 
   Result BeginFunction(const TypeVector& sig);
   Result OnAtomicFence(uint32_t consistency_model);

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -58,6 +58,7 @@ class TypeChecker {
   bool IsUnreachable();
   Result GetLabel(Index depth, Label** out_label);
   Result GetRethrowLabel(Index depth, Label** out_label);
+  Result GetCatchDepth(Index depth, Index* out_depth);
 
   Result BeginFunction(const TypeVector& sig);
   Result OnAtomicFence(uint32_t consistency_model);

--- a/test/interp/rethrow-and-br.txt
+++ b/test/interp/rethrow-and-br.txt
@@ -3,6 +3,8 @@
 (module
   (tag $e1)
   (tag $e2)
+  (type $helper-type (func (result i32)))
+  (table anyfunc (elem $helper))
   (func (export "rethrow-br") (result i32)
     (try (result i32)
       (do
@@ -64,6 +66,16 @@
           (catch $e2
             (return_call $helper)))
         (i32.const 0))))
+  (func (export "rethrow-return-call-indirect") (result i32)
+    (try (result i32)
+      (do (throw $e1))
+      (catch $e1
+        (try $l
+          (do (throw $e2))
+          (catch $e2
+            (i32.const 0)
+            (return_call_indirect (type $helper-type))))
+        (i32.const 0))))
   (func $helper-2
     (try
       (do (throw $e2))
@@ -107,6 +119,7 @@ rethrow-br() => i32:1
 rethrow-br-if() => i32:1
 rethrow-br-table() => i32:1
 rethrow-return-call() => i32:1
+rethrow-return-call-indirect() => i32:1
 rethrow-return() => i32:1
 rethrow-throw() => i32:1
 ;;; STDOUT ;;)

--- a/test/interp/rethrow-and-br.txt
+++ b/test/interp/rethrow-and-br.txt
@@ -1,0 +1,73 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-exceptions --enable-tail-call
+(module
+  (tag $e1)
+  (tag $e2)
+  (func (export "rethrow-br") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (catch $e1
+            (try $l
+              (do (throw $e2))
+              (catch $e2
+                ;; exception stack has two entries
+                ;; br should reset to height of one
+                (br $l)))
+            ;; exception stack has one entry
+            (rethrow 0)))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "rethrow-br-if") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (catch $e1
+            (try $l
+              (do (throw $e2))
+              (catch $e2
+                (i32.const 1)
+                (br_if $l)))
+            (rethrow 0)))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "rethrow-br-table") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (catch $e1
+            (try $l
+              (do (throw $e2))
+              (catch $e2
+                (i32.const 1)
+                (br_table 1 $l 1)))
+            (rethrow 0)))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func $helper (result i32)
+    (try (result i32)
+      (do (throw $e1))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "rethrow-return-call") (result i32)
+    (try (result i32)
+      (do (throw $e1))
+      (catch $e1
+        (try $l
+          (do (throw $e2))
+          (catch $e2
+            (return_call $helper)))
+        (i32.const 0))))
+  )
+(;; STDOUT ;;;
+rethrow-br() => i32:1
+rethrow-br-if() => i32:1
+rethrow-br-table() => i32:1
+rethrow-return-call() => i32:1
+;;; STDOUT ;;)

--- a/test/interp/rethrow-and-br.txt
+++ b/test/interp/rethrow-and-br.txt
@@ -105,10 +105,11 @@
                 (try
                   (do (throw $e2))
                   (catch $e2
-                    ;; exception stack has $e2
+                    ;; exception stack has $e1, $e2
+                    ;; should get unwound on throw to $e1
                     (throw $e2))))
               (catch $e2
-                ;; exception stack *should* have $e1, $e2
+                ;; should reference $e1
                 (rethrow 1)))))
         (i32.const 0))
       (catch $e1 (i32.const 1))

--- a/test/interp/rethrow-and-br.txt
+++ b/test/interp/rethrow-and-br.txt
@@ -64,10 +64,49 @@
           (catch $e2
             (return_call $helper)))
         (i32.const 0))))
+  (func $helper-2
+    (try
+      (do (throw $e2))
+      (catch $e2
+        return)))
+  (func (export "rethrow-return") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do (throw $e1))
+          (catch $e1
+            (call $helper-2)
+            (rethrow 0))))
+      (catch $e1
+        (i32.const 1))
+      (catch $e2
+        (i32.const 0))))
+  ;; test rethrow stack interaction with throw, as if it were a br
+  (func (export "rethrow-throw") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (catch $e1
+            (try
+              (do
+                (try
+                  (do (throw $e2))
+                  (catch $e2
+                    ;; exception stack has $e2
+                    (throw $e2))))
+              (catch $e2
+                ;; exception stack *should* have $e1, $e2
+                (rethrow 1)))))
+        (i32.const 0))
+      (catch $e1 (i32.const 1))
+      (catch_all (i32.const 0))))
   )
 (;; STDOUT ;;;
 rethrow-br() => i32:1
 rethrow-br-if() => i32:1
 rethrow-br-table() => i32:1
 rethrow-return-call() => i32:1
+rethrow-return() => i32:1
+rethrow-throw() => i32:1
 ;;; STDOUT ;;)

--- a/test/interp/rethrow.txt
+++ b/test/interp/rethrow.txt
@@ -1,0 +1,43 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-exceptions
+(module
+  (tag $e1)
+  (tag $e2)
+  (func (export "rethrow-uncaught")
+    (try
+      (do
+        (throw $e1))
+      (catch $e1
+        (rethrow 0))))
+  (func (export "rethrow-1") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do
+            (throw $e1))
+          (catch $e1
+            (rethrow 0)))
+        (i32.const 0))
+      (catch_all
+        (i32.const 1))))
+  (func (export "rethrow-2") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do
+            (throw $e1))
+          (catch $e1
+            (try
+              (do
+                (throw $e2))
+              (catch $e2
+                (rethrow 1)))))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  )
+(;; STDOUT ;;;
+rethrow-uncaught() => error: uncaught exception
+rethrow-1() => i32:1
+rethrow-2() => i32:1
+;;; STDOUT ;;)

--- a/test/interp/throw-across-frame.txt
+++ b/test/interp/throw-across-frame.txt
@@ -1,0 +1,52 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-exceptions
+(module
+  (tag $e1)
+  (tag $e2)
+  (tag $e3)
+  (func $thrower
+    (throw $e1))
+  (func $thrower2
+    (try
+      (do (throw $e1))
+      (catch $e2)))
+  (func (export "call-thrower") (result i32)
+    (try (result i32)
+      (do
+        (call $thrower)
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "call-thrower2") (result i32)
+    (try (result i32)
+      (do
+        (call $thrower2)
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func $helper (result i32)
+    (try (result i32)
+      (do
+        (call $thrower2)
+        (i32.const 0))
+      (catch $e3
+        (i32.const 1))))
+  (func (export "call-thrower3") (result i32)
+    (try (result i32)
+      (do
+        (call $helper))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "call-thrower4") (result i32)
+    (try (result i32)
+      (do
+        (call $helper))
+      (catch $e2
+        (i32.const 1))))
+  )
+(;; STDOUT ;;;
+call-thrower() => i32:1
+call-thrower2() => i32:1
+call-thrower3() => i32:1
+call-thrower4() => error: uncaught exception
+;;; STDOUT ;;)

--- a/test/interp/try-delegate.txt
+++ b/test/interp/try-delegate.txt
@@ -1,0 +1,81 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-exceptions
+(module
+  (tag $e1)
+  (tag $e2)
+  (func (export "try-delegate") (result i32)
+    (try $l (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (delegate $l))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "try-delegate-2") (result i32)
+    (try $l (result i32)
+      (do
+        (try
+          (do
+            (try
+              (do (throw $e1))
+              (delegate $l)))
+          (catch_all))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "try-delegate-uncaught") (result i32)
+    (try $l (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (delegate $l))
+        (i32.const 0))
+      (catch $e2
+        (i32.const 0))))
+  (func (export "try-delegate-to-caller") (result i32)
+    (try (result i32)
+      (do
+        (try
+          (do (throw $e1))
+          (delegate 1))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "try-delegate-to-delegate") (result i32)
+    (try $l1 (result i32)
+      (do
+        (try $l2
+          (do
+            (try
+              (do
+                (try
+                  (do (throw $e1))
+                  (delegate $l2)))
+              (catch_all)))
+          (delegate $l1))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "try-delegate-to-block") (result i32)
+    (try (result i32)
+      (do
+        (block $l
+          (try
+            (do
+              (try
+                (do (throw $e1))
+                (delegate $l)))
+            (catch_all)))
+        (i32.const 0))
+      (catch $e1
+        (i32.const 1))))
+  )
+(;; STDOUT ;;;
+try-delegate() => i32:1
+try-delegate-2() => i32:1
+try-delegate-uncaught() => error: uncaught exception
+try-delegate-to-caller() => error: uncaught exception
+try-delegate-to-delegate() => i32:1
+try-delegate-to-block() => i32:1
+;;; STDOUT ;;)

--- a/test/interp/try.txt
+++ b/test/interp/try.txt
@@ -73,12 +73,56 @@
             (i32.const 2))))
       (catch_all
         (i32.const 3))))
+  (func (export "try-catch-nested-4") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do
+            (throw $e1))
+          (catch $e1
+            (try (do (throw $e2)))
+            (i32.const 0))
+          (catch $e2
+            (i32.const 0))))
+      (catch $e2
+        (i32.const 1))))
+  (func (export "try-catch-nested-5") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do
+            (throw $e1))
+          (catch $e1
+            (try (do (throw $e2)))
+            (i32.const 0))
+          (catch_all
+            (i32.const 0))))
+      (catch $e2
+        (i32.const 1))))
   (func (export "try-catch-uncaught") (result i32)
     (try (result i32)
       (do
         (throw $e1))
       (catch $e2
         (i32.const 1))))
+  (func (export "try-catch-stack-size") (result i32)
+    (i32.const 1)
+    (try
+      (do
+        (i32.const 0)
+        (throw $e1))
+      (catch $e1))
+    ;; here the value stack should have just 1
+    )
+  (func $helper
+    (try
+      (do
+        (i32.const 0)
+        (throw $e1))
+      (catch $e1)))
+  (func (export "try-catch-stack-size-2") (result i32)
+    (i32.const 1)
+    (call $helper))
         )
 (;; STDOUT ;;;
 throw-uncaught() => error: uncaught exception
@@ -91,5 +135,9 @@ try-catch-multi() => i32:2
 try-catch-nested() => i32:2
 try-catch-nested-2() => i32:1
 try-catch-nested-3() => i32:2
+try-catch-nested-4() => i32:1
+try-catch-nested-5() => i32:1
 try-catch-uncaught() => error: uncaught exception
+try-catch-stack-size() => i32:1
+try-catch-stack-size-2() => i32:1
 ;;; STDOUT ;;)

--- a/test/interp/try.txt
+++ b/test/interp/try.txt
@@ -1,0 +1,95 @@
+;;; TOOL: run-interp
+;;; ARGS*: --enable-exceptions
+(module
+  (tag $e1)
+  (tag $e2)
+  (tag $e3 (param i32))
+  (func (export "throw-uncaught")
+    (throw $e1))
+  (func (export "throw-uncaught-2")
+    (try
+      (do
+        (throw $e1))))
+  (func (export "try-catch") (result i32)
+    (try (result i32)
+      (do
+        (throw $e1))
+      (catch $e1
+        (i32.const 1))))
+  (func (export "try-catch-all") (result i32)
+    (try (result i32)
+      (do
+        (throw $e1))
+      (catch_all
+        (i32.const 1))))
+  (func (export "try-catch-all-2")
+    (try
+      (do
+        (i32.const 1)
+        (throw $e3))
+      (catch_all)))
+  (func (export "try-catch-payload") (result i32)
+    (try (result i32)
+      (do
+        (i32.const 42)
+        (throw $e3))
+      (catch $e3)))
+  (func (export "try-catch-multi") (result i32)
+    (try (result i32)
+      (do
+        (throw $e2))
+      (catch $e1
+        (i32.const 1))
+      (catch $e2
+        (i32.const 2))))
+  (func (export "try-catch-nested") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do (throw $e2))
+          (catch $e1
+            (i32.const 1))))
+      (catch $e2
+        (i32.const 2))))
+  (func (export "try-catch-nested-2") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do (throw $e1))
+          (catch $e1
+            (i32.const 1))))
+      (catch $e1
+        (i32.const 2))))
+  (func (export "try-catch-nested-3") (result i32)
+    (try (result i32)
+      (do
+        (try (result i32)
+          (do
+            (try (result i32)
+              (do (throw $e2))
+              (catch $e1
+                (i32.const 1))))
+          (catch $e2
+            (i32.const 2))))
+      (catch_all
+        (i32.const 3))))
+  (func (export "try-catch-uncaught") (result i32)
+    (try (result i32)
+      (do
+        (throw $e1))
+      (catch $e2
+        (i32.const 1))))
+        )
+(;; STDOUT ;;;
+throw-uncaught() => error: uncaught exception
+throw-uncaught-2() => error: uncaught exception
+try-catch() => i32:1
+try-catch-all() => i32:1
+try-catch-all-2() =>
+try-catch-payload() => i32:42
+try-catch-multi() => i32:2
+try-catch-nested() => i32:2
+try-catch-nested-2() => i32:1
+try-catch-nested-3() => i32:2
+try-catch-uncaught() => error: uncaught exception
+;;; STDOUT ;;)

--- a/test/interp/try.txt
+++ b/test/interp/try.txt
@@ -122,8 +122,7 @@
       (catch $e1)))
   (func (export "try-catch-stack-size-2") (result i32)
     (i32.const 1)
-    (call $helper))
-        )
+    (call $helper)))
 (;; STDOUT ;;;
 throw-uncaught() => error: uncaught exception
 throw-uncaught-2() => error: uncaught exception


### PR DESCRIPTION
This PR adds interpreter support for the exception handling proposal.

Details about the implementation approach:

  * Try blocks generate metadata tracking the instruction ranges for the handlers and which exception tags are handled (or if a `catch_all` is present). The metadata is stored in a function's `FuncDesc`, and is transferred into the `Frame` when a function call is executed.
  * The stack is unwound when a `throw` is executed. This unwinding also handles tag dispatch to the appropriate catch. The metadata to find the matching handler is looked up in the call `Frame` stack.
  * If a `try-delegate` is present, it is used in the stack unwinding process to skip over to the relevant handler.
  * A separate `exceptions_` stack in call frames tracks caught exceptions that can be accessed via a `rethrow`. The stack is popped on exit from a try block or when exiting via control instructions like `br`.
  * Because stack unwinding relies on finding metadata in the call frame, `return_call` needs to be modified slightly to adjust the current frame when executing the call, rather than re-using the frame completely as-is.

Spec tests will be followed up in future PRs once the proposal tests are merged into the official testsuite.