### PR TITLE
Create explicit class in the IR for initializer expressions. NFC

### DIFF
--- a/src/apply-names.cc
+++ b/src/apply-names.cc
@@ -439,7 +439,7 @@ Result NameApplier::VisitFunc(Index func_index, Func* func) {
 }
 
 Result NameApplier::VisitGlobal(Global* global) {
-  CHECK_RESULT(visitor_.VisitExprList(global->init_expr));
+  CHECK_RESULT(visitor_.VisitExprList(global->init_expr.exprs));
   return Result::Ok;
 }
 
@@ -460,9 +460,9 @@ Result NameApplier::VisitExport(Index export_index, Export* export_) {
 Result NameApplier::VisitElemSegment(Index elem_segment_index,
                                      ElemSegment* segment) {
   CHECK_RESULT(UseNameForTableVar(&segment->table_var));
-  CHECK_RESULT(visitor_.VisitExprList(segment->offset));
-  for (ExprList& elem_expr : segment->elem_exprs) {
-    Expr* expr = &elem_expr.front();
+  CHECK_RESULT(visitor_.VisitExprList(segment->offset.exprs));
+  for (InitExpr& init_expr : segment->elem_exprs) {
+    Expr* expr = &init_expr.exprs.front();
     if (expr->type() == ExprType::RefFunc) {
       CHECK_RESULT(UseNameForFuncVar(&cast<RefFuncExpr>(expr)->var));
     }
@@ -473,7 +473,7 @@ Result NameApplier::VisitElemSegment(Index elem_segment_index,
 Result NameApplier::VisitDataSegment(Index data_segment_index,
                                      DataSegment* segment) {
   CHECK_RESULT(UseNameForMemoryVar(&segment->memory_var));
-  CHECK_RESULT(visitor_.VisitExprList(segment->offset));
+  CHECK_RESULT(visitor_.VisitExprList(segment->offset.exprs));
   return Result::Ok;
 }
 

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -304,7 +304,7 @@ class BinaryReaderIR : public BinaryReaderNop {
 
   Func* current_func_ = nullptr;
   std::vector<LabelNode> label_stack_;
-  ExprList* current_init_expr_ = nullptr;
+  InitExpr* current_init_expr_ = nullptr;
   bool current_init_expr_ended_ = false;
   const char* filename_;
 };
@@ -369,7 +369,7 @@ Result BinaryReaderIR::TopLabelExpr(LabelNode** label, Expr** expr) {
 Result BinaryReaderIR::AppendExpr(std::unique_ptr<Expr> expr) {
   expr->loc = GetLocation();
   if (current_init_expr_) {
-    current_init_expr_->push_back(std::move(expr));
+    current_init_expr_->exprs.push_back(std::move(expr));
   } else {
     LabelNode* label;
     CHECK_RESULT(TopLabel(&label));
@@ -1200,8 +1200,8 @@ Result BinaryReaderIR::OnElemSegmentElemExpr_RefNull(Index segment_index,
   assert(segment_index == module_->elem_segments.size() - 1);
   ElemSegment* segment = module_->elem_segments[segment_index];
   Location loc = GetLocation();
-  ExprList init_expr;
-  init_expr.push_back(MakeUnique<RefNullExpr>(type, loc));
+  InitExpr init_expr;
+  init_expr.exprs.push_back(MakeUnique<RefNullExpr>(type, loc));
   segment->elem_exprs.push_back(std::move(init_expr));
   return Result::Ok;
 }
@@ -1211,8 +1211,8 @@ Result BinaryReaderIR::OnElemSegmentElemExpr_RefFunc(Index segment_index,
   assert(segment_index == module_->elem_segments.size() - 1);
   ElemSegment* segment = module_->elem_segments[segment_index];
   Location loc = GetLocation();
-  ExprList init_expr;
-  init_expr.push_back(MakeUnique<RefFuncExpr>(Var(func_index, loc), loc));
+  InitExpr init_expr;
+  init_expr.exprs.push_back(MakeUnique<RefFuncExpr>(Var(func_index, loc), loc));
   segment->elem_exprs.push_back(std::move(init_expr));
   return Result::Ok;
 }

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -395,7 +395,7 @@ class BinaryWriter {
                                   const char* desc);
   void WriteExpr(const Func* func, const Expr* expr);
   void WriteExprList(const Func* func, const ExprList& exprs);
-  void WriteInitExpr(const ExprList& expr);
+  void WriteInitExpr(const InitExpr& expr);
   void WriteFuncLocals(const Func* func, const LocalTypes& local_types);
   void WriteFunc(const Func* func);
   void WriteTable(const Table* table);
@@ -1112,8 +1112,8 @@ void BinaryWriter::WriteExprList(const Func* func, const ExprList& exprs) {
   }
 }
 
-void BinaryWriter::WriteInitExpr(const ExprList& expr) {
-  WriteExprList(nullptr, expr);
+void BinaryWriter::WriteInitExpr(const InitExpr& expr) {
+  WriteExprList(nullptr, expr.exprs);
   WriteOpcode(stream_, Opcode::End);
 }
 
@@ -1539,13 +1539,13 @@ Result BinaryWriter::WriteModule() {
       // preceeded by length
       WriteU32Leb128(stream_, segment->elem_exprs.size(), "num elems");
       if (flags & SegUseElemExprs) {
-        for (const ExprList& elem_expr : segment->elem_exprs) {
+        for (const InitExpr& elem_expr : segment->elem_exprs) {
           WriteInitExpr(elem_expr);
         }
       } else {
-        for (const ExprList& elem_expr : segment->elem_exprs) {
-          assert(elem_expr.size() == 1);
-          const Expr* expr = &elem_expr.front();
+        for (const InitExpr& elem_expr : segment->elem_exprs) {
+          assert(elem_expr.exprs.size() == 1);
+          const Expr* expr = &elem_expr.exprs.front();
           assert(expr->type() == ExprType::RefFunc);
           WriteU32Leb128(stream_,
                          module_->GetFuncIndex(cast<RefFuncExpr>(expr)->var),

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -266,8 +266,8 @@ struct Decompiler {
       // FIXME: make this less expensive with a binary search or whatever.
       for (auto dat : mc.module.data_segments) {
         uint64_t dat_base;
-        if (dat->offset.size() == 1 &&
-            ConstIntVal(&dat->offset.front(), dat_base) &&
+        if (dat->offset.exprs.size() == 1 &&
+            ConstIntVal(&dat->offset.exprs.front(), dat_base) &&
             abs_base >= dat_base &&
             abs_base < dat_base + dat->data.size()) {
           // We are inside the range of this data segment!
@@ -719,7 +719,7 @@ struct Decompiler {
           CheckImportExport(s, ExternalKind::Global, global_index, g->name);
       s += cat("global ", g->name, ":", GetDecompTypeName(g->type));
       if (!is_import) {
-        s += cat(" = ", InitExp(g->init_expr));
+        s += cat(" = ", InitExp(g->init_expr.exprs));
       }
       s += ";\n";
       global_index++;
@@ -745,7 +745,7 @@ struct Decompiler {
 
     // Data.
     for (auto dat : mc.module.data_segments) {
-      s += cat("data ", dat->name, "(offset: ", InitExp(dat->offset), ") =");
+      s += cat("data ", dat->name, "(offset: ", InitExp(dat->offset.exprs), ") =");
       auto ds = BinaryToString(dat->data);
       if (ds.size() > target_exp_width / 2) {
         s += "\n";

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -667,8 +667,8 @@ uint8_t ElemSegment::GetFlags(const Module* module) const {
   all_ref_func =
       all_ref_func &&
       std::all_of(elem_exprs.begin(), elem_exprs.end(),
-                  [](const ExprList& elem_expr) {
-                    return elem_expr.front().type() == ExprType::RefFunc;
+                  [](const InitExpr& elem_expr) {
+                    return elem_expr.exprs.front().type() == ExprType::RefFunc;
                   });
   if (!all_ref_func) {
     flags |= SegUseElemExprs;

--- a/src/ir.h
+++ b/src/ir.h
@@ -372,6 +372,13 @@ struct Block {
   Location end_loc;
 };
 
+struct InitExpr {
+  InitExpr() = default;
+  explicit InitExpr(ExprList exprs) : exprs(std::move(exprs)) {}
+
+  ExprList exprs;
+};
+
 struct Catch {
   explicit Catch(const Location& loc = Location()) : loc(loc) {}
   explicit Catch(const Var& var, const Location& loc = Location())
@@ -835,7 +842,7 @@ struct Global {
   std::string name;
   Type type = Type::Void;
   bool mutable_ = false;
-  ExprList init_expr;
+  InitExpr init_expr;
 };
 
 struct Table {
@@ -847,7 +854,7 @@ struct Table {
   Type elem_type;
 };
 
-typedef std::vector<ExprList> ExprListVector;
+typedef std::vector<InitExpr> InitExprVector;
 
 struct ElemSegment {
   explicit ElemSegment(string_view name) : name(name.to_string()) {}
@@ -857,8 +864,8 @@ struct ElemSegment {
   std::string name;
   Var table_var;
   Type elem_type;
-  ExprList offset;
-  ExprListVector elem_exprs;
+  InitExpr offset;
+  InitExprVector elem_exprs;
 };
 
 struct Memory {
@@ -875,7 +882,7 @@ struct DataSegment {
   SegmentKind kind = SegmentKind::Active;
   std::string name;
   Var memory_var;
-  ExprList offset;
+  InitExpr offset;
   std::vector<uint8_t> data;
 };
 

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -514,7 +514,7 @@ void NameResolver::VisitExport(Export* export_) {
 }
 
 void NameResolver::VisitGlobal(Global* global) {
-  visitor_.VisitExprList(global->init_expr);
+  visitor_.VisitExprList(global->init_expr.exprs);
 }
 
 void NameResolver::VisitTag(Tag* tag) {
@@ -525,18 +525,18 @@ void NameResolver::VisitTag(Tag* tag) {
 
 void NameResolver::VisitElemSegment(ElemSegment* segment) {
   ResolveTableVar(&segment->table_var);
-  visitor_.VisitExprList(segment->offset);
-  for (ExprList& elem_expr : segment->elem_exprs) {
-    if (elem_expr.size() == 1 &&
-        elem_expr.front().type() == ExprType::RefFunc) {
-      ResolveFuncVar(&cast<RefFuncExpr>(&elem_expr.front())->var);
+  visitor_.VisitExprList(segment->offset.exprs);
+  for (InitExpr& elem_expr : segment->elem_exprs) {
+    if (elem_expr.exprs.size() == 1 &&
+        elem_expr.exprs.front().type() == ExprType::RefFunc) {
+      ResolveFuncVar(&cast<RefFuncExpr>(&elem_expr.exprs.front())->var);
     }
   }
 }
 
 void NameResolver::VisitDataSegment(DataSegment* segment) {
   ResolveMemoryVar(&segment->memory_var);
-  visitor_.VisitExprList(segment->offset);
+  visitor_.VisitExprList(segment->offset.exprs);
 }
 
 Result NameResolver::VisitModule(Module* module) {

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -731,8 +731,8 @@ Result Validator::CheckModule() {
       result_ |=
           validator_.OnGlobal(field.loc, f->global.type, f->global.mutable_);
 
-      if (f->global.init_expr.size() == 1) {
-        const Expr* expr = &f->global.init_expr.front();
+      if (f->global.init_expr.exprs.size() == 1) {
+        const Expr* expr = &f->global.init_expr.exprs.front();
 
         switch (expr->type()) {
           case ExprType::Const:
@@ -798,8 +798,8 @@ Result Validator::CheckModule() {
       validator_.OnElemSegmentElemType(f->elem_segment.elem_type);
 
       // Init expr.
-      if (f->elem_segment.offset.size() == 1) {
-        const Expr* expr = &f->elem_segment.offset.front();
+      if (f->elem_segment.offset.exprs.size() == 1) {
+        const Expr* expr = &f->elem_segment.offset.exprs.front();
 
         switch (expr->type()) {
           case ExprType::Const:
@@ -818,14 +818,14 @@ Result Validator::CheckModule() {
             result_ |= validator_.OnElemSegmentInitExpr_Other(expr->loc);
             break;
         }
-      } else if (f->elem_segment.offset.size() > 1) {
+      } else if (f->elem_segment.offset.exprs.size() > 1) {
         result_ |= validator_.OnElemSegmentInitExpr_Other(field.loc);
       }
 
       // Element expr.
       for (auto&& elem_expr : f->elem_segment.elem_exprs) {
-        if (elem_expr.size() == 1) {
-          const Expr* expr = &elem_expr.front();
+        if (elem_expr.exprs.size() == 1) {
+          const Expr* expr = &elem_expr.exprs.front();
           switch (expr->type()) {
             case ExprType::RefNull:
               result_ |= validator_.OnElemSegmentElemExpr_RefNull(
@@ -839,7 +839,7 @@ Result Validator::CheckModule() {
               result_ |= validator_.OnElemSegmentElemExpr_Other(expr->loc);
               break;
           }
-        } else if (elem_expr.size() > 1) {
+        } else if (elem_expr.exprs.size() > 1) {
           result_ |= validator_.OnElemSegmentElemExpr_Other(field.loc);
         }
       }
@@ -873,8 +873,8 @@ Result Validator::CheckModule() {
           field.loc, f->data_segment.memory_var, f->data_segment.kind);
 
       // Init expr.
-      if (f->data_segment.offset.size() == 1) {
-        const Expr* expr = &f->data_segment.offset.front();
+      if (f->data_segment.offset.exprs.size() == 1) {
+        const Expr* expr = &f->data_segment.offset.exprs.front();
 
         switch (expr->type()) {
           case ExprType::Const:
@@ -893,7 +893,7 @@ Result Validator::CheckModule() {
             result_ |= validator_.OnDataSegmentInitExpr_Other(expr->loc);
             break;
         }
-      } else if (f->data_segment.offset.size() > 1) {
+      } else if (f->data_segment.offset.exprs.size() > 1) {
         result_ |= validator_.OnDataSegmentInitExpr_Other(field.loc);
       }
     }

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -822,20 +822,20 @@ bool WastParser::ParseElemExprOpt(ExprList* out_elem_expr) {
   return true;
 }
 
-bool WastParser::ParseElemExprListOpt(ExprListVector* out_list) {
-  ExprList elem_expr;
-  while (ParseElemExprOpt(&elem_expr)) {
-    out_list->push_back(std::move(elem_expr));
+bool WastParser::ParseElemExprListOpt(InitExprVector* out_list) {
+  InitExpr init_expr;
+  while (ParseElemExprOpt(&init_expr.exprs)) {
+    out_list->push_back(std::move(init_expr));
   }
   return !out_list->empty();
 }
 
-bool WastParser::ParseElemExprVarListOpt(ExprListVector* out_list) {
+bool WastParser::ParseElemExprVarListOpt(InitExprVector* out_list) {
   WABT_TRACE(ParseElemExprVarListOpt);
   Var var;
-  ExprList init_expr;
+  InitExpr init_expr;
   while (ParseVarOpt(&var)) {
-    init_expr.push_back(MakeUnique<RefFuncExpr>(var));
+    init_expr.exprs.push_back(MakeUnique<RefFuncExpr>(var));
     out_list->push_back(std::move(init_expr));
   }
   return !out_list->empty();
@@ -1200,10 +1200,10 @@ Result WastParser::ParseDataModuleField(Module* module) {
     EXPECT(Memory);
     CHECK_RESULT(ParseVar(&field->data_segment.memory_var));
     EXPECT(Rpar);
-    CHECK_RESULT(ParseOffsetExpr(&field->data_segment.offset));
+    CHECK_RESULT(ParseOffsetExpr(&field->data_segment.offset.exprs));
   } else if (ParseVarOpt(&field->data_segment.memory_var, Var(0, loc))) {
-    CHECK_RESULT(ParseOffsetExpr(&field->data_segment.offset));
-  } else if (!ParseOffsetExprOpt(&field->data_segment.offset)) {
+    CHECK_RESULT(ParseOffsetExpr(&field->data_segment.offset.exprs));
+  } else if (!ParseOffsetExprOpt(&field->data_segment.offset.exprs)) {
     if (!options_->features.bulk_memory_enabled()) {
       Error(loc, "passive data segments are not allowed");
       return Result::Error;
@@ -1263,11 +1263,11 @@ Result WastParser::ParseElemModuleField(Module* module) {
   // Parse offset expression, if not declared/passive segment.
   if (options_->features.bulk_memory_enabled()) {
     if (field->elem_segment.kind != SegmentKind::Declared &&
-        !ParseOffsetExprOpt(&field->elem_segment.offset)) {
+        !ParseOffsetExprOpt(&field->elem_segment.offset.exprs)) {
       field->elem_segment.kind = SegmentKind::Passive;
     }
   } else {
-    CHECK_RESULT(ParseOffsetExpr(&field->elem_segment.offset));
+    CHECK_RESULT(ParseOffsetExpr(&field->elem_segment.offset.exprs));
   }
 
   if (ParseRefTypeOpt(&field->elem_segment.elem_type)) {
@@ -1473,7 +1473,7 @@ Result WastParser::ParseGlobalModuleField(Module* module) {
   } else {
     auto field = MakeUnique<GlobalModuleField>(loc, name);
     CHECK_RESULT(ParseGlobalType(&field->global));
-    CHECK_RESULT(ParseTerminatingInstrList(&field->global.init_expr));
+    CHECK_RESULT(ParseTerminatingInstrList(&field->global.init_expr.exprs));
     module->AppendField(std::move(field));
   }
 
@@ -1599,9 +1599,9 @@ Result WastParser::ParseMemoryModuleField(Module* module) {
       auto data_segment_field = MakeUnique<DataSegmentModuleField>(loc);
       DataSegment& data_segment = data_segment_field->data_segment;
       data_segment.memory_var = Var(module->memories.size());
-      data_segment.offset.push_back(MakeUnique<ConstExpr>(
+      data_segment.offset.exprs.push_back(MakeUnique<ConstExpr>(
           field->memory.page_limits.is_64 ? Const::I64(0) : Const::I32(0)));
-      data_segment.offset.back().loc = loc;
+      data_segment.offset.exprs.back().loc = loc;
       ParseTextListOpt(&data_segment.data);
       EXPECT(Rpar);
 
@@ -1671,13 +1671,13 @@ Result WastParser::ParseTableModuleField(Module* module) {
     auto elem_segment_field = MakeUnique<ElemSegmentModuleField>(loc);
     ElemSegment& elem_segment = elem_segment_field->elem_segment;
     elem_segment.table_var = Var(module->tables.size());
-    elem_segment.offset.push_back(MakeUnique<ConstExpr>(Const::I32(0)));
-    elem_segment.offset.back().loc = loc;
+    elem_segment.offset.exprs.push_back(MakeUnique<ConstExpr>(Const::I32(0)));
+    elem_segment.offset.exprs.back().loc = loc;
     elem_segment.elem_type = elem_type;
     // Syntax is either an optional list of var (legacy), or a non-empty list
     // of elem expr.
-    ExprList elem_expr;
-    if (ParseElemExprOpt(&elem_expr)) {
+    InitExpr elem_expr;
+    if (ParseElemExprOpt(&elem_expr.exprs)) {
       elem_segment.elem_exprs.push_back(std::move(elem_expr));
       // Parse the rest.
       ParseElemExprListOpt(&elem_segment.elem_exprs);

--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -131,8 +131,8 @@ class WastParser {
   bool ParseTextListOpt(std::vector<uint8_t>* out_data);
   Result ParseVarList(VarVector* out_var_list);
   bool ParseElemExprOpt(ExprList* out_elem_expr);
-  bool ParseElemExprListOpt(ExprListVector* out_list);
-  bool ParseElemExprVarListOpt(ExprListVector* out_list);
+  bool ParseElemExprListOpt(InitExprVector* out_list);
+  bool ParseElemExprVarListOpt(InitExprVector* out_list);
   Result ParseValueType(Var* out_type);
   Result ParseValueTypeList(
       TypeVector* out_type_list,

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -142,7 +142,7 @@ class WatWriter : ModuleContext {
   template <typename T>
   void WriteMemoryLoadStoreExpr(const Expr* expr);
   void WriteExprList(const ExprList& exprs);
-  void WriteInitExpr(const ExprList& expr);
+  void WriteInitExpr(const InitExpr& expr);
   template <typename T>
   void WriteTypeBindings(const char* prefix,
                          const T& types,
@@ -1263,10 +1263,10 @@ void WatWriter::FlushExprTreeStack() {
   FlushExprTreeVector(stack_copy);
 }
 
-void WatWriter::WriteInitExpr(const ExprList& expr) {
-  if (!expr.empty()) {
+void WatWriter::WriteInitExpr(const InitExpr& expr) {
+  if (!expr.exprs.empty()) {
     WritePuts("(", NextChar::None);
-    WriteExprList(expr);
+    WriteExprList(expr.exprs);
     /* clear the next char, so we don't write a newline after the expr */
     next_char_ = NextChar::None;
     WritePuts(")", NextChar::Space);
@@ -1448,13 +1448,13 @@ void WatWriter::WriteElemSegment(const ElemSegment& segment) {
     WritePuts("func", NextChar::Space);
   }
 
-  for (const ExprList& expr : segment.elem_exprs) {
+  for (const InitExpr& init_expr : segment.elem_exprs) {
     if (flags & SegUseElemExprs) {
-      WriteInitExpr(expr);
+      WriteInitExpr(init_expr);
     } else {
-      assert(expr.size() == 1);
-      assert(expr.front().type() == ExprType::RefFunc);
-      WriteVar(cast<const RefFuncExpr>(&expr.front())->var, NextChar::Space);
+      assert(init_expr.exprs.size() == 1);
+      assert(init_expr.exprs.front().type() == ExprType::RefFunc);
+      WriteVar(cast<const RefFuncExpr>(&init_expr.exprs.front())->var, NextChar::Space);
     }
   }
   WriteCloseNewline();


### PR DESCRIPTION
Rather than treating an init expression as a raw expressions list wrap
it into its own class.  While this does nothing now I plan to followup
by attaching an end_loc (like we do for Block) so that we can have the
validator handle checking the correct placement of the END instruction.

Its also good for readability to have an explict class for this class
of expression list.