### PR TITLE
wasm-objdump: Fix disassembly output of selectT instruction

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -793,7 +793,11 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeType(Type type) {
     return Result::Ok;
   }
   Offset immediate_len = state->offset - current_opcode_offset;
-  LogOpcode(immediate_len, type.GetRefKindName());
+  if (current_opcode == Opcode::SelectT) {
+    LogOpcode(immediate_len, type.GetName());
+  } else {
+    LogOpcode(immediate_len, type.GetRefKindName());
+  }
   return Result::Ok;
 }
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -673,9 +673,13 @@ Result BinaryReader::ReadInstructions(bool stop_on_end,
           result_types_[i] = result_type;
         }
 
-        Type* result_types = num_results ? result_types_.data() : nullptr;
-        CALLBACK(OnSelectExpr, num_results, result_types);
-        CALLBACK0(OnOpcodeBare);
+        if (num_results) {
+          CALLBACK(OnSelectExpr, num_results, result_types_.data());
+          CALLBACK(OnOpcodeType, result_types_[0]);
+        } else {
+          CALLBACK(OnSelectExpr, 0, NULL);
+          CALLBACK0(OnOpcodeBare);
+        }
         break;
       }
 

--- a/test/dump/select.txt
+++ b/test/dump/select.txt
@@ -15,7 +15,7 @@
     f32.const 2
     f32.const 3
     i32.const 1
-    select
+    select (result f32)
     drop
     f64.const 2
     f64.const 3
@@ -69,19 +69,21 @@
 000002d: 0000 4040                                 ; f32 literal
 0000031: 41                                        ; i32.const
 0000032: 01                                        ; i32 literal
-0000033: 1b                                        ; select
-0000034: 1a                                        ; drop
-0000035: 44                                        ; f64.const
-0000036: 0000 0000 0000 0040                       ; f64 literal
-000003e: 44                                        ; f64.const
-000003f: 0000 0000 0000 0840                       ; f64 literal
-0000047: 41                                        ; i32.const
-0000048: 01                                        ; i32 literal
-0000049: 1b                                        ; select
-000004a: 1a                                        ; drop
-000004b: 0b                                        ; end
-0000015: 36                                        ; FIXUP func body size
-0000013: 38                                        ; FIXUP section size
+0000033: 1c                                        ; select
+0000034: 01                                        ; num result types
+0000035: 7d                                        ; result type
+0000036: 1a                                        ; drop
+0000037: 44                                        ; f64.const
+0000038: 0000 0000 0000 0040                       ; f64 literal
+0000040: 44                                        ; f64.const
+0000041: 0000 0000 0000 0840                       ; f64 literal
+0000049: 41                                        ; i32.const
+000004a: 01                                        ; i32 literal
+000004b: 1b                                        ; select
+000004c: 1a                                        ; drop
+000004d: 0b                                        ; end
+0000015: 38                                        ; FIXUP func body size
+0000013: 3a                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
@@ -103,12 +105,12 @@ Code Disassembly:
  000027: 43 00 00 00 40             | f32.const 0x1p+1
  00002c: 43 00 00 40 40             | f32.const 0x1.8p+1
  000031: 41 01                      | i32.const 1
- 000033: 1b                         | select
- 000034: 1a                         | drop
- 000035: 44 00 00 00 00 00 00 00 40 | f64.const 0x1p+1
- 00003e: 44 00 00 00 00 00 00 08 40 | f64.const 0x1.8p+1
- 000047: 41 01                      | i32.const 1
- 000049: 1b                         | select
- 00004a: 1a                         | drop
- 00004b: 0b                         | end
+ 000033: 1c 01 7d                   | select f32
+ 000036: 1a                         | drop
+ 000037: 44 00 00 00 00 00 00 00 40 | f64.const 0x1p+1
+ 000040: 44 00 00 00 00 00 00 08 40 | f64.const 0x1.8p+1
+ 000049: 41 01                      | i32.const 1
+ 00004b: 1b                         | select
+ 00004c: 1a                         | drop
+ 00004d: 0b                         | end
 ;;; STDOUT ;;)


### PR DESCRIPTION
Use `LogOpcodeType` rather than` LogOpcodeBare` when the select
instruction has a type.