### PR TITLE
OnRefFuncExpr takes a func index. NFC

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -186,7 +186,7 @@ class BinaryReaderIR : public BinaryReaderNop {
   Result OnTableGrowExpr(Index table_index) override;
   Result OnTableSizeExpr(Index table_index) override;
   Result OnTableFillExpr(Index table_index) override;
-  Result OnRefFuncExpr(Index type_index) override;
+  Result OnRefFuncExpr(Index func_index) override;
   Result OnRefNullExpr(Type type) override;
   Result OnRefIsNullExpr() override;
   Result OnNopExpr() override;
@@ -948,8 +948,8 @@ Result BinaryReaderIR::OnTableFillExpr(Index table_index) {
   return AppendExpr(MakeUnique<TableFillExpr>(Var(table_index)));
 }
 
-Result BinaryReaderIR::OnRefFuncExpr(Index type_index) {
-  return AppendExpr(MakeUnique<RefFuncExpr>(Var(type_index)));
+Result BinaryReaderIR::OnRefFuncExpr(Index func_index) {
+  return AppendExpr(MakeUnique<RefFuncExpr>(Var(func_index)));
 }
 
 Result BinaryReaderIR::OnRefNullExpr(Type type) {

--- a/src/binary-reader-nop.h
+++ b/src/binary-reader-nop.h
@@ -287,7 +287,7 @@ class BinaryReaderNop : public BinaryReaderDelegate {
   Result OnTableGrowExpr(Index table_index) override { return Result::Ok; }
   Result OnTableSizeExpr(Index table_index) override { return Result::Ok; }
   Result OnTableFillExpr(Index table_index) override { return Result::Ok; }
-  Result OnRefFuncExpr(Index type_index) override { return Result::Ok; }
+  Result OnRefFuncExpr(Index func_index) override { return Result::Ok; }
   Result OnRefNullExpr(Type type) override { return Result::Ok; }
   Result OnRefIsNullExpr() override { return Result::Ok; }
   Result OnNopExpr() override { return Result::Ok; }

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -272,7 +272,7 @@ class BinaryReaderDelegate {
   virtual Result OnTableGrowExpr(Index table_index) = 0;
   virtual Result OnTableSizeExpr(Index table_index) = 0;
   virtual Result OnTableFillExpr(Index table_index) = 0;
-  virtual Result OnRefFuncExpr(Index type_index) = 0;
+  virtual Result OnRefFuncExpr(Index func_index) = 0;
   virtual Result OnRefNullExpr(Type type) = 0;
   virtual Result OnRefIsNullExpr() = 0;
   virtual Result OnNopExpr() = 0;

--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -1382,9 +1382,9 @@ Result BinaryReaderInterp::OnTableFillExpr(Index table_index) {
   return Result::Ok;
 }
 
-Result BinaryReaderInterp::OnRefFuncExpr(Index type_index) {
-  CHECK_RESULT(validator_.OnRefFunc(loc, Var(type_index)));
-  istream_.Emit(Opcode::RefFunc, type_index);
+Result BinaryReaderInterp::OnRefFuncExpr(Index func_index) {
+  CHECK_RESULT(validator_.OnRefFunc(loc, Var(func_index)));
+  istream_.Emit(Opcode::RefFunc, func_index);
   return Result::Ok;
 }
 

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -769,9 +769,9 @@ Result TypeChecker::OnTableFill(Type elem_type) {
   return PopAndCheck3Types(Type::I32, elem_type, Type::I32, "table.fill");
 }
 
-Result TypeChecker::OnRefFuncExpr(Index type_index) {
+Result TypeChecker::OnRefFuncExpr(Index func_index) {
   if (features_.function_references_enabled()) {
-    PushType(Type(Type::Reference, type_index));
+    PushType(Type(Type::Reference, func_index));
   } else {
     PushType(Type::FuncRef);
   }

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -111,7 +111,7 @@ class TypeChecker {
   Result OnTableGrow(Type elem_type);
   Result OnTableSize();
   Result OnTableFill(Type elem_type);
-  Result OnRefFuncExpr(Index type_index);
+  Result OnRefFuncExpr(Index func_index);
   Result OnRefNullExpr(Type type);
   Result OnRefIsNullExpr();
   Result OnRethrow(Index depth);


### PR DESCRIPTION
The name of this argument was recently changed from `func_index`
to `type_index` as part of #1695, but I think that might have been incorrect.

The immediate that read in the binary reader is (IIRC) a function
index:

```
      case Opcode::RefFunc: {
        Index func;
        CHECK_RESULT(ReadIndex(&func, "func index"));
        CALLBACK(OnRefFuncExpr, func);
        CALLBACK(OnOpcodeUint32, func);
        break;
      }
```

and not a type index.   Indeed the interpreter seems to treat it
as a function index too:

```
Result BinaryReaderInterp::OnRefFuncExpr(Index func_index) {
  CHECK_RESULT(validator_.OnRefFunc(loc, Var(func_index)));
  istream_.Emit(Opcode::RefFunc, func_index);
  return Result::Ok;
}
```