### PR TITLE
Add error locations to BinaryReaderInterp

### DIFF
--- a/src/interp/binary-reader-interp.h
+++ b/src/interp/binary-reader-interp.h
@@ -27,7 +27,8 @@ struct ReadBinaryOptions;
 
 namespace interp {
 
-Result ReadBinaryInterp(const void* data,
+Result ReadBinaryInterp(string_view filename,
+                        const void* data,
                         size_t size,
                         const ReadBinaryOptions& options,
                         Errors*,

--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -632,8 +632,8 @@ own wasm_module_t* wasm_module_new(wasm_store_t* store,
                                    const wasm_byte_vec_t* binary) {
   Errors errors;
   ModuleDesc module_desc;
-  if (Failed(ReadBinaryInterp(binary->data, binary->size, GetOptions(), &errors,
-                              &module_desc))) {
+  if (Failed(ReadBinaryInterp("<internal>", binary->data, binary->size,
+                              GetOptions(), &errors, &module_desc))) {
     FormatErrorsToFile(errors, Location::Type::Binary);
     return nullptr;
   }

--- a/src/test-interp.cc
+++ b/src/test-interp.cc
@@ -30,8 +30,8 @@ class InterpTest : public ::testing::Test {
   void ReadModule(const std::vector<u8>& data) {
     Errors errors;
     ReadBinaryOptions options;
-    Result result = ReadBinaryInterp(data.data(), data.size(), options, &errors,
-                                     &module_desc_);
+    Result result = ReadBinaryInterp("<internal>", data.data(), data.size(),
+                                     options, &errors, &module_desc_);
     ASSERT_EQ(Result::Ok, result)
         << FormatErrorsToString(errors, Location::Type::Binary);
   }

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1409,8 +1409,9 @@ interp::Module::Ptr CommandRunner::ReadModule(string_view module_filename,
   ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
                             kStopOnFirstError, kFailOnCustomSectionError);
   ModuleDesc module_desc;
-  if (Failed(ReadBinaryInterp(file_data.data(), file_data.size(), options,
-                              errors, &module_desc))) {
+  if (Failed(ReadBinaryInterp(module_filename, file_data.data(),
+                              file_data.size(), options, errors,
+                              &module_desc))) {
     return {};
   }
 

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -205,8 +205,9 @@ static Result ReadModule(const char* module_filename,
   const bool kFailOnCustomSectionError = true;
   ReadBinaryOptions options(s_features, s_log_stream.get(), kReadDebugNames,
                             kStopOnFirstError, kFailOnCustomSectionError);
-  CHECK_RESULT(ReadBinaryInterp(file_data.data(), file_data.size(), options,
-                                errors, &module_desc));
+  CHECK_RESULT(ReadBinaryInterp(module_filename, file_data.data(),
+                                file_data.size(), options, errors,
+                                &module_desc));
 
   if (s_verbose) {
     module_desc.istream.Disassemble(stream);

--- a/test/regress/regress-26.txt
+++ b/test/regress/regress-26.txt
@@ -14,6 +14,6 @@ section(ELEM) {
   addr[end]
 }
 (;; STDERR ;;;
-error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+out/test/regress/regress-26/regress-26.wasm:0000013: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
 0000013: error: EndElemSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-27.txt
+++ b/test/regress/regress-27.txt
@@ -14,6 +14,6 @@ section(DATA) {
   data[str("test")]
 }
 (;; STDERR ;;;
-error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+out/test/regress/regress-27/regress-27.wasm:0000012: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
 0000012: error: EndDataSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-28.txt
+++ b/test/regress/regress-28.txt
@@ -15,6 +15,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-error: type mismatch in function, expected [] but got [any]
+out/test/regress/regress-28/regress-28.wasm:000001b: error: type mismatch in function, expected [] but got [any]
 000001c: error: EndFunctionBody callback failed
 ;;; STDERR ;;)

--- a/test/spec/align.txt
+++ b/test/spec/align.txt
@@ -186,115 +186,115 @@ out/test/spec/align.wast:299: assert_malformed passed:
   (module (memory 0) (func (f64.store align=7 (i32.const 0) (f32.const 0))))
                                       ^^^^^^^
 out/test/spec/align.wast:306: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.69.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:310: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.70.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:314: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.71.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:318: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.72.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:322: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.73.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:326: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.74.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:330: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.75.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:334: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.76.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:338: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.77.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:342: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.78.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:346: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.79.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:350: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/align/align.80.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:354: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.81.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:358: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/align/align.82.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:363: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.83.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:367: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.84.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:371: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.85.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:375: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.86.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:379: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.87.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:383: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.88.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:387: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.89.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:391: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.90.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:395: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.91.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:399: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.92.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:403: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.93.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:407: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/align/align.94.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:411: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.95.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:415: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/align/align.96.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/align.wast:420: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.97.wasm:0000023: error: alignment must not be larger than natural alignment (1)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:424: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.98.wasm:0000023: error: alignment must not be larger than natural alignment (2)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:428: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.99.wasm:0000023: error: alignment must not be larger than natural alignment (4)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:432: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/align/align.100.wasm:0000023: error: alignment must not be larger than natural alignment (1)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:436: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/align/align.101.wasm:0000023: error: alignment must not be larger than natural alignment (2)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:440: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.102.wasm:0000023: error: alignment must not be larger than natural alignment (4)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:444: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/align/align.103.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/align.wast:448: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/align/align.104.wasm:0000026: error: alignment must not be larger than natural alignment (4)
   0000026: error: OnStoreExpr callback failed
 out/test/spec/align.wast:452: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/align/align.105.wasm:000002a: error: alignment must not be larger than natural alignment (8)
   000002a: error: OnStoreExpr callback failed
 out/test/spec/align.wast:864: assert_trap passed: out of bounds memory access: access at 65532+8 >= max value 65536
 131/131 tests passed.

--- a/test/spec/binary.txt
+++ b/test/spec/binary.txt
@@ -271,7 +271,7 @@ out/test/spec/binary.wast:1671: assert_malformed passed:
 out/test/spec/binary.wast:1685: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/binary.wast:1716: assert_malformed passed:
-  error: function type variable out of range: 11 (max 1)
+  out/test/spec/binary/binary.166.wasm:0000025: error: function type variable out of range: 11 (max 1)
   0000025: error: OnBlockExpr callback failed
 out/test/spec/binary.wast:1751: assert_malformed passed:
   0000017: error: multiple Start sections

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -49,469 +49,469 @@ out/test/spec/block.wast:489: assert_malformed passed:
   ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (resul...
                                           ^
 out/test/spec/block.wast:497: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/block/block.12.wasm:000001c: error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:505: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/block/block.13.wasm:000001b: error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:509: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/block/block.14.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:513: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/block/block.15.wasm:000001b: error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:517: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/block/block.16.wasm:000001b: error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:522: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/block/block.17.wasm:000001c: error: type mismatch in block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:528: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i64]
+  out/test/spec/block/block.18.wasm:000001c: error: type mismatch in block, expected [] but got [i64]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:534: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [f32]
+  out/test/spec/block/block.19.wasm:000001f: error: type mismatch in block, expected [] but got [f32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/block.wast:540: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [f64]
+  out/test/spec/block/block.20.wasm:0000023: error: type mismatch in block, expected [] but got [f64]
   0000023: error: OnEndExpr callback failed
 out/test/spec/block.wast:546: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32, i32]
+  out/test/spec/block/block.21.wasm:000001e: error: type mismatch in block, expected [] but got [i32, i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/block.wast:552: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.22.wasm:000001b: error: type mismatch in block, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
 out/test/spec/block.wast:558: assert_invalid passed:
-  error: type mismatch in block, expected [i64] but got []
+  out/test/spec/block/block.23.wasm:000001b: error: type mismatch in block, expected [i64] but got []
   000001b: error: OnEndExpr callback failed
 out/test/spec/block.wast:564: assert_invalid passed:
-  error: type mismatch in block, expected [f32] but got []
+  out/test/spec/block/block.24.wasm:000001b: error: type mismatch in block, expected [f32] but got []
   000001b: error: OnEndExpr callback failed
 out/test/spec/block.wast:570: assert_invalid passed:
-  error: type mismatch in block, expected [f64] but got []
+  out/test/spec/block/block.25.wasm:000001b: error: type mismatch in block, expected [f64] but got []
   000001b: error: OnEndExpr callback failed
 out/test/spec/block.wast:576: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got []
+  out/test/spec/block/block.26.wasm:000001c: error: type mismatch in block, expected [i32, i32] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:583: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.27.wasm:000001e: error: type mismatch in block, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
 out/test/spec/block.wast:592: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.28.wasm:000001e: error: type mismatch in block, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
 out/test/spec/block.wast:601: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.29.wasm:0000020: error: type mismatch in block, expected [i32] but got []
   0000020: error: OnEndExpr callback failed
 out/test/spec/block.wast:611: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.30.wasm:000001c: error: type mismatch in block, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:617: assert_invalid passed:
-  error: type mismatch in block, expected [i64] but got []
+  out/test/spec/block/block.31.wasm:000001c: error: type mismatch in block, expected [i64] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:623: assert_invalid passed:
-  error: type mismatch in block, expected [f32] but got []
+  out/test/spec/block/block.32.wasm:000001c: error: type mismatch in block, expected [f32] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:629: assert_invalid passed:
-  error: type mismatch in block, expected [f64] but got []
+  out/test/spec/block/block.33.wasm:000001c: error: type mismatch in block, expected [f64] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:635: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got []
+  out/test/spec/block/block.34.wasm:000001d: error: type mismatch in block, expected [i32, i32] but got []
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:641: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [i64]
+  out/test/spec/block/block.35.wasm:000001d: error: type mismatch in block, expected [i32] but got [i64]
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:647: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/block/block.36.wasm:0000020: error: type mismatch in block, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/block.wast:653: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f64]
+  out/test/spec/block/block.37.wasm:0000024: error: type mismatch in block, expected [i32] but got [f64]
   0000024: error: OnEndExpr callback failed
 out/test/spec/block.wast:659: assert_invalid passed:
-  error: type mismatch in block, expected [i64] but got [i32]
+  out/test/spec/block/block.38.wasm:000001d: error: type mismatch in block, expected [i64] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:665: assert_invalid passed:
-  error: type mismatch in block, expected [i64] but got [f32]
+  out/test/spec/block/block.39.wasm:0000020: error: type mismatch in block, expected [i64] but got [f32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/block.wast:671: assert_invalid passed:
-  error: type mismatch in block, expected [i64] but got [f64]
+  out/test/spec/block/block.40.wasm:0000024: error: type mismatch in block, expected [i64] but got [f64]
   0000024: error: OnEndExpr callback failed
 out/test/spec/block.wast:677: assert_invalid passed:
-  error: type mismatch in block, expected [f32] but got [i32]
+  out/test/spec/block/block.41.wasm:000001d: error: type mismatch in block, expected [f32] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:683: assert_invalid passed:
-  error: type mismatch in block, expected [f32] but got [i64]
+  out/test/spec/block/block.42.wasm:000001d: error: type mismatch in block, expected [f32] but got [i64]
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:689: assert_invalid passed:
-  error: type mismatch in block, expected [f32] but got [f64]
+  out/test/spec/block/block.43.wasm:0000024: error: type mismatch in block, expected [f32] but got [f64]
   0000024: error: OnEndExpr callback failed
 out/test/spec/block.wast:695: assert_invalid passed:
-  error: type mismatch in block, expected [f64] but got [i32]
+  out/test/spec/block/block.44.wasm:000001d: error: type mismatch in block, expected [f64] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:701: assert_invalid passed:
-  error: type mismatch in block, expected [f64] but got [i64]
+  out/test/spec/block/block.45.wasm:000001d: error: type mismatch in block, expected [f64] but got [i64]
   000001d: error: OnEndExpr callback failed
 out/test/spec/block.wast:707: assert_invalid passed:
-  error: type mismatch in block, expected [f64] but got [f32]
+  out/test/spec/block/block.46.wasm:0000020: error: type mismatch in block, expected [f64] but got [f32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/block.wast:713: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got [i32]
+  out/test/spec/block/block.47.wasm:000001e: error: type mismatch in block, expected [i32, i32] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/block.wast:719: assert_invalid passed:
-  error: type mismatch in block, expected [i32, i32] but got [i32]
+  out/test/spec/block/block.48.wasm:0000020: error: type mismatch in block, expected [i32, i32] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/block.wast:725: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/block/block.49.wasm:000001f: error: type mismatch in block, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/block.wast:732: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/block/block.50.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:738: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/block/block.51.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:744: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f64]
+  out/test/spec/block/block.52.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [f64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:750: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/block/block.53.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [i32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:756: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [f32]
+  out/test/spec/block/block.54.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [f32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:762: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [f64]
+  out/test/spec/block/block.55.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [f64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:768: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/block/block.56.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:774: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i64]
+  out/test/spec/block/block.57.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:780: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [f64]
+  out/test/spec/block/block.58.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [f64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:786: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got [i32]
+  out/test/spec/block/block.59.wasm:000001f: error: type mismatch in implicit return, expected [f64] but got [i32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:792: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got [i64]
+  out/test/spec/block/block.60.wasm:000001f: error: type mismatch in implicit return, expected [f64] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:798: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got [f32]
+  out/test/spec/block/block.61.wasm:000001f: error: type mismatch in implicit return, expected [f64] but got [f32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:805: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/block/block.62.wasm:000001c: error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:811: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got []
+  out/test/spec/block/block.63.wasm:000001c: error: type mismatch in br, expected [i64] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:817: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got []
+  out/test/spec/block/block.64.wasm:000001c: error: type mismatch in br, expected [f32] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:823: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got []
+  out/test/spec/block/block.65.wasm:000001c: error: type mismatch in br, expected [f64] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:829: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/block/block.66.wasm:000001d: error: type mismatch in br, expected [i32, i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:836: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/block/block.67.wasm:000001c: error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:842: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got []
+  out/test/spec/block/block.68.wasm:000001c: error: type mismatch in br, expected [i64] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:848: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got []
+  out/test/spec/block/block.69.wasm:000001c: error: type mismatch in br, expected [f32] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:854: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got []
+  out/test/spec/block/block.70.wasm:000001c: error: type mismatch in br, expected [f64] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/block.wast:860: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/block/block.71.wasm:000001d: error: type mismatch in br, expected [i32, i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:867: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/block/block.72.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:873: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got []
+  out/test/spec/block/block.73.wasm:000001d: error: type mismatch in br, expected [i64] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:879: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got []
+  out/test/spec/block/block.74.wasm:000001d: error: type mismatch in br, expected [f32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:885: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got []
+  out/test/spec/block/block.75.wasm:000001d: error: type mismatch in br, expected [f64] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:892: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/block/block.76.wasm:000001e: error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:898: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f32]
+  out/test/spec/block/block.77.wasm:0000021: error: type mismatch in br, expected [i32] but got [f32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:904: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f64]
+  out/test/spec/block/block.78.wasm:0000025: error: type mismatch in br, expected [i32] but got [f64]
   0000025: error: OnBrExpr callback failed
 out/test/spec/block.wast:910: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [i32]
+  out/test/spec/block/block.79.wasm:000001e: error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:916: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [f32]
+  out/test/spec/block/block.80.wasm:0000021: error: type mismatch in br, expected [i64] but got [f32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:922: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [f64]
+  out/test/spec/block/block.81.wasm:0000025: error: type mismatch in br, expected [i64] but got [f64]
   0000025: error: OnBrExpr callback failed
 out/test/spec/block.wast:928: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [i32]
+  out/test/spec/block/block.82.wasm:000001e: error: type mismatch in br, expected [f32] but got [i32]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:934: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [i64]
+  out/test/spec/block/block.83.wasm:000001e: error: type mismatch in br, expected [f32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:940: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [f64]
+  out/test/spec/block/block.84.wasm:0000025: error: type mismatch in br, expected [f32] but got [f64]
   0000025: error: OnBrExpr callback failed
 out/test/spec/block.wast:946: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [i32]
+  out/test/spec/block/block.85.wasm:000001e: error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:952: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [i64]
+  out/test/spec/block/block.86.wasm:000001e: error: type mismatch in br, expected [f64] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:958: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [f32]
+  out/test/spec/block/block.87.wasm:0000021: error: type mismatch in br, expected [f64] but got [f32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:964: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/block/block.88.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:970: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/block/block.89.wasm:0000021: error: type mismatch in br, expected [i32, i32] but got [i32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:977: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/block/block.90.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:983: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got []
+  out/test/spec/block/block.91.wasm:000001d: error: type mismatch in br, expected [i64] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:989: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got []
+  out/test/spec/block/block.92.wasm:000001d: error: type mismatch in br, expected [f32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:995: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got []
+  out/test/spec/block/block.93.wasm:000001d: error: type mismatch in br, expected [f64] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/block.wast:1001: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/block/block.94.wasm:000001e: error: type mismatch in br, expected [i32, i32] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1008: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/block/block.95.wasm:000001e: error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1014: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f32]
+  out/test/spec/block/block.96.wasm:0000021: error: type mismatch in br, expected [i32] but got [f32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:1020: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f64]
+  out/test/spec/block/block.97.wasm:0000025: error: type mismatch in br, expected [i32] but got [f64]
   0000025: error: OnBrExpr callback failed
 out/test/spec/block.wast:1026: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [i32]
+  out/test/spec/block/block.98.wasm:000001e: error: type mismatch in br, expected [i64] but got [i32]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1032: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [f32]
+  out/test/spec/block/block.99.wasm:0000021: error: type mismatch in br, expected [i64] but got [f32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:1038: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [f64]
+  out/test/spec/block/block.100.wasm:0000025: error: type mismatch in br, expected [i64] but got [f64]
   0000025: error: OnBrExpr callback failed
 out/test/spec/block.wast:1044: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [i32]
+  out/test/spec/block/block.101.wasm:000001e: error: type mismatch in br, expected [f32] but got [i32]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1050: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [i64]
+  out/test/spec/block/block.102.wasm:000001e: error: type mismatch in br, expected [f32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1056: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [f64]
+  out/test/spec/block/block.103.wasm:0000025: error: type mismatch in br, expected [f32] but got [f64]
   0000025: error: OnBrExpr callback failed
 out/test/spec/block.wast:1062: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [i32]
+  out/test/spec/block/block.104.wasm:000001e: error: type mismatch in br, expected [f64] but got [i32]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1068: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [i64]
+  out/test/spec/block/block.105.wasm:000001e: error: type mismatch in br, expected [f64] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1074: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [f32]
+  out/test/spec/block/block.106.wasm:0000021: error: type mismatch in br, expected [f64] but got [f32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:1080: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/block/block.107.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1087: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/block/block.108.wasm:0000023: error: type mismatch in function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1093: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/block/block.109.wasm:0000023: error: type mismatch in function, expected [] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1099: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/block/block.110.wasm:0000026: error: type mismatch in function, expected [] but got [f32]
   0000027: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1105: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/block/block.111.wasm:000002a: error: type mismatch in function, expected [] but got [f64]
   000002b: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1111: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32, i32]
+  out/test/spec/block/block.112.wasm:000002a: error: type mismatch in function, expected [] but got [i32, i32]
   000002b: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1118: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/block/block.113.wasm:000001e: error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1124: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got []
+  out/test/spec/block/block.114.wasm:000001e: error: type mismatch in br, expected [i64] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1130: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got []
+  out/test/spec/block/block.115.wasm:000001e: error: type mismatch in br, expected [f32] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1136: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got []
+  out/test/spec/block/block.116.wasm:000001e: error: type mismatch in br, expected [f64] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/block.wast:1142: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/block/block.117.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1149: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/block/block.118.wasm:000001f: error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1155: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got []
+  out/test/spec/block/block.119.wasm:000001f: error: type mismatch in br, expected [i64] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1161: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got []
+  out/test/spec/block/block.120.wasm:000001f: error: type mismatch in br, expected [f32] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1167: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got []
+  out/test/spec/block/block.121.wasm:000001f: error: type mismatch in br, expected [f64] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1173: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/block/block.122.wasm:0000020: error: type mismatch in br, expected [i32, i32] but got []
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1180: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/block/block.123.wasm:0000020: error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1188: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f32]
+  out/test/spec/block/block.124.wasm:0000023: error: type mismatch in br, expected [i32] but got [f32]
   0000023: error: OnBrExpr callback failed
 out/test/spec/block.wast:1196: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f64]
+  out/test/spec/block/block.125.wasm:0000027: error: type mismatch in br, expected [i32] but got [f64]
   0000027: error: OnBrExpr callback failed
 out/test/spec/block.wast:1204: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [i32]
+  out/test/spec/block/block.126.wasm:0000020: error: type mismatch in br, expected [i64] but got [i32]
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1212: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [f32]
+  out/test/spec/block/block.127.wasm:0000023: error: type mismatch in br, expected [i64] but got [f32]
   0000023: error: OnBrExpr callback failed
 out/test/spec/block.wast:1220: assert_invalid passed:
-  error: type mismatch in br, expected [i64] but got [f64]
+  out/test/spec/block/block.128.wasm:0000027: error: type mismatch in br, expected [i64] but got [f64]
   0000027: error: OnBrExpr callback failed
 out/test/spec/block.wast:1228: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [i32]
+  out/test/spec/block/block.129.wasm:0000020: error: type mismatch in br, expected [f32] but got [i32]
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1236: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [i64]
+  out/test/spec/block/block.130.wasm:0000020: error: type mismatch in br, expected [f32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1244: assert_invalid passed:
-  error: type mismatch in br, expected [f32] but got [f64]
+  out/test/spec/block/block.131.wasm:0000027: error: type mismatch in br, expected [f32] but got [f64]
   0000027: error: OnBrExpr callback failed
 out/test/spec/block.wast:1252: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [i32]
+  out/test/spec/block/block.132.wasm:0000020: error: type mismatch in br, expected [f64] but got [i32]
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1260: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [i64]
+  out/test/spec/block/block.133.wasm:0000020: error: type mismatch in br, expected [f64] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/test/spec/block.wast:1268: assert_invalid passed:
-  error: type mismatch in br, expected [f64] but got [f32]
+  out/test/spec/block/block.134.wasm:0000023: error: type mismatch in br, expected [f64] but got [f32]
   0000023: error: OnBrExpr callback failed
 out/test/spec/block.wast:1276: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/block/block.135.wasm:0000021: error: type mismatch in br, expected [i32, i32] but got [i32]
   0000021: error: OnBrExpr callback failed
 out/test/spec/block.wast:1285: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/block/block.136.wasm:000001e: error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1291: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
+  out/test/spec/block/block.137.wasm:000001e: error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1297: assert_invalid passed:
-  error: type mismatch in f32.floor, expected [f32] but got []
+  out/test/spec/block/block.138.wasm:000001e: error: type mismatch in f32.floor, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1303: assert_invalid passed:
-  error: type mismatch in f64.floor, expected [f64] but got []
+  out/test/spec/block/block.139.wasm:000001e: error: type mismatch in f64.floor, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1309: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/block/block.140.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/block.wast:1316: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/block/block.141.wasm:000001f: error: type mismatch in i32.ctz, expected [i32] but got []
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1322: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
+  out/test/spec/block/block.142.wasm:000001f: error: type mismatch in i64.ctz, expected [i64] but got []
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1328: assert_invalid passed:
-  error: type mismatch in f32.floor, expected [f32] but got []
+  out/test/spec/block/block.143.wasm:000001f: error: type mismatch in f32.floor, expected [f32] but got []
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1334: assert_invalid passed:
-  error: type mismatch in f64.floor, expected [f64] but got []
+  out/test/spec/block/block.144.wasm:000001f: error: type mismatch in f64.floor, expected [f64] but got []
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1340: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/block/block.145.wasm:000001f: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/block.wast:1347: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
+  out/test/spec/block/block.146.wasm:0000020: error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1353: assert_invalid passed:
-  error: type mismatch in f32.floor, expected [f32] but got []
+  out/test/spec/block/block.147.wasm:0000023: error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1359: assert_invalid passed:
-  error: type mismatch in f64.floor, expected [f64] but got []
+  out/test/spec/block/block.148.wasm:0000027: error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1365: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/block/block.149.wasm:0000020: error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1371: assert_invalid passed:
-  error: type mismatch in f32.floor, expected [f32] but got []
+  out/test/spec/block/block.150.wasm:0000023: error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1377: assert_invalid passed:
-  error: type mismatch in f64.floor, expected [f64] but got []
+  out/test/spec/block/block.151.wasm:0000027: error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1383: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/block/block.152.wasm:0000020: error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1389: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
+  out/test/spec/block/block.153.wasm:0000020: error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1395: assert_invalid passed:
-  error: type mismatch in f64.floor, expected [f64] but got []
+  out/test/spec/block/block.154.wasm:0000027: error: type mismatch in f64.floor, expected [f64] but got []
   0000027: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1401: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/block/block.155.wasm:0000020: error: type mismatch in i32.ctz, expected [i32] but got []
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1407: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
+  out/test/spec/block/block.156.wasm:0000020: error: type mismatch in i64.ctz, expected [i64] but got []
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1413: assert_invalid passed:
-  error: type mismatch in f32.floor, expected [f32] but got []
+  out/test/spec/block/block.157.wasm:0000023: error: type mismatch in f32.floor, expected [f32] but got []
   0000023: error: OnUnaryExpr callback failed
 out/test/spec/block.wast:1419: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/block/block.158.wasm:0000022: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/block.wast:1426: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.159.wasm:000001d: error: type mismatch in block, expected [i32] but got []
   000001d: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1432: assert_invalid passed:
-  error: type mismatch in block, expected [i32, f64] but got []
+  out/test/spec/block/block.160.wasm:000001e: error: type mismatch in block, expected [i32, f64] but got []
   000001e: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1438: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/block/block.161.wasm:0000022: error: type mismatch in block, expected [i32] but got [f32]
   0000022: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1444: assert_invalid passed:
-  error: type mismatch in block, expected [f32, i32] but got [f32]
+  out/test/spec/block/block.162.wasm:0000023: error: type mismatch in block, expected [f32, i32] but got [f32]
   0000023: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1450: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/block/block.163.wasm:000001f: error: type mismatch in block, expected [i32] but got []
   000001f: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1456: assert_invalid passed:
-  error: type mismatch in block, expected [i32, f64] but got []
+  out/test/spec/block/block.164.wasm:0000020: error: type mismatch in block, expected [i32, f64] but got []
   0000020: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1462: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/block/block.165.wasm:0000024: error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1468: assert_invalid passed:
-  error: type mismatch in block, expected [f32, i32] but got [f32]
+  out/test/spec/block/block.166.wasm:0000025: error: type mismatch in block, expected [f32, i32] but got [f32]
   0000025: error: OnBlockExpr callback failed
 out/test/spec/block.wast:1475: assert_malformed passed:
   out/test/spec/block/block.167.wat:1:45: error: unexpected token $x, expected ).

--- a/test/spec/br.txt
+++ b/test/spec/br.txt
@@ -2,64 +2,64 @@
 ;;; STDIN_FILE: third_party/testsuite/br.wast
 (;; STDOUT ;;;
 out/test/spec/br.wast:471: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.1.wasm:000001c: error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/br.wast:478: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.2.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:484: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.3.wasm:0000020: error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
 out/test/spec/br.wast:490: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/br/br.4.wasm:000001e: error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/br.wast:497: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.5.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:506: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.6.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:515: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.7.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:524: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.8.wasm:000001b: error: type mismatch in br, expected [i32] but got []
   000001b: error: OnBrExpr callback failed
 out/test/spec/br.wast:535: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.9.wasm:000001b: error: type mismatch in br, expected [i32] but got []
   000001b: error: OnBrExpr callback failed
 out/test/spec/br.wast:546: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.10.wasm:0000021: error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/test/spec/br.wast:558: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.11.wasm:0000036: error: type mismatch in br, expected [i32] but got []
   0000036: error: OnBrExpr callback failed
 out/test/spec/br.wast:574: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.12.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:586: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.13.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:598: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.14.wasm:0000023: error: type mismatch in br, expected [i32] but got []
   0000023: error: OnBrExpr callback failed
 out/test/spec/br.wast:610: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.15.wasm:0000020: error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
 out/test/spec/br.wast:622: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.16.wasm:0000020: error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
 out/test/spec/br.wast:634: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/br/br.17.wasm:0000020: error: type mismatch in br, expected [i32] but got []
   0000020: error: OnBrExpr callback failed
 out/test/spec/br.wast:647: assert_invalid passed:
-  error: invalid depth: 1 (max 0)
+  out/test/spec/br/br.18.wasm:0000016: error: invalid depth: 1 (max 0)
   0000019: error: OnBrExpr callback failed
 out/test/spec/br.wast:651: assert_invalid passed:
-  error: invalid depth: 5 (max 2)
+  out/test/spec/br/br.19.wasm:000001b: error: invalid depth: 5 (max 2)
   000001d: error: OnBrExpr callback failed
 out/test/spec/br.wast:655: assert_invalid passed:
-  error: invalid depth: 268435457 (max 0)
+  out/test/spec/br/br.20.wasm:0000016: error: invalid depth: 268435457 (max 0)
   000001d: error: OnBrExpr callback failed
 96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_if.txt
+++ b/test/spec/br_if.txt
@@ -2,93 +2,93 @@
 ;;; STDIN_FILE: third_party/testsuite/br_if.wast
 (;; STDOUT ;;;
 out/test/spec/br_if.wast:481: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/br_if/br_if.1.wasm:000001e: error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/br_if.wast:485: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got []
+  out/test/spec/br_if/br_if.2.wasm:000001e: error: type mismatch in i64.ctz, expected [i64] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/br_if.wast:489: assert_invalid passed:
-  error: type mismatch in f32.neg, expected [f32] but got []
+  out/test/spec/br_if/br_if.3.wasm:000001e: error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/br_if.wast:493: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got []
+  out/test/spec/br_if/br_if.4.wasm:000001e: error: type mismatch in f64.neg, expected [f64] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/br_if.wast:498: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got []
+  out/test/spec/br_if/br_if.5.wasm:000001e: error: type mismatch in i32.ctz, expected [i32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/br_if.wast:502: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [i64]
+  out/test/spec/br_if/br_if.6.wasm:000001d: error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:506: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [f32]
+  out/test/spec/br_if/br_if.7.wasm:0000020: error: type mismatch in br_if, expected [i32] but got [f32]
   0000020: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:510: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [i64]
+  out/test/spec/br_if/br_if.8.wasm:000001d: error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:515: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.9.wasm:000001e: error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:521: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.10.wasm:000001e: error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:527: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_if/br_if.11.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/br_if.wast:533: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_if/br_if.12.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/br_if.wast:540: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.13.wasm:000001f: error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:546: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.14.wasm:000001f: error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:552: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [i64]
+  out/test/spec/br_if/br_if.15.wasm:0000020: error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:560: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [i64]
+  out/test/spec/br_if/br_if.16.wasm:0000020: error: type mismatch in br_if, expected [i32] but got [i64]
   0000020: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:569: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.17.wasm:000001b: error: type mismatch in br_if, expected [i32] but got []
   000001b: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:575: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.18.wasm:000001c: error: type mismatch in br_if, expected [i32] but got []
   000001c: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:581: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [i64]
+  out/test/spec/br_if/br_if.19.wasm:000001d: error: type mismatch in br_if, expected [i32] but got [i64]
   000001d: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:587: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.20.wasm:000001f: error: type mismatch in br_if, expected [i32] but got []
   000001f: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:593: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.21.wasm:0000022: error: type mismatch in br_if, expected [i32] but got []
   0000022: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:599: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [... i64]
+  out/test/spec/br_if/br_if.22.wasm:0000020: error: type mismatch in br_if, expected [i32] but got [... i64]
   0000020: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:606: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.23.wasm:0000021: error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.23.wasm:0000021: error: type mismatch in br_if, expected [i32] but got []
   0000021: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:618: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.24.wasm:0000023: error: type mismatch in br_if, expected [i32] but got []
   0000023: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:630: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.25.wasm:000001b: error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.25.wasm:000001b: error: type mismatch in br_if, expected [i32] but got []
   000001b: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:641: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got []
+  out/test/spec/br_if/br_if.26.wasm:000001d: error: type mismatch in br_if, expected [i32] but got []
   000001d: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:654: assert_invalid passed:
-  error: invalid depth: 1 (max 0)
+  out/test/spec/br_if/br_if.27.wasm:000001b: error: invalid depth: 1 (max 0)
   000001b: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:658: assert_invalid passed:
-  error: invalid depth: 5 (max 2)
+  out/test/spec/br_if/br_if.28.wasm:000001f: error: invalid depth: 5 (max 2)
   000001f: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:662: assert_invalid passed:
-  error: invalid depth: 268435457 (max 0)
+  out/test/spec/br_if/br_if.29.wasm:000001f: error: invalid depth: 268435457 (max 0)
   000001f: error: OnBrIfExpr callback failed
 117/117 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -2,76 +2,76 @@
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
 out/test/spec/br_table.wast:1442: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_table/br_table.1.wasm:0000022: error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/br_table.wast:1449: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.2.wasm:000001d: error: type mismatch in br_table, expected [i32] but got []
   000001d: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1456: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.3.wasm:0000020: error: type mismatch in br_table, expected [i32] but got []
   0000020: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1462: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got [i64]
+  out/test/spec/br_table/br_table.4.wasm:0000023: error: type mismatch in br_table, expected [i32] but got [i64]
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1470: assert_invalid passed:
-  error: br_table labels have inconsistent types: expected [f32], got []
+  out/test/spec/br_table/br_table.5.wasm:0000026: error: br_table labels have inconsistent types: expected [f32], got []
   0000026: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1481: assert_invalid passed:
-  error: type mismatch in br_table, expected [i64] but got [i32]
+  out/test/spec/br_table/br_table.6.wasm:0000023: error: type mismatch in br_table, expected [i64] but got [i32]
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1492: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.7.wasm:000001f: error: type mismatch in br_table, expected [i32] but got []
   000001f: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1498: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got [i64]
+  out/test/spec/br_table/br_table.8.wasm:000001e: error: type mismatch in br_table, expected [i32] but got [i64]
   000001e: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1504: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.9.wasm:0000021: error: type mismatch in br_table, expected [i32] but got []
   0000021: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1510: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.10.wasm:0000023: error: type mismatch in br_table, expected [i32] but got []
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1516: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got [... i64]
+  out/test/spec/br_table/br_table.11.wasm:0000022: error: type mismatch in br_table, expected [i32] but got [... i64]
   0000022: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1525: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_table/br_table.12.wasm:0000022: error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/br_table.wast:1532: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.13.wasm:0000022: error: type mismatch in br_table, expected [i32] but got []
   0000022: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1544: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.14.wasm:0000024: error: type mismatch in br_table, expected [i32] but got []
   0000024: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1556: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.15.wasm:000001c: error: type mismatch in br_table, expected [i32] but got []
   000001c: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1567: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got []
+  out/test/spec/br_table/br_table.16.wasm:000001e: error: type mismatch in br_table, expected [i32] but got []
   000001e: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1579: assert_invalid passed:
-  error: br_table labels have inconsistent types: expected [i32], got []
+  out/test/spec/br_table/br_table.17.wasm:0000025: error: br_table labels have inconsistent types: expected [i32], got []
   0000025: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1591: assert_invalid passed:
-  error: br_table labels have inconsistent types: expected [], got [i32]
+  out/test/spec/br_table/br_table.18.wasm:0000025: error: br_table labels have inconsistent types: expected [], got [i32]
   0000025: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1605: assert_invalid passed:
-  error: invalid depth: 2 (max 1)
+  out/test/spec/br_table/br_table.19.wasm:000001f: error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1611: assert_invalid passed:
-  error: invalid depth: 5 (max 2)
+  out/test/spec/br_table/br_table.20.wasm:0000021: error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1617: assert_invalid passed:
-  error: invalid depth: 268435457 (max 1)
+  out/test/spec/br_table/br_table.21.wasm:0000024: error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1624: assert_invalid passed:
-  error: invalid depth: 2 (max 1)
+  out/test/spec/br_table/br_table.22.wasm:000001f: error: invalid depth: 2 (max 1)
   000001f: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1630: assert_invalid passed:
-  error: invalid depth: 5 (max 2)
+  out/test/spec/br_table/br_table.23.wasm:0000021: error: invalid depth: 5 (max 2)
   0000021: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1636: assert_invalid passed:
-  error: invalid depth: 268435457 (max 1)
+  out/test/spec/br_table/br_table.24.wasm:0000024: error: invalid depth: 268435457 (max 1)
   0000024: error: OnBrTableExpr callback failed
 173/173 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -3,52 +3,52 @@
 (;; STDOUT ;;;
 out/test/spec/call.wast:354: assert_trap passed: undefined table index
 out/test/spec/call.wast:381: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/call/call.1.wasm:000001b: error: type mismatch in i32.eqz, expected [i32] but got []
   000001b: error: OnConvertExpr callback failed
 out/test/spec/call.wast:388: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [i64]
+  out/test/spec/call/call.2.wasm:000001f: error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001f: error: OnConvertExpr callback failed
 out/test/spec/call.wast:396: assert_invalid passed:
-  error: type mismatch in call, expected [i32] but got []
+  out/test/spec/call/call.3.wasm:000001e: error: type mismatch in call, expected [i32] but got []
   000001e: error: OnCallExpr callback failed
 out/test/spec/call.wast:403: assert_invalid passed:
-  error: type mismatch in call, expected [f64, i32] but got []
+  out/test/spec/call/call.4.wasm:000001f: error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
 out/test/spec/call.wast:410: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/call/call.5.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/call.wast:417: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64, i32]
+  out/test/spec/call/call.6.wasm:0000025: error: type mismatch in function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
 out/test/spec/call.wast:425: assert_invalid passed:
-  error: type mismatch in call, expected [i32, i32] but got [i32]
+  out/test/spec/call/call.7.wasm:0000022: error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
 out/test/spec/call.wast:432: assert_invalid passed:
-  error: type mismatch in call, expected [i32, i32] but got [i32]
+  out/test/spec/call/call.8.wasm:0000022: error: type mismatch in call, expected [i32, i32] but got [i32]
   0000022: error: OnCallExpr callback failed
 out/test/spec/call.wast:439: assert_invalid passed:
-  error: type mismatch in call, expected [i32, f64] but got [f64, i32]
+  out/test/spec/call/call.9.wasm:000002a: error: type mismatch in call, expected [i32, f64] but got [f64, i32]
   000002a: error: OnCallExpr callback failed
 out/test/spec/call.wast:446: assert_invalid passed:
-  error: type mismatch in call, expected [f64, i32] but got [i32, f64]
+  out/test/spec/call/call.10.wasm:000002a: error: type mismatch in call, expected [f64, i32] but got [i32, f64]
   000002a: error: OnCallExpr callback failed
 out/test/spec/call.wast:454: assert_invalid passed:
-  error: type mismatch in call, expected [i32] but got []
+  out/test/spec/call/call.11.wasm:0000020: error: type mismatch in call, expected [i32] but got []
   0000020: error: OnCallExpr callback failed
 out/test/spec/call.wast:463: assert_invalid passed:
-  error: type mismatch in call, expected [i32, i32] but got [i32]
+  out/test/spec/call/call.12.wasm:0000023: error: type mismatch in call, expected [i32, i32] but got [i32]
   0000023: error: OnCallExpr callback failed
 out/test/spec/call.wast:472: assert_invalid passed:
-  error: type mismatch in call, expected [i32] but got []
+  out/test/spec/call/call.13.wasm:0000020: error: type mismatch in call, expected [i32] but got []
   0000020: error: OnCallExpr callback failed
 out/test/spec/call.wast:481: assert_invalid passed:
-  error: type mismatch in call, expected [i32, i32] but got [i32]
+  out/test/spec/call/call.14.wasm:0000023: error: type mismatch in call, expected [i32, i32] but got [i32]
   0000023: error: OnCallExpr callback failed
 out/test/spec/call.wast:490: assert_invalid passed:
-  error: type mismatch in call, expected [i32] but got []
+  out/test/spec/call/call.15.wasm:0000022: error: type mismatch in call, expected [i32] but got []
   0000022: error: OnCallExpr callback failed
 out/test/spec/call.wast:499: assert_invalid passed:
-  error: type mismatch in call, expected [i32, i32] but got [i32]
+  out/test/spec/call/call.16.wasm:0000025: error: type mismatch in call, expected [i32, i32] but got [i32]
   0000025: error: OnCallExpr callback failed
 out/test/spec/call.wast:512: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -88,58 +88,58 @@ out/test/spec/call_indirect.wast:791: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   000001c: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:799: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/call_indirect/call_indirect.14.wasm:0000023: error: type mismatch in i32.eqz, expected [i32] but got []
   0000023: error: OnConvertExpr callback failed
 out/test/spec/call_indirect.wast:807: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [i64]
+  out/test/spec/call_indirect/call_indirect.15.wasm:0000027: error: type mismatch in i32.eqz, expected [i32] but got [i64]
   0000027: error: OnConvertExpr callback failed
 out/test/spec/call_indirect.wast:816: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got []
+  out/test/spec/call_indirect/call_indirect.16.wasm:0000026: error: type mismatch in call_indirect, expected [i32] but got []
   0000026: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:824: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [f64, i32] but got []
+  out/test/spec/call_indirect/call_indirect.17.wasm:0000027: error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:832: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/call_indirect/call_indirect.18.wasm:0000024: error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/call_indirect.wast:840: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64, i32]
+  out/test/spec/call_indirect/call_indirect.19.wasm:000002d: error: type mismatch in function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
 out/test/spec/call_indirect.wast:851: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got []
+  out/test/spec/call_indirect/call_indirect.20.wasm:0000027: error: type mismatch in call_indirect, expected [i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:859: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got [... i64]
+  out/test/spec/call_indirect/call_indirect.21.wasm:0000028: error: type mismatch in call_indirect, expected [i32] but got [... i64]
   0000028: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:868: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  out/test/spec/call_indirect/call_indirect.22.wasm:000002a: error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:878: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  out/test/spec/call_indirect/call_indirect.23.wasm:000002a: error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000002a: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:888: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
+  out/test/spec/call_indirect/call_indirect.24.wasm:0000032: error: type mismatch in call_indirect, expected [i32, f64] but got [f64, i32]
   0000032: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:898: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
+  out/test/spec/call_indirect/call_indirect.25.wasm:0000032: error: type mismatch in call_indirect, expected [f64, i32] but got [i32, f64]
   0000032: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:909: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got []
+  out/test/spec/call_indirect/call_indirect.26.wasm:0000036: error: type mismatch in call_indirect, expected [i32] but got []
   0000036: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:922: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  out/test/spec/call_indirect/call_indirect.27.wasm:0000039: error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   0000039: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:935: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got []
+  out/test/spec/call_indirect/call_indirect.28.wasm:0000036: error: type mismatch in call_indirect, expected [i32] but got []
   0000036: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:948: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  out/test/spec/call_indirect/call_indirect.29.wasm:0000039: error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   0000039: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:961: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32] but got []
+  out/test/spec/call_indirect/call_indirect.30.wasm:000003a: error: type mismatch in call_indirect, expected [i32] but got []
   000003a: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:977: assert_invalid passed:
-  error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
+  out/test/spec/call_indirect/call_indirect.31.wasm:000003d: error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000003d: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:997: assert_invalid passed:
   0000000: error: function type variable out of range: 1 (max 1)

--- a/test/spec/conversions.txt
+++ b/test/spec/conversions.txt
@@ -69,79 +69,79 @@ out/test/spec/conversions.wast:252: assert_trap passed: invalid conversion to in
 out/test/spec/conversions.wast:253: assert_trap passed: invalid conversion to integer
 out/test/spec/conversions.wast:254: assert_trap passed: invalid conversion to integer
 out/test/spec/conversions.wast:678: assert_invalid passed:
-  error: type mismatch in i32.wrap_i64, expected [i64] but got [f32]
+  out/test/spec/conversions/conversions.1.wasm:000001e: error: type mismatch in i32.wrap_i64, expected [i64] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:679: assert_invalid passed:
-  error: type mismatch in i32.trunc_f32_s, expected [f32] but got [i64]
+  out/test/spec/conversions/conversions.2.wasm:000001b: error: type mismatch in i32.trunc_f32_s, expected [f32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:680: assert_invalid passed:
-  error: type mismatch in i32.trunc_f32_u, expected [f32] but got [i64]
+  out/test/spec/conversions/conversions.3.wasm:000001b: error: type mismatch in i32.trunc_f32_u, expected [f32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:681: assert_invalid passed:
-  error: type mismatch in i32.trunc_f64_s, expected [f64] but got [i64]
+  out/test/spec/conversions/conversions.4.wasm:000001b: error: type mismatch in i32.trunc_f64_s, expected [f64] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:682: assert_invalid passed:
-  error: type mismatch in i32.trunc_f64_u, expected [f64] but got [i64]
+  out/test/spec/conversions/conversions.5.wasm:000001b: error: type mismatch in i32.trunc_f64_u, expected [f64] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:683: assert_invalid passed:
-  error: type mismatch in i32.reinterpret_f32, expected [f32] but got [i64]
+  out/test/spec/conversions/conversions.6.wasm:000001b: error: type mismatch in i32.reinterpret_f32, expected [f32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:684: assert_invalid passed:
-  error: type mismatch in i64.extend_i32_s, expected [i32] but got [f32]
+  out/test/spec/conversions/conversions.7.wasm:000001e: error: type mismatch in i64.extend_i32_s, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:685: assert_invalid passed:
-  error: type mismatch in i64.extend_i32_u, expected [i32] but got [f32]
+  out/test/spec/conversions/conversions.8.wasm:000001e: error: type mismatch in i64.extend_i32_u, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:686: assert_invalid passed:
-  error: type mismatch in i64.trunc_f32_s, expected [f32] but got [i32]
+  out/test/spec/conversions/conversions.9.wasm:000001b: error: type mismatch in i64.trunc_f32_s, expected [f32] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:687: assert_invalid passed:
-  error: type mismatch in i64.trunc_f32_u, expected [f32] but got [i32]
+  out/test/spec/conversions/conversions.10.wasm:000001b: error: type mismatch in i64.trunc_f32_u, expected [f32] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:688: assert_invalid passed:
-  error: type mismatch in i64.trunc_f64_s, expected [f64] but got [i32]
+  out/test/spec/conversions/conversions.11.wasm:000001b: error: type mismatch in i64.trunc_f64_s, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:689: assert_invalid passed:
-  error: type mismatch in i64.trunc_f64_u, expected [f64] but got [i32]
+  out/test/spec/conversions/conversions.12.wasm:000001b: error: type mismatch in i64.trunc_f64_u, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:690: assert_invalid passed:
-  error: type mismatch in i64.reinterpret_f64, expected [f64] but got [i32]
+  out/test/spec/conversions/conversions.13.wasm:000001b: error: type mismatch in i64.reinterpret_f64, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:691: assert_invalid passed:
-  error: type mismatch in f32.convert_i32_s, expected [i32] but got [i64]
+  out/test/spec/conversions/conversions.14.wasm:000001b: error: type mismatch in f32.convert_i32_s, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:692: assert_invalid passed:
-  error: type mismatch in f32.convert_i32_u, expected [i32] but got [i64]
+  out/test/spec/conversions/conversions.15.wasm:000001b: error: type mismatch in f32.convert_i32_u, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:693: assert_invalid passed:
-  error: type mismatch in f32.convert_i64_s, expected [i64] but got [i32]
+  out/test/spec/conversions/conversions.16.wasm:000001b: error: type mismatch in f32.convert_i64_s, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:694: assert_invalid passed:
-  error: type mismatch in f32.convert_i64_u, expected [i64] but got [i32]
+  out/test/spec/conversions/conversions.17.wasm:000001b: error: type mismatch in f32.convert_i64_u, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:695: assert_invalid passed:
-  error: type mismatch in f32.demote_f64, expected [f64] but got [i32]
+  out/test/spec/conversions/conversions.18.wasm:000001b: error: type mismatch in f32.demote_f64, expected [f64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:696: assert_invalid passed:
-  error: type mismatch in f32.reinterpret_i32, expected [i32] but got [i64]
+  out/test/spec/conversions/conversions.19.wasm:000001b: error: type mismatch in f32.reinterpret_i32, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:697: assert_invalid passed:
-  error: type mismatch in f64.convert_i32_s, expected [i32] but got [i64]
+  out/test/spec/conversions/conversions.20.wasm:000001b: error: type mismatch in f64.convert_i32_s, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:698: assert_invalid passed:
-  error: type mismatch in f64.convert_i32_u, expected [i32] but got [i64]
+  out/test/spec/conversions/conversions.21.wasm:000001b: error: type mismatch in f64.convert_i32_u, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:699: assert_invalid passed:
-  error: type mismatch in f64.convert_i64_s, expected [i64] but got [i32]
+  out/test/spec/conversions/conversions.22.wasm:000001b: error: type mismatch in f64.convert_i64_s, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:700: assert_invalid passed:
-  error: type mismatch in f64.convert_i64_u, expected [i64] but got [i32]
+  out/test/spec/conversions/conversions.23.wasm:000001b: error: type mismatch in f64.convert_i64_u, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:701: assert_invalid passed:
-  error: type mismatch in f64.promote_f32, expected [f32] but got [i32]
+  out/test/spec/conversions/conversions.24.wasm:000001b: error: type mismatch in f64.promote_f32, expected [f32] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/conversions.wast:702: assert_invalid passed:
-  error: type mismatch in f64.reinterpret_i64, expected [i64] but got [i32]
+  out/test/spec/conversions/conversions.25.wasm:000001b: error: type mismatch in f64.reinterpret_i64, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 618/618 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -20,13 +20,13 @@ out/test/spec/data.wast:359: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/data.wast:378: assert_invalid passed:
-  error: type mismatch at data segment offset. got i64, expected i32
+  out/test/spec/data/data.45.wasm:0000014: error: type mismatch at data segment offset. got i64, expected i32
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:386: assert_invalid passed:
-  error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/data/data.46.wasm:0000014: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:394: assert_invalid passed:
-  error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/data/data.47.wasm:0000012: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:402: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -51,14 +51,14 @@ out/test/spec/data.wast:452: assert_invalid passed:
   0000014: error: OnNopExpr callback failed
 out/test/spec/data.wast:466: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/data/data.55.wasm:0000014: error: initializer expression cannot reference a mutable global
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:474: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/data/data.56.wasm:000002a: error: initializer expression cannot reference a mutable global
   000002a: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:483: assert_invalid passed:
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/data/data.57.wasm:000002e: error: initializer expression cannot reference a mutable global
   000002e: error: EndDataSegmentInitExpr callback failed
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -7,13 +7,13 @@ out/test/spec/elem.wast:336: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/elem.wast:346: assert_invalid passed:
-  error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/elem/elem.34.wasm:0000015: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:354: assert_invalid passed:
-  error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/elem/elem.35.wasm:0000015: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:362: assert_invalid passed:
-  error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/elem/elem.36.wasm:0000013: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
   0000013: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:370: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -38,17 +38,17 @@ out/test/spec/elem.wast:421: assert_invalid passed:
   0000015: error: OnNopExpr callback failed
 out/test/spec/elem.wast:435: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/elem/elem.44.wasm:0000015: error: initializer expression cannot reference a mutable global
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:443: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/elem/elem.45.wasm:000002b: error: initializer expression cannot reference a mutable global
   000002b: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:452: assert_invalid passed:
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/elem/elem.46.wasm:000002f: error: initializer expression cannot reference a mutable global
   000002f: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:463: assert_invalid passed:
-  error: type mismatch at elem expression. got externref, expected funcref
+  out/test/spec/elem/elem.47.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
   0000018: error: OnElemSegmentElemExpr_RefNull callback failed
 out/test/spec/elem.wast:471: assert_invalid passed:
   0000019: error: expected END opcode after element expression

--- a/test/spec/exception-handling/binary.txt
+++ b/test/spec/exception-handling/binary.txt
@@ -272,7 +272,7 @@ out/test/spec/exception-handling/binary.wast:1671: assert_malformed passed:
 out/test/spec/exception-handling/binary.wast:1685: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/exception-handling/binary.wast:1716: assert_malformed passed:
-  error: function type variable out of range: 11 (max 1)
+  out/test/spec/exception-handling/binary/binary.166.wasm:0000025: error: function type variable out of range: 11 (max 1)
   0000025: error: OnBlockExpr callback failed
 out/test/spec/exception-handling/binary.wast:1751: assert_malformed passed:
   0000017: error: multiple Start sections

--- a/test/spec/exception-handling/exports.txt
+++ b/test/spec/exception-handling/exports.txt
@@ -12,22 +12,22 @@ out/test/spec/exception-handling/exports.wast:47: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)
   000002e: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:51: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.18.wasm:000001d: error: duplicate export "a"
   000001d: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:55: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.19.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:59: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.20.wasm:0000025: error: duplicate export "a"
   0000025: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:63: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.21.wasm:0000023: error: duplicate export "a"
   0000023: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:67: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.22.wasm:0000022: error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:71: assert_invalid passed:
-  error: duplicate export "t0"
+  out/test/spec/exception-handling/exports/exports.23.wasm:0000022: error: duplicate export "t0"
   0000022: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:100: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
@@ -39,19 +39,19 @@ out/test/spec/exception-handling/exports.wast:108: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
   0000029: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:112: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.39.wasm:000001b: error: duplicate export "a"
   000001b: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:116: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.40.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:120: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.41.wasm:0000025: error: duplicate export "a"
   0000025: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:124: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.42.wasm:0000021: error: duplicate export "a"
   0000021: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:128: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.43.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:155: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
@@ -63,19 +63,19 @@ out/test/spec/exception-handling/exports.wast:163: assert_invalid passed:
   0000000: error: table variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:167: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.62.wasm:0000019: error: duplicate export "a"
   0000019: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:171: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.63.wasm:000001c: error: duplicate export "a"
   000001c: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:175: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.64.wasm:0000023: error: duplicate export "a"
   0000023: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:179: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.65.wasm:0000021: error: duplicate export "a"
   0000021: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:183: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.66.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:211: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
@@ -87,16 +87,16 @@ out/test/spec/exception-handling/exports.wast:219: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:223: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.84.wasm:0000018: error: duplicate export "a"
   0000018: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:232: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.85.wasm:0000022: error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:236: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.86.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:240: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exception-handling/exports/exports.87.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 41/41 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/imports.txt
+++ b/test/spec/exception-handling/imports.txt
@@ -149,13 +149,13 @@ out/test/spec/exception-handling/imports.wast:488: assert_unlinkable passed:
 out/test/spec/exception-handling/imports.wast:506: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/exception-handling/imports.wast:517: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/exception-handling/imports.wast:520: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/exception-handling/imports/imports.103.wasm:0000015: error: only one memory block allowed
   0000015: error: OnImportMemory callback failed
 out/test/spec/exception-handling/imports.wast:524: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/exception-handling/imports/imports.104.wasm:0000015: error: only one memory block allowed
   0000015: error: OnMemory callback failed
 out/test/spec/exception-handling/imports.wast:528: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/exception-handling/imports/imports.105.wasm:000000f: error: only one memory block allowed
   000000f: error: OnMemory callback failed
 out/test/spec/exception-handling/imports.wast:543: assert_unlinkable passed:
   error: invalid import "test.unknown"

--- a/test/spec/exception-handling/rethrow.txt
+++ b/test/spec/exception-handling/rethrow.txt
@@ -10,13 +10,13 @@ out/test/spec/exception-handling/rethrow.wast:84: assert_exception passed
 out/test/spec/exception-handling/rethrow.wast:85: assert_exception passed
 out/test/spec/exception-handling/rethrow.wast:91: assert_exception passed
 out/test/spec/exception-handling/rethrow.wast:93: assert_invalid passed:
-  error: rethrow not in try catch block
+  out/test/spec/exception-handling/rethrow/rethrow.1.wasm:0000019: error: rethrow not in try catch block
   0000019: error: OnRethrowExpr callback failed
 out/test/spec/exception-handling/rethrow.wast:94: assert_invalid passed:
-  error: rethrow not in try catch block
+  out/test/spec/exception-handling/rethrow/rethrow.2.wasm:000001b: error: rethrow not in try catch block
   000001b: error: OnRethrowExpr callback failed
 out/test/spec/exception-handling/rethrow.wast:95: assert_invalid passed:
-  error: rethrow not in try catch block
+  out/test/spec/exception-handling/rethrow/rethrow.3.wasm:000001b: error: rethrow not in try catch block
   000001b: error: OnRethrowExpr callback failed
 15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/tag.txt
+++ b/test/spec/exception-handling/tag.txt
@@ -3,7 +3,7 @@
 ;;; ARGS*: --enable-exceptions
 (;; STDOUT ;;;
 out/test/spec/exception-handling/tag.wast:19: assert_invalid passed:
-  error: Tag signature must have 0 results.
+  out/test/spec/exception-handling/tag/tag.2.wasm:0000014: error: Tag signature must have 0 results.
   0000014: error: OnTagType callback failed
 1/1 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/throw.txt
+++ b/test/spec/exception-handling/throw.txt
@@ -11,10 +11,10 @@ out/test/spec/exception-handling/throw.wast:47: assert_invalid passed:
   0000000: error: tag variable out of range: 0 (max 0)
   0000019: error: OnThrowExpr callback failed
 out/test/spec/exception-handling/throw.wast:48: assert_invalid passed:
-  error: type mismatch in throw, expected [i32] but got []
+  out/test/spec/exception-handling/throw/throw.2.wasm:0000022: error: type mismatch in throw, expected [i32] but got []
   0000022: error: OnThrowExpr callback failed
 out/test/spec/exception-handling/throw.wast:50: assert_invalid passed:
-  error: type mismatch in throw, expected [i32] but got [i64]
+  out/test/spec/exception-handling/throw/throw.3.wasm:0000024: error: type mismatch in throw, expected [i32] but got [i64]
   0000024: error: OnThrowExpr callback failed
 10/10 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/try_catch.txt
+++ b/test/spec/exception-handling/try_catch.txt
@@ -19,19 +19,19 @@ out/test/spec/exception-handling/try_catch.wast:224: assert_malformed passed:
   (module (func (try (do) (catch_all) (catch_all))))
                                        ^^^^^^^^^
 out/test/spec/exception-handling/try_catch.wast:230: assert_invalid passed:
-  error: type mismatch in try, expected [i32] but got []
+  out/test/spec/exception-handling/try_catch/try_catch.6.wasm:000001b: error: type mismatch in try, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:232: assert_invalid passed:
-  error: type mismatch in try, expected [i32] but got [i64]
+  out/test/spec/exception-handling/try_catch/try_catch.7.wasm:000001d: error: type mismatch in try, expected [i32] but got [i64]
   000001d: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:234: assert_invalid passed:
-  error: type mismatch in try catch, expected [] but got [i32]
+  out/test/spec/exception-handling/try_catch/try_catch.8.wasm:0000023: error: type mismatch in try catch, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:236: assert_invalid passed:
-  error: type mismatch in try catch, expected [i32] but got [i64]
+  out/test/spec/exception-handling/try_catch/try_catch.9.wasm:0000028: error: type mismatch in try catch, expected [i32] but got [i64]
   0000028: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:241: assert_invalid passed:
-  error: type mismatch in try catch, expected [] but got [i32]
+  out/test/spec/exception-handling/try_catch/try_catch.10.wasm:000001d: error: type mismatch in try catch, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exception-handling/try_delegate.txt
+++ b/test/spec/exception-handling/try_delegate.txt
@@ -23,7 +23,7 @@ out/test/spec/exception-handling/try_delegate.wast:133: assert_malformed passed:
   (module (func (try (do) (delegate) (delegate 0))))
                                    ^
 out/test/spec/exception-handling/try_delegate.wast:138: assert_invalid passed:
-  error: invalid depth: 2 (max 1)
+  out/test/spec/exception-handling/try_delegate/try_delegate.5.wasm:000001b: error: invalid depth: 2 (max 1)
   000001b: error: OnDelegateExpr callback failed
 18/18 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/exports.txt
+++ b/test/spec/exports.txt
@@ -11,19 +11,19 @@ out/test/spec/exports.wast:47: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)
   000002e: error: OnExport callback failed
 out/test/spec/exports.wast:51: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.18.wasm:000001d: error: duplicate export "a"
   000001d: error: OnExport callback failed
 out/test/spec/exports.wast:55: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.19.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exports.wast:59: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.20.wasm:0000025: error: duplicate export "a"
   0000025: error: OnExport callback failed
 out/test/spec/exports.wast:63: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.21.wasm:0000023: error: duplicate export "a"
   0000023: error: OnExport callback failed
 out/test/spec/exports.wast:67: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.22.wasm:0000022: error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/exports.wast:96: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
@@ -35,19 +35,19 @@ out/test/spec/exports.wast:104: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
   0000029: error: OnExport callback failed
 out/test/spec/exports.wast:108: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.38.wasm:000001b: error: duplicate export "a"
   000001b: error: OnExport callback failed
 out/test/spec/exports.wast:112: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.39.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exports.wast:116: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.40.wasm:0000025: error: duplicate export "a"
   0000025: error: OnExport callback failed
 out/test/spec/exports.wast:120: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.41.wasm:0000021: error: duplicate export "a"
   0000021: error: OnExport callback failed
 out/test/spec/exports.wast:124: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.42.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exports.wast:151: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
@@ -59,19 +59,19 @@ out/test/spec/exports.wast:159: assert_invalid passed:
   0000000: error: table variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exports.wast:163: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.61.wasm:0000019: error: duplicate export "a"
   0000019: error: OnExport callback failed
 out/test/spec/exports.wast:167: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.62.wasm:000001c: error: duplicate export "a"
   000001c: error: OnExport callback failed
 out/test/spec/exports.wast:171: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.63.wasm:0000023: error: duplicate export "a"
   0000023: error: OnExport callback failed
 out/test/spec/exports.wast:175: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.64.wasm:0000021: error: duplicate export "a"
   0000021: error: OnExport callback failed
 out/test/spec/exports.wast:179: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.65.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exports.wast:207: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
@@ -83,16 +83,16 @@ out/test/spec/exports.wast:215: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exports.wast:219: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.83.wasm:0000018: error: duplicate export "a"
   0000018: error: OnExport callback failed
 out/test/spec/exports.wast:228: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.84.wasm:0000022: error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/exports.wast:232: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.85.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exports.wast:236: assert_invalid passed:
-  error: duplicate export "a"
+  out/test/spec/exports/exports.86.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 40/40 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/f32.txt
+++ b/test/spec/f32.txt
@@ -3,37 +3,37 @@
 ;;; STDIN_FILE: third_party/testsuite/f32.wast
 (;; STDOUT ;;;
 out/test/spec/f32.wast:2523: assert_invalid passed:
-  error: type mismatch in f32.add, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32/f32.1.wasm:0000024: error: type mismatch in f32.add, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32.wast:2524: assert_invalid passed:
-  error: type mismatch in f32.div, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32/f32.2.wasm:0000024: error: type mismatch in f32.div, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32.wast:2525: assert_invalid passed:
-  error: type mismatch in f32.max, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32/f32.3.wasm:0000024: error: type mismatch in f32.max, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32.wast:2526: assert_invalid passed:
-  error: type mismatch in f32.min, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32/f32.4.wasm:0000024: error: type mismatch in f32.min, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32.wast:2527: assert_invalid passed:
-  error: type mismatch in f32.mul, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32/f32.5.wasm:0000024: error: type mismatch in f32.mul, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32.wast:2528: assert_invalid passed:
-  error: type mismatch in f32.sub, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32/f32.6.wasm:0000024: error: type mismatch in f32.sub, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32.wast:2529: assert_invalid passed:
-  error: type mismatch in f32.ceil, expected [f32] but got [i64]
+  out/test/spec/f32/f32.7.wasm:000001b: error: type mismatch in f32.ceil, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f32.wast:2530: assert_invalid passed:
-  error: type mismatch in f32.floor, expected [f32] but got [i64]
+  out/test/spec/f32/f32.8.wasm:000001b: error: type mismatch in f32.floor, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f32.wast:2531: assert_invalid passed:
-  error: type mismatch in f32.nearest, expected [f32] but got [i64]
+  out/test/spec/f32/f32.9.wasm:000001b: error: type mismatch in f32.nearest, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f32.wast:2532: assert_invalid passed:
-  error: type mismatch in f32.sqrt, expected [f32] but got [i64]
+  out/test/spec/f32/f32.10.wasm:000001b: error: type mismatch in f32.sqrt, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f32.wast:2533: assert_invalid passed:
-  error: type mismatch in f32.trunc, expected [f32] but got [i64]
+  out/test/spec/f32/f32.11.wasm:000001b: error: type mismatch in f32.trunc, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f32.wast:2537: assert_malformed passed:
   out/test/spec/f32/f32.12.wat:1:31: error: invalid literal "nan:arithmetic"

--- a/test/spec/f32_bitwise.txt
+++ b/test/spec/f32_bitwise.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/f32_bitwise.wast
 (;; STDOUT ;;;
 out/test/spec/f32_bitwise.wast:374: assert_invalid passed:
-  error: type mismatch in f32.copysign, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_bitwise/f32_bitwise.1.wasm:0000024: error: type mismatch in f32.copysign, expected [f32, f32] but got [i64, f64]
   0000024: error: OnBinaryExpr callback failed
 out/test/spec/f32_bitwise.wast:375: assert_invalid passed:
-  error: type mismatch in f32.abs, expected [f32] but got [i64]
+  out/test/spec/f32_bitwise/f32_bitwise.2.wasm:000001b: error: type mismatch in f32.abs, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f32_bitwise.wast:376: assert_invalid passed:
-  error: type mismatch in f32.neg, expected [f32] but got [i64]
+  out/test/spec/f32_bitwise/f32_bitwise.3.wasm:000001b: error: type mismatch in f32.neg, expected [f32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 363/363 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/f32_cmp.txt
+++ b/test/spec/f32_cmp.txt
@@ -3,22 +3,22 @@
 ;;; STDIN_FILE: third_party/testsuite/f32_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/f32_cmp.wast:2417: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_cmp/f32_cmp.1.wasm:0000024: error: type mismatch in f32.eq, expected [f32, f32] but got [i64, f64]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/f32_cmp.wast:2418: assert_invalid passed:
-  error: type mismatch in f32.ge, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_cmp/f32_cmp.2.wasm:0000024: error: type mismatch in f32.ge, expected [f32, f32] but got [i64, f64]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/f32_cmp.wast:2419: assert_invalid passed:
-  error: type mismatch in f32.gt, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_cmp/f32_cmp.3.wasm:0000024: error: type mismatch in f32.gt, expected [f32, f32] but got [i64, f64]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/f32_cmp.wast:2420: assert_invalid passed:
-  error: type mismatch in f32.le, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_cmp/f32_cmp.4.wasm:0000024: error: type mismatch in f32.le, expected [f32, f32] but got [i64, f64]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/f32_cmp.wast:2421: assert_invalid passed:
-  error: type mismatch in f32.lt, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_cmp/f32_cmp.5.wasm:0000024: error: type mismatch in f32.lt, expected [f32, f32] but got [i64, f64]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/f32_cmp.wast:2422: assert_invalid passed:
-  error: type mismatch in f32.ne, expected [f32, f32] but got [i64, f64]
+  out/test/spec/f32_cmp/f32_cmp.6.wasm:0000024: error: type mismatch in f32.ne, expected [f32, f32] but got [i64, f64]
   0000024: error: OnCompareExpr callback failed
 2406/2406 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/f64.txt
+++ b/test/spec/f64.txt
@@ -3,37 +3,37 @@
 ;;; STDIN_FILE: third_party/testsuite/f64.wast
 (;; STDOUT ;;;
 out/test/spec/f64.wast:2523: assert_invalid passed:
-  error: type mismatch in f64.add, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64/f64.1.wasm:0000020: error: type mismatch in f64.add, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64.wast:2524: assert_invalid passed:
-  error: type mismatch in f64.div, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64/f64.2.wasm:0000020: error: type mismatch in f64.div, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64.wast:2525: assert_invalid passed:
-  error: type mismatch in f64.max, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64/f64.3.wasm:0000020: error: type mismatch in f64.max, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64.wast:2526: assert_invalid passed:
-  error: type mismatch in f64.min, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64/f64.4.wasm:0000020: error: type mismatch in f64.min, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64.wast:2527: assert_invalid passed:
-  error: type mismatch in f64.mul, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64/f64.5.wasm:0000020: error: type mismatch in f64.mul, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64.wast:2528: assert_invalid passed:
-  error: type mismatch in f64.sub, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64/f64.6.wasm:0000020: error: type mismatch in f64.sub, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64.wast:2529: assert_invalid passed:
-  error: type mismatch in f64.ceil, expected [f64] but got [i64]
+  out/test/spec/f64/f64.7.wasm:000001b: error: type mismatch in f64.ceil, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f64.wast:2530: assert_invalid passed:
-  error: type mismatch in f64.floor, expected [f64] but got [i64]
+  out/test/spec/f64/f64.8.wasm:000001b: error: type mismatch in f64.floor, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f64.wast:2531: assert_invalid passed:
-  error: type mismatch in f64.nearest, expected [f64] but got [i64]
+  out/test/spec/f64/f64.9.wasm:000001b: error: type mismatch in f64.nearest, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f64.wast:2532: assert_invalid passed:
-  error: type mismatch in f64.sqrt, expected [f64] but got [i64]
+  out/test/spec/f64/f64.10.wasm:000001b: error: type mismatch in f64.sqrt, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f64.wast:2533: assert_invalid passed:
-  error: type mismatch in f64.trunc, expected [f64] but got [i64]
+  out/test/spec/f64/f64.11.wasm:000001b: error: type mismatch in f64.trunc, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f64.wast:2537: assert_malformed passed:
   out/test/spec/f64/f64.12.wat:1:31: error: invalid literal "nan:arithmetic"

--- a/test/spec/f64_bitwise.txt
+++ b/test/spec/f64_bitwise.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/f64_bitwise.wast
 (;; STDOUT ;;;
 out/test/spec/f64_bitwise.wast:374: assert_invalid passed:
-  error: type mismatch in f64.copysign, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_bitwise/f64_bitwise.1.wasm:0000020: error: type mismatch in f64.copysign, expected [f64, f64] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/f64_bitwise.wast:375: assert_invalid passed:
-  error: type mismatch in f64.abs, expected [f64] but got [i64]
+  out/test/spec/f64_bitwise/f64_bitwise.2.wasm:000001b: error: type mismatch in f64.abs, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/f64_bitwise.wast:376: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/f64_bitwise/f64_bitwise.3.wasm:000001b: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 363/363 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/f64_cmp.txt
+++ b/test/spec/f64_cmp.txt
@@ -3,22 +3,22 @@
 ;;; STDIN_FILE: third_party/testsuite/f64_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/f64_cmp.wast:2417: assert_invalid passed:
-  error: type mismatch in f64.eq, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_cmp/f64_cmp.1.wasm:0000020: error: type mismatch in f64.eq, expected [f64, f64] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/f64_cmp.wast:2418: assert_invalid passed:
-  error: type mismatch in f64.ge, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_cmp/f64_cmp.2.wasm:0000020: error: type mismatch in f64.ge, expected [f64, f64] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/f64_cmp.wast:2419: assert_invalid passed:
-  error: type mismatch in f64.gt, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_cmp/f64_cmp.3.wasm:0000020: error: type mismatch in f64.gt, expected [f64, f64] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/f64_cmp.wast:2420: assert_invalid passed:
-  error: type mismatch in f64.le, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_cmp/f64_cmp.4.wasm:0000020: error: type mismatch in f64.le, expected [f64, f64] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/f64_cmp.wast:2421: assert_invalid passed:
-  error: type mismatch in f64.lt, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_cmp/f64_cmp.5.wasm:0000020: error: type mismatch in f64.lt, expected [f64, f64] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/f64_cmp.wast:2422: assert_invalid passed:
-  error: type mismatch in f64.ne, expected [f64, f64] but got [i64, f32]
+  out/test/spec/f64_cmp/f64_cmp.6.wasm:0000020: error: type mismatch in f64.ne, expected [f64, f64] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 2406/2406 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -52,148 +52,148 @@ out/test/spec/func.wast:623: assert_malformed passed:
   ...unc (param i32 i32) (result i32)))(func (type $sig) (param i32) (result i3...
                                         ^^^^
 out/test/spec/func.wast:634: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/func/func.16.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/func.wast:638: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/func/func.17.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
 out/test/spec/func.wast:642: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/func/func.18.wasm:000001e: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/func.wast:650: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/func/func.19.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/func.wast:654: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/func/func.20.wasm:000001b: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/func.wast:658: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/func/func.21.wasm:000001c: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/func.wast:666: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/func/func.22.wasm:0000017: error: type mismatch in implicit return, expected [i32] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:670: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/func/func.23.wasm:0000017: error: type mismatch in implicit return, expected [i64] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:674: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/func/func.24.wasm:0000017: error: type mismatch in implicit return, expected [f32] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:678: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/func/func.25.wasm:0000017: error: type mismatch in implicit return, expected [f64] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:682: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64, i32] but got []
+  out/test/spec/func/func.26.wasm:0000018: error: type mismatch in implicit return, expected [f64, i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:687: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/func/func.27.wasm:0000019: error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:693: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32, i32] but got []
+  out/test/spec/func/func.28.wasm:000001a: error: type mismatch in implicit return, expected [i32, i32] but got []
   000001b: error: EndFunctionBody callback failed
 out/test/spec/func.wast:699: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/func/func.29.wasm:0000019: error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:705: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32, i64]
+  out/test/spec/func/func.30.wasm:000001b: error: type mismatch in function, expected [] but got [i32, i64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/func.wast:711: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/func/func.31.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got [f32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/func.wast:717: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32, f32] but got [f32]
+  out/test/spec/func/func.32.wasm:000001e: error: type mismatch in implicit return, expected [f32, f32] but got [f32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/func.wast:723: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/func/func.33.wasm:0000022: error: type mismatch in function, expected [] but got [f32]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/func.wast:730: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/func/func.34.wasm:0000019: error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/test/spec/func.wast:736: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i32] but got []
+  out/test/spec/func/func.35.wasm:000001a: error: type mismatch in return, expected [i32, i32] but got []
   000001a: error: OnReturnExpr callback failed
 out/test/spec/func.wast:742: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/func/func.36.wasm:000001a: error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
 out/test/spec/func.wast:748: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i64] but got []
+  out/test/spec/func/func.37.wasm:000001b: error: type mismatch in return, expected [i32, i64] but got []
   000001b: error: OnReturnExpr callback failed
 out/test/spec/func.wast:754: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got [i64]
+  out/test/spec/func/func.38.wasm:000001b: error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/test/spec/func.wast:760: assert_invalid passed:
-  error: type mismatch in return, expected [i64, i64] but got [i64]
+  out/test/spec/func/func.39.wasm:000001c: error: type mismatch in return, expected [i64, i64] but got [i64]
   000001c: error: OnReturnExpr callback failed
 out/test/spec/func.wast:767: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/func/func.40.wasm:0000019: error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/test/spec/func.wast:773: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i32] but got []
+  out/test/spec/func/func.41.wasm:000001a: error: type mismatch in return, expected [i32, i32] but got []
   000001a: error: OnReturnExpr callback failed
 out/test/spec/func.wast:779: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i32] but got [i32]
+  out/test/spec/func/func.42.wasm:000001c: error: type mismatch in return, expected [i32, i32] but got [i32]
   000001c: error: OnReturnExpr callback failed
 out/test/spec/func.wast:785: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/func/func.43.wasm:000001a: error: type mismatch in return, expected [i32] but got []
   000001a: error: OnReturnExpr callback failed
 out/test/spec/func.wast:791: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i32] but got []
+  out/test/spec/func/func.44.wasm:000001b: error: type mismatch in return, expected [i32, i32] but got []
   000001b: error: OnReturnExpr callback failed
 out/test/spec/func.wast:797: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got [i64]
+  out/test/spec/func/func.45.wasm:000001b: error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/test/spec/func.wast:803: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i32] but got [i64]
+  out/test/spec/func/func.46.wasm:000001c: error: type mismatch in return, expected [i32, i32] but got [i64]
   000001c: error: OnReturnExpr callback failed
 out/test/spec/func.wast:809: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got [i64]
+  out/test/spec/func/func.47.wasm:000001b: error: type mismatch in return, expected [i32] but got [i64]
   000001b: error: OnReturnExpr callback failed
 out/test/spec/func.wast:815: assert_invalid passed:
-  error: type mismatch in return, expected [i32, i32] but got [i32]
+  out/test/spec/func/func.48.wasm:000001c: error: type mismatch in return, expected [i32, i32] but got [i32]
   000001c: error: OnReturnExpr callback failed
 out/test/spec/func.wast:822: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/func/func.49.wasm:000001a: error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
 out/test/spec/func.wast:828: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/func/func.50.wasm:000001b: error: type mismatch in br, expected [i32, i32] but got []
   000001b: error: OnBrExpr callback failed
 out/test/spec/func.wast:834: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f32]
+  out/test/spec/func/func.51.wasm:000001f: error: type mismatch in br, expected [i32] but got [f32]
   000001f: error: OnBrExpr callback failed
 out/test/spec/func.wast:840: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/func/func.52.wasm:000001d: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001d: error: OnBrExpr callback failed
 out/test/spec/func.wast:846: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/func/func.53.wasm:000001a: error: type mismatch in br, expected [i32] but got []
   000001a: error: OnBrExpr callback failed
 out/test/spec/func.wast:852: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/func/func.54.wasm:000001b: error: type mismatch in br, expected [i32, i32] but got []
   000001b: error: OnBrExpr callback failed
 out/test/spec/func.wast:858: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/func/func.55.wasm:000001c: error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
 out/test/spec/func.wast:864: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/func/func.56.wasm:000001d: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001d: error: OnBrExpr callback failed
 out/test/spec/func.wast:870: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/func/func.57.wasm:000001c: error: type mismatch in br, expected [i32] but got [i64]
   000001c: error: OnBrExpr callback failed
 out/test/spec/func.wast:877: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/func/func.58.wasm:000001c: error: type mismatch in br, expected [i32] but got []
   000001c: error: OnBrExpr callback failed
 out/test/spec/func.wast:883: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/func/func.59.wasm:000001d: error: type mismatch in br, expected [i32, i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/func.wast:889: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/func/func.60.wasm:000001d: error: type mismatch in br, expected [i32] but got []
   000001d: error: OnBrExpr callback failed
 out/test/spec/func.wast:895: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/func/func.61.wasm:000001e: error: type mismatch in br, expected [i32, i32] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/func.wast:901: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/func/func.62.wasm:000001e: error: type mismatch in br, expected [i32] but got [i64]
   000001e: error: OnBrExpr callback failed
 out/test/spec/func.wast:907: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i32]
+  out/test/spec/func/func.63.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001f: error: OnBrExpr callback failed
 out/test/spec/func.wast:917: assert_malformed passed:
   out/test/spec/func/func.64.wat:1:14: error: unexpected token "local", expected an instr.

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -10,7 +10,7 @@ out/test/spec/func_ptrs.wast:33: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:36: assert_invalid passed:
-  error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/func_ptrs/func_ptrs.3.wasm:0000015: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/func_ptrs.wast:40: assert_invalid passed:
   error: Unepxected opcode in init expr

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -3,10 +3,10 @@
 (;; STDOUT ;;;
 out/test/spec/global.wast:251: assert_trap passed: undefined table index
 out/test/spec/global.wast:273: assert_invalid passed:
-  error: can't global.set on immutable global at index 0.
+  out/test/spec/global/global.1.wasm:0000029: error: can't global.set on immutable global at index 0.
   0000029: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:278: assert_invalid passed:
-  error: can't global.set on immutable global at index 0.
+  out/test/spec/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
   0000035: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:287: assert_invalid passed:
   error: Unepxected opcode in init expr
@@ -27,16 +27,16 @@ out/test/spec/global.wast:312: assert_invalid passed:
   error: Unepxected opcode in init expr
   000000e: error: OnNopExpr callback failed
 out/test/spec/global.wast:317: assert_invalid passed:
-  error: type mismatch at global initializer expression. got f32, expected i32
+  out/test/spec/global/global.11.wasm:0000013: error: type mismatch at global initializer expression. got f32, expected i32
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:322: assert_invalid passed:
   error: expected END opcode after initializer expression
   0000011: error: OnI32ConstExpr callback failed
 out/test/spec/global.wast:327: assert_invalid passed:
-  error: invalid global initializer expression, must be a constant expression
+  out/test/spec/global/global.13.wasm:000000e: error: invalid global initializer expression, must be a constant expression
   000000e: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:332: assert_invalid passed:
-  error: type mismatch at global initializer expression. got externref, expected funcref
+  out/test/spec/global/global.14.wasm:0000018: error: type mismatch at global initializer expression. got externref, expected funcref
   0000018: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:337: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -54,7 +54,7 @@ out/test/spec/global.wast:357: assert_invalid passed:
   0000000: error: global variable out of range: 2 (max 2)
   0000026: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:362: assert_invalid passed:
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/global/global.20.wasm:000002a: error: initializer expression cannot reference a mutable global
   000002a: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:370: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
@@ -89,40 +89,40 @@ out/test/spec/global.wast:478: assert_invalid passed:
   0000000: error: global variable out of range: 2 (max 2)
   000003d: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:488: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.35.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:497: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.36.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:507: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.37.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:517: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.38.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
   0000027: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:527: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.39.wasm:000002a: error: type mismatch in global.set, expected [i32] but got []
   000002a: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:537: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.40.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:547: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.41.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:557: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.42.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
   0000025: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:567: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.43.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:576: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.44.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
   0000021: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:585: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.45.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
   0000027: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:595: assert_invalid passed:
-  error: type mismatch in global.set, expected [i32] but got []
+  out/test/spec/global/global.46.wasm:000003e: error: type mismatch in global.set, expected [i32] but got []
   000003e: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:613: assert_malformed passed:
   out/test/spec/global/global.47.wat:1:33: error: redefinition of global "$foo"

--- a/test/spec/i32.txt
+++ b/test/spec/i32.txt
@@ -12,253 +12,253 @@ out/test/spec/i32.wast:103: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:123: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:124: assert_trap passed: integer divide by zero
 out/test/spec/i32.wast:444: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.1.wasm:0000018: error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:452: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.2.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:461: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.3.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:470: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.4.wasm:000001e: error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:479: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.5.wasm:0000021: error: type mismatch in i32.eqz, expected [i32] but got []
   0000021: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:488: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.6.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:497: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.7.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:506: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.8.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:515: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.9.wasm:0000018: error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:523: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.10.wasm:0000018: error: type mismatch in i32.eqz, expected [i32] but got []
   0000018: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:531: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.11.wasm:000001e: error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:540: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.12.wasm:0000035: error: type mismatch in i32.eqz, expected [i32] but got []
   0000035: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:556: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.13.wasm:000001a: error: type mismatch in i32.eqz, expected [i32] but got []
   000001a: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:565: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.14.wasm:000001a: error: type mismatch in i32.eqz, expected [i32] but got []
   000001a: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:574: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.15.wasm:0000020: error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:583: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.16.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:592: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.17.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:601: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/i32/i32.18.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:611: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.19.wasm:0000018: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:619: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.20.wasm:000001a: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:627: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.21.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:636: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.22.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:645: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.23.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:654: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.24.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:663: assert_invalid passed:
-  error: type mismatch in drop, expected [any] but got []
+  out/test/spec/i32/i32.25.wasm:0000021: error: type mismatch in drop, expected [any] but got []
   0000021: error: OnDropExpr callback failed
 out/test/spec/i32.wast:672: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.26.wasm:0000020: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:681: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.27.wasm:0000023: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000023: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:691: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.28.wasm:0000021: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:701: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.29.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:710: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.30.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:719: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.31.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:728: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.32.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:737: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.33.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:746: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.34.wasm:000001e: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:755: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.35.wasm:0000018: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:763: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.36.wasm:000001a: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:771: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.37.wasm:0000018: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000018: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:779: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.38.wasm:000001a: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:787: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.39.wasm:000001f: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:796: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.40.wasm:0000021: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:805: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.41.wasm:0000035: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000035: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:821: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.42.wasm:0000037: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000037: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:837: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.43.wasm:000001a: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:846: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.44.wasm:000001c: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001c: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:855: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.45.wasm:000001a: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:864: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.46.wasm:000001c: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001c: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:873: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.47.wasm:0000020: error: type mismatch in i32.add, expected [i32, i32] but got []
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:882: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.48.wasm:0000022: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:891: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.49.wasm:000001d: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:900: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.50.wasm:000001f: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:909: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.51.wasm:000001d: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:918: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.52.wasm:000001f: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:927: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got []
+  out/test/spec/i32/i32.53.wasm:000001d: error: type mismatch in i32.add, expected [i32, i32] but got []
   000001d: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:936: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i32]
+  out/test/spec/i32/i32.54.wasm:000001f: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:948: assert_invalid passed:
-  error: type mismatch in i32.add, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.55.wasm:0000020: error: type mismatch in i32.add, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:949: assert_invalid passed:
-  error: type mismatch in i32.and, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.56.wasm:0000020: error: type mismatch in i32.and, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:950: assert_invalid passed:
-  error: type mismatch in i32.div_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.57.wasm:0000020: error: type mismatch in i32.div_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:951: assert_invalid passed:
-  error: type mismatch in i32.div_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.58.wasm:0000020: error: type mismatch in i32.div_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:952: assert_invalid passed:
-  error: type mismatch in i32.mul, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.59.wasm:0000020: error: type mismatch in i32.mul, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:953: assert_invalid passed:
-  error: type mismatch in i32.or, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.60.wasm:0000020: error: type mismatch in i32.or, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:954: assert_invalid passed:
-  error: type mismatch in i32.rem_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.61.wasm:0000020: error: type mismatch in i32.rem_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:955: assert_invalid passed:
-  error: type mismatch in i32.rem_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.62.wasm:0000020: error: type mismatch in i32.rem_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:956: assert_invalid passed:
-  error: type mismatch in i32.rotl, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.63.wasm:0000020: error: type mismatch in i32.rotl, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:957: assert_invalid passed:
-  error: type mismatch in i32.rotr, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.64.wasm:0000020: error: type mismatch in i32.rotr, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:958: assert_invalid passed:
-  error: type mismatch in i32.shl, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.65.wasm:0000020: error: type mismatch in i32.shl, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:959: assert_invalid passed:
-  error: type mismatch in i32.shr_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.66.wasm:0000020: error: type mismatch in i32.shr_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:960: assert_invalid passed:
-  error: type mismatch in i32.shr_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.67.wasm:0000020: error: type mismatch in i32.shr_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:961: assert_invalid passed:
-  error: type mismatch in i32.sub, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.68.wasm:0000020: error: type mismatch in i32.sub, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:962: assert_invalid passed:
-  error: type mismatch in i32.xor, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.69.wasm:0000020: error: type mismatch in i32.xor, expected [i32, i32] but got [i64, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i32.wast:963: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [i64]
+  out/test/spec/i32/i32.70.wasm:000001b: error: type mismatch in i32.eqz, expected [i32] but got [i64]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/i32.wast:964: assert_invalid passed:
-  error: type mismatch in i32.clz, expected [i32] but got [i64]
+  out/test/spec/i32/i32.71.wasm:000001b: error: type mismatch in i32.clz, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/i32.wast:965: assert_invalid passed:
-  error: type mismatch in i32.ctz, expected [i32] but got [i64]
+  out/test/spec/i32/i32.72.wasm:000001b: error: type mismatch in i32.ctz, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/i32.wast:966: assert_invalid passed:
-  error: type mismatch in i32.popcnt, expected [i32] but got [i64]
+  out/test/spec/i32/i32.73.wasm:000001b: error: type mismatch in i32.popcnt, expected [i32] but got [i64]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/i32.wast:967: assert_invalid passed:
-  error: type mismatch in i32.eq, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.74.wasm:0000020: error: type mismatch in i32.eq, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:968: assert_invalid passed:
-  error: type mismatch in i32.ge_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.75.wasm:0000020: error: type mismatch in i32.ge_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:969: assert_invalid passed:
-  error: type mismatch in i32.ge_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.76.wasm:0000020: error: type mismatch in i32.ge_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:970: assert_invalid passed:
-  error: type mismatch in i32.gt_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.77.wasm:0000020: error: type mismatch in i32.gt_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:971: assert_invalid passed:
-  error: type mismatch in i32.gt_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.78.wasm:0000020: error: type mismatch in i32.gt_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:972: assert_invalid passed:
-  error: type mismatch in i32.le_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.79.wasm:0000020: error: type mismatch in i32.le_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:973: assert_invalid passed:
-  error: type mismatch in i32.le_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.80.wasm:0000020: error: type mismatch in i32.le_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:974: assert_invalid passed:
-  error: type mismatch in i32.lt_s, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.81.wasm:0000020: error: type mismatch in i32.lt_s, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:975: assert_invalid passed:
-  error: type mismatch in i32.lt_u, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.82.wasm:0000020: error: type mismatch in i32.lt_u, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i32.wast:976: assert_invalid passed:
-  error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
+  out/test/spec/i32/i32.83.wasm:0000020: error: type mismatch in i32.ne, expected [i32, i32] but got [i64, f32]
   0000020: error: OnCompareExpr callback failed
 459/459 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/i64.txt
+++ b/test/spec/i64.txt
@@ -12,91 +12,91 @@ out/test/spec/i64.wast:104: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:124: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:125: assert_trap passed: integer divide by zero
 out/test/spec/i64.wast:457: assert_invalid passed:
-  error: type mismatch in i64.add, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.1.wasm:0000020: error: type mismatch in i64.add, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:458: assert_invalid passed:
-  error: type mismatch in i64.and, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.2.wasm:0000020: error: type mismatch in i64.and, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:459: assert_invalid passed:
-  error: type mismatch in i64.div_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.3.wasm:0000020: error: type mismatch in i64.div_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:460: assert_invalid passed:
-  error: type mismatch in i64.div_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.4.wasm:0000020: error: type mismatch in i64.div_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:461: assert_invalid passed:
-  error: type mismatch in i64.mul, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.5.wasm:0000020: error: type mismatch in i64.mul, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:462: assert_invalid passed:
-  error: type mismatch in i64.or, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.6.wasm:0000020: error: type mismatch in i64.or, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:463: assert_invalid passed:
-  error: type mismatch in i64.rem_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.7.wasm:0000020: error: type mismatch in i64.rem_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:464: assert_invalid passed:
-  error: type mismatch in i64.rem_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.8.wasm:0000020: error: type mismatch in i64.rem_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:465: assert_invalid passed:
-  error: type mismatch in i64.rotl, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.9.wasm:0000020: error: type mismatch in i64.rotl, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:466: assert_invalid passed:
-  error: type mismatch in i64.rotr, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.10.wasm:0000020: error: type mismatch in i64.rotr, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:467: assert_invalid passed:
-  error: type mismatch in i64.shl, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.11.wasm:0000020: error: type mismatch in i64.shl, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:468: assert_invalid passed:
-  error: type mismatch in i64.shr_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.12.wasm:0000020: error: type mismatch in i64.shr_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:469: assert_invalid passed:
-  error: type mismatch in i64.shr_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.13.wasm:0000020: error: type mismatch in i64.shr_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:470: assert_invalid passed:
-  error: type mismatch in i64.sub, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.14.wasm:0000020: error: type mismatch in i64.sub, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:471: assert_invalid passed:
-  error: type mismatch in i64.xor, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.15.wasm:0000020: error: type mismatch in i64.xor, expected [i64, i64] but got [i32, f32]
   0000020: error: OnBinaryExpr callback failed
 out/test/spec/i64.wast:472: assert_invalid passed:
-  error: type mismatch in i64.eqz, expected [i64] but got [i32]
+  out/test/spec/i64/i64.16.wasm:000001b: error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/i64.wast:473: assert_invalid passed:
-  error: type mismatch in i64.clz, expected [i64] but got [i32]
+  out/test/spec/i64/i64.17.wasm:000001b: error: type mismatch in i64.clz, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/i64.wast:474: assert_invalid passed:
-  error: type mismatch in i64.ctz, expected [i64] but got [i32]
+  out/test/spec/i64/i64.18.wasm:000001b: error: type mismatch in i64.ctz, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/i64.wast:475: assert_invalid passed:
-  error: type mismatch in i64.popcnt, expected [i64] but got [i32]
+  out/test/spec/i64/i64.19.wasm:000001b: error: type mismatch in i64.popcnt, expected [i64] but got [i32]
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/i64.wast:476: assert_invalid passed:
-  error: type mismatch in i64.eq, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.20.wasm:0000020: error: type mismatch in i64.eq, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:477: assert_invalid passed:
-  error: type mismatch in i64.ge_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.21.wasm:0000020: error: type mismatch in i64.ge_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:478: assert_invalid passed:
-  error: type mismatch in i64.ge_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.22.wasm:0000020: error: type mismatch in i64.ge_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:479: assert_invalid passed:
-  error: type mismatch in i64.gt_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.23.wasm:0000020: error: type mismatch in i64.gt_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:480: assert_invalid passed:
-  error: type mismatch in i64.gt_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.24.wasm:0000020: error: type mismatch in i64.gt_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:481: assert_invalid passed:
-  error: type mismatch in i64.le_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.25.wasm:0000020: error: type mismatch in i64.le_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:482: assert_invalid passed:
-  error: type mismatch in i64.le_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.26.wasm:0000020: error: type mismatch in i64.le_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:483: assert_invalid passed:
-  error: type mismatch in i64.lt_s, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.27.wasm:0000020: error: type mismatch in i64.lt_s, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:484: assert_invalid passed:
-  error: type mismatch in i64.lt_u, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.28.wasm:0000020: error: type mismatch in i64.lt_u, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/i64.wast:485: assert_invalid passed:
-  error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
+  out/test/spec/i64/i64.29.wasm:0000020: error: type mismatch in i64.ne, expected [i64, i64] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 415/415 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -68,280 +68,280 @@ out/test/spec/if.wast:816: assert_malformed passed:
   ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (result i...
                                           ^
 out/test/spec/if.wast:826: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/if/if.12.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/if.wast:834: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/if/if.13.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:838: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/if/if.14.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:842: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/if/if.15.wasm:000001d: error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:846: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/if/if.16.wasm:000001d: error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:851: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/if/if.17.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:855: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/if/if.18.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:859: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/if/if.19.wasm:000001d: error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:863: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/if/if.20.wasm:000001d: error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:868: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.21.wasm:000001e: error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:874: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.22.wasm:000001e: error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:880: assert_invalid passed:
-  error: type mismatch in if false branch, expected [] but got [i32]
+  out/test/spec/if/if.23.wasm:000001f: error: type mismatch in if false branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:886: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.24.wasm:000001d: error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:893: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.25.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32, i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/if.wast:899: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.26.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32, i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/if.wast:905: assert_invalid passed:
-  error: type mismatch in if false branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.27.wasm:0000021: error: type mismatch in if false branch, expected [] but got [i32, i32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/if.wast:911: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.28.wasm:000001f: error: type mismatch in if true branch, expected [] but got [i32, i32]
   0000020: error: OnElseExpr callback failed
 out/test/spec/if.wast:918: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.29.wasm:000001c: error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
 out/test/spec/if.wast:924: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32] but got []
+  out/test/spec/if/if.30.wasm:000001f: error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:930: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.31.wasm:000001d: error: type mismatch in if true branch, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
 out/test/spec/if.wast:937: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.32.wasm:000001d: error: type mismatch in if true branch, expected [i32, i32] but got []
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:943: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32, i32] but got []
+  out/test/spec/if/if.33.wasm:0000022: error: type mismatch in if false branch, expected [i32, i32] but got []
   0000022: error: OnEndExpr callback failed
 out/test/spec/if.wast:949: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.34.wasm:000001e: error: type mismatch in if true branch, expected [i32, i32] but got []
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:956: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32] but got []
+  out/test/spec/if/if.35.wasm:000001f: error: type mismatch in if false branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:962: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32, i32] but got []
+  out/test/spec/if/if.36.wasm:0000022: error: type mismatch in if false branch, expected [i32, i32] but got []
   0000022: error: OnEndExpr callback failed
 out/test/spec/if.wast:969: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.37.wasm:000001d: error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:975: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32] but got []
+  out/test/spec/if/if.38.wasm:0000021: error: type mismatch in if false branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
 out/test/spec/if.wast:981: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.39.wasm:000001d: error: type mismatch in if true branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:988: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.40.wasm:000001e: error: type mismatch in if true branch, expected [i32, i32] but got []
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:994: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32, i32] but got []
+  out/test/spec/if/if.41.wasm:0000024: error: type mismatch in if false branch, expected [i32, i32] but got []
   0000024: error: OnEndExpr callback failed
 out/test/spec/if.wast:1000: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.42.wasm:000001e: error: type mismatch in if true branch, expected [i32, i32] but got []
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1007: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got [i64]
+  out/test/spec/if/if.43.wasm:000001e: error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1013: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32] but got [i64]
+  out/test/spec/if/if.44.wasm:0000022: error: type mismatch in if false branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
 out/test/spec/if.wast:1019: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got [i64]
+  out/test/spec/if/if.45.wasm:000001e: error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1026: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.46.wasm:000001f: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000020: error: OnElseExpr callback failed
 out/test/spec/if.wast:1032: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.47.wasm:0000025: error: type mismatch in if false branch, expected [i32, i32] but got [i32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/if.wast:1038: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.48.wasm:000001f: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000020: error: OnElseExpr callback failed
 out/test/spec/if.wast:1045: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.49.wasm:0000021: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
 out/test/spec/if.wast:1052: assert_invalid passed:
-  error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.50.wasm:0000027: error: type mismatch in if false branch, expected [i32, i32] but got [i32]
   0000027: error: OnEndExpr callback failed
 out/test/spec/if.wast:1059: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.51.wasm:0000021: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
 out/test/spec/if.wast:1067: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.52.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32]
   0000021: error: OnElseExpr callback failed
 out/test/spec/if.wast:1073: assert_invalid passed:
-  error: type mismatch in if false branch, expected [] but got [i32]
+  out/test/spec/if/if.53.wasm:0000024: error: type mismatch in if false branch, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/if.wast:1079: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.54.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32]
   0000021: error: OnElseExpr callback failed
 out/test/spec/if.wast:1086: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got [i64]
+  out/test/spec/if/if.55.wasm:000001e: error: type mismatch in if true branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1092: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.56.wasm:0000023: error: type mismatch in if true branch, expected [] but got [i32]
   0000024: error: OnElseExpr callback failed
 out/test/spec/if.wast:1099: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/if/if.57.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/if.wast:1109: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/if/if.58.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/if.wast:1119: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/if/if.59.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
 out/test/spec/if.wast:1130: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/if/if.60.wasm:000001e: error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/if.wast:1136: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/if/if.61.wasm:0000021: error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/test/spec/if.wast:1142: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/if/if.62.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/if.wast:1148: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/if/if.63.wasm:0000024: error: type mismatch in br, expected [i32, i32] but got []
   0000024: error: OnBrExpr callback failed
 out/test/spec/if.wast:1155: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/if/if.64.wasm:000001e: error: type mismatch in br, expected [i32] but got []
   000001e: error: OnBrExpr callback failed
 out/test/spec/if.wast:1164: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/if/if.65.wasm:0000021: error: type mismatch in br, expected [i32] but got []
   0000021: error: OnBrExpr callback failed
 out/test/spec/if.wast:1173: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/if/if.66.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/if.wast:1182: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/if/if.67.wasm:0000024: error: type mismatch in br, expected [i32, i32] but got []
   0000024: error: OnBrExpr callback failed
 out/test/spec/if.wast:1192: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/if/if.68.wasm:000001f: error: type mismatch in br, expected [i32] but got []
   000001f: error: OnBrExpr callback failed
 out/test/spec/if.wast:1201: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got []
+  out/test/spec/if/if.69.wasm:0000022: error: type mismatch in br, expected [i32] but got []
   0000022: error: OnBrExpr callback failed
 out/test/spec/if.wast:1210: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/if/if.70.wasm:0000020: error: type mismatch in br, expected [i32, i32] but got []
   0000020: error: OnBrExpr callback failed
 out/test/spec/if.wast:1219: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got []
+  out/test/spec/if/if.71.wasm:0000025: error: type mismatch in br, expected [i32, i32] but got []
   0000025: error: OnBrExpr callback failed
 out/test/spec/if.wast:1229: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/if/if.72.wasm:0000020: error: type mismatch in br, expected [i32] but got [i64]
   0000020: error: OnBrExpr callback failed
 out/test/spec/if.wast:1238: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [i64]
+  out/test/spec/if/if.73.wasm:0000023: error: type mismatch in br, expected [i32] but got [i64]
   0000023: error: OnBrExpr callback failed
 out/test/spec/if.wast:1247: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i64]
+  out/test/spec/if/if.74.wasm:0000021: error: type mismatch in br, expected [i32, i32] but got [i64]
   0000021: error: OnBrExpr callback failed
 out/test/spec/if.wast:1256: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i64]
+  out/test/spec/if/if.75.wasm:0000026: error: type mismatch in br, expected [i32, i32] but got [i64]
   0000026: error: OnBrExpr callback failed
 out/test/spec/if.wast:1265: assert_invalid passed:
-  error: type mismatch in br, expected [i32, i32] but got [i64]
+  out/test/spec/if/if.76.wasm:0000023: error: type mismatch in br, expected [i32, i32] but got [i64]
   0000023: error: OnBrExpr callback failed
 out/test/spec/if.wast:1275: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.77.wasm:0000021: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
 out/test/spec/if.wast:1286: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.78.wasm:0000019: error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
 out/test/spec/if.wast:1294: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.79.wasm:000001d: error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/test/spec/if.wast:1303: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.80.wasm:000001d: error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/test/spec/if.wast:1312: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.81.wasm:000001f: error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
 out/test/spec/if.wast:1321: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.82.wasm:0000022: error: type mismatch in if, expected [i32] but got []
   0000022: error: OnIfExpr callback failed
 out/test/spec/if.wast:1331: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.83.wasm:000001d: error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/test/spec/if.wast:1340: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.84.wasm:000001d: error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/test/spec/if.wast:1349: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.85.wasm:000001d: error: type mismatch in if, expected [i32] but got []
   000001d: error: OnIfExpr callback failed
 out/test/spec/if.wast:1358: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.86.wasm:0000019: error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
 out/test/spec/if.wast:1366: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.87.wasm:0000019: error: type mismatch in if, expected [i32] but got []
   0000019: error: OnIfExpr callback failed
 out/test/spec/if.wast:1374: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.88.wasm:000001f: error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
 out/test/spec/if.wast:1383: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.89.wasm:0000036: error: type mismatch in if, expected [i32] but got []
   0000036: error: OnIfExpr callback failed
 out/test/spec/if.wast:1399: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.90.wasm:000001b: error: type mismatch in if, expected [i32] but got []
   000001b: error: OnIfExpr callback failed
 out/test/spec/if.wast:1408: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.91.wasm:000001b: error: type mismatch in if, expected [i32] but got []
   000001b: error: OnIfExpr callback failed
 out/test/spec/if.wast:1417: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.92.wasm:0000021: error: type mismatch in if, expected [i32] but got []
   0000021: error: OnIfExpr callback failed
 out/test/spec/if.wast:1426: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.93.wasm:000001e: error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
 out/test/spec/if.wast:1435: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.94.wasm:000001e: error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
 out/test/spec/if.wast:1444: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.95.wasm:000001e: error: type mismatch in if, expected [i32] but got []
   000001e: error: OnIfExpr callback failed
 out/test/spec/if.wast:1454: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.96.wasm:000001f: error: type mismatch in if, expected [i32] but got []
   000001f: error: OnIfExpr callback failed
 out/test/spec/if.wast:1460: assert_invalid passed:
-  error: type mismatch in if, expected [i32, f64] but got []
+  out/test/spec/if/if.97.wasm:0000020: error: type mismatch in if, expected [i32, f64] but got []
   0000020: error: OnIfExpr callback failed
 out/test/spec/if.wast:1466: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got [f32]
+  out/test/spec/if/if.98.wasm:0000024: error: type mismatch in if, expected [i32] but got [f32]
   0000024: error: OnIfExpr callback failed
 out/test/spec/if.wast:1472: assert_invalid passed:
-  error: type mismatch in if, expected [f32, i32] but got [f32]
+  out/test/spec/if/if.99.wasm:0000025: error: type mismatch in if, expected [f32, i32] but got [f32]
   0000025: error: OnIfExpr callback failed
 out/test/spec/if.wast:1478: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got []
+  out/test/spec/if/if.100.wasm:0000021: error: type mismatch in if, expected [i32] but got []
   0000021: error: OnIfExpr callback failed
 out/test/spec/if.wast:1484: assert_invalid passed:
-  error: type mismatch in if, expected [i32, f64] but got []
+  out/test/spec/if/if.101.wasm:0000022: error: type mismatch in if, expected [i32, f64] but got []
   0000022: error: OnIfExpr callback failed
 out/test/spec/if.wast:1490: assert_invalid passed:
-  error: type mismatch in if, expected [i32] but got [f32]
+  out/test/spec/if/if.102.wasm:0000026: error: type mismatch in if, expected [i32] but got [f32]
   0000026: error: OnIfExpr callback failed
 out/test/spec/if.wast:1496: assert_invalid passed:
-  error: type mismatch in if, expected [f32, i32] but got [f32]
+  out/test/spec/if/if.103.wasm:0000027: error: type mismatch in if, expected [f32, i32] but got [f32]
   0000027: error: OnIfExpr callback failed
 out/test/spec/if.wast:1503: assert_malformed passed:
   out/test/spec/if/if.104.wat:1:42: error: unexpected token $x, expected ).

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -136,13 +136,13 @@ out/test/spec/imports.wast:456: assert_unlinkable passed:
 out/test/spec/imports.wast:474: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/imports.wast:485: assert_trap passed: out of bounds memory access: access at 1000000+4 >= max value 65536
 out/test/spec/imports.wast:488: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/imports/imports.97.wasm:0000015: error: only one memory block allowed
   0000015: error: OnImportMemory callback failed
 out/test/spec/imports.wast:492: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/imports/imports.98.wasm:0000015: error: only one memory block allowed
   0000015: error: OnMemory callback failed
 out/test/spec/imports.wast:496: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/imports/imports.99.wasm:000000f: error: only one memory block allowed
   000000f: error: OnMemory callback failed
 out/test/spec/imports.wast:511: assert_unlinkable passed:
   error: invalid import "test.unknown"

--- a/test/spec/labels.txt
+++ b/test/spec/labels.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/labels.wast
 (;; STDOUT ;;;
 out/test/spec/labels.wast:318: assert_invalid passed:
-  error: type mismatch in f32.neg, expected [f32] but got []
+  out/test/spec/labels/labels.1.wasm:000001e: error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/labels.wast:322: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [f32]
+  out/test/spec/labels/labels.2.wasm:0000023: error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/labels.wast:326: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [f32]
+  out/test/spec/labels/labels.3.wasm:0000023: error: type mismatch in block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 28/28 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/load.txt
+++ b/test/spec/load.txt
@@ -54,142 +54,142 @@ out/test/spec/load.wast:301: assert_malformed passed:
   (memory 1)(func (param i32) (result f64) (f64.load64 (local.get 0)))
                                             ^^^^^^^^^^
 out/test/spec/load.wast:312: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.14.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:316: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.15.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:320: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.16.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:324: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.17.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:328: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.18.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:332: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.19.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:336: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.20.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:340: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.21.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:344: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.22.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:348: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.23.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:352: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.24.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:356: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.25.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:360: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/load/load.26.wasm:0000021: error: type mismatch in function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:364: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/load/load.27.wasm:0000021: error: type mismatch in function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:371: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got [f32]
+  out/test/spec/load/load.28.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:372: assert_invalid passed:
-  error: type mismatch in i32.load8_s, expected [i32] but got [f32]
+  out/test/spec/load/load.29.wasm:0000025: error: type mismatch in i32.load8_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:373: assert_invalid passed:
-  error: type mismatch in i32.load8_u, expected [i32] but got [f32]
+  out/test/spec/load/load.30.wasm:0000025: error: type mismatch in i32.load8_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:374: assert_invalid passed:
-  error: type mismatch in i32.load16_s, expected [i32] but got [f32]
+  out/test/spec/load/load.31.wasm:0000025: error: type mismatch in i32.load16_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:375: assert_invalid passed:
-  error: type mismatch in i32.load16_u, expected [i32] but got [f32]
+  out/test/spec/load/load.32.wasm:0000025: error: type mismatch in i32.load16_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:376: assert_invalid passed:
-  error: type mismatch in i64.load, expected [i32] but got [f32]
+  out/test/spec/load/load.33.wasm:0000025: error: type mismatch in i64.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:377: assert_invalid passed:
-  error: type mismatch in i64.load8_s, expected [i32] but got [f32]
+  out/test/spec/load/load.34.wasm:0000025: error: type mismatch in i64.load8_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:378: assert_invalid passed:
-  error: type mismatch in i64.load8_u, expected [i32] but got [f32]
+  out/test/spec/load/load.35.wasm:0000025: error: type mismatch in i64.load8_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:379: assert_invalid passed:
-  error: type mismatch in i64.load16_s, expected [i32] but got [f32]
+  out/test/spec/load/load.36.wasm:0000025: error: type mismatch in i64.load16_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:380: assert_invalid passed:
-  error: type mismatch in i64.load16_u, expected [i32] but got [f32]
+  out/test/spec/load/load.37.wasm:0000025: error: type mismatch in i64.load16_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:381: assert_invalid passed:
-  error: type mismatch in i64.load32_s, expected [i32] but got [f32]
+  out/test/spec/load/load.38.wasm:0000025: error: type mismatch in i64.load32_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:382: assert_invalid passed:
-  error: type mismatch in i64.load32_u, expected [i32] but got [f32]
+  out/test/spec/load/load.39.wasm:0000025: error: type mismatch in i64.load32_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:383: assert_invalid passed:
-  error: type mismatch in f32.load, expected [i32] but got [f32]
+  out/test/spec/load/load.40.wasm:0000025: error: type mismatch in f32.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:384: assert_invalid passed:
-  error: type mismatch in f64.load, expected [i32] but got [f32]
+  out/test/spec/load/load.41.wasm:0000025: error: type mismatch in f64.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:388: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.42.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/load.wast:397: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.43.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/load.wast:407: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.44.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/load.wast:417: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.45.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got []
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:427: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.46.wasm:0000028: error: type mismatch in i32.load, expected [i32] but got []
   0000028: error: OnLoadExpr callback failed
 out/test/spec/load.wast:437: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.47.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/load.wast:447: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.48.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/load.wast:457: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.49.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/load.wast:467: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.50.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/load.wast:476: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.51.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/load.wast:485: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.52.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got []
   0000025: error: OnLoadExpr callback failed
 out/test/spec/load.wast:495: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.53.wasm:000003c: error: type mismatch in i32.load, expected [i32] but got []
   000003c: error: OnLoadExpr callback failed
 out/test/spec/load.wast:512: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.54.wasm:0000021: error: type mismatch in i32.load, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/load.wast:522: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.55.wasm:0000021: error: type mismatch in i32.load, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/load.wast:532: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.56.wasm:0000027: error: type mismatch in i32.load, expected [i32] but got []
   0000027: error: OnLoadExpr callback failed
 out/test/spec/load.wast:542: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.57.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/load.wast:551: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.58.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/load.wast:560: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/load/load.59.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/local_get.txt
+++ b/test/spec/local_get.txt
@@ -2,34 +2,34 @@
 ;;; STDIN_FILE: third_party/testsuite/local_get.wast
 (;; STDOUT ;;;
 out/test/spec/local_get.wast:149: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_get/local_get.1.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:153: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/local_get/local_get.2.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/local_get.wast:157: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/local_get/local_get.3.wasm:000001f: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/local_get.wast:165: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_get/local_get.4.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:169: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/local_get/local_get.5.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001c: error: OnConvertExpr callback failed
 out/test/spec/local_get.wast:173: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/local_get/local_get.6.wasm:000001d: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/local_get.wast:181: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/local_get/local_get.7.wasm:000001b: error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:185: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/local_get/local_get.8.wasm:000001b: error: type mismatch in function, expected [] but got [i64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:189: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/local_get/local_get.9.wasm:000001b: error: type mismatch in function, expected [] but got [f32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:193: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/local_get/local_get.10.wasm:000001b: error: type mismatch in function, expected [] but got [f64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:201: assert_invalid passed:
   0000000: error: local variable out of range (max 2)

--- a/test/spec/local_set.txt
+++ b/test/spec/local_set.txt
@@ -2,85 +2,85 @@
 ;;; STDIN_FILE: third_party/testsuite/local_set.wast
 (;; STDOUT ;;;
 out/test/spec/local_set.wast:148: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.1.wasm:000001c: error: type mismatch in local.set, expected [i32] but got []
   000001c: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:152: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got [f32]
+  out/test/spec/local_set/local_set.2.wasm:0000020: error: type mismatch in local.set, expected [i32] but got [f32]
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:156: assert_invalid passed:
-  error: type mismatch in local.set, expected [f32] but got [f64]
+  out/test/spec/local_set/local_set.3.wasm:0000024: error: type mismatch in local.set, expected [f32] but got [f64]
   0000024: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:160: assert_invalid passed:
-  error: type mismatch in local.set, expected [i64] but got [f64]
+  out/test/spec/local_set/local_set.4.wasm:0000026: error: type mismatch in local.set, expected [i64] but got [f64]
   0000026: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:169: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.5.wasm:000001b: error: type mismatch in local.set, expected [i32] but got []
   000001b: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:173: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got [f32]
+  out/test/spec/local_set/local_set.6.wasm:000001f: error: type mismatch in local.set, expected [i32] but got [f32]
   000001f: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:177: assert_invalid passed:
-  error: type mismatch in local.set, expected [f32] but got [f64]
+  out/test/spec/local_set/local_set.7.wasm:0000023: error: type mismatch in local.set, expected [f32] but got [f64]
   0000023: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:181: assert_invalid passed:
-  error: type mismatch in local.set, expected [i64] but got [f64]
+  out/test/spec/local_set/local_set.8.wasm:0000024: error: type mismatch in local.set, expected [i64] but got [f64]
   0000024: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:186: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.9.wasm:000001a: error: type mismatch in local.set, expected [i32] but got []
   000001a: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:194: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.10.wasm:000001e: error: type mismatch in local.set, expected [i32] but got []
   000001e: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:203: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.11.wasm:000001e: error: type mismatch in local.set, expected [i32] but got []
   000001e: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:212: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.12.wasm:0000020: error: type mismatch in local.set, expected [i32] but got []
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:221: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.13.wasm:0000023: error: type mismatch in local.set, expected [i32] but got []
   0000023: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:230: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.14.wasm:000001e: error: type mismatch in local.set, expected [i32] but got []
   000001e: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:239: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.15.wasm:000001e: error: type mismatch in local.set, expected [i32] but got []
   000001e: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:248: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.16.wasm:000001e: error: type mismatch in local.set, expected [i32] but got []
   000001e: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:257: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.17.wasm:000001a: error: type mismatch in local.set, expected [i32] but got []
   000001a: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:265: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.18.wasm:000001a: error: type mismatch in local.set, expected [i32] but got []
   000001a: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:273: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.19.wasm:0000020: error: type mismatch in local.set, expected [i32] but got []
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:282: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got []
+  out/test/spec/local_set/local_set.20.wasm:0000037: error: type mismatch in local.set, expected [i32] but got []
   0000037: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:301: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got [f32]
+  out/test/spec/local_set/local_set.21.wasm:0000021: error: type mismatch in local.set, expected [i32] but got [f32]
   0000021: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:305: assert_invalid passed:
-  error: type mismatch in local.set, expected [i32] but got [f32]
+  out/test/spec/local_set/local_set.22.wasm:0000022: error: type mismatch in local.set, expected [i32] but got [f32]
   0000022: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:309: assert_invalid passed:
-  error: type mismatch in local.set, expected [f64] but got [i64]
+  out/test/spec/local_set/local_set.23.wasm:0000020: error: type mismatch in local.set, expected [f64] but got [i64]
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:317: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/local_set/local_set.24.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:321: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/local_set/local_set.25.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:325: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/local_set/local_set.26.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got []
   0000021: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:329: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/local_set/local_set.27.wasm:0000024: error: type mismatch in implicit return, expected [f64] but got []
   0000025: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:337: assert_invalid passed:
   0000000: error: local variable out of range (max 2)

--- a/test/spec/local_tee.txt
+++ b/test/spec/local_tee.txt
@@ -2,109 +2,109 @@
 ;;; STDIN_FILE: third_party/testsuite/local_tee.wast
 (;; STDOUT ;;;
 out/test/spec/local_tee.wast:371: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_tee/local_tee.1.wasm:000001e: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/local_tee.wast:375: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/local_tee/local_tee.2.wasm:0000021: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/test/spec/local_tee.wast:379: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/local_tee/local_tee.3.wasm:0000020: error: type mismatch in f64.neg, expected [f64] but got [i64]
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/local_tee.wast:384: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.4.wasm:000001c: error: type mismatch in local.tee, expected [i32] but got []
   000001c: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:388: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got [f32]
+  out/test/spec/local_tee/local_tee.5.wasm:0000020: error: type mismatch in local.tee, expected [i32] but got [f32]
   0000020: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:392: assert_invalid passed:
-  error: type mismatch in local.tee, expected [f32] but got [f64]
+  out/test/spec/local_tee/local_tee.6.wasm:0000024: error: type mismatch in local.tee, expected [f32] but got [f64]
   0000024: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:396: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i64] but got [f64]
+  out/test/spec/local_tee/local_tee.7.wasm:0000026: error: type mismatch in local.tee, expected [i64] but got [f64]
   0000026: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:404: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_tee/local_tee.8.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_tee.wast:408: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/local_tee/local_tee.9.wasm:000001b: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/local_tee.wast:412: assert_invalid passed:
-  error: type mismatch in f64.neg, expected [f64] but got [i64]
+  out/test/spec/local_tee/local_tee.10.wasm:000001c: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/local_tee.wast:417: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.11.wasm:000001b: error: type mismatch in local.tee, expected [i32] but got []
   000001b: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:421: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got [f32]
+  out/test/spec/local_tee/local_tee.12.wasm:000001f: error: type mismatch in local.tee, expected [i32] but got [f32]
   000001f: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:425: assert_invalid passed:
-  error: type mismatch in local.tee, expected [f32] but got [f64]
+  out/test/spec/local_tee/local_tee.13.wasm:0000023: error: type mismatch in local.tee, expected [f32] but got [f64]
   0000023: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:429: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i64] but got [f64]
+  out/test/spec/local_tee/local_tee.14.wasm:0000024: error: type mismatch in local.tee, expected [i64] but got [f64]
   0000024: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:434: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.15.wasm:000001a: error: type mismatch in local.tee, expected [i32] but got []
   000001a: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:442: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.16.wasm:000001e: error: type mismatch in local.tee, expected [i32] but got []
   000001e: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:451: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.17.wasm:000001e: error: type mismatch in local.tee, expected [i32] but got []
   000001e: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:460: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.18.wasm:0000020: error: type mismatch in local.tee, expected [i32] but got []
   0000020: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:469: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.19.wasm:0000023: error: type mismatch in local.tee, expected [i32] but got []
   0000023: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:478: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.20.wasm:000001e: error: type mismatch in local.tee, expected [i32] but got []
   000001e: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:487: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.21.wasm:000001e: error: type mismatch in local.tee, expected [i32] but got []
   000001e: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:496: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.22.wasm:000001e: error: type mismatch in local.tee, expected [i32] but got []
   000001e: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:505: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.23.wasm:000001a: error: type mismatch in local.tee, expected [i32] but got []
   000001a: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:513: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.24.wasm:000001a: error: type mismatch in local.tee, expected [i32] but got []
   000001a: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:521: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.25.wasm:0000020: error: type mismatch in local.tee, expected [i32] but got []
   0000020: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:530: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.26.wasm:0000037: error: type mismatch in local.tee, expected [i32] but got []
   0000037: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:546: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.27.wasm:000001a: error: type mismatch in local.tee, expected [i32] but got []
   000001a: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:554: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.28.wasm:000001a: error: type mismatch in local.tee, expected [i32] but got []
   000001a: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:562: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.29.wasm:0000022: error: type mismatch in local.tee, expected [i32] but got []
   0000022: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:571: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.30.wasm:000001f: error: type mismatch in local.tee, expected [i32] but got []
   000001f: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:580: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.31.wasm:000001f: error: type mismatch in local.tee, expected [i32] but got []
   000001f: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:589: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got []
+  out/test/spec/local_tee/local_tee.32.wasm:000001f: error: type mismatch in local.tee, expected [i32] but got []
   000001f: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:599: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got [f32]
+  out/test/spec/local_tee/local_tee.33.wasm:0000021: error: type mismatch in local.tee, expected [i32] but got [f32]
   0000021: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:603: assert_invalid passed:
-  error: type mismatch in local.tee, expected [i32] but got [f32]
+  out/test/spec/local_tee/local_tee.34.wasm:0000022: error: type mismatch in local.tee, expected [i32] but got [f32]
   0000022: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:607: assert_invalid passed:
-  error: type mismatch in local.tee, expected [f64] but got [i64]
+  out/test/spec/local_tee/local_tee.35.wasm:0000020: error: type mismatch in local.tee, expected [f64] but got [i64]
   0000020: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:615: assert_invalid passed:
   0000000: error: local variable out of range (max 2)

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -49,85 +49,85 @@ out/test/spec/loop.wast:593: assert_malformed passed:
   ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (result...
                                           ^
 out/test/spec/loop.wast:601: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/loop/loop.12.wasm:000001c: error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:609: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/loop/loop.13.wasm:000001b: error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:613: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/loop/loop.14.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:617: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/loop/loop.15.wasm:000001b: error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:621: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/loop/loop.16.wasm:000001b: error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:626: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/loop/loop.17.wasm:000001c: error: type mismatch in loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:632: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32, i32]
+  out/test/spec/loop/loop.18.wasm:000001e: error: type mismatch in loop, expected [] but got [i32, i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/loop.wast:638: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.19.wasm:000001b: error: type mismatch in loop, expected [i32] but got []
   000001b: error: OnEndExpr callback failed
 out/test/spec/loop.wast:644: assert_invalid passed:
-  error: type mismatch in loop, expected [i32, i32] but got []
+  out/test/spec/loop/loop.20.wasm:000001c: error: type mismatch in loop, expected [i32, i32] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:650: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.21.wasm:000001c: error: type mismatch in loop, expected [i32] but got []
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:656: assert_invalid passed:
-  error: type mismatch in loop, expected [i32, i32] but got []
+  out/test/spec/loop/loop.22.wasm:000001d: error: type mismatch in loop, expected [i32, i32] but got []
   000001d: error: OnEndExpr callback failed
 out/test/spec/loop.wast:662: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/loop/loop.23.wasm:0000020: error: type mismatch in loop, expected [i32] but got [f32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/loop.wast:668: assert_invalid passed:
-  error: type mismatch in loop, expected [i32, i32] but got [i32]
+  out/test/spec/loop/loop.24.wasm:000001e: error: type mismatch in loop, expected [i32, i32] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/loop.wast:674: assert_invalid passed:
-  error: type mismatch in loop, expected [i32, i32] but got [i32]
+  out/test/spec/loop/loop.25.wasm:0000020: error: type mismatch in loop, expected [i32, i32] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/loop.wast:680: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/loop/loop.26.wasm:000001f: error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/loop.wast:686: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/loop/loop.27.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:693: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.28.wasm:000001e: error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
 out/test/spec/loop.wast:702: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.29.wasm:000001e: error: type mismatch in loop, expected [i32] but got []
   000001e: error: OnEndExpr callback failed
 out/test/spec/loop.wast:711: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.30.wasm:0000020: error: type mismatch in loop, expected [i32] but got []
   0000020: error: OnEndExpr callback failed
 out/test/spec/loop.wast:721: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.31.wasm:000001d: error: type mismatch in loop, expected [i32] but got []
   000001d: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:727: assert_invalid passed:
-  error: type mismatch in loop, expected [i32, f64] but got []
+  out/test/spec/loop/loop.32.wasm:000001e: error: type mismatch in loop, expected [i32, f64] but got []
   000001e: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:733: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/loop/loop.33.wasm:0000022: error: type mismatch in loop, expected [i32] but got [f32]
   0000022: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:739: assert_invalid passed:
-  error: type mismatch in loop, expected [f32, i32] but got [f32]
+  out/test/spec/loop/loop.34.wasm:0000023: error: type mismatch in loop, expected [f32, i32] but got [f32]
   0000023: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:745: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got []
+  out/test/spec/loop/loop.35.wasm:000001f: error: type mismatch in loop, expected [i32] but got []
   000001f: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:751: assert_invalid passed:
-  error: type mismatch in loop, expected [i32, f64] but got []
+  out/test/spec/loop/loop.36.wasm:0000020: error: type mismatch in loop, expected [i32, f64] but got []
   0000020: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:757: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/loop/loop.37.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:763: assert_invalid passed:
-  error: type mismatch in loop, expected [f32, i32] but got [f32]
+  out/test/spec/loop/loop.38.wasm:0000025: error: type mismatch in loop, expected [f32, i32] but got [f32]
   0000025: error: OnLoopExpr callback failed
 out/test/spec/loop.wast:770: assert_malformed passed:
   out/test/spec/loop/loop.39.wat:1:44: error: unexpected token $x, expected ).

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/memory.wast
 (;; STDOUT ;;;
 out/test/spec/memory.wast:10: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/memory/memory.6.wasm:000000f: error: only one memory block allowed
   000000f: error: OnMemory callback failed
 out/test/spec/memory.wast:11: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/memory/memory.7.wasm:0000023: error: only one memory block allowed
   0000023: error: OnMemory callback failed
 out/test/spec/memory.wast:20: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
@@ -31,25 +31,25 @@ out/test/spec/memory.wast:45: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory.wast:51: assert_invalid passed:
-  error: max pages (0) must be >= initial pages (1)
+  out/test/spec/memory/memory.20.wasm:000000e: error: max pages (0) must be >= initial pages (1)
   000000e: error: OnMemory callback failed
 out/test/spec/memory.wast:55: assert_invalid passed:
-  error: initial pages (65537) must be <= (65536)
+  out/test/spec/memory/memory.21.wasm:000000f: error: initial pages (65537) must be <= (65536)
   000000f: error: OnMemory callback failed
 out/test/spec/memory.wast:59: assert_invalid passed:
-  error: initial pages (2147483648) must be <= (65536)
+  out/test/spec/memory/memory.22.wasm:0000011: error: initial pages (2147483648) must be <= (65536)
   0000011: error: OnMemory callback failed
 out/test/spec/memory.wast:63: assert_invalid passed:
-  error: initial pages (4294967295) must be <= (65536)
+  out/test/spec/memory/memory.23.wasm:0000011: error: initial pages (4294967295) must be <= (65536)
   0000011: error: OnMemory callback failed
 out/test/spec/memory.wast:67: assert_invalid passed:
-  error: max pages (65537) must be <= (65536)
+  out/test/spec/memory/memory.24.wasm:0000010: error: max pages (65537) must be <= (65536)
   0000010: error: OnMemory callback failed
 out/test/spec/memory.wast:71: assert_invalid passed:
-  error: max pages (2147483648) must be <= (65536)
+  out/test/spec/memory/memory.25.wasm:0000012: error: max pages (2147483648) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/memory.wast:75: assert_invalid passed:
-  error: max pages (4294967295) must be <= (65536)
+  out/test/spec/memory/memory.26.wasm:0000012: error: max pages (4294967295) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/memory.wast:80: assert_malformed passed:
   out/test/spec/memory/memory.27.wat:1:9: error: invalid int "0x1_0000_0000"

--- a/test/spec/memory64/align64.txt
+++ b/test/spec/memory64/align64.txt
@@ -187,115 +187,115 @@ out/test/spec/memory64/align64.wast:299: assert_malformed passed:
   (module (memory i64 0) (func (f64.store align=7 (i64.const 0) (f32.const 0))))
                                           ^^^^^^^
 out/test/spec/memory64/align64.wast:306: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.69.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:310: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.70.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:314: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.71.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:318: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.72.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:322: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.73.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:326: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.74.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:330: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.75.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:334: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.76.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:338: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.77.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:342: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.78.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:346: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.79.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:350: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/memory64/align64/align64.80.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:354: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.81.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:358: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/memory64/align64/align64.82.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:363: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.83.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:367: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.84.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:371: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.85.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:375: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.86.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:379: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.87.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:383: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.88.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:387: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.89.wasm:0000021: error: alignment must not be larger than natural alignment (1)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:391: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.90.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:395: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.91.wasm:0000021: error: alignment must not be larger than natural alignment (2)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:399: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.92.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:403: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.93.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:407: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/memory64/align64/align64.94.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:411: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.95.wasm:0000021: error: alignment must not be larger than natural alignment (4)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:415: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/memory64/align64/align64.96.wasm:0000021: error: alignment must not be larger than natural alignment (8)
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/align64.wast:420: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.97.wasm:0000023: error: alignment must not be larger than natural alignment (1)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:424: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.98.wasm:0000023: error: alignment must not be larger than natural alignment (2)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:428: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.99.wasm:0000023: error: alignment must not be larger than natural alignment (4)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:432: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/memory64/align64/align64.100.wasm:0000023: error: alignment must not be larger than natural alignment (1)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:436: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/memory64/align64/align64.101.wasm:0000023: error: alignment must not be larger than natural alignment (2)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:440: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.102.wasm:0000023: error: alignment must not be larger than natural alignment (4)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:444: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/memory64/align64/align64.103.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:448: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/memory64/align64/align64.104.wasm:0000026: error: alignment must not be larger than natural alignment (4)
   0000026: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:452: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/memory64/align64/align64.105.wasm:000002a: error: alignment must not be larger than natural alignment (8)
   000002a: error: OnStoreExpr callback failed
 out/test/spec/memory64/align64.wast:864: assert_trap passed: out of bounds memory access: access at 65532+8 >= max value 65536
 131/131 tests passed.

--- a/test/spec/memory64/binary.txt
+++ b/test/spec/memory64/binary.txt
@@ -175,7 +175,7 @@ out/test/spec/memory64/binary.wast:900: assert_malformed passed:
 out/test/spec/memory64/binary.wast:914: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/memory64/binary.wast:945: assert_malformed passed:
-  error: function type variable out of range: 11 (max 1)
+  out/test/spec/memory64/binary/binary.102.wasm:0000025: error: function type variable out of range: 11 (max 1)
   0000025: error: OnBlockExpr callback failed
 out/test/spec/memory64/binary.wast:980: assert_malformed passed:
   0000017: error: multiple Start sections

--- a/test/spec/memory64/load64.txt
+++ b/test/spec/memory64/load64.txt
@@ -55,142 +55,142 @@ out/test/spec/memory64/load64.wast:301: assert_malformed passed:
   (memory i64 1)(func (param i64) (result f64) (f64.load64 (local.get 0)))
                                                 ^^^^^^^^^^
 out/test/spec/memory64/load64.wast:312: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.14.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:316: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.15.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:320: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.16.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:324: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.17.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:328: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.18.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:332: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.19.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:336: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.20.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:340: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.21.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:344: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.22.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:348: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.23.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:352: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.24.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:356: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.25.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:360: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/memory64/load64/load64.26.wasm:0000021: error: type mismatch in function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:364: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/memory64/load64/load64.27.wasm:0000021: error: type mismatch in function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:371: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.28.wasm:0000025: error: type mismatch in i32.load, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:372: assert_invalid passed:
-  error: type mismatch in i32.load8_s, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.29.wasm:0000025: error: type mismatch in i32.load8_s, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:373: assert_invalid passed:
-  error: type mismatch in i32.load8_u, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.30.wasm:0000025: error: type mismatch in i32.load8_u, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:374: assert_invalid passed:
-  error: type mismatch in i32.load16_s, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.31.wasm:0000025: error: type mismatch in i32.load16_s, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:375: assert_invalid passed:
-  error: type mismatch in i32.load16_u, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.32.wasm:0000025: error: type mismatch in i32.load16_u, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:376: assert_invalid passed:
-  error: type mismatch in i64.load, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.33.wasm:0000025: error: type mismatch in i64.load, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:377: assert_invalid passed:
-  error: type mismatch in i64.load8_s, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.34.wasm:0000025: error: type mismatch in i64.load8_s, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:378: assert_invalid passed:
-  error: type mismatch in i64.load8_u, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.35.wasm:0000025: error: type mismatch in i64.load8_u, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:379: assert_invalid passed:
-  error: type mismatch in i64.load16_s, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.36.wasm:0000025: error: type mismatch in i64.load16_s, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:380: assert_invalid passed:
-  error: type mismatch in i64.load16_u, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.37.wasm:0000025: error: type mismatch in i64.load16_u, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:381: assert_invalid passed:
-  error: type mismatch in i64.load32_s, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.38.wasm:0000025: error: type mismatch in i64.load32_s, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:382: assert_invalid passed:
-  error: type mismatch in i64.load32_u, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.39.wasm:0000025: error: type mismatch in i64.load32_u, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:383: assert_invalid passed:
-  error: type mismatch in f32.load, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.40.wasm:0000025: error: type mismatch in f32.load, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:384: assert_invalid passed:
-  error: type mismatch in f64.load, expected [i64] but got [f32]
+  out/test/spec/memory64/load64/load64.41.wasm:0000025: error: type mismatch in f64.load, expected [i64] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:388: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.42.wasm:000001f: error: type mismatch in i32.load, expected [i64] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:397: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.43.wasm:0000023: error: type mismatch in i32.load, expected [i64] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:407: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.44.wasm:0000023: error: type mismatch in i32.load, expected [i64] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:417: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.45.wasm:0000025: error: type mismatch in i32.load, expected [i64] but got []
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:427: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.46.wasm:0000028: error: type mismatch in i32.load, expected [i64] but got []
   0000028: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:437: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.47.wasm:0000023: error: type mismatch in i32.load, expected [i64] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:447: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.48.wasm:0000023: error: type mismatch in i32.load, expected [i64] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:457: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.49.wasm:0000023: error: type mismatch in i32.load, expected [i64] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:467: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.50.wasm:000001f: error: type mismatch in i32.load, expected [i64] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:476: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.51.wasm:000001f: error: type mismatch in i32.load, expected [i64] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:485: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.52.wasm:0000025: error: type mismatch in i32.load, expected [i64] but got []
   0000025: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:495: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.53.wasm:000003c: error: type mismatch in i32.load, expected [i64] but got []
   000003c: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:512: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.54.wasm:0000021: error: type mismatch in i32.load, expected [i64] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:522: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.55.wasm:0000021: error: type mismatch in i32.load, expected [i64] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:532: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.56.wasm:0000027: error: type mismatch in i32.load, expected [i64] but got []
   0000027: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:542: assert_invalid passed:
-  error: type mismatch in i64.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.57.wasm:000001f: error: type mismatch in i64.load, expected [i64] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:551: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.58.wasm:000001f: error: type mismatch in i32.load, expected [i64] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/memory64/load64.wast:560: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i64] but got []
+  out/test/spec/memory64/load64/load64.59.wasm:000001f: error: type mismatch in i32.load, expected [i64] but got []
   000001f: error: OnLoadExpr callback failed
 96/96 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory64/memory.txt
+++ b/test/spec/memory64/memory.txt
@@ -3,10 +3,10 @@
 ;;; ARGS*: --enable-memory64
 (;; STDOUT ;;;
 out/test/spec/memory64/memory.wast:10: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/memory64/memory/memory.6.wasm:000000f: error: only one memory block allowed
   000000f: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:11: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/memory64/memory/memory.7.wasm:0000023: error: only one memory block allowed
   0000023: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:20: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
@@ -32,25 +32,25 @@ out/test/spec/memory64/memory.wast:45: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory64/memory.wast:51: assert_invalid passed:
-  error: max pages (0) must be >= initial pages (1)
+  out/test/spec/memory64/memory/memory.20.wasm:000000e: error: max pages (0) must be >= initial pages (1)
   000000e: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:55: assert_invalid passed:
-  error: initial pages (65537) must be <= (65536)
+  out/test/spec/memory64/memory/memory.21.wasm:000000f: error: initial pages (65537) must be <= (65536)
   000000f: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:59: assert_invalid passed:
-  error: initial pages (2147483648) must be <= (65536)
+  out/test/spec/memory64/memory/memory.22.wasm:0000011: error: initial pages (2147483648) must be <= (65536)
   0000011: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:63: assert_invalid passed:
-  error: initial pages (4294967295) must be <= (65536)
+  out/test/spec/memory64/memory/memory.23.wasm:0000011: error: initial pages (4294967295) must be <= (65536)
   0000011: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:67: assert_invalid passed:
-  error: max pages (65537) must be <= (65536)
+  out/test/spec/memory64/memory/memory.24.wasm:0000010: error: max pages (65537) must be <= (65536)
   0000010: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:71: assert_invalid passed:
-  error: max pages (2147483648) must be <= (65536)
+  out/test/spec/memory64/memory/memory.25.wasm:0000012: error: max pages (2147483648) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:75: assert_invalid passed:
-  error: max pages (4294967295) must be <= (65536)
+  out/test/spec/memory64/memory/memory.26.wasm:0000012: error: max pages (4294967295) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:80: assert_invalid passed:
   out/test/spec/memory64/memory/memory.27.wat:1:9: error: invalid int "0x1_0000_0000"

--- a/test/spec/memory64/memory64.txt
+++ b/test/spec/memory64/memory64.txt
@@ -3,10 +3,10 @@
 ;;; ARGS*: --enable-memory64
 (;; STDOUT ;;;
 out/test/spec/memory64/memory64.wast:8: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/memory64/memory64/memory64.4.wasm:000000f: error: only one memory block allowed
   000000f: error: OnMemory callback failed
 out/test/spec/memory64/memory64.wast:9: assert_invalid passed:
-  error: only one memory block allowed
+  out/test/spec/memory64/memory64/memory64.5.wasm:0000023: error: only one memory block allowed
   0000023: error: OnMemory callback failed
 out/test/spec/memory64/memory64.wast:18: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
@@ -30,10 +30,10 @@ out/test/spec/memory64/memory64.wast:39: assert_invalid passed:
   0000019: error: OnMemorySizeExpr callback failed
 out/test/spec/memory64/memory64.wast:43: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
-  error: type mismatch in memory.grow, expected [i32] but got [i64]
+  out/test/spec/memory64/memory64/memory64.17.wasm:000001b: error: type mismatch in memory.grow, expected [i32] but got [i64]
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory64/memory64.wast:49: assert_invalid passed:
-  error: max pages (0) must be >= initial pages (1)
+  out/test/spec/memory64/memory64/memory64.18.wasm:000000e: error: max pages (0) must be >= initial pages (1)
   000000e: error: OnMemory callback failed
 57/57 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory_copy.txt
+++ b/test/spec/memory_copy.txt
@@ -25,193 +25,193 @@ out/test/spec/memory_copy.wast:4316: assert_invalid passed:
   0000000: error: memory variable out of range: 0 (max 0)
   000002d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4322: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f32]
+  out/test/spec/memory_copy/memory_copy.20.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4329: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
+  out/test/spec/memory_copy/memory_copy.21.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, i64]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4336: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f64]
+  out/test/spec/memory_copy/memory_copy.22.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4343: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
+  out/test/spec/memory_copy/memory_copy.23.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4350: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f32]
+  out/test/spec/memory_copy/memory_copy.24.wasm:0000039: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f32]
   0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4357: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i64]
+  out/test/spec/memory_copy/memory_copy.25.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, i64]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4364: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f64]
+  out/test/spec/memory_copy/memory_copy.26.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f32, f64]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4371: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i32]
+  out/test/spec/memory_copy/memory_copy.27.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i32]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4378: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f32]
+  out/test/spec/memory_copy/memory_copy.28.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4385: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i64]
+  out/test/spec/memory_copy/memory_copy.29.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, i64]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4392: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f64]
+  out/test/spec/memory_copy/memory_copy.30.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i64, f64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4399: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i32]
+  out/test/spec/memory_copy/memory_copy.31.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i32]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4406: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f32]
+  out/test/spec/memory_copy/memory_copy.32.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f32]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4413: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i64]
+  out/test/spec/memory_copy/memory_copy.33.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, i64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4420: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f64]
+  out/test/spec/memory_copy/memory_copy.34.wasm:0000041: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, f64, f64]
   0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4427: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
+  out/test/spec/memory_copy/memory_copy.35.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4434: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f32]
+  out/test/spec/memory_copy/memory_copy.36.wasm:0000039: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f32]
   0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4441: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i64]
+  out/test/spec/memory_copy/memory_copy.37.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, i64]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4448: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f64]
+  out/test/spec/memory_copy/memory_copy.38.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i32, f64]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4455: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i32]
+  out/test/spec/memory_copy/memory_copy.39.wasm:0000039: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i32]
   0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4462: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f32]
+  out/test/spec/memory_copy/memory_copy.40.wasm:000003c: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f32]
   000003c: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4469: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i64]
+  out/test/spec/memory_copy/memory_copy.41.wasm:0000039: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, i64]
   0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4476: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f64]
+  out/test/spec/memory_copy/memory_copy.42.wasm:0000040: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f32, f64]
   0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4483: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i32]
+  out/test/spec/memory_copy/memory_copy.43.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4490: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f32]
+  out/test/spec/memory_copy/memory_copy.44.wasm:0000039: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f32]
   0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4497: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i64]
+  out/test/spec/memory_copy/memory_copy.45.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, i64]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4504: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f64]
+  out/test/spec/memory_copy/memory_copy.46.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, i64, f64]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4511: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i32]
+  out/test/spec/memory_copy/memory_copy.47.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i32]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4518: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f32]
+  out/test/spec/memory_copy/memory_copy.48.wasm:0000040: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f32]
   0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4525: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i64]
+  out/test/spec/memory_copy/memory_copy.49.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, i64]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4532: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f64]
+  out/test/spec/memory_copy/memory_copy.50.wasm:0000044: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f32, f64, f64]
   0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4539: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i32]
+  out/test/spec/memory_copy/memory_copy.51.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i32]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4546: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f32]
+  out/test/spec/memory_copy/memory_copy.52.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4553: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i64]
+  out/test/spec/memory_copy/memory_copy.53.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, i64]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4560: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f64]
+  out/test/spec/memory_copy/memory_copy.54.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i32, f64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4567: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i32]
+  out/test/spec/memory_copy/memory_copy.55.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4574: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f32]
+  out/test/spec/memory_copy/memory_copy.56.wasm:0000039: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f32]
   0000039: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4581: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i64]
+  out/test/spec/memory_copy/memory_copy.57.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, i64]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4588: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f64]
+  out/test/spec/memory_copy/memory_copy.58.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f32, f64]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4595: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i32]
+  out/test/spec/memory_copy/memory_copy.59.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i32]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4602: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f32]
+  out/test/spec/memory_copy/memory_copy.60.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f32]
   0000036: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4609: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i64]
+  out/test/spec/memory_copy/memory_copy.61.wasm:0000033: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, i64]
   0000033: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4616: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f64]
+  out/test/spec/memory_copy/memory_copy.62.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, i64, f64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4623: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i32]
+  out/test/spec/memory_copy/memory_copy.63.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i32]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4630: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f32]
+  out/test/spec/memory_copy/memory_copy.64.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f32]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4637: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i64]
+  out/test/spec/memory_copy/memory_copy.65.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, i64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4644: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f64]
+  out/test/spec/memory_copy/memory_copy.66.wasm:0000041: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i64, f64, f64]
   0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4651: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i32]
+  out/test/spec/memory_copy/memory_copy.67.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i32]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4658: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f32]
+  out/test/spec/memory_copy/memory_copy.68.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f32]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4665: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i64]
+  out/test/spec/memory_copy/memory_copy.69.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, i64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4672: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f64]
+  out/test/spec/memory_copy/memory_copy.70.wasm:0000041: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i32, f64]
   0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4679: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i32]
+  out/test/spec/memory_copy/memory_copy.71.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i32]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4686: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f32]
+  out/test/spec/memory_copy/memory_copy.72.wasm:0000040: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f32]
   0000040: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4693: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i64]
+  out/test/spec/memory_copy/memory_copy.73.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, i64]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4700: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f64]
+  out/test/spec/memory_copy/memory_copy.74.wasm:0000044: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f32, f64]
   0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4707: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i32]
+  out/test/spec/memory_copy/memory_copy.75.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i32]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4714: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f32]
+  out/test/spec/memory_copy/memory_copy.76.wasm:000003d: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f32]
   000003d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4721: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i64]
+  out/test/spec/memory_copy/memory_copy.77.wasm:000003a: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, i64]
   000003a: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4728: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f64]
+  out/test/spec/memory_copy/memory_copy.78.wasm:0000041: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, i64, f64]
   0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4735: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i32]
+  out/test/spec/memory_copy/memory_copy.79.wasm:0000041: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i32]
   0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4742: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f32]
+  out/test/spec/memory_copy/memory_copy.80.wasm:0000044: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f32]
   0000044: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4749: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i64]
+  out/test/spec/memory_copy/memory_copy.81.wasm:0000041: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, i64]
   0000041: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4756: assert_invalid passed:
-  error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f64]
+  out/test/spec/memory_copy/memory_copy.82.wasm:0000048: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [f64, f64, f64]
   0000048: error: OnMemoryCopyExpr callback failed
 test() =>
 test() =>

--- a/test/spec/memory_fill.txt
+++ b/test/spec/memory_fill.txt
@@ -10,196 +10,196 @@ out/test/spec/memory_fill.wast:118: assert_trap passed: out of bounds memory acc
 test() =>
 test() =>
 out/test/spec/memory_fill.wast:175: assert_invalid passed:
-  error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory_fill/memory_fill.8.wasm:000002c: error: memory variable out of range: 0 (max 0)
   000002c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:181: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f32]
+  out/test/spec/memory_fill/memory_fill.9.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:188: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, i64]
+  out/test/spec/memory_fill/memory_fill.10.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, i64]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:195: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f64]
+  out/test/spec/memory_fill/memory_fill.11.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i32, f64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:202: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i32]
+  out/test/spec/memory_fill/memory_fill.12.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:209: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f32]
+  out/test/spec/memory_fill/memory_fill.13.wasm:0000038: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f32]
   0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:216: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i64]
+  out/test/spec/memory_fill/memory_fill.14.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, i64]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:223: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f64]
+  out/test/spec/memory_fill/memory_fill.15.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f32, f64]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:230: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i32]
+  out/test/spec/memory_fill/memory_fill.16.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i32]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:237: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f32]
+  out/test/spec/memory_fill/memory_fill.17.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:244: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i64]
+  out/test/spec/memory_fill/memory_fill.18.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, i64]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:251: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f64]
+  out/test/spec/memory_fill/memory_fill.19.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, i64, f64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:258: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i32]
+  out/test/spec/memory_fill/memory_fill.20.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i32]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:265: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f32]
+  out/test/spec/memory_fill/memory_fill.21.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f32]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:272: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i64]
+  out/test/spec/memory_fill/memory_fill.22.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, i64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:279: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f64]
+  out/test/spec/memory_fill/memory_fill.23.wasm:0000040: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i32, f64, f64]
   0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:286: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i32]
+  out/test/spec/memory_fill/memory_fill.24.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:293: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f32]
+  out/test/spec/memory_fill/memory_fill.25.wasm:0000038: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f32]
   0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:300: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i64]
+  out/test/spec/memory_fill/memory_fill.26.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, i64]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:307: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f64]
+  out/test/spec/memory_fill/memory_fill.27.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i32, f64]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:314: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i32]
+  out/test/spec/memory_fill/memory_fill.28.wasm:0000038: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i32]
   0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:321: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f32]
+  out/test/spec/memory_fill/memory_fill.29.wasm:000003b: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f32]
   000003b: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:328: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i64]
+  out/test/spec/memory_fill/memory_fill.30.wasm:0000038: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, i64]
   0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:335: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f64]
+  out/test/spec/memory_fill/memory_fill.31.wasm:000003f: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f32, f64]
   000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:342: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i32]
+  out/test/spec/memory_fill/memory_fill.32.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:349: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f32]
+  out/test/spec/memory_fill/memory_fill.33.wasm:0000038: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f32]
   0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:356: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i64]
+  out/test/spec/memory_fill/memory_fill.34.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, i64]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:363: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f64]
+  out/test/spec/memory_fill/memory_fill.35.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, i64, f64]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:370: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i32]
+  out/test/spec/memory_fill/memory_fill.36.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i32]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:377: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f32]
+  out/test/spec/memory_fill/memory_fill.37.wasm:000003f: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f32]
   000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:384: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i64]
+  out/test/spec/memory_fill/memory_fill.38.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, i64]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:391: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f64]
+  out/test/spec/memory_fill/memory_fill.39.wasm:0000043: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f32, f64, f64]
   0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:398: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i32]
+  out/test/spec/memory_fill/memory_fill.40.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i32]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:405: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f32]
+  out/test/spec/memory_fill/memory_fill.41.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:412: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i64]
+  out/test/spec/memory_fill/memory_fill.42.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, i64]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:419: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f64]
+  out/test/spec/memory_fill/memory_fill.43.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i32, f64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:426: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i32]
+  out/test/spec/memory_fill/memory_fill.44.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:433: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f32]
+  out/test/spec/memory_fill/memory_fill.45.wasm:0000038: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f32]
   0000038: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:440: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i64]
+  out/test/spec/memory_fill/memory_fill.46.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, i64]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:447: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f64]
+  out/test/spec/memory_fill/memory_fill.47.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f32, f64]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:454: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i32]
+  out/test/spec/memory_fill/memory_fill.48.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i32]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:461: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f32]
+  out/test/spec/memory_fill/memory_fill.49.wasm:0000035: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f32]
   0000035: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:468: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i64]
+  out/test/spec/memory_fill/memory_fill.50.wasm:0000032: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, i64]
   0000032: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:475: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f64]
+  out/test/spec/memory_fill/memory_fill.51.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, i64, f64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:482: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i32]
+  out/test/spec/memory_fill/memory_fill.52.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i32]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:489: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f32]
+  out/test/spec/memory_fill/memory_fill.53.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f32]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:496: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i64]
+  out/test/spec/memory_fill/memory_fill.54.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, i64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:503: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f64]
+  out/test/spec/memory_fill/memory_fill.55.wasm:0000040: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [i64, f64, f64]
   0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:510: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i32]
+  out/test/spec/memory_fill/memory_fill.56.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i32]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:517: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f32]
+  out/test/spec/memory_fill/memory_fill.57.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f32]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:524: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i64]
+  out/test/spec/memory_fill/memory_fill.58.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, i64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:531: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f64]
+  out/test/spec/memory_fill/memory_fill.59.wasm:0000040: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i32, f64]
   0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:538: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i32]
+  out/test/spec/memory_fill/memory_fill.60.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i32]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:545: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f32]
+  out/test/spec/memory_fill/memory_fill.61.wasm:000003f: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f32]
   000003f: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:552: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i64]
+  out/test/spec/memory_fill/memory_fill.62.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, i64]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:559: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f64]
+  out/test/spec/memory_fill/memory_fill.63.wasm:0000043: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f32, f64]
   0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:566: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i32]
+  out/test/spec/memory_fill/memory_fill.64.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i32]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:573: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f32]
+  out/test/spec/memory_fill/memory_fill.65.wasm:000003c: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f32]
   000003c: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:580: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i64]
+  out/test/spec/memory_fill/memory_fill.66.wasm:0000039: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, i64]
   0000039: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:587: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f64]
+  out/test/spec/memory_fill/memory_fill.67.wasm:0000040: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, i64, f64]
   0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:594: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i32]
+  out/test/spec/memory_fill/memory_fill.68.wasm:0000040: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i32]
   0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:601: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f32]
+  out/test/spec/memory_fill/memory_fill.69.wasm:0000043: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f32]
   0000043: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:608: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i64]
+  out/test/spec/memory_fill/memory_fill.70.wasm:0000040: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, i64]
   0000040: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:615: assert_invalid passed:
-  error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f64]
+  out/test/spec/memory_fill/memory_fill.71.wasm:0000047: error: type mismatch in memory.fill, expected [i32, i32, i32] but got [f64, f64, f64]
   0000047: error: OnMemoryFillExpr callback failed
 out/test/spec/memory_fill.wast:638: assert_trap passed: out of bounds memory access: memory.fill out of bounds
 out/test/spec/memory_fill.wast:660: assert_trap passed: out of bounds memory access: memory.fill out of bounds

--- a/test/spec/memory_grow.txt
+++ b/test/spec/memory_grow.txt
@@ -10,25 +10,25 @@ out/test/spec/memory_grow.wast:24: assert_trap passed: out of bounds memory acce
 out/test/spec/memory_grow.wast:25: assert_trap passed: out of bounds memory access: access at 65536+4 >= max value 65536
 out/test/spec/memory_grow.wast:286: assert_trap passed: undefined table index
 out/test/spec/memory_grow.wast:313: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/memory_grow/memory_grow.5.wasm:000001f: error: type mismatch in memory.grow, expected [i32] but got []
   000001f: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:322: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/memory_grow/memory_grow.6.wasm:0000023: error: type mismatch in memory.grow, expected [i32] but got []
   0000023: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:332: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/memory_grow/memory_grow.7.wasm:0000023: error: type mismatch in memory.grow, expected [i32] but got []
   0000023: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:342: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/memory_grow/memory_grow.8.wasm:0000025: error: type mismatch in memory.grow, expected [i32] but got []
   0000025: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:353: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got [f32]
+  out/test/spec/memory_grow/memory_grow.9.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:363: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory_grow/memory_grow.10.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/memory_grow.wast:372: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/memory_grow/memory_grow.11.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000022: error: EndFunctionBody callback failed
 91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory_init.txt
+++ b/test/spec/memory_init.txt
@@ -29,193 +29,193 @@ test() =>
 test() =>
 out/test/spec/memory_init.wast:309: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/memory_init.wast:312: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, f32]
+  out/test/spec/memory_init/memory_init.21.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, f32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:320: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, i64]
+  out/test/spec/memory_init/memory_init.22.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, i64]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:328: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, f64]
+  out/test/spec/memory_init/memory_init.23.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i32, f64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:336: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, i32]
+  out/test/spec/memory_init/memory_init.24.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, i32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:344: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, f32]
+  out/test/spec/memory_init/memory_init.25.wasm:0000039: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, f32]
   0000039: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:352: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, i64]
+  out/test/spec/memory_init/memory_init.26.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, i64]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:360: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, f64]
+  out/test/spec/memory_init/memory_init.27.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f32, f64]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:368: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, i32]
+  out/test/spec/memory_init/memory_init.28.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, i32]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:376: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, f32]
+  out/test/spec/memory_init/memory_init.29.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, f32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:384: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, i64]
+  out/test/spec/memory_init/memory_init.30.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, i64]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:392: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, f64]
+  out/test/spec/memory_init/memory_init.31.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, i64, f64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:400: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, i32]
+  out/test/spec/memory_init/memory_init.32.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, i32]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:408: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, f32]
+  out/test/spec/memory_init/memory_init.33.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, f32]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:416: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, i64]
+  out/test/spec/memory_init/memory_init.34.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, i64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:424: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, f64]
+  out/test/spec/memory_init/memory_init.35.wasm:0000041: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i32, f64, f64]
   0000041: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:432: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, i32]
+  out/test/spec/memory_init/memory_init.36.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, i32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:440: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, f32]
+  out/test/spec/memory_init/memory_init.37.wasm:0000039: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, f32]
   0000039: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:448: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, i64]
+  out/test/spec/memory_init/memory_init.38.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, i64]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:456: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, f64]
+  out/test/spec/memory_init/memory_init.39.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i32, f64]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:464: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, i32]
+  out/test/spec/memory_init/memory_init.40.wasm:0000039: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, i32]
   0000039: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:472: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, f32]
+  out/test/spec/memory_init/memory_init.41.wasm:000003c: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, f32]
   000003c: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:480: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, i64]
+  out/test/spec/memory_init/memory_init.42.wasm:0000039: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, i64]
   0000039: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:488: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, f64]
+  out/test/spec/memory_init/memory_init.43.wasm:0000040: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f32, f64]
   0000040: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:496: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, i32]
+  out/test/spec/memory_init/memory_init.44.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, i32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:504: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, f32]
+  out/test/spec/memory_init/memory_init.45.wasm:0000039: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, f32]
   0000039: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:512: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, i64]
+  out/test/spec/memory_init/memory_init.46.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, i64]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:520: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, f64]
+  out/test/spec/memory_init/memory_init.47.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, i64, f64]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:528: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, i32]
+  out/test/spec/memory_init/memory_init.48.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, i32]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:536: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, f32]
+  out/test/spec/memory_init/memory_init.49.wasm:0000040: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, f32]
   0000040: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:544: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, i64]
+  out/test/spec/memory_init/memory_init.50.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, i64]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:552: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, f64]
+  out/test/spec/memory_init/memory_init.51.wasm:0000044: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f32, f64, f64]
   0000044: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:560: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, i32]
+  out/test/spec/memory_init/memory_init.52.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, i32]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:568: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, f32]
+  out/test/spec/memory_init/memory_init.53.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, f32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:576: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, i64]
+  out/test/spec/memory_init/memory_init.54.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, i64]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:584: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, f64]
+  out/test/spec/memory_init/memory_init.55.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i32, f64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:592: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, i32]
+  out/test/spec/memory_init/memory_init.56.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, i32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:600: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, f32]
+  out/test/spec/memory_init/memory_init.57.wasm:0000039: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, f32]
   0000039: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:608: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, i64]
+  out/test/spec/memory_init/memory_init.58.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, i64]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:616: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, f64]
+  out/test/spec/memory_init/memory_init.59.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f32, f64]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:624: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, i32]
+  out/test/spec/memory_init/memory_init.60.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, i32]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:632: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, f32]
+  out/test/spec/memory_init/memory_init.61.wasm:0000036: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, f32]
   0000036: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:640: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, i64]
+  out/test/spec/memory_init/memory_init.62.wasm:0000033: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, i64]
   0000033: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:648: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, f64]
+  out/test/spec/memory_init/memory_init.63.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, i64, f64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:656: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, i32]
+  out/test/spec/memory_init/memory_init.64.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, i32]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:664: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, f32]
+  out/test/spec/memory_init/memory_init.65.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, f32]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:672: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, i64]
+  out/test/spec/memory_init/memory_init.66.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, i64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:680: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, f64]
+  out/test/spec/memory_init/memory_init.67.wasm:0000041: error: type mismatch in memory.init, expected [i32, i32, i32] but got [i64, f64, f64]
   0000041: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:688: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, i32]
+  out/test/spec/memory_init/memory_init.68.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, i32]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:696: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, f32]
+  out/test/spec/memory_init/memory_init.69.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, f32]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:704: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, i64]
+  out/test/spec/memory_init/memory_init.70.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, i64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:712: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, f64]
+  out/test/spec/memory_init/memory_init.71.wasm:0000041: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i32, f64]
   0000041: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:720: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, i32]
+  out/test/spec/memory_init/memory_init.72.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, i32]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:728: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, f32]
+  out/test/spec/memory_init/memory_init.73.wasm:0000040: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, f32]
   0000040: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:736: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, i64]
+  out/test/spec/memory_init/memory_init.74.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, i64]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:744: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, f64]
+  out/test/spec/memory_init/memory_init.75.wasm:0000044: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f32, f64]
   0000044: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:752: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, i32]
+  out/test/spec/memory_init/memory_init.76.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, i32]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:760: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, f32]
+  out/test/spec/memory_init/memory_init.77.wasm:000003d: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, f32]
   000003d: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:768: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, i64]
+  out/test/spec/memory_init/memory_init.78.wasm:000003a: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, i64]
   000003a: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:776: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, f64]
+  out/test/spec/memory_init/memory_init.79.wasm:0000041: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, i64, f64]
   0000041: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:784: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, i32]
+  out/test/spec/memory_init/memory_init.80.wasm:0000041: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, i32]
   0000041: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:792: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, f32]
+  out/test/spec/memory_init/memory_init.81.wasm:0000044: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, f32]
   0000044: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:800: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, i64]
+  out/test/spec/memory_init/memory_init.82.wasm:0000041: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, i64]
   0000041: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:808: assert_invalid passed:
-  error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, f64]
+  out/test/spec/memory_init/memory_init.83.wasm:0000048: error: type mismatch in memory.init, expected [i32, i32, i32] but got [f64, f64, f64]
   0000048: error: OnMemoryInitExpr callback failed
 out/test/spec/memory_init.wast:833: assert_trap passed: out of bounds memory access: memory.init out of bounds
 out/test/spec/memory_init.wast:856: assert_trap passed: out of bounds memory access: memory.init out of bounds

--- a/test/spec/memory_size.txt
+++ b/test/spec/memory_size.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/memory_size.wast
 (;; STDOUT ;;;
 out/test/spec/memory_size.wast:69: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory_size/memory_size.4.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/memory_size.wast:78: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/memory_size/memory_size.5.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
 38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/binary.txt
+++ b/test/spec/multi-memory/binary.txt
@@ -252,7 +252,7 @@ out/test/spec/multi-memory/binary.wast:1480: assert_malformed passed:
 out/test/spec/multi-memory/binary.wast:1494: assert_malformed passed:
   000001a: error: unfinished section (expected end: 0x1b)
 out/test/spec/multi-memory/binary.wast:1525: assert_malformed passed:
-  error: function type variable out of range: 11 (max 1)
+  out/test/spec/multi-memory/binary/binary.156.wasm:0000025: error: function type variable out of range: 11 (max 1)
   0000025: error: OnBlockExpr callback failed
 out/test/spec/multi-memory/binary.wast:1560: assert_malformed passed:
   0000017: error: multiple Start sections

--- a/test/spec/multi-memory/data.txt
+++ b/test/spec/multi-memory/data.txt
@@ -21,13 +21,13 @@ out/test/spec/multi-memory/data.wast:360: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:379: assert_invalid passed:
-  error: type mismatch at data segment offset. got i64, expected i32
+  out/test/spec/multi-memory/data/data.45.wasm:0000014: error: type mismatch at data segment offset. got i64, expected i32
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:387: assert_invalid passed:
-  error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/multi-memory/data/data.46.wasm:0000014: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:395: assert_invalid passed:
-  error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/multi-memory/data/data.47.wasm:0000012: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:403: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -52,14 +52,14 @@ out/test/spec/multi-memory/data.wast:453: assert_invalid passed:
   0000014: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:467: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/multi-memory/data/data.55.wasm:0000014: error: initializer expression cannot reference a mutable global
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:475: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/multi-memory/data/data.56.wasm:000002a: error: initializer expression cannot reference a mutable global
   000002a: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:484: assert_invalid passed:
-  error: initializer expression cannot reference a mutable global
+  out/test/spec/multi-memory/data/data.57.wasm:000002e: error: initializer expression cannot reference a mutable global
   000002e: error: EndDataSegmentInitExpr callback failed
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/load.txt
+++ b/test/spec/multi-memory/load.txt
@@ -55,142 +55,142 @@ out/test/spec/multi-memory/load.wast:365: assert_malformed passed:
   (memory 1)(func (param i32) (result f64) (f64.load64 (local.get 0)))
                                             ^^^^^^^^^^
 out/test/spec/multi-memory/load.wast:376: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.17.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:380: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.18.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:384: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.19.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:388: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.20.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:392: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.21.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:396: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.22.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:400: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.23.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:404: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.24.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:408: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.25.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:412: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.26.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:416: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.27.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:420: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.28.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:424: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/multi-memory/load/load.29.wasm:0000021: error: type mismatch in function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:428: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/multi-memory/load/load.30.wasm:0000021: error: type mismatch in function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:435: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.31.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:436: assert_invalid passed:
-  error: type mismatch in i32.load8_s, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.32.wasm:0000025: error: type mismatch in i32.load8_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:437: assert_invalid passed:
-  error: type mismatch in i32.load8_u, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.33.wasm:0000025: error: type mismatch in i32.load8_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:438: assert_invalid passed:
-  error: type mismatch in i32.load16_s, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.34.wasm:0000025: error: type mismatch in i32.load16_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:439: assert_invalid passed:
-  error: type mismatch in i32.load16_u, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.35.wasm:0000025: error: type mismatch in i32.load16_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:440: assert_invalid passed:
-  error: type mismatch in i64.load, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.36.wasm:0000025: error: type mismatch in i64.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:441: assert_invalid passed:
-  error: type mismatch in i64.load8_s, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.37.wasm:0000025: error: type mismatch in i64.load8_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:442: assert_invalid passed:
-  error: type mismatch in i64.load8_u, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.38.wasm:0000025: error: type mismatch in i64.load8_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:443: assert_invalid passed:
-  error: type mismatch in i64.load16_s, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.39.wasm:0000025: error: type mismatch in i64.load16_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:444: assert_invalid passed:
-  error: type mismatch in i64.load16_u, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.40.wasm:0000025: error: type mismatch in i64.load16_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:445: assert_invalid passed:
-  error: type mismatch in i64.load32_s, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.41.wasm:0000025: error: type mismatch in i64.load32_s, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:446: assert_invalid passed:
-  error: type mismatch in i64.load32_u, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.42.wasm:0000025: error: type mismatch in i64.load32_u, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:447: assert_invalid passed:
-  error: type mismatch in f32.load, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.43.wasm:0000025: error: type mismatch in f32.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:448: assert_invalid passed:
-  error: type mismatch in f64.load, expected [i32] but got [f32]
+  out/test/spec/multi-memory/load/load.44.wasm:0000025: error: type mismatch in f64.load, expected [i32] but got [f32]
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:452: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.45.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:461: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.46.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:471: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.47.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:481: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.48.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got []
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:491: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.49.wasm:0000028: error: type mismatch in i32.load, expected [i32] but got []
   0000028: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:501: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.50.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:511: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.51.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:521: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.52.wasm:0000023: error: type mismatch in i32.load, expected [i32] but got []
   0000023: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:531: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.53.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:540: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.54.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:549: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.55.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got []
   0000025: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:559: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.56.wasm:000003c: error: type mismatch in i32.load, expected [i32] but got []
   000003c: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:576: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.57.wasm:0000021: error: type mismatch in i32.load, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:586: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.58.wasm:0000021: error: type mismatch in i32.load, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:596: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.59.wasm:0000027: error: type mismatch in i32.load, expected [i32] but got []
   0000027: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:606: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.60.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:615: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.61.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 out/test/spec/multi-memory/load.wast:624: assert_invalid passed:
-  error: type mismatch in i32.load, expected [i32] but got []
+  out/test/spec/multi-memory/load/load.62.wasm:000001f: error: type mismatch in i32.load, expected [i32] but got []
   000001f: error: OnLoadExpr callback failed
 113/113 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/memory.txt
+++ b/test/spec/multi-memory/memory.txt
@@ -24,25 +24,25 @@ out/test/spec/multi-memory/memory.wast:38: assert_invalid passed:
 out/test/spec/multi-memory/memory.wast:42: assert_invalid passed:
   000001b: error: memory index 0 out of range
 out/test/spec/multi-memory/memory.wast:48: assert_invalid passed:
-  error: max pages (0) must be >= initial pages (1)
+  out/test/spec/multi-memory/memory/memory.18.wasm:000000e: error: max pages (0) must be >= initial pages (1)
   000000e: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:52: assert_invalid passed:
-  error: initial pages (65537) must be <= (65536)
+  out/test/spec/multi-memory/memory/memory.19.wasm:000000f: error: initial pages (65537) must be <= (65536)
   000000f: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:56: assert_invalid passed:
-  error: initial pages (2147483648) must be <= (65536)
+  out/test/spec/multi-memory/memory/memory.20.wasm:0000011: error: initial pages (2147483648) must be <= (65536)
   0000011: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:60: assert_invalid passed:
-  error: initial pages (4294967295) must be <= (65536)
+  out/test/spec/multi-memory/memory/memory.21.wasm:0000011: error: initial pages (4294967295) must be <= (65536)
   0000011: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:64: assert_invalid passed:
-  error: max pages (65537) must be <= (65536)
+  out/test/spec/multi-memory/memory/memory.22.wasm:0000010: error: max pages (65537) must be <= (65536)
   0000010: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:68: assert_invalid passed:
-  error: max pages (2147483648) must be <= (65536)
+  out/test/spec/multi-memory/memory/memory.23.wasm:0000012: error: max pages (2147483648) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:72: assert_invalid passed:
-  error: max pages (4294967295) must be <= (65536)
+  out/test/spec/multi-memory/memory/memory.24.wasm:0000012: error: max pages (4294967295) must be <= (65536)
   0000012: error: OnMemory callback failed
 out/test/spec/multi-memory/memory.wast:77: assert_malformed passed:
   out/test/spec/multi-memory/memory/memory.25.wat:1:9: error: invalid int "0x1_0000_0000"

--- a/test/spec/multi-memory/memory_grow.txt
+++ b/test/spec/multi-memory/memory_grow.txt
@@ -10,31 +10,31 @@ out/test/spec/multi-memory/memory_grow.wast:95: assert_trap passed: out of bound
 out/test/spec/multi-memory/memory_grow.wast:96: assert_trap passed: out of bounds memory access: access at 65536+4 >= max value 65536
 out/test/spec/multi-memory/memory_grow.wast:376: assert_trap passed: undefined table index
 out/test/spec/multi-memory/memory_grow.wast:431: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got [f32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.8.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:440: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/multi-memory/memory_grow/memory_grow.9.wasm:000001f: error: type mismatch in memory.grow, expected [i32] but got []
   000001f: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:449: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/multi-memory/memory_grow/memory_grow.10.wasm:0000023: error: type mismatch in memory.grow, expected [i32] but got []
   0000023: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:459: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/multi-memory/memory_grow/memory_grow.11.wasm:0000023: error: type mismatch in memory.grow, expected [i32] but got []
   0000023: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:469: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got []
+  out/test/spec/multi-memory/memory_grow/memory_grow.12.wasm:0000025: error: type mismatch in memory.grow, expected [i32] but got []
   0000025: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:480: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.13.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_grow.wast:489: assert_invalid passed:
-  error: type mismatch in memory.grow, expected [i32] but got [f32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.14.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:499: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.15.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_grow.wast:508: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.16.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000022: error: EndFunctionBody callback failed
 140/140 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/memory_size.txt
+++ b/test/spec/multi-memory/memory_size.txt
@@ -3,10 +3,10 @@
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
 out/test/spec/multi-memory/memory_size.wast:95: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_size/memory_size.6.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_size.wast:104: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/multi-memory/memory_size/memory_size.7.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
 42/42 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/store.txt
+++ b/test/spec/multi-memory/store.txt
@@ -39,157 +39,157 @@ out/test/spec/multi-memory/store.wast:251: assert_malformed passed:
   (memory 1)(func (param i32) (f64.store64 (local.get 0) (f64.const 0)))
                                ^^^^^^^^^^^
 out/test/spec/multi-memory/store.wast:260: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/multi-memory/store/store.14.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:264: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.15.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:268: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/multi-memory/store/store.16.wasm:0000028: error: type mismatch in implicit return, expected [f32] but got []
   0000029: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:272: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/multi-memory/store/store.17.wasm:000002c: error: type mismatch in implicit return, expected [f64] but got []
   000002d: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:276: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/multi-memory/store/store.18.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:280: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/multi-memory/store/store.19.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:284: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.20.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:288: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.21.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:292: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.22.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:298: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.23.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []
   000001f: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:307: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.24.wasm:0000021: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000021: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:316: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.25.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:326: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.26.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:336: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.27.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:346: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.28.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:356: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.29.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:366: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.30.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:376: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.31.wasm:0000028: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000028: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:386: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.32.wasm:0000028: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000028: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:396: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.33.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:406: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.34.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:416: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.35.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:426: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.36.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:436: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.37.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:446: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.38.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:456: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.39.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []
   000001f: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:465: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.40.wasm:0000021: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000021: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:474: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.41.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []
   000001f: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:483: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.42.wasm:0000021: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000021: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:492: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.43.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:502: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.44.wasm:0000027: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000027: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:512: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/multi-memory/store/store.45.wasm:000003c: error: type mismatch in i32.store, expected [i32, i32] but got []
   000003c: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:528: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/multi-memory/store/store.46.wasm:000003e: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   000003e: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:547: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [f32, i32]
+  out/test/spec/multi-memory/store/store.47.wasm:0000026: error: type mismatch in i32.store, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:548: assert_invalid passed:
-  error: type mismatch in i32.store8, expected [i32, i32] but got [f32, i32]
+  out/test/spec/multi-memory/store/store.48.wasm:0000026: error: type mismatch in i32.store8, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:549: assert_invalid passed:
-  error: type mismatch in i32.store16, expected [i32, i32] but got [f32, i32]
+  out/test/spec/multi-memory/store/store.49.wasm:0000026: error: type mismatch in i32.store16, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:550: assert_invalid passed:
-  error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
+  out/test/spec/multi-memory/store/store.50.wasm:0000026: error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:551: assert_invalid passed:
-  error: type mismatch in i64.store8, expected [i32, i64] but got [f32, i64]
+  out/test/spec/multi-memory/store/store.51.wasm:0000026: error: type mismatch in i64.store8, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:552: assert_invalid passed:
-  error: type mismatch in i64.store16, expected [i32, i64] but got [f32, i64]
+  out/test/spec/multi-memory/store/store.52.wasm:0000026: error: type mismatch in i64.store16, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:553: assert_invalid passed:
-  error: type mismatch in i64.store32, expected [i32, i64] but got [f32, i64]
+  out/test/spec/multi-memory/store/store.53.wasm:0000026: error: type mismatch in i64.store32, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:554: assert_invalid passed:
-  error: type mismatch in f32.store, expected [i32, f32] but got [f32, f32]
+  out/test/spec/multi-memory/store/store.54.wasm:0000029: error: type mismatch in f32.store, expected [i32, f32] but got [f32, f32]
   0000029: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:555: assert_invalid passed:
-  error: type mismatch in f64.store, expected [i32, f64] but got [f32, f64]
+  out/test/spec/multi-memory/store/store.55.wasm:000002d: error: type mismatch in f64.store, expected [i32, f64] but got [f32, f64]
   000002d: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:557: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
+  out/test/spec/multi-memory/store/store.56.wasm:0000026: error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:558: assert_invalid passed:
-  error: type mismatch in i32.store8, expected [i32, i32] but got [i32, f32]
+  out/test/spec/multi-memory/store/store.57.wasm:0000026: error: type mismatch in i32.store8, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:559: assert_invalid passed:
-  error: type mismatch in i32.store16, expected [i32, i32] but got [i32, f32]
+  out/test/spec/multi-memory/store/store.58.wasm:0000026: error: type mismatch in i32.store16, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:560: assert_invalid passed:
-  error: type mismatch in i64.store, expected [i32, i64] but got [i32, f32]
+  out/test/spec/multi-memory/store/store.59.wasm:0000026: error: type mismatch in i64.store, expected [i32, i64] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:561: assert_invalid passed:
-  error: type mismatch in i64.store8, expected [i32, i64] but got [i32, f64]
+  out/test/spec/multi-memory/store/store.60.wasm:000002a: error: type mismatch in i64.store8, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:562: assert_invalid passed:
-  error: type mismatch in i64.store16, expected [i32, i64] but got [i32, f64]
+  out/test/spec/multi-memory/store/store.61.wasm:000002a: error: type mismatch in i64.store16, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:563: assert_invalid passed:
-  error: type mismatch in i64.store32, expected [i32, i64] but got [i32, f64]
+  out/test/spec/multi-memory/store/store.62.wasm:000002a: error: type mismatch in i64.store32, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:564: assert_invalid passed:
-  error: type mismatch in f32.store, expected [i32, f32] but got [i32, i32]
+  out/test/spec/multi-memory/store/store.63.wasm:0000023: error: type mismatch in f32.store, expected [i32, f32] but got [i32, i32]
   0000023: error: OnStoreExpr callback failed
 out/test/spec/multi-memory/store.wast:565: assert_invalid passed:
-  error: type mismatch in f64.store, expected [i32, f64] but got [i32, i64]
+  out/test/spec/multi-memory/store/store.64.wasm:0000023: error: type mismatch in f64.store, expected [i32, f64] but got [i32, i64]
   0000023: error: OnStoreExpr callback failed
 101/101 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/nop.txt
+++ b/test/spec/nop.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/nop.wast
 (;; STDOUT ;;;
 out/test/spec/nop.wast:412: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/nop/nop.1.wasm:0000019: error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/nop.wast:416: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/nop/nop.2.wasm:0000019: error: type mismatch in implicit return, expected [i64] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/nop.wast:420: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/nop/nop.3.wasm:0000019: error: type mismatch in implicit return, expected [f32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/nop.wast:424: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/nop/nop.4.wasm:0000019: error: type mismatch in implicit return, expected [f64] but got []
   000001a: error: EndFunctionBody callback failed
 87/87 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/ref_is_null.txt
+++ b/test/spec/ref_is_null.txt
@@ -4,7 +4,7 @@
 init(externref:1) =>
 deinit() =>
 out/test/spec/ref_is_null.wast:52: assert_invalid passed:
-  error: type mismatch in ref.is_null, expected reference but got [i32]
+  out/test/spec/ref_is_null/ref_is_null.1.wasm:000001b: error: type mismatch in ref.is_null, expected reference but got [i32]
   000001b: error: OnRefIsNullExpr callback failed
 out/test/spec/ref_is_null.wast:56: assert_invalid passed:
   0000018: error: OnRefIsNullExpr callback failed

--- a/test/spec/return.txt
+++ b/test/spec/return.txt
@@ -2,64 +2,64 @@
 ;;; STDIN_FILE: third_party/testsuite/return.wast
 (;; STDOUT ;;;
 out/test/spec/return.wast:311: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.1.wasm:0000019: error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/test/spec/return.wast:315: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.2.wasm:000001d: error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/test/spec/return.wast:324: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.3.wasm:000001d: error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/test/spec/return.wast:333: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.4.wasm:000001f: error: type mismatch in return, expected [i32] but got []
   000001f: error: OnReturnExpr callback failed
 out/test/spec/return.wast:342: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.5.wasm:0000022: error: type mismatch in return, expected [i32] but got []
   0000022: error: OnReturnExpr callback failed
 out/test/spec/return.wast:351: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.6.wasm:000001d: error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/test/spec/return.wast:360: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.7.wasm:000001d: error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/test/spec/return.wast:369: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.8.wasm:000001d: error: type mismatch in return, expected [i32] but got []
   000001d: error: OnReturnExpr callback failed
 out/test/spec/return.wast:378: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.9.wasm:0000019: error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/test/spec/return.wast:386: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.10.wasm:0000019: error: type mismatch in return, expected [i32] but got []
   0000019: error: OnReturnExpr callback failed
 out/test/spec/return.wast:394: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.11.wasm:000001f: error: type mismatch in return, expected [i32] but got []
   000001f: error: OnReturnExpr callback failed
 out/test/spec/return.wast:403: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.12.wasm:0000036: error: type mismatch in return, expected [i32] but got []
   0000036: error: OnReturnExpr callback failed
 out/test/spec/return.wast:418: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.13.wasm:000001b: error: type mismatch in return, expected [i32] but got []
   000001b: error: OnReturnExpr callback failed
 out/test/spec/return.wast:427: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.14.wasm:000001b: error: type mismatch in return, expected [i32] but got []
   000001b: error: OnReturnExpr callback failed
 out/test/spec/return.wast:436: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.15.wasm:0000021: error: type mismatch in return, expected [i32] but got []
   0000021: error: OnReturnExpr callback failed
 out/test/spec/return.wast:445: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.16.wasm:000001e: error: type mismatch in return, expected [i32] but got []
   000001e: error: OnReturnExpr callback failed
 out/test/spec/return.wast:454: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.17.wasm:000001e: error: type mismatch in return, expected [i32] but got []
   000001e: error: OnReturnExpr callback failed
 out/test/spec/return.wast:463: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got []
+  out/test/spec/return/return.18.wasm:000001e: error: type mismatch in return, expected [i32] but got []
   000001e: error: OnReturnExpr callback failed
 out/test/spec/return.wast:472: assert_invalid passed:
-  error: type mismatch in return, expected [f64] but got []
+  out/test/spec/return/return.19.wasm:000001a: error: type mismatch in return, expected [f64] but got []
   000001a: error: OnReturnExpr callback failed
 out/test/spec/return.wast:476: assert_invalid passed:
-  error: type mismatch in return, expected [f64] but got [i64]
+  out/test/spec/return/return.20.wasm:000001b: error: type mismatch in return, expected [f64] but got [i64]
   000001b: error: OnReturnExpr callback failed
 83/83 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -4,88 +4,88 @@
 out/test/spec/select.wast:278: assert_trap passed: undefined table index
 out/test/spec/select.wast:279: assert_trap passed: undefined table index
 out/test/spec/select.wast:320: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i32]
+  out/test/spec/select/select.1.wasm:000001c: error: type mismatch in select, expected [any, any, i32] but got [i32]
   000001c: error: OnSelectExpr callback failed
 out/test/spec/select.wast:324: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i32]
+  out/test/spec/select/select.2.wasm:000001c: error: type mismatch in select, expected [any, any, i32] but got [i32]
   000001c: error: OnSelectExpr callback failed
 out/test/spec/select.wast:328: assert_invalid passed:
-  error: invalid arity in select instruction: 2.
+  out/test/spec/select/select.3.wasm:0000027: error: invalid arity in select instruction: 2.
   0000027: error: OnSelectExpr callback failed
 out/test/spec/select.wast:340: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [externref, externref, i32]
+  out/test/spec/select/select.4.wasm:000001f: error: type mismatch in select, expected [any, any, i32] but got [externref, externref, i32]
   000001f: error: OnSelectExpr callback failed
 out/test/spec/select.wast:347: assert_invalid passed:
-  error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
+  out/test/spec/select/select.5.wasm:000001e: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
   000001e: error: OnSelectExpr callback failed
 out/test/spec/select.wast:353: assert_invalid passed:
-  error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
+  out/test/spec/select/select.6.wasm:0000021: error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
   0000021: error: OnSelectExpr callback failed
 out/test/spec/select.wast:359: assert_invalid passed:
-  error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, i32]
+  out/test/spec/select/select.7.wasm:0000025: error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, i32]
   0000025: error: OnSelectExpr callback failed
 out/test/spec/select.wast:366: assert_invalid passed:
-  error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
+  out/test/spec/select/select.8.wasm:000001e: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
   000001e: error: OnSelectExpr callback failed
 out/test/spec/select.wast:370: assert_invalid passed:
-  error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
+  out/test/spec/select/select.9.wasm:0000021: error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
   0000021: error: OnSelectExpr callback failed
 out/test/spec/select.wast:374: assert_invalid passed:
-  error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
+  out/test/spec/select/select.10.wasm:000001e: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
   000001e: error: OnSelectExpr callback failed
 out/test/spec/select.wast:378: assert_invalid passed:
-  error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
+  out/test/spec/select/select.11.wasm:0000021: error: type mismatch in select, expected [f32, f32, i32] but got [i32, f32, i32]
   0000021: error: OnSelectExpr callback failed
 out/test/spec/select.wast:382: assert_invalid passed:
-  error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, i32]
+  out/test/spec/select/select.12.wasm:0000025: error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, i32]
   0000025: error: OnSelectExpr callback failed
 out/test/spec/select.wast:388: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got []
+  out/test/spec/select/select.13.wasm:0000018: error: type mismatch in select, expected [any, any, i32] but got []
   0000018: error: OnSelectExpr callback failed
 out/test/spec/select.wast:396: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i32]
+  out/test/spec/select/select.14.wasm:000001a: error: type mismatch in select, expected [any, any, i32] but got [i32]
   000001a: error: OnSelectExpr callback failed
 out/test/spec/select.wast:404: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
+  out/test/spec/select/select.15.wasm:000001c: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   000001c: error: OnSelectExpr callback failed
 out/test/spec/select.wast:412: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got []
+  out/test/spec/select/select.16.wasm:0000020: error: type mismatch in select, expected [any, any, i32] but got []
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:421: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i32]
+  out/test/spec/select/select.17.wasm:0000020: error: type mismatch in select, expected [any, any, i32] but got [i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:430: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
+  out/test/spec/select/select.18.wasm:0000020: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:439: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got []
+  out/test/spec/select/select.19.wasm:0000020: error: type mismatch in select, expected [any, any, i32] but got []
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:448: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i32]
+  out/test/spec/select/select.20.wasm:0000020: error: type mismatch in select, expected [any, any, i32] but got [i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:457: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
+  out/test/spec/select/select.21.wasm:0000020: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:466: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got []
+  out/test/spec/select/select.22.wasm:0000020: error: type mismatch in select, expected [any, any, i32] but got []
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:475: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i32]
+  out/test/spec/select/select.23.wasm:0000020: error: type mismatch in select, expected [any, any, i32] but got [i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:484: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
+  out/test/spec/select/select.24.wasm:0000020: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32]
   0000020: error: OnSelectExpr callback failed
 out/test/spec/select.wast:496: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, i64]
+  out/test/spec/select/select.25.wasm:000001e: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, i64]
   000001e: error: OnSelectExpr callback failed
 out/test/spec/select.wast:500: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, f32]
+  out/test/spec/select/select.26.wasm:0000021: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, f32]
   0000021: error: OnSelectExpr callback failed
 out/test/spec/select.wast:504: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, f64]
+  out/test/spec/select/select.27.wasm:0000025: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, f64]
   0000025: error: OnSelectExpr callback failed
 out/test/spec/select.wast:511: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/select/select.28.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 146/146 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_align.txt
+++ b/test/spec/simd_align.txt
@@ -2,40 +2,40 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_align.wast
 (;; STDOUT ;;;
 out/test/spec/simd_align.wast:54: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (16)
+  out/test/spec/simd_align/simd_align.44.wasm:0000022: error: alignment must not be larger than natural alignment (16)
   0000022: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:58: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (16)
+  out/test/spec/simd_align/simd_align.45.wasm:0000034: error: alignment must not be larger than natural alignment (16)
   0000034: error: OnStoreExpr callback failed
 out/test/spec/simd_align.wast:62: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.46.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:66: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.47.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:70: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.48.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:74: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.49.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:78: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.50.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:82: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.51.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadExpr callback failed
 out/test/spec/simd_align.wast:86: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/simd_align/simd_align.52.wasm:0000023: error: alignment must not be larger than natural alignment (1)
   0000023: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_align.wast:90: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/simd_align/simd_align.53.wasm:0000023: error: alignment must not be larger than natural alignment (2)
   0000023: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_align.wast:94: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/simd_align/simd_align.54.wasm:0000023: error: alignment must not be larger than natural alignment (4)
   0000023: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_align.wast:98: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_align/simd_align.55.wasm:0000023: error: alignment must not be larger than natural alignment (8)
   0000023: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_align.wast:105: assert_malformed passed:
   out/test/spec/simd_align/simd_align.56.wat:1:35: error: unexpected token align=-1, expected ).

--- a/test/spec/simd_bit_shift.txt
+++ b/test/spec/simd_bit_shift.txt
@@ -2,40 +2,40 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_bit_shift.wast
 (;; STDOUT ;;;
 out/test/spec/simd_bit_shift.wast:976: assert_invalid passed:
-  error: type mismatch in i8x16.shl, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.2.wasm:000001e: error: type mismatch in i8x16.shl, expected [v128, i32] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:977: assert_invalid passed:
-  error: type mismatch in i8x16.shr_s, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.3.wasm:000001e: error: type mismatch in i8x16.shr_s, expected [v128, i32] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:978: assert_invalid passed:
-  error: type mismatch in i8x16.shr_u, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.4.wasm:000001e: error: type mismatch in i8x16.shr_u, expected [v128, i32] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:979: assert_invalid passed:
-  error: type mismatch in i16x8.shl, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.5.wasm:000001f: error: type mismatch in i16x8.shl, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:980: assert_invalid passed:
-  error: type mismatch in i16x8.shr_s, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.6.wasm:000001f: error: type mismatch in i16x8.shr_s, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:981: assert_invalid passed:
-  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.7.wasm:000001f: error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:982: assert_invalid passed:
-  error: type mismatch in i32x4.shl, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.8.wasm:000001f: error: type mismatch in i32x4.shl, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:983: assert_invalid passed:
-  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.9.wasm:000001f: error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:984: assert_invalid passed:
-  error: type mismatch in i32x4.shr_u, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.10.wasm:000001f: error: type mismatch in i32x4.shr_u, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:985: assert_invalid passed:
-  error: type mismatch in i64x2.shl, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.11.wasm:000001f: error: type mismatch in i64x2.shl, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:986: assert_invalid passed:
-  error: type mismatch in i64x2.shr_s, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.12.wasm:000001f: error: type mismatch in i64x2.shr_s, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:987: assert_invalid passed:
-  error: type mismatch in i64x2.shr_u, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.13.wasm:000001f: error: type mismatch in i64x2.shr_u, expected [v128, i32] but got [i32, i32]
   000001f: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:991: assert_malformed passed:
   out/test/spec/simd_bit_shift/simd_bit_shift.14.wat:1:33: error: unexpected token "i8x16.shl_s", expected an instr.
@@ -98,40 +98,40 @@ out/test/spec/simd_bit_shift.wast:1005: assert_malformed passed:
   (memory 1) (func (result v128) (f32x4.shr_u (v128.const i32x4 0 0 0 0)))
                                   ^^^^^^^^^^^
 out/test/spec/simd_bit_shift.wast:1010: assert_invalid passed:
-  error: type mismatch in i8x16.shl, expected [v128, i32] but got [i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.29.wasm:000001c: error: type mismatch in i8x16.shl, expected [v128, i32] but got [i32]
   000001c: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1018: assert_invalid passed:
-  error: type mismatch in i8x16.shl, expected [v128, i32] but got [v128]
+  out/test/spec/simd_bit_shift/simd_bit_shift.30.wasm:000002c: error: type mismatch in i8x16.shl, expected [v128, i32] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1026: assert_invalid passed:
-  error: type mismatch in i8x16.shl, expected [v128, i32] but got []
+  out/test/spec/simd_bit_shift/simd_bit_shift.31.wasm:000001a: error: type mismatch in i8x16.shl, expected [v128, i32] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1034: assert_invalid passed:
-  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.32.wasm:000001d: error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [i32]
   000001d: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1042: assert_invalid passed:
-  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [v128]
+  out/test/spec/simd_bit_shift/simd_bit_shift.33.wasm:000002d: error: type mismatch in i16x8.shr_u, expected [v128, i32] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1050: assert_invalid passed:
-  error: type mismatch in i16x8.shr_u, expected [v128, i32] but got []
+  out/test/spec/simd_bit_shift/simd_bit_shift.34.wasm:000001b: error: type mismatch in i16x8.shr_u, expected [v128, i32] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1058: assert_invalid passed:
-  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.35.wasm:000001d: error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [i32]
   000001d: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1066: assert_invalid passed:
-  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [v128]
+  out/test/spec/simd_bit_shift/simd_bit_shift.36.wasm:000002d: error: type mismatch in i32x4.shr_s, expected [v128, i32] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1074: assert_invalid passed:
-  error: type mismatch in i32x4.shr_s, expected [v128, i32] but got []
+  out/test/spec/simd_bit_shift/simd_bit_shift.37.wasm:000001b: error: type mismatch in i32x4.shr_s, expected [v128, i32] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1082: assert_invalid passed:
-  error: type mismatch in i64x2.shl, expected [v128, i32] but got [i32]
+  out/test/spec/simd_bit_shift/simd_bit_shift.38.wasm:000001d: error: type mismatch in i64x2.shl, expected [v128, i32] but got [i32]
   000001d: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1090: assert_invalid passed:
-  error: type mismatch in i64x2.shr_u, expected [v128, i32] but got [v128]
+  out/test/spec/simd_bit_shift/simd_bit_shift.39.wasm:000002d: error: type mismatch in i64x2.shr_u, expected [v128, i32] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_bit_shift.wast:1098: assert_invalid passed:
-  error: type mismatch in i64x2.shr_s, expected [v128, i32] but got []
+  out/test/spec/simd_bit_shift/simd_bit_shift.40.wasm:000001b: error: type mismatch in i64x2.shr_s, expected [v128, i32] but got []
   000001b: error: OnBinaryExpr callback failed
 250/250 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_bitwise.txt
+++ b/test/spec/simd_bitwise.txt
@@ -2,88 +2,88 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_bitwise.wast
 (;; STDOUT ;;;
 out/test/spec/simd_bitwise.wast:405: assert_invalid passed:
-  error: type mismatch in v128.not, expected [v128] but got [i32]
+  out/test/spec/simd_bitwise/simd_bitwise.1.wasm:000001c: error: type mismatch in v128.not, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_bitwise.wast:407: assert_invalid passed:
-  error: type mismatch in v128.and, expected [v128, v128] but got [i32, v128]
+  out/test/spec/simd_bitwise/simd_bitwise.2.wasm:000002e: error: type mismatch in v128.and, expected [v128, v128] but got [i32, v128]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:408: assert_invalid passed:
-  error: type mismatch in v128.and, expected [v128, v128] but got [v128, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.3.wasm:000002e: error: type mismatch in v128.and, expected [v128, v128] but got [v128, i32]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:409: assert_invalid passed:
-  error: type mismatch in v128.and, expected [v128, v128] but got [i32, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.4.wasm:000001e: error: type mismatch in v128.and, expected [v128, v128] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:411: assert_invalid passed:
-  error: type mismatch in v128.or, expected [v128, v128] but got [i32, v128]
+  out/test/spec/simd_bitwise/simd_bitwise.5.wasm:000002e: error: type mismatch in v128.or, expected [v128, v128] but got [i32, v128]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:412: assert_invalid passed:
-  error: type mismatch in v128.or, expected [v128, v128] but got [v128, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.6.wasm:000002e: error: type mismatch in v128.or, expected [v128, v128] but got [v128, i32]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:413: assert_invalid passed:
-  error: type mismatch in v128.or, expected [v128, v128] but got [i32, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.7.wasm:000001e: error: type mismatch in v128.or, expected [v128, v128] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:415: assert_invalid passed:
-  error: type mismatch in v128.xor, expected [v128, v128] but got [i32, v128]
+  out/test/spec/simd_bitwise/simd_bitwise.8.wasm:000002e: error: type mismatch in v128.xor, expected [v128, v128] but got [i32, v128]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:416: assert_invalid passed:
-  error: type mismatch in v128.xor, expected [v128, v128] but got [v128, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.9.wasm:000002e: error: type mismatch in v128.xor, expected [v128, v128] but got [v128, i32]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:417: assert_invalid passed:
-  error: type mismatch in v128.xor, expected [v128, v128] but got [i32, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.10.wasm:000001e: error: type mismatch in v128.xor, expected [v128, v128] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:419: assert_invalid passed:
-  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [i32, v128, v128]
+  out/test/spec/simd_bitwise/simd_bitwise.11.wasm:0000040: error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [i32, v128, v128]
   0000040: error: OnTernaryExpr callback failed
 out/test/spec/simd_bitwise.wast:420: assert_invalid passed:
-  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128, v128, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.12.wasm:0000040: error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128, v128, i32]
   0000040: error: OnTernaryExpr callback failed
 out/test/spec/simd_bitwise.wast:421: assert_invalid passed:
-  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [i32, i32, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.13.wasm:0000020: error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [i32, i32, i32]
   0000020: error: OnTernaryExpr callback failed
 out/test/spec/simd_bitwise.wast:423: assert_invalid passed:
-  error: type mismatch in v128.andnot, expected [v128, v128] but got [i32, v128]
+  out/test/spec/simd_bitwise/simd_bitwise.14.wasm:000002e: error: type mismatch in v128.andnot, expected [v128, v128] but got [i32, v128]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:424: assert_invalid passed:
-  error: type mismatch in v128.andnot, expected [v128, v128] but got [v128, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.15.wasm:000002e: error: type mismatch in v128.andnot, expected [v128, v128] but got [v128, i32]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:425: assert_invalid passed:
-  error: type mismatch in v128.andnot, expected [v128, v128] but got [i32, i32]
+  out/test/spec/simd_bitwise/simd_bitwise.16.wasm:000001e: error: type mismatch in v128.andnot, expected [v128, v128] but got [i32, i32]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:718: assert_invalid passed:
-  error: type mismatch in v128.not, expected [v128] but got []
+  out/test/spec/simd_bitwise/simd_bitwise.18.wasm:000001a: error: type mismatch in v128.not, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_bitwise.wast:726: assert_invalid passed:
-  error: type mismatch in v128.and, expected [v128, v128] but got [v128]
+  out/test/spec/simd_bitwise/simd_bitwise.19.wasm:000002c: error: type mismatch in v128.and, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:734: assert_invalid passed:
-  error: type mismatch in v128.and, expected [v128, v128] but got []
+  out/test/spec/simd_bitwise/simd_bitwise.20.wasm:000001a: error: type mismatch in v128.and, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:742: assert_invalid passed:
-  error: type mismatch in v128.or, expected [v128, v128] but got [v128]
+  out/test/spec/simd_bitwise/simd_bitwise.21.wasm:000002c: error: type mismatch in v128.or, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:750: assert_invalid passed:
-  error: type mismatch in v128.or, expected [v128, v128] but got []
+  out/test/spec/simd_bitwise/simd_bitwise.22.wasm:000001a: error: type mismatch in v128.or, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:758: assert_invalid passed:
-  error: type mismatch in v128.xor, expected [v128, v128] but got [v128]
+  out/test/spec/simd_bitwise/simd_bitwise.23.wasm:000002c: error: type mismatch in v128.xor, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:766: assert_invalid passed:
-  error: type mismatch in v128.xor, expected [v128, v128] but got []
+  out/test/spec/simd_bitwise/simd_bitwise.24.wasm:000001a: error: type mismatch in v128.xor, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:774: assert_invalid passed:
-  error: type mismatch in v128.andnot, expected [v128, v128] but got [v128]
+  out/test/spec/simd_bitwise/simd_bitwise.25.wasm:000002c: error: type mismatch in v128.andnot, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:782: assert_invalid passed:
-  error: type mismatch in v128.andnot, expected [v128, v128] but got []
+  out/test/spec/simd_bitwise/simd_bitwise.26.wasm:000001a: error: type mismatch in v128.andnot, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_bitwise.wast:790: assert_invalid passed:
-  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128, v128]
+  out/test/spec/simd_bitwise/simd_bitwise.27.wasm:000003e: error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128, v128]
   000003e: error: OnTernaryExpr callback failed
 out/test/spec/simd_bitwise.wast:798: assert_invalid passed:
-  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128]
+  out/test/spec/simd_bitwise/simd_bitwise.28.wasm:000002c: error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got [v128]
   000002c: error: OnTernaryExpr callback failed
 out/test/spec/simd_bitwise.wast:806: assert_invalid passed:
-  error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got []
+  out/test/spec/simd_bitwise/simd_bitwise.29.wasm:000001a: error: type mismatch in v128.bitselect, expected [v128, v128, v128] but got []
   000001a: error: OnTernaryExpr callback failed
 167/167 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_boolean.txt
+++ b/test/spec/simd_boolean.txt
@@ -2,22 +2,22 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_boolean.wast
 (;; STDOUT ;;;
 out/test/spec/simd_boolean.wast:995: assert_invalid passed:
-  error: type mismatch in v128.any_true, expected [v128] but got [i32]
+  out/test/spec/simd_boolean/simd_boolean.2.wasm:000001c: error: type mismatch in v128.any_true, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:996: assert_invalid passed:
-  error: type mismatch in i8x16.all_true, expected [v128] but got [i32]
+  out/test/spec/simd_boolean/simd_boolean.3.wasm:000001c: error: type mismatch in i8x16.all_true, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:997: assert_invalid passed:
-  error: type mismatch in v128.any_true, expected [v128] but got [i32]
+  out/test/spec/simd_boolean/simd_boolean.4.wasm:000001c: error: type mismatch in v128.any_true, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:998: assert_invalid passed:
-  error: type mismatch in i16x8.all_true, expected [v128] but got [i32]
+  out/test/spec/simd_boolean/simd_boolean.5.wasm:000001d: error: type mismatch in i16x8.all_true, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:999: assert_invalid passed:
-  error: type mismatch in v128.any_true, expected [v128] but got [i32]
+  out/test/spec/simd_boolean/simd_boolean.6.wasm:000001c: error: type mismatch in v128.any_true, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1000: assert_invalid passed:
-  error: type mismatch in i32x4.all_true, expected [v128] but got [i32]
+  out/test/spec/simd_boolean/simd_boolean.7.wasm:000001d: error: type mismatch in i32x4.all_true, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1004: assert_malformed passed:
   out/test/spec/simd_boolean/simd_boolean.8.wat:1:32: error: unexpected token "f32x4.any_true", expected an instr.
@@ -36,22 +36,22 @@ out/test/spec/simd_boolean.wast:1007: assert_malformed passed:
   (memory 1) (func (result i32) (f64x2.all_true (v128.const i32x4 0 0 0 0)))
                                  ^^^^^^^^^^^^^^
 out/test/spec/simd_boolean.wast:1012: assert_invalid passed:
-  error: type mismatch in v128.any_true, expected [v128] but got []
+  out/test/spec/simd_boolean/simd_boolean.12.wasm:000001a: error: type mismatch in v128.any_true, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1020: assert_invalid passed:
-  error: type mismatch in i8x16.all_true, expected [v128] but got []
+  out/test/spec/simd_boolean/simd_boolean.13.wasm:000001a: error: type mismatch in i8x16.all_true, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1028: assert_invalid passed:
-  error: type mismatch in v128.any_true, expected [v128] but got []
+  out/test/spec/simd_boolean/simd_boolean.14.wasm:000001a: error: type mismatch in v128.any_true, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1036: assert_invalid passed:
-  error: type mismatch in i16x8.all_true, expected [v128] but got []
+  out/test/spec/simd_boolean/simd_boolean.15.wasm:000001b: error: type mismatch in i16x8.all_true, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1044: assert_invalid passed:
-  error: type mismatch in v128.any_true, expected [v128] but got []
+  out/test/spec/simd_boolean/simd_boolean.16.wasm:000001a: error: type mismatch in v128.any_true, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_boolean.wast:1052: assert_invalid passed:
-  error: type mismatch in i32x4.all_true, expected [v128] but got []
+  out/test/spec/simd_boolean/simd_boolean.17.wasm:000001b: error: type mismatch in i32x4.all_true, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 275/275 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_conversions.txt
+++ b/test/spec/simd_conversions.txt
@@ -122,58 +122,58 @@ out/test/spec/simd_conversions.wast:695: assert_malformed passed:
   (func (result v128) (i16x8.extend_high_i32x4_u (v128.const i32x4 0 0 0 0)))
                        ^^^^^^^^^^^^^^^^^^^^^^^^^
 out/test/spec/simd_conversions.wast:702: assert_invalid passed:
-  error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got [i32]
+  out/test/spec/simd_conversions/simd_conversions.31.wasm:000001d: error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got [i32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_conversions.wast:703: assert_invalid passed:
-  error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got [i64]
+  out/test/spec/simd_conversions/simd_conversions.32.wasm:000001d: error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got [i64]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_conversions.wast:704: assert_invalid passed:
-  error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got [i32]
+  out/test/spec/simd_conversions/simd_conversions.33.wasm:000001d: error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got [i32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_conversions.wast:705: assert_invalid passed:
-  error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got [i64]
+  out/test/spec/simd_conversions/simd_conversions.34.wasm:000001d: error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got [i64]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_conversions.wast:707: assert_invalid passed:
-  error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got [i32, i64]
+  out/test/spec/simd_conversions/simd_conversions.35.wasm:000001e: error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got [i32, i64]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:708: assert_invalid passed:
-  error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got [i32, i64]
+  out/test/spec/simd_conversions/simd_conversions.36.wasm:000001e: error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got [i32, i64]
   000001e: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:709: assert_invalid passed:
-  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [f32, f64]
+  out/test/spec/simd_conversions/simd_conversions.37.wasm:0000029: error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [f32, f64]
   0000029: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:710: assert_invalid passed:
-  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [f32, f64]
+  out/test/spec/simd_conversions/simd_conversions.38.wasm:0000029: error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [f32, f64]
   0000029: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:821: assert_invalid passed:
-  error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got []
+  out/test/spec/simd_conversions/simd_conversions.40.wasm:000001b: error: type mismatch in f32x4.convert_i32x4_s, expected [v128] but got []
   000001b: error: OnConvertExpr callback failed
 out/test/spec/simd_conversions.wast:829: assert_invalid passed:
-  error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got []
+  out/test/spec/simd_conversions/simd_conversions.41.wasm:000001b: error: type mismatch in f32x4.convert_i32x4_u, expected [v128] but got []
   000001b: error: OnConvertExpr callback failed
 out/test/spec/simd_conversions.wast:837: assert_invalid passed:
-  error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_conversions/simd_conversions.42.wasm:000002c: error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:845: assert_invalid passed:
-  error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got []
+  out/test/spec/simd_conversions/simd_conversions.43.wasm:000001a: error: type mismatch in i8x16.narrow_i16x8_s, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:853: assert_invalid passed:
-  error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_conversions/simd_conversions.44.wasm:000002c: error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:861: assert_invalid passed:
-  error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got []
+  out/test/spec/simd_conversions/simd_conversions.45.wasm:000001a: error: type mismatch in i8x16.narrow_i16x8_u, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:869: assert_invalid passed:
-  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_conversions/simd_conversions.46.wasm:000002d: error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:877: assert_invalid passed:
-  error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got []
+  out/test/spec/simd_conversions/simd_conversions.47.wasm:000001b: error: type mismatch in i16x8.narrow_i32x4_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:885: assert_invalid passed:
-  error: type mismatch in i16x8.narrow_i32x4_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_conversions/simd_conversions.48.wasm:000002d: error: type mismatch in i16x8.narrow_i32x4_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_conversions.wast:893: assert_invalid passed:
-  error: type mismatch in i16x8.narrow_i32x4_u, expected [v128, v128] but got []
+  out/test/spec/simd_conversions/simd_conversions.49.wasm:000001b: error: type mismatch in i16x8.narrow_i32x4_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 280/280 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f32x4.txt
+++ b/test/spec/simd_f32x4.txt
@@ -34,28 +34,28 @@ out/test/spec/simd_f32x4.wast:2332: assert_malformed passed:
   (memory 1) (func (result v128) (i64x2.max (v128.const i32x4 0 0 0 0) (v128.co...
                                   ^^^^^^^^^
 out/test/spec/simd_f32x4.wast:2335: assert_invalid passed:
-  error: type mismatch in f32x4.abs, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4/simd_f32x4.9.wasm:000001d: error: type mismatch in f32x4.abs, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2336: assert_invalid passed:
-  error: type mismatch in f32x4.min, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4/simd_f32x4.10.wasm:0000022: error: type mismatch in f32x4.min, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2337: assert_invalid passed:
-  error: type mismatch in f32x4.max, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4/simd_f32x4.11.wasm:0000022: error: type mismatch in f32x4.max, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2342: assert_invalid passed:
-  error: type mismatch in f32x4.abs, expected [v128] but got []
+  out/test/spec/simd_f32x4/simd_f32x4.12.wasm:000001b: error: type mismatch in f32x4.abs, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2350: assert_invalid passed:
-  error: type mismatch in f32x4.min, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4/simd_f32x4.13.wasm:000002d: error: type mismatch in f32x4.min, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2358: assert_invalid passed:
-  error: type mismatch in f32x4.min, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4/simd_f32x4.14.wasm:000001b: error: type mismatch in f32x4.min, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2366: assert_invalid passed:
-  error: type mismatch in f32x4.max, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4/simd_f32x4.15.wasm:000002d: error: type mismatch in f32x4.max, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4.wast:2374: assert_invalid passed:
-  error: type mismatch in f32x4.max, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4/simd_f32x4.16.wasm:000001b: error: type mismatch in f32x4.max, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 788/788 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f32x4_arith.txt
+++ b/test/spec/simd_f32x4_arith.txt
@@ -2,52 +2,52 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_f32x4_arith.wast
 (;; STDOUT ;;;
 out/test/spec/simd_f32x4_arith.wast:5295: assert_invalid passed:
-  error: type mismatch in f32x4.neg, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.2.wasm:000001d: error: type mismatch in f32x4.neg, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5296: assert_invalid passed:
-  error: type mismatch in f32x4.sqrt, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.3.wasm:000001d: error: type mismatch in f32x4.sqrt, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5297: assert_invalid passed:
-  error: type mismatch in f32x4.add, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.4.wasm:0000022: error: type mismatch in f32x4.add, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5298: assert_invalid passed:
-  error: type mismatch in f32x4.sub, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.5.wasm:0000022: error: type mismatch in f32x4.sub, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5299: assert_invalid passed:
-  error: type mismatch in f32x4.mul, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.6.wasm:0000022: error: type mismatch in f32x4.mul, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5300: assert_invalid passed:
-  error: type mismatch in f32x4.div, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.7.wasm:0000022: error: type mismatch in f32x4.div, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5305: assert_invalid passed:
-  error: type mismatch in f32x4.neg, expected [v128] but got []
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.8.wasm:000001b: error: type mismatch in f32x4.neg, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5313: assert_invalid passed:
-  error: type mismatch in f32x4.sqrt, expected [v128] but got []
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.9.wasm:000001b: error: type mismatch in f32x4.sqrt, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5321: assert_invalid passed:
-  error: type mismatch in f32x4.add, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.10.wasm:000002d: error: type mismatch in f32x4.add, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5329: assert_invalid passed:
-  error: type mismatch in f32x4.add, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.11.wasm:000001b: error: type mismatch in f32x4.add, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5337: assert_invalid passed:
-  error: type mismatch in f32x4.sub, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.12.wasm:000002d: error: type mismatch in f32x4.sub, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5345: assert_invalid passed:
-  error: type mismatch in f32x4.sub, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.13.wasm:000001b: error: type mismatch in f32x4.sub, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5353: assert_invalid passed:
-  error: type mismatch in f32x4.mul, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.14.wasm:000002d: error: type mismatch in f32x4.mul, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5361: assert_invalid passed:
-  error: type mismatch in f32x4.mul, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.15.wasm:000001b: error: type mismatch in f32x4.mul, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5369: assert_invalid passed:
-  error: type mismatch in f32x4.div, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.16.wasm:000002d: error: type mismatch in f32x4.div, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_arith.wast:5377: assert_invalid passed:
-  error: type mismatch in f32x4.div, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_arith/simd_f32x4_arith.17.wasm:000001b: error: type mismatch in f32x4.div, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 1819/1819 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f32x4_cmp.txt
+++ b/test/spec/simd_f32x4_cmp.txt
@@ -2,22 +2,22 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_f32x4_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/simd_f32x4_cmp.wast:7779: assert_invalid passed:
-  error: type mismatch in f32x4.eq, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.1.wasm:0000025: error: type mismatch in f32x4.eq, expected [v128, v128] but got [i64, f64]
   0000025: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:7780: assert_invalid passed:
-  error: type mismatch in f32x4.ge, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.2.wasm:0000025: error: type mismatch in f32x4.ge, expected [v128, v128] but got [i64, f64]
   0000025: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:7781: assert_invalid passed:
-  error: type mismatch in f32x4.gt, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.3.wasm:0000025: error: type mismatch in f32x4.gt, expected [v128, v128] but got [i64, f64]
   0000025: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:7782: assert_invalid passed:
-  error: type mismatch in f32x4.le, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.4.wasm:0000025: error: type mismatch in f32x4.le, expected [v128, v128] but got [i64, f64]
   0000025: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:7783: assert_invalid passed:
-  error: type mismatch in f32x4.lt, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.5.wasm:0000025: error: type mismatch in f32x4.lt, expected [v128, v128] but got [i64, f64]
   0000025: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:7784: assert_invalid passed:
-  error: type mismatch in f32x4.ne, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.6.wasm:0000025: error: type mismatch in f32x4.ne, expected [v128, v128] but got [i64, f64]
   0000025: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:7789: assert_malformed passed:
   out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.7.wat:1:65: error: unexpected token "f4x32.eq", expected an instr.
@@ -44,40 +44,40 @@ out/test/spec/simd_f32x4_cmp.wast:7794: assert_malformed passed:
   ...v128) (param $y v128) (result v128) (f4x32.ne (local.get $x) (local.get $y)))
                                           ^^^^^^^^
 out/test/spec/simd_f32x4_cmp.wast:8073: assert_invalid passed:
-  error: type mismatch in f32x4.eq, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.14.wasm:000002c: error: type mismatch in f32x4.eq, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8081: assert_invalid passed:
-  error: type mismatch in f32x4.eq, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.15.wasm:000001a: error: type mismatch in f32x4.eq, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8089: assert_invalid passed:
-  error: type mismatch in f32x4.ne, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.16.wasm:000002c: error: type mismatch in f32x4.ne, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8097: assert_invalid passed:
-  error: type mismatch in f32x4.ne, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.17.wasm:000001a: error: type mismatch in f32x4.ne, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8105: assert_invalid passed:
-  error: type mismatch in f32x4.lt, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.18.wasm:000002c: error: type mismatch in f32x4.lt, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8113: assert_invalid passed:
-  error: type mismatch in f32x4.lt, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.19.wasm:000001a: error: type mismatch in f32x4.lt, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8121: assert_invalid passed:
-  error: type mismatch in f32x4.le, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.20.wasm:000002c: error: type mismatch in f32x4.le, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8129: assert_invalid passed:
-  error: type mismatch in f32x4.le, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.21.wasm:000001a: error: type mismatch in f32x4.le, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8137: assert_invalid passed:
-  error: type mismatch in f32x4.gt, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.22.wasm:000002c: error: type mismatch in f32x4.gt, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8145: assert_invalid passed:
-  error: type mismatch in f32x4.gt, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.23.wasm:000001a: error: type mismatch in f32x4.gt, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8153: assert_invalid passed:
-  error: type mismatch in f32x4.ge, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.24.wasm:000002c: error: type mismatch in f32x4.ge, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f32x4_cmp.wast:8161: assert_invalid passed:
-  error: type mismatch in f32x4.ge, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_cmp/simd_f32x4_cmp.25.wasm:000001a: error: type mismatch in f32x4.ge, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 2605/2605 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f32x4_pmin_pmax.txt
+++ b/test/spec/simd_f32x4_pmin_pmax.txt
@@ -34,22 +34,22 @@ out/test/spec/simd_f32x4_pmin_pmax.wast:11636: assert_malformed passed:
   (memory 1) (func (result v128) (i64x2.pmax (v128.const i32x4 0 0 0 0) (v128.c...
                                   ^^^^^^^^^^
 out/test/spec/simd_f32x4_pmin_pmax.wast:11639: assert_invalid passed:
-  error: type mismatch in f32x4.pmin, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4_pmin_pmax/simd_f32x4_pmin_pmax.9.wasm:0000022: error: type mismatch in f32x4.pmin, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_pmin_pmax.wast:11640: assert_invalid passed:
-  error: type mismatch in f32x4.pmax, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f32x4_pmin_pmax/simd_f32x4_pmin_pmax.10.wasm:0000022: error: type mismatch in f32x4.pmax, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_pmin_pmax.wast:11645: assert_invalid passed:
-  error: type mismatch in f32x4.pmin, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_pmin_pmax/simd_f32x4_pmin_pmax.11.wasm:000002d: error: type mismatch in f32x4.pmin, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_pmin_pmax.wast:11653: assert_invalid passed:
-  error: type mismatch in f32x4.pmin, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_pmin_pmax/simd_f32x4_pmin_pmax.12.wasm:000001b: error: type mismatch in f32x4.pmin, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_pmin_pmax.wast:11661: assert_invalid passed:
-  error: type mismatch in f32x4.pmax, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f32x4_pmin_pmax/simd_f32x4_pmin_pmax.13.wasm:000002d: error: type mismatch in f32x4.pmax, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f32x4_pmin_pmax.wast:11669: assert_invalid passed:
-  error: type mismatch in f32x4.pmax, expected [v128, v128] but got []
+  out/test/spec/simd_f32x4_pmin_pmax/simd_f32x4_pmin_pmax.14.wasm:000001b: error: type mismatch in f32x4.pmax, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 3886/3886 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f32x4_rounding.txt
+++ b/test/spec/simd_f32x4_rounding.txt
@@ -66,28 +66,28 @@ out/test/spec/simd_f32x4_rounding.wast:382: assert_malformed passed:
   (memory 1) (func (result v128) (i64x2.nearest (v128.const i32x4 0 0 0 0)))
                                   ^^^^^^^^^^^^^
 out/test/spec/simd_f32x4_rounding.wast:385: assert_invalid passed:
-  error: type mismatch in f32x4.ceil, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.17.wasm:000001c: error: type mismatch in f32x4.ceil, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:386: assert_invalid passed:
-  error: type mismatch in f32x4.floor, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.18.wasm:000001c: error: type mismatch in f32x4.floor, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:387: assert_invalid passed:
-  error: type mismatch in f32x4.trunc, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.19.wasm:000001c: error: type mismatch in f32x4.trunc, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:388: assert_invalid passed:
-  error: type mismatch in f32x4.nearest, expected [v128] but got [i32]
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.20.wasm:000001c: error: type mismatch in f32x4.nearest, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:393: assert_invalid passed:
-  error: type mismatch in f32x4.ceil, expected [v128] but got []
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.21.wasm:000001a: error: type mismatch in f32x4.ceil, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:401: assert_invalid passed:
-  error: type mismatch in f32x4.floor, expected [v128] but got []
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.22.wasm:000001a: error: type mismatch in f32x4.floor, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:409: assert_invalid passed:
-  error: type mismatch in f32x4.trunc, expected [v128] but got []
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.23.wasm:000001a: error: type mismatch in f32x4.trunc, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_f32x4_rounding.wast:417: assert_invalid passed:
-  error: type mismatch in f32x4.nearest, expected [v128] but got []
+  out/test/spec/simd_f32x4_rounding/simd_f32x4_rounding.24.wasm:000001a: error: type mismatch in f32x4.nearest, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 200/200 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f64x2.txt
+++ b/test/spec/simd_f64x2.txt
@@ -2,28 +2,28 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_f64x2.wast
 (;; STDOUT ;;;
 out/test/spec/simd_f64x2.wast:2387: assert_invalid passed:
-  error: type mismatch in f64x2.abs, expected [v128] but got [i32]
+  out/test/spec/simd_f64x2/simd_f64x2.1.wasm:000001d: error: type mismatch in f64x2.abs, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2388: assert_invalid passed:
-  error: type mismatch in f64x2.min, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2/simd_f64x2.2.wasm:0000022: error: type mismatch in f64x2.min, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2389: assert_invalid passed:
-  error: type mismatch in f64x2.max, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2/simd_f64x2.3.wasm:0000022: error: type mismatch in f64x2.max, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2394: assert_invalid passed:
-  error: type mismatch in f64x2.abs, expected [v128] but got []
+  out/test/spec/simd_f64x2/simd_f64x2.4.wasm:000001b: error: type mismatch in f64x2.abs, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2402: assert_invalid passed:
-  error: type mismatch in f64x2.min, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2/simd_f64x2.5.wasm:000002d: error: type mismatch in f64x2.min, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2410: assert_invalid passed:
-  error: type mismatch in f64x2.min, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2/simd_f64x2.6.wasm:000001b: error: type mismatch in f64x2.min, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2418: assert_invalid passed:
-  error: type mismatch in f64x2.max, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2/simd_f64x2.7.wasm:000002d: error: type mismatch in f64x2.max, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2.wast:2426: assert_invalid passed:
-  error: type mismatch in f64x2.max, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2/simd_f64x2.8.wasm:000001b: error: type mismatch in f64x2.max, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 801/801 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f64x2_arith.txt
+++ b/test/spec/simd_f64x2_arith.txt
@@ -2,52 +2,52 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_f64x2_arith.wast
 (;; STDOUT ;;;
 out/test/spec/simd_f64x2_arith.wast:5302: assert_invalid passed:
-  error: type mismatch in f64x2.neg, expected [v128] but got [i64]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.2.wasm:000001d: error: type mismatch in f64x2.neg, expected [v128] but got [i64]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5303: assert_invalid passed:
-  error: type mismatch in f64x2.sqrt, expected [v128] but got [i64]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.3.wasm:000001d: error: type mismatch in f64x2.sqrt, expected [v128] but got [i64]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5304: assert_invalid passed:
-  error: type mismatch in f64x2.add, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.4.wasm:0000026: error: type mismatch in f64x2.add, expected [v128, v128] but got [i64, f64]
   0000026: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5305: assert_invalid passed:
-  error: type mismatch in f64x2.sub, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.5.wasm:0000026: error: type mismatch in f64x2.sub, expected [v128, v128] but got [i64, f64]
   0000026: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5306: assert_invalid passed:
-  error: type mismatch in f64x2.mul, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.6.wasm:0000026: error: type mismatch in f64x2.mul, expected [v128, v128] but got [i64, f64]
   0000026: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5307: assert_invalid passed:
-  error: type mismatch in f64x2.div, expected [v128, v128] but got [i64, f64]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.7.wasm:0000026: error: type mismatch in f64x2.div, expected [v128, v128] but got [i64, f64]
   0000026: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5312: assert_invalid passed:
-  error: type mismatch in f64x2.neg, expected [v128] but got []
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.8.wasm:000001b: error: type mismatch in f64x2.neg, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5320: assert_invalid passed:
-  error: type mismatch in f64x2.sqrt, expected [v128] but got []
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.9.wasm:000001b: error: type mismatch in f64x2.sqrt, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5328: assert_invalid passed:
-  error: type mismatch in f64x2.add, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.10.wasm:000002d: error: type mismatch in f64x2.add, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5336: assert_invalid passed:
-  error: type mismatch in f64x2.add, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.11.wasm:000001b: error: type mismatch in f64x2.add, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5344: assert_invalid passed:
-  error: type mismatch in f64x2.sub, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.12.wasm:000002d: error: type mismatch in f64x2.sub, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5352: assert_invalid passed:
-  error: type mismatch in f64x2.sub, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.13.wasm:000001b: error: type mismatch in f64x2.sub, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5360: assert_invalid passed:
-  error: type mismatch in f64x2.mul, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.14.wasm:000002d: error: type mismatch in f64x2.mul, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5368: assert_invalid passed:
-  error: type mismatch in f64x2.mul, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.15.wasm:000001b: error: type mismatch in f64x2.mul, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5376: assert_invalid passed:
-  error: type mismatch in f64x2.div, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.16.wasm:000002d: error: type mismatch in f64x2.div, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_arith.wast:5384: assert_invalid passed:
-  error: type mismatch in f64x2.div, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_arith/simd_f64x2_arith.17.wasm:000001b: error: type mismatch in f64x2.div, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 1822/1822 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f64x2_cmp.txt
+++ b/test/spec/simd_f64x2_cmp.txt
@@ -26,58 +26,58 @@ out/test/spec/simd_f64x2_cmp.wast:7959: assert_malformed passed:
   ...v128) (param $y v128) (result v128) (f2x64.ge (local.get $x) (local.get $y)))
                                           ^^^^^^^^
 out/test/spec/simd_f64x2_cmp.wast:7962: assert_invalid passed:
-  error: type mismatch in f64x2.eq, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.7.wasm:0000021: error: type mismatch in f64x2.eq, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7963: assert_invalid passed:
-  error: type mismatch in f64x2.ne, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.8.wasm:0000021: error: type mismatch in f64x2.ne, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7964: assert_invalid passed:
-  error: type mismatch in f64x2.lt, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.9.wasm:0000021: error: type mismatch in f64x2.lt, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7965: assert_invalid passed:
-  error: type mismatch in f64x2.le, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.10.wasm:0000021: error: type mismatch in f64x2.le, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7966: assert_invalid passed:
-  error: type mismatch in f64x2.gt, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.11.wasm:0000021: error: type mismatch in f64x2.gt, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7967: assert_invalid passed:
-  error: type mismatch in f64x2.ge, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.12.wasm:0000021: error: type mismatch in f64x2.ge, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7972: assert_invalid passed:
-  error: type mismatch in f64x2.eq, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.13.wasm:000002c: error: type mismatch in f64x2.eq, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7980: assert_invalid passed:
-  error: type mismatch in f64x2.eq, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.14.wasm:000001a: error: type mismatch in f64x2.eq, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7988: assert_invalid passed:
-  error: type mismatch in f64x2.ne, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.15.wasm:000002c: error: type mismatch in f64x2.ne, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:7996: assert_invalid passed:
-  error: type mismatch in f64x2.ne, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.16.wasm:000001a: error: type mismatch in f64x2.ne, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8004: assert_invalid passed:
-  error: type mismatch in f64x2.lt, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.17.wasm:000002c: error: type mismatch in f64x2.lt, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8012: assert_invalid passed:
-  error: type mismatch in f64x2.lt, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.18.wasm:000001a: error: type mismatch in f64x2.lt, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8020: assert_invalid passed:
-  error: type mismatch in f64x2.le, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.19.wasm:000002c: error: type mismatch in f64x2.le, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8028: assert_invalid passed:
-  error: type mismatch in f64x2.le, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.20.wasm:000001a: error: type mismatch in f64x2.le, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8036: assert_invalid passed:
-  error: type mismatch in f64x2.gt, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.21.wasm:000002c: error: type mismatch in f64x2.gt, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8044: assert_invalid passed:
-  error: type mismatch in f64x2.gt, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.22.wasm:000001a: error: type mismatch in f64x2.gt, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8052: assert_invalid passed:
-  error: type mismatch in f64x2.ge, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.23.wasm:000002c: error: type mismatch in f64x2.ge, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_f64x2_cmp.wast:8060: assert_invalid passed:
-  error: type mismatch in f64x2.ge, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_cmp/simd_f64x2_cmp.24.wasm:000001a: error: type mismatch in f64x2.ge, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 2683/2683 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f64x2_pmin_pmax.txt
+++ b/test/spec/simd_f64x2_pmin_pmax.txt
@@ -34,22 +34,22 @@ out/test/spec/simd_f64x2_pmin_pmax.wast:11636: assert_malformed passed:
   (memory 1) (func (result v128) (i64x2.pmax (v128.const i32x4 0 0 0 0) (v128.c...
                                   ^^^^^^^^^^
 out/test/spec/simd_f64x2_pmin_pmax.wast:11639: assert_invalid passed:
-  error: type mismatch in f64x2.pmin, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_pmin_pmax/simd_f64x2_pmin_pmax.9.wasm:0000022: error: type mismatch in f64x2.pmin, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_pmin_pmax.wast:11640: assert_invalid passed:
-  error: type mismatch in f64x2.pmax, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_f64x2_pmin_pmax/simd_f64x2_pmin_pmax.10.wasm:0000022: error: type mismatch in f64x2.pmax, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_pmin_pmax.wast:11645: assert_invalid passed:
-  error: type mismatch in f64x2.pmin, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_pmin_pmax/simd_f64x2_pmin_pmax.11.wasm:000002d: error: type mismatch in f64x2.pmin, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_pmin_pmax.wast:11653: assert_invalid passed:
-  error: type mismatch in f64x2.pmin, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_pmin_pmax/simd_f64x2_pmin_pmax.12.wasm:000001b: error: type mismatch in f64x2.pmin, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_pmin_pmax.wast:11661: assert_invalid passed:
-  error: type mismatch in f64x2.pmax, expected [v128, v128] but got [v128]
+  out/test/spec/simd_f64x2_pmin_pmax/simd_f64x2_pmin_pmax.13.wasm:000002d: error: type mismatch in f64x2.pmax, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_f64x2_pmin_pmax.wast:11669: assert_invalid passed:
-  error: type mismatch in f64x2.pmax, expected [v128, v128] but got []
+  out/test/spec/simd_f64x2_pmin_pmax/simd_f64x2_pmin_pmax.14.wasm:000001b: error: type mismatch in f64x2.pmax, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 3886/3886 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_f64x2_rounding.txt
+++ b/test/spec/simd_f64x2_rounding.txt
@@ -66,28 +66,28 @@ out/test/spec/simd_f64x2_rounding.wast:382: assert_malformed passed:
   (memory 1) (func (result v128) (i64x2.nearest (v128.const i32x4 0 0 0 0)))
                                   ^^^^^^^^^^^^^
 out/test/spec/simd_f64x2_rounding.wast:385: assert_invalid passed:
-  error: type mismatch in f64x2.ceil, expected [v128] but got [i32]
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.17.wasm:000001c: error: type mismatch in f64x2.ceil, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:386: assert_invalid passed:
-  error: type mismatch in f64x2.floor, expected [v128] but got [i32]
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.18.wasm:000001c: error: type mismatch in f64x2.floor, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:387: assert_invalid passed:
-  error: type mismatch in f64x2.trunc, expected [v128] but got [i32]
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.19.wasm:000001c: error: type mismatch in f64x2.trunc, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:388: assert_invalid passed:
-  error: type mismatch in f64x2.nearest, expected [v128] but got [i32]
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.20.wasm:000001d: error: type mismatch in f64x2.nearest, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:393: assert_invalid passed:
-  error: type mismatch in f64x2.ceil, expected [v128] but got []
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.21.wasm:000001a: error: type mismatch in f64x2.ceil, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:401: assert_invalid passed:
-  error: type mismatch in f64x2.floor, expected [v128] but got []
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.22.wasm:000001a: error: type mismatch in f64x2.floor, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:409: assert_invalid passed:
-  error: type mismatch in f64x2.trunc, expected [v128] but got []
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.23.wasm:000001a: error: type mismatch in f64x2.trunc, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_f64x2_rounding.wast:417: assert_invalid passed:
-  error: type mismatch in f64x2.nearest, expected [v128] but got []
+  out/test/spec/simd_f64x2_rounding/simd_f64x2_rounding.24.wasm:000001b: error: type mismatch in f64x2.nearest, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 200/200 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_arith.txt
+++ b/test/spec/simd_i16x8_arith.txt
@@ -2,37 +2,37 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i16x8_arith.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i16x8_arith.wast:528: assert_invalid passed:
-  error: type mismatch in i16x8.neg, expected [v128] but got [i32]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.1.wasm:000001d: error: type mismatch in i16x8.neg, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:529: assert_invalid passed:
-  error: type mismatch in i16x8.add, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.2.wasm:0000022: error: type mismatch in i16x8.add, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:530: assert_invalid passed:
-  error: type mismatch in i16x8.sub, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.3.wasm:0000022: error: type mismatch in i16x8.sub, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:531: assert_invalid passed:
-  error: type mismatch in i16x8.mul, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.4.wasm:0000022: error: type mismatch in i16x8.mul, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:536: assert_invalid passed:
-  error: type mismatch in i16x8.neg, expected [v128] but got []
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.5.wasm:000001b: error: type mismatch in i16x8.neg, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:544: assert_invalid passed:
-  error: type mismatch in i16x8.add, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.6.wasm:000002d: error: type mismatch in i16x8.add, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:552: assert_invalid passed:
-  error: type mismatch in i16x8.add, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.7.wasm:000001b: error: type mismatch in i16x8.add, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:560: assert_invalid passed:
-  error: type mismatch in i16x8.sub, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.8.wasm:000002d: error: type mismatch in i16x8.sub, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:568: assert_invalid passed:
-  error: type mismatch in i16x8.sub, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.9.wasm:000001b: error: type mismatch in i16x8.sub, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:576: assert_invalid passed:
-  error: type mismatch in i16x8.mul, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.10.wasm:000002d: error: type mismatch in i16x8.mul, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith.wast:584: assert_invalid passed:
-  error: type mismatch in i16x8.mul, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith/simd_i16x8_arith.11.wasm:000001b: error: type mismatch in i16x8.mul, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 192/192 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_arith2.txt
+++ b/test/spec/simd_i16x8_arith2.txt
@@ -10,55 +10,55 @@ out/test/spec/simd_i16x8_arith2.wast:338: assert_malformed passed:
   (memory 1) (func (result v128) (i16x8.avgr_s (v128.const i16x8 0 0 0 0 0 0 0 ...
                                   ^^^^^^^^^^^^
 out/test/spec/simd_i16x8_arith2.wast:341: assert_invalid passed:
-  error: type mismatch in i16x8.min_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.3.wasm:0000022: error: type mismatch in i16x8.min_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:342: assert_invalid passed:
-  error: type mismatch in i16x8.min_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.4.wasm:0000022: error: type mismatch in i16x8.min_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:343: assert_invalid passed:
-  error: type mismatch in i16x8.max_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.5.wasm:0000022: error: type mismatch in i16x8.max_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:344: assert_invalid passed:
-  error: type mismatch in i16x8.max_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.6.wasm:0000022: error: type mismatch in i16x8.max_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:345: assert_invalid passed:
-  error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.7.wasm:0000022: error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:346: assert_invalid passed:
-  error: type mismatch in i16x8.abs, expected [v128] but got [f32]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.8.wasm:0000020: error: type mismatch in i16x8.abs, expected [v128] but got [f32]
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:351: assert_invalid passed:
-  error: type mismatch in i16x8.min_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.9.wasm:000002d: error: type mismatch in i16x8.min_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:359: assert_invalid passed:
-  error: type mismatch in i16x8.min_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.10.wasm:000001b: error: type mismatch in i16x8.min_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:367: assert_invalid passed:
-  error: type mismatch in i16x8.min_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.11.wasm:000002d: error: type mismatch in i16x8.min_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:375: assert_invalid passed:
-  error: type mismatch in i16x8.min_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.12.wasm:000001b: error: type mismatch in i16x8.min_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:383: assert_invalid passed:
-  error: type mismatch in i16x8.max_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.13.wasm:000002d: error: type mismatch in i16x8.max_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:391: assert_invalid passed:
-  error: type mismatch in i16x8.max_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.14.wasm:000001b: error: type mismatch in i16x8.max_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:399: assert_invalid passed:
-  error: type mismatch in i16x8.max_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.15.wasm:000002d: error: type mismatch in i16x8.max_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:407: assert_invalid passed:
-  error: type mismatch in i16x8.max_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.16.wasm:000001b: error: type mismatch in i16x8.max_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:415: assert_invalid passed:
-  error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.17.wasm:000002d: error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:423: assert_invalid passed:
-  error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.18.wasm:000001b: error: type mismatch in i16x8.avgr_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_arith2.wast:431: assert_invalid passed:
-  error: type mismatch in i16x8.abs, expected [v128] but got []
+  out/test/spec/simd_i16x8_arith2/simd_i16x8_arith2.19.wasm:000001b: error: type mismatch in i16x8.abs, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 170/170 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_cmp.txt
+++ b/test/spec/simd_i16x8_cmp.txt
@@ -2,94 +2,94 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i16x8_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i16x8_cmp.wast:1455: assert_invalid passed:
-  error: type mismatch in i16x8.eq, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.1.wasm:0000021: error: type mismatch in i16x8.eq, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1456: assert_invalid passed:
-  error: type mismatch in i16x8.ge_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.2.wasm:0000021: error: type mismatch in i16x8.ge_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1457: assert_invalid passed:
-  error: type mismatch in i16x8.ge_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.3.wasm:0000021: error: type mismatch in i16x8.ge_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1458: assert_invalid passed:
-  error: type mismatch in i16x8.gt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.4.wasm:0000021: error: type mismatch in i16x8.gt_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1459: assert_invalid passed:
-  error: type mismatch in i16x8.gt_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.5.wasm:0000021: error: type mismatch in i16x8.gt_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1460: assert_invalid passed:
-  error: type mismatch in i16x8.le_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.6.wasm:0000021: error: type mismatch in i16x8.le_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1461: assert_invalid passed:
-  error: type mismatch in i16x8.le_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.7.wasm:0000021: error: type mismatch in i16x8.le_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1462: assert_invalid passed:
-  error: type mismatch in i16x8.lt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.8.wasm:0000021: error: type mismatch in i16x8.lt_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1463: assert_invalid passed:
-  error: type mismatch in i16x8.lt_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.9.wasm:0000021: error: type mismatch in i16x8.lt_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1464: assert_invalid passed:
-  error: type mismatch in i16x8.ne, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.10.wasm:0000021: error: type mismatch in i16x8.ne, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1743: assert_invalid passed:
-  error: type mismatch in i16x8.eq, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.12.wasm:000002c: error: type mismatch in i16x8.eq, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1751: assert_invalid passed:
-  error: type mismatch in i16x8.eq, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.13.wasm:000001a: error: type mismatch in i16x8.eq, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1759: assert_invalid passed:
-  error: type mismatch in i16x8.ne, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.14.wasm:000002c: error: type mismatch in i16x8.ne, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1767: assert_invalid passed:
-  error: type mismatch in i16x8.ne, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.15.wasm:000001a: error: type mismatch in i16x8.ne, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1775: assert_invalid passed:
-  error: type mismatch in i16x8.lt_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.16.wasm:000002c: error: type mismatch in i16x8.lt_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1783: assert_invalid passed:
-  error: type mismatch in i16x8.lt_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.17.wasm:000001a: error: type mismatch in i16x8.lt_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1791: assert_invalid passed:
-  error: type mismatch in i16x8.lt_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.18.wasm:000002c: error: type mismatch in i16x8.lt_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1799: assert_invalid passed:
-  error: type mismatch in i16x8.lt_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.19.wasm:000001a: error: type mismatch in i16x8.lt_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1807: assert_invalid passed:
-  error: type mismatch in i16x8.le_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.20.wasm:000002c: error: type mismatch in i16x8.le_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1815: assert_invalid passed:
-  error: type mismatch in i16x8.le_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.21.wasm:000001a: error: type mismatch in i16x8.le_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1823: assert_invalid passed:
-  error: type mismatch in i16x8.le_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.22.wasm:000002c: error: type mismatch in i16x8.le_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1831: assert_invalid passed:
-  error: type mismatch in i16x8.le_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.23.wasm:000001a: error: type mismatch in i16x8.le_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1839: assert_invalid passed:
-  error: type mismatch in i16x8.gt_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.24.wasm:000002c: error: type mismatch in i16x8.gt_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1847: assert_invalid passed:
-  error: type mismatch in i16x8.gt_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.25.wasm:000001a: error: type mismatch in i16x8.gt_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1855: assert_invalid passed:
-  error: type mismatch in i16x8.gt_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.26.wasm:000002c: error: type mismatch in i16x8.gt_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1863: assert_invalid passed:
-  error: type mismatch in i16x8.gt_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.27.wasm:000001a: error: type mismatch in i16x8.gt_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1871: assert_invalid passed:
-  error: type mismatch in i16x8.ge_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.28.wasm:000002c: error: type mismatch in i16x8.ge_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1879: assert_invalid passed:
-  error: type mismatch in i16x8.ge_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.29.wasm:000001a: error: type mismatch in i16x8.ge_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1887: assert_invalid passed:
-  error: type mismatch in i16x8.ge_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.30.wasm:000002c: error: type mismatch in i16x8.ge_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i16x8_cmp.wast:1895: assert_invalid passed:
-  error: type mismatch in i16x8.ge_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_cmp/simd_i16x8_cmp.31.wasm:000001a: error: type mismatch in i16x8.ge_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 463/463 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_extadd_pairwise_i8x16.txt
+++ b/test/spec/simd_i16x8_extadd_pairwise_i8x16.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i16x8_extadd_pairwise_i8x16.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i16x8_extadd_pairwise_i8x16.wast:47: assert_invalid passed:
-  error: type mismatch in i16x8.extadd_pairwise_i8x16_s, expected [v128] but got [i32]
+  out/test/spec/simd_i16x8_extadd_pairwise_i8x16/simd_i16x8_extadd_pairwise_i8x16.1.wasm:000001c: error: type mismatch in i16x8.extadd_pairwise_i8x16_s, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_i16x8_extadd_pairwise_i8x16.wast:48: assert_invalid passed:
-  error: type mismatch in i16x8.extadd_pairwise_i8x16_u, expected [v128] but got [i32]
+  out/test/spec/simd_i16x8_extadd_pairwise_i8x16/simd_i16x8_extadd_pairwise_i8x16.2.wasm:000001c: error: type mismatch in i16x8.extadd_pairwise_i8x16_u, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_i16x8_extadd_pairwise_i8x16.wast:53: assert_invalid passed:
-  error: type mismatch in i16x8.extadd_pairwise_i8x16_s, expected [v128] but got []
+  out/test/spec/simd_i16x8_extadd_pairwise_i8x16/simd_i16x8_extadd_pairwise_i8x16.3.wasm:000001a: error: type mismatch in i16x8.extadd_pairwise_i8x16_s, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_i16x8_extadd_pairwise_i8x16.wast:61: assert_invalid passed:
-  error: type mismatch in i16x8.extadd_pairwise_i8x16_u, expected [v128] but got []
+  out/test/spec/simd_i16x8_extadd_pairwise_i8x16/simd_i16x8_extadd_pairwise_i8x16.4.wasm:000001a: error: type mismatch in i16x8.extadd_pairwise_i8x16_u, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 20/20 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_extmul_i8x16.txt
+++ b/test/spec/simd_i16x8_extmul_i8x16.txt
@@ -2,40 +2,40 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i16x8_extmul_i8x16.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i16x8_extmul_i8x16.wast:333: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_low_i8x16_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.1.wasm:0000022: error: type mismatch in i16x8.extmul_low_i8x16_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:334: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_high_i8x16_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.2.wasm:0000022: error: type mismatch in i16x8.extmul_high_i8x16_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:335: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_low_i8x16_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.3.wasm:0000022: error: type mismatch in i16x8.extmul_low_i8x16_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:336: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_high_i8x16_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.4.wasm:0000022: error: type mismatch in i16x8.extmul_high_i8x16_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:341: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_low_i8x16_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.5.wasm:000002d: error: type mismatch in i16x8.extmul_low_i8x16_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:349: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_low_i8x16_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.6.wasm:000001b: error: type mismatch in i16x8.extmul_low_i8x16_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:357: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_high_i8x16_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.7.wasm:000002d: error: type mismatch in i16x8.extmul_high_i8x16_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:365: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_high_i8x16_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.8.wasm:000001b: error: type mismatch in i16x8.extmul_high_i8x16_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:373: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_low_i8x16_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.9.wasm:000002d: error: type mismatch in i16x8.extmul_low_i8x16_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:381: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_low_i8x16_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.10.wasm:000001b: error: type mismatch in i16x8.extmul_low_i8x16_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:389: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_high_i8x16_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.11.wasm:000002d: error: type mismatch in i16x8.extmul_high_i8x16_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_extmul_i8x16.wast:397: assert_invalid passed:
-  error: type mismatch in i16x8.extmul_high_i8x16_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_extmul_i8x16/simd_i16x8_extmul_i8x16.12.wasm:000001b: error: type mismatch in i16x8.extmul_high_i8x16_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 116/116 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_q15mulr_sat_s.txt
+++ b/test/spec/simd_i16x8_q15mulr_sat_s.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i16x8_q15mulr_sat_s.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i16x8_q15mulr_sat_s.wast:90: assert_invalid passed:
-  error: type mismatch in i16x8.q15mulr_sat_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_q15mulr_sat_s/simd_i16x8_q15mulr_sat_s.1.wasm:0000022: error: type mismatch in i16x8.q15mulr_sat_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_q15mulr_sat_s.wast:95: assert_invalid passed:
-  error: type mismatch in i16x8.q15mulr_sat_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_q15mulr_sat_s/simd_i16x8_q15mulr_sat_s.2.wasm:000002d: error: type mismatch in i16x8.q15mulr_sat_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_q15mulr_sat_s.wast:103: assert_invalid passed:
-  error: type mismatch in i16x8.q15mulr_sat_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_q15mulr_sat_s/simd_i16x8_q15mulr_sat_s.3.wasm:000001b: error: type mismatch in i16x8.q15mulr_sat_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i16x8_sat_arith.txt
+++ b/test/spec/simd_i16x8_sat_arith.txt
@@ -18,40 +18,40 @@ out/test/spec/simd_i16x8_sat_arith.wast:618: assert_malformed passed:
   (func (result v128) (i16x8.div_sat (v128.const i16x8 1 1 1 1 1 1 1 1) (v128.c...
                        ^^^^^^^^^^^^^
 out/test/spec/simd_i16x8_sat_arith.wast:623: assert_invalid passed:
-  error: type mismatch in i16x8.add_sat_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.5.wasm:0000022: error: type mismatch in i16x8.add_sat_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:624: assert_invalid passed:
-  error: type mismatch in i16x8.add_sat_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.6.wasm:0000022: error: type mismatch in i16x8.add_sat_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:625: assert_invalid passed:
-  error: type mismatch in i16x8.sub_sat_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.7.wasm:0000022: error: type mismatch in i16x8.sub_sat_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:626: assert_invalid passed:
-  error: type mismatch in i16x8.sub_sat_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.8.wasm:0000022: error: type mismatch in i16x8.sub_sat_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:631: assert_invalid passed:
-  error: type mismatch in i16x8.add_sat_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.9.wasm:000002d: error: type mismatch in i16x8.add_sat_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:639: assert_invalid passed:
-  error: type mismatch in i16x8.add_sat_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.10.wasm:000001b: error: type mismatch in i16x8.add_sat_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:647: assert_invalid passed:
-  error: type mismatch in i16x8.add_sat_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.11.wasm:000002d: error: type mismatch in i16x8.add_sat_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:655: assert_invalid passed:
-  error: type mismatch in i16x8.add_sat_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.12.wasm:000001b: error: type mismatch in i16x8.add_sat_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:663: assert_invalid passed:
-  error: type mismatch in i16x8.sub_sat_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.13.wasm:000002d: error: type mismatch in i16x8.sub_sat_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:671: assert_invalid passed:
-  error: type mismatch in i16x8.sub_sat_s, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.14.wasm:000001b: error: type mismatch in i16x8.sub_sat_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:679: assert_invalid passed:
-  error: type mismatch in i16x8.sub_sat_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.15.wasm:000002d: error: type mismatch in i16x8.sub_sat_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i16x8_sat_arith.wast:687: assert_invalid passed:
-  error: type mismatch in i16x8.sub_sat_u, expected [v128, v128] but got []
+  out/test/spec/simd_i16x8_sat_arith/simd_i16x8_sat_arith.16.wasm:000001b: error: type mismatch in i16x8.sub_sat_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 220/220 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_arith.txt
+++ b/test/spec/simd_i32x4_arith.txt
@@ -2,37 +2,37 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_arith.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_arith.wast:528: assert_invalid passed:
-  error: type mismatch in i32x4.neg, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.1.wasm:000001d: error: type mismatch in i32x4.neg, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:529: assert_invalid passed:
-  error: type mismatch in i32x4.add, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.2.wasm:0000022: error: type mismatch in i32x4.add, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:530: assert_invalid passed:
-  error: type mismatch in i32x4.sub, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.3.wasm:0000022: error: type mismatch in i32x4.sub, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:531: assert_invalid passed:
-  error: type mismatch in i32x4.mul, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.4.wasm:0000022: error: type mismatch in i32x4.mul, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:536: assert_invalid passed:
-  error: type mismatch in i32x4.neg, expected [v128] but got []
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.5.wasm:000001b: error: type mismatch in i32x4.neg, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:544: assert_invalid passed:
-  error: type mismatch in i32x4.add, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.6.wasm:000002d: error: type mismatch in i32x4.add, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:552: assert_invalid passed:
-  error: type mismatch in i32x4.add, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.7.wasm:000001b: error: type mismatch in i32x4.add, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:560: assert_invalid passed:
-  error: type mismatch in i32x4.sub, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.8.wasm:000002d: error: type mismatch in i32x4.sub, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:568: assert_invalid passed:
-  error: type mismatch in i32x4.sub, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.9.wasm:000001b: error: type mismatch in i32x4.sub, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:576: assert_invalid passed:
-  error: type mismatch in i32x4.mul, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.10.wasm:000002d: error: type mismatch in i32x4.mul, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith.wast:584: assert_invalid passed:
-  error: type mismatch in i32x4.mul, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith/simd_i32x4_arith.11.wasm:000001b: error: type mismatch in i32x4.mul, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 192/192 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_arith2.txt
+++ b/test/spec/simd_i32x4_arith2.txt
@@ -50,46 +50,46 @@ out/test/spec/simd_i32x4_arith2.wast:292: assert_malformed passed:
   (memory 1) (func (result v128) (f64x2.max_u (v128.const i32x4 0 0 0 0) (v128....
                                   ^^^^^^^^^^^
 out/test/spec/simd_i32x4_arith2.wast:295: assert_invalid passed:
-  error: type mismatch in i32x4.min_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.13.wasm:0000022: error: type mismatch in i32x4.min_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:296: assert_invalid passed:
-  error: type mismatch in i32x4.min_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.14.wasm:0000022: error: type mismatch in i32x4.min_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:297: assert_invalid passed:
-  error: type mismatch in i32x4.max_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.15.wasm:0000022: error: type mismatch in i32x4.max_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:298: assert_invalid passed:
-  error: type mismatch in i32x4.max_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.16.wasm:0000022: error: type mismatch in i32x4.max_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:299: assert_invalid passed:
-  error: type mismatch in i32x4.abs, expected [v128] but got [f32]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.17.wasm:0000020: error: type mismatch in i32x4.abs, expected [v128] but got [f32]
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:304: assert_invalid passed:
-  error: type mismatch in i32x4.min_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.18.wasm:000002d: error: type mismatch in i32x4.min_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:312: assert_invalid passed:
-  error: type mismatch in i32x4.min_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.19.wasm:000001b: error: type mismatch in i32x4.min_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:320: assert_invalid passed:
-  error: type mismatch in i32x4.min_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.20.wasm:000002d: error: type mismatch in i32x4.min_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:328: assert_invalid passed:
-  error: type mismatch in i32x4.min_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.21.wasm:000001b: error: type mismatch in i32x4.min_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:336: assert_invalid passed:
-  error: type mismatch in i32x4.max_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.22.wasm:000002d: error: type mismatch in i32x4.max_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:344: assert_invalid passed:
-  error: type mismatch in i32x4.max_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.23.wasm:000001b: error: type mismatch in i32x4.max_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:352: assert_invalid passed:
-  error: type mismatch in i32x4.max_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.24.wasm:000002d: error: type mismatch in i32x4.max_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:360: assert_invalid passed:
-  error: type mismatch in i32x4.max_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.25.wasm:000001b: error: type mismatch in i32x4.max_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_arith2.wast:368: assert_invalid passed:
-  error: type mismatch in i32x4.abs, expected [v128] but got []
+  out/test/spec/simd_i32x4_arith2/simd_i32x4_arith2.26.wasm:000001b: error: type mismatch in i32x4.abs, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 147/147 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_cmp.txt
+++ b/test/spec/simd_i32x4_cmp.txt
@@ -2,94 +2,94 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_cmp.wast:1461: assert_invalid passed:
-  error: type mismatch in i32x4.eq, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.1.wasm:0000021: error: type mismatch in i32x4.eq, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1462: assert_invalid passed:
-  error: type mismatch in i32x4.ge_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.2.wasm:0000021: error: type mismatch in i32x4.ge_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1463: assert_invalid passed:
-  error: type mismatch in i32x4.ge_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.3.wasm:0000021: error: type mismatch in i32x4.ge_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1464: assert_invalid passed:
-  error: type mismatch in i32x4.gt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.4.wasm:0000021: error: type mismatch in i32x4.gt_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1465: assert_invalid passed:
-  error: type mismatch in i32x4.gt_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.5.wasm:0000021: error: type mismatch in i32x4.gt_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1466: assert_invalid passed:
-  error: type mismatch in i32x4.le_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.6.wasm:0000021: error: type mismatch in i32x4.le_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1467: assert_invalid passed:
-  error: type mismatch in i32x4.le_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.7.wasm:0000021: error: type mismatch in i32x4.le_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1468: assert_invalid passed:
-  error: type mismatch in i32x4.lt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.8.wasm:0000021: error: type mismatch in i32x4.lt_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1469: assert_invalid passed:
-  error: type mismatch in i32x4.lt_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.9.wasm:0000021: error: type mismatch in i32x4.lt_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1470: assert_invalid passed:
-  error: type mismatch in i32x4.ne, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.10.wasm:0000021: error: type mismatch in i32x4.ne, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1749: assert_invalid passed:
-  error: type mismatch in i32x4.eq, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.12.wasm:000002c: error: type mismatch in i32x4.eq, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1757: assert_invalid passed:
-  error: type mismatch in i32x4.eq, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.13.wasm:000001a: error: type mismatch in i32x4.eq, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1765: assert_invalid passed:
-  error: type mismatch in i32x4.ne, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.14.wasm:000002c: error: type mismatch in i32x4.ne, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1773: assert_invalid passed:
-  error: type mismatch in i32x4.ne, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.15.wasm:000001a: error: type mismatch in i32x4.ne, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1781: assert_invalid passed:
-  error: type mismatch in i32x4.lt_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.16.wasm:000002c: error: type mismatch in i32x4.lt_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1789: assert_invalid passed:
-  error: type mismatch in i32x4.lt_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.17.wasm:000001a: error: type mismatch in i32x4.lt_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1797: assert_invalid passed:
-  error: type mismatch in i32x4.lt_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.18.wasm:000002c: error: type mismatch in i32x4.lt_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1805: assert_invalid passed:
-  error: type mismatch in i32x4.lt_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.19.wasm:000001a: error: type mismatch in i32x4.lt_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1813: assert_invalid passed:
-  error: type mismatch in i32x4.le_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.20.wasm:000002c: error: type mismatch in i32x4.le_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1821: assert_invalid passed:
-  error: type mismatch in i32x4.le_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.21.wasm:000001a: error: type mismatch in i32x4.le_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1829: assert_invalid passed:
-  error: type mismatch in i32x4.le_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.22.wasm:000002c: error: type mismatch in i32x4.le_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1837: assert_invalid passed:
-  error: type mismatch in i32x4.le_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.23.wasm:000001a: error: type mismatch in i32x4.le_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1845: assert_invalid passed:
-  error: type mismatch in i32x4.gt_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.24.wasm:000002c: error: type mismatch in i32x4.gt_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1853: assert_invalid passed:
-  error: type mismatch in i32x4.gt_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.25.wasm:000001a: error: type mismatch in i32x4.gt_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1861: assert_invalid passed:
-  error: type mismatch in i32x4.gt_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.26.wasm:000002c: error: type mismatch in i32x4.gt_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1869: assert_invalid passed:
-  error: type mismatch in i32x4.gt_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.27.wasm:000001a: error: type mismatch in i32x4.gt_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1877: assert_invalid passed:
-  error: type mismatch in i32x4.ge_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.28.wasm:000002c: error: type mismatch in i32x4.ge_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1885: assert_invalid passed:
-  error: type mismatch in i32x4.ge_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.29.wasm:000001a: error: type mismatch in i32x4.ge_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1893: assert_invalid passed:
-  error: type mismatch in i32x4.ge_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.30.wasm:000002c: error: type mismatch in i32x4.ge_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1901: assert_invalid passed:
-  error: type mismatch in i32x4.ge_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.31.wasm:000001a: error: type mismatch in i32x4.ge_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i32x4_cmp.wast:1910: assert_malformed passed:
   out/test/spec/simd_i32x4_cmp/simd_i32x4_cmp.32.wat:1:65: error: unexpected token "i4x32.eq", expected an instr.

--- a/test/spec/simd_i32x4_dot_i16x8.txt
+++ b/test/spec/simd_i32x4_dot_i16x8.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_dot_i16x8.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_dot_i16x8.wast:90: assert_invalid passed:
-  error: type mismatch in i32x4.dot_i16x8_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_dot_i16x8/simd_i32x4_dot_i16x8.1.wasm:0000022: error: type mismatch in i32x4.dot_i16x8_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_dot_i16x8.wast:95: assert_invalid passed:
-  error: type mismatch in i32x4.dot_i16x8_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_dot_i16x8/simd_i32x4_dot_i16x8.2.wasm:000002d: error: type mismatch in i32x4.dot_i16x8_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_dot_i16x8.wast:103: assert_invalid passed:
-  error: type mismatch in i32x4.dot_i16x8_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_dot_i16x8/simd_i32x4_dot_i16x8.3.wasm:000001b: error: type mismatch in i32x4.dot_i16x8_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 29/29 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_extadd_pairwise_i16x8.txt
+++ b/test/spec/simd_i32x4_extadd_pairwise_i16x8.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_extadd_pairwise_i16x8.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_extadd_pairwise_i16x8.wast:47: assert_invalid passed:
-  error: type mismatch in i32x4.extadd_pairwise_i16x8_s, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_extadd_pairwise_i16x8/simd_i32x4_extadd_pairwise_i16x8.1.wasm:000001c: error: type mismatch in i32x4.extadd_pairwise_i16x8_s, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_i32x4_extadd_pairwise_i16x8.wast:48: assert_invalid passed:
-  error: type mismatch in i32x4.extadd_pairwise_i16x8_u, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_extadd_pairwise_i16x8/simd_i32x4_extadd_pairwise_i16x8.2.wasm:000001c: error: type mismatch in i32x4.extadd_pairwise_i16x8_u, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_i32x4_extadd_pairwise_i16x8.wast:53: assert_invalid passed:
-  error: type mismatch in i32x4.extadd_pairwise_i16x8_s, expected [v128] but got []
+  out/test/spec/simd_i32x4_extadd_pairwise_i16x8/simd_i32x4_extadd_pairwise_i16x8.3.wasm:000001a: error: type mismatch in i32x4.extadd_pairwise_i16x8_s, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_i32x4_extadd_pairwise_i16x8.wast:61: assert_invalid passed:
-  error: type mismatch in i32x4.extadd_pairwise_i16x8_u, expected [v128] but got []
+  out/test/spec/simd_i32x4_extadd_pairwise_i16x8/simd_i32x4_extadd_pairwise_i16x8.4.wasm:000001a: error: type mismatch in i32x4.extadd_pairwise_i16x8_u, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 20/20 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_extmul_i16x8.txt
+++ b/test/spec/simd_i32x4_extmul_i16x8.txt
@@ -2,40 +2,40 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_extmul_i16x8.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_extmul_i16x8.wast:333: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_low_i16x8_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.1.wasm:0000022: error: type mismatch in i32x4.extmul_low_i16x8_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:334: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_high_i16x8_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.2.wasm:0000022: error: type mismatch in i32x4.extmul_high_i16x8_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:335: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_low_i16x8_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.3.wasm:0000022: error: type mismatch in i32x4.extmul_low_i16x8_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:336: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_high_i16x8_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.4.wasm:0000022: error: type mismatch in i32x4.extmul_high_i16x8_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:341: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_low_i16x8_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.5.wasm:000002d: error: type mismatch in i32x4.extmul_low_i16x8_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:349: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_low_i16x8_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.6.wasm:000001b: error: type mismatch in i32x4.extmul_low_i16x8_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:357: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_high_i16x8_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.7.wasm:000002d: error: type mismatch in i32x4.extmul_high_i16x8_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:365: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_high_i16x8_s, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.8.wasm:000001b: error: type mismatch in i32x4.extmul_high_i16x8_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:373: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_low_i16x8_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.9.wasm:000002d: error: type mismatch in i32x4.extmul_low_i16x8_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:381: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_low_i16x8_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.10.wasm:000001b: error: type mismatch in i32x4.extmul_low_i16x8_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:389: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_high_i16x8_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.11.wasm:000002d: error: type mismatch in i32x4.extmul_high_i16x8_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i32x4_extmul_i16x8.wast:397: assert_invalid passed:
-  error: type mismatch in i32x4.extmul_high_i16x8_u, expected [v128, v128] but got []
+  out/test/spec/simd_i32x4_extmul_i16x8/simd_i32x4_extmul_i16x8.12.wasm:000001b: error: type mismatch in i32x4.extmul_high_i16x8_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 116/116 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_trunc_sat_f32x4.txt
+++ b/test/spec/simd_i32x4_trunc_sat_f32x4.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_trunc_sat_f32x4.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_trunc_sat_f32x4.wast:218: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_trunc_sat_f32x4/simd_i32x4_trunc_sat_f32x4.1.wasm:000001d: error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got [i32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_i32x4_trunc_sat_f32x4.wast:219: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_trunc_sat_f32x4/simd_i32x4_trunc_sat_f32x4.2.wasm:000001d: error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got [i32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_i32x4_trunc_sat_f32x4.wast:224: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got []
+  out/test/spec/simd_i32x4_trunc_sat_f32x4/simd_i32x4_trunc_sat_f32x4.3.wasm:000001b: error: type mismatch in i32x4.trunc_sat_f32x4_s, expected [v128] but got []
   000001b: error: OnConvertExpr callback failed
 out/test/spec/simd_i32x4_trunc_sat_f32x4.wast:232: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got []
+  out/test/spec/simd_i32x4_trunc_sat_f32x4/simd_i32x4_trunc_sat_f32x4.4.wasm:000001b: error: type mismatch in i32x4.trunc_sat_f32x4_u, expected [v128] but got []
   000001b: error: OnConvertExpr callback failed
 106/106 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i32x4_trunc_sat_f64x2.txt
+++ b/test/spec/simd_i32x4_trunc_sat_f64x2.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i32x4_trunc_sat_f64x2.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i32x4_trunc_sat_f64x2.wast:218: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f64x2_s_zero, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_trunc_sat_f64x2/simd_i32x4_trunc_sat_f64x2.1.wasm:000001d: error: type mismatch in i32x4.trunc_sat_f64x2_s_zero, expected [v128] but got [i32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_i32x4_trunc_sat_f64x2.wast:219: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f64x2_u_zero, expected [v128] but got [i32]
+  out/test/spec/simd_i32x4_trunc_sat_f64x2/simd_i32x4_trunc_sat_f64x2.2.wasm:000001d: error: type mismatch in i32x4.trunc_sat_f64x2_u_zero, expected [v128] but got [i32]
   000001d: error: OnConvertExpr callback failed
 out/test/spec/simd_i32x4_trunc_sat_f64x2.wast:224: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f64x2_s_zero, expected [v128] but got []
+  out/test/spec/simd_i32x4_trunc_sat_f64x2/simd_i32x4_trunc_sat_f64x2.3.wasm:000001b: error: type mismatch in i32x4.trunc_sat_f64x2_s_zero, expected [v128] but got []
   000001b: error: OnConvertExpr callback failed
 out/test/spec/simd_i32x4_trunc_sat_f64x2.wast:232: assert_invalid passed:
-  error: type mismatch in i32x4.trunc_sat_f64x2_u_zero, expected [v128] but got []
+  out/test/spec/simd_i32x4_trunc_sat_f64x2/simd_i32x4_trunc_sat_f64x2.4.wasm:000001b: error: type mismatch in i32x4.trunc_sat_f64x2_u_zero, expected [v128] but got []
   000001b: error: OnConvertExpr callback failed
 106/106 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i64x2_arith.txt
+++ b/test/spec/simd_i64x2_arith.txt
@@ -2,37 +2,37 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i64x2_arith.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i64x2_arith.wast:546: assert_invalid passed:
-  error: type mismatch in i64x2.neg, expected [v128] but got [i32]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.1.wasm:000001d: error: type mismatch in i64x2.neg, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:547: assert_invalid passed:
-  error: type mismatch in i64x2.add, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.2.wasm:0000022: error: type mismatch in i64x2.add, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:548: assert_invalid passed:
-  error: type mismatch in i64x2.sub, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.3.wasm:0000022: error: type mismatch in i64x2.sub, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:549: assert_invalid passed:
-  error: type mismatch in i64x2.mul, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.4.wasm:0000022: error: type mismatch in i64x2.mul, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:554: assert_invalid passed:
-  error: type mismatch in i64x2.neg, expected [v128] but got []
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.5.wasm:000001b: error: type mismatch in i64x2.neg, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:562: assert_invalid passed:
-  error: type mismatch in i64x2.add, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.6.wasm:000002d: error: type mismatch in i64x2.add, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:570: assert_invalid passed:
-  error: type mismatch in i64x2.add, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.7.wasm:000001b: error: type mismatch in i64x2.add, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:578: assert_invalid passed:
-  error: type mismatch in i64x2.sub, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.8.wasm:000002d: error: type mismatch in i64x2.sub, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:586: assert_invalid passed:
-  error: type mismatch in i64x2.sub, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.9.wasm:000001b: error: type mismatch in i64x2.sub, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:594: assert_invalid passed:
-  error: type mismatch in i64x2.mul, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.10.wasm:000002d: error: type mismatch in i64x2.mul, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_arith.wast:602: assert_invalid passed:
-  error: type mismatch in i64x2.mul, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_arith/simd_i64x2_arith.11.wasm:000001b: error: type mismatch in i64x2.mul, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 198/198 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i64x2_arith2.txt
+++ b/test/spec/simd_i64x2_arith2.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i64x2_arith2.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i64x2_arith2.wast:59: assert_invalid passed:
-  error: type mismatch in i64x2.abs, expected [v128] but got [f32]
+  out/test/spec/simd_i64x2_arith2/simd_i64x2_arith2.1.wasm:0000020: error: type mismatch in i64x2.abs, expected [v128] but got [f32]
   0000020: error: OnUnaryExpr callback failed
 out/test/spec/simd_i64x2_arith2.wast:64: assert_invalid passed:
-  error: type mismatch in i64x2.abs, expected [v128] but got []
+  out/test/spec/simd_i64x2_arith2/simd_i64x2_arith2.2.wasm:000001b: error: type mismatch in i64x2.abs, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 23/23 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i64x2_cmp.txt
+++ b/test/spec/simd_i64x2_cmp.txt
@@ -2,34 +2,34 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i64x2_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i64x2_cmp.wast:380: assert_invalid passed:
-  error: type mismatch in i64x2.eq, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.1.wasm:0000022: error: type mismatch in i64x2.eq, expected [v128, v128] but got [i32, f32]
   0000022: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:381: assert_invalid passed:
-  error: type mismatch in i64x2.ne, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.2.wasm:0000022: error: type mismatch in i64x2.ne, expected [v128, v128] but got [i32, f32]
   0000022: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:382: assert_invalid passed:
-  error: type mismatch in i64x2.ge_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.3.wasm:0000022: error: type mismatch in i64x2.ge_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:383: assert_invalid passed:
-  error: type mismatch in i64x2.gt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.4.wasm:0000022: error: type mismatch in i64x2.gt_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:384: assert_invalid passed:
-  error: type mismatch in i64x2.le_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.5.wasm:0000022: error: type mismatch in i64x2.le_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:385: assert_invalid passed:
-  error: type mismatch in i64x2.lt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.6.wasm:0000022: error: type mismatch in i64x2.lt_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:390: assert_invalid passed:
-  error: type mismatch in i64x2.eq, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.7.wasm:000002d: error: type mismatch in i64x2.eq, expected [v128, v128] but got [v128]
   000002d: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:398: assert_invalid passed:
-  error: type mismatch in i64x2.eq, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.8.wasm:000001b: error: type mismatch in i64x2.eq, expected [v128, v128] but got []
   000001b: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:406: assert_invalid passed:
-  error: type mismatch in i64x2.ne, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.9.wasm:000002d: error: type mismatch in i64x2.ne, expected [v128, v128] but got [v128]
   000002d: error: OnCompareExpr callback failed
 out/test/spec/simd_i64x2_cmp.wast:414: assert_invalid passed:
-  error: type mismatch in i64x2.ne, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_cmp/simd_i64x2_cmp.10.wasm:000001b: error: type mismatch in i64x2.ne, expected [v128, v128] but got []
   000001b: error: OnCompareExpr callback failed
 112/112 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i64x2_extmul_i32x4.txt
+++ b/test/spec/simd_i64x2_extmul_i32x4.txt
@@ -2,40 +2,40 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i64x2_extmul_i32x4.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i64x2_extmul_i32x4.wast:333: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_low_i32x4_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.1.wasm:0000022: error: type mismatch in i64x2.extmul_low_i32x4_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:334: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_high_i32x4_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.2.wasm:0000022: error: type mismatch in i64x2.extmul_high_i32x4_s, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:335: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_low_i32x4_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.3.wasm:0000022: error: type mismatch in i64x2.extmul_low_i32x4_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:336: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_high_i32x4_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.4.wasm:0000022: error: type mismatch in i64x2.extmul_high_i32x4_u, expected [v128, v128] but got [i32, f32]
   0000022: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:341: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_low_i32x4_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.5.wasm:000002d: error: type mismatch in i64x2.extmul_low_i32x4_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:349: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_low_i32x4_s, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.6.wasm:000001b: error: type mismatch in i64x2.extmul_low_i32x4_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:357: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_high_i32x4_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.7.wasm:000002d: error: type mismatch in i64x2.extmul_high_i32x4_s, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:365: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_high_i32x4_s, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.8.wasm:000001b: error: type mismatch in i64x2.extmul_high_i32x4_s, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:373: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_low_i32x4_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.9.wasm:000002d: error: type mismatch in i64x2.extmul_low_i32x4_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:381: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_low_i32x4_u, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.10.wasm:000001b: error: type mismatch in i64x2.extmul_low_i32x4_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:389: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_high_i32x4_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.11.wasm:000002d: error: type mismatch in i64x2.extmul_high_i32x4_u, expected [v128, v128] but got [v128]
   000002d: error: OnBinaryExpr callback failed
 out/test/spec/simd_i64x2_extmul_i32x4.wast:397: assert_invalid passed:
-  error: type mismatch in i64x2.extmul_high_i32x4_u, expected [v128, v128] but got []
+  out/test/spec/simd_i64x2_extmul_i32x4/simd_i64x2_extmul_i32x4.12.wasm:000001b: error: type mismatch in i64x2.extmul_high_i32x4_u, expected [v128, v128] but got []
   000001b: error: OnBinaryExpr callback failed
 116/116 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i8x16_arith.txt
+++ b/test/spec/simd_i8x16_arith.txt
@@ -2,28 +2,28 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i8x16_arith.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i8x16_arith.wast:354: assert_invalid passed:
-  error: type mismatch in i8x16.neg, expected [v128] but got [i32]
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.1.wasm:000001c: error: type mismatch in i8x16.neg, expected [v128] but got [i32]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:355: assert_invalid passed:
-  error: type mismatch in i8x16.add, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.2.wasm:0000021: error: type mismatch in i8x16.add, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:356: assert_invalid passed:
-  error: type mismatch in i8x16.sub, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.3.wasm:0000021: error: type mismatch in i8x16.sub, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:361: assert_invalid passed:
-  error: type mismatch in i8x16.neg, expected [v128] but got []
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.4.wasm:000001a: error: type mismatch in i8x16.neg, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:369: assert_invalid passed:
-  error: type mismatch in i8x16.add, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.5.wasm:000002c: error: type mismatch in i8x16.add, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:377: assert_invalid passed:
-  error: type mismatch in i8x16.add, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.6.wasm:000001a: error: type mismatch in i8x16.add, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:385: assert_invalid passed:
-  error: type mismatch in i8x16.sub, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.7.wasm:000002c: error: type mismatch in i8x16.sub, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith.wast:393: assert_invalid passed:
-  error: type mismatch in i8x16.sub, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith/simd_i8x16_arith.8.wasm:000001a: error: type mismatch in i8x16.sub, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 129/129 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i8x16_arith2.txt
+++ b/test/spec/simd_i8x16_arith2.txt
@@ -26,61 +26,61 @@ out/test/spec/simd_i8x16_arith2.wast:383: assert_malformed passed:
   (memory 1) (func (result v128) (i8x16.avgr_s (v128.const i8x16 0 0 0 0 0 0 0 ...
                                   ^^^^^^^^^^^^
 out/test/spec/simd_i8x16_arith2.wast:386: assert_invalid passed:
-  error: type mismatch in i8x16.min_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.7.wasm:0000021: error: type mismatch in i8x16.min_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:387: assert_invalid passed:
-  error: type mismatch in i8x16.min_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.8.wasm:0000021: error: type mismatch in i8x16.min_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:388: assert_invalid passed:
-  error: type mismatch in i8x16.max_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.9.wasm:0000021: error: type mismatch in i8x16.max_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:389: assert_invalid passed:
-  error: type mismatch in i8x16.max_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.10.wasm:0000021: error: type mismatch in i8x16.max_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:390: assert_invalid passed:
-  error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.11.wasm:0000021: error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:391: assert_invalid passed:
-  error: type mismatch in i8x16.abs, expected [v128] but got [f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.12.wasm:000001f: error: type mismatch in i8x16.abs, expected [v128] but got [f32]
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:392: assert_invalid passed:
-  error: type mismatch in i8x16.popcnt, expected [v128] but got [f32]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.13.wasm:000001f: error: type mismatch in i8x16.popcnt, expected [v128] but got [f32]
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:397: assert_invalid passed:
-  error: type mismatch in i8x16.min_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.14.wasm:000002c: error: type mismatch in i8x16.min_s, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:405: assert_invalid passed:
-  error: type mismatch in i8x16.min_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.15.wasm:000001a: error: type mismatch in i8x16.min_s, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:413: assert_invalid passed:
-  error: type mismatch in i8x16.min_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.16.wasm:000002c: error: type mismatch in i8x16.min_u, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:421: assert_invalid passed:
-  error: type mismatch in i8x16.min_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.17.wasm:000001a: error: type mismatch in i8x16.min_u, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:429: assert_invalid passed:
-  error: type mismatch in i8x16.max_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.18.wasm:000002c: error: type mismatch in i8x16.max_s, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:437: assert_invalid passed:
-  error: type mismatch in i8x16.max_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.19.wasm:000001a: error: type mismatch in i8x16.max_s, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:445: assert_invalid passed:
-  error: type mismatch in i8x16.max_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.20.wasm:000002c: error: type mismatch in i8x16.max_u, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:453: assert_invalid passed:
-  error: type mismatch in i8x16.max_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.21.wasm:000001a: error: type mismatch in i8x16.max_u, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:461: assert_invalid passed:
-  error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.22.wasm:000002c: error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:469: assert_invalid passed:
-  error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.23.wasm:000001a: error: type mismatch in i8x16.avgr_u, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:477: assert_invalid passed:
-  error: type mismatch in i8x16.abs, expected [v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.24.wasm:000001a: error: type mismatch in i8x16.abs, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_i8x16_arith2.wast:485: assert_invalid passed:
-  error: type mismatch in i8x16.popcnt, expected [v128] but got []
+  out/test/spec/simd_i8x16_arith2/simd_i8x16_arith2.25.wasm:000001a: error: type mismatch in i8x16.popcnt, expected [v128] but got []
   000001a: error: OnUnaryExpr callback failed
 209/209 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i8x16_cmp.txt
+++ b/test/spec/simd_i8x16_cmp.txt
@@ -2,94 +2,94 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_i8x16_cmp.wast
 (;; STDOUT ;;;
 out/test/spec/simd_i8x16_cmp.wast:1401: assert_invalid passed:
-  error: type mismatch in i8x16.eq, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.1.wasm:0000021: error: type mismatch in i8x16.eq, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1402: assert_invalid passed:
-  error: type mismatch in i8x16.ge_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.2.wasm:0000021: error: type mismatch in i8x16.ge_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1403: assert_invalid passed:
-  error: type mismatch in i8x16.ge_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.3.wasm:0000021: error: type mismatch in i8x16.ge_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1404: assert_invalid passed:
-  error: type mismatch in i8x16.gt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.4.wasm:0000021: error: type mismatch in i8x16.gt_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1405: assert_invalid passed:
-  error: type mismatch in i8x16.gt_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.5.wasm:0000021: error: type mismatch in i8x16.gt_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1406: assert_invalid passed:
-  error: type mismatch in i8x16.le_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.6.wasm:0000021: error: type mismatch in i8x16.le_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1407: assert_invalid passed:
-  error: type mismatch in i8x16.le_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.7.wasm:0000021: error: type mismatch in i8x16.le_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1408: assert_invalid passed:
-  error: type mismatch in i8x16.lt_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.8.wasm:0000021: error: type mismatch in i8x16.lt_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1409: assert_invalid passed:
-  error: type mismatch in i8x16.lt_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.9.wasm:0000021: error: type mismatch in i8x16.lt_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1410: assert_invalid passed:
-  error: type mismatch in i8x16.ne, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.10.wasm:0000021: error: type mismatch in i8x16.ne, expected [v128, v128] but got [i32, f32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1689: assert_invalid passed:
-  error: type mismatch in i8x16.eq, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.12.wasm:000002c: error: type mismatch in i8x16.eq, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1697: assert_invalid passed:
-  error: type mismatch in i8x16.eq, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.13.wasm:000001a: error: type mismatch in i8x16.eq, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1705: assert_invalid passed:
-  error: type mismatch in i8x16.ne, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.14.wasm:000002c: error: type mismatch in i8x16.ne, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1713: assert_invalid passed:
-  error: type mismatch in i8x16.ne, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.15.wasm:000001a: error: type mismatch in i8x16.ne, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1721: assert_invalid passed:
-  error: type mismatch in i8x16.lt_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.16.wasm:000002c: error: type mismatch in i8x16.lt_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1729: assert_invalid passed:
-  error: type mismatch in i8x16.lt_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.17.wasm:000001a: error: type mismatch in i8x16.lt_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1737: assert_invalid passed:
-  error: type mismatch in i8x16.lt_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.18.wasm:000002c: error: type mismatch in i8x16.lt_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1745: assert_invalid passed:
-  error: type mismatch in i8x16.lt_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.19.wasm:000001a: error: type mismatch in i8x16.lt_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1753: assert_invalid passed:
-  error: type mismatch in i8x16.le_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.20.wasm:000002c: error: type mismatch in i8x16.le_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1761: assert_invalid passed:
-  error: type mismatch in i8x16.le_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.21.wasm:000001a: error: type mismatch in i8x16.le_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1769: assert_invalid passed:
-  error: type mismatch in i8x16.le_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.22.wasm:000002c: error: type mismatch in i8x16.le_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1777: assert_invalid passed:
-  error: type mismatch in i8x16.le_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.23.wasm:000001a: error: type mismatch in i8x16.le_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1785: assert_invalid passed:
-  error: type mismatch in i8x16.gt_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.24.wasm:000002c: error: type mismatch in i8x16.gt_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1793: assert_invalid passed:
-  error: type mismatch in i8x16.gt_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.25.wasm:000001a: error: type mismatch in i8x16.gt_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1801: assert_invalid passed:
-  error: type mismatch in i8x16.gt_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.26.wasm:000002c: error: type mismatch in i8x16.gt_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1809: assert_invalid passed:
-  error: type mismatch in i8x16.gt_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.27.wasm:000001a: error: type mismatch in i8x16.gt_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1817: assert_invalid passed:
-  error: type mismatch in i8x16.ge_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.28.wasm:000002c: error: type mismatch in i8x16.ge_s, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1825: assert_invalid passed:
-  error: type mismatch in i8x16.ge_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.29.wasm:000001a: error: type mismatch in i8x16.ge_s, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1833: assert_invalid passed:
-  error: type mismatch in i8x16.ge_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.30.wasm:000002c: error: type mismatch in i8x16.ge_u, expected [v128, v128] but got [v128]
   000002c: error: OnCompareExpr callback failed
 out/test/spec/simd_i8x16_cmp.wast:1841: assert_invalid passed:
-  error: type mismatch in i8x16.ge_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_cmp/simd_i8x16_cmp.31.wasm:000001a: error: type mismatch in i8x16.ge_u, expected [v128, v128] but got []
   000001a: error: OnCompareExpr callback failed
 443/443 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_i8x16_sat_arith.txt
+++ b/test/spec/simd_i8x16_sat_arith.txt
@@ -50,40 +50,40 @@ out/test/spec/simd_i8x16_sat_arith.wast:594: assert_malformed passed:
   (func (result v128) (f32x4.sub_sat_u (v128.const f32x4 0 0 0 0) (v128.const f...
                        ^^^^^^^^^^^^^^^
 out/test/spec/simd_i8x16_sat_arith.wast:599: assert_invalid passed:
-  error: type mismatch in i8x16.add_sat_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.13.wasm:0000021: error: type mismatch in i8x16.add_sat_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:600: assert_invalid passed:
-  error: type mismatch in i8x16.add_sat_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.14.wasm:0000021: error: type mismatch in i8x16.add_sat_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:601: assert_invalid passed:
-  error: type mismatch in i8x16.sub_sat_s, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.15.wasm:0000021: error: type mismatch in i8x16.sub_sat_s, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:602: assert_invalid passed:
-  error: type mismatch in i8x16.sub_sat_u, expected [v128, v128] but got [i32, f32]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.16.wasm:0000021: error: type mismatch in i8x16.sub_sat_u, expected [v128, v128] but got [i32, f32]
   0000021: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:607: assert_invalid passed:
-  error: type mismatch in i8x16.add_sat_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.17.wasm:000002c: error: type mismatch in i8x16.add_sat_s, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:615: assert_invalid passed:
-  error: type mismatch in i8x16.add_sat_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.18.wasm:000001a: error: type mismatch in i8x16.add_sat_s, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:623: assert_invalid passed:
-  error: type mismatch in i8x16.add_sat_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.19.wasm:000002c: error: type mismatch in i8x16.add_sat_u, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:631: assert_invalid passed:
-  error: type mismatch in i8x16.add_sat_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.20.wasm:000001a: error: type mismatch in i8x16.add_sat_u, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:639: assert_invalid passed:
-  error: type mismatch in i8x16.sub_sat_s, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.21.wasm:000002c: error: type mismatch in i8x16.sub_sat_s, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:647: assert_invalid passed:
-  error: type mismatch in i8x16.sub_sat_s, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.22.wasm:000001a: error: type mismatch in i8x16.sub_sat_s, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:655: assert_invalid passed:
-  error: type mismatch in i8x16.sub_sat_u, expected [v128, v128] but got [v128]
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.23.wasm:000002c: error: type mismatch in i8x16.sub_sat_u, expected [v128, v128] but got [v128]
   000002c: error: OnBinaryExpr callback failed
 out/test/spec/simd_i8x16_sat_arith.wast:663: assert_invalid passed:
-  error: type mismatch in i8x16.sub_sat_u, expected [v128, v128] but got []
+  out/test/spec/simd_i8x16_sat_arith/simd_i8x16_sat_arith.24.wasm:000001a: error: type mismatch in i8x16.sub_sat_u, expected [v128, v128] but got []
   000001a: error: OnBinaryExpr callback failed
 212/212 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_int_to_int_extend.txt
+++ b/test/spec/simd_int_to_int_extend.txt
@@ -2,76 +2,76 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_int_to_int_extend.wast
 (;; STDOUT ;;;
 out/test/spec/simd_int_to_int_extend.wast:488: assert_invalid passed:
-  error: type mismatch in i16x8.extend_high_i8x16_s, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.1.wasm:000001d: error: type mismatch in i16x8.extend_high_i8x16_s, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:489: assert_invalid passed:
-  error: type mismatch in i16x8.extend_high_i8x16_u, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.2.wasm:000001d: error: type mismatch in i16x8.extend_high_i8x16_u, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:490: assert_invalid passed:
-  error: type mismatch in i16x8.extend_low_i8x16_s, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.3.wasm:000001d: error: type mismatch in i16x8.extend_low_i8x16_s, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:491: assert_invalid passed:
-  error: type mismatch in i16x8.extend_low_i8x16_u, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.4.wasm:000001d: error: type mismatch in i16x8.extend_low_i8x16_u, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:492: assert_invalid passed:
-  error: type mismatch in i32x4.extend_high_i16x8_s, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.5.wasm:000001d: error: type mismatch in i32x4.extend_high_i16x8_s, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:493: assert_invalid passed:
-  error: type mismatch in i32x4.extend_high_i16x8_u, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.6.wasm:000001d: error: type mismatch in i32x4.extend_high_i16x8_u, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:494: assert_invalid passed:
-  error: type mismatch in i32x4.extend_low_i16x8_s, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.7.wasm:000001d: error: type mismatch in i32x4.extend_low_i16x8_s, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:495: assert_invalid passed:
-  error: type mismatch in i32x4.extend_low_i16x8_u, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.8.wasm:000001d: error: type mismatch in i32x4.extend_low_i16x8_u, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:496: assert_invalid passed:
-  error: type mismatch in i64x2.extend_high_i32x4_s, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.9.wasm:000001d: error: type mismatch in i64x2.extend_high_i32x4_s, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:497: assert_invalid passed:
-  error: type mismatch in i64x2.extend_high_i32x4_u, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.10.wasm:000001d: error: type mismatch in i64x2.extend_high_i32x4_u, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:498: assert_invalid passed:
-  error: type mismatch in i64x2.extend_low_i32x4_s, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.11.wasm:000001d: error: type mismatch in i64x2.extend_low_i32x4_s, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:499: assert_invalid passed:
-  error: type mismatch in i64x2.extend_low_i32x4_u, expected [v128] but got [i32]
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.12.wasm:000001d: error: type mismatch in i64x2.extend_low_i32x4_u, expected [v128] but got [i32]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:504: assert_invalid passed:
-  error: type mismatch in i16x8.extend_high_i8x16_s, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.13.wasm:000001b: error: type mismatch in i16x8.extend_high_i8x16_s, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:512: assert_invalid passed:
-  error: type mismatch in i16x8.extend_high_i8x16_u, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.14.wasm:000001b: error: type mismatch in i16x8.extend_high_i8x16_u, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:520: assert_invalid passed:
-  error: type mismatch in i16x8.extend_low_i8x16_s, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.15.wasm:000001b: error: type mismatch in i16x8.extend_low_i8x16_s, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:528: assert_invalid passed:
-  error: type mismatch in i16x8.extend_low_i8x16_u, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.16.wasm:000001b: error: type mismatch in i16x8.extend_low_i8x16_u, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:536: assert_invalid passed:
-  error: type mismatch in i32x4.extend_high_i16x8_s, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.17.wasm:000001b: error: type mismatch in i32x4.extend_high_i16x8_s, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:544: assert_invalid passed:
-  error: type mismatch in i32x4.extend_high_i16x8_u, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.18.wasm:000001b: error: type mismatch in i32x4.extend_high_i16x8_u, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:552: assert_invalid passed:
-  error: type mismatch in i32x4.extend_low_i16x8_s, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.19.wasm:000001b: error: type mismatch in i32x4.extend_low_i16x8_s, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:560: assert_invalid passed:
-  error: type mismatch in i32x4.extend_low_i16x8_u, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.20.wasm:000001b: error: type mismatch in i32x4.extend_low_i16x8_u, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:568: assert_invalid passed:
-  error: type mismatch in i64x2.extend_high_i32x4_s, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.21.wasm:000001b: error: type mismatch in i64x2.extend_high_i32x4_s, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:576: assert_invalid passed:
-  error: type mismatch in i64x2.extend_high_i32x4_u, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.22.wasm:000001b: error: type mismatch in i64x2.extend_high_i32x4_u, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:584: assert_invalid passed:
-  error: type mismatch in i64x2.extend_low_i32x4_s, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.23.wasm:000001b: error: type mismatch in i64x2.extend_low_i32x4_s, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 out/test/spec/simd_int_to_int_extend.wast:592: assert_invalid passed:
-  error: type mismatch in i64x2.extend_low_i32x4_u, expected [v128] but got []
+  out/test/spec/simd_int_to_int_extend/simd_int_to_int_extend.24.wasm:000001b: error: type mismatch in i64x2.extend_low_i32x4_u, expected [v128] but got []
   000001b: error: OnUnaryExpr callback failed
 252/252 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_lane.txt
+++ b/test/spec/simd_lane.txt
@@ -198,196 +198,196 @@ out/test/spec/simd_lane.wast:428: assert_malformed passed:
   ... (result v128) (f64x2.replace_lane 256 (v128.const f64x2 0 0) (f64.const 1)))
                                                                                  ^
 out/test/spec/simd_lane.wast:432: assert_invalid passed:
-  error: lane index must be less than 16 (got 16)
+  out/test/spec/simd_lane/simd_lane.29.wasm:000002d: error: lane index must be less than 16 (got 16)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:433: assert_invalid passed:
-  error: lane index must be less than 16 (got 255)
+  out/test/spec/simd_lane/simd_lane.30.wasm:000002d: error: lane index must be less than 16 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:434: assert_invalid passed:
-  error: lane index must be less than 16 (got 16)
+  out/test/spec/simd_lane/simd_lane.31.wasm:000002d: error: lane index must be less than 16 (got 16)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:435: assert_invalid passed:
-  error: lane index must be less than 16 (got 255)
+  out/test/spec/simd_lane/simd_lane.32.wasm:000002d: error: lane index must be less than 16 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:436: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_lane/simd_lane.33.wasm:000002d: error: lane index must be less than 8 (got 8)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:437: assert_invalid passed:
-  error: lane index must be less than 8 (got 255)
+  out/test/spec/simd_lane/simd_lane.34.wasm:000002d: error: lane index must be less than 8 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:438: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_lane/simd_lane.35.wasm:000002d: error: lane index must be less than 8 (got 8)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:439: assert_invalid passed:
-  error: lane index must be less than 8 (got 255)
+  out/test/spec/simd_lane/simd_lane.36.wasm:000002d: error: lane index must be less than 8 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:440: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.37.wasm:000002d: error: lane index must be less than 4 (got 4)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:441: assert_invalid passed:
-  error: lane index must be less than 4 (got 255)
+  out/test/spec/simd_lane/simd_lane.38.wasm:000002d: error: lane index must be less than 4 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:442: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.39.wasm:000002d: error: lane index must be less than 4 (got 4)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:443: assert_invalid passed:
-  error: lane index must be less than 4 (got 255)
+  out/test/spec/simd_lane/simd_lane.40.wasm:000002d: error: lane index must be less than 4 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:444: assert_invalid passed:
-  error: lane index must be less than 16 (got 16)
+  out/test/spec/simd_lane/simd_lane.41.wasm:000002f: error: lane index must be less than 16 (got 16)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:445: assert_invalid passed:
-  error: lane index must be less than 16 (got 255)
+  out/test/spec/simd_lane/simd_lane.42.wasm:000002f: error: lane index must be less than 16 (got 255)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:446: assert_invalid passed:
-  error: lane index must be less than 8 (got 16)
+  out/test/spec/simd_lane/simd_lane.43.wasm:000002f: error: lane index must be less than 8 (got 16)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:447: assert_invalid passed:
-  error: lane index must be less than 8 (got 255)
+  out/test/spec/simd_lane/simd_lane.44.wasm:000002f: error: lane index must be less than 8 (got 255)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:448: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.45.wasm:000002f: error: lane index must be less than 4 (got 4)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:449: assert_invalid passed:
-  error: lane index must be less than 4 (got 255)
+  out/test/spec/simd_lane/simd_lane.46.wasm:000002f: error: lane index must be less than 4 (got 255)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:450: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  out/test/spec/simd_lane/simd_lane.47.wasm:000002f: error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.47.wasm:000002f: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:451: assert_invalid passed:
-  error: lane index must be less than 4 (got 255)
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  out/test/spec/simd_lane/simd_lane.48.wasm:000002f: error: lane index must be less than 4 (got 255)
+  out/test/spec/simd_lane/simd_lane.48.wasm:000002f: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:452: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.49.wasm:000002d: error: lane index must be less than 2 (got 2)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:453: assert_invalid passed:
-  error: lane index must be less than 2 (got 255)
+  out/test/spec/simd_lane/simd_lane.50.wasm:000002d: error: lane index must be less than 2 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:454: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.51.wasm:000002d: error: lane index must be less than 2 (got 2)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:455: assert_invalid passed:
-  error: lane index must be less than 2 (got 255)
+  out/test/spec/simd_lane/simd_lane.52.wasm:000002d: error: lane index must be less than 2 (got 255)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:456: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.53.wasm:000002f: error: lane index must be less than 2 (got 2)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:457: assert_invalid passed:
-  error: lane index must be less than 2 (got 255)
+  out/test/spec/simd_lane/simd_lane.54.wasm:000002f: error: lane index must be less than 2 (got 255)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:458: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.55.wasm:0000036: error: lane index must be less than 2 (got 2)
   0000036: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:459: assert_invalid passed:
-  error: lane index must be less than 2 (got 255)
+  out/test/spec/simd_lane/simd_lane.56.wasm:0000036: error: lane index must be less than 2 (got 255)
   0000036: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:463: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_lane/simd_lane.57.wasm:000002d: error: lane index must be less than 8 (got 8)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:464: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_lane/simd_lane.58.wasm:000002d: error: lane index must be less than 8 (got 8)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:465: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.59.wasm:000002d: error: lane index must be less than 4 (got 4)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:466: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.60.wasm:000002d: error: lane index must be less than 4 (got 4)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:467: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_lane/simd_lane.61.wasm:000002f: error: lane index must be less than 8 (got 8)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:468: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.62.wasm:000002f: error: lane index must be less than 4 (got 4)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:469: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  out/test/spec/simd_lane/simd_lane.63.wasm:000002f: error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_lane/simd_lane.63.wasm:000002f: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:470: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.64.wasm:000002d: error: lane index must be less than 2 (got 2)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:471: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.65.wasm:000002d: error: lane index must be less than 2 (got 2)
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:472: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.66.wasm:000002f: error: lane index must be less than 2 (got 2)
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:473: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_lane/simd_lane.67.wasm:0000036: error: lane index must be less than 2 (got 2)
   0000036: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:477: assert_invalid passed:
-  error: type mismatch in i8x16.extract_lane_s, expected [v128] but got [i32]
+  out/test/spec/simd_lane/simd_lane.68.wasm:000001d: error: type mismatch in i8x16.extract_lane_s, expected [v128] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:478: assert_invalid passed:
-  error: type mismatch in i8x16.extract_lane_u, expected [v128] but got [i64]
+  out/test/spec/simd_lane/simd_lane.69.wasm:000001d: error: type mismatch in i8x16.extract_lane_u, expected [v128] but got [i64]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:479: assert_invalid passed:
-  error: type mismatch in i8x16.extract_lane_s, expected [v128] but got [f32]
+  out/test/spec/simd_lane/simd_lane.70.wasm:0000020: error: type mismatch in i8x16.extract_lane_s, expected [v128] but got [f32]
   0000020: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:480: assert_invalid passed:
-  error: type mismatch in i8x16.extract_lane_u, expected [v128] but got [f64]
+  out/test/spec/simd_lane/simd_lane.71.wasm:0000024: error: type mismatch in i8x16.extract_lane_u, expected [v128] but got [f64]
   0000024: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:481: assert_invalid passed:
-  error: type mismatch in i32x4.extract_lane, expected [v128] but got [i32]
+  out/test/spec/simd_lane/simd_lane.72.wasm:000001d: error: type mismatch in i32x4.extract_lane, expected [v128] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:482: assert_invalid passed:
-  error: type mismatch in f32x4.extract_lane, expected [v128] but got [f32]
+  out/test/spec/simd_lane/simd_lane.73.wasm:0000020: error: type mismatch in f32x4.extract_lane, expected [v128] but got [f32]
   0000020: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:483: assert_invalid passed:
-  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_lane/simd_lane.74.wasm:000001f: error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32, i32]
   000001f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:484: assert_invalid passed:
-  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i64, i32]
+  out/test/spec/simd_lane/simd_lane.75.wasm:000001f: error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i64, i32]
   000001f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:485: assert_invalid passed:
-  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_lane/simd_lane.76.wasm:000001f: error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32, i32]
   000001f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:486: assert_invalid passed:
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32, i32]
+  out/test/spec/simd_lane/simd_lane.77.wasm:0000022: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32, i32]
   0000022: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:487: assert_invalid passed:
-  error: type mismatch in i64x2.extract_lane, expected [v128] but got [i64]
+  out/test/spec/simd_lane/simd_lane.78.wasm:000001d: error: type mismatch in i64x2.extract_lane, expected [v128] but got [i64]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:488: assert_invalid passed:
-  error: type mismatch in f64x2.extract_lane, expected [v128] but got [f64]
+  out/test/spec/simd_lane/simd_lane.79.wasm:0000024: error: type mismatch in f64x2.extract_lane, expected [v128] but got [f64]
   0000024: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:489: assert_invalid passed:
-  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32, i32]
+  out/test/spec/simd_lane/simd_lane.80.wasm:000001f: error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32, i32]
   000001f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:490: assert_invalid passed:
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32, i32]
+  out/test/spec/simd_lane/simd_lane.81.wasm:0000022: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32, i32]
   0000022: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:494: assert_invalid passed:
-  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [v128, f32]
+  out/test/spec/simd_lane/simd_lane.82.wasm:0000032: error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [v128, f32]
   0000032: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:495: assert_invalid passed:
-  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [v128, f64]
+  out/test/spec/simd_lane/simd_lane.83.wasm:0000036: error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [v128, f64]
   0000036: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:496: assert_invalid passed:
-  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [v128, f32]
+  out/test/spec/simd_lane/simd_lane.84.wasm:0000032: error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [v128, f32]
   0000032: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:497: assert_invalid passed:
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
+  out/test/spec/simd_lane/simd_lane.85.wasm:000002f: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128, i32]
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:499: assert_invalid passed:
-  error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [v128, f64]
+  out/test/spec/simd_lane/simd_lane.86.wasm:0000036: error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [v128, f64]
   0000036: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:500: assert_invalid passed:
-  error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [v128, i64]
+  out/test/spec/simd_lane/simd_lane.87.wasm:000002f: error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [v128, i64]
   000002f: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:503: assert_invalid passed:
-  error: type mismatch in i8x16.swizzle, expected [v128, v128] but got [i32, v128]
+  out/test/spec/simd_lane/simd_lane.88.wasm:000002e: error: type mismatch in i8x16.swizzle, expected [v128, v128] but got [i32, v128]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_lane.wast:505: assert_invalid passed:
-  error: type mismatch in i8x16.swizzle, expected [v128, v128] but got [v128, i32]
+  out/test/spec/simd_lane/simd_lane.89.wasm:000002e: error: type mismatch in i8x16.swizzle, expected [v128, v128] but got [v128, i32]
   000002e: error: OnBinaryExpr callback failed
 out/test/spec/simd_lane.wast:507: assert_invalid passed:
-  error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [f32, v128]
+  out/test/spec/simd_lane/simd_lane.90.wasm:0000041: error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [f32, v128]
   0000041: error: OnSimdShuffleOpExpr callback failed
 out/test/spec/simd_lane.wast:510: assert_invalid passed:
-  error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [v128, f32]
+  out/test/spec/simd_lane/simd_lane.91.wasm:0000041: error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [v128, f32]
   0000041: error: OnSimdShuffleOpExpr callback failed
 out/test/spec/simd_lane.wast:515: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.92.wat:1:83: error: unexpected token "(", expected a natural number in range [0, 32).
@@ -418,7 +418,7 @@ out/test/spec/simd_lane.wast:525: assert_malformed passed:
   ... 8 7 6 5 4 3 2 1 0)(v128.const i8x16 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15)))
                                                                                  ^
 out/test/spec/simd_lane.wast:529: assert_invalid passed:
-  error: lane index must be less than 32 (got 255)
+  out/test/spec/simd_lane/simd_lane.96.wasm:000004e: error: lane index must be less than 32 (got 255)
   000004e: error: OnSimdShuffleOpExpr callback failed
 out/test/spec/simd_lane.wast:536: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.97.wat:1:21: error: unexpected token "i8x16.extract_lane", expected an instr.
@@ -725,7 +725,7 @@ out/test/spec/simd_lane.wast:902: assert_malformed passed:
   ...)  (i8x16.extract_lane_s (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0)))
                                                                                 ^
 out/test/spec/simd_lane.wast:910: assert_invalid passed:
-  error: type mismatch in i8x16.extract_lane_s, expected [v128] but got []
+  out/test/spec/simd_lane/simd_lane.157.wasm:000001b: error: type mismatch in i8x16.extract_lane_s, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:918: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.158.wat:1:74: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -739,7 +739,7 @@ out/test/spec/simd_lane.wast:926: assert_malformed passed:
   ...mpty (result i32)  (i16x8.extract_lane_u (v128.const i16x8 0 0 0 0 0 0 0 0)))
                                                                                 ^
 out/test/spec/simd_lane.wast:934: assert_invalid passed:
-  error: type mismatch in i16x8.extract_lane_u, expected [v128] but got []
+  out/test/spec/simd_lane/simd_lane.160.wasm:000001b: error: type mismatch in i16x8.extract_lane_u, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:942: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.161.wat:1:74: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -753,7 +753,7 @@ out/test/spec/simd_lane.wast:950: assert_malformed passed:
   ...-1st-arg-empty (result i32)  (i32x4.extract_lane (v128.const i32x4 0 0 0 0)))
                                                                                 ^
 out/test/spec/simd_lane.wast:958: assert_invalid passed:
-  error: type mismatch in i32x4.extract_lane, expected [v128] but got []
+  out/test/spec/simd_lane/simd_lane.163.wasm:000001b: error: type mismatch in i32x4.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:966: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.164.wat:1:70: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -767,7 +767,7 @@ out/test/spec/simd_lane.wast:974: assert_malformed passed:
   ...lane-1st-arg-empty (result i64)  (i64x2.extract_lane (v128.const i64x2 0 0)))
                                                                                 ^
 out/test/spec/simd_lane.wast:982: assert_invalid passed:
-  error: type mismatch in i64x2.extract_lane, expected [v128] but got []
+  out/test/spec/simd_lane/simd_lane.166.wasm:000001b: error: type mismatch in i64x2.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:990: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.167.wat:1:70: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -781,7 +781,7 @@ out/test/spec/simd_lane.wast:998: assert_malformed passed:
   ...-1st-arg-empty (result f32)  (f32x4.extract_lane (v128.const f32x4 0 0 0 0)))
                                                                                 ^
 out/test/spec/simd_lane.wast:1006: assert_invalid passed:
-  error: type mismatch in f32x4.extract_lane, expected [v128] but got []
+  out/test/spec/simd_lane/simd_lane.169.wasm:000001b: error: type mismatch in f32x4.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1014: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.170.wat:1:70: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -795,7 +795,7 @@ out/test/spec/simd_lane.wast:1022: assert_malformed passed:
   ...lane-1st-arg-empty (result f64)  (f64x2.extract_lane (v128.const f64x2 0 0)))
                                                                                 ^
 out/test/spec/simd_lane.wast:1030: assert_invalid passed:
-  error: type mismatch in f64x2.extract_lane, expected [v128] but got []
+  out/test/spec/simd_lane/simd_lane.172.wasm:000001b: error: type mismatch in f64x2.extract_lane, expected [v128] but got []
   000001b: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1038: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.173.wat:1:70: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -809,10 +809,10 @@ out/test/spec/simd_lane.wast:1046: assert_malformed passed:
   ...place_lane (v128.const i8x16 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0) (i32.const 1)))
                                                                    ^
 out/test/spec/simd_lane.wast:1054: assert_invalid passed:
-  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32]
+  out/test/spec/simd_lane/simd_lane.175.wasm:000001d: error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1062: assert_invalid passed:
-  error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [v128]
+  out/test/spec/simd_lane/simd_lane.176.wasm:000002d: error: type mismatch in i8x16.replace_lane, expected [v128, i32] but got [v128]
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1070: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.177.wat:1:71: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -826,10 +826,10 @@ out/test/spec/simd_lane.wast:1078: assert_malformed passed:
   ...v128)  (i16x8.replace_lane (v128.const i16x8 0 0 0 0 0 0 0 0) (i32.const 1)))
                                                                    ^
 out/test/spec/simd_lane.wast:1086: assert_invalid passed:
-  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i32]
+  out/test/spec/simd_lane/simd_lane.179.wasm:000001d: error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1094: assert_invalid passed:
-  error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [v128]
+  out/test/spec/simd_lane/simd_lane.180.wasm:000002d: error: type mismatch in i16x8.replace_lane, expected [v128, i32] but got [v128]
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1102: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.181.wat:1:71: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -843,10 +843,10 @@ out/test/spec/simd_lane.wast:1110: assert_malformed passed:
   ...(result v128)  (i32x4.replace_lane (v128.const i32x4 0 0 0 0) (i32.const 1)))
                                                                    ^
 out/test/spec/simd_lane.wast:1118: assert_invalid passed:
-  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32]
+  out/test/spec/simd_lane/simd_lane.183.wasm:000001d: error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [i32]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1126: assert_invalid passed:
-  error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [v128]
+  out/test/spec/simd_lane/simd_lane.184.wasm:000002d: error: type mismatch in i32x4.replace_lane, expected [v128, i32] but got [v128]
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1134: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.185.wat:1:71: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -860,10 +860,10 @@ out/test/spec/simd_lane.wast:1142: assert_malformed passed:
   ...esult v128)  (f32x4.replace_lane (v128.const f32x4 0 0 0 0) (f32.const 1.0)))
                                                                  ^
 out/test/spec/simd_lane.wast:1150: assert_invalid passed:
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32]
+  out/test/spec/simd_lane/simd_lane.187.wasm:0000020: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [f32]
   0000020: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1158: assert_invalid passed:
-  error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128]
+  out/test/spec/simd_lane/simd_lane.188.wasm:000002d: error: type mismatch in f32x4.replace_lane, expected [v128, f32] but got [v128]
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1166: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.189.wat:1:71: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -877,10 +877,10 @@ out/test/spec/simd_lane.wast:1174: assert_malformed passed:
   ...pty (result v128)  (i64x2.replace_lane (v128.const i64x2 0 0) (i64.const 1)))
                                                                    ^
 out/test/spec/simd_lane.wast:1182: assert_invalid passed:
-  error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [i64]
+  out/test/spec/simd_lane/simd_lane.191.wasm:000001d: error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [i64]
   000001d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1190: assert_invalid passed:
-  error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [v128]
+  out/test/spec/simd_lane/simd_lane.192.wasm:000002d: error: type mismatch in i64x2.replace_lane, expected [v128, i64] but got [v128]
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1198: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.193.wat:1:71: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -894,10 +894,10 @@ out/test/spec/simd_lane.wast:1206: assert_malformed passed:
   ...y (result v128)  (f64x2.replace_lane (v128.const f64x2 0 0) (f64.const 1.0)))
                                                                  ^
 out/test/spec/simd_lane.wast:1214: assert_invalid passed:
-  error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [f64]
+  out/test/spec/simd_lane/simd_lane.195.wasm:0000024: error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [f64]
   0000024: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1222: assert_invalid passed:
-  error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [v128]
+  out/test/spec/simd_lane/simd_lane.196.wasm:000002d: error: type mismatch in f64x2.replace_lane, expected [v128, f64] but got [v128]
   000002d: error: OnSimdLaneOpExpr callback failed
 out/test/spec/simd_lane.wast:1230: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.197.wat:1:71: error: unexpected token ")", expected a natural number in range [0, 32).
@@ -911,7 +911,7 @@ out/test/spec/simd_lane.wast:1238: assert_malformed passed:
   ... 3 5 6 6 7 8 9 10 11 12 13 14 15)    (v128.const i8x16 1 2 3 5 6 6 7 8 9 1...
                                           ^
 out/test/spec/simd_lane.wast:1249: assert_invalid passed:
-  error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [v128]
+  out/test/spec/simd_lane/simd_lane.199.wasm:000003c: error: type mismatch in i8x16.shuffle, expected [v128, v128] but got [v128]
   000003c: error: OnSimdShuffleOpExpr callback failed
 out/test/spec/simd_lane.wast:1259: assert_malformed passed:
   out/test/spec/simd_lane/simd_lane.200.wat:1:61: error: unexpected token ")", expected a natural number in range [0, 32).

--- a/test/spec/simd_load.txt
+++ b/test/spec/simd_load.txt
@@ -23,19 +23,19 @@ out/test/spec/simd_load.wast:155: assert_malformed passed:
   (memory 1)(func (local v128) (drop (v128.load32 (i32.const 0))))
                                                                 ^
 out/test/spec/simd_load.wast:166: assert_invalid passed:
-  error: type mismatch in v128.load, expected [i32] but got [f32]
+  out/test/spec/simd_load/simd_load.17.wasm:0000027: error: type mismatch in v128.load, expected [i32] but got [f32]
   0000027: error: OnLoadExpr callback failed
 out/test/spec/simd_load.wast:170: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [v128]
+  out/test/spec/simd_load/simd_load.18.wasm:0000028: error: type mismatch in br_if, expected [i32] but got [v128]
   0000028: error: OnBrIfExpr callback failed
 out/test/spec/simd_load.wast:174: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [v128]
+  out/test/spec/simd_load/simd_load.19.wasm:0000024: error: type mismatch in function, expected [] but got [v128]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/simd_load.wast:182: assert_invalid passed:
   0000000: error: local variable out of range (max 0)
   000001e: error: OnLocalGetExpr callback failed
 out/test/spec/simd_load.wast:186: assert_invalid passed:
-  error: type mismatch in v128.load, expected [i32] but got []
+  out/test/spec/simd_load/simd_load.21.wasm:0000020: error: type mismatch in v128.load, expected [i32] but got []
   0000020: error: OnLoadExpr callback failed
 25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load16_lane.txt
+++ b/test/spec/simd_load16_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_load16_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_load16_lane.wast:195: assert_invalid passed:
-  error: type mismatch in v128.load16_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_load16_lane/simd_load16_lane.1.wasm:0000027: error: type mismatch in v128.load16_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load16_lane.wast:201: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_load16_lane/simd_load16_lane.2.wasm:0000027: error: lane index must be less than 8 (got 8)
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load16_lane.wast:208: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/simd_load16_lane/simd_load16_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (2)
   0000027: error: OnSimdLoadLaneExpr callback failed
 35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load32_lane.txt
+++ b/test/spec/simd_load32_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_load32_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_load32_lane.wast:127: assert_invalid passed:
-  error: type mismatch in v128.load32_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_load32_lane/simd_load32_lane.1.wasm:0000027: error: type mismatch in v128.load32_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load32_lane.wast:133: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_load32_lane/simd_load32_lane.2.wasm:0000027: error: lane index must be less than 4 (got 4)
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load32_lane.wast:140: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/simd_load32_lane/simd_load32_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (4)
   0000027: error: OnSimdLoadLaneExpr callback failed
 23/23 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load64_lane.txt
+++ b/test/spec/simd_load64_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_load64_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_load64_lane.wast:81: assert_invalid passed:
-  error: type mismatch in v128.load64_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_load64_lane/simd_load64_lane.1.wasm:0000027: error: type mismatch in v128.load64_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load64_lane.wast:87: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_load64_lane/simd_load64_lane.2.wasm:0000027: error: lane index must be less than 2 (got 2)
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load64_lane.wast:94: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_load64_lane/simd_load64_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (8)
   0000027: error: OnSimdLoadLaneExpr callback failed
 15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load8_lane.txt
+++ b/test/spec/simd_load8_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_load8_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_load8_lane.wast:283: assert_invalid passed:
-  error: type mismatch in v128.load8_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_load8_lane/simd_load8_lane.1.wasm:0000027: error: type mismatch in v128.load8_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load8_lane.wast:289: assert_invalid passed:
-  error: lane index must be less than 16 (got 16)
+  out/test/spec/simd_load8_lane/simd_load8_lane.2.wasm:0000027: error: lane index must be less than 16 (got 16)
   0000027: error: OnSimdLoadLaneExpr callback failed
 out/test/spec/simd_load8_lane.wast:296: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/simd_load8_lane/simd_load8_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (1)
   0000027: error: OnSimdLoadLaneExpr callback failed
 51/51 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load_extend.txt
+++ b/test/spec/simd_load_extend.txt
@@ -14,40 +14,40 @@ out/test/spec/simd_load_extend.wast:236: assert_trap passed: out of bounds memor
 out/test/spec/simd_load_extend.wast:237: assert_trap passed: out of bounds memory access: access at 4294967296+8 >= max value 65536
 out/test/spec/simd_load_extend.wast:238: assert_trap passed: out of bounds memory access: access at 4294967296+8 >= max value 65536
 out/test/spec/simd_load_extend.wast:241: assert_invalid passed:
-  error: type mismatch in v128.load8x8_s, expected [i32] but got [f32]
+  out/test/spec/simd_load_extend/simd_load_extend.1.wasm:0000026: error: type mismatch in v128.load8x8_s, expected [i32] but got [f32]
   0000026: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:242: assert_invalid passed:
-  error: type mismatch in v128.load8x8_u, expected [i32] but got [f32]
+  out/test/spec/simd_load_extend/simd_load_extend.2.wasm:0000026: error: type mismatch in v128.load8x8_u, expected [i32] but got [f32]
   0000026: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:243: assert_invalid passed:
-  error: type mismatch in v128.load16x4_s, expected [i32] but got [f64]
+  out/test/spec/simd_load_extend/simd_load_extend.3.wasm:000002a: error: type mismatch in v128.load16x4_s, expected [i32] but got [f64]
   000002a: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:244: assert_invalid passed:
-  error: type mismatch in v128.load16x4_u, expected [i32] but got [f64]
+  out/test/spec/simd_load_extend/simd_load_extend.4.wasm:000002a: error: type mismatch in v128.load16x4_u, expected [i32] but got [f64]
   000002a: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:245: assert_invalid passed:
-  error: type mismatch in v128.load32x2_s, expected [i32] but got [v128]
+  out/test/spec/simd_load_extend/simd_load_extend.5.wasm:0000033: error: type mismatch in v128.load32x2_s, expected [i32] but got [v128]
   0000033: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:246: assert_invalid passed:
-  error: type mismatch in v128.load32x2_u, expected [i32] but got [v128]
+  out/test/spec/simd_load_extend/simd_load_extend.6.wasm:0000033: error: type mismatch in v128.load32x2_u, expected [i32] but got [v128]
   0000033: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:251: assert_invalid passed:
-  error: type mismatch in v128.load8x8_s, expected [i32] but got []
+  out/test/spec/simd_load_extend/simd_load_extend.7.wasm:0000021: error: type mismatch in v128.load8x8_s, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:259: assert_invalid passed:
-  error: type mismatch in v128.load8x8_u, expected [i32] but got []
+  out/test/spec/simd_load_extend/simd_load_extend.8.wasm:0000021: error: type mismatch in v128.load8x8_u, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:267: assert_invalid passed:
-  error: type mismatch in v128.load16x4_s, expected [i32] but got []
+  out/test/spec/simd_load_extend/simd_load_extend.9.wasm:0000021: error: type mismatch in v128.load16x4_s, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:275: assert_invalid passed:
-  error: type mismatch in v128.load16x4_u, expected [i32] but got []
+  out/test/spec/simd_load_extend/simd_load_extend.10.wasm:0000021: error: type mismatch in v128.load16x4_u, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:283: assert_invalid passed:
-  error: type mismatch in v128.load32x2_s, expected [i32] but got []
+  out/test/spec/simd_load_extend/simd_load_extend.11.wasm:0000021: error: type mismatch in v128.load32x2_s, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:291: assert_invalid passed:
-  error: type mismatch in v128.load32x2_u, expected [i32] but got []
+  out/test/spec/simd_load_extend/simd_load_extend.12.wasm:0000021: error: type mismatch in v128.load32x2_u, expected [i32] but got []
   0000021: error: OnLoadExpr callback failed
 out/test/spec/simd_load_extend.wast:301: assert_malformed passed:
   out/test/spec/simd_load_extend/simd_load_extend.13.wat:1:25: error: unexpected token "i16x8.load16x4_s", expected an expr.

--- a/test/spec/simd_load_splat.txt
+++ b/test/spec/simd_load_splat.txt
@@ -34,16 +34,16 @@ out/test/spec/simd_load_splat.wast:151: assert_trap passed: out of bounds memory
 out/test/spec/simd_load_splat.wast:152: assert_trap passed: out of bounds memory access: access at 65534+4 >= max value 65536
 out/test/spec/simd_load_splat.wast:153: assert_trap passed: out of bounds memory access: access at 65530+8 >= max value 65536
 out/test/spec/simd_load_splat.wast:214: assert_invalid passed:
-  error: type mismatch in v128.load8_splat, expected [i32] but got [v128]
+  out/test/spec/simd_load_splat/simd_load_splat.2.wasm:0000033: error: type mismatch in v128.load8_splat, expected [i32] but got [v128]
   0000033: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:215: assert_invalid passed:
-  error: type mismatch in v128.load16_splat, expected [i32] but got [v128]
+  out/test/spec/simd_load_splat/simd_load_splat.3.wasm:0000033: error: type mismatch in v128.load16_splat, expected [i32] but got [v128]
   0000033: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:216: assert_invalid passed:
-  error: type mismatch in v128.load32_splat, expected [i32] but got [v128]
+  out/test/spec/simd_load_splat/simd_load_splat.4.wasm:0000033: error: type mismatch in v128.load32_splat, expected [i32] but got [v128]
   0000033: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:217: assert_invalid passed:
-  error: type mismatch in v128.load64_splat, expected [i32] but got [v128]
+  out/test/spec/simd_load_splat/simd_load_splat.5.wasm:0000033: error: type mismatch in v128.load64_splat, expected [i32] but got [v128]
   0000033: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:222: assert_malformed passed:
   out/test/spec/simd_load_splat/simd_load_splat.6.wat:1:25: error: unexpected token "i8x16.load_splat", expected an expr.
@@ -74,16 +74,16 @@ out/test/spec/simd_load_splat.wast:225: assert_malformed passed:
   (memory 1) (func (drop (i64x2.load_splat (i32.const 0))))
                                                          ^
 out/test/spec/simd_load_splat.wast:231: assert_invalid passed:
-  error: type mismatch in v128.load8_splat, expected [i32] but got []
+  out/test/spec/simd_load_splat/simd_load_splat.10.wasm:0000021: error: type mismatch in v128.load8_splat, expected [i32] but got []
   0000021: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:239: assert_invalid passed:
-  error: type mismatch in v128.load16_splat, expected [i32] but got []
+  out/test/spec/simd_load_splat/simd_load_splat.11.wasm:0000021: error: type mismatch in v128.load16_splat, expected [i32] but got []
   0000021: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:247: assert_invalid passed:
-  error: type mismatch in v128.load32_splat, expected [i32] but got []
+  out/test/spec/simd_load_splat/simd_load_splat.12.wasm:0000021: error: type mismatch in v128.load32_splat, expected [i32] but got []
   0000021: error: OnLoadSplatExpr callback failed
 out/test/spec/simd_load_splat.wast:255: assert_invalid passed:
-  error: type mismatch in v128.load64_splat, expected [i32] but got []
+  out/test/spec/simd_load_splat/simd_load_splat.13.wasm:0000021: error: type mismatch in v128.load64_splat, expected [i32] but got []
   0000021: error: OnLoadSplatExpr callback failed
 124/124 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load_zero.txt
+++ b/test/spec/simd_load_zero.txt
@@ -6,16 +6,16 @@ out/test/spec/simd_load_zero.wast:89: assert_trap passed: out of bounds memory a
 out/test/spec/simd_load_zero.wast:91: assert_trap passed: out of bounds memory access: access at 4294967296+4 >= max value 65536
 out/test/spec/simd_load_zero.wast:92: assert_trap passed: out of bounds memory access: access at 4294967296+8 >= max value 65536
 out/test/spec/simd_load_zero.wast:95: assert_invalid passed:
-  error: type mismatch in v128.load32_zero, expected [i32] but got [f32]
+  out/test/spec/simd_load_zero/simd_load_zero.1.wasm:0000026: error: type mismatch in v128.load32_zero, expected [i32] but got [f32]
   0000026: error: OnLoadZeroExpr callback failed
 out/test/spec/simd_load_zero.wast:96: assert_invalid passed:
-  error: type mismatch in v128.load64_zero, expected [i32] but got [f32]
+  out/test/spec/simd_load_zero/simd_load_zero.2.wasm:0000026: error: type mismatch in v128.load64_zero, expected [i32] but got [f32]
   0000026: error: OnLoadZeroExpr callback failed
 out/test/spec/simd_load_zero.wast:101: assert_invalid passed:
-  error: type mismatch in v128.load32_zero, expected [i32] but got []
+  out/test/spec/simd_load_zero/simd_load_zero.3.wasm:0000021: error: type mismatch in v128.load32_zero, expected [i32] but got []
   0000021: error: OnLoadZeroExpr callback failed
 out/test/spec/simd_load_zero.wast:109: assert_invalid passed:
-  error: type mismatch in v128.load64_zero, expected [i32] but got []
+  out/test/spec/simd_load_zero/simd_load_zero.4.wasm:0000021: error: type mismatch in v128.load64_zero, expected [i32] but got []
   0000021: error: OnLoadZeroExpr callback failed
 out/test/spec/simd_load_zero.wast:119: assert_malformed passed:
   out/test/spec/simd_load_zero/simd_load_zero.5.wat:1:25: error: unexpected token "i16x8.load16x4_s", expected an expr.

--- a/test/spec/simd_splat.txt
+++ b/test/spec/simd_splat.txt
@@ -6,70 +6,70 @@ out/test/spec/simd_splat.wast:122: assert_malformed passed:
   (func (result v128) (v128.splat (i32.const 0)))
                        ^^^^^^^^^^
 out/test/spec/simd_splat.wast:127: assert_invalid passed:
-  error: type mismatch in i8x16.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.2.wasm:000001a: error: type mismatch in i8x16.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:128: assert_invalid passed:
-  error: type mismatch in i8x16.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.3.wasm:000001a: error: type mismatch in i8x16.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:129: assert_invalid passed:
-  error: type mismatch in i8x16.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.4.wasm:000001a: error: type mismatch in i8x16.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:130: assert_invalid passed:
-  error: type mismatch in i16x8.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.5.wasm:000001a: error: type mismatch in i16x8.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:131: assert_invalid passed:
-  error: type mismatch in i16x8.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.6.wasm:000001a: error: type mismatch in i16x8.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:132: assert_invalid passed:
-  error: type mismatch in i16x8.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.7.wasm:000001a: error: type mismatch in i16x8.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:133: assert_invalid passed:
-  error: type mismatch in i32x4.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.8.wasm:000001a: error: type mismatch in i32x4.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:134: assert_invalid passed:
-  error: type mismatch in i32x4.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.9.wasm:000001a: error: type mismatch in i32x4.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:135: assert_invalid passed:
-  error: type mismatch in i32x4.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.10.wasm:000001a: error: type mismatch in i32x4.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:136: assert_invalid passed:
-  error: type mismatch in f32x4.splat, expected [f32] but got []
+  out/test/spec/simd_splat/simd_splat.11.wasm:000001a: error: type mismatch in f32x4.splat, expected [f32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:137: assert_invalid passed:
-  error: type mismatch in f32x4.splat, expected [f32] but got []
+  out/test/spec/simd_splat/simd_splat.12.wasm:000001a: error: type mismatch in f32x4.splat, expected [f32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:138: assert_invalid passed:
-  error: type mismatch in f32x4.splat, expected [f32] but got []
+  out/test/spec/simd_splat/simd_splat.13.wasm:000001a: error: type mismatch in f32x4.splat, expected [f32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:139: assert_invalid passed:
-  error: type mismatch in i64x2.splat, expected [i64] but got []
+  out/test/spec/simd_splat/simd_splat.14.wasm:000001a: error: type mismatch in i64x2.splat, expected [i64] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:140: assert_invalid passed:
-  error: type mismatch in i64x2.splat, expected [i64] but got []
+  out/test/spec/simd_splat/simd_splat.15.wasm:000001a: error: type mismatch in i64x2.splat, expected [i64] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:141: assert_invalid passed:
-  error: type mismatch in f64x2.splat, expected [f64] but got []
+  out/test/spec/simd_splat/simd_splat.16.wasm:000001a: error: type mismatch in f64x2.splat, expected [f64] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:142: assert_invalid passed:
-  error: type mismatch in f64x2.splat, expected [f64] but got []
+  out/test/spec/simd_splat/simd_splat.17.wasm:000001a: error: type mismatch in f64x2.splat, expected [f64] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:384: assert_invalid passed:
-  error: type mismatch in i8x16.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.21.wasm:000001a: error: type mismatch in i8x16.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:392: assert_invalid passed:
-  error: type mismatch in i16x8.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.22.wasm:000001a: error: type mismatch in i16x8.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:400: assert_invalid passed:
-  error: type mismatch in i32x4.splat, expected [i32] but got []
+  out/test/spec/simd_splat/simd_splat.23.wasm:000001a: error: type mismatch in i32x4.splat, expected [i32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:408: assert_invalid passed:
-  error: type mismatch in f32x4.splat, expected [f32] but got []
+  out/test/spec/simd_splat/simd_splat.24.wasm:000001a: error: type mismatch in f32x4.splat, expected [f32] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:416: assert_invalid passed:
-  error: type mismatch in i64x2.splat, expected [i64] but got []
+  out/test/spec/simd_splat/simd_splat.25.wasm:000001a: error: type mismatch in i64x2.splat, expected [i64] but got []
   000001a: error: OnUnaryExpr callback failed
 out/test/spec/simd_splat.wast:424: assert_invalid passed:
-  error: type mismatch in f64x2.splat, expected [f64] but got []
+  out/test/spec/simd_splat/simd_splat.26.wasm:000001a: error: type mismatch in f64x2.splat, expected [f64] but got []
   000001a: error: OnUnaryExpr callback failed
 181/181 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_store.txt
+++ b/test/spec/simd_store.txt
@@ -14,22 +14,22 @@ out/test/spec/simd_store.wast:117: assert_malformed passed:
   (memory 1)(func (v128.store32 (i32.const 0) (v128.const i32x4 0 0 0 0)))
                    ^^^^^^^^^^^^
 out/test/spec/simd_store.wast:128: assert_invalid passed:
-  error: type mismatch in v128.store, expected [i32, v128] but got [f32, v128]
+  out/test/spec/simd_store/simd_store.5.wasm:0000037: error: type mismatch in v128.store, expected [i32, v128] but got [f32, v128]
   0000037: error: OnStoreExpr callback failed
 out/test/spec/simd_store.wast:132: assert_invalid passed:
-  error: type mismatch in v128.store, expected [i32, v128] but got []
+  out/test/spec/simd_store/simd_store.6.wasm:0000024: error: type mismatch in v128.store, expected [i32, v128] but got []
   0000024: error: OnStoreExpr callback failed
 out/test/spec/simd_store.wast:136: assert_invalid passed:
-  error: type mismatch in implicit return, expected [v128] but got []
+  out/test/spec/simd_store/simd_store.7.wasm:0000035: error: type mismatch in implicit return, expected [v128] but got []
   0000036: error: EndFunctionBody callback failed
 out/test/spec/simd_store.wast:144: assert_invalid passed:
-  error: type mismatch in v128.store, expected [i32, v128] but got [v128]
+  out/test/spec/simd_store/simd_store.8.wasm:0000032: error: type mismatch in v128.store, expected [i32, v128] but got [v128]
   0000032: error: OnStoreExpr callback failed
 out/test/spec/simd_store.wast:152: assert_invalid passed:
-  error: type mismatch in v128.store, expected [i32, v128] but got [i32]
+  out/test/spec/simd_store/simd_store.9.wasm:0000022: error: type mismatch in v128.store, expected [i32, v128] but got [i32]
   0000022: error: OnStoreExpr callback failed
 out/test/spec/simd_store.wast:160: assert_invalid passed:
-  error: type mismatch in v128.store, expected [i32, v128] but got []
+  out/test/spec/simd_store/simd_store.10.wasm:0000020: error: type mismatch in v128.store, expected [i32, v128] but got []
   0000020: error: OnStoreExpr callback failed
 26/26 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_store16_lane.txt
+++ b/test/spec/simd_store16_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_store16_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_store16_lane.wast:283: assert_invalid passed:
-  error: type mismatch in v128.store16_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_store16_lane/simd_store16_lane.1.wasm:0000027: error: type mismatch in v128.store16_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store16_lane.wast:289: assert_invalid passed:
-  error: lane index must be less than 8 (got 8)
+  out/test/spec/simd_store16_lane/simd_store16_lane.2.wasm:0000027: error: lane index must be less than 8 (got 8)
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store16_lane.wast:296: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (2)
+  out/test/spec/simd_store16_lane/simd_store16_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (2)
   0000027: error: OnSimdStoreLaneExpr callback failed
 35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_store32_lane.txt
+++ b/test/spec/simd_store32_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_store32_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_store32_lane.wast:183: assert_invalid passed:
-  error: type mismatch in v128.store32_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_store32_lane/simd_store32_lane.1.wasm:0000027: error: type mismatch in v128.store32_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store32_lane.wast:189: assert_invalid passed:
-  error: lane index must be less than 4 (got 4)
+  out/test/spec/simd_store32_lane/simd_store32_lane.2.wasm:0000027: error: lane index must be less than 4 (got 4)
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store32_lane.wast:196: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (4)
+  out/test/spec/simd_store32_lane/simd_store32_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (4)
   0000027: error: OnSimdStoreLaneExpr callback failed
 23/23 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_store64_lane.txt
+++ b/test/spec/simd_store64_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_store64_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_store64_lane.wast:115: assert_invalid passed:
-  error: type mismatch in v128.store64_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_store64_lane/simd_store64_lane.1.wasm:0000027: error: type mismatch in v128.store64_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store64_lane.wast:121: assert_invalid passed:
-  error: lane index must be less than 2 (got 2)
+  out/test/spec/simd_store64_lane/simd_store64_lane.2.wasm:0000027: error: lane index must be less than 2 (got 2)
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store64_lane.wast:128: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (8)
+  out/test/spec/simd_store64_lane/simd_store64_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (8)
   0000027: error: OnSimdStoreLaneExpr callback failed
 15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_store8_lane.txt
+++ b/test/spec/simd_store8_lane.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/simd_store8_lane.wast
 (;; STDOUT ;;;
 out/test/spec/simd_store8_lane.wast:411: assert_invalid passed:
-  error: type mismatch in v128.store8_lane, expected [i32, v128] but got [v128, i32]
+  out/test/spec/simd_store8_lane/simd_store8_lane.1.wasm:0000027: error: type mismatch in v128.store8_lane, expected [i32, v128] but got [v128, i32]
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store8_lane.wast:417: assert_invalid passed:
-  error: lane index must be less than 16 (got 16)
+  out/test/spec/simd_store8_lane/simd_store8_lane.2.wasm:0000027: error: lane index must be less than 16 (got 16)
   0000027: error: OnSimdStoreLaneExpr callback failed
 out/test/spec/simd_store8_lane.wast:424: assert_invalid passed:
-  error: alignment must not be larger than natural alignment (1)
+  out/test/spec/simd_store8_lane/simd_store8_lane.3.wasm:0000027: error: alignment must not be larger than natural alignment (1)
   0000027: error: OnSimdStoreLaneExpr callback failed
 51/51 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -5,10 +5,10 @@ out/test/spec/start.wast:2: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)
   0000015: error: OnStartFunction callback failed
 out/test/spec/start.wast:7: assert_invalid passed:
-  error: start function must not return anything
+  out/test/spec/start/start.1.wasm:0000016: error: start function must not return anything
   0000016: error: OnStartFunction callback failed
 out/test/spec/start.wast:14: assert_invalid passed:
-  error: start function must be nullary
+  out/test/spec/start/start.2.wasm:0000016: error: start function must be nullary
   0000016: error: OnStartFunction callback failed
 inc() =>
 inc() =>

--- a/test/spec/store.txt
+++ b/test/spec/store.txt
@@ -30,157 +30,157 @@ out/test/spec/store.wast:103: assert_malformed passed:
   (memory 1)(func (param i32) (f64.store64 (local.get 0) (f64.const 0)))
                                ^^^^^^^^^^^
 out/test/spec/store.wast:112: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/store/store.8.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:116: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.9.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:120: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/store/store.10.wasm:0000028: error: type mismatch in implicit return, expected [f32] but got []
   0000029: error: EndFunctionBody callback failed
 out/test/spec/store.wast:124: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/store/store.11.wasm:000002c: error: type mismatch in implicit return, expected [f64] but got []
   000002d: error: EndFunctionBody callback failed
 out/test/spec/store.wast:128: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/store/store.12.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:132: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/store/store.13.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:136: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.14.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:140: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.15.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:144: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.16.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:150: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.17.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []
   000001f: error: OnStoreExpr callback failed
 out/test/spec/store.wast:159: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.18.wasm:0000021: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000021: error: OnStoreExpr callback failed
 out/test/spec/store.wast:168: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.19.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:178: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.20.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:188: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.21.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:198: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.22.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:208: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.23.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:218: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.24.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:228: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.25.wasm:0000028: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000028: error: OnStoreExpr callback failed
 out/test/spec/store.wast:238: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.26.wasm:0000028: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000028: error: OnStoreExpr callback failed
 out/test/spec/store.wast:248: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.27.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:258: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.28.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:268: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.29.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:278: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.30.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:288: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.31.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:298: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.32.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:308: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.33.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []
   000001f: error: OnStoreExpr callback failed
 out/test/spec/store.wast:317: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.34.wasm:0000021: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000021: error: OnStoreExpr callback failed
 out/test/spec/store.wast:326: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.35.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []
   000001f: error: OnStoreExpr callback failed
 out/test/spec/store.wast:335: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.36.wasm:0000021: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000021: error: OnStoreExpr callback failed
 out/test/spec/store.wast:344: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.37.wasm:0000025: error: type mismatch in i32.store, expected [i32, i32] but got []
   0000025: error: OnStoreExpr callback failed
 out/test/spec/store.wast:354: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.38.wasm:0000027: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   0000027: error: OnStoreExpr callback failed
 out/test/spec/store.wast:364: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got []
+  out/test/spec/store/store.39.wasm:000003c: error: type mismatch in i32.store, expected [i32, i32] but got []
   000003c: error: OnStoreExpr callback failed
 out/test/spec/store.wast:380: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32]
+  out/test/spec/store/store.40.wasm:000003e: error: type mismatch in i32.store, expected [i32, i32] but got [i32]
   000003e: error: OnStoreExpr callback failed
 out/test/spec/store.wast:399: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [f32, i32]
+  out/test/spec/store/store.41.wasm:0000026: error: type mismatch in i32.store, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:400: assert_invalid passed:
-  error: type mismatch in i32.store8, expected [i32, i32] but got [f32, i32]
+  out/test/spec/store/store.42.wasm:0000026: error: type mismatch in i32.store8, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:401: assert_invalid passed:
-  error: type mismatch in i32.store16, expected [i32, i32] but got [f32, i32]
+  out/test/spec/store/store.43.wasm:0000026: error: type mismatch in i32.store16, expected [i32, i32] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:402: assert_invalid passed:
-  error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
+  out/test/spec/store/store.44.wasm:0000026: error: type mismatch in i64.store, expected [i32, i64] but got [f32, i32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:403: assert_invalid passed:
-  error: type mismatch in i64.store8, expected [i32, i64] but got [f32, i64]
+  out/test/spec/store/store.45.wasm:0000026: error: type mismatch in i64.store8, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:404: assert_invalid passed:
-  error: type mismatch in i64.store16, expected [i32, i64] but got [f32, i64]
+  out/test/spec/store/store.46.wasm:0000026: error: type mismatch in i64.store16, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:405: assert_invalid passed:
-  error: type mismatch in i64.store32, expected [i32, i64] but got [f32, i64]
+  out/test/spec/store/store.47.wasm:0000026: error: type mismatch in i64.store32, expected [i32, i64] but got [f32, i64]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:406: assert_invalid passed:
-  error: type mismatch in f32.store, expected [i32, f32] but got [f32, f32]
+  out/test/spec/store/store.48.wasm:0000029: error: type mismatch in f32.store, expected [i32, f32] but got [f32, f32]
   0000029: error: OnStoreExpr callback failed
 out/test/spec/store.wast:407: assert_invalid passed:
-  error: type mismatch in f64.store, expected [i32, f64] but got [f32, f64]
+  out/test/spec/store/store.49.wasm:000002d: error: type mismatch in f64.store, expected [i32, f64] but got [f32, f64]
   000002d: error: OnStoreExpr callback failed
 out/test/spec/store.wast:409: assert_invalid passed:
-  error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
+  out/test/spec/store/store.50.wasm:0000026: error: type mismatch in i32.store, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:410: assert_invalid passed:
-  error: type mismatch in i32.store8, expected [i32, i32] but got [i32, f32]
+  out/test/spec/store/store.51.wasm:0000026: error: type mismatch in i32.store8, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:411: assert_invalid passed:
-  error: type mismatch in i32.store16, expected [i32, i32] but got [i32, f32]
+  out/test/spec/store/store.52.wasm:0000026: error: type mismatch in i32.store16, expected [i32, i32] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:412: assert_invalid passed:
-  error: type mismatch in i64.store, expected [i32, i64] but got [i32, f32]
+  out/test/spec/store/store.53.wasm:0000026: error: type mismatch in i64.store, expected [i32, i64] but got [i32, f32]
   0000026: error: OnStoreExpr callback failed
 out/test/spec/store.wast:413: assert_invalid passed:
-  error: type mismatch in i64.store8, expected [i32, i64] but got [i32, f64]
+  out/test/spec/store/store.54.wasm:000002a: error: type mismatch in i64.store8, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/test/spec/store.wast:414: assert_invalid passed:
-  error: type mismatch in i64.store16, expected [i32, i64] but got [i32, f64]
+  out/test/spec/store/store.55.wasm:000002a: error: type mismatch in i64.store16, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/test/spec/store.wast:415: assert_invalid passed:
-  error: type mismatch in i64.store32, expected [i32, i64] but got [i32, f64]
+  out/test/spec/store/store.56.wasm:000002a: error: type mismatch in i64.store32, expected [i32, i64] but got [i32, f64]
   000002a: error: OnStoreExpr callback failed
 out/test/spec/store.wast:416: assert_invalid passed:
-  error: type mismatch in f32.store, expected [i32, f32] but got [i32, i32]
+  out/test/spec/store/store.57.wasm:0000023: error: type mismatch in f32.store, expected [i32, f32] but got [i32, i32]
   0000023: error: OnStoreExpr callback failed
 out/test/spec/store.wast:417: assert_invalid passed:
-  error: type mismatch in f64.store, expected [i32, f64] but got [i32, i64]
+  out/test/spec/store/store.58.wasm:0000023: error: type mismatch in f64.store, expected [i32, f64] but got [i32, i64]
   0000023: error: OnStoreExpr callback failed
 67/67 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/switch.txt
+++ b/test/spec/switch.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/switch.wast
 (;; STDOUT ;;;
 out/test/spec/switch.wast:150: assert_invalid passed:
-  error: invalid depth: 3 (max 0)
+  out/test/spec/switch/switch.1.wasm:000001c: error: invalid depth: 3 (max 0)
   000001c: error: OnBrTableExpr callback failed
 27/27 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table-sub.txt
+++ b/test/spec/table-sub.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/table-sub.wast
 (;; STDOUT ;;;
 out/test/spec/table-sub.wast:2: assert_invalid passed:
-  error: type mismatch at table.copy. got externref, expected funcref
+  out/test/spec/table-sub/table-sub.0.wasm:000002a: error: type mismatch at table.copy. got externref, expected funcref
   000002a: error: OnTableCopyExpr callback failed
 out/test/spec/table-sub.wast:13: assert_invalid passed:
-  error: type mismatch at table.init. got externref, expected funcref
+  out/test/spec/table-sub/table-sub.1.wasm:000002d: error: type mismatch at table.init. got externref, expected funcref
   000002d: error: OnTableInitExpr callback failed
 2/2 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table.txt
+++ b/test/spec/table.txt
@@ -8,10 +8,10 @@ out/test/spec/table.wast:15: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/table.wast:19: assert_invalid passed:
-  error: max elems (0) must be >= initial elems (1)
+  out/test/spec/table/table.11.wasm:000000f: error: max elems (0) must be >= initial elems (1)
   000000f: error: OnTable callback failed
 out/test/spec/table.wast:23: assert_invalid passed:
-  error: max elems (0) must be >= initial elems (4294967295)
+  out/test/spec/table/table.12.wasm:0000013: error: max elems (0) must be >= initial elems (4294967295)
   0000013: error: OnTable callback failed
 out/test/spec/table.wast:28: assert_malformed passed:
   out/test/spec/table/table.13.wat:1:8: error: invalid int "0x1_0000_0000"

--- a/test/spec/table_fill.txt
+++ b/test/spec/table_fill.txt
@@ -5,31 +5,31 @@ out/test/spec/table_fill.wast:50: assert_trap passed: out of bounds table access
 out/test/spec/table_fill.wast:58: assert_trap passed: out of bounds table access: table.fill out of bounds
 out/test/spec/table_fill.wast:63: assert_trap passed: out of bounds table access: table.fill out of bounds
 out/test/spec/table_fill.wast:71: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, externref, i32] but got []
+  out/test/spec/table_fill/table_fill.1.wasm:0000020: error: type mismatch in table.fill, expected [i32, externref, i32] but got []
   0000020: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:80: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, externref, i32] but got [externref, i32]
+  out/test/spec/table_fill/table_fill.2.wasm:0000024: error: type mismatch in table.fill, expected [i32, externref, i32] but got [externref, i32]
   0000024: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:89: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, i32]
+  out/test/spec/table_fill/table_fill.3.wasm:0000024: error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, i32]
   0000024: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:98: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, externref]
+  out/test/spec/table_fill/table_fill.4.wasm:0000024: error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, externref]
   0000024: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:107: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, externref, i32] but got [f32, externref, i32]
+  out/test/spec/table_fill/table_fill.5.wasm:0000029: error: type mismatch in table.fill, expected [i32, externref, i32] but got [f32, externref, i32]
   0000029: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:116: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
+  out/test/spec/table_fill/table_fill.6.wasm:0000027: error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
   0000027: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:125: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, externref, f32]
+  out/test/spec/table_fill/table_fill.7.wasm:0000029: error: type mismatch in table.fill, expected [i32, externref, i32] but got [i32, externref, f32]
   0000029: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:135: assert_invalid passed:
-  error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
+  out/test/spec/table_fill/table_fill.8.wasm:000002a: error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
   000002a: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:146: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/table_fill/table_fill.9.wasm:0000027: error: type mismatch in implicit return, expected [i32] but got []
   0000028: error: EndFunctionBody callback failed
 44/44 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_get.txt
+++ b/test/spec/table_get.txt
@@ -7,19 +7,19 @@ out/test/spec/table_get.wast:34: assert_trap passed: out of bounds table access:
 out/test/spec/table_get.wast:35: assert_trap passed: out of bounds table access: table.get at 4294967295 >= max value 2
 out/test/spec/table_get.wast:36: assert_trap passed: out of bounds table access: table.get at 4294967295 >= max value 3
 out/test/spec/table_get.wast:42: assert_invalid passed:
-  error: type mismatch in table.get, expected [i32] but got []
+  out/test/spec/table_get/table_get.1.wasm:0000020: error: type mismatch in table.get, expected [i32] but got []
   0000020: error: OnTableGetExpr callback failed
 out/test/spec/table_get.wast:51: assert_invalid passed:
-  error: type mismatch in table.get, expected [i32] but got [f32]
+  out/test/spec/table_get/table_get.2.wasm:0000025: error: type mismatch in table.get, expected [i32] but got [f32]
   0000025: error: OnTableGetExpr callback failed
 out/test/spec/table_get.wast:61: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [externref]
+  out/test/spec/table_get/table_get.3.wasm:0000021: error: type mismatch in function, expected [] but got [externref]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/table_get.wast:70: assert_invalid passed:
-  error: type mismatch in implicit return, expected [funcref] but got [externref]
+  out/test/spec/table_get/table_get.4.wasm:0000022: error: type mismatch in implicit return, expected [funcref] but got [externref]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/table_get.wast:80: assert_invalid passed:
-  error: type mismatch in implicit return, expected [funcref] but got [externref]
+  out/test/spec/table_get/table_get.5.wasm:0000025: error: type mismatch in implicit return, expected [funcref] but got [externref]
   0000026: error: EndFunctionBody callback failed
 15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_grow.txt
+++ b/test/spec/table_grow.txt
@@ -8,25 +8,25 @@ out/test/spec/table_grow.wast:23: assert_trap passed: out of bounds table access
 out/test/spec/table_grow.wast:34: assert_trap passed: out of bounds table access: table.set at 5 >= max value 5
 out/test/spec/table_grow.wast:35: assert_trap passed: out of bounds table access: table.get at 5 >= max value 5
 out/test/spec/table_grow.wast:111: assert_invalid passed:
-  error: type mismatch in table.grow, expected [externref, i32] but got []
+  out/test/spec/table_grow/table_grow.5.wasm:0000021: error: type mismatch in table.grow, expected [externref, i32] but got []
   0000021: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:120: assert_invalid passed:
-  error: type mismatch in table.grow, expected [externref, i32] but got [externref]
+  out/test/spec/table_grow/table_grow.6.wasm:0000023: error: type mismatch in table.grow, expected [externref, i32] but got [externref]
   0000023: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:129: assert_invalid passed:
-  error: type mismatch in table.grow, expected [externref, i32] but got [i32]
+  out/test/spec/table_grow/table_grow.7.wasm:0000023: error: type mismatch in table.grow, expected [externref, i32] but got [i32]
   0000023: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:138: assert_invalid passed:
-  error: type mismatch in table.grow, expected [externref, i32] but got [externref, f32]
+  out/test/spec/table_grow/table_grow.8.wasm:0000028: error: type mismatch in table.grow, expected [externref, i32] but got [externref, f32]
   0000028: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:147: assert_invalid passed:
-  error: type mismatch in table.grow, expected [funcref, i32] but got [externref, i32]
+  out/test/spec/table_grow/table_grow.9.wasm:0000026: error: type mismatch in table.grow, expected [funcref, i32] but got [externref, i32]
   0000026: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:157: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/table_grow/table_grow.10.wasm:0000024: error: type mismatch in function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/table_grow.wast:166: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/table_grow/table_grow.11.wasm:0000025: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000026: error: EndFunctionBody callback failed
 45/45 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_init.txt
+++ b/test/spec/table_init.txt
@@ -143,193 +143,193 @@ out/test/spec/table_init.wast:861: assert_trap passed: out of bounds table acces
 test() =>
 out/test/spec/table_init.wast:909: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/table_init.wast:912: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f32]
+  out/test/spec/table_init/table_init.32.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:921: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, i64]
+  out/test/spec/table_init/table_init.33.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, i64]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:930: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f64]
+  out/test/spec/table_init/table_init.34.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i32, f64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:939: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i32]
+  out/test/spec/table_init/table_init.35.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:948: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f32]
+  out/test/spec/table_init/table_init.36.wasm:0000044: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f32]
   0000044: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:957: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i64]
+  out/test/spec/table_init/table_init.37.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, i64]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:966: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f64]
+  out/test/spec/table_init/table_init.38.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f32, f64]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:975: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i32]
+  out/test/spec/table_init/table_init.39.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i32]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:984: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f32]
+  out/test/spec/table_init/table_init.40.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:993: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i64]
+  out/test/spec/table_init/table_init.41.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, i64]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1002: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f64]
+  out/test/spec/table_init/table_init.42.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, i64, f64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1011: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i32]
+  out/test/spec/table_init/table_init.43.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i32]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1020: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f32]
+  out/test/spec/table_init/table_init.44.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f32]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1029: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i64]
+  out/test/spec/table_init/table_init.45.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, i64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1038: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f64]
+  out/test/spec/table_init/table_init.46.wasm:000004c: error: type mismatch in table.init, expected [i32, i32, i32] but got [i32, f64, f64]
   000004c: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1047: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i32]
+  out/test/spec/table_init/table_init.47.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1056: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f32]
+  out/test/spec/table_init/table_init.48.wasm:0000044: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f32]
   0000044: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1065: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i64]
+  out/test/spec/table_init/table_init.49.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, i64]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1074: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f64]
+  out/test/spec/table_init/table_init.50.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i32, f64]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1083: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i32]
+  out/test/spec/table_init/table_init.51.wasm:0000044: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i32]
   0000044: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1092: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f32]
+  out/test/spec/table_init/table_init.52.wasm:0000047: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f32]
   0000047: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1101: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i64]
+  out/test/spec/table_init/table_init.53.wasm:0000044: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, i64]
   0000044: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1110: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f64]
+  out/test/spec/table_init/table_init.54.wasm:000004b: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f32, f64]
   000004b: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1119: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i32]
+  out/test/spec/table_init/table_init.55.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1128: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f32]
+  out/test/spec/table_init/table_init.56.wasm:0000044: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f32]
   0000044: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1137: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i64]
+  out/test/spec/table_init/table_init.57.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, i64]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1146: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f64]
+  out/test/spec/table_init/table_init.58.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, i64, f64]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1155: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i32]
+  out/test/spec/table_init/table_init.59.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i32]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1164: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f32]
+  out/test/spec/table_init/table_init.60.wasm:000004b: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f32]
   000004b: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1173: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i64]
+  out/test/spec/table_init/table_init.61.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, i64]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1182: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f64]
+  out/test/spec/table_init/table_init.62.wasm:000004f: error: type mismatch in table.init, expected [i32, i32, i32] but got [f32, f64, f64]
   000004f: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1191: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i32]
+  out/test/spec/table_init/table_init.63.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i32]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1200: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f32]
+  out/test/spec/table_init/table_init.64.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1209: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i64]
+  out/test/spec/table_init/table_init.65.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, i64]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1218: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f64]
+  out/test/spec/table_init/table_init.66.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i32, f64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1227: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i32]
+  out/test/spec/table_init/table_init.67.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1236: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f32]
+  out/test/spec/table_init/table_init.68.wasm:0000044: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f32]
   0000044: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1245: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i64]
+  out/test/spec/table_init/table_init.69.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, i64]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1254: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f64]
+  out/test/spec/table_init/table_init.70.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f32, f64]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1263: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i32]
+  out/test/spec/table_init/table_init.71.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i32]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1272: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f32]
+  out/test/spec/table_init/table_init.72.wasm:0000041: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f32]
   0000041: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1281: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i64]
+  out/test/spec/table_init/table_init.73.wasm:000003e: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, i64]
   000003e: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1290: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f64]
+  out/test/spec/table_init/table_init.74.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, i64, f64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1299: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i32]
+  out/test/spec/table_init/table_init.75.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i32]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1308: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f32]
+  out/test/spec/table_init/table_init.76.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f32]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1317: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i64]
+  out/test/spec/table_init/table_init.77.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, i64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1326: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f64]
+  out/test/spec/table_init/table_init.78.wasm:000004c: error: type mismatch in table.init, expected [i32, i32, i32] but got [i64, f64, f64]
   000004c: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1335: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i32]
+  out/test/spec/table_init/table_init.79.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i32]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1344: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f32]
+  out/test/spec/table_init/table_init.80.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f32]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1353: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i64]
+  out/test/spec/table_init/table_init.81.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, i64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1362: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f64]
+  out/test/spec/table_init/table_init.82.wasm:000004c: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i32, f64]
   000004c: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1371: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i32]
+  out/test/spec/table_init/table_init.83.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i32]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1380: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f32]
+  out/test/spec/table_init/table_init.84.wasm:000004b: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f32]
   000004b: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1389: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i64]
+  out/test/spec/table_init/table_init.85.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, i64]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1398: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f64]
+  out/test/spec/table_init/table_init.86.wasm:000004f: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f32, f64]
   000004f: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1407: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i32]
+  out/test/spec/table_init/table_init.87.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i32]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1416: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f32]
+  out/test/spec/table_init/table_init.88.wasm:0000048: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f32]
   0000048: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1425: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i64]
+  out/test/spec/table_init/table_init.89.wasm:0000045: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, i64]
   0000045: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1434: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f64]
+  out/test/spec/table_init/table_init.90.wasm:000004c: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, i64, f64]
   000004c: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1443: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i32]
+  out/test/spec/table_init/table_init.91.wasm:000004c: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i32]
   000004c: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1452: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f32]
+  out/test/spec/table_init/table_init.92.wasm:000004f: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f32]
   000004f: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1461: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i64]
+  out/test/spec/table_init/table_init.93.wasm:000004c: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, i64]
   000004c: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1470: assert_invalid passed:
-  error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f64]
+  out/test/spec/table_init/table_init.94.wasm:0000053: error: type mismatch in table.init, expected [i32, i32, i32] but got [f64, f64, f64]
   0000053: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:1506: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/table_init.wast:1507: assert_trap passed: uninitialized table element

--- a/test/spec/table_set.txt
+++ b/test/spec/table_set.txt
@@ -10,25 +10,25 @@ out/test/spec/table_set.wast:47: assert_trap passed: out of bounds table access:
 out/test/spec/table_set.wast:48: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 1
 out/test/spec/table_set.wast:49: assert_trap passed: out of bounds table access: table.set at 4294967295 >= max value 2
 out/test/spec/table_set.wast:55: assert_invalid passed:
-  error: type mismatch in table.set, expected [i32, externref] but got []
+  out/test/spec/table_set/table_set.1.wasm:000001f: error: type mismatch in table.set, expected [i32, externref] but got []
   000001f: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:64: assert_invalid passed:
-  error: type mismatch in table.set, expected [i32, externref] but got [externref]
+  out/test/spec/table_set/table_set.2.wasm:0000021: error: type mismatch in table.set, expected [i32, externref] but got [externref]
   0000021: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:73: assert_invalid passed:
-  error: type mismatch in table.set, expected [i32, externref] but got [i32]
+  out/test/spec/table_set/table_set.3.wasm:0000021: error: type mismatch in table.set, expected [i32, externref] but got [i32]
   0000021: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:82: assert_invalid passed:
-  error: type mismatch in table.set, expected [i32, externref] but got [f32, externref]
+  out/test/spec/table_set/table_set.4.wasm:0000026: error: type mismatch in table.set, expected [i32, externref] but got [f32, externref]
   0000026: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:91: assert_invalid passed:
-  error: type mismatch in table.set, expected [i32, funcref] but got [i32, externref]
+  out/test/spec/table_set/table_set.5.wasm:0000024: error: type mismatch in table.set, expected [i32, funcref] but got [i32, externref]
   0000024: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:101: assert_invalid passed:
-  error: type mismatch in table.set, expected [i32, funcref] but got [i32, externref]
+  out/test/spec/table_set/table_set.6.wasm:0000027: error: type mismatch in table.set, expected [i32, funcref] but got [i32, externref]
   0000027: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:112: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/table_set/table_set.7.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got []
   0000025: error: EndFunctionBody callback failed
 25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_size.txt
+++ b/test/spec/table_size.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/table_size.wast
 (;; STDOUT ;;;
 out/test/spec/table_size.wast:70: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/table_size/table_size.1.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/table_size.wast:79: assert_invalid passed:
-  error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/table_size/table_size.2.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000022: error: EndFunctionBody callback failed
 38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -11,351 +11,351 @@ out/test/spec/unreached-invalid.wast:12: assert_invalid passed:
   0000000: error: function variable out of range: 1 (max 1)
   000001a: error: OnCallExpr callback failed
 out/test/spec/unreached-invalid.wast:16: assert_invalid passed:
-  error: invalid depth: 1 (max 0)
+  out/test/spec/unreached-invalid/unreached-invalid.3.wasm:0000018: error: invalid depth: 1 (max 0)
   000001a: error: OnBrExpr callback failed
 out/test/spec/unreached-invalid.wast:21: assert_invalid passed:
-  error: type mismatch in i64.eqz, expected [i64] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.4.wasm:000001b: error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:27: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.5.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:33: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
+  out/test/spec/unreached-invalid/unreached-invalid.6.wasm:0000023: error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
   0000023: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:42: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.7.wasm:000001a: error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:46: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.8.wasm:0000019: error: type mismatch in function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:50: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.9.wasm:000001b: error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:56: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.10.wasm:0000019: error: type mismatch in function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:60: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.11.wasm:000001b: error: type mismatch in function, expected [] but got [any]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:64: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.12.wasm:000001d: error: type mismatch in function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:71: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.13.wasm:000001f: error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:77: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.14.wasm:0000021: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:83: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.15.wasm:0000020: error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:89: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
+  out/test/spec/unreached-invalid/unreached-invalid.16.wasm:0000023: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:95: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.17.wasm:000001e: error: type mismatch in block, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:101: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.18.wasm:0000024: error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:107: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.19.wasm:0000020: error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:113: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.20.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:119: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.21.wasm:000001b: error: type mismatch in function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:125: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.22.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:132: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.23.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:138: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.24.wasm:000001e: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:144: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.25.wasm:000001d: error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001d: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:150: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
+  out/test/spec/unreached-invalid/unreached-invalid.26.wasm:0000020: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:156: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.27.wasm:000001d: error: type mismatch in block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:162: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.28.wasm:0000025: error: type mismatch in block, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:168: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.29.wasm:000001f: error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:174: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.30.wasm:0000023: error: type mismatch in loop, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:180: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.31.wasm:000001a: error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:186: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.32.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:193: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.33.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:199: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.34.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:205: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.35.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
   000001c: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:211: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.36.wasm:000001e: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   000001e: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:217: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.37.wasm:000001d: error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001d: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:223: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
+  out/test/spec/unreached-invalid/unreached-invalid.38.wasm:0000020: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:229: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.39.wasm:000001d: error: type mismatch in block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:235: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.40.wasm:0000023: error: type mismatch in block, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:241: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.41.wasm:000001f: error: type mismatch in loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:247: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.42.wasm:0000021: error: type mismatch in loop, expected [i32] but got [f32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:253: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.43.wasm:000001a: error: type mismatch in function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:259: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.44.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [f32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:265: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.45.wasm:000001e: error: type mismatch in i32.eqz, expected [i32] but got []
   000001e: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:271: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.46.wasm:0000020: error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:277: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.47.wasm:000001f: error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:284: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.48.wasm:000001f: error: type mismatch in i32.eqz, expected [i32] but got []
   000001f: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:290: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.49.wasm:0000021: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:296: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.50.wasm:0000020: error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:302: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
+  out/test/spec/unreached-invalid/unreached-invalid.51.wasm:0000023: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:308: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.52.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:314: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [... f32]
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.53.wasm:0000026: error: type mismatch in block, expected [i32] but got [... f32]
+  out/test/spec/unreached-invalid/unreached-invalid.53.wasm:0000026: error: type mismatch in block, expected [] but got [i32]
   0000026: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:321: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.54.wasm:0000022: error: type mismatch in loop, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:327: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.55.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:334: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.56.wasm:000001d: error: type mismatch in function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:340: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.57.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:348: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.58.wasm:0000020: error: type mismatch in i32.eqz, expected [i32] but got []
   0000020: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:354: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.59.wasm:0000022: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000022: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:360: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.60.wasm:0000021: error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   0000021: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:366: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
+  out/test/spec/unreached-invalid/unreached-invalid.61.wasm:0000024: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:372: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.62.wasm:0000021: error: type mismatch in block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:378: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [... f32]
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.63.wasm:0000027: error: type mismatch in block, expected [i32] but got [... f32]
+  out/test/spec/unreached-invalid/unreached-invalid.63.wasm:0000027: error: type mismatch in block, expected [] but got [i32]
   0000027: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:384: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.64.wasm:0000023: error: type mismatch in loop, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:390: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.65.wasm:0000025: error: type mismatch in loop, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:396: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.66.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:402: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.67.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:409: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.68.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got []
   000001d: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:415: assert_invalid passed:
-  error: type mismatch in i32.eqz, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.69.wasm:0000021: error: type mismatch in i32.eqz, expected [i32] but got [f32]
   0000021: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:421: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.70.wasm:000001e: error: type mismatch in f32.eq, expected [f32, f32] but got [i32]
   000001e: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:427: assert_invalid passed:
-  error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
+  out/test/spec/unreached-invalid/unreached-invalid.71.wasm:0000023: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:433: assert_invalid passed:
-  error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.72.wasm:000001e: error: type mismatch in if true branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:439: assert_invalid passed:
-  error: type mismatch in if true branch, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.73.wasm:0000022: error: type mismatch in if true branch, expected [i32] but got [f32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:445: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.74.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:451: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.75.wasm:0000024: error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:457: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.76.wasm:0000020: error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:463: assert_invalid passed:
-  error: type mismatch in loop, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.77.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:470: assert_invalid passed:
-  error: type mismatch in return, expected [i32] but got [f64]
+  out/test/spec/unreached-invalid/unreached-invalid.78.wasm:0000025: error: type mismatch in return, expected [i32] but got [f64]
   0000025: error: OnReturnExpr callback failed
 out/test/spec/unreached-invalid.wast:477: assert_invalid passed:
-  error: type mismatch in br, expected [i32] but got [f64]
+  out/test/spec/unreached-invalid/unreached-invalid.79.wasm:0000029: error: type mismatch in br, expected [i32] but got [f64]
   0000029: error: OnBrExpr callback failed
 out/test/spec/unreached-invalid.wast:484: assert_invalid passed:
-  error: type mismatch in br_if, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.80.wasm:0000021: error: type mismatch in br_if, expected [i32] but got [f32]
   0000021: error: OnBrIfExpr callback failed
 out/test/spec/unreached-invalid.wast:490: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.81.wasm:0000024: error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:498: assert_invalid passed:
-  error: type mismatch in block, expected [f32] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.82.wasm:0000024: error: type mismatch in block, expected [f32] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:507: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.83.wasm:0000024: error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:515: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.84.wasm:0000022: error: type mismatch in br_table, expected [i32] but got [f32]
   0000022: error: OnBrTableExpr callback failed
 out/test/spec/unreached-invalid.wast:521: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.85.wasm:0000025: error: type mismatch in br_table, expected [i32] but got [f32]
   0000025: error: OnBrTableExpr callback failed
 out/test/spec/unreached-invalid.wast:527: assert_invalid passed:
-  error: br_table labels have inconsistent types: expected [f32], got []
+  out/test/spec/unreached-invalid/unreached-invalid.86.wasm:0000023: error: br_table labels have inconsistent types: expected [f32], got []
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/unreached-invalid.wast:540: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.87.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:546: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.88.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:552: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.89.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:558: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.90.wasm:0000023: error: type mismatch in block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:565: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.91.wasm:0000021: error: type mismatch in block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:571: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.92.wasm:0000022: error: type mismatch in block, expected [i32] but got []
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:577: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.93.wasm:0000024: error: type mismatch in block, expected [i32] but got [i64]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:584: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.94.wasm:0000023: error: type mismatch in block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:590: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.95.wasm:0000025: error: type mismatch in block, expected [i32] but got []
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:596: assert_invalid passed:
-  error: type mismatch in block, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.96.wasm:0000027: error: type mismatch in block, expected [i32] but got [i64]
   0000027: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:604: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.97.wasm:0000024: error: type mismatch in block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:611: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.98.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:617: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.99.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got []
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:623: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.100.wasm:0000023: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:629: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.101.wasm:0000025: error: type mismatch in block, expected [] but got [i32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:637: assert_invalid passed:
-  error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.102.wasm:0000020: error: type mismatch in loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:643: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.103.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:649: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.104.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:656: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.105.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got []
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:662: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.106.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:669: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.107.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:676: assert_invalid passed:
-  error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.108.wasm:0000022: error: type mismatch in block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:687: assert_invalid passed:
-  error: type mismatch in i64.extend_i32_u, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.109.wasm:000001c: error: type mismatch in i64.extend_i32_u, expected [i32] but got [i64]
   000001c: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:699: assert_invalid passed:
-  error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
+  out/test/spec/unreached-invalid/unreached-invalid.110.wasm:000001f: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, i32]
   000001f: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:704: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
+  out/test/spec/unreached-invalid/unreached-invalid.111.wasm:000001f: error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
   000001f: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:710: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, i64]
+  out/test/spec/unreached-invalid/unreached-invalid.112.wasm:000001f: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, i64]
   000001f: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:715: assert_invalid passed:
-  error: type mismatch in select, expected [i32, i32, i32] but got [i32, i64]
+  out/test/spec/unreached-invalid/unreached-invalid.113.wasm:000001d: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i64]
   000001d: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:720: assert_invalid passed:
-  error: type mismatch in select, expected [any, any, i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.114.wasm:000001b: error: type mismatch in select, expected [any, any, i32] but got [i64]
   000001b: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:726: assert_invalid passed:
-  error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.115.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:733: assert_invalid passed:
-  error: type mismatch in function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.116.wasm:0000019: error: type mismatch in function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:738: assert_invalid passed:
-  error: type mismatch in br_table, expected [i32] but got [externref]
+  out/test/spec/unreached-invalid/unreached-invalid.117.wasm:0000026: error: type mismatch in br_table, expected [i32] but got [externref]
   0000026: error: OnBrTableExpr callback failed
 118/118 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreached-valid.txt
+++ b/test/spec/unreached-valid.txt
@@ -7,7 +7,7 @@ out/test/spec/unreached-valid.wast:54:10: error: br_table labels have inconsiste
 out/test/spec/unreached-valid.wast:54:10: error: br_table labels have inconsistent types: expected [f32], got [f64]
         (br_table 0 1 1 (i32.const 1))
          ^^^^^^^^
-error: br_table labels have inconsistent types: expected [f32], got [f64]
+out/test/spec/unreached-valid/unreached-valid.1.wasm:0000034: error: br_table labels have inconsistent types: expected [f32], got [f64]
 0000034: error: OnBrTableExpr callback failed
 ;;; STDERR ;;)
 (;; STDOUT ;;;


### PR DESCRIPTION
I think it was always intended to work this way but was
left as a TODO.