### PR TITLE
Fix syntax for assert_return typecheck test

### DIFF
--- a/test/typecheck/bad-assertreturn-invoke-type-mismatch.txt
+++ b/test/typecheck/bad-assertreturn-invoke-type-mismatch.txt
@@ -2,10 +2,10 @@
 ;;; ERROR: 1
 (module
   (func (param i32) (result i32) get_local 0)
-  (export "foo" 0))
+  (export "foo" (func 0)))
 (assert_return (invoke "foo" (f32.const 0)) (i32.const 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-assertreturn-invoke-type-mismatch.txt:5:17: error: unexpected token 0, expected (.
-  (export "foo" 0))
-                ^
+out/test/typecheck/bad-assertreturn-invoke-type-mismatch.txt:6:41: error: type mismatch for argument 0 of invoke. got f32, expected i32
+(assert_return (invoke "foo" (f32.const 0)) (i32.const 0))
+                                        ^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-assertreturn-type-mismatch.txt
+++ b/test/typecheck/bad-assertreturn-type-mismatch.txt
@@ -2,10 +2,10 @@
 ;;; ERROR: 1
 (module
   (func (param i32) (result i32) get_local 0)
-  (export "foo" 0))
+  (export "foo" (func 0)))
 (assert_return (invoke "foo" (i32.const 0)) (f32.const 0))
 (;; STDERR ;;;
-out/test/typecheck/bad-assertreturn-type-mismatch.txt:5:17: error: unexpected token 0, expected (.
-  (export "foo" 0))
-                ^
+out/test/typecheck/bad-assertreturn-type-mismatch.txt:6:17: error: type mismatch for result 0 of action. got f32, expected i32
+(assert_return (invoke "foo" (i32.const 0)) (f32.const 0))
+                ^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
This test seems to be intended to test the type checking behavior, but due to a syntax error in an export statement was just testing the parsing behavior instead. This PR fixes the syntax and adjusts the test expectations.