### PR TITLE
Add specification tests for exception handling proposal

### DIFF
--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -586,6 +586,9 @@ void BinaryWriterSpec::WriteCommands() {
         WriteLocation(assert_exception_command->action->loc);
         WriteSeparator();
         WriteAction(*assert_exception_command->action);
+        WriteSeparator();
+        WriteKey("expected");
+        WriteActionResultType(*assert_exception_command->action);
         break;
       }
     }

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -135,6 +135,7 @@ void BinaryWriterSpec::WriteCommandType(const Command& command) {
       "assert_return",
       "assert_trap",
       "assert_exhaustion",
+      "assert_exception",
   };
   WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(s_command_names) == kCommandTypeCount);
 
@@ -577,6 +578,14 @@ void BinaryWriterSpec::WriteCommands() {
         WriteSeparator();
         WriteKey("expected");
         WriteActionResultType(*assert_exhaustion_command->action);
+        break;
+      }
+
+      case CommandType::AssertException: {
+        auto* assert_exception_command = cast<AssertExceptionCommand>(command);
+        WriteLocation(assert_exception_command->action->loc);
+        WriteSeparator();
+        WriteAction(*assert_exception_command->action);
         break;
       }
     }

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -164,7 +164,12 @@ std::unique_ptr<ExternType> TagType::Clone() const {
 Result Match(const TagType& expected,
              const TagType& actual,
              std::string* out_msg) {
-  // TODO signature
+  if (expected.signature != actual.signature) {
+    if (out_msg) {
+      *out_msg = "signature mismatch in imported tag";
+    }
+    return Result::Error;
+  }
   return Result::Ok;
 }
 

--- a/src/ir.h
+++ b/src/ir.h
@@ -1296,9 +1296,10 @@ enum class CommandType {
   AssertReturn,
   AssertTrap,
   AssertExhaustion,
+  AssertException,
 
   First = Module,
-  Last = AssertExhaustion,
+  Last = AssertException,
 };
 static const int kCommandTypeCount = WABT_ENUM_COUNT(CommandType);
 
@@ -1374,6 +1375,12 @@ typedef AssertModuleCommand<CommandType::AssertUnlinkable>
     AssertUnlinkableCommand;
 typedef AssertModuleCommand<CommandType::AssertUninstantiable>
     AssertUninstantiableCommand;
+
+class AssertExceptionCommand
+    : public CommandMixin<CommandType::AssertException> {
+ public:
+  ActionPtr action;
+};
 
 typedef std::unique_ptr<Command> CommandPtr;
 typedef std::vector<CommandPtr> CommandPtrVector;

--- a/src/lexer-keywords.txt
+++ b/src/lexer-keywords.txt
@@ -18,6 +18,7 @@ struct TokenInfo {
 };
 %%
 array, Type::Array, TokenType::Array
+assert_exception, TokenType::AssertException
 assert_exhaustion, TokenType::AssertExhaustion
 assert_invalid, TokenType::AssertInvalid
 assert_malformed, TokenType::AssertMalformed

--- a/src/prebuilt/lexer-keywords.cc
+++ b/src/prebuilt/lexer-keywords.cc
@@ -61,29 +61,35 @@ public:
 inline unsigned int
 Perfect_Hash::hash (const char *str, size_t len)
 {
-  static unsigned short asso_values[] = {
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 19,   16,
-      2793, 305,  12,   114,  11,   253,  141,  593,  392,  531,  13,   2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 11,
-      55,   57,   13,   97,   20,   17,   11,   554,  871,  14,   37,   52,
-      28,   12,   49,   66,   529,  42,   115,  11,   11,   13,   191,  133,
-      336,  72,   56,   2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
-      2793, 2793, 2793, 2793, 2793};
+  static unsigned short asso_values[] =
+    {
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793,   19,   16, 2793,  305,
+        12,  114,   11,  253,  141,  593,  392,  531,   13, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793,   11,   55,   57,   13,   97,
+        20,   17,   11,  554,  871,   14,   37,   52,   28,   12,
+        49,   66,  529,   42,  115,   11,   11,   13,  191,  133,
+       336,   72,   56, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793, 2793,
+      2793, 2793, 2793, 2793, 2793, 2793, 2793
+    };
   unsigned int hval = len;
 
   switch (hval)
@@ -150,3499 +156,1733 @@ Perfect_Hash::hash (const char *str, size_t len)
 struct TokenInfo *
 Perfect_Hash::InWordSet (const char *str, size_t len)
 {
-  enum {
-    TOTAL_KEYWORDS = 612,
-    MIN_WORD_LENGTH = 2,
-    MAX_WORD_LENGTH = 29,
-    MIN_HASH_VALUE = 27,
-    MAX_HASH_VALUE = 2792
-  };
+  enum
+    {
+      TOTAL_KEYWORDS = 613,
+      MIN_WORD_LENGTH = 2,
+      MAX_WORD_LENGTH = 29,
+      MIN_HASH_VALUE = 27,
+      MAX_HASH_VALUE = 2792
+    };
 
-  static struct TokenInfo wordlist[] = {
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 507 "src/lexer-keywords.txt"
+  static struct TokenInfo wordlist[] =
+    {
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 508 "src/lexer-keywords.txt"
       {"if", TokenType::If, Opcode::If},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 140 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 141 "src/lexer-keywords.txt"
       {"f64", Type::F64},
-#line 527 "src/lexer-keywords.txt"
+#line 528 "src/lexer-keywords.txt"
       {"mut", TokenType::Mut},
-#line 82 "src/lexer-keywords.txt"
+#line 83 "src/lexer-keywords.txt"
       {"f32", Type::F32},
-#line 439 "src/lexer-keywords.txt"
+#line 440 "src/lexer-keywords.txt"
       {"i64", Type::I64},
       {""},
-#line 301 "src/lexer-keywords.txt"
+#line 302 "src/lexer-keywords.txt"
       {"i32", Type::I32},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 511 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""},
+#line 512 "src/lexer-keywords.txt"
       {"item", TokenType::Item},
       {""},
-#line 47 "src/lexer-keywords.txt"
-      {"else", TokenType::Else, Opcode::Else},
-#line 46 "src/lexer-keywords.txt"
-      {"elem", TokenType::Elem},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 557 "src/lexer-keywords.txt"
-      {"table", TokenType::Table},
-      {""},
-      {""},
 #line 48 "src/lexer-keywords.txt"
+      {"else", TokenType::Else, Opcode::Else},
+#line 47 "src/lexer-keywords.txt"
+      {"elem", TokenType::Elem},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 558 "src/lexer-keywords.txt"
+      {"table", TokenType::Table},
+      {""}, {""},
+#line 49 "src/lexer-keywords.txt"
       {"end", TokenType::End, Opcode::End},
       {""},
-#line 127 "src/lexer-keywords.txt"
+#line 128 "src/lexer-keywords.txt"
       {"f64.lt", TokenType::Compare, Opcode::F64Lt},
-#line 70 "src/lexer-keywords.txt"
+#line 71 "src/lexer-keywords.txt"
       {"f32.lt", TokenType::Compare, Opcode::F32Lt},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 169 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 170 "src/lexer-keywords.txt"
       {"field", TokenType::Field},
-      {""},
-      {""},
-      {""},
-#line 125 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 126 "src/lexer-keywords.txt"
       {"f64.le", TokenType::Compare, Opcode::F64Le},
-#line 68 "src/lexer-keywords.txt"
+#line 69 "src/lexer-keywords.txt"
       {"f32.le", TokenType::Compare, Opcode::F32Le},
       {""},
-#line 111 "src/lexer-keywords.txt"
+#line 112 "src/lexer-keywords.txt"
       {"f64.abs", TokenType::Unary, Opcode::F64Abs},
-#line 53 "src/lexer-keywords.txt"
+#line 54 "src/lexer-keywords.txt"
       {"f32.abs", TokenType::Unary, Opcode::F32Abs},
-#line 138 "src/lexer-keywords.txt"
+#line 139 "src/lexer-keywords.txt"
       {"f64.sub", TokenType::Binary, Opcode::F64Sub},
-#line 80 "src/lexer-keywords.txt"
+#line 81 "src/lexer-keywords.txt"
       {"f32.sub", TokenType::Binary, Opcode::F32Sub},
-#line 558 "src/lexer-keywords.txt"
+#line 559 "src/lexer-keywords.txt"
       {"then", TokenType::Then},
-#line 430 "src/lexer-keywords.txt"
+#line 431 "src/lexer-keywords.txt"
       {"i64.sub", TokenType::Binary, Opcode::I64Sub},
-#line 292 "src/lexer-keywords.txt"
+#line 293 "src/lexer-keywords.txt"
       {"i32.sub", TokenType::Binary, Opcode::I32Sub},
-#line 526 "src/lexer-keywords.txt"
+#line 527 "src/lexer-keywords.txt"
       {"module", TokenType::Module},
-      {""},
-      {""},
-#line 546 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 547 "src/lexer-keywords.txt"
       {"select", TokenType::Select, Opcode::Select},
-#line 43 "src/lexer-keywords.txt"
+#line 44 "src/lexer-keywords.txt"
       {"do", TokenType::Do},
-#line 412 "src/lexer-keywords.txt"
+#line 413 "src/lexer-keywords.txt"
       {"i64.lt_s", TokenType::Compare, Opcode::I64LtS},
-#line 275 "src/lexer-keywords.txt"
+#line 276 "src/lexer-keywords.txt"
       {"i32.lt_s", TokenType::Compare, Opcode::I32LtS},
       {""},
-#line 40 "src/lexer-keywords.txt"
+#line 41 "src/lexer-keywords.txt"
       {"data", TokenType::Data},
-#line 413 "src/lexer-keywords.txt"
+#line 414 "src/lexer-keywords.txt"
       {"i64.lt_u", TokenType::Compare, Opcode::I64LtU},
-#line 276 "src/lexer-keywords.txt"
+#line 277 "src/lexer-keywords.txt"
       {"i32.lt_u", TokenType::Compare, Opcode::I32LtU},
-#line 403 "src/lexer-keywords.txt"
+#line 404 "src/lexer-keywords.txt"
       {"i64.le_s", TokenType::Compare, Opcode::I64LeS},
-#line 268 "src/lexer-keywords.txt"
+#line 269 "src/lexer-keywords.txt"
       {"i32.le_s", TokenType::Compare, Opcode::I32LeS},
-#line 548 "src/lexer-keywords.txt"
+#line 549 "src/lexer-keywords.txt"
       {"start", TokenType::Start},
       {""},
-#line 404 "src/lexer-keywords.txt"
+#line 405 "src/lexer-keywords.txt"
       {"i64.le_u", TokenType::Compare, Opcode::I64LeU},
-#line 269 "src/lexer-keywords.txt"
+#line 270 "src/lexer-keywords.txt"
       {"i32.le_u", TokenType::Compare, Opcode::I32LeU},
       {""},
-#line 112 "src/lexer-keywords.txt"
+#line 113 "src/lexer-keywords.txt"
       {"f64.add", TokenType::Binary, Opcode::F64Add},
-#line 54 "src/lexer-keywords.txt"
+#line 55 "src/lexer-keywords.txt"
       {"f32.add", TokenType::Binary, Opcode::F32Add},
       {""},
-#line 349 "src/lexer-keywords.txt"
+#line 350 "src/lexer-keywords.txt"
       {"i64.add", TokenType::Binary, Opcode::I64Add},
-#line 226 "src/lexer-keywords.txt"
+#line 227 "src/lexer-keywords.txt"
       {"i32.add", TokenType::Binary, Opcode::I32Add},
-#line 419 "src/lexer-keywords.txt"
-      {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
-#line 282 "src/lexer-keywords.txt"
-      {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
-      {""},
-      {""},
 #line 420 "src/lexer-keywords.txt"
-      {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
+      {"i64.rem_s", TokenType::Binary, Opcode::I64RemS},
 #line 283 "src/lexer-keywords.txt"
+      {"i32.rem_s", TokenType::Binary, Opcode::I32RemS},
+      {""}, {""},
+#line 421 "src/lexer-keywords.txt"
+      {"i64.rem_u", TokenType::Binary, Opcode::I64RemU},
+#line 284 "src/lexer-keywords.txt"
       {"i32.rem_u", TokenType::Binary, Opcode::I32RemU},
-#line 555 "src/lexer-keywords.txt"
+#line 556 "src/lexer-keywords.txt"
       {"table.set", TokenType::TableSet, Opcode::TableSet},
-      {""},
-      {""},
-#line 531 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 532 "src/lexer-keywords.txt"
       {"offset", TokenType::Offset},
-#line 170 "src/lexer-keywords.txt"
+#line 171 "src/lexer-keywords.txt"
       {"funcref", Type::FuncRef},
-      {""},
-      {""},
-#line 31 "src/lexer-keywords.txt"
-      {"br_table", TokenType::BrTable, Opcode::BrTable},
-      {""},
-      {""},
-#line 121 "src/lexer-keywords.txt"
-      {"f64.eq", TokenType::Compare, Opcode::F64Eq},
-#line 64 "src/lexer-keywords.txt"
-      {"f32.eq", TokenType::Compare, Opcode::F32Eq},
-#line 547 "src/lexer-keywords.txt"
-      {"shared", TokenType::Shared},
-#line 392 "src/lexer-keywords.txt"
-      {"i64.eq", TokenType::Compare, Opcode::I64Eq},
-#line 260 "src/lexer-keywords.txt"
-      {"i32.eq", TokenType::Compare, Opcode::I32Eq},
-#line 133 "src/lexer-keywords.txt"
-      {"f64.ne", TokenType::Compare, Opcode::F64Ne},
-#line 76 "src/lexer-keywords.txt"
-      {"f32.ne", TokenType::Compare, Opcode::F32Ne},
+      {""}, {""},
 #line 32 "src/lexer-keywords.txt"
+      {"br_table", TokenType::BrTable, Opcode::BrTable},
+      {""}, {""},
+#line 122 "src/lexer-keywords.txt"
+      {"f64.eq", TokenType::Compare, Opcode::F64Eq},
+#line 65 "src/lexer-keywords.txt"
+      {"f32.eq", TokenType::Compare, Opcode::F32Eq},
+#line 548 "src/lexer-keywords.txt"
+      {"shared", TokenType::Shared},
+#line 393 "src/lexer-keywords.txt"
+      {"i64.eq", TokenType::Compare, Opcode::I64Eq},
+#line 261 "src/lexer-keywords.txt"
+      {"i32.eq", TokenType::Compare, Opcode::I32Eq},
+#line 134 "src/lexer-keywords.txt"
+      {"f64.ne", TokenType::Compare, Opcode::F64Ne},
+#line 77 "src/lexer-keywords.txt"
+      {"f32.ne", TokenType::Compare, Opcode::F32Ne},
+#line 33 "src/lexer-keywords.txt"
       {"br", TokenType::Br, Opcode::Br},
-#line 415 "src/lexer-keywords.txt"
+#line 416 "src/lexer-keywords.txt"
       {"i64.ne", TokenType::Compare, Opcode::I64Ne},
-#line 278 "src/lexer-keywords.txt"
+#line 279 "src/lexer-keywords.txt"
       {"i32.ne", TokenType::Compare, Opcode::I32Ne},
       {""},
-#line 350 "src/lexer-keywords.txt"
+#line 351 "src/lexer-keywords.txt"
       {"i64.and", TokenType::Binary, Opcode::I64And},
-#line 227 "src/lexer-keywords.txt"
+#line 228 "src/lexer-keywords.txt"
       {"i32.and", TokenType::Binary, Opcode::I32And},
       {""},
-#line 113 "src/lexer-keywords.txt"
+#line 114 "src/lexer-keywords.txt"
       {"f64.ceil", TokenType::Unary, Opcode::F64Ceil},
-#line 55 "src/lexer-keywords.txt"
+#line 56 "src/lexer-keywords.txt"
       {"f32.ceil", TokenType::Unary, Opcode::F32Ceil},
       {""},
-#line 534 "src/lexer-keywords.txt"
-      {"ref", TokenType::Ref},
 #line 535 "src/lexer-keywords.txt"
+      {"ref", TokenType::Ref},
+#line 536 "src/lexer-keywords.txt"
       {"quote", TokenType::Quote},
       {""},
-#line 50 "src/lexer-keywords.txt"
+#line 51 "src/lexer-keywords.txt"
       {"extern", Type::ExternRef, TokenType::Extern},
       {""},
-#line 551 "src/lexer-keywords.txt"
+#line 552 "src/lexer-keywords.txt"
       {"table.fill", TokenType::TableFill, Opcode::TableFill},
       {""},
-#line 130 "src/lexer-keywords.txt"
+#line 131 "src/lexer-keywords.txt"
       {"f64.mul", TokenType::Binary, Opcode::F64Mul},
-#line 73 "src/lexer-keywords.txt"
+#line 74 "src/lexer-keywords.txt"
       {"f32.mul", TokenType::Binary, Opcode::F32Mul},
       {""},
-#line 414 "src/lexer-keywords.txt"
+#line 415 "src/lexer-keywords.txt"
       {"i64.mul", TokenType::Binary, Opcode::I64Mul},
-#line 277 "src/lexer-keywords.txt"
+#line 278 "src/lexer-keywords.txt"
       {"i32.mul", TokenType::Binary, Opcode::I32Mul},
-#line 554 "src/lexer-keywords.txt"
+#line 555 "src/lexer-keywords.txt"
       {"table.init", TokenType::TableInit, Opcode::TableInit},
-#line 168 "src/lexer-keywords.txt"
+#line 169 "src/lexer-keywords.txt"
       {"f64x2", TokenType::F64X2},
-      {""},
-      {""},
-#line 469 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 470 "src/lexer-keywords.txt"
       {"i64x2", TokenType::I64X2},
-#line 35 "src/lexer-keywords.txt"
+#line 36 "src/lexer-keywords.txt"
       {"call", TokenType::Call, Opcode::Call},
-#line 560 "src/lexer-keywords.txt"
+#line 561 "src/lexer-keywords.txt"
       {"try", TokenType::Try, Opcode::Try},
-      {""},
-      {""},
-#line 171 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 172 "src/lexer-keywords.txt"
       {"func", Type::FuncRef, TokenType::Func},
-#line 556 "src/lexer-keywords.txt"
+#line 557 "src/lexer-keywords.txt"
       {"table.size", TokenType::TableSize, Opcode::TableSize},
       {""},
-#line 29 "src/lexer-keywords.txt"
+#line 30 "src/lexer-keywords.txt"
       {"block", TokenType::Block, Opcode::Block},
       {""},
-#line 541 "src/lexer-keywords.txt"
+#line 542 "src/lexer-keywords.txt"
       {"result", TokenType::Result},
-      {""},
-      {""},
-      {""},
-#line 515 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 516 "src/lexer-keywords.txt"
       {"local", TokenType::Local},
-      {""},
-      {""},
-      {""},
-#line 549 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 550 "src/lexer-keywords.txt"
       {"struct", Type::Struct, TokenType::Struct},
-#line 389 "src/lexer-keywords.txt"
+#line 390 "src/lexer-keywords.txt"
       {"i64.ctz", TokenType::Unary, Opcode::I64Ctz},
-#line 257 "src/lexer-keywords.txt"
+#line 258 "src/lexer-keywords.txt"
       {"i32.ctz", TokenType::Unary, Opcode::I32Ctz},
-#line 421 "src/lexer-keywords.txt"
+#line 422 "src/lexer-keywords.txt"
       {"i64.rotl", TokenType::Binary, Opcode::I64Rotl},
-#line 284 "src/lexer-keywords.txt"
+#line 285 "src/lexer-keywords.txt"
       {"i32.rotl", TokenType::Binary, Opcode::I32Rotl},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 525 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 526 "src/lexer-keywords.txt"
       {"memory", TokenType::Memory},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 129 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 130 "src/lexer-keywords.txt"
       {"f64.min", TokenType::Binary, Opcode::F64Min},
-#line 72 "src/lexer-keywords.txt"
+#line 73 "src/lexer-keywords.txt"
       {"f32.min", TokenType::Binary, Opcode::F32Min},
-#line 387 "src/lexer-keywords.txt"
+#line 388 "src/lexer-keywords.txt"
       {"i64.clz", TokenType::Unary, Opcode::I64Clz},
-#line 255 "src/lexer-keywords.txt"
+#line 256 "src/lexer-keywords.txt"
       {"i32.clz", TokenType::Unary, Opcode::I32Clz},
-      {""},
-      {""},
-#line 524 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 525 "src/lexer-keywords.txt"
       {"memory.size", TokenType::MemorySize, Opcode::MemorySize},
-#line 393 "src/lexer-keywords.txt"
+#line 394 "src/lexer-keywords.txt"
       {"i64.eqz", TokenType::Convert, Opcode::I64Eqz},
-#line 261 "src/lexer-keywords.txt"
+#line 262 "src/lexer-keywords.txt"
       {"i32.eqz", TokenType::Convert, Opcode::I32Eqz},
-#line 114 "src/lexer-keywords.txt"
+#line 115 "src/lexer-keywords.txt"
       {"f64.const", TokenType::Const, Opcode::F64Const},
-#line 56 "src/lexer-keywords.txt"
+#line 57 "src/lexer-keywords.txt"
       {"f32.const", TokenType::Const, Opcode::F32Const},
       {""},
-#line 388 "src/lexer-keywords.txt"
+#line 389 "src/lexer-keywords.txt"
       {"i64.const", TokenType::Const, Opcode::I64Const},
-#line 256 "src/lexer-keywords.txt"
+#line 257 "src/lexer-keywords.txt"
       {"i32.const", TokenType::Const, Opcode::I32Const},
       {""},
-#line 126 "src/lexer-keywords.txt"
+#line 127 "src/lexer-keywords.txt"
       {"f64.load", TokenType::Load, Opcode::F64Load},
-#line 69 "src/lexer-keywords.txt"
+#line 70 "src/lexer-keywords.txt"
       {"f32.load", TokenType::Load, Opcode::F32Load},
       {""},
-#line 411 "src/lexer-keywords.txt"
+#line 412 "src/lexer-keywords.txt"
       {"i64.load", TokenType::Load, Opcode::I64Load},
-#line 274 "src/lexer-keywords.txt"
+#line 275 "src/lexer-keywords.txt"
       {"i32.load", TokenType::Load, Opcode::I32Load},
-      {""},
-      {""},
-      {""},
-#line 151 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 152 "src/lexer-keywords.txt"
       {"f64x2.lt", TokenType::Compare, Opcode::F64X2Lt},
-#line 163 "src/lexer-keywords.txt"
+#line 164 "src/lexer-keywords.txt"
       {"f64x2.sub", TokenType::Binary, Opcode::F64X2Sub},
-#line 513 "src/lexer-keywords.txt"
+#line 514 "src/lexer-keywords.txt"
       {"local.set", TokenType::LocalSet, Opcode::LocalSet},
       {""},
-#line 464 "src/lexer-keywords.txt"
+#line 465 "src/lexer-keywords.txt"
       {"i64x2.sub", TokenType::Binary, Opcode::I64X2Sub},
-#line 521 "src/lexer-keywords.txt"
+#line 522 "src/lexer-keywords.txt"
       {"memory.fill", TokenType::MemoryFill, Opcode::MemoryFill},
       {""},
-#line 136 "src/lexer-keywords.txt"
+#line 137 "src/lexer-keywords.txt"
       {"f64.sqrt", TokenType::Unary, Opcode::F64Sqrt},
-#line 78 "src/lexer-keywords.txt"
+#line 79 "src/lexer-keywords.txt"
       {"f32.sqrt", TokenType::Unary, Opcode::F32Sqrt},
-#line 523 "src/lexer-keywords.txt"
+#line 524 "src/lexer-keywords.txt"
       {"memory.init", TokenType::MemoryInit, Opcode::MemoryInit},
-#line 28 "src/lexer-keywords.txt"
+#line 29 "src/lexer-keywords.txt"
       {"binary", TokenType::Bin},
       {""},
-#line 150 "src/lexer-keywords.txt"
+#line 151 "src/lexer-keywords.txt"
       {"f64x2.le", TokenType::Compare, Opcode::F64X2Le},
       {""},
-#line 514 "src/lexer-keywords.txt"
+#line 515 "src/lexer-keywords.txt"
       {"local.tee", TokenType::LocalTee, Opcode::LocalTee},
       {""},
-#line 447 "src/lexer-keywords.txt"
+#line 448 "src/lexer-keywords.txt"
       {"i64x2.lt_s", TokenType::Binary, Opcode::I64X2LtS},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 449 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""},
+#line 450 "src/lexer-keywords.txt"
       {"i64x2.le_s", TokenType::Binary, Opcode::I64X2LeS},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 545 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""},
+#line 546 "src/lexer-keywords.txt"
       {"return", TokenType::Return, Opcode::Return},
-      {""},
-      {""},
-      {""},
-#line 154 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 155 "src/lexer-keywords.txt"
       {"f64x2.mul", TokenType::Binary, Opcode::F64X2Mul},
-#line 157 "src/lexer-keywords.txt"
+#line 158 "src/lexer-keywords.txt"
       {"f64x2.ne", TokenType::Compare, Opcode::F64X2Ne},
       {""},
-#line 444 "src/lexer-keywords.txt"
+#line 445 "src/lexer-keywords.txt"
       {"i64x2.mul", TokenType::Binary, Opcode::I64X2Mul},
-#line 446 "src/lexer-keywords.txt"
+#line 447 "src/lexer-keywords.txt"
       {"i64x2.ne", TokenType::Binary, Opcode::I64X2Ne},
       {""},
-#line 51 "src/lexer-keywords.txt"
+#line 52 "src/lexer-keywords.txt"
       {"externref", Type::ExternRef},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 141 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 142 "src/lexer-keywords.txt"
       {"f64x2.abs", TokenType::Unary, Opcode::F64X2Abs},
-      {""},
-      {""},
-#line 451 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 452 "src/lexer-keywords.txt"
       {"i64x2.abs", TokenType::Unary, Opcode::I64X2Abs},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 145 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 146 "src/lexer-keywords.txt"
       {"f64x2.eq", TokenType::Compare, Opcode::F64X2Eq},
-      {""},
-      {""},
-#line 445 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 446 "src/lexer-keywords.txt"
       {"i64x2.eq", TokenType::Binary, Opcode::I64X2Eq},
-#line 137 "src/lexer-keywords.txt"
+#line 138 "src/lexer-keywords.txt"
       {"f64.store", TokenType::Store, Opcode::F64Store},
-#line 79 "src/lexer-keywords.txt"
+#line 80 "src/lexer-keywords.txt"
       {"f32.store", TokenType::Store, Opcode::F32Store},
       {""},
-#line 429 "src/lexer-keywords.txt"
+#line 430 "src/lexer-keywords.txt"
       {"i64.store", TokenType::Store, Opcode::I64Store},
-#line 291 "src/lexer-keywords.txt"
+#line 292 "src/lexer-keywords.txt"
       {"i32.store", TokenType::Store, Opcode::I32Store},
-#line 510 "src/lexer-keywords.txt"
+#line 511 "src/lexer-keywords.txt"
       {"invoke", TokenType::Invoke},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 427 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 428 "src/lexer-keywords.txt"
       {"i64.store32", TokenType::Store, Opcode::I64Store32},
-#line 142 "src/lexer-keywords.txt"
+#line 143 "src/lexer-keywords.txt"
       {"f64x2.add", TokenType::Binary, Opcode::F64X2Add},
       {""},
-#line 37 "src/lexer-keywords.txt"
+#line 38 "src/lexer-keywords.txt"
       {"catch_all", TokenType::CatchAll, Opcode::CatchAll},
-#line 440 "src/lexer-keywords.txt"
+#line 441 "src/lexer-keywords.txt"
       {"i64x2.add", TokenType::Binary, Opcode::I64X2Add},
       {""},
-#line 41 "src/lexer-keywords.txt"
+#line 42 "src/lexer-keywords.txt"
       {"declare", TokenType::Declare},
       {""},
-#line 153 "src/lexer-keywords.txt"
+#line 154 "src/lexer-keywords.txt"
       {"f64x2.min", TokenType::Binary, Opcode::F64X2Min},
-#line 390 "src/lexer-keywords.txt"
+#line 391 "src/lexer-keywords.txt"
       {"i64.div_s", TokenType::Binary, Opcode::I64DivS},
-#line 258 "src/lexer-keywords.txt"
+#line 259 "src/lexer-keywords.txt"
       {"i32.div_s", TokenType::Binary, Opcode::I32DivS},
       {""},
-#line 110 "src/lexer-keywords.txt"
+#line 111 "src/lexer-keywords.txt"
       {"f32x4", TokenType::F32X4},
-#line 391 "src/lexer-keywords.txt"
+#line 392 "src/lexer-keywords.txt"
       {"i64.div_u", TokenType::Binary, Opcode::I64DivU},
-#line 259 "src/lexer-keywords.txt"
+#line 260 "src/lexer-keywords.txt"
       {"i32.div_u", TokenType::Binary, Opcode::I32DivU},
-#line 339 "src/lexer-keywords.txt"
+#line 340 "src/lexer-keywords.txt"
       {"i32x4", TokenType::I32X4},
-#line 532 "src/lexer-keywords.txt"
+#line 533 "src/lexer-keywords.txt"
       {"output", TokenType::Output},
-#line 539 "src/lexer-keywords.txt"
+#line 540 "src/lexer-keywords.txt"
       {"ref.null", TokenType::RefNull, Opcode::RefNull},
-#line 386 "src/lexer-keywords.txt"
+#line 387 "src/lexer-keywords.txt"
       {"i64.atomic.store", TokenType::AtomicStore, Opcode::I64AtomicStore},
-#line 254 "src/lexer-keywords.txt"
+#line 255 "src/lexer-keywords.txt"
       {"i32.atomic.store", TokenType::AtomicStore, Opcode::I32AtomicStore},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+      {""}, {""}, {""}, {""}, {""},
 #line 20 "src/lexer-keywords.txt"
       {"array", Type::Array, TokenType::Array},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 538 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 539 "src/lexer-keywords.txt"
       {"ref.is_null", TokenType::RefIsNull, Opcode::RefIsNull},
-      {""},
-      {""},
-#line 22 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 23 "src/lexer-keywords.txt"
       {"assert_invalid", TokenType::AssertInvalid},
-#line 384 "src/lexer-keywords.txt"
+#line 385 "src/lexer-keywords.txt"
       {"i64.atomic.store32", TokenType::AtomicStore, Opcode::I64AtomicStore32},
-#line 631 "src/lexer-keywords.txt"
+#line 632 "src/lexer-keywords.txt"
       {"set_local", TokenType::LocalSet, Opcode::LocalSet},
       {""},
-#line 143 "src/lexer-keywords.txt"
+#line 144 "src/lexer-keywords.txt"
       {"f64x2.ceil", TokenType::Unary, Opcode::F64X2Ceil},
-      {""},
-      {""},
-      {""},
-#line 632 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 633 "src/lexer-keywords.txt"
       {"tee_local", TokenType::LocalTee, Opcode::LocalTee},
       {""},
-#line 131 "src/lexer-keywords.txt"
+#line 132 "src/lexer-keywords.txt"
       {"f64.nearest", TokenType::Unary, Opcode::F64Nearest},
-#line 74 "src/lexer-keywords.txt"
+#line 75 "src/lexer-keywords.txt"
       {"f32.nearest", TokenType::Unary, Opcode::F32Nearest},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 407 "src/lexer-keywords.txt"
+#line 408 "src/lexer-keywords.txt"
       {"i64.load32_s", TokenType::Load, Opcode::I64Load32S},
       {""},
-#line 155 "src/lexer-keywords.txt"
+#line 156 "src/lexer-keywords.txt"
       {"f64x2.nearest", TokenType::Unary, Opcode::F64X2Nearest},
-#line 34 "src/lexer-keywords.txt"
+#line 35 "src/lexer-keywords.txt"
       {"call_ref", TokenType::CallRef, Opcode::CallRef},
-#line 408 "src/lexer-keywords.txt"
+#line 409 "src/lexer-keywords.txt"
       {"i64.load32_u", TokenType::Load, Opcode::I64Load32U},
-#line 162 "src/lexer-keywords.txt"
+#line 163 "src/lexer-keywords.txt"
       {"f64x2.sqrt", TokenType::Unary, Opcode::F64X2Sqrt},
-#line 62 "src/lexer-keywords.txt"
+#line 63 "src/lexer-keywords.txt"
       {"f32.demote_f64", TokenType::Convert, Opcode::F32DemoteF64},
-#line 354 "src/lexer-keywords.txt"
+#line 355 "src/lexer-keywords.txt"
       {"i64.atomic.load", TokenType::AtomicLoad, Opcode::I64AtomicLoad},
-#line 230 "src/lexer-keywords.txt"
+#line 231 "src/lexer-keywords.txt"
       {"i32.atomic.load", TokenType::AtomicLoad, Opcode::I32AtomicLoad},
-      {""},
-      {""},
-#line 599 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 600 "src/lexer-keywords.txt"
       {"f32.demote/f64", TokenType::Convert, Opcode::F32DemoteF64},
-#line 422 "src/lexer-keywords.txt"
+#line 423 "src/lexer-keywords.txt"
       {"i64.rotr", TokenType::Binary, Opcode::I64Rotr},
-#line 285 "src/lexer-keywords.txt"
+#line 286 "src/lexer-keywords.txt"
       {"i32.rotr", TokenType::Binary, Opcode::I32Rotr},
-#line 95 "src/lexer-keywords.txt"
+#line 96 "src/lexer-keywords.txt"
       {"f32x4.lt", TokenType::Compare, Opcode::F32X4Lt},
-#line 107 "src/lexer-keywords.txt"
+#line 108 "src/lexer-keywords.txt"
       {"f32x4.sub", TokenType::Binary, Opcode::F32X4Sub},
-      {""},
-      {""},
-#line 332 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 333 "src/lexer-keywords.txt"
       {"i32x4.sub", TokenType::Binary, Opcode::I32X4Sub},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 568 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 569 "src/lexer-keywords.txt"
       {"v128.not", TokenType::Unary, Opcode::V128Not},
-#line 94 "src/lexer-keywords.txt"
+#line 95 "src/lexer-keywords.txt"
       {"f32x4.le", TokenType::Compare, Opcode::F32X4Le},
-      {""},
-      {""},
-      {""},
-#line 317 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 318 "src/lexer-keywords.txt"
       {"i32x4.lt_s", TokenType::Compare, Opcode::I32X4LtS},
       {""},
-#line 318 "src/lexer-keywords.txt"
+#line 319 "src/lexer-keywords.txt"
       {"i32x4.lt_u", TokenType::Compare, Opcode::I32X4LtU},
       {""},
-#line 564 "src/lexer-keywords.txt"
+#line 565 "src/lexer-keywords.txt"
       {"v128.and", TokenType::Binary, Opcode::V128And},
       {""},
-#line 313 "src/lexer-keywords.txt"
+#line 314 "src/lexer-keywords.txt"
       {"i32x4.le_s", TokenType::Compare, Opcode::I32X4LeS},
       {""},
-#line 314 "src/lexer-keywords.txt"
+#line 315 "src/lexer-keywords.txt"
       {"i32x4.le_u", TokenType::Compare, Opcode::I32X4LeU},
-      {""},
-      {""},
-      {""},
-#line 454 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 455 "src/lexer-keywords.txt"
       {"i64x2.bitmask", TokenType::Unary, Opcode::I64X2Bitmask},
-      {""},
-      {""},
-      {""},
-#line 98 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 99 "src/lexer-keywords.txt"
       {"f32x4.mul", TokenType::Binary, Opcode::F32X4Mul},
-#line 101 "src/lexer-keywords.txt"
+#line 102 "src/lexer-keywords.txt"
       {"f32x4.ne", TokenType::Compare, Opcode::F32X4Ne},
       {""},
-#line 324 "src/lexer-keywords.txt"
+#line 325 "src/lexer-keywords.txt"
       {"i32x4.mul", TokenType::Binary, Opcode::I32X4Mul},
-#line 326 "src/lexer-keywords.txt"
+#line 327 "src/lexer-keywords.txt"
       {"i32x4.ne", TokenType::Compare, Opcode::I32X4Ne},
-#line 593 "src/lexer-keywords.txt"
+#line 594 "src/lexer-keywords.txt"
       {"i64.atomic.wait", TokenType::AtomicWait, Opcode::MemoryAtomicWait64},
-#line 592 "src/lexer-keywords.txt"
+#line 593 "src/lexer-keywords.txt"
       {"i32.atomic.wait", TokenType::AtomicWait, Opcode::MemoryAtomicWait32},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 83 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 84 "src/lexer-keywords.txt"
       {"f32x4.abs", TokenType::Unary, Opcode::F32X4Abs},
-      {""},
-      {""},
-#line 303 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 304 "src/lexer-keywords.txt"
       {"i32x4.abs", TokenType::Unary, Opcode::I32X4Abs},
-#line 470 "src/lexer-keywords.txt"
+#line 471 "src/lexer-keywords.txt"
       {"i64.xor", TokenType::Binary, Opcode::I64Xor},
-#line 348 "src/lexer-keywords.txt"
+#line 349 "src/lexer-keywords.txt"
       {"i32.xor", TokenType::Binary, Opcode::I32Xor},
-      {""},
-      {""},
-#line 89 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 90 "src/lexer-keywords.txt"
       {"f32x4.eq", TokenType::Compare, Opcode::F32X4Eq},
       {""},
-#line 321 "src/lexer-keywords.txt"
+#line 322 "src/lexer-keywords.txt"
       {"i32x4.min_s", TokenType::Binary, Opcode::I32X4MinS},
-#line 307 "src/lexer-keywords.txt"
+#line 308 "src/lexer-keywords.txt"
       {"i32x4.eq", TokenType::Compare, Opcode::I32X4Eq},
-#line 26 "src/lexer-keywords.txt"
+#line 27 "src/lexer-keywords.txt"
       {"assert_unlinkable", TokenType::AssertUnlinkable},
       {""},
-#line 322 "src/lexer-keywords.txt"
+#line 323 "src/lexer-keywords.txt"
       {"i32x4.min_u", TokenType::Binary, Opcode::I32X4MinU},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 139 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 140 "src/lexer-keywords.txt"
       {"f64.trunc", TokenType::Unary, Opcode::F64Trunc},
-#line 81 "src/lexer-keywords.txt"
+#line 82 "src/lexer-keywords.txt"
       {"f32.trunc", TokenType::Unary, Opcode::F32Trunc},
       {""},
-#line 544 "src/lexer-keywords.txt"
+#line 545 "src/lexer-keywords.txt"
       {"return_call", TokenType::ReturnCall, Opcode::ReturnCall},
-#line 567 "src/lexer-keywords.txt"
+#line 568 "src/lexer-keywords.txt"
       {"v128.load", TokenType::Load, Opcode::V128Load},
       {""},
-#line 84 "src/lexer-keywords.txt"
+#line 85 "src/lexer-keywords.txt"
       {"f32x4.add", TokenType::Binary, Opcode::F32X4Add},
-      {""},
-      {""},
-#line 304 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 305 "src/lexer-keywords.txt"
       {"i32x4.add", TokenType::Binary, Opcode::I32X4Add},
       {""},
-#line 33 "src/lexer-keywords.txt"
+#line 34 "src/lexer-keywords.txt"
       {"call_indirect", TokenType::CallIndirect, Opcode::CallIndirect},
-#line 563 "src/lexer-keywords.txt"
+#line 564 "src/lexer-keywords.txt"
       {"v128.andnot", TokenType::Binary, Opcode::V128Andnot},
-#line 97 "src/lexer-keywords.txt"
+#line 98 "src/lexer-keywords.txt"
       {"f32x4.min", TokenType::Binary, Opcode::F32X4Min},
       {""},
-#line 23 "src/lexer-keywords.txt"
+#line 24 "src/lexer-keywords.txt"
       {"assert_malformed", TokenType::AssertMalformed},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 120 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 121 "src/lexer-keywords.txt"
       {"f64.div", TokenType::Binary, Opcode::F64Div},
-#line 63 "src/lexer-keywords.txt"
+#line 64 "src/lexer-keywords.txt"
       {"f32.div", TokenType::Binary, Opcode::F32Div},
-#line 520 "src/lexer-keywords.txt"
+#line 521 "src/lexer-keywords.txt"
       {"memory.copy", TokenType::MemoryCopy, Opcode::MemoryCopy},
       {""},
-#line 565 "src/lexer-keywords.txt"
+#line 566 "src/lexer-keywords.txt"
       {"v128.bitselect", TokenType::Ternary, Opcode::V128BitSelect},
-#line 27 "src/lexer-keywords.txt"
+#line 28 "src/lexer-keywords.txt"
       {"atomic.fence", TokenType::AtomicFence, Opcode::AtomicFence},
       {""},
-#line 573 "src/lexer-keywords.txt"
+#line 574 "src/lexer-keywords.txt"
       {"v128.store", TokenType::Store, Opcode::V128Store},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 453 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 454 "src/lexer-keywords.txt"
       {"i64x2.all_true", TokenType::Unary, Opcode::I64X2AllTrue},
-      {""},
-      {""},
-#line 85 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 86 "src/lexer-keywords.txt"
       {"f32x4.ceil", TokenType::Unary, Opcode::F32X4Ceil},
       {""},
-#line 566 "src/lexer-keywords.txt"
+#line 567 "src/lexer-keywords.txt"
       {"v128.const", TokenType::Const, Opcode::V128Const},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 24 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 25 "src/lexer-keywords.txt"
       {"assert_return", TokenType::AssertReturn},
-      {""},
-      {""},
-      {""},
-#line 542 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 543 "src/lexer-keywords.txt"
       {"rethrow", TokenType::Rethrow, Opcode::Rethrow},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 99 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 100 "src/lexer-keywords.txt"
       {"f32x4.nearest", TokenType::Unary, Opcode::F32X4Nearest},
-      {""},
-      {""},
-#line 106 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 107 "src/lexer-keywords.txt"
       {"f32x4.sqrt", TokenType::Unary, Opcode::F32X4Sqrt},
       {""},
-#line 431 "src/lexer-keywords.txt"
-      {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
-#line 293 "src/lexer-keywords.txt"
-      {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
 #line 432 "src/lexer-keywords.txt"
-      {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
+      {"i64.trunc_f32_s", TokenType::Convert, Opcode::I64TruncF32S},
 #line 294 "src/lexer-keywords.txt"
+      {"i32.trunc_f32_s", TokenType::Convert, Opcode::I32TruncF32S},
+#line 433 "src/lexer-keywords.txt"
+      {"i64.trunc_f32_u", TokenType::Convert, Opcode::I64TruncF32U},
+#line 295 "src/lexer-keywords.txt"
       {"i32.trunc_f32_u", TokenType::Convert, Opcode::I32TruncF32U},
       {""},
-#line 622 "src/lexer-keywords.txt"
+#line 623 "src/lexer-keywords.txt"
       {"i64.trunc_s/f32", TokenType::Convert, Opcode::I64TruncF32S},
-#line 610 "src/lexer-keywords.txt"
+#line 611 "src/lexer-keywords.txt"
       {"i32.trunc_s/f32", TokenType::Convert, Opcode::I32TruncF32S},
-#line 626 "src/lexer-keywords.txt"
+#line 627 "src/lexer-keywords.txt"
       {"i64.trunc_u/f32", TokenType::Convert, Opcode::I64TruncF32U},
-#line 614 "src/lexer-keywords.txt"
+#line 615 "src/lexer-keywords.txt"
       {"i32.trunc_u/f32", TokenType::Convert, Opcode::I32TruncF32U},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 164 "src/lexer-keywords.txt"
+      {""}, {""}, {""}, {""},
+#line 165 "src/lexer-keywords.txt"
       {"f64x2.trunc", TokenType::Unary, Opcode::F64X2Trunc},
       {""},
-#line 147 "src/lexer-keywords.txt"
+#line 148 "src/lexer-keywords.txt"
       {"f64x2.floor", TokenType::Unary, Opcode::F64X2Floor},
       {""},
-#line 134 "src/lexer-keywords.txt"
+#line 135 "src/lexer-keywords.txt"
       {"f64.promote_f32", TokenType::Convert, Opcode::F64PromoteF32},
-      {""},
-      {""},
-      {""},
-#line 366 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.sub_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw32SubU},
-#line 605 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 367 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32SubU},
+#line 606 "src/lexer-keywords.txt"
       {"f64.promote/f32", TokenType::Convert, Opcode::F64PromoteF32},
       {""},
-#line 373 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.sub_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw8SubU},
-#line 242 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.sub_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw8SubU},
-#line 433 "src/lexer-keywords.txt"
-      {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
-#line 295 "src/lexer-keywords.txt"
-      {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
+#line 374 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8SubU},
+#line 243 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8SubU},
 #line 434 "src/lexer-keywords.txt"
-      {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
+      {"i64.trunc_f64_s", TokenType::Convert, Opcode::I64TruncF64S},
 #line 296 "src/lexer-keywords.txt"
+      {"i32.trunc_f64_s", TokenType::Convert, Opcode::I32TruncF64S},
+#line 435 "src/lexer-keywords.txt"
+      {"i64.trunc_f64_u", TokenType::Convert, Opcode::I64TruncF64U},
+#line 297 "src/lexer-keywords.txt"
       {"i32.trunc_f64_u", TokenType::Convert, Opcode::I32TruncF64U},
       {""},
-#line 623 "src/lexer-keywords.txt"
+#line 624 "src/lexer-keywords.txt"
       {"i64.trunc_s/f64", TokenType::Convert, Opcode::I64TruncF64S},
-#line 611 "src/lexer-keywords.txt"
+#line 612 "src/lexer-keywords.txt"
       {"i32.trunc_s/f64", TokenType::Convert, Opcode::I32TruncF64S},
-#line 627 "src/lexer-keywords.txt"
+#line 628 "src/lexer-keywords.txt"
       {"i64.trunc_u/f64", TokenType::Convert, Opcode::I64TruncF64U},
-#line 615 "src/lexer-keywords.txt"
+#line 616 "src/lexer-keywords.txt"
       {"i32.trunc_u/f64", TokenType::Convert, Opcode::I32TruncF64U},
-#line 306 "src/lexer-keywords.txt"
+#line 307 "src/lexer-keywords.txt"
       {"i32x4.bitmask", TokenType::Unary, Opcode::I32X4Bitmask},
-#line 569 "src/lexer-keywords.txt"
+#line 570 "src/lexer-keywords.txt"
       {"v128.or", TokenType::Binary, Opcode::V128Or},
-      {""},
-      {""},
-      {""},
-#line 369 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.add_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw8AddU},
-#line 238 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.add_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw8AddU},
-      {""},
-      {""},
-#line 405 "src/lexer-keywords.txt"
-      {"i64.load16_s", TokenType::Load, Opcode::I64Load16S},
-#line 270 "src/lexer-keywords.txt"
-      {"i32.load16_s", TokenType::Load, Opcode::I32Load16S},
-#line 517 "src/lexer-keywords.txt"
-      {"memory.atomic.notify", TokenType::AtomicNotify,
-       Opcode::MemoryAtomicNotify},
-      {""},
+      {""}, {""}, {""},
+#line 370 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AddU},
+#line 239 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AddU},
+      {""}, {""},
 #line 406 "src/lexer-keywords.txt"
-      {"i64.load16_u", TokenType::Load, Opcode::I64Load16U},
+      {"i64.load16_s", TokenType::Load, Opcode::I64Load16S},
 #line 271 "src/lexer-keywords.txt"
+      {"i32.load16_s", TokenType::Load, Opcode::I32Load16S},
+#line 518 "src/lexer-keywords.txt"
+      {"memory.atomic.notify", TokenType::AtomicNotify, Opcode::MemoryAtomicNotify},
+      {""},
+#line 407 "src/lexer-keywords.txt"
+      {"i64.load16_u", TokenType::Load, Opcode::I64Load16U},
+#line 272 "src/lexer-keywords.txt"
       {"i32.load16_u", TokenType::Load, Opcode::I32Load16U},
-      {""},
-      {""},
-#line 426 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 427 "src/lexer-keywords.txt"
       {"i64.store16", TokenType::Store, Opcode::I64Store16},
-#line 289 "src/lexer-keywords.txt"
+#line 290 "src/lexer-keywords.txt"
       {"i32.store16", TokenType::Store, Opcode::I32Store16},
       {""},
-#line 619 "src/lexer-keywords.txt"
+#line 620 "src/lexer-keywords.txt"
       {"i64.extend_s/i32", TokenType::Convert, Opcode::I64ExtendI32S},
       {""},
-#line 620 "src/lexer-keywords.txt"
+#line 621 "src/lexer-keywords.txt"
       {"i64.extend_u/i32", TokenType::Convert, Opcode::I64ExtendI32U},
-      {""},
-      {""},
-      {""},
-#line 583 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 584 "src/lexer-keywords.txt"
       {"v128.load64_lane", TokenType::SimdLoadLane, Opcode::V128Load64Lane},
-#line 582 "src/lexer-keywords.txt"
+#line 583 "src/lexer-keywords.txt"
       {"v128.load32_lane", TokenType::SimdLoadLane, Opcode::V128Load32Lane},
-      {""},
-      {""},
-      {""},
-#line 376 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 377 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I64AtomicRmwAdd},
-#line 245 "src/lexer-keywords.txt"
+#line 246 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.add", TokenType::AtomicRmw, Opcode::I32AtomicRmwAdd},
       {""},
-#line 370 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.and_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw8AndU},
-#line 239 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.and_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw8AndU},
-      {""},
-      {""},
-      {""},
-#line 362 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.add_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw32AddU},
-#line 561 "src/lexer-keywords.txt"
+#line 371 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8AndU},
+#line 240 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8AndU},
+      {""}, {""}, {""},
+#line 363 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AddU},
+#line 562 "src/lexer-keywords.txt"
       {"type", TokenType::Type},
-#line 529 "src/lexer-keywords.txt"
+#line 530 "src/lexer-keywords.txt"
       {"nan:canonical", TokenType::NanCanonical},
-      {""},
-      {""},
-#line 115 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 116 "src/lexer-keywords.txt"
       {"f64.convert_i32_s", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 57 "src/lexer-keywords.txt"
+#line 58 "src/lexer-keywords.txt"
       {"f32.convert_i32_s", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 580 "src/lexer-keywords.txt"
+#line 581 "src/lexer-keywords.txt"
       {"v128.load8_lane", TokenType::SimdLoadLane, Opcode::V128Load8Lane},
-      {""},
-      {""},
-#line 594 "src/lexer-keywords.txt"
+      {""}, {""},
+#line 595 "src/lexer-keywords.txt"
       {"anyfunc", Type::FuncRef},
       {""},
-#line 509 "src/lexer-keywords.txt"
+#line 510 "src/lexer-keywords.txt"
       {"input", TokenType::Input},
-#line 591 "src/lexer-keywords.txt"
+#line 592 "src/lexer-keywords.txt"
       {"atomic.notify", TokenType::AtomicNotify, Opcode::MemoryAtomicNotify},
-      {""},
-      {""},
-      {""},
-#line 383 "src/lexer-keywords.txt"
+      {""}, {""}, {""},
+#line 384 "src/lexer-keywords.txt"
       {"i64.atomic.store16", TokenType::AtomicStore, Opcode::I64AtomicStore16},
-#line 252 "src/lexer-keywords.txt"
+#line 253 "src/lexer-keywords.txt"
       {"i32.atomic.store16", TokenType::AtomicStore, Opcode::I32AtomicStore16},
-#line 172 "src/lexer-keywords.txt"
+#line 173 "src/lexer-keywords.txt"
       {"get", TokenType::Get},
-#line 144 "src/lexer-keywords.txt"
+#line 145 "src/lexer-keywords.txt"
       {"f64x2.div", TokenType::Binary, Opcode::F64X2Div},
       {""},
-#line 508 "src/lexer-keywords.txt"
+#line 509 "src/lexer-keywords.txt"
       {"import", TokenType::Import},
-#line 570 "src/lexer-keywords.txt"
+#line 571 "src/lexer-keywords.txt"
       {"v128.any_true", TokenType::Unary, Opcode::V128AnyTrue},
       {""},
-#line 52 "src/lexer-keywords.txt"
+#line 53 "src/lexer-keywords.txt"
       {"export", TokenType::Export},
       {""},
-#line 518 "src/lexer-keywords.txt"
-      {"memory.atomic.wait32", TokenType::AtomicWait,
-       Opcode::MemoryAtomicWait32},
-      {""},
-#line 363 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.and_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw32AndU},
-      {""},
-      {""},
-#line 117 "src/lexer-keywords.txt"
-      {"f64.convert_i64_s", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 59 "src/lexer-keywords.txt"
-      {"f32.convert_i64_s", TokenType::Convert, Opcode::F32ConvertI64S},
-#line 30 "src/lexer-keywords.txt"
-      {"br_if", TokenType::BrIf, Opcode::BrIf},
-#line 352 "src/lexer-keywords.txt"
-      {"i64.atomic.load32_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad32U},
-      {""},
-      {""},
-#line 305 "src/lexer-keywords.txt"
-      {"i32x4.all_true", TokenType::Unary, Opcode::I32X4AllTrue},
-#line 574 "src/lexer-keywords.txt"
-      {"v128", Type::V128},
-#line 559 "src/lexer-keywords.txt"
-      {"throw", TokenType::Throw, Opcode::Throw},
-#line 377 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I64AtomicRmwAnd},
-#line 246 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I32AtomicRmwAnd},
-      {""},
-      {""},
-#line 409 "src/lexer-keywords.txt"
-      {"i64.load8_s", TokenType::Load, Opcode::I64Load8S},
-#line 272 "src/lexer-keywords.txt"
-      {"i32.load8_s", TokenType::Load, Opcode::I32Load8S},
-      {""},
-      {""},
-#line 410 "src/lexer-keywords.txt"
-      {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
-#line 273 "src/lexer-keywords.txt"
-      {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
-      {""},
-      {""},
 #line 519 "src/lexer-keywords.txt"
-      {"memory.atomic.wait64", TokenType::AtomicWait,
-       Opcode::MemoryAtomicWait64},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 44 "src/lexer-keywords.txt"
-      {"drop", TokenType::Drop, Opcode::Drop},
-      {""},
-      {""},
-#line 395 "src/lexer-keywords.txt"
-      {"i64.extend32_s", TokenType::Unary, Opcode::I64Extend32S},
-#line 543 "src/lexer-keywords.txt"
-      {"return_call_indirect", TokenType::ReturnCallIndirect,
-       Opcode::ReturnCallIndirect},
-      {""},
-      {""},
-      {""},
-#line 516 "src/lexer-keywords.txt"
-      {"loop", TokenType::Loop, Opcode::Loop},
-      {""},
-#line 379 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I64AtomicRmwOr},
-#line 248 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I32AtomicRmwOr},
-      {""},
-      {""},
-#line 572 "src/lexer-keywords.txt"
-      {"v128.load64_zero", TokenType::Load, Opcode::V128Load64Zero},
-#line 571 "src/lexer-keywords.txt"
-      {"v128.load32_zero", TokenType::Load, Opcode::V128Load32Zero},
-      {""},
-#line 359 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.sub_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw16SubU},
-#line 235 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.sub_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw16SubU},
-#line 397 "src/lexer-keywords.txt"
-      {"i64.extend_i32_s", TokenType::Convert, Opcode::I64ExtendI32S},
-#line 108 "src/lexer-keywords.txt"
-      {"f32x4.trunc", TokenType::Unary, Opcode::F32X4Trunc},
-      {""},
-#line 91 "src/lexer-keywords.txt"
-      {"f32x4.floor", TokenType::Unary, Opcode::F32X4Floor},
-#line 398 "src/lexer-keywords.txt"
-      {"i64.extend_i32_u", TokenType::Convert, Opcode::I64ExtendI32U},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 428 "src/lexer-keywords.txt"
-      {"i64.store8", TokenType::Store, Opcode::I64Store8},
-#line 290 "src/lexer-keywords.txt"
-      {"i32.store8", TokenType::Store, Opcode::I32Store8},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 109 "src/lexer-keywords.txt"
-      {"f32x4.demote_f64x2_zero", TokenType::Unary,
-       Opcode::F32X4DemoteF64X2Zero},
-#line 552 "src/lexer-keywords.txt"
-      {"table.get", TokenType::TableGet, Opcode::TableGet},
-#line 38 "src/lexer-keywords.txt"
-      {"current_memory", TokenType::MemorySize, Opcode::MemorySize},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 365 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.or_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw32OrU},
-      {""},
-      {""},
-#line 380 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I64AtomicRmwSub},
-#line 249 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I32AtomicRmwSub},
-      {""},
-      {""},
-      {""},
-#line 601 "src/lexer-keywords.txt"
-      {"f64.convert_s/i32", TokenType::Convert, Opcode::F64ConvertI32S},
-#line 595 "src/lexer-keywords.txt"
-      {"f32.convert_s/i32", TokenType::Convert, Opcode::F32ConvertI32S},
-#line 603 "src/lexer-keywords.txt"
-      {"f64.convert_u/i32", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 597 "src/lexer-keywords.txt"
-      {"f32.convert_u/i32", TokenType::Convert, Opcode::F32ConvertI32U},
-#line 536 "src/lexer-keywords.txt"
-      {"ref.extern", TokenType::RefExtern},
-      {""},
-#line 581 "src/lexer-keywords.txt"
-      {"v128.load16_lane", TokenType::SimdLoadLane, Opcode::V128Load16Lane},
-      {""},
-      {""},
-      {""},
-#line 586 "src/lexer-keywords.txt"
-      {"v128.store32_lane", TokenType::SimdStoreLane, Opcode::V128Store32Lane},
-#line 435 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f32_s", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 297 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f32_s", TokenType::Convert, Opcode::I32TruncSatF32S},
-      {""},
-      {""},
-#line 436 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f32_u", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 298 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f32_u", TokenType::Convert, Opcode::I32TruncSatF32U},
-      {""},
-#line 355 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.add_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw16AddU},
-#line 231 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.add_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw16AddU},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 175 "src/lexer-keywords.txt"
-      {"global", TokenType::Global},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 587 "src/lexer-keywords.txt"
-      {"v128.store64_lane", TokenType::SimdStoreLane, Opcode::V128Store64Lane},
-      {""},
-      {""},
-#line 533 "src/lexer-keywords.txt"
-      {"param", TokenType::Param},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 356 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.and_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw16AndU},
-#line 232 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.and_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw16AndU},
-#line 88 "src/lexer-keywords.txt"
-      {"f32x4.div", TokenType::Binary, Opcode::F32X4Div},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 375 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.xor_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw8XorU},
-#line 244 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.xor_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw8XorU},
-      {""},
-#line 174 "src/lexer-keywords.txt"
-      {"global.set", TokenType::GlobalSet, Opcode::GlobalSet},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 319 "src/lexer-keywords.txt"
-      {"i32x4.max_s", TokenType::Binary, Opcode::I32X4MaxS},
-      {""},
-      {""},
-#line 149 "src/lexer-keywords.txt"
-      {"f64x2.gt", TokenType::Compare, Opcode::F64X2Gt},
-#line 320 "src/lexer-keywords.txt"
-      {"i32x4.max_u", TokenType::Binary, Opcode::I32X4MaxU},
-      {""},
-      {""},
-      {""},
-#line 21 "src/lexer-keywords.txt"
-      {"assert_exhaustion", TokenType::AssertExhaustion},
-      {""},
-      {""},
-#line 116 "src/lexer-keywords.txt"
-      {"f64.convert_i32_u", TokenType::Convert, Opcode::F64ConvertI32U},
-#line 58 "src/lexer-keywords.txt"
-      {"f32.convert_i32_u", TokenType::Convert, Opcode::F32ConvertI32U},
-      {""},
-      {""},
-#line 148 "src/lexer-keywords.txt"
-      {"f64x2.ge", TokenType::Compare, Opcode::F64X2Ge},
-      {""},
-      {""},
-      {""},
-#line 448 "src/lexer-keywords.txt"
-      {"i64x2.gt_s", TokenType::Binary, Opcode::I64X2GtS},
-#line 161 "src/lexer-keywords.txt"
-      {"f64x2.splat", TokenType::Unary, Opcode::F64X2Splat},
-      {""},
-#line 512 "src/lexer-keywords.txt"
-      {"local.get", TokenType::LocalGet, Opcode::LocalGet},
-#line 463 "src/lexer-keywords.txt"
-      {"i64x2.splat", TokenType::Unary, Opcode::I64X2Splat},
-      {""},
-#line 450 "src/lexer-keywords.txt"
-      {"i64x2.ge_s", TokenType::Binary, Opcode::I64X2GeS},
-      {""},
-      {""},
-#line 214 "src/lexer-keywords.txt"
-      {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 159 "src/lexer-keywords.txt"
-      {"f64x2.pmin", TokenType::Binary, Opcode::F64X2PMin},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 118 "src/lexer-keywords.txt"
-      {"f64.convert_i64_u", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 60 "src/lexer-keywords.txt"
-      {"f32.convert_i64_u", TokenType::Convert, Opcode::F32ConvertI64U},
-#line 195 "src/lexer-keywords.txt"
-      {"i16x8.lt_s", TokenType::Compare, Opcode::I16X8LtS},
-      {""},
-#line 196 "src/lexer-keywords.txt"
-      {"i16x8.lt_u", TokenType::Compare, Opcode::I16X8LtU},
-      {""},
-      {""},
-      {""},
-#line 191 "src/lexer-keywords.txt"
-      {"i16x8.le_s", TokenType::Compare, Opcode::I16X8LeS},
-      {""},
-#line 192 "src/lexer-keywords.txt"
-      {"i16x8.le_u", TokenType::Compare, Opcode::I16X8LeU},
-      {""},
-      {""},
-#line 442 "src/lexer-keywords.txt"
-      {"v128.load32x2_s", TokenType::Load, Opcode::V128Load32X2S},
-      {""},
-#line 443 "src/lexer-keywords.txt"
-      {"v128.load32x2_u", TokenType::Load, Opcode::V128Load32X2U},
-#line 416 "src/lexer-keywords.txt"
-      {"i64.or", TokenType::Binary, Opcode::I64Or},
-#line 279 "src/lexer-keywords.txt"
-      {"i32.or", TokenType::Binary, Opcode::I32Or},
-#line 358 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.or_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw16OrU},
-#line 234 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.or_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw16OrU},
-      {""},
-#line 201 "src/lexer-keywords.txt"
-      {"i16x8.mul", TokenType::Binary, Opcode::I16X8Mul},
-#line 206 "src/lexer-keywords.txt"
-      {"i16x8.ne", TokenType::Compare, Opcode::I16X8Ne},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 353 "src/lexer-keywords.txt"
-      {"i64.atomic.load8_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad8U},
-#line 229 "src/lexer-keywords.txt"
-      {"i32.atomic.load8_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad8U},
-      {""},
-      {""},
-#line 177 "src/lexer-keywords.txt"
-      {"i16x8.abs", TokenType::Unary, Opcode::I16X8Abs},
-#line 128 "src/lexer-keywords.txt"
-      {"f64.max", TokenType::Binary, Opcode::F64Max},
-#line 71 "src/lexer-keywords.txt"
-      {"f32.max", TokenType::Binary, Opcode::F32Max},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 199 "src/lexer-keywords.txt"
-      {"i16x8.min_s", TokenType::Binary, Opcode::I16X8MinS},
-#line 184 "src/lexer-keywords.txt"
-      {"i16x8.eq", TokenType::Compare, Opcode::I16X8Eq},
-      {""},
-      {""},
-#line 200 "src/lexer-keywords.txt"
-      {"i16x8.min_u", TokenType::Binary, Opcode::I16X8MinU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 550 "src/lexer-keywords.txt"
-      {"table.copy", TokenType::TableCopy, Opcode::TableCopy},
-#line 417 "src/lexer-keywords.txt"
-      {"i64.popcnt", TokenType::Unary, Opcode::I64Popcnt},
-#line 280 "src/lexer-keywords.txt"
-      {"i32.popcnt", TokenType::Unary, Opcode::I32Popcnt},
-#line 180 "src/lexer-keywords.txt"
-      {"i16x8.add", TokenType::Binary, Opcode::I16X8Add},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 602 "src/lexer-keywords.txt"
-      {"f64.convert_s/i64", TokenType::Convert, Opcode::F64ConvertI64S},
-#line 596 "src/lexer-keywords.txt"
-      {"f32.convert_s/i64", TokenType::Convert, Opcode::F32ConvertI64S},
-#line 604 "src/lexer-keywords.txt"
-      {"f64.convert_u/i64", TokenType::Convert, Opcode::F64ConvertI64U},
-#line 598 "src/lexer-keywords.txt"
-      {"f32.convert_u/i64", TokenType::Convert, Opcode::F32ConvertI64U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 437 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f64_s", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 299 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f64_s", TokenType::Convert, Opcode::I32TruncSatF64S},
-      {""},
-      {""},
-#line 438 "src/lexer-keywords.txt"
-      {"i64.trunc_sat_f64_u", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 300 "src/lexer-keywords.txt"
-      {"i32.trunc_sat_f64_u", TokenType::Convert, Opcode::I32TruncSatF64U},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 212 "src/lexer-keywords.txt"
-      {"i16x8.sub_sat_s", TokenType::Binary, Opcode::I16X8SubSatS},
-#line 575 "src/lexer-keywords.txt"
-      {"v128.xor", TokenType::Binary, Opcode::V128Xor},
-#line 213 "src/lexer-keywords.txt"
-      {"i16x8.sub_sat_u", TokenType::Binary, Opcode::I16X8SubSatU},
-      {""},
-#line 608 "src/lexer-keywords.txt"
-      {"get_local", TokenType::LocalGet, Opcode::LocalGet},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 146 "src/lexer-keywords.txt"
-      {"f64x2.extract_lane", TokenType::SimdLaneOp, Opcode::F64X2ExtractLane},
-      {""},
-      {""},
-#line 441 "src/lexer-keywords.txt"
-      {"i64x2.extract_lane", TokenType::SimdLaneOp, Opcode::I64X2ExtractLane},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 93 "src/lexer-keywords.txt"
-      {"f32x4.gt", TokenType::Compare, Opcode::F32X4Gt},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 368 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.xor_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw32XorU},
-      {""},
-#line 396 "src/lexer-keywords.txt"
-      {"i64.extend8_s", TokenType::Unary, Opcode::I64Extend8S},
-#line 263 "src/lexer-keywords.txt"
-      {"i32.extend8_s", TokenType::Unary, Opcode::I32Extend8S},
-      {""},
-      {""},
-#line 92 "src/lexer-keywords.txt"
-      {"f32x4.ge", TokenType::Compare, Opcode::F32X4Ge},
-      {""},
-      {""},
-      {""},
-#line 311 "src/lexer-keywords.txt"
-      {"i32x4.gt_s", TokenType::Compare, Opcode::I32X4GtS},
-#line 105 "src/lexer-keywords.txt"
-      {"f32x4.splat", TokenType::Unary, Opcode::F32X4Splat},
-#line 312 "src/lexer-keywords.txt"
-      {"i32x4.gt_u", TokenType::Compare, Opcode::I32X4GtU},
-      {""},
-#line 331 "src/lexer-keywords.txt"
-      {"i32x4.splat", TokenType::Unary, Opcode::I32X4Splat},
-      {""},
-#line 309 "src/lexer-keywords.txt"
-      {"i32x4.ge_s", TokenType::Compare, Opcode::I32X4GeS},
-      {""},
-#line 310 "src/lexer-keywords.txt"
-      {"i32x4.ge_u", TokenType::Compare, Opcode::I32X4GeU},
-      {""},
-#line 152 "src/lexer-keywords.txt"
-      {"f64x2.max", TokenType::Binary, Opcode::F64X2Max},
-      {""},
-      {""},
-      {""},
-#line 103 "src/lexer-keywords.txt"
-      {"f32x4.pmin", TokenType::Binary, Opcode::F32X4PMin},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 315 "src/lexer-keywords.txt"
-      {"v128.load16x4_s", TokenType::Load, Opcode::V128Load16X4S},
-      {""},
-#line 316 "src/lexer-keywords.txt"
-      {"v128.load16x4_u", TokenType::Load, Opcode::V128Load16X4U},
-#line 178 "src/lexer-keywords.txt"
-      {"i16x8.add_sat_s", TokenType::Binary, Opcode::I16X8AddSatS},
-      {""},
-#line 179 "src/lexer-keywords.txt"
-      {"i16x8.add_sat_u", TokenType::Binary, Opcode::I16X8AddSatU},
-#line 124 "src/lexer-keywords.txt"
-      {"f64.gt", TokenType::Compare, Opcode::F64Gt},
-#line 67 "src/lexer-keywords.txt"
-      {"f32.gt", TokenType::Compare, Opcode::F32Gt},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 183 "src/lexer-keywords.txt"
-      {"i16x8.bitmask", TokenType::Unary, Opcode::I16X8Bitmask},
-      {""},
-#line 367 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.xchg_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw32XchgU},
-      {""},
-#line 553 "src/lexer-keywords.txt"
-      {"table.grow", TokenType::TableGrow, Opcode::TableGrow},
-#line 123 "src/lexer-keywords.txt"
-      {"f64.ge", TokenType::Compare, Opcode::F64Ge},
-#line 66 "src/lexer-keywords.txt"
-      {"f32.ge", TokenType::Compare, Opcode::F32Ge},
-      {""},
-      {""},
-#line 176 "src/lexer-keywords.txt"
-      {"grow_memory", TokenType::MemoryGrow, Opcode::MemoryGrow},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 394 "src/lexer-keywords.txt"
-      {"i64.extend16_s", TokenType::Unary, Opcode::I64Extend16S},
-#line 262 "src/lexer-keywords.txt"
-      {"i32.extend16_s", TokenType::Unary, Opcode::I32Extend16S},
-#line 537 "src/lexer-keywords.txt"
-      {"ref.func", TokenType::RefFunc, Opcode::RefFunc},
-      {""},
-#line 540 "src/lexer-keywords.txt"
-      {"register", TokenType::Register},
-      {""},
-#line 401 "src/lexer-keywords.txt"
-      {"i64.gt_s", TokenType::Compare, Opcode::I64GtS},
-#line 266 "src/lexer-keywords.txt"
-      {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
-      {""},
-      {""},
-#line 402 "src/lexer-keywords.txt"
-      {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
-#line 267 "src/lexer-keywords.txt"
-      {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
-#line 399 "src/lexer-keywords.txt"
-      {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
-#line 264 "src/lexer-keywords.txt"
-      {"i32.ge_s", TokenType::Compare, Opcode::I32GeS},
-      {""},
-      {""},
-#line 400 "src/lexer-keywords.txt"
-      {"i64.ge_u", TokenType::Compare, Opcode::I64GeU},
-#line 265 "src/lexer-keywords.txt"
-      {"i32.ge_u", TokenType::Compare, Opcode::I32GeU},
-#line 584 "src/lexer-keywords.txt"
-      {"v128.store8_lane", TokenType::SimdStoreLane, Opcode::V128Store8Lane},
-      {""},
-      {""},
-      {""},
-#line 465 "src/lexer-keywords.txt"
-      {"i64x2.extmul_low_i32x4_s", TokenType::Binary,
-       Opcode::I64X2ExtmulLowI32X4S},
-      {""},
-#line 467 "src/lexer-keywords.txt"
-      {"i64x2.extmul_low_i32x4_u", TokenType::Binary,
-       Opcode::I64X2ExtmulLowI32X4U},
-      {""},
-      {""},
-      {""},
-#line 423 "src/lexer-keywords.txt"
-      {"i64.shl", TokenType::Binary, Opcode::I64Shl},
-#line 286 "src/lexer-keywords.txt"
-      {"i32.shl", TokenType::Binary, Opcode::I32Shl},
-      {""},
-      {""},
-      {""},
-#line 122 "src/lexer-keywords.txt"
-      {"f64.floor", TokenType::Unary, Opcode::F64Floor},
-#line 65 "src/lexer-keywords.txt"
-      {"f32.floor", TokenType::Unary, Opcode::F32Floor},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 455 "src/lexer-keywords.txt"
-      {"i64x2.extend_low_i32x4_s", TokenType::Unary,
-       Opcode::I64X2ExtendLowI32X4S},
-      {""},
-#line 457 "src/lexer-keywords.txt"
-      {"i64x2.extend_low_i32x4_u", TokenType::Unary,
-       Opcode::I64X2ExtendLowI32X4U},
-#line 165 "src/lexer-keywords.txt"
-      {"f64x2.convert_low_i32x4_s", TokenType::Unary,
-       Opcode::F64X2ConvertLowI32X4S},
-      {""},
-#line 166 "src/lexer-keywords.txt"
-      {"f64x2.convert_low_i32x4_u", TokenType::Unary,
-       Opcode::F64X2ConvertLowI32X4U},
-#line 36 "src/lexer-keywords.txt"
-      {"catch", TokenType::Catch, Opcode::Catch},
-      {""},
-      {""},
-#line 585 "src/lexer-keywords.txt"
-      {"v128.store16_lane", TokenType::SimdStoreLane, Opcode::V128Store16Lane},
-      {""},
-      {""},
-      {""},
-#line 181 "src/lexer-keywords.txt"
-      {"i16x8.all_true", TokenType::Unary, Opcode::I16X8AllTrue},
-      {""},
-#line 579 "src/lexer-keywords.txt"
-      {"v128.load8_splat", TokenType::Load, Opcode::V128Load8Splat},
-      {""},
-      {""},
-#line 90 "src/lexer-keywords.txt"
-      {"f32x4.extract_lane", TokenType::SimdLaneOp, Opcode::F32X4ExtractLane},
-      {""},
-      {""},
-#line 308 "src/lexer-keywords.txt"
-      {"i32x4.extract_lane", TokenType::SimdLaneOp, Opcode::I32X4ExtractLane},
-#line 361 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.xor_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw16XorU},
-#line 237 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.xor_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw16XorU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 505 "src/lexer-keywords.txt"
-      {"i8x16.sub", TokenType::Binary, Opcode::I8X16Sub},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 42 "src/lexer-keywords.txt"
-      {"delegate", TokenType::Delegate},
-      {""},
-      {""},
-      {""},
-#line 487 "src/lexer-keywords.txt"
-      {"i8x16.lt_s", TokenType::Compare, Opcode::I8X16LtS},
-      {""},
-#line 488 "src/lexer-keywords.txt"
-      {"i8x16.lt_u", TokenType::Compare, Opcode::I8X16LtU},
-      {""},
-      {""},
-      {""},
-#line 485 "src/lexer-keywords.txt"
-      {"i8x16.le_s", TokenType::Compare, Opcode::I8X16LeS},
-      {""},
-#line 486 "src/lexer-keywords.txt"
-      {"i8x16.le_u", TokenType::Compare, Opcode::I8X16LeU},
-      {""},
-      {""},
-      {""},
-#line 96 "src/lexer-keywords.txt"
-      {"f32x4.max", TokenType::Binary, Opcode::F32X4Max},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 578 "src/lexer-keywords.txt"
-      {"v128.load64_splat", TokenType::Load, Opcode::V128Load64Splat},
-#line 577 "src/lexer-keywords.txt"
-      {"v128.load32_splat", TokenType::Load, Opcode::V128Load32Splat},
-      {""},
-#line 497 "src/lexer-keywords.txt"
-      {"i8x16.ne", TokenType::Compare, Opcode::I8X16Ne},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 360 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.xchg_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw16XchgU},
-#line 236 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.xchg_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw16XchgU},
-      {""},
-      {""},
-#line 471 "src/lexer-keywords.txt"
-      {"i8x16.abs", TokenType::Unary, Opcode::I8X16Abs},
-#line 424 "src/lexer-keywords.txt"
-      {"i64.shr_s", TokenType::Binary, Opcode::I64ShrS},
-#line 287 "src/lexer-keywords.txt"
-      {"i32.shr_s", TokenType::Binary, Opcode::I32ShrS},
-      {""},
-      {""},
-#line 425 "src/lexer-keywords.txt"
-      {"i64.shr_u", TokenType::Binary, Opcode::I64ShrU},
-#line 288 "src/lexer-keywords.txt"
-      {"i32.shr_u", TokenType::Binary, Opcode::I32ShrU},
-#line 491 "src/lexer-keywords.txt"
-      {"i8x16.min_s", TokenType::Binary, Opcode::I8X16MinS},
-#line 478 "src/lexer-keywords.txt"
-      {"i8x16.eq", TokenType::Compare, Opcode::I8X16Eq},
-#line 522 "src/lexer-keywords.txt"
-      {"memory.grow", TokenType::MemoryGrow, Opcode::MemoryGrow},
-      {""},
-#line 492 "src/lexer-keywords.txt"
-      {"i8x16.min_u", TokenType::Binary, Opcode::I8X16MinU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 221 "src/lexer-keywords.txt"
-      {"i16x8", TokenType::I16X8},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 474 "src/lexer-keywords.txt"
-      {"i8x16.add", TokenType::Binary, Opcode::I8X16Add},
-#line 506 "src/lexer-keywords.txt"
-      {"i8x16", TokenType::I8X16},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 630 "src/lexer-keywords.txt"
-      {"set_global", TokenType::GlobalSet, Opcode::GlobalSet},
-      {""},
-      {""},
-      {""},
-#line 158 "src/lexer-keywords.txt"
-      {"f64x2.pmax", TokenType::Binary, Opcode::F64X2PMax},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 460 "src/lexer-keywords.txt"
-      {"i64x2.shl", TokenType::Binary, Opcode::I64X2Shl},
-#line 77 "src/lexer-keywords.txt"
-      {"f32.reinterpret_i32", TokenType::Convert, Opcode::F32ReinterpretI32},
-      {""},
-      {""},
-      {""},
-#line 530 "src/lexer-keywords.txt"
-      {"nop", TokenType::Nop, Opcode::Nop},
-#line 600 "src/lexer-keywords.txt"
-      {"f32.reinterpret/i32", TokenType::Convert, Opcode::F32ReinterpretI32},
-      {""},
-      {""},
-      {""},
-#line 503 "src/lexer-keywords.txt"
-      {"i8x16.sub_sat_s", TokenType::Binary, Opcode::I8X16SubSatS},
-      {""},
-#line 504 "src/lexer-keywords.txt"
-      {"i8x16.sub_sat_u", TokenType::Binary, Opcode::I8X16SubSatU},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 49 "src/lexer-keywords.txt"
-      {"tag", TokenType::Tag},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 372 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8OrU},
-#line 241 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8OrU},
-      {""},
-#line 135 "src/lexer-keywords.txt"
-      {"f64.reinterpret_i64", TokenType::Convert, Opcode::F64ReinterpretI64},
-#line 624 "src/lexer-keywords.txt"
-      {"i64.trunc_s:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32S},
-#line 612 "src/lexer-keywords.txt"
-      {"i32.trunc_s:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32S},
-#line 628 "src/lexer-keywords.txt"
-      {"i64.trunc_u:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32U},
-#line 616 "src/lexer-keywords.txt"
-      {"i32.trunc_u:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32U},
-#line 606 "src/lexer-keywords.txt"
-      {"f64.reinterpret/i64", TokenType::Convert, Opcode::F64ReinterpretI64},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 197 "src/lexer-keywords.txt"
-      {"i16x8.max_s", TokenType::Binary, Opcode::I16X8MaxS},
-      {""},
-      {""},
-      {""},
-#line 198 "src/lexer-keywords.txt"
-      {"i16x8.max_u", TokenType::Binary, Opcode::I16X8MaxU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 625 "src/lexer-keywords.txt"
-      {"i64.trunc_s:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64S},
-#line 613 "src/lexer-keywords.txt"
-      {"i32.trunc_s:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64S},
-#line 629 "src/lexer-keywords.txt"
-      {"i64.trunc_u:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64U},
-#line 617 "src/lexer-keywords.txt"
-      {"i32.trunc_u:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 193 "src/lexer-keywords.txt"
-      {"v128.load8x8_s", TokenType::Load, Opcode::V128Load8X8S},
-      {""},
-      {""},
-      {""},
-#line 194 "src/lexer-keywords.txt"
-      {"v128.load8x8_u", TokenType::Load, Opcode::V128Load8X8U},
-      {""},
-      {""},
-      {""},
-#line 160 "src/lexer-keywords.txt"
-      {"f64x2.replace_lane", TokenType::SimdLaneOp, Opcode::F64X2ReplaceLane},
-      {""},
-#line 472 "src/lexer-keywords.txt"
-      {"i8x16.add_sat_s", TokenType::Binary, Opcode::I8X16AddSatS},
-#line 459 "src/lexer-keywords.txt"
-      {"i64x2.replace_lane", TokenType::SimdLaneOp, Opcode::I64X2ReplaceLane},
-#line 473 "src/lexer-keywords.txt"
-      {"i8x16.add_sat_u", TokenType::Binary, Opcode::I8X16AddSatU},
-      {""},
-      {""},
-#line 576 "src/lexer-keywords.txt"
-      {"v128.load16_splat", TokenType::Load, Opcode::V128Load16Splat},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 477 "src/lexer-keywords.txt"
-      {"i8x16.bitmask", TokenType::Unary, Opcode::I8X16Bitmask},
-      {""},
-      {""},
-#line 461 "src/lexer-keywords.txt"
-      {"i64x2.shr_s", TokenType::Binary, Opcode::I64X2ShrS},
-      {""},
-      {""},
-      {""},
-#line 462 "src/lexer-keywords.txt"
-      {"i64x2.shr_u", TokenType::Binary, Opcode::I64X2ShrU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 385 "src/lexer-keywords.txt"
-      {"i64.atomic.store8", TokenType::AtomicStore, Opcode::I64AtomicStore8},
-#line 253 "src/lexer-keywords.txt"
-      {"i32.atomic.store8", TokenType::AtomicStore, Opcode::I32AtomicStore8},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 132 "src/lexer-keywords.txt"
-      {"f64.neg", TokenType::Unary, Opcode::F64Neg},
-#line 75 "src/lexer-keywords.txt"
-      {"f32.neg", TokenType::Unary, Opcode::F32Neg},
-      {""},
-      {""},
-#line 562 "src/lexer-keywords.txt"
-      {"unreachable", TokenType::Unreachable, Opcode::Unreachable},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 102 "src/lexer-keywords.txt"
-      {"f32x4.pmax", TokenType::Binary, Opcode::F32X4PMax},
-      {""},
-#line 323 "src/lexer-keywords.txt"
-      {"i32x4.dot_i16x8_s", TokenType::Binary, Opcode::I32X4DotI16X8S},
-      {""},
-      {""},
-      {""},
-#line 328 "src/lexer-keywords.txt"
-      {"i32x4.shl", TokenType::Binary, Opcode::I32X4Shl},
-      {""},
-      {""},
-      {""},
-#line 302 "src/lexer-keywords.txt"
-      {"i32.wrap_i64", TokenType::Convert, Opcode::I32WrapI64},
-      {""},
-#line 589 "src/lexer-keywords.txt"
-      {"i8x16.swizzle", TokenType::Binary, Opcode::I8X16Swizzle},
-      {""},
-      {""},
-#line 618 "src/lexer-keywords.txt"
-      {"i32.wrap/i64", TokenType::Convert, Opcode::I32WrapI64},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 475 "src/lexer-keywords.txt"
-      {"i8x16.all_true", TokenType::Unary, Opcode::I8X16AllTrue},
-      {""},
-      {""},
-#line 351 "src/lexer-keywords.txt"
-      {"i64.atomic.load16_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad16U},
-#line 228 "src/lexer-keywords.txt"
-      {"i32.atomic.load16_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad16U},
-      {""},
-#line 86 "src/lexer-keywords.txt"
-      {"f32x4.convert_i32x4_s", TokenType::Unary, Opcode::F32X4ConvertI32X4S},
-      {""},
-#line 87 "src/lexer-keywords.txt"
-      {"f32x4.convert_i32x4_u", TokenType::Unary, Opcode::F32X4ConvertI32X4U},
-      {""},
-#line 173 "src/lexer-keywords.txt"
-      {"global.get", TokenType::GlobalGet, Opcode::GlobalGet},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 202 "src/lexer-keywords.txt"
-      {"i16x8.narrow_i32x4_s", TokenType::Binary, Opcode::I16X8NarrowI32X4S},
-      {""},
-#line 203 "src/lexer-keywords.txt"
-      {"i16x8.narrow_i32x4_u", TokenType::Binary, Opcode::I16X8NarrowI32X4U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 335 "src/lexer-keywords.txt"
-      {"i32x4.extmul_low_i16x8_s", TokenType::Binary,
-       Opcode::I32X4ExtmulLowI16X8S},
-#line 25 "src/lexer-keywords.txt"
-      {"assert_trap", TokenType::AssertTrap},
-#line 337 "src/lexer-keywords.txt"
-      {"i32x4.extmul_low_i16x8_u", TokenType::Binary,
-       Opcode::I32X4ExtmulLowI16X8U},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 189 "src/lexer-keywords.txt"
-      {"i16x8.gt_s", TokenType::Compare, Opcode::I16X8GtS},
-      {""},
-#line 190 "src/lexer-keywords.txt"
-      {"i16x8.gt_u", TokenType::Compare, Opcode::I16X8GtU},
-      {""},
-#line 211 "src/lexer-keywords.txt"
-      {"i16x8.splat", TokenType::Unary, Opcode::I16X8Splat},
-      {""},
-#line 187 "src/lexer-keywords.txt"
-      {"i16x8.ge_s", TokenType::Compare, Opcode::I16X8GeS},
-      {""},
-#line 188 "src/lexer-keywords.txt"
-      {"i16x8.ge_u", TokenType::Compare, Opcode::I16X8GeU},
-      {""},
-      {""},
-#line 104 "src/lexer-keywords.txt"
-      {"f32x4.replace_lane", TokenType::SimdLaneOp, Opcode::F32X4ReplaceLane},
-      {""},
-#line 39 "src/lexer-keywords.txt"
-      {"data.drop", TokenType::DataDrop, Opcode::DataDrop},
-#line 327 "src/lexer-keywords.txt"
-      {"i32x4.replace_lane", TokenType::SimdLaneOp, Opcode::I32X4ReplaceLane},
-      {""},
-#line 45 "src/lexer-keywords.txt"
-      {"elem.drop", TokenType::ElemDrop, Opcode::ElemDrop},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 344 "src/lexer-keywords.txt"
-      {"i32x4.extend_low_i16x8_s", TokenType::Unary,
-       Opcode::I32X4ExtendLowI16X8S},
-      {""},
-#line 345 "src/lexer-keywords.txt"
-      {"i32x4.extend_low_i16x8_u", TokenType::Unary,
-       Opcode::I32X4ExtendLowI16X8U},
-      {""},
-      {""},
-#line 329 "src/lexer-keywords.txt"
-      {"i32x4.shr_s", TokenType::Binary, Opcode::I32X4ShrS},
-      {""},
-      {""},
-      {""},
-#line 330 "src/lexer-keywords.txt"
-      {"i32x4.shr_u", TokenType::Binary, Opcode::I32X4ShrU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 156 "src/lexer-keywords.txt"
-      {"f64x2.neg", TokenType::Unary, Opcode::F64X2Neg},
-      {""},
-      {""},
-#line 452 "src/lexer-keywords.txt"
-      {"i64x2.neg", TokenType::Unary, Opcode::I64X2Neg},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 340 "src/lexer-keywords.txt"
-      {"i32x4.trunc_sat_f32x4_s", TokenType::Unary,
-       Opcode::I32X4TruncSatF32X4S},
-      {""},
-      {""},
-      {""},
-#line 341 "src/lexer-keywords.txt"
-      {"i32x4.trunc_sat_f32x4_u", TokenType::Unary,
-       Opcode::I32X4TruncSatF32X4U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 528 "src/lexer-keywords.txt"
-      {"nan:arithmetic", TokenType::NanArithmetic},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 119 "src/lexer-keywords.txt"
-      {"f64.copysign", TokenType::Binary, Opcode::F64Copysign},
-#line 61 "src/lexer-keywords.txt"
-      {"f32.copysign", TokenType::Binary, Opcode::F32Copysign},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 489 "src/lexer-keywords.txt"
-      {"i8x16.max_s", TokenType::Binary, Opcode::I8X16MaxS},
-      {""},
-      {""},
-      {""},
-#line 490 "src/lexer-keywords.txt"
-      {"i8x16.max_u", TokenType::Binary, Opcode::I8X16MaxU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 185 "src/lexer-keywords.txt"
-      {"i16x8.extract_lane_s", TokenType::SimdLaneOp,
-       Opcode::I16X8ExtractLaneS},
-      {""},
-#line 186 "src/lexer-keywords.txt"
-      {"i16x8.extract_lane_u", TokenType::SimdLaneOp,
-       Opcode::I16X8ExtractLaneU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 346 "src/lexer-keywords.txt"
-      {"i32x4.trunc_sat_f64x2_s_zero", TokenType::Unary,
-       Opcode::I32X4TruncSatF64X2SZero},
-      {""},
-#line 347 "src/lexer-keywords.txt"
-      {"i32x4.trunc_sat_f64x2_u_zero", TokenType::Unary,
-       Opcode::I32X4TruncSatF64X2UZero},
-      {""},
-#line 167 "src/lexer-keywords.txt"
-      {"f64x2.promote_low_f32x4", TokenType::Unary,
-       Opcode::F64X2PromoteLowF32X4},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+      {"memory.atomic.wait32", TokenType::AtomicWait, Opcode::MemoryAtomicWait32},
       {""},
 #line 364 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw32.cmpxchg_u", TokenType::AtomicRmwCmpxchg,
-       Opcode::I64AtomicRmw32CmpxchgU},
-#line 333 "src/lexer-keywords.txt"
-      {"i32x4.extadd_pairwise_i16x8_s", TokenType::Unary,
-       Opcode::I32X4ExtaddPairwiseI16X8S},
-      {""},
-#line 334 "src/lexer-keywords.txt"
-      {"i32x4.extadd_pairwise_i16x8_u", TokenType::Unary,
-       Opcode::I32X4ExtaddPairwiseI16X8U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 100 "src/lexer-keywords.txt"
-      {"f32x4.neg", TokenType::Unary, Opcode::F32X4Neg},
-      {""},
-      {""},
-#line 325 "src/lexer-keywords.txt"
-      {"i32x4.neg", TokenType::Unary, Opcode::I32X4Neg},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 374 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.xchg_u", TokenType::AtomicRmw,
-       Opcode::I64AtomicRmw8XchgU},
-#line 243 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.xchg_u", TokenType::AtomicRmw,
-       Opcode::I32AtomicRmw8XchgU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 382 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I64AtomicRmwXor},
-#line 251 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I32AtomicRmwXor},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 182 "src/lexer-keywords.txt"
-      {"i16x8.avgr_u", TokenType::Binary, Opcode::I16X8AvgrU},
-      {""},
-      {""},
-#line 483 "src/lexer-keywords.txt"
-      {"i8x16.gt_s", TokenType::Compare, Opcode::I8X16GtS},
-      {""},
-#line 484 "src/lexer-keywords.txt"
-      {"i8x16.gt_u", TokenType::Compare, Opcode::I8X16GtU},
-      {""},
-#line 502 "src/lexer-keywords.txt"
-      {"i8x16.splat", TokenType::Unary, Opcode::I8X16Splat},
-      {""},
-#line 481 "src/lexer-keywords.txt"
-      {"i8x16.ge_s", TokenType::Compare, Opcode::I8X16GeS},
-      {""},
-#line 482 "src/lexer-keywords.txt"
-      {"i8x16.ge_u", TokenType::Compare, Opcode::I8X16GeU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 371 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg,
-       Opcode::I64AtomicRmw8CmpxchgU},
-#line 240 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg,
-       Opcode::I32AtomicRmw8CmpxchgU},
-#line 205 "src/lexer-keywords.txt"
-      {"i16x8.q15mulr_sat_s", TokenType::Binary, Opcode::I16X8Q15mulrSatS},
-      {""},
+      {"i64.atomic.rmw32.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32AndU},
+      {""}, {""},
+#line 118 "src/lexer-keywords.txt"
+      {"f64.convert_i64_s", TokenType::Convert, Opcode::F64ConvertI64S},
+#line 60 "src/lexer-keywords.txt"
+      {"f32.convert_i64_s", TokenType::Convert, Opcode::F32ConvertI64S},
+#line 31 "src/lexer-keywords.txt"
+      {"br_if", TokenType::BrIf, Opcode::BrIf},
+#line 353 "src/lexer-keywords.txt"
+      {"i64.atomic.load32_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad32U},
+      {""}, {""},
+#line 306 "src/lexer-keywords.txt"
+      {"i32x4.all_true", TokenType::Unary, Opcode::I32X4AllTrue},
+#line 575 "src/lexer-keywords.txt"
+      {"v128", Type::V128},
+#line 560 "src/lexer-keywords.txt"
+      {"throw", TokenType::Throw, Opcode::Throw},
+#line 378 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I64AtomicRmwAnd},
+#line 247 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.and", TokenType::AtomicRmw, Opcode::I32AtomicRmwAnd},
+      {""}, {""},
+#line 410 "src/lexer-keywords.txt"
+      {"i64.load8_s", TokenType::Load, Opcode::I64Load8S},
+#line 273 "src/lexer-keywords.txt"
+      {"i32.load8_s", TokenType::Load, Opcode::I32Load8S},
+      {""}, {""},
+#line 411 "src/lexer-keywords.txt"
+      {"i64.load8_u", TokenType::Load, Opcode::I64Load8U},
+#line 274 "src/lexer-keywords.txt"
+      {"i32.load8_u", TokenType::Load, Opcode::I32Load8U},
+      {""}, {""},
+#line 520 "src/lexer-keywords.txt"
+      {"memory.atomic.wait64", TokenType::AtomicWait, Opcode::MemoryAtomicWait64},
+      {""}, {""}, {""}, {""}, {""},
+#line 45 "src/lexer-keywords.txt"
+      {"drop", TokenType::Drop, Opcode::Drop},
+      {""}, {""},
+#line 396 "src/lexer-keywords.txt"
+      {"i64.extend32_s", TokenType::Unary, Opcode::I64Extend32S},
+#line 544 "src/lexer-keywords.txt"
+      {"return_call_indirect", TokenType::ReturnCallIndirect, Opcode::ReturnCallIndirect},
+      {""}, {""}, {""},
+#line 517 "src/lexer-keywords.txt"
+      {"loop", TokenType::Loop, Opcode::Loop},
+      {""},
+#line 380 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I64AtomicRmwOr},
+#line 249 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.or", TokenType::AtomicRmw, Opcode::I32AtomicRmwOr},
+      {""}, {""},
+#line 573 "src/lexer-keywords.txt"
+      {"v128.load64_zero", TokenType::Load, Opcode::V128Load64Zero},
+#line 572 "src/lexer-keywords.txt"
+      {"v128.load32_zero", TokenType::Load, Opcode::V128Load32Zero},
+      {""},
+#line 360 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16SubU},
+#line 236 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.sub_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16SubU},
+#line 398 "src/lexer-keywords.txt"
+      {"i64.extend_i32_s", TokenType::Convert, Opcode::I64ExtendI32S},
+#line 109 "src/lexer-keywords.txt"
+      {"f32x4.trunc", TokenType::Unary, Opcode::F32X4Trunc},
+      {""},
+#line 92 "src/lexer-keywords.txt"
+      {"f32x4.floor", TokenType::Unary, Opcode::F32X4Floor},
+#line 399 "src/lexer-keywords.txt"
+      {"i64.extend_i32_u", TokenType::Convert, Opcode::I64ExtendI32U},
+      {""}, {""}, {""}, {""},
+#line 429 "src/lexer-keywords.txt"
+      {"i64.store8", TokenType::Store, Opcode::I64Store8},
+#line 291 "src/lexer-keywords.txt"
+      {"i32.store8", TokenType::Store, Opcode::I32Store8},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 110 "src/lexer-keywords.txt"
+      {"f32x4.demote_f64x2_zero", TokenType::Unary, Opcode::F32X4DemoteF64X2Zero},
+#line 553 "src/lexer-keywords.txt"
+      {"table.get", TokenType::TableGet, Opcode::TableGet},
+#line 39 "src/lexer-keywords.txt"
+      {"current_memory", TokenType::MemorySize, Opcode::MemorySize},
+      {""}, {""}, {""}, {""}, {""},
+#line 366 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32OrU},
+      {""}, {""},
+#line 381 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I64AtomicRmwSub},
+#line 250 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.sub", TokenType::AtomicRmw, Opcode::I32AtomicRmwSub},
+      {""}, {""}, {""},
+#line 602 "src/lexer-keywords.txt"
+      {"f64.convert_s/i32", TokenType::Convert, Opcode::F64ConvertI32S},
+#line 596 "src/lexer-keywords.txt"
+      {"f32.convert_s/i32", TokenType::Convert, Opcode::F32ConvertI32S},
+#line 604 "src/lexer-keywords.txt"
+      {"f64.convert_u/i32", TokenType::Convert, Opcode::F64ConvertI32U},
+#line 598 "src/lexer-keywords.txt"
+      {"f32.convert_u/i32", TokenType::Convert, Opcode::F32ConvertI32U},
+#line 537 "src/lexer-keywords.txt"
+      {"ref.extern", TokenType::RefExtern},
+      {""},
+#line 582 "src/lexer-keywords.txt"
+      {"v128.load16_lane", TokenType::SimdLoadLane, Opcode::V128Load16Lane},
+      {""}, {""}, {""},
+#line 587 "src/lexer-keywords.txt"
+      {"v128.store32_lane", TokenType::SimdStoreLane, Opcode::V128Store32Lane},
+#line 436 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f32_s", TokenType::Convert, Opcode::I64TruncSatF32S},
+#line 298 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f32_s", TokenType::Convert, Opcode::I32TruncSatF32S},
+      {""}, {""},
+#line 437 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f32_u", TokenType::Convert, Opcode::I64TruncSatF32U},
+#line 299 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f32_u", TokenType::Convert, Opcode::I32TruncSatF32U},
+      {""},
+#line 356 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AddU},
+#line 232 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.add_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AddU},
+      {""}, {""}, {""}, {""},
+#line 176 "src/lexer-keywords.txt"
+      {"global", TokenType::Global},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 588 "src/lexer-keywords.txt"
+      {"v128.store64_lane", TokenType::SimdStoreLane, Opcode::V128Store64Lane},
+      {""}, {""},
+#line 534 "src/lexer-keywords.txt"
+      {"param", TokenType::Param},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
 #line 357 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg,
-       Opcode::I64AtomicRmw16CmpxchgU},
+      {"i64.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16AndU},
 #line 233 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg,
-       Opcode::I32AtomicRmw16CmpxchgU},
+      {"i32.atomic.rmw16.and_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16AndU},
+#line 89 "src/lexer-keywords.txt"
+      {"f32x4.div", TokenType::Binary, Opcode::F32X4Div},
+      {""}, {""}, {""}, {""}, {""},
+#line 376 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XorU},
+#line 245 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XorU},
       {""},
+#line 175 "src/lexer-keywords.txt"
+      {"global.set", TokenType::GlobalSet, Opcode::GlobalSet},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 320 "src/lexer-keywords.txt"
+      {"i32x4.max_s", TokenType::Binary, Opcode::I32X4MaxS},
+      {""}, {""},
+#line 150 "src/lexer-keywords.txt"
+      {"f64x2.gt", TokenType::Compare, Opcode::F64X2Gt},
+#line 321 "src/lexer-keywords.txt"
+      {"i32x4.max_u", TokenType::Binary, Opcode::I32X4MaxU},
+      {""}, {""}, {""},
+#line 22 "src/lexer-keywords.txt"
+      {"assert_exhaustion", TokenType::AssertExhaustion},
+      {""}, {""},
+#line 117 "src/lexer-keywords.txt"
+      {"f64.convert_i32_u", TokenType::Convert, Opcode::F64ConvertI32U},
+#line 59 "src/lexer-keywords.txt"
+      {"f32.convert_i32_u", TokenType::Convert, Opcode::F32ConvertI32U},
+      {""}, {""},
+#line 149 "src/lexer-keywords.txt"
+      {"f64x2.ge", TokenType::Compare, Opcode::F64X2Ge},
+      {""}, {""}, {""},
+#line 449 "src/lexer-keywords.txt"
+      {"i64x2.gt_s", TokenType::Binary, Opcode::I64X2GtS},
+#line 162 "src/lexer-keywords.txt"
+      {"f64x2.splat", TokenType::Unary, Opcode::F64X2Splat},
       {""},
+#line 513 "src/lexer-keywords.txt"
+      {"local.get", TokenType::LocalGet, Opcode::LocalGet},
+#line 464 "src/lexer-keywords.txt"
+      {"i64x2.splat", TokenType::Unary, Opcode::I64X2Splat},
       {""},
+#line 451 "src/lexer-keywords.txt"
+      {"i64x2.ge_s", TokenType::Binary, Opcode::I64X2GeS},
+      {""}, {""},
+#line 215 "src/lexer-keywords.txt"
+      {"i16x8.sub", TokenType::Binary, Opcode::I16X8Sub},
+      {""}, {""}, {""}, {""},
+#line 160 "src/lexer-keywords.txt"
+      {"f64x2.pmin", TokenType::Binary, Opcode::F64X2PMin},
+      {""}, {""}, {""}, {""},
+#line 119 "src/lexer-keywords.txt"
+      {"f64.convert_i64_u", TokenType::Convert, Opcode::F64ConvertI64U},
+#line 61 "src/lexer-keywords.txt"
+      {"f32.convert_i64_u", TokenType::Convert, Opcode::F32ConvertI64U},
+#line 196 "src/lexer-keywords.txt"
+      {"i16x8.lt_s", TokenType::Compare, Opcode::I16X8LtS},
       {""},
+#line 197 "src/lexer-keywords.txt"
+      {"i16x8.lt_u", TokenType::Compare, Opcode::I16X8LtU},
+      {""}, {""}, {""},
+#line 192 "src/lexer-keywords.txt"
+      {"i16x8.le_s", TokenType::Compare, Opcode::I16X8LeS},
       {""},
+#line 193 "src/lexer-keywords.txt"
+      {"i16x8.le_u", TokenType::Compare, Opcode::I16X8LeU},
+      {""}, {""},
+#line 443 "src/lexer-keywords.txt"
+      {"v128.load32x2_s", TokenType::Load, Opcode::V128Load32X2S},
       {""},
+#line 444 "src/lexer-keywords.txt"
+      {"v128.load32x2_u", TokenType::Load, Opcode::V128Load32X2U},
+#line 417 "src/lexer-keywords.txt"
+      {"i64.or", TokenType::Binary, Opcode::I64Or},
+#line 280 "src/lexer-keywords.txt"
+      {"i32.or", TokenType::Binary, Opcode::I32Or},
+#line 359 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16OrU},
+#line 235 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16OrU},
       {""},
+#line 202 "src/lexer-keywords.txt"
+      {"i16x8.mul", TokenType::Binary, Opcode::I16X8Mul},
+#line 207 "src/lexer-keywords.txt"
+      {"i16x8.ne", TokenType::Compare, Opcode::I16X8Ne},
+      {""}, {""}, {""}, {""}, {""},
+#line 354 "src/lexer-keywords.txt"
+      {"i64.atomic.load8_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad8U},
+#line 230 "src/lexer-keywords.txt"
+      {"i32.atomic.load8_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad8U},
+      {""}, {""},
+#line 178 "src/lexer-keywords.txt"
+      {"i16x8.abs", TokenType::Unary, Opcode::I16X8Abs},
+#line 129 "src/lexer-keywords.txt"
+      {"f64.max", TokenType::Binary, Opcode::F64Max},
+#line 72 "src/lexer-keywords.txt"
+      {"f32.max", TokenType::Binary, Opcode::F32Max},
+      {""}, {""}, {""}, {""},
+#line 200 "src/lexer-keywords.txt"
+      {"i16x8.min_s", TokenType::Binary, Opcode::I16X8MinS},
+#line 185 "src/lexer-keywords.txt"
+      {"i16x8.eq", TokenType::Compare, Opcode::I16X8Eq},
+      {""}, {""},
+#line 201 "src/lexer-keywords.txt"
+      {"i16x8.min_u", TokenType::Binary, Opcode::I16X8MinU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+#line 551 "src/lexer-keywords.txt"
+      {"table.copy", TokenType::TableCopy, Opcode::TableCopy},
+#line 418 "src/lexer-keywords.txt"
+      {"i64.popcnt", TokenType::Unary, Opcode::I64Popcnt},
 #line 281 "src/lexer-keywords.txt"
-      {"i32.reinterpret_f32", TokenType::Convert, Opcode::I32ReinterpretF32},
-      {""},
-      {""},
-      {""},
+      {"i32.popcnt", TokenType::Unary, Opcode::I32Popcnt},
+#line 181 "src/lexer-keywords.txt"
+      {"i16x8.add", TokenType::Binary, Opcode::I16X8Add},
+      {""}, {""}, {""}, {""},
+#line 603 "src/lexer-keywords.txt"
+      {"f64.convert_s/i64", TokenType::Convert, Opcode::F64ConvertI64S},
+#line 597 "src/lexer-keywords.txt"
+      {"f32.convert_s/i64", TokenType::Convert, Opcode::F32ConvertI64S},
+#line 605 "src/lexer-keywords.txt"
+      {"f64.convert_u/i64", TokenType::Convert, Opcode::F64ConvertI64U},
+#line 599 "src/lexer-keywords.txt"
+      {"f32.convert_u/i64", TokenType::Convert, Opcode::F32ConvertI64U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 438 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f64_s", TokenType::Convert, Opcode::I64TruncSatF64S},
+#line 300 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f64_s", TokenType::Convert, Opcode::I32TruncSatF64S},
+      {""}, {""},
+#line 439 "src/lexer-keywords.txt"
+      {"i64.trunc_sat_f64_u", TokenType::Convert, Opcode::I64TruncSatF64U},
+#line 301 "src/lexer-keywords.txt"
+      {"i32.trunc_sat_f64_u", TokenType::Convert, Opcode::I32TruncSatF64U},
+      {""}, {""}, {""}, {""},
+#line 213 "src/lexer-keywords.txt"
+      {"i16x8.sub_sat_s", TokenType::Binary, Opcode::I16X8SubSatS},
+#line 576 "src/lexer-keywords.txt"
+      {"v128.xor", TokenType::Binary, Opcode::V128Xor},
+#line 214 "src/lexer-keywords.txt"
+      {"i16x8.sub_sat_u", TokenType::Binary, Opcode::I16X8SubSatU},
       {""},
 #line 609 "src/lexer-keywords.txt"
-      {"i32.reinterpret/f32", TokenType::Convert, Opcode::I32ReinterpretF32},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 607 "src/lexer-keywords.txt"
-      {"get_global", TokenType::GlobalGet, Opcode::GlobalGet},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 418 "src/lexer-keywords.txt"
-      {"i64.reinterpret_f64", TokenType::Convert, Opcode::I64ReinterpretF64},
-      {""},
-#line 208 "src/lexer-keywords.txt"
-      {"i16x8.shl", TokenType::Binary, Opcode::I16X8Shl},
-      {""},
-      {""},
-#line 621 "src/lexer-keywords.txt"
-      {"i64.reinterpret/f64", TokenType::Convert, Opcode::I64ReinterpretF64},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 479 "src/lexer-keywords.txt"
-      {"i8x16.extract_lane_s", TokenType::SimdLaneOp,
-       Opcode::I8X16ExtractLaneS},
-      {""},
-#line 480 "src/lexer-keywords.txt"
-      {"i8x16.extract_lane_u", TokenType::SimdLaneOp,
-       Opcode::I8X16ExtractLaneU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 207 "src/lexer-keywords.txt"
-      {"i16x8.replace_lane", TokenType::SimdLaneOp, Opcode::I16X8ReplaceLane},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 209 "src/lexer-keywords.txt"
-      {"i16x8.shr_s", TokenType::Binary, Opcode::I16X8ShrS},
-      {""},
-      {""},
-      {""},
-#line 210 "src/lexer-keywords.txt"
-      {"i16x8.shr_u", TokenType::Binary, Opcode::I16X8ShrU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 217 "src/lexer-keywords.txt"
-      {"i16x8.extmul_low_i8x16_s", TokenType::Binary,
-       Opcode::I16X8ExtmulLowI8X16S},
-      {""},
-#line 219 "src/lexer-keywords.txt"
-      {"i16x8.extmul_low_i8x16_u", TokenType::Binary,
-       Opcode::I16X8ExtmulLowI8X16U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 476 "src/lexer-keywords.txt"
-      {"i8x16.avgr_u", TokenType::Binary, Opcode::I8X16AvgrU},
-      {""},
-      {""},
-      {""},
-#line 224 "src/lexer-keywords.txt"
-      {"i16x8.extend_low_i8x16_s", TokenType::Unary,
-       Opcode::I16X8ExtendLowI8X16S},
-      {""},
-#line 225 "src/lexer-keywords.txt"
-      {"i16x8.extend_low_i8x16_u", TokenType::Unary,
-       Opcode::I16X8ExtendLowI8X16U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 215 "src/lexer-keywords.txt"
-      {"i16x8.extadd_pairwise_i8x16_s", TokenType::Unary,
-       Opcode::I16X8ExtaddPairwiseI8X16S},
-      {""},
-#line 216 "src/lexer-keywords.txt"
-      {"i16x8.extadd_pairwise_i8x16_u", TokenType::Unary,
-       Opcode::I16X8ExtaddPairwiseI8X16U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 204 "src/lexer-keywords.txt"
-      {"i16x8.neg", TokenType::Unary, Opcode::I16X8Neg},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 499 "src/lexer-keywords.txt"
-      {"i8x16.shl", TokenType::Binary, Opcode::I8X16Shl},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 588 "src/lexer-keywords.txt"
-      {"i8x16.shuffle", TokenType::SimdShuffleOp, Opcode::I8X16Shuffle},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 498 "src/lexer-keywords.txt"
-      {"i8x16.replace_lane", TokenType::SimdLaneOp, Opcode::I8X16ReplaceLane},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 500 "src/lexer-keywords.txt"
-      {"i8x16.shr_s", TokenType::Binary, Opcode::I8X16ShrS},
-      {""},
-      {""},
-      {""},
-#line 501 "src/lexer-keywords.txt"
-      {"i8x16.shr_u", TokenType::Binary, Opcode::I8X16ShrU},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 378 "src/lexer-keywords.txt"
-      {"i64.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg,
-       Opcode::I64AtomicRmwCmpxchg},
-#line 247 "src/lexer-keywords.txt"
-      {"i32.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg,
-       Opcode::I32AtomicRmwCmpxchg},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 493 "src/lexer-keywords.txt"
-      {"i8x16.narrow_i16x8_s", TokenType::Binary, Opcode::I8X16NarrowI16X8S},
-      {""},
-#line 494 "src/lexer-keywords.txt"
-      {"i8x16.narrow_i16x8_u", TokenType::Binary, Opcode::I8X16NarrowI16X8U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+      {"get_local", TokenType::LocalGet, Opcode::LocalGet},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 147 "src/lexer-keywords.txt"
+      {"f64x2.extract_lane", TokenType::SimdLaneOp, Opcode::F64X2ExtractLane},
+      {""}, {""},
+#line 442 "src/lexer-keywords.txt"
+      {"i64x2.extract_lane", TokenType::SimdLaneOp, Opcode::I64X2ExtractLane},
+      {""}, {""}, {""}, {""}, {""},
+#line 94 "src/lexer-keywords.txt"
+      {"f32x4.gt", TokenType::Compare, Opcode::F32X4Gt},
+      {""}, {""}, {""}, {""}, {""},
+#line 369 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XorU},
+      {""},
+#line 397 "src/lexer-keywords.txt"
+      {"i64.extend8_s", TokenType::Unary, Opcode::I64Extend8S},
+#line 264 "src/lexer-keywords.txt"
+      {"i32.extend8_s", TokenType::Unary, Opcode::I32Extend8S},
+      {""}, {""},
+#line 93 "src/lexer-keywords.txt"
+      {"f32x4.ge", TokenType::Compare, Opcode::F32X4Ge},
+      {""}, {""}, {""},
+#line 312 "src/lexer-keywords.txt"
+      {"i32x4.gt_s", TokenType::Compare, Opcode::I32X4GtS},
+#line 106 "src/lexer-keywords.txt"
+      {"f32x4.splat", TokenType::Unary, Opcode::F32X4Splat},
+#line 313 "src/lexer-keywords.txt"
+      {"i32x4.gt_u", TokenType::Compare, Opcode::I32X4GtU},
+      {""},
+#line 332 "src/lexer-keywords.txt"
+      {"i32x4.splat", TokenType::Unary, Opcode::I32X4Splat},
+      {""},
+#line 310 "src/lexer-keywords.txt"
+      {"i32x4.ge_s", TokenType::Compare, Opcode::I32X4GeS},
+      {""},
+#line 311 "src/lexer-keywords.txt"
+      {"i32x4.ge_u", TokenType::Compare, Opcode::I32X4GeU},
+      {""},
+#line 153 "src/lexer-keywords.txt"
+      {"f64x2.max", TokenType::Binary, Opcode::F64X2Max},
+      {""}, {""}, {""},
+#line 104 "src/lexer-keywords.txt"
+      {"f32x4.pmin", TokenType::Binary, Opcode::F32X4PMin},
+      {""}, {""}, {""}, {""}, {""},
+#line 316 "src/lexer-keywords.txt"
+      {"v128.load16x4_s", TokenType::Load, Opcode::V128Load16X4S},
+      {""},
+#line 317 "src/lexer-keywords.txt"
+      {"v128.load16x4_u", TokenType::Load, Opcode::V128Load16X4U},
+#line 179 "src/lexer-keywords.txt"
+      {"i16x8.add_sat_s", TokenType::Binary, Opcode::I16X8AddSatS},
+      {""},
+#line 180 "src/lexer-keywords.txt"
+      {"i16x8.add_sat_u", TokenType::Binary, Opcode::I16X8AddSatU},
+#line 125 "src/lexer-keywords.txt"
+      {"f64.gt", TokenType::Compare, Opcode::F64Gt},
+#line 68 "src/lexer-keywords.txt"
+      {"f32.gt", TokenType::Compare, Opcode::F32Gt},
+      {""}, {""}, {""}, {""}, {""},
+#line 184 "src/lexer-keywords.txt"
+      {"i16x8.bitmask", TokenType::Unary, Opcode::I16X8Bitmask},
+      {""},
+#line 368 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw32XchgU},
+      {""},
+#line 554 "src/lexer-keywords.txt"
+      {"table.grow", TokenType::TableGrow, Opcode::TableGrow},
+#line 124 "src/lexer-keywords.txt"
+      {"f64.ge", TokenType::Compare, Opcode::F64Ge},
+#line 67 "src/lexer-keywords.txt"
+      {"f32.ge", TokenType::Compare, Opcode::F32Ge},
+      {""}, {""},
+#line 177 "src/lexer-keywords.txt"
+      {"grow_memory", TokenType::MemoryGrow, Opcode::MemoryGrow},
+      {""}, {""}, {""}, {""},
+#line 395 "src/lexer-keywords.txt"
+      {"i64.extend16_s", TokenType::Unary, Opcode::I64Extend16S},
+#line 263 "src/lexer-keywords.txt"
+      {"i32.extend16_s", TokenType::Unary, Opcode::I32Extend16S},
+#line 538 "src/lexer-keywords.txt"
+      {"ref.func", TokenType::RefFunc, Opcode::RefFunc},
+      {""},
+#line 541 "src/lexer-keywords.txt"
+      {"register", TokenType::Register},
+      {""},
+#line 402 "src/lexer-keywords.txt"
+      {"i64.gt_s", TokenType::Compare, Opcode::I64GtS},
+#line 267 "src/lexer-keywords.txt"
+      {"i32.gt_s", TokenType::Compare, Opcode::I32GtS},
+      {""}, {""},
+#line 403 "src/lexer-keywords.txt"
+      {"i64.gt_u", TokenType::Compare, Opcode::I64GtU},
+#line 268 "src/lexer-keywords.txt"
+      {"i32.gt_u", TokenType::Compare, Opcode::I32GtU},
+#line 400 "src/lexer-keywords.txt"
+      {"i64.ge_s", TokenType::Compare, Opcode::I64GeS},
+#line 265 "src/lexer-keywords.txt"
+      {"i32.ge_s", TokenType::Compare, Opcode::I32GeS},
+      {""}, {""},
+#line 401 "src/lexer-keywords.txt"
+      {"i64.ge_u", TokenType::Compare, Opcode::I64GeU},
+#line 266 "src/lexer-keywords.txt"
+      {"i32.ge_u", TokenType::Compare, Opcode::I32GeU},
+#line 585 "src/lexer-keywords.txt"
+      {"v128.store8_lane", TokenType::SimdStoreLane, Opcode::V128Store8Lane},
+      {""}, {""}, {""},
 #line 466 "src/lexer-keywords.txt"
-      {"i64x2.extmul_high_i32x4_s", TokenType::Binary,
-       Opcode::I64X2ExtmulHighI32X4S},
+      {"i64x2.extmul_low_i32x4_s", TokenType::Binary, Opcode::I64X2ExtmulLowI32X4S},
       {""},
 #line 468 "src/lexer-keywords.txt"
-      {"i64x2.extmul_high_i32x4_u", TokenType::Binary,
-       Opcode::I64X2ExtmulHighI32X4U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+      {"i64x2.extmul_low_i32x4_u", TokenType::Binary, Opcode::I64X2ExtmulLowI32X4U},
+      {""}, {""}, {""},
+#line 424 "src/lexer-keywords.txt"
+      {"i64.shl", TokenType::Binary, Opcode::I64Shl},
+#line 287 "src/lexer-keywords.txt"
+      {"i32.shl", TokenType::Binary, Opcode::I32Shl},
+      {""}, {""}, {""},
+#line 123 "src/lexer-keywords.txt"
+      {"f64.floor", TokenType::Unary, Opcode::F64Floor},
+#line 66 "src/lexer-keywords.txt"
+      {"f32.floor", TokenType::Unary, Opcode::F32Floor},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""},
 #line 456 "src/lexer-keywords.txt"
-      {"i64x2.extend_high_i32x4_s", TokenType::Unary,
-       Opcode::I64X2ExtendHighI32X4S},
+      {"i64x2.extend_low_i32x4_s", TokenType::Unary, Opcode::I64X2ExtendLowI32X4S},
       {""},
 #line 458 "src/lexer-keywords.txt"
-      {"i64x2.extend_high_i32x4_u", TokenType::Unary,
-       Opcode::I64X2ExtendHighI32X4U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 495 "src/lexer-keywords.txt"
-      {"i8x16.neg", TokenType::Unary, Opcode::I8X16Neg},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 496 "src/lexer-keywords.txt"
-      {"i8x16.popcnt", TokenType::Unary, Opcode::I8X16Popcnt},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+      {"i64x2.extend_low_i32x4_u", TokenType::Unary, Opcode::I64X2ExtendLowI32X4U},
+#line 166 "src/lexer-keywords.txt"
+      {"f64x2.convert_low_i32x4_s", TokenType::Unary, Opcode::F64X2ConvertLowI32X4S},
+      {""},
+#line 167 "src/lexer-keywords.txt"
+      {"f64x2.convert_low_i32x4_u", TokenType::Unary, Opcode::F64X2ConvertLowI32X4U},
+#line 37 "src/lexer-keywords.txt"
+      {"catch", TokenType::Catch, Opcode::Catch},
+      {""}, {""},
+#line 586 "src/lexer-keywords.txt"
+      {"v128.store16_lane", TokenType::SimdStoreLane, Opcode::V128Store16Lane},
+      {""}, {""}, {""},
+#line 182 "src/lexer-keywords.txt"
+      {"i16x8.all_true", TokenType::Unary, Opcode::I16X8AllTrue},
+      {""},
+#line 580 "src/lexer-keywords.txt"
+      {"v128.load8_splat", TokenType::Load, Opcode::V128Load8Splat},
+      {""}, {""},
+#line 91 "src/lexer-keywords.txt"
+      {"f32x4.extract_lane", TokenType::SimdLaneOp, Opcode::F32X4ExtractLane},
+      {""}, {""},
+#line 309 "src/lexer-keywords.txt"
+      {"i32x4.extract_lane", TokenType::SimdLaneOp, Opcode::I32X4ExtractLane},
+#line 362 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XorU},
+#line 238 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.xor_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XorU},
+      {""}, {""}, {""}, {""}, {""},
+#line 506 "src/lexer-keywords.txt"
+      {"i8x16.sub", TokenType::Binary, Opcode::I8X16Sub},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 43 "src/lexer-keywords.txt"
+      {"delegate", TokenType::Delegate},
+      {""}, {""}, {""},
+#line 488 "src/lexer-keywords.txt"
+      {"i8x16.lt_s", TokenType::Compare, Opcode::I8X16LtS},
+      {""},
+#line 489 "src/lexer-keywords.txt"
+      {"i8x16.lt_u", TokenType::Compare, Opcode::I8X16LtU},
+      {""}, {""}, {""},
+#line 486 "src/lexer-keywords.txt"
+      {"i8x16.le_s", TokenType::Compare, Opcode::I8X16LeS},
+      {""},
+#line 487 "src/lexer-keywords.txt"
+      {"i8x16.le_u", TokenType::Compare, Opcode::I8X16LeU},
+      {""}, {""}, {""},
+#line 97 "src/lexer-keywords.txt"
+      {"f32x4.max", TokenType::Binary, Opcode::F32X4Max},
+      {""}, {""}, {""}, {""},
+#line 579 "src/lexer-keywords.txt"
+      {"v128.load64_splat", TokenType::Load, Opcode::V128Load64Splat},
+#line 578 "src/lexer-keywords.txt"
+      {"v128.load32_splat", TokenType::Load, Opcode::V128Load32Splat},
+      {""},
+#line 498 "src/lexer-keywords.txt"
+      {"i8x16.ne", TokenType::Compare, Opcode::I8X16Ne},
+      {""}, {""}, {""}, {""}, {""},
+#line 361 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw16XchgU},
+#line 237 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw16XchgU},
+      {""}, {""},
+#line 472 "src/lexer-keywords.txt"
+      {"i8x16.abs", TokenType::Unary, Opcode::I8X16Abs},
+#line 425 "src/lexer-keywords.txt"
+      {"i64.shr_s", TokenType::Binary, Opcode::I64ShrS},
+#line 288 "src/lexer-keywords.txt"
+      {"i32.shr_s", TokenType::Binary, Opcode::I32ShrS},
+      {""}, {""},
+#line 426 "src/lexer-keywords.txt"
+      {"i64.shr_u", TokenType::Binary, Opcode::I64ShrU},
+#line 289 "src/lexer-keywords.txt"
+      {"i32.shr_u", TokenType::Binary, Opcode::I32ShrU},
+#line 492 "src/lexer-keywords.txt"
+      {"i8x16.min_s", TokenType::Binary, Opcode::I8X16MinS},
+#line 479 "src/lexer-keywords.txt"
+      {"i8x16.eq", TokenType::Compare, Opcode::I8X16Eq},
+#line 523 "src/lexer-keywords.txt"
+      {"memory.grow", TokenType::MemoryGrow, Opcode::MemoryGrow},
+      {""},
+#line 493 "src/lexer-keywords.txt"
+      {"i8x16.min_u", TokenType::Binary, Opcode::I8X16MinU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 222 "src/lexer-keywords.txt"
+      {"i16x8", TokenType::I16X8},
+      {""}, {""}, {""}, {""},
+#line 475 "src/lexer-keywords.txt"
+      {"i8x16.add", TokenType::Binary, Opcode::I8X16Add},
+#line 507 "src/lexer-keywords.txt"
+      {"i8x16", TokenType::I8X16},
+      {""}, {""}, {""}, {""}, {""},
+#line 631 "src/lexer-keywords.txt"
+      {"set_global", TokenType::GlobalSet, Opcode::GlobalSet},
+      {""}, {""}, {""},
+#line 159 "src/lexer-keywords.txt"
+      {"f64x2.pmax", TokenType::Binary, Opcode::F64X2PMax},
+      {""}, {""}, {""}, {""}, {""},
+#line 461 "src/lexer-keywords.txt"
+      {"i64x2.shl", TokenType::Binary, Opcode::I64X2Shl},
+#line 78 "src/lexer-keywords.txt"
+      {"f32.reinterpret_i32", TokenType::Convert, Opcode::F32ReinterpretI32},
+      {""}, {""}, {""},
+#line 531 "src/lexer-keywords.txt"
+      {"nop", TokenType::Nop, Opcode::Nop},
+#line 601 "src/lexer-keywords.txt"
+      {"f32.reinterpret/i32", TokenType::Convert, Opcode::F32ReinterpretI32},
+      {""}, {""}, {""},
+#line 504 "src/lexer-keywords.txt"
+      {"i8x16.sub_sat_s", TokenType::Binary, Opcode::I8X16SubSatS},
+      {""},
+#line 505 "src/lexer-keywords.txt"
+      {"i8x16.sub_sat_u", TokenType::Binary, Opcode::I8X16SubSatU},
+      {""}, {""}, {""}, {""},
+#line 50 "src/lexer-keywords.txt"
+      {"tag", TokenType::Tag},
+      {""}, {""}, {""}, {""},
+#line 373 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8OrU},
+#line 242 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.or_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8OrU},
+      {""},
+#line 136 "src/lexer-keywords.txt"
+      {"f64.reinterpret_i64", TokenType::Convert, Opcode::F64ReinterpretI64},
+#line 625 "src/lexer-keywords.txt"
+      {"i64.trunc_s:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32S},
+#line 613 "src/lexer-keywords.txt"
+      {"i32.trunc_s:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32S},
+#line 629 "src/lexer-keywords.txt"
+      {"i64.trunc_u:sat/f32", TokenType::Convert, Opcode::I64TruncSatF32U},
+#line 617 "src/lexer-keywords.txt"
+      {"i32.trunc_u:sat/f32", TokenType::Convert, Opcode::I32TruncSatF32U},
+#line 607 "src/lexer-keywords.txt"
+      {"f64.reinterpret/i64", TokenType::Convert, Opcode::F64ReinterpretI64},
+      {""}, {""}, {""},
+#line 21 "src/lexer-keywords.txt"
+      {"assert_exception", TokenType::AssertException},
+      {""}, {""}, {""},
+#line 198 "src/lexer-keywords.txt"
+      {"i16x8.max_s", TokenType::Binary, Opcode::I16X8MaxS},
+      {""}, {""}, {""},
+#line 199 "src/lexer-keywords.txt"
+      {"i16x8.max_u", TokenType::Binary, Opcode::I16X8MaxU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 626 "src/lexer-keywords.txt"
+      {"i64.trunc_s:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64S},
+#line 614 "src/lexer-keywords.txt"
+      {"i32.trunc_s:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64S},
+#line 630 "src/lexer-keywords.txt"
+      {"i64.trunc_u:sat/f64", TokenType::Convert, Opcode::I64TruncSatF64U},
+#line 618 "src/lexer-keywords.txt"
+      {"i32.trunc_u:sat/f64", TokenType::Convert, Opcode::I32TruncSatF64U},
+      {""}, {""}, {""}, {""}, {""},
+#line 194 "src/lexer-keywords.txt"
+      {"v128.load8x8_s", TokenType::Load, Opcode::V128Load8X8S},
+      {""}, {""}, {""},
+#line 195 "src/lexer-keywords.txt"
+      {"v128.load8x8_u", TokenType::Load, Opcode::V128Load8X8U},
+      {""}, {""}, {""},
+#line 161 "src/lexer-keywords.txt"
+      {"f64x2.replace_lane", TokenType::SimdLaneOp, Opcode::F64X2ReplaceLane},
+      {""},
+#line 473 "src/lexer-keywords.txt"
+      {"i8x16.add_sat_s", TokenType::Binary, Opcode::I8X16AddSatS},
+#line 460 "src/lexer-keywords.txt"
+      {"i64x2.replace_lane", TokenType::SimdLaneOp, Opcode::I64X2ReplaceLane},
+#line 474 "src/lexer-keywords.txt"
+      {"i8x16.add_sat_u", TokenType::Binary, Opcode::I8X16AddSatU},
+      {""}, {""},
+#line 577 "src/lexer-keywords.txt"
+      {"v128.load16_splat", TokenType::Load, Opcode::V128Load16Splat},
+      {""}, {""}, {""}, {""},
+#line 478 "src/lexer-keywords.txt"
+      {"i8x16.bitmask", TokenType::Unary, Opcode::I8X16Bitmask},
+      {""}, {""},
+#line 462 "src/lexer-keywords.txt"
+      {"i64x2.shr_s", TokenType::Binary, Opcode::I64X2ShrS},
+      {""}, {""}, {""},
+#line 463 "src/lexer-keywords.txt"
+      {"i64x2.shr_u", TokenType::Binary, Opcode::I64X2ShrU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""},
+#line 386 "src/lexer-keywords.txt"
+      {"i64.atomic.store8", TokenType::AtomicStore, Opcode::I64AtomicStore8},
+#line 254 "src/lexer-keywords.txt"
+      {"i32.atomic.store8", TokenType::AtomicStore, Opcode::I32AtomicStore8},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 133 "src/lexer-keywords.txt"
+      {"f64.neg", TokenType::Unary, Opcode::F64Neg},
+#line 76 "src/lexer-keywords.txt"
+      {"f32.neg", TokenType::Unary, Opcode::F32Neg},
+      {""}, {""},
+#line 563 "src/lexer-keywords.txt"
+      {"unreachable", TokenType::Unreachable, Opcode::Unreachable},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 103 "src/lexer-keywords.txt"
+      {"f32x4.pmax", TokenType::Binary, Opcode::F32X4PMax},
+      {""},
+#line 324 "src/lexer-keywords.txt"
+      {"i32x4.dot_i16x8_s", TokenType::Binary, Opcode::I32X4DotI16X8S},
+      {""}, {""}, {""},
+#line 329 "src/lexer-keywords.txt"
+      {"i32x4.shl", TokenType::Binary, Opcode::I32X4Shl},
+      {""}, {""}, {""},
+#line 303 "src/lexer-keywords.txt"
+      {"i32.wrap_i64", TokenType::Convert, Opcode::I32WrapI64},
+      {""},
+#line 590 "src/lexer-keywords.txt"
+      {"i8x16.swizzle", TokenType::Binary, Opcode::I8X16Swizzle},
+      {""}, {""},
+#line 619 "src/lexer-keywords.txt"
+      {"i32.wrap/i64", TokenType::Convert, Opcode::I32WrapI64},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 476 "src/lexer-keywords.txt"
+      {"i8x16.all_true", TokenType::Unary, Opcode::I8X16AllTrue},
+      {""}, {""},
+#line 352 "src/lexer-keywords.txt"
+      {"i64.atomic.load16_u", TokenType::AtomicLoad, Opcode::I64AtomicLoad16U},
+#line 229 "src/lexer-keywords.txt"
+      {"i32.atomic.load16_u", TokenType::AtomicLoad, Opcode::I32AtomicLoad16U},
+      {""},
+#line 87 "src/lexer-keywords.txt"
+      {"f32x4.convert_i32x4_s", TokenType::Unary, Opcode::F32X4ConvertI32X4S},
+      {""},
+#line 88 "src/lexer-keywords.txt"
+      {"f32x4.convert_i32x4_u", TokenType::Unary, Opcode::F32X4ConvertI32X4U},
+      {""},
+#line 174 "src/lexer-keywords.txt"
+      {"global.get", TokenType::GlobalGet, Opcode::GlobalGet},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 203 "src/lexer-keywords.txt"
+      {"i16x8.narrow_i32x4_s", TokenType::Binary, Opcode::I16X8NarrowI32X4S},
+      {""},
+#line 204 "src/lexer-keywords.txt"
+      {"i16x8.narrow_i32x4_u", TokenType::Binary, Opcode::I16X8NarrowI32X4U},
+      {""}, {""}, {""}, {""}, {""},
 #line 336 "src/lexer-keywords.txt"
-      {"i32x4.extmul_high_i16x8_s", TokenType::Binary,
-       Opcode::I32X4ExtmulHighI16X8S},
-      {""},
+      {"i32x4.extmul_low_i16x8_s", TokenType::Binary, Opcode::I32X4ExtmulLowI16X8S},
+#line 26 "src/lexer-keywords.txt"
+      {"assert_trap", TokenType::AssertTrap},
 #line 338 "src/lexer-keywords.txt"
-      {"i32x4.extmul_high_i16x8_u", TokenType::Binary,
-       Opcode::I32X4ExtmulHighI16X8U},
+      {"i32x4.extmul_low_i16x8_u", TokenType::Binary, Opcode::I32X4ExtmulLowI16X8U},
+      {""}, {""}, {""}, {""},
+#line 190 "src/lexer-keywords.txt"
+      {"i16x8.gt_s", TokenType::Compare, Opcode::I16X8GtS},
       {""},
+#line 191 "src/lexer-keywords.txt"
+      {"i16x8.gt_u", TokenType::Compare, Opcode::I16X8GtU},
       {""},
+#line 212 "src/lexer-keywords.txt"
+      {"i16x8.splat", TokenType::Unary, Opcode::I16X8Splat},
       {""},
+#line 188 "src/lexer-keywords.txt"
+      {"i16x8.ge_s", TokenType::Compare, Opcode::I16X8GeS},
       {""},
+#line 189 "src/lexer-keywords.txt"
+      {"i16x8.ge_u", TokenType::Compare, Opcode::I16X8GeU},
+      {""}, {""},
+#line 105 "src/lexer-keywords.txt"
+      {"f32x4.replace_lane", TokenType::SimdLaneOp, Opcode::F32X4ReplaceLane},
       {""},
+#line 40 "src/lexer-keywords.txt"
+      {"data.drop", TokenType::DataDrop, Opcode::DataDrop},
+#line 328 "src/lexer-keywords.txt"
+      {"i32x4.replace_lane", TokenType::SimdLaneOp, Opcode::I32X4ReplaceLane},
       {""},
+#line 46 "src/lexer-keywords.txt"
+      {"elem.drop", TokenType::ElemDrop, Opcode::ElemDrop},
+      {""}, {""}, {""}, {""},
+#line 345 "src/lexer-keywords.txt"
+      {"i32x4.extend_low_i16x8_s", TokenType::Unary, Opcode::I32X4ExtendLowI16X8S},
       {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+#line 346 "src/lexer-keywords.txt"
+      {"i32x4.extend_low_i16x8_u", TokenType::Unary, Opcode::I32X4ExtendLowI16X8U},
+      {""}, {""},
+#line 330 "src/lexer-keywords.txt"
+      {"i32x4.shr_s", TokenType::Binary, Opcode::I32X4ShrS},
+      {""}, {""}, {""},
+#line 331 "src/lexer-keywords.txt"
+      {"i32x4.shr_u", TokenType::Binary, Opcode::I32X4ShrU},
+      {""}, {""}, {""}, {""}, {""},
+#line 157 "src/lexer-keywords.txt"
+      {"f64x2.neg", TokenType::Unary, Opcode::F64X2Neg},
+      {""}, {""},
+#line 453 "src/lexer-keywords.txt"
+      {"i64x2.neg", TokenType::Unary, Opcode::I64X2Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 341 "src/lexer-keywords.txt"
+      {"i32x4.trunc_sat_f32x4_s", TokenType::Unary, Opcode::I32X4TruncSatF32X4S},
+      {""}, {""}, {""},
 #line 342 "src/lexer-keywords.txt"
-      {"i32x4.extend_high_i16x8_s", TokenType::Unary,
-       Opcode::I32X4ExtendHighI16X8S},
-      {""},
-#line 343 "src/lexer-keywords.txt"
-      {"i32x4.extend_high_i16x8_u", TokenType::Unary,
-       Opcode::I32X4ExtendHighI16X8U},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
+      {"i32x4.trunc_sat_f32x4_u", TokenType::Unary, Opcode::I32X4TruncSatF32X4U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 529 "src/lexer-keywords.txt"
+      {"nan:arithmetic", TokenType::NanArithmetic},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 120 "src/lexer-keywords.txt"
+      {"f64.copysign", TokenType::Binary, Opcode::F64Copysign},
+#line 62 "src/lexer-keywords.txt"
+      {"f32.copysign", TokenType::Binary, Opcode::F32Copysign},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 490 "src/lexer-keywords.txt"
+      {"i8x16.max_s", TokenType::Binary, Opcode::I8X16MaxS},
+      {""}, {""}, {""},
+#line 491 "src/lexer-keywords.txt"
+      {"i8x16.max_u", TokenType::Binary, Opcode::I8X16MaxU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 186 "src/lexer-keywords.txt"
+      {"i16x8.extract_lane_s", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneS},
+      {""},
+#line 187 "src/lexer-keywords.txt"
+      {"i16x8.extract_lane_u", TokenType::SimdLaneOp, Opcode::I16X8ExtractLaneU},
+      {""}, {""}, {""}, {""}, {""},
+#line 347 "src/lexer-keywords.txt"
+      {"i32x4.trunc_sat_f64x2_s_zero", TokenType::Unary, Opcode::I32X4TruncSatF64X2SZero},
+      {""},
+#line 348 "src/lexer-keywords.txt"
+      {"i32x4.trunc_sat_f64x2_u_zero", TokenType::Unary, Opcode::I32X4TruncSatF64X2UZero},
+      {""},
+#line 168 "src/lexer-keywords.txt"
+      {"f64x2.promote_low_f32x4", TokenType::Unary, Opcode::F64X2PromoteLowF32X4},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 365 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw32.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw32CmpxchgU},
+#line 334 "src/lexer-keywords.txt"
+      {"i32x4.extadd_pairwise_i16x8_s", TokenType::Unary, Opcode::I32X4ExtaddPairwiseI16X8S},
+      {""},
+#line 335 "src/lexer-keywords.txt"
+      {"i32x4.extadd_pairwise_i16x8_u", TokenType::Unary, Opcode::I32X4ExtaddPairwiseI16X8U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 101 "src/lexer-keywords.txt"
+      {"f32x4.neg", TokenType::Unary, Opcode::F32X4Neg},
+      {""}, {""},
+#line 326 "src/lexer-keywords.txt"
+      {"i32x4.neg", TokenType::Unary, Opcode::I32X4Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 375 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I64AtomicRmw8XchgU},
+#line 244 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.xchg_u", TokenType::AtomicRmw, Opcode::I32AtomicRmw8XchgU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 383 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I64AtomicRmwXor},
+#line 252 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.xor", TokenType::AtomicRmw, Opcode::I32AtomicRmwXor},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""},
+#line 183 "src/lexer-keywords.txt"
+      {"i16x8.avgr_u", TokenType::Binary, Opcode::I16X8AvgrU},
+      {""}, {""},
+#line 484 "src/lexer-keywords.txt"
+      {"i8x16.gt_s", TokenType::Compare, Opcode::I8X16GtS},
+      {""},
+#line 485 "src/lexer-keywords.txt"
+      {"i8x16.gt_u", TokenType::Compare, Opcode::I8X16GtU},
+      {""},
+#line 503 "src/lexer-keywords.txt"
+      {"i8x16.splat", TokenType::Unary, Opcode::I8X16Splat},
+      {""},
+#line 482 "src/lexer-keywords.txt"
+      {"i8x16.ge_s", TokenType::Compare, Opcode::I8X16GeS},
+      {""},
+#line 483 "src/lexer-keywords.txt"
+      {"i8x16.ge_u", TokenType::Compare, Opcode::I8X16GeU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 372 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw8CmpxchgU},
+#line 241 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw8.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw8CmpxchgU},
+#line 206 "src/lexer-keywords.txt"
+      {"i16x8.q15mulr_sat_s", TokenType::Binary, Opcode::I16X8Q15mulrSatS},
+      {""},
+#line 358 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmw16CmpxchgU},
+#line 234 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw16.cmpxchg_u", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmw16CmpxchgU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 282 "src/lexer-keywords.txt"
+      {"i32.reinterpret_f32", TokenType::Convert, Opcode::I32ReinterpretF32},
+      {""}, {""}, {""}, {""},
+#line 610 "src/lexer-keywords.txt"
+      {"i32.reinterpret/f32", TokenType::Convert, Opcode::I32ReinterpretF32},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 608 "src/lexer-keywords.txt"
+      {"get_global", TokenType::GlobalGet, Opcode::GlobalGet},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 419 "src/lexer-keywords.txt"
+      {"i64.reinterpret_f64", TokenType::Convert, Opcode::I64ReinterpretF64},
+      {""},
+#line 209 "src/lexer-keywords.txt"
+      {"i16x8.shl", TokenType::Binary, Opcode::I16X8Shl},
+      {""}, {""},
+#line 622 "src/lexer-keywords.txt"
+      {"i64.reinterpret/f64", TokenType::Convert, Opcode::I64ReinterpretF64},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""},
+#line 480 "src/lexer-keywords.txt"
+      {"i8x16.extract_lane_s", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneS},
+      {""},
+#line 481 "src/lexer-keywords.txt"
+      {"i8x16.extract_lane_u", TokenType::SimdLaneOp, Opcode::I8X16ExtractLaneU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 208 "src/lexer-keywords.txt"
+      {"i16x8.replace_lane", TokenType::SimdLaneOp, Opcode::I16X8ReplaceLane},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 210 "src/lexer-keywords.txt"
+      {"i16x8.shr_s", TokenType::Binary, Opcode::I16X8ShrS},
+      {""}, {""}, {""},
+#line 211 "src/lexer-keywords.txt"
+      {"i16x8.shr_u", TokenType::Binary, Opcode::I16X8ShrU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
 #line 218 "src/lexer-keywords.txt"
-      {"i16x8.extmul_high_i8x16_s", TokenType::Binary,
-       Opcode::I16X8ExtmulHighI8X16S},
+      {"i16x8.extmul_low_i8x16_s", TokenType::Binary, Opcode::I16X8ExtmulLowI8X16S},
       {""},
 #line 220 "src/lexer-keywords.txt"
-      {"i16x8.extmul_high_i8x16_u", TokenType::Binary,
-       Opcode::I16X8ExtmulHighI8X16U},
+      {"i16x8.extmul_low_i8x16_u", TokenType::Binary, Opcode::I16X8ExtmulLowI8X16U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""},
+#line 477 "src/lexer-keywords.txt"
+      {"i8x16.avgr_u", TokenType::Binary, Opcode::I8X16AvgrU},
+      {""}, {""}, {""},
+#line 225 "src/lexer-keywords.txt"
+      {"i16x8.extend_low_i8x16_s", TokenType::Unary, Opcode::I16X8ExtendLowI8X16S},
       {""},
+#line 226 "src/lexer-keywords.txt"
+      {"i16x8.extend_low_i8x16_u", TokenType::Unary, Opcode::I16X8ExtendLowI8X16U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
+#line 216 "src/lexer-keywords.txt"
+      {"i16x8.extadd_pairwise_i8x16_s", TokenType::Unary, Opcode::I16X8ExtaddPairwiseI8X16S},
       {""},
+#line 217 "src/lexer-keywords.txt"
+      {"i16x8.extadd_pairwise_i8x16_u", TokenType::Unary, Opcode::I16X8ExtaddPairwiseI8X16U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
+#line 205 "src/lexer-keywords.txt"
+      {"i16x8.neg", TokenType::Unary, Opcode::I16X8Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 500 "src/lexer-keywords.txt"
+      {"i8x16.shl", TokenType::Binary, Opcode::I8X16Shl},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""},
+#line 589 "src/lexer-keywords.txt"
+      {"i8x16.shuffle", TokenType::SimdShuffleOp, Opcode::I8X16Shuffle},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 499 "src/lexer-keywords.txt"
+      {"i8x16.replace_lane", TokenType::SimdLaneOp, Opcode::I8X16ReplaceLane},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 501 "src/lexer-keywords.txt"
+      {"i8x16.shr_s", TokenType::Binary, Opcode::I8X16ShrS},
+      {""}, {""}, {""},
+#line 502 "src/lexer-keywords.txt"
+      {"i8x16.shr_u", TokenType::Binary, Opcode::I8X16ShrU},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
+#line 379 "src/lexer-keywords.txt"
+      {"i64.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I64AtomicRmwCmpxchg},
+#line 248 "src/lexer-keywords.txt"
+      {"i32.atomic.rmw.cmpxchg", TokenType::AtomicRmwCmpxchg, Opcode::I32AtomicRmwCmpxchg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 494 "src/lexer-keywords.txt"
+      {"i8x16.narrow_i16x8_s", TokenType::Binary, Opcode::I8X16NarrowI16X8S},
       {""},
+#line 495 "src/lexer-keywords.txt"
+      {"i8x16.narrow_i16x8_u", TokenType::Binary, Opcode::I8X16NarrowI16X8U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
       {""},
+#line 467 "src/lexer-keywords.txt"
+      {"i64x2.extmul_high_i32x4_s", TokenType::Binary, Opcode::I64X2ExtmulHighI32X4S},
       {""},
+#line 469 "src/lexer-keywords.txt"
+      {"i64x2.extmul_high_i32x4_u", TokenType::Binary, Opcode::I64X2ExtmulHighI32X4U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 457 "src/lexer-keywords.txt"
+      {"i64x2.extend_high_i32x4_s", TokenType::Unary, Opcode::I64X2ExtendHighI32X4S},
       {""},
-#line 381 "src/lexer-keywords.txt"
+#line 459 "src/lexer-keywords.txt"
+      {"i64x2.extend_high_i32x4_u", TokenType::Unary, Opcode::I64X2ExtendHighI32X4U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""},
+#line 496 "src/lexer-keywords.txt"
+      {"i8x16.neg", TokenType::Unary, Opcode::I8X16Neg},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
+#line 497 "src/lexer-keywords.txt"
+      {"i8x16.popcnt", TokenType::Unary, Opcode::I8X16Popcnt},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""},
+#line 337 "src/lexer-keywords.txt"
+      {"i32x4.extmul_high_i16x8_s", TokenType::Binary, Opcode::I32X4ExtmulHighI16X8S},
+      {""},
+#line 339 "src/lexer-keywords.txt"
+      {"i32x4.extmul_high_i16x8_u", TokenType::Binary, Opcode::I32X4ExtmulHighI16X8U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 343 "src/lexer-keywords.txt"
+      {"i32x4.extend_high_i16x8_s", TokenType::Unary, Opcode::I32X4ExtendHighI16X8S},
+      {""},
+#line 344 "src/lexer-keywords.txt"
+      {"i32x4.extend_high_i16x8_u", TokenType::Unary, Opcode::I32X4ExtendHighI16X8U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 219 "src/lexer-keywords.txt"
+      {"i16x8.extmul_high_i8x16_s", TokenType::Binary, Opcode::I16X8ExtmulHighI8X16S},
+      {""},
+#line 221 "src/lexer-keywords.txt"
+      {"i16x8.extmul_high_i8x16_u", TokenType::Binary, Opcode::I16X8ExtmulHighI8X16U},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+#line 382 "src/lexer-keywords.txt"
       {"i64.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I64AtomicRmwXchg},
-#line 250 "src/lexer-keywords.txt"
+#line 251 "src/lexer-keywords.txt"
       {"i32.atomic.rmw.xchg", TokenType::AtomicRmw, Opcode::I32AtomicRmwXchg},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-      {""},
-#line 222 "src/lexer-keywords.txt"
-      {"i16x8.extend_high_i8x16_s", TokenType::Unary,
-       Opcode::I16X8ExtendHighI8X16S},
-      {""},
+      {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""}, {""},
+      {""}, {""}, {""}, {""}, {""},
 #line 223 "src/lexer-keywords.txt"
-      {"i16x8.extend_high_i8x16_u", TokenType::Unary,
-       Opcode::I16X8ExtendHighI8X16U}};
+      {"i16x8.extend_high_i8x16_s", TokenType::Unary, Opcode::I16X8ExtendHighI8X16S},
+      {""},
+#line 224 "src/lexer-keywords.txt"
+      {"i16x8.extend_high_i8x16_u", TokenType::Unary, Opcode::I16X8ExtendHighI8X16U}
+    };
 
   if (len <= MAX_WORD_LENGTH && len >= MIN_WORD_LENGTH)
     {

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -583,6 +583,7 @@ void NameResolver::VisitCommand(Command* command) {
     case CommandType::AssertReturn:
     case CommandType::AssertTrap:
     case CommandType::AssertExhaustion:
+    case CommandType::AssertException:
     case CommandType::Register:
       /* Don't resolve a module_var, since it doesn't really behave like other
        * vars. You can't reference a module by index. */

--- a/src/token.def
+++ b/src/token.def
@@ -21,6 +21,7 @@
 /* Tokens with no additional data (i.e. bare). */
 WABT_TOKEN(Invalid, "Invalid")
 WABT_TOKEN(Array, "array")
+WABT_TOKEN(AssertException, "assert_exception")
 WABT_TOKEN(AssertExhaustion, "assert_exhaustion")
 WABT_TOKEN(AssertInvalid, "assert_invalid")
 WABT_TOKEN(AssertMalformed, "assert_malformed")

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1121,6 +1121,8 @@ wabt::Result JSONParser::ParseCommand(CommandPtr* out_command) {
     CHECK_RESULT(ParseLine(&command->line));
     EXPECT(",");
     CHECK_RESULT(ParseAction(&command->action));
+    EXPECT(",");
+    CHECK_RESULT(ParseActionResult());
     *out_command = std::move(command);
   } else {
     PrintError("unknown command type");
@@ -1841,6 +1843,7 @@ wabt::Result CommandRunner::OnAssertExceptionCommand(
     PrintError(command->line, "expected an exception to be thrown");
     return wabt::Result::Error;
   }
+  PrintError(command->line, "assert_exception passed");
 
   return wabt::Result::Ok;
 }

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -43,7 +43,7 @@ using namespace wabt;
 using namespace wabt::interp;
 
 static int s_verbose;
-static const char* s_infile;
+static std::string s_infile;
 static Thread::Options s_thread_options;
 static Stream* s_trace_stream;
 static Features s_features;
@@ -88,7 +88,10 @@ static void ParseOptions(int argc, char** argv) {
                    []() { s_trace_stream = s_stdout_stream.get(); });
 
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
-                     [](const char* argument) { s_infile = argument; });
+                     [](const char* argument) {
+                       s_infile = argument;
+                       ConvertBackslashToSlash(&s_infile);
+                     });
   parser.Parse(argc, argv);
 }
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -1013,7 +1013,6 @@ void ScriptValidator::CheckCommand(const Command* command) {
     case CommandType::AssertInvalid:
     case CommandType::AssertUnlinkable:
     case CommandType::AssertUninstantiable:
-    case CommandType::AssertException:
       // Ignore.
       break;
 
@@ -1050,6 +1049,10 @@ void ScriptValidator::CheckCommand(const Command* command) {
     case CommandType::AssertExhaustion:
       // ignore result type.
       CheckAction(cast<AssertExhaustionCommand>(command)->action.get());
+      break;
+    case CommandType::AssertException:
+      // ignore result type.
+      CheckAction(cast<AssertExceptionCommand>(command)->action.get());
       break;
   }
 }

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -1013,6 +1013,7 @@ void ScriptValidator::CheckCommand(const Command* command) {
     case CommandType::AssertInvalid:
     case CommandType::AssertUnlinkable:
     case CommandType::AssertUninstantiable:
+    case CommandType::AssertException:
       // Ignore.
       break;
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -227,6 +227,7 @@ bool IsCommand(TokenTypePair pair) {
   }
 
   switch (pair[1]) {
+    case TokenType::AssertException:
     case TokenType::AssertExhaustion:
     case TokenType::AssertInvalid:
     case TokenType::AssertMalformed:
@@ -3114,6 +3115,9 @@ Result WastParser::ParseCommandList(Script* script,
 Result WastParser::ParseCommand(Script* script, CommandPtr* out_command) {
   WABT_TRACE(ParseCommand);
   switch (Peek(1)) {
+    case TokenType::AssertException:
+      return ParseAssertExceptionCommand(out_command);
+
     case TokenType::AssertExhaustion:
       return ParseAssertExhaustionCommand(out_command);
 
@@ -3152,6 +3156,12 @@ Result WastParser::ParseCommand(Script* script, CommandPtr* out_command) {
       assert(!"ParseCommand should only be called when IsCommand() is true");
       return Result::Error;
   }
+}
+
+Result WastParser::ParseAssertExceptionCommand(CommandPtr* out_command) {
+  WABT_TRACE(ParseAssertExceptionCommand);
+  return ParseAssertActionCommand<AssertExceptionCommand>(
+      TokenType::AssertException, out_command);
 }
 
 Result WastParser::ParseAssertExhaustionCommand(CommandPtr* out_command) {

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -217,6 +217,7 @@ class WastParser {
 
   Result ParseCommandList(Script*, CommandPtrVector*);
   Result ParseCommand(Script*, CommandPtr*);
+  Result ParseAssertExceptionCommand(CommandPtr*);
   Result ParseAssertExhaustionCommand(CommandPtr*);
   Result ParseAssertInvalidCommand(CommandPtr*);
   Result ParseAssertMalformedCommand(CommandPtr*);

--- a/test/gen-spec-wast.py
+++ b/test/gen-spec-wast.py
@@ -138,6 +138,7 @@ class WastWriter(object):
             'assert_return': self._WriteAssertReturnCommand,
             'assert_trap': self._WriteAssertActionCommand,
             'assert_exhaustion': self._WriteAssertActionCommand,
+            'assert_exception': self._WriteAssertActionCommand,
         }
 
         func = command_funcs.get(command['type'])

--- a/test/parse/assert/assertexception.txt
+++ b/test/parse/assert/assertexception.txt
@@ -1,0 +1,8 @@
+;;; TOOL: wast2json
+;;; ARGS: --enable-exceptions
+(module
+  (tag $t)
+  (func $foo (throw $t))
+  (export "foo" (func $foo)))
+
+(assert_exception (invoke "foo"))

--- a/test/parse/assert/bad-assertexception.txt
+++ b/test/parse/assert/bad-assertexception.txt
@@ -1,0 +1,7 @@
+;;; TOOL: run-interp-spec
+;;; ARGS:
+;;; ERROR: 1
+(assert_exception (invoke "foo"))
+(;; STDERR ;;;
+out/test/parse/assert/bad-assertexception/bad-assertexception.json:3:30: invalid command: exceptions not allowed
+;;; STDERR ;;)

--- a/test/parse/assert/bad-assertexception.txt
+++ b/test/parse/assert/bad-assertexception.txt
@@ -1,7 +1,8 @@
 ;;; TOOL: run-interp-spec
 ;;; ARGS:
 ;;; ERROR: 1
+(module (func (export "foo")))
 (assert_exception (invoke "foo"))
 (;; STDERR ;;;
-out/test/parse/assert/bad-assertexception/bad-assertexception.json:3:30: invalid command: exceptions not allowed
+out/test/parse/assert/bad-assertexception/bad-assertexception.json:4:30: invalid command: exceptions not allowed
 ;;; STDERR ;;)

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -73,41 +73,41 @@ out/test/spec/exception-handling/binary.wast:165: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:178: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
 out/test/spec/exception-handling/binary.wast:188: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:198: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:209: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:219: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:231: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
 out/test/spec/exception-handling/binary.wast:239: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
 out/test/spec/exception-handling/binary.wast:249: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:259: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:269: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:279: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:290: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:300: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:310: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:320: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:331: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:341: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:351: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:361: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:374: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
 out/test/spec/exception-handling/binary.wast:382: assert_malformed passed:
@@ -119,13 +119,13 @@ out/test/spec/exception-handling/binary.wast:420: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:439: assert_malformed passed:
   0000024: error: unable to read u32 leb128: store offset
 out/test/spec/exception-handling/binary.wast:460: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:470: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:481: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:491: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:503: assert_malformed passed:
   000000c: error: unable to read u32 leb128: memory initial page count
 out/test/spec/exception-handling/binary.wast:511: assert_malformed passed:
@@ -147,21 +147,21 @@ out/test/spec/exception-handling/binary.wast:632: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:651: assert_malformed passed:
   0000024: error: unable to read u32 leb128: store offset
 out/test/spec/exception-handling/binary.wast:673: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:683: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:693: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:703: assert_malformed passed:
-  000000e: error: unable to read i32 leb128: init_expr i32.const value
+  000000e: error: unable to read i32 leb128: i32.const value
 out/test/spec/exception-handling/binary.wast:714: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:724: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:734: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:744: assert_malformed passed:
-  000000e: error: unable to read i64 leb128: init_expr i64.const value
+  000000e: error: unable to read i64 leb128: i64.const value
 out/test/spec/exception-handling/binary.wast:756: assert_malformed passed:
   0000020: error: memory.grow reserved value must be 0
 out/test/spec/exception-handling/binary.wast:776: assert_malformed passed:

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -1,0 +1,280 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/binary.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/binary.wast:6: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/exception-handling/binary.wast:7: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/exception-handling/binary.wast:8: assert_malformed passed:
+  0000000: error: unable to read uint32_t: magic
+out/test/spec/exception-handling/binary.wast:9: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:10: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:11: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:12: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:13: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:14: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:15: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:16: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:17: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:18: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:21: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:24: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:25: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:28: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:31: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:34: assert_malformed passed:
+  0000004: error: bad magic value
+out/test/spec/exception-handling/binary.wast:37: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/exception-handling/binary.wast:38: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/exception-handling/binary.wast:39: assert_malformed passed:
+  0000004: error: unable to read uint32_t: version
+out/test/spec/exception-handling/binary.wast:40: assert_malformed passed:
+  0000008: error: bad wasm file version: 0 (expected 0x1)
+out/test/spec/exception-handling/binary.wast:41: assert_malformed passed:
+  0000008: error: bad wasm file version: 0xd (expected 0x1)
+out/test/spec/exception-handling/binary.wast:42: assert_malformed passed:
+  0000008: error: bad wasm file version: 0xe (expected 0x1)
+out/test/spec/exception-handling/binary.wast:43: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x100 (expected 0x1)
+out/test/spec/exception-handling/binary.wast:44: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x10000 (expected 0x1)
+out/test/spec/exception-handling/binary.wast:45: assert_malformed passed:
+  0000008: error: bad wasm file version: 0x1000000 (expected 0x1)
+out/test/spec/exception-handling/binary.wast:48: assert_malformed passed:
+  000000a: error: invalid section code: 14
+out/test/spec/exception-handling/binary.wast:49: assert_malformed passed:
+  000000a: error: invalid section code: 127
+out/test/spec/exception-handling/binary.wast:50: assert_malformed passed:
+  000000a: error: invalid section code: 128
+out/test/spec/exception-handling/binary.wast:51: assert_malformed passed:
+  000000a: error: invalid section code: 129
+out/test/spec/exception-handling/binary.wast:52: assert_malformed passed:
+  000000a: error: invalid section code: 255
+out/test/spec/exception-handling/binary.wast:165: assert_malformed passed:
+  000000c: error: unexpected type form (got 0xe0)
+out/test/spec/exception-handling/binary.wast:178: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/exception-handling/binary.wast:188: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:198: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:209: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:219: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:231: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/exception-handling/binary.wast:239: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/exception-handling/binary.wast:249: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:259: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:269: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:279: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:290: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:300: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:310: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:320: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:331: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:341: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:351: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:361: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:374: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/exception-handling/binary.wast:382: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/exception-handling/binary.wast:401: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/exception-handling/binary.wast:420: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/exception-handling/binary.wast:439: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/exception-handling/binary.wast:460: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:470: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:481: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:491: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:503: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/exception-handling/binary.wast:511: assert_malformed passed:
+  000000c: error: unable to read u32 leb128: memory initial page count
+out/test/spec/exception-handling/binary.wast:519: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/exception-handling/binary.wast:538: assert_malformed passed:
+  0000022: error: unable to read u32 leb128: load offset
+out/test/spec/exception-handling/binary.wast:557: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/exception-handling/binary.wast:575: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: load alignment
+out/test/spec/exception-handling/binary.wast:594: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/exception-handling/binary.wast:613: assert_malformed passed:
+  0000023: error: unable to read u32 leb128: store alignment
+out/test/spec/exception-handling/binary.wast:632: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/exception-handling/binary.wast:651: assert_malformed passed:
+  0000024: error: unable to read u32 leb128: store offset
+out/test/spec/exception-handling/binary.wast:673: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:683: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:693: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:703: assert_malformed passed:
+  000000e: error: unable to read i32 leb128: init_expr i32.const value
+out/test/spec/exception-handling/binary.wast:714: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:724: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:734: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:744: assert_malformed passed:
+  000000e: error: unable to read i64 leb128: init_expr i64.const value
+out/test/spec/exception-handling/binary.wast:756: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/exception-handling/binary.wast:776: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/exception-handling/binary.wast:796: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/exception-handling/binary.wast:815: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/exception-handling/binary.wast:834: assert_malformed passed:
+  0000020: error: memory.grow reserved value must be 0
+out/test/spec/exception-handling/binary.wast:854: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/exception-handling/binary.wast:873: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/exception-handling/binary.wast:892: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/exception-handling/binary.wast:910: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/exception-handling/binary.wast:928: assert_malformed passed:
+  000001e: error: memory.size reserved value must be 0
+out/test/spec/exception-handling/binary.wast:947: assert_malformed passed:
+  0000017: error: unable to read u32 leb128: local type count
+out/test/spec/exception-handling/binary.wast:964: assert_malformed passed:
+  0000017: error: unable to read u32 leb128: local type count
+out/test/spec/exception-handling/binary.wast:981: assert_malformed passed:
+  000001c: error: local count must be < 0x10000000
+out/test/spec/exception-handling/binary.wast:997: assert_malformed passed:
+  0000030: error: local count must be < 0x10000000
+out/test/spec/exception-handling/binary.wast:1031: assert_malformed passed:
+  0000013: error: function signature count != function body count
+out/test/spec/exception-handling/binary.wast:1041: assert_malformed passed:
+  000000b: error: function signature count != function body count
+out/test/spec/exception-handling/binary.wast:1050: assert_malformed passed:
+  0000016: error: function signature count != function body count
+out/test/spec/exception-handling/binary.wast:1061: assert_malformed passed:
+  0000015: error: function signature count != function body count
+out/test/spec/exception-handling/binary.wast:1084: assert_malformed passed:
+  000000e: error: data segment count does not equal count in DataCount section
+out/test/spec/exception-handling/binary.wast:1094: assert_malformed passed:
+  000000e: error: data segment count does not equal count in DataCount section
+out/test/spec/exception-handling/binary.wast:1104: assert_malformed passed:
+  0000024: error: memory.init requires data count section
+out/test/spec/exception-handling/binary.wast:1126: assert_malformed passed:
+  000001e: error: data.drop requires data count section
+out/test/spec/exception-handling/binary.wast:1145: assert_malformed passed:
+  0000024: error: expected ref.null or ref.func in passive element segment
+  0000025: error: expected END opcode after element expression
+out/test/spec/exception-handling/binary.wast:1171: assert_malformed passed:
+  0000022: error: table elem type must be a reference type
+out/test/spec/exception-handling/binary.wast:1252: assert_malformed passed:
+  000000a: error: invalid section size: extends past end
+out/test/spec/exception-handling/binary.wast:1263: assert_malformed passed:
+  000000e: error: unfinished section (expected end: 0x11)
+out/test/spec/exception-handling/binary.wast:1282: assert_malformed passed:
+  000000e: error: malformed import kind: 5
+out/test/spec/exception-handling/binary.wast:1292: assert_malformed passed:
+  000000e: error: malformed import kind: 5
+out/test/spec/exception-handling/binary.wast:1303: assert_malformed passed:
+  000000e: error: malformed import kind: 5
+out/test/spec/exception-handling/binary.wast:1313: assert_malformed passed:
+  000000e: error: malformed import kind: 5
+out/test/spec/exception-handling/binary.wast:1324: assert_malformed passed:
+  000000e: error: malformed import kind: 128
+out/test/spec/exception-handling/binary.wast:1334: assert_malformed passed:
+  000000e: error: malformed import kind: 128
+out/test/spec/exception-handling/binary.wast:1347: assert_malformed passed:
+  0000027: error: unable to read u32 leb128: string length
+out/test/spec/exception-handling/binary.wast:1366: assert_malformed passed:
+  000002b: error: unfinished section (expected end: 0x40)
+out/test/spec/exception-handling/binary.wast:1397: assert_malformed passed:
+  000000b: error: invalid table count 1, only 0 bytes left in section
+out/test/spec/exception-handling/binary.wast:1407: assert_malformed passed:
+  000000d: error: tables may not be shared
+out/test/spec/exception-handling/binary.wast:1416: assert_malformed passed:
+  000000d: error: tables may not be shared
+out/test/spec/exception-handling/binary.wast:1426: assert_malformed passed:
+  000000d: error: malformed table limits flag: 129
+out/test/spec/exception-handling/binary.wast:1444: assert_malformed passed:
+  000000b: error: invalid memory count 1, only 0 bytes left in section
+out/test/spec/exception-handling/binary.wast:1454: assert_malformed passed:
+  000000c: error: memory may not be shared: threads not allowed
+out/test/spec/exception-handling/binary.wast:1462: assert_malformed passed:
+  000000c: error: memory may not be shared: threads not allowed
+out/test/spec/exception-handling/binary.wast:1471: assert_malformed passed:
+  000000c: error: malformed memory limits flag: 129
+out/test/spec/exception-handling/binary.wast:1480: assert_malformed passed:
+  000000c: error: malformed memory limits flag: 129
+out/test/spec/exception-handling/binary.wast:1497: assert_malformed passed:
+  0000010: error: unable to read i32 leb128: global type
+out/test/spec/exception-handling/binary.wast:1508: assert_malformed passed:
+  0000010: error: unfinished section (expected end: 0x15)
+out/test/spec/exception-handling/binary.wast:1531: assert_malformed passed:
+  000001b: error: unable to read u32 leb128: string length
+out/test/spec/exception-handling/binary.wast:1552: assert_malformed passed:
+  000001b: error: unfinished section (expected end: 0x20)
+out/test/spec/exception-handling/binary.wast:1586: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: elem segment flags
+out/test/spec/exception-handling/binary.wast:1602: assert_malformed passed:
+  0000021: error: unable to read u32 leb128: elem segment flags
+out/test/spec/exception-handling/binary.wast:1619: assert_malformed passed:
+  0000021: error: unfinished section (expected end: 0x27)
+out/test/spec/exception-handling/binary.wast:1645: assert_malformed passed:
+  0000016: error: unable to read u32 leb128: data segment flags
+out/test/spec/exception-handling/binary.wast:1658: assert_malformed passed:
+  0000016: error: unfinished section (expected end: 0x1c)
+out/test/spec/exception-handling/binary.wast:1671: assert_malformed passed:
+  0000015: error: unable to read data: data segment data
+out/test/spec/exception-handling/binary.wast:1685: assert_malformed passed:
+  000001a: error: unfinished section (expected end: 0x1b)
+out/test/spec/exception-handling/binary.wast:1716: assert_malformed passed:
+  error: function type variable out of range: 11 (max 1)
+  0000025: error: OnBlockExpr callback failed
+out/test/spec/exception-handling/binary.wast:1751: assert_malformed passed:
+  0000017: error: multiple Start sections
+136/136 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/exports.txt
+++ b/test/spec/exception-handling/exports.txt
@@ -1,0 +1,102 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/exports.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/exports.wast:39: assert_invalid passed:
+  0000000: error: function variable out of range: 0 (max 0)
+  000000f: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:43: assert_invalid passed:
+  0000000: error: function variable out of range: 1 (max 1)
+  0000019: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:47: assert_invalid passed:
+  0000000: error: function variable out of range: 1 (max 1)
+  000002e: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:51: assert_invalid passed:
+  error: duplicate export "a"
+  000001d: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:55: assert_invalid passed:
+  error: duplicate export "a"
+  000001e: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:59: assert_invalid passed:
+  error: duplicate export "a"
+  0000025: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:63: assert_invalid passed:
+  error: duplicate export "a"
+  0000023: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:67: assert_invalid passed:
+  error: duplicate export "a"
+  0000022: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:71: assert_invalid passed:
+  error: duplicate export "t0"
+  0000022: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:100: assert_invalid passed:
+  0000000: error: global variable out of range: 0 (max 0)
+  000000f: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:104: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000017: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:108: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000029: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:112: assert_invalid passed:
+  error: duplicate export "a"
+  000001b: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:116: assert_invalid passed:
+  error: duplicate export "a"
+  0000020: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:120: assert_invalid passed:
+  error: duplicate export "a"
+  0000025: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:124: assert_invalid passed:
+  error: duplicate export "a"
+  0000021: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:128: assert_invalid passed:
+  error: duplicate export "a"
+  0000020: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:155: assert_invalid passed:
+  0000000: error: table variable out of range: 0 (max 0)
+  000000f: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:159: assert_invalid passed:
+  0000000: error: table variable out of range: 1 (max 1)
+  0000015: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:163: assert_invalid passed:
+  0000000: error: table variable out of range: 1 (max 1)
+  0000026: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:167: assert_invalid passed:
+  error: duplicate export "a"
+  0000019: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:171: assert_invalid passed:
+  error: duplicate export "a"
+  000001c: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:175: assert_invalid passed:
+  error: duplicate export "a"
+  0000023: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:179: assert_invalid passed:
+  error: duplicate export "a"
+  0000021: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:183: assert_invalid passed:
+  error: duplicate export "a"
+  000001e: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:211: assert_invalid passed:
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000f: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:215: assert_invalid passed:
+  0000000: error: memory variable out of range: 1 (max 1)
+  0000014: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:219: assert_invalid passed:
+  0000000: error: memory variable out of range: 1 (max 1)
+  0000026: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:223: assert_invalid passed:
+  error: duplicate export "a"
+  0000018: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:232: assert_invalid passed:
+  error: duplicate export "a"
+  0000022: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:236: assert_invalid passed:
+  error: duplicate export "a"
+  0000020: error: OnExport callback failed
+out/test/spec/exception-handling/exports.wast:240: assert_invalid passed:
+  error: duplicate export "a"
+  000001e: error: OnExport callback failed
+41/41 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/imports.txt
+++ b/test/spec/exception-handling/imports.txt
@@ -1,0 +1,255 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/imports.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32_f32(i32:14, f32:42.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f32(f32:13.000000) =>
+called host spectest.print_i32(i32:13) =>
+called host spectest.print_f64_f64(f64:25.000000, f64:53.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+called host spectest.print_f64(f64:24.000000) =>
+out/test/spec/exception-handling/imports.wast:100: assert_invalid passed:
+  0000000: error: function type variable out of range: 1 (max 1)
+  000001e: error: OnImportFunc callback failed
+called host spectest.print_i32(i32:13) =>
+out/test/spec/exception-handling/imports.wast:136: assert_unlinkable passed:
+  error: invalid import "test.unknown"
+out/test/spec/exception-handling/imports.wast:140: assert_unlinkable passed:
+  error: invalid import "spectest.unknown"
+out/test/spec/exception-handling/imports.wast:145: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:149: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:153: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:157: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:161: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:165: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:169: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:173: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:177: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:181: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:185: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:189: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:193: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:197: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:201: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:205: assert_unlinkable passed:
+  error: import signature mismatch
+out/test/spec/exception-handling/imports.wast:210: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind func, not global
+out/test/spec/exception-handling/imports.wast:214: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind func, not table
+out/test/spec/exception-handling/imports.wast:218: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind func, not memory
+out/test/spec/exception-handling/imports.wast:222: assert_unlinkable passed:
+  error: expected import "test.tag" to have kind func, not tag
+out/test/spec/exception-handling/imports.wast:226: assert_unlinkable passed:
+  error: expected import "spectest.global_i32" to have kind func, not global
+out/test/spec/exception-handling/imports.wast:230: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind func, not table
+out/test/spec/exception-handling/imports.wast:234: assert_unlinkable passed:
+  error: expected import "spectest.memory" to have kind func, not memory
+out/test/spec/exception-handling/imports.wast:239: assert_unlinkable passed:
+  error: invalid import "test.unknown"
+out/test/spec/exception-handling/imports.wast:243: assert_unlinkable passed:
+  error: signature mismatch in imported tag
+out/test/spec/exception-handling/imports.wast:247: assert_unlinkable passed:
+  error: signature mismatch in imported tag
+out/test/spec/exception-handling/imports.wast:251: assert_unlinkable passed:
+  error: signature mismatch in imported tag
+out/test/spec/exception-handling/imports.wast:255: assert_unlinkable passed:
+  error: expected import "test.func-i32" to have kind tag, not func
+out/test/spec/exception-handling/imports.wast:290: assert_unlinkable passed:
+  error: invalid import "test.unknown"
+out/test/spec/exception-handling/imports.wast:294: assert_unlinkable passed:
+  error: invalid import "spectest.unknown"
+out/test/spec/exception-handling/imports.wast:299: assert_unlinkable passed:
+  error: type mismatch in imported global, expected i64 but got i32.
+out/test/spec/exception-handling/imports.wast:303: assert_unlinkable passed:
+  error: type mismatch in imported global, expected f32 but got i32.
+out/test/spec/exception-handling/imports.wast:307: assert_unlinkable passed:
+  error: type mismatch in imported global, expected f64 but got i32.
+out/test/spec/exception-handling/imports.wast:311: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected immutable but got mutable.
+out/test/spec/exception-handling/imports.wast:315: assert_unlinkable passed:
+  error: type mismatch in imported global, expected i32 but got f32.
+out/test/spec/exception-handling/imports.wast:319: assert_unlinkable passed:
+  error: type mismatch in imported global, expected i64 but got f32.
+out/test/spec/exception-handling/imports.wast:323: assert_unlinkable passed:
+  error: type mismatch in imported global, expected f64 but got f32.
+out/test/spec/exception-handling/imports.wast:327: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected immutable but got mutable.
+out/test/spec/exception-handling/imports.wast:331: assert_unlinkable passed:
+  error: type mismatch in imported global, expected i32 but got i64.
+out/test/spec/exception-handling/imports.wast:335: assert_unlinkable passed:
+  error: type mismatch in imported global, expected f32 but got i64.
+out/test/spec/exception-handling/imports.wast:339: assert_unlinkable passed:
+  error: type mismatch in imported global, expected f64 but got i64.
+out/test/spec/exception-handling/imports.wast:343: assert_unlinkable passed:
+  error: mutability mismatch in imported global, expected mutable but got immutable.
+out/test/spec/exception-handling/imports.wast:348: assert_unlinkable passed:
+  error: expected import "test.func" to have kind global, not func
+out/test/spec/exception-handling/imports.wast:352: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind global, not table
+out/test/spec/exception-handling/imports.wast:356: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind global, not memory
+out/test/spec/exception-handling/imports.wast:360: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind global, not func
+out/test/spec/exception-handling/imports.wast:364: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind global, not table
+out/test/spec/exception-handling/imports.wast:368: assert_unlinkable passed:
+  error: expected import "spectest.memory" to have kind global, not memory
+out/test/spec/exception-handling/imports.wast:387: assert_trap passed: uninitialized table element
+out/test/spec/exception-handling/imports.wast:390: assert_trap passed: uninitialized table element
+out/test/spec/exception-handling/imports.wast:391: assert_trap passed: undefined table index
+out/test/spec/exception-handling/imports.wast:406: assert_trap passed: uninitialized table element
+out/test/spec/exception-handling/imports.wast:409: assert_trap passed: uninitialized table element
+out/test/spec/exception-handling/imports.wast:410: assert_trap passed: undefined table index
+out/test/spec/exception-handling/imports.wast:442: assert_unlinkable passed:
+  error: invalid import "test.unknown"
+out/test/spec/exception-handling/imports.wast:446: assert_unlinkable passed:
+  error: invalid import "spectest.unknown"
+out/test/spec/exception-handling/imports.wast:451: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+out/test/spec/exception-handling/imports.wast:455: assert_unlinkable passed:
+  error: max size (unspecified) larger than declared (20)
+out/test/spec/exception-handling/imports.wast:459: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+out/test/spec/exception-handling/imports.wast:463: assert_unlinkable passed:
+  error: max size (20) larger than declared (18)
+out/test/spec/exception-handling/imports.wast:467: assert_unlinkable passed:
+  error: actual size (10) smaller than declared (12)
+out/test/spec/exception-handling/imports.wast:471: assert_unlinkable passed:
+  error: max size (20) larger than declared (15)
+out/test/spec/exception-handling/imports.wast:476: assert_unlinkable passed:
+  error: expected import "test.func" to have kind table, not func
+out/test/spec/exception-handling/imports.wast:480: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind table, not global
+out/test/spec/exception-handling/imports.wast:484: assert_unlinkable passed:
+  error: expected import "test.memory-2-inf" to have kind table, not memory
+out/test/spec/exception-handling/imports.wast:488: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind table, not func
+out/test/spec/exception-handling/imports.wast:506: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
+out/test/spec/exception-handling/imports.wast:517: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
+out/test/spec/exception-handling/imports.wast:520: assert_invalid passed:
+  error: only one memory block allowed
+  0000015: error: OnImportMemory callback failed
+out/test/spec/exception-handling/imports.wast:524: assert_invalid passed:
+  error: only one memory block allowed
+  0000015: error: OnMemory callback failed
+out/test/spec/exception-handling/imports.wast:528: assert_invalid passed:
+  error: only one memory block allowed
+  000000f: error: OnMemory callback failed
+out/test/spec/exception-handling/imports.wast:543: assert_unlinkable passed:
+  error: invalid import "test.unknown"
+out/test/spec/exception-handling/imports.wast:547: assert_unlinkable passed:
+  error: invalid import "spectest.unknown"
+out/test/spec/exception-handling/imports.wast:552: assert_unlinkable passed:
+  error: actual size (2) smaller than declared (3)
+out/test/spec/exception-handling/imports.wast:556: assert_unlinkable passed:
+  error: max size (unspecified) larger than declared (3)
+out/test/spec/exception-handling/imports.wast:560: assert_unlinkable passed:
+  error: actual size (1) smaller than declared (2)
+out/test/spec/exception-handling/imports.wast:564: assert_unlinkable passed:
+  error: max size (2) larger than declared (1)
+out/test/spec/exception-handling/imports.wast:569: assert_unlinkable passed:
+  error: expected import "test.func-i32" to have kind memory, not func
+out/test/spec/exception-handling/imports.wast:573: assert_unlinkable passed:
+  error: expected import "test.global-i32" to have kind memory, not global
+out/test/spec/exception-handling/imports.wast:577: assert_unlinkable passed:
+  error: expected import "test.table-10-inf" to have kind memory, not table
+out/test/spec/exception-handling/imports.wast:581: assert_unlinkable passed:
+  error: expected import "spectest.print_i32" to have kind memory, not func
+out/test/spec/exception-handling/imports.wast:585: assert_unlinkable passed:
+  error: expected import "spectest.global_i32" to have kind memory, not global
+out/test/spec/exception-handling/imports.wast:589: assert_unlinkable passed:
+  error: expected import "spectest.table" to have kind memory, not table
+out/test/spec/exception-handling/imports.wast:594: assert_unlinkable passed:
+  error: actual size (1) smaller than declared (2)
+out/test/spec/exception-handling/imports.wast:598: assert_unlinkable passed:
+  error: max size (2) larger than declared (1)
+out/test/spec/exception-handling/imports.wast:636: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.133.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (func))
+          ^^^^^^
+out/test/spec/exception-handling/imports.wast:640: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.134.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (global i64))
+          ^^^^^^
+out/test/spec/exception-handling/imports.wast:644: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.135.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (table 0 funcref))
+          ^^^^^^
+out/test/spec/exception-handling/imports.wast:648: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.136.wat:1:9: error: imports must occur before all non-import definitions
+  (func) (import "" "" (memory 0))
+          ^^^^^^
+out/test/spec/exception-handling/imports.wast:653: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.137.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (func))
+                              ^^^^^^
+out/test/spec/exception-handling/imports.wast:657: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.138.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (global f32))
+                              ^^^^^^
+out/test/spec/exception-handling/imports.wast:661: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.139.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (table 0 funcref))
+                              ^^^^^^
+out/test/spec/exception-handling/imports.wast:665: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.140.wat:1:29: error: imports must occur before all non-import definitions
+  (global i64 (i64.const 0)) (import "" "" (memory 0))
+                              ^^^^^^
+out/test/spec/exception-handling/imports.wast:670: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.141.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (func))
+                     ^^^^^^
+out/test/spec/exception-handling/imports.wast:674: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.142.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (global i32))
+                     ^^^^^^
+out/test/spec/exception-handling/imports.wast:678: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.143.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (table 0 funcref))
+                     ^^^^^^
+out/test/spec/exception-handling/imports.wast:682: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.144.wat:1:20: error: imports must occur before all non-import definitions
+  (table 0 funcref) (import "" "" (memory 0))
+                     ^^^^^^
+out/test/spec/exception-handling/imports.wast:687: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.145.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (func))
+              ^^^^^^
+out/test/spec/exception-handling/imports.wast:691: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.146.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (global i32))
+              ^^^^^^
+out/test/spec/exception-handling/imports.wast:695: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.147.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (table 1 3 funcref))
+              ^^^^^^
+out/test/spec/exception-handling/imports.wast:699: assert_malformed passed:
+  out/test/spec/exception-handling/imports/imports.148.wat:1:13: error: imports must occur before all non-import definitions
+  (memory 0) (import "" "" (memory 1 2))
+              ^^^^^^
+out/test/spec/exception-handling/imports.wast:709: assert_unlinkable passed:
+  error: invalid import "not wasm.overloaded"
+131/131 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/rethrow.txt
+++ b/test/spec/exception-handling/rethrow.txt
@@ -2,6 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/rethrow.wast
 ;;; ARGS*: --enable-exceptions
 (;; STDOUT ;;;
+out/test/spec/exception-handling/rethrow.wast:75: assert_exception passed
+out/test/spec/exception-handling/rethrow.wast:77: assert_exception passed
+out/test/spec/exception-handling/rethrow.wast:80: assert_exception passed
+out/test/spec/exception-handling/rethrow.wast:82: assert_exception passed
+out/test/spec/exception-handling/rethrow.wast:84: assert_exception passed
+out/test/spec/exception-handling/rethrow.wast:85: assert_exception passed
+out/test/spec/exception-handling/rethrow.wast:91: assert_exception passed
 out/test/spec/exception-handling/rethrow.wast:93: assert_invalid passed:
   error: rethrow not in try catch block
   0000019: error: OnRethrowExpr callback failed

--- a/test/spec/exception-handling/rethrow.txt
+++ b/test/spec/exception-handling/rethrow.txt
@@ -1,0 +1,15 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/rethrow.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/rethrow.wast:93: assert_invalid passed:
+  error: rethrow not in try catch block
+  0000019: error: OnRethrowExpr callback failed
+out/test/spec/exception-handling/rethrow.wast:94: assert_invalid passed:
+  error: rethrow not in try catch block
+  000001b: error: OnRethrowExpr callback failed
+out/test/spec/exception-handling/rethrow.wast:95: assert_invalid passed:
+  error: rethrow not in try catch block
+  000001b: error: OnRethrowExpr callback failed
+15/15 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/tag.txt
+++ b/test/spec/exception-handling/tag.txt
@@ -1,0 +1,9 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/tag.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/tag.wast:19: assert_invalid passed:
+  error: Tag signature must have 0 results.
+  0000014: error: OnTagType callback failed
+1/1 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/throw.txt
+++ b/test/spec/exception-handling/throw.txt
@@ -1,0 +1,15 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/throw.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/throw.wast:47: assert_invalid passed:
+  0000000: error: tag variable out of range: 0 (max 0)
+  0000019: error: OnThrowExpr callback failed
+out/test/spec/exception-handling/throw.wast:48: assert_invalid passed:
+  error: type mismatch in throw, expected [i32] but got []
+  0000022: error: OnThrowExpr callback failed
+out/test/spec/exception-handling/throw.wast:50: assert_invalid passed:
+  error: type mismatch in throw, expected [i32] but got [i64]
+  0000024: error: OnThrowExpr callback failed
+10/10 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/throw.txt
+++ b/test/spec/exception-handling/throw.txt
@@ -2,6 +2,11 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/throw.wast
 ;;; ARGS*: --enable-exceptions
 (;; STDOUT ;;;
+out/test/spec/exception-handling/throw.wast:38: assert_exception passed
+out/test/spec/exception-handling/throw.wast:39: assert_exception passed
+out/test/spec/exception-handling/throw.wast:41: assert_exception passed
+out/test/spec/exception-handling/throw.wast:42: assert_exception passed
+out/test/spec/exception-handling/throw.wast:43: assert_exception passed
 out/test/spec/exception-handling/throw.wast:47: assert_invalid passed:
   0000000: error: tag variable out of range: 0 (max 0)
   0000019: error: OnThrowExpr callback failed

--- a/test/spec/exception-handling/try_catch.txt
+++ b/test/spec/exception-handling/try_catch.txt
@@ -1,0 +1,35 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_catch.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/try_catch.wast:157: assert_trap passed: unreachable executed
+out/test/spec/exception-handling/try_catch.wast:160: assert_trap passed: integer divide by zero
+out/test/spec/exception-handling/try_catch.wast:214: assert_malformed passed:
+  out/test/spec/exception-handling/try_catch/try_catch.3.wat:1:16: error: unexpected token "catch_all", expected an instr.
+  (module (func (catch_all)))
+                 ^^^^^^^^^
+out/test/spec/exception-handling/try_catch.wast:219: assert_malformed passed:
+  out/test/spec/exception-handling/try_catch/try_catch.4.wat:1:25: error: unexpected token "catch", expected an instr.
+  (module (tag $e) (func (catch $e)))
+                          ^^^^^
+out/test/spec/exception-handling/try_catch.wast:224: assert_malformed passed:
+  out/test/spec/exception-handling/try_catch/try_catch.5.wat:1:38: error: multiple catch_all clauses not allowed
+  (module (func (try (do) (catch_all) (catch_all))))
+                                       ^^^^^^^^^
+out/test/spec/exception-handling/try_catch.wast:230: assert_invalid passed:
+  error: type mismatch in try, expected [i32] but got []
+  000001b: error: OnEndExpr callback failed
+out/test/spec/exception-handling/try_catch.wast:232: assert_invalid passed:
+  error: type mismatch in try, expected [i32] but got [i64]
+  000001d: error: OnEndExpr callback failed
+out/test/spec/exception-handling/try_catch.wast:234: assert_invalid passed:
+  error: type mismatch in try catch, expected [] but got [i32]
+  0000023: error: OnEndExpr callback failed
+out/test/spec/exception-handling/try_catch.wast:236: assert_invalid passed:
+  error: type mismatch in try catch, expected [i32] but got [i64]
+  0000028: error: OnEndExpr callback failed
+out/test/spec/exception-handling/try_catch.wast:241: assert_invalid passed:
+  error: type mismatch in try catch, expected [] but got [i32]
+  000001d: error: OnEndExpr callback failed
+35/35 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/exception-handling/try_catch.txt
+++ b/test/spec/exception-handling/try_catch.txt
@@ -4,6 +4,8 @@
 (;; STDOUT ;;;
 out/test/spec/exception-handling/try_catch.wast:157: assert_trap passed: unreachable executed
 out/test/spec/exception-handling/try_catch.wast:160: assert_trap passed: integer divide by zero
+out/test/spec/exception-handling/try_catch.wast:164: assert_exception passed
+out/test/spec/exception-handling/try_catch.wast:168: assert_exception passed
 out/test/spec/exception-handling/try_catch.wast:214: assert_malformed passed:
   out/test/spec/exception-handling/try_catch/try_catch.3.wat:1:16: error: unexpected token "catch_all", expected an instr.
   (module (func (catch_all)))

--- a/test/spec/exception-handling/try_delegate.txt
+++ b/test/spec/exception-handling/try_delegate.txt
@@ -2,6 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_delegate.wast
 ;;; ARGS*: --enable-exceptions
 (;; STDOUT ;;;
+out/test/spec/exception-handling/try_delegate.wast:102: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:105: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:107: assert_exception passed
+out/test/spec/exception-handling/try_delegate.wast:115: assert_exception passed
 out/test/spec/exception-handling/try_delegate.wast:118: assert_malformed passed:
   out/test/spec/exception-handling/try_delegate/try_delegate.1.wat:1:16: error: unexpected token "delegate", expected an instr.
   (module (func (delegate 0)))

--- a/test/spec/exception-handling/try_delegate.txt
+++ b/test/spec/exception-handling/try_delegate.txt
@@ -1,0 +1,25 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/exception-handling/try_delegate.wast
+;;; ARGS*: --enable-exceptions
+(;; STDOUT ;;;
+out/test/spec/exception-handling/try_delegate.wast:118: assert_malformed passed:
+  out/test/spec/exception-handling/try_delegate/try_delegate.1.wat:1:16: error: unexpected token "delegate", expected an instr.
+  (module (func (delegate 0)))
+                 ^^^^^^^^
+out/test/spec/exception-handling/try_delegate.wast:123: assert_malformed passed:
+  out/test/spec/exception-handling/try_delegate/try_delegate.2.wat:1:46: error: unexpected token delegate, expected ).
+  (module (tag $e) (func (try (do) (catch $e) (delegate 0))))
+                                               ^^^^^^^^
+out/test/spec/exception-handling/try_delegate.wast:128: assert_malformed passed:
+  out/test/spec/exception-handling/try_delegate/try_delegate.3.wat:1:38: error: unexpected token delegate, expected ).
+  (module (func (try (do) (catch_all) (delegate 0))))
+                                       ^^^^^^^^
+out/test/spec/exception-handling/try_delegate.wast:133: assert_malformed passed:
+  out/test/spec/exception-handling/try_delegate/try_delegate.4.wat:1:34: error: unexpected token ")", expected a numeric index or a name (e.g. 12 or $foo).
+  (module (func (try (do) (delegate) (delegate 0))))
+                                   ^
+out/test/spec/exception-handling/try_delegate.wast:138: assert_invalid passed:
+  error: invalid depth: 2 (max 1)
+  000001b: error: OnDelegateExpr callback failed
+18/18 tests passed.
+;;; STDOUT ;;)

--- a/test/typecheck/bad-assertexception-type-mismatch.txt
+++ b/test/typecheck/bad-assertexception-type-mismatch.txt
@@ -1,0 +1,11 @@
+;;; TOOL: wast2json
+;;; ERROR: 1
+(module
+  (func (export "foo") (param i32) (result i32) get_local 0)
+  )
+(assert_exception (invoke "foo" (f32.const 0)))
+(;; STDERR ;;;
+out/test/typecheck/bad-assertexception-type-mismatch.txt:6:44: error: type mismatch for argument 0 of invoke. got f32, expected i32
+(assert_exception (invoke "foo" (f32.const 0)))
+                                           ^
+;;; STDERR ;;)

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -90,7 +90,8 @@ def main(args):
 
     flags = {
         'memory64': '--enable-memory64',
-        'multi-memory': '--enable-multi-memory'
+        'multi-memory': '--enable-multi-memory',
+        'exception-handling': '--enable-exceptions'
     }
 
     unimplemented = set([
@@ -99,7 +100,6 @@ def main(args):
         'function-references',
         'threads',
         'annotations',
-        'exception-handling',
         'extended-const',
     ])
 


### PR DESCRIPTION
This PR imports the spec tests from the Wasm testsuite repo and adds infrastructure to run them correctly.

  * Adds test expectations for exception handling proposal spec tests.
  * Adds missing tag signature matching code for import tests.
  * Adds support for the `assert_exception` command used in new tests.
  * Fix filename normalization for the spec test runner.