### PR TITLE
Re-enable simd in update-spec-tests.py

### DIFF
--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -90,6 +90,7 @@ def main(args):
     ProcessProposalDir('nontrapping-float-to-int-conversions',
                        '--enable-saturating-float-to-int')
     ProcessProposalDir('sign-extension-ops', '--enable-sign-extension')
+    ProcessProposalDir('simd')  # Already enabled by default.
     ProcessProposalDir('memory64', '--enable-memory64')
 
     return 0


### PR DESCRIPTION
This was removed as part of #1712 but I think it still needs to be here
until simd is actually merge into the main spec repo and no longer
exists as proposal in the testsuite repo.