### PR TITLE
Remove separate OnEndFunc vs OnEndExpr.

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -801,29 +801,31 @@ Result BinaryReaderIR::OnElseExpr() {
 }
 
 Result BinaryReaderIR::OnEndExpr() {
-  LabelNode* label;
-  Expr* expr;
-  CHECK_RESULT(TopLabelExpr(&label, &expr));
-  switch (label->label_type) {
-    case LabelType::Block:
-      cast<BlockExpr>(expr)->block.end_loc = GetLocation();
-      break;
-    case LabelType::Loop:
-      cast<LoopExpr>(expr)->block.end_loc = GetLocation();
-      break;
-    case LabelType::If:
-      cast<IfExpr>(expr)->true_.end_loc = GetLocation();
-      break;
-    case LabelType::Else:
-      cast<IfExpr>(expr)->false_end_loc = GetLocation();
-      break;
-    case LabelType::Try:
-      cast<TryExpr>(expr)->block.end_loc = GetLocation();
-      break;
+  if (label_stack_.size() > 1) {
+    LabelNode* label;
+    Expr* expr;
+    CHECK_RESULT(TopLabelExpr(&label, &expr));
+    switch (label->label_type) {
+      case LabelType::Block:
+        cast<BlockExpr>(expr)->block.end_loc = GetLocation();
+        break;
+      case LabelType::Loop:
+        cast<LoopExpr>(expr)->block.end_loc = GetLocation();
+        break;
+      case LabelType::If:
+        cast<IfExpr>(expr)->true_.end_loc = GetLocation();
+        break;
+      case LabelType::Else:
+        cast<IfExpr>(expr)->false_end_loc = GetLocation();
+        break;
+      case LabelType::Try:
+        cast<TryExpr>(expr)->block.end_loc = GetLocation();
+        break;
 
-    case LabelType::Func:
-    case LabelType::Catch:
-      break;
+      case LabelType::Func:
+      case LabelType::Catch:
+        break;
+    }
   }
 
   return PopLabel();
@@ -1078,7 +1080,6 @@ Result BinaryReaderIR::OnUnreachableExpr() {
 }
 
 Result BinaryReaderIR::EndFunctionBody(Index index) {
-  CHECK_RESULT(PopLabel());
   current_func_ = nullptr;
   return Result::Ok;
 }

--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -981,8 +981,4 @@ Result BinaryReaderLogging::OnOpcodeType(Type type) {
   return reader_->OnOpcodeType(type);
 }
 
-Result BinaryReaderLogging::OnEndFunc() {
-  return reader_->OnEndFunc();
-}
-
 }  // namespace wabt

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -176,7 +176,6 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
   Result OnDropExpr() override;
   Result OnElseExpr() override;
   Result OnEndExpr() override;
-  Result OnEndFunc() override;
   Result OnF32ConstExpr(uint32_t value_bits) override;
   Result OnF64ConstExpr(uint64_t value_bits) override;
   Result OnV128ConstExpr(v128 value_bits) override;

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -247,7 +247,6 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnDropExpr() override { return Result::Ok; }
   Result OnElseExpr() override { return Result::Ok; }
   Result OnEndExpr() override { return Result::Ok; }
-  Result OnEndFunc() override { return Result::Ok; }
   Result OnF32ConstExpr(uint32_t value_bits) override { return Result::Ok; }
   Result OnF64ConstExpr(uint64_t value_bits) override { return Result::Ok; }
   Result OnV128ConstExpr(v128 value_bits) override { return Result::Ok; }

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -485,7 +485,6 @@ class BinaryReaderObjdumpDisassemble : public BinaryReaderObjdumpBase {
                        Index default_target_depth) override;
   Result OnDelegateExpr(Index) override;
   Result OnEndExpr() override;
-  Result OnEndFunc() override;
 
  private:
   void LogOpcode(size_t data_size, const char* fmt, ...);
@@ -766,11 +765,6 @@ Result BinaryReaderObjdumpDisassemble::OnDelegateExpr(Index depth) {
   if (indent_level > 0) {
     indent_level--;
   }
-  return Result::Ok;
-}
-
-Result BinaryReaderObjdumpDisassemble::OnEndFunc() {
-  LogOpcode(0, nullptr);
   return Result::Ok;
 }
 

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -219,7 +219,6 @@ class BinaryReaderOpcnt : public BinaryReaderNop {
                        Index* target_depths,
                        Index default_target_depth) override;
   Result OnEndExpr() override;
-  Result OnEndFunc() override;
 
  private:
   template <typename... Args>
@@ -302,10 +301,6 @@ Result BinaryReaderOpcnt::OnBrTableExpr(Index num_targets,
 }
 
 Result BinaryReaderOpcnt::OnEndExpr() {
-  return Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
-}
-
-Result BinaryReaderOpcnt::OnEndFunc() {
   return Emplace(Opcode::End, OpcodeInfo::Kind::Bare);
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -782,11 +782,9 @@ Result BinaryReader::ReadFunctionBody(Offset end_offset) {
         break;
 
       case Opcode::End:
+        CALLBACK0(OnEndExpr);
         if (state_.offset == end_offset) {
           seen_end_opcode = true;
-          CALLBACK0(OnEndFunc);
-        } else {
-          CALLBACK0(OnEndExpr);
         }
         break;
 

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -242,7 +242,6 @@ class BinaryReaderDelegate {
   virtual Result OnDropExpr() = 0;
   virtual Result OnElseExpr() = 0;
   virtual Result OnEndExpr() = 0;
-  virtual Result OnEndFunc() = 0;
   virtual Result OnF32ConstExpr(uint32_t value_bits) = 0;
   virtual Result OnF64ConstExpr(uint64_t value_bits) = 0;
   virtual Result OnV128ConstExpr(v128 value_bits) = 0;

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1018,6 +1018,9 @@ Result BinaryReaderInterp::OnElseExpr() {
 }
 
 Result BinaryReaderInterp::OnEndExpr() {
+  if (label_stack_.size() == 1) {
+    return Result::Ok;
+  }
   SharedValidator::Label* label;
   CHECK_RESULT(validator_.GetLabel(0, &label));
   LabelType label_type = label->label_type;

--- a/test/binary/bad-extra-end.txt
+++ b/test/binary/bad-extra-end.txt
@@ -12,8 +12,8 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: accessing stack depth: 1 >= max: 1
-0000019: error: OnEndExpr callback failed
-error: accessing stack depth: 1 >= max: 1
-0000019: error: OnEndExpr callback failed
+error: popping empty label stack
+000001a: error: OnEndExpr callback failed
+error: popping empty label stack
+000001a: error: OnEndExpr callback failed
 ;;; STDERR ;;)

--- a/test/binary/bad-op-after-end.txt
+++ b/test/binary/bad-op-after-end.txt
@@ -12,8 +12,8 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: accessing stack depth: 1 >= max: 1
-0000019: error: OnEndExpr callback failed
-error: accessing stack depth: 1 >= max: 1
-0000019: error: OnEndExpr callback failed
+error: accessing stack depth: 0 >= max: 0
+000001a: error: OnNopExpr callback failed
+error: accessing stack depth: 0 >= max: 0
+000001a: error: OnNopExpr callback failed
 ;;; STDERR ;;)

--- a/test/interp/basic-logging.txt
+++ b/test/interp/basic-logging.txt
@@ -64,6 +64,7 @@ BeginModule(version: 1)
     OnLocalDeclCount(0)
     OnI32ConstExpr(42 (0x2a))
     OnReturnExpr
+    OnEndExpr
     EndFunctionBody(0)
   EndCodeSection
 EndModule

--- a/test/regress/regress-28.txt
+++ b/test/regress/regress-28.txt
@@ -15,6 +15,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: Unexpected instruction after end of function
-000001a: error: OnOpcode callback failed
+error: type mismatch in function, expected [] but got [any]
+000001c: error: EndFunctionBody callback failed
 ;;; STDERR ;;)


### PR DESCRIPTION
We already have EndFunctionBody, and this extra distinction
doesn't seem like it is needed.