### PR TITLE
Remove unused checks from #1770. NFC

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -627,10 +627,6 @@ Result BinaryReaderInterp::BeginGlobalInitExpr(Index index) {
 Result BinaryReaderInterp::EndInitExpr() {
   assert(reading_init_expr_);
   reading_init_expr_ = false;
-  if (!init_expr_.ended) {
-    PrintError("expected END opcode after initializer expression");
-    return Result::Error;
-  }
   return Result::Ok;
 }
 
@@ -638,7 +634,6 @@ Result BinaryReaderInterp::BeginInitExpr() {
   assert(!reading_init_expr_);
   reading_init_expr_ = true;
   init_expr_.kind = InitExprKind::None;
-  init_expr_.ended = false;
   return Result::Ok;
 }
 
@@ -1101,11 +1096,6 @@ Result BinaryReaderInterp::OnElseExpr() {
 
 Result BinaryReaderInterp::OnEndExpr() {
   if (reading_init_expr_) {
-    if (init_expr_.ended) {
-      PrintError("duplicate END opcode init initializer expression");
-      return Result::Error;
-    }
-    init_expr_.ended = true;
     return Result::Ok;
   }
   if (label_stack_.size() == 1) {

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -109,7 +109,6 @@ enum class InitExprKind {
 
 struct InitExpr {
   InitExprKind kind;
-  bool ended = false;
   union {
     u32 i32_;
     u64 i64_;


### PR DESCRIPTION
In #1770 I introduced these (duplicate) checks but it turns
out neither were necessary in the final version of the patch.