### PR TITLE
Share validation code between constant expressions and function bodie…

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -280,6 +280,7 @@ class BinaryReaderIR : public BinaryReaderNop {
   void PushLabel(LabelType label_type,
                  ExprList* first,
                  Expr* context = nullptr);
+  Result BeginInitExpr(ExprList* init_expr);
   Result EndInitExpr();
   Result PopLabel();
   Result GetLabelAt(LabelNode** label, Index depth);
@@ -305,7 +306,6 @@ class BinaryReaderIR : public BinaryReaderNop {
 
   Func* current_func_ = nullptr;
   std::vector<LabelNode> label_stack_;
-  ExprList* current_init_expr_ = nullptr;
   const char* filename_;
 };
 
@@ -368,13 +368,9 @@ Result BinaryReaderIR::TopLabelExpr(LabelNode** label, Expr** expr) {
 
 Result BinaryReaderIR::AppendExpr(std::unique_ptr<Expr> expr) {
   expr->loc = GetLocation();
-  if (current_init_expr_) {
-    current_init_expr_->push_back(std::move(expr));
-  } else {
-    LabelNode* label;
-    CHECK_RESULT(TopLabel(&label));
-    label->exprs->push_back(std::move(expr));
-  }
+  LabelNode* label;
+  CHECK_RESULT(TopLabel(&label));
+  label->exprs->push_back(std::move(expr));
   return Result::Ok;
 }
 
@@ -607,8 +603,7 @@ Result BinaryReaderIR::BeginGlobal(Index index, Type type, bool mutable_) {
 Result BinaryReaderIR::BeginGlobalInitExpr(Index index) {
   assert(index == module_->globals.size() - 1);
   Global* global = module_->globals[index];
-  current_init_expr_ = &global->init_expr;
-  return Result::Ok;
+  return BeginInitExpr(&global->init_expr);
 }
 
 Result BinaryReaderIR::EndGlobalInitExpr(Index index) {
@@ -799,9 +794,6 @@ Result BinaryReaderIR::OnElseExpr() {
 }
 
 Result BinaryReaderIR::OnEndExpr() {
-  if (current_init_expr_) {
-    return Result::Ok;
-  }
   if (label_stack_.size() > 1) {
     LabelNode* label;
     Expr* expr;
@@ -823,6 +815,7 @@ Result BinaryReaderIR::OnEndExpr() {
         cast<TryExpr>(expr)->block.end_loc = GetLocation();
         break;
 
+      case LabelType::InitExpr:
       case LabelType::Func:
       case LabelType::Catch:
         break;
@@ -1152,15 +1145,18 @@ Result BinaryReaderIR::BeginElemSegment(Index index,
   return Result::Ok;
 }
 
-Result BinaryReaderIR::BeginElemSegmentInitExpr(Index index) {
-  assert(index == module_->elem_segments.size() - 1);
-  ElemSegment* segment = module_->elem_segments[index];
-  current_init_expr_ = &segment->offset;
+Result BinaryReaderIR::BeginInitExpr(ExprList* expr) {
+  PushLabel(LabelType::InitExpr, expr);
   return Result::Ok;
 }
 
+Result BinaryReaderIR::BeginElemSegmentInitExpr(Index index) {
+  assert(index == module_->elem_segments.size() - 1);
+  ElemSegment* segment = module_->elem_segments[index];
+  return BeginInitExpr(&segment->offset);
+}
+
 Result BinaryReaderIR::EndInitExpr() {
-  current_init_expr_ = nullptr;
   return Result::Ok;
 }
 
@@ -1231,8 +1227,7 @@ Result BinaryReaderIR::BeginDataSegment(Index index,
 Result BinaryReaderIR::BeginDataSegmentInitExpr(Index index) {
   assert(index == module_->data_segments.size() - 1);
   DataSegment* segment = module_->data_segments[index];
-  current_init_expr_ = &segment->offset;
-  return Result::Ok;
+  return BeginInitExpr(&segment->offset);
 }
 
 Result BinaryReaderIR::EndDataSegmentInitExpr(Index index) {

--- a/src/common.h
+++ b/src/common.h
@@ -224,6 +224,7 @@ inline std::string WABT_PRINTF_FORMAT(1, 2)
 
 enum class LabelType {
   Func,
+  InitExpr,
   Block,
   Loop,
   If,

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -184,56 +184,6 @@ Result SharedValidator::CheckType(const Location& loc,
   return Result::Ok;
 }
 
-Result SharedValidator::OnGlobalInitExpr_Const(const Location& loc,
-                                               Type actual) {
-  return CheckType(loc, actual, globals_.back().type,
-                   "global initializer expression");
-}
-
-Result SharedValidator::OnGlobalInitExpr_GlobalGet(const Location& loc,
-                                                   Var ref_global_var) {
-  Result result = Result::Ok;
-  GlobalType ref_global;
-  CHECK_RESULT(CheckGlobalIndex(ref_global_var, &ref_global));
-
-  if (ref_global_var.index() >= num_imported_globals_) {
-    result |= PrintError(
-        ref_global_var.loc,
-        "initializer expression can only reference an imported global");
-  }
-
-  if (ref_global.mutable_) {
-    result |= PrintError(
-        loc, "initializer expression cannot reference a mutable global");
-  }
-
-  result |= CheckType(loc, ref_global.type, globals_.back().type,
-                      "global initializer expression");
-  return result;
-}
-
-Result SharedValidator::OnGlobalInitExpr_RefNull(const Location& loc,
-                                                 Type type) {
-  return CheckType(loc, type, globals_.back().type,
-                   "global initializer expression");
-}
-
-Result SharedValidator::OnGlobalInitExpr_RefFunc(const Location& loc,
-                                                 Var func_var) {
-  Result result = Result::Ok;
-  result |= CheckFuncIndex(func_var);
-  init_expr_funcs_.push_back(func_var);
-  result |= CheckType(loc, Type::FuncRef, globals_.back().type,
-                      "global initializer expression");
-  return result;
-}
-
-Result SharedValidator::OnGlobalInitExpr_Other(const Location& loc) {
-  return PrintError(
-      loc,
-      "invalid global initializer expression, must be a constant expression");
-}
-
 Result SharedValidator::OnTag(const Location& loc, Var sig_var) {
   Result result = Result::Ok;
   FuncType type;
@@ -312,33 +262,6 @@ void SharedValidator::OnElemSegmentElemType(Type elem_type) {
   elems_.back().element = elem_type;
 }
 
-Result SharedValidator::OnElemSegmentInitExpr_Const(const Location& loc,
-                                                    Type type) {
-  return CheckType(loc, type, Type::I32, "elem segment offset");
-}
-
-Result SharedValidator::OnElemSegmentInitExpr_GlobalGet(const Location& loc,
-                                                        Var global_var) {
-  Result result = Result::Ok;
-  GlobalType ref_global;
-  result |= CheckGlobalIndex(global_var, &ref_global);
-
-  if (ref_global.mutable_) {
-    result |= PrintError(
-        loc, "initializer expression cannot reference a mutable global");
-  }
-
-  result |= CheckType(loc, ref_global.type, Type::I32, "elem segment offset");
-  return result;
-}
-
-Result SharedValidator::OnElemSegmentInitExpr_Other(const Location& loc) {
-  return PrintError(loc,
-                    "invalid elem segment offset, must be a constant "
-                    "expression; either i32.const or "
-                    "global.get.");
-}
-
 Result SharedValidator::OnElemSegmentElemExpr_RefNull(const Location& loc,
                                                       Type type) {
   return CheckType(loc, type, elems_.back().element, "elem expression");
@@ -372,41 +295,12 @@ Result SharedValidator::OnDataSegment(const Location& loc,
   return result;
 }
 
-Result SharedValidator::OnDataSegmentInitExpr_Const(const Location& loc,
-                                                    Type type) {
-  auto required =
-      memories_.empty() ? Type(Type::I32) : memories_[0].limits.IndexType();
-  return CheckType(loc, type, required, "data segment offset");
-}
-
-Result SharedValidator::OnDataSegmentInitExpr_GlobalGet(const Location& loc,
-                                                        Var global_var) {
-  Result result = Result::Ok;
-  GlobalType ref_global;
-  result |= CheckGlobalIndex(global_var, &ref_global);
-
-  if (ref_global.mutable_) {
-    result |= PrintError(
-        loc, "initializer expression cannot reference a mutable global");
-  }
-
-  auto required =
-      memories_.empty() ? Type(Type::I32) : memories_[0].limits.IndexType();
-  result |= CheckType(loc, ref_global.type, required, "data segment offset");
-  return result;
-}
-
-Result SharedValidator::OnDataSegmentInitExpr_Other(const Location& loc) {
-  return PrintError(loc,
-                    "invalid data segment offset, must be a constant "
-                    "expression; either iXX.const or "
-                    "global.get.");
-}
-
 Result SharedValidator::CheckDeclaredFunc(Var func_var) {
   if (declared_funcs_.count(func_var.index()) == 0) {
     return PrintError(func_var.loc,
-                      "function is not declared in any elem sections");
+                      "function %" PRIindex
+                      " is not declared in any elem sections",
+                      func_var.index());
   }
   return Result::Ok;
 }
@@ -416,7 +310,7 @@ Result SharedValidator::EndModule() {
   // mentioned in an elems section.  This can't be done while process the
   // globals because the global section comes before the elem section.
   Result result = Result::Ok;
-  for (Var func_var : init_expr_funcs_) {
+  for (Var func_var : check_declared_funcs_) {
     result |= CheckDeclaredFunc(func_var);
   }
   return result;
@@ -538,6 +432,17 @@ Index SharedValidator::GetFunctionTypeIndex(Index func_index) const {
   return funcs_[func_index].type_index;
 }
 
+Result SharedValidator::BeginInitExpr(const Location& loc, Type type) {
+  expr_loc_ = loc;
+  in_init_expr_ = true;
+  return typechecker_.BeginInitExpr(type);
+}
+
+Result SharedValidator::EndInitExpr() {
+  in_init_expr_ = false;
+  return typechecker_.EndInitExpr();
+}
+
 Result SharedValidator::BeginFunctionBody(const Location& loc,
                                           Index func_index) {
   expr_loc_ = loc;
@@ -613,9 +518,28 @@ Result SharedValidator::CheckAtomicAlign(const Location& loc,
   return Result::Ok;
 }
 
+static bool ValidInitOpcode(Opcode opcode) {
+  return opcode == Opcode::GlobalGet || opcode == Opcode::I32Const ||
+         opcode == Opcode::I64Const || opcode == Opcode::F32Const ||
+         opcode == Opcode::F64Const || opcode == Opcode::RefFunc ||
+         opcode == Opcode::RefNull;
+}
+
+Result SharedValidator::CheckInstr(Opcode opcode, const Location& loc) {
+  expr_loc_ = loc;
+  if (in_init_expr_ && !ValidInitOpcode(opcode)) {
+    PrintError(loc,
+               "invalid initializer: instruction not valid in initializer "
+               "expression: %s",
+               opcode.GetName());
+    return Result::Error;
+  }
+  return Result::Ok;
+}
+
 Result SharedValidator::OnAtomicFence(const Location& loc,
                                       uint32_t consistency_model) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::AtomicFence, loc);
   if (consistency_model != 0) {
     result |= PrintError(
         loc, "unexpected atomic.fence consistency model (expected 0): %u",
@@ -628,9 +552,8 @@ Result SharedValidator::OnAtomicFence(const Location& loc,
 Result SharedValidator::OnAtomicLoad(const Location& loc,
                                      Opcode opcode,
                                      Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnAtomicLoad(opcode, mt.limits);
@@ -640,9 +563,8 @@ Result SharedValidator::OnAtomicLoad(const Location& loc,
 Result SharedValidator::OnAtomicNotify(const Location& loc,
                                        Opcode opcode,
                                        Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnAtomicNotify(opcode, mt.limits);
@@ -652,9 +574,8 @@ Result SharedValidator::OnAtomicNotify(const Location& loc,
 Result SharedValidator::OnAtomicRmwCmpxchg(const Location& loc,
                                            Opcode opcode,
                                            Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnAtomicRmwCmpxchg(opcode, mt.limits);
@@ -664,9 +585,8 @@ Result SharedValidator::OnAtomicRmwCmpxchg(const Location& loc,
 Result SharedValidator::OnAtomicRmw(const Location& loc,
                                     Opcode opcode,
                                     Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnAtomicRmw(opcode, mt.limits);
@@ -676,9 +596,8 @@ Result SharedValidator::OnAtomicRmw(const Location& loc,
 Result SharedValidator::OnAtomicStore(const Location& loc,
                                       Opcode opcode,
                                       Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnAtomicStore(opcode, mt.limits);
@@ -688,9 +607,8 @@ Result SharedValidator::OnAtomicStore(const Location& loc,
 Result SharedValidator::OnAtomicWait(const Location& loc,
                                      Opcode opcode,
                                      Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAtomicAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnAtomicWait(opcode, mt.limits);
@@ -698,16 +616,14 @@ Result SharedValidator::OnAtomicWait(const Location& loc,
 }
 
 Result SharedValidator::OnBinary(const Location& loc, Opcode opcode) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnBinary(opcode);
   return result;
 }
 
 Result SharedValidator::OnBlock(const Location& loc, Type sig_type) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::Block, loc);
   TypeVector param_types, result_types;
-  expr_loc_ = loc;
   result |= CheckBlockSignature(loc, Opcode::Block, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnBlock(param_types, result_types);
@@ -715,22 +631,19 @@ Result SharedValidator::OnBlock(const Location& loc, Type sig_type) {
 }
 
 Result SharedValidator::OnBr(const Location& loc, Var depth) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Br, loc);
   result |= typechecker_.OnBr(depth.index());
   return result;
 }
 
 Result SharedValidator::OnBrIf(const Location& loc, Var depth) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::BrIf, loc);
   result |= typechecker_.OnBrIf(depth.index());
   return result;
 }
 
 Result SharedValidator::BeginBrTable(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::BrTable, loc);
   result |= typechecker_.BeginBrTable();
   return result;
 }
@@ -743,15 +656,13 @@ Result SharedValidator::OnBrTableTarget(const Location& loc, Var depth) {
 }
 
 Result SharedValidator::EndBrTable(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::BrTable, loc);
   result |= typechecker_.EndBrTable();
   return result;
 }
 
 Result SharedValidator::OnCall(const Location& loc, Var func_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Call, loc);
   FuncType func_type;
   result |= CheckFuncIndex(func_var, &func_type);
   result |= typechecker_.OnCall(func_type.params, func_type.results);
@@ -761,8 +672,7 @@ Result SharedValidator::OnCall(const Location& loc, Var func_var) {
 Result SharedValidator::OnCallIndirect(const Location& loc,
                                        Var sig_var,
                                        Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::CallIndirect, loc);
   FuncType func_type;
   result |= CheckFuncTypeIndex(sig_var, &func_type);
   result |= CheckTableIndex(table_var);
@@ -772,8 +682,7 @@ Result SharedValidator::OnCallIndirect(const Location& loc,
 
 Result SharedValidator::OnCallRef(const Location& loc,
                                   Index* function_type_index) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::CallRef, loc);
   Index func_index;
   result |= typechecker_.OnIndexedFuncRef(&func_index);
   if (Failed(result)) {
@@ -791,8 +700,7 @@ Result SharedValidator::OnCallRef(const Location& loc,
 Result SharedValidator::OnCatch(const Location& loc,
                                 Var tag_var,
                                 bool is_catch_all) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Catch, loc);
   if (is_catch_all) {
     TypeVector empty;
     result |= typechecker_.OnCatch(empty);
@@ -805,8 +713,7 @@ Result SharedValidator::OnCatch(const Location& loc,
 }
 
 Result SharedValidator::OnCompare(const Location& loc, Opcode opcode) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnCompare(opcode);
   return result;
 }
@@ -819,66 +726,74 @@ Result SharedValidator::OnConst(const Location& loc, Type type) {
 }
 
 Result SharedValidator::OnConvert(const Location& loc, Opcode opcode) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnConvert(opcode);
   return result;
 }
 
 Result SharedValidator::OnDataDrop(const Location& loc, Var segment_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::DataDrop, loc);
   result |= CheckDataSegmentIndex(segment_var);
   result |= typechecker_.OnDataDrop(segment_var.index());
   return result;
 }
 
 Result SharedValidator::OnDelegate(const Location& loc, Var depth) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Delegate, loc);
   result |= typechecker_.OnDelegate(depth.index());
   return result;
 }
 
 Result SharedValidator::OnDrop(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Drop, loc);
   result |= typechecker_.OnDrop();
   return result;
 }
 
 Result SharedValidator::OnElemDrop(const Location& loc, Var segment_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::ElemDrop, loc);
   result |= CheckElemSegmentIndex(segment_var);
   result |= typechecker_.OnElemDrop(segment_var.index());
   return result;
 }
 
 Result SharedValidator::OnElse(const Location& loc) {
+  // Don't call CheckInstr or update expr_loc_ here because if we fail we want
+  // the last expression in the If block to be reported as the error location,
+  // not the else itself.
   Result result = Result::Ok;
   result |= typechecker_.OnElse();
   return result;
 }
 
 Result SharedValidator::OnEnd(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::End, loc);
   result |= typechecker_.OnEnd();
   return result;
 }
 
 Result SharedValidator::OnGlobalGet(const Location& loc, Var global_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::GlobalGet, loc);
   GlobalType global_type;
   result |= CheckGlobalIndex(global_var, &global_type);
   result |= typechecker_.OnGlobalGet(global_type.type);
+  if (Succeeded(result) && in_init_expr_) {
+    if (global_var.index() >= num_imported_globals_) {
+      result |= PrintError(
+          global_var.loc,
+          "initializer expression can only reference an imported global");
+    }
+    if (global_type.mutable_) {
+      result |= PrintError(
+          loc, "initializer expression cannot reference a mutable global");
+    }
+  }
+
   return result;
 }
 
 Result SharedValidator::OnGlobalSet(const Location& loc, Var global_var) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::GlobalSet, loc);
   GlobalType global_type;
   result |= CheckGlobalIndex(global_var, &global_type);
   if (!global_type.mutable_) {
@@ -886,15 +801,13 @@ Result SharedValidator::OnGlobalSet(const Location& loc, Var global_var) {
         loc, "can't global.set on immutable global at index %" PRIindex ".",
         global_var.index());
   }
-  expr_loc_ = loc;
   result |= typechecker_.OnGlobalSet(global_type.type);
   return result;
 }
 
 Result SharedValidator::OnIf(const Location& loc, Type sig_type) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::If, loc);
   TypeVector param_types, result_types;
-  expr_loc_ = loc;
   result |= CheckBlockSignature(loc, Opcode::If, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnIf(param_types, result_types);
@@ -905,9 +818,8 @@ Result SharedValidator::OnLoad(const Location& loc,
                                Opcode opcode,
                                Var memidx,
                                Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnLoad(opcode, mt.limits);
@@ -917,9 +829,8 @@ Result SharedValidator::OnLoad(const Location& loc,
 Result SharedValidator::OnLoadSplat(const Location& loc,
                                     Opcode opcode,
                                     Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnLoad(opcode, mt.limits);
@@ -929,9 +840,8 @@ Result SharedValidator::OnLoadSplat(const Location& loc,
 Result SharedValidator::OnLoadZero(const Location& loc,
                                    Opcode opcode,
                                    Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnLoad(opcode, mt.limits);
@@ -939,36 +849,35 @@ Result SharedValidator::OnLoadZero(const Location& loc,
 }
 
 Result SharedValidator::OnLocalGet(const Location& loc, Var local_var) {
+  CHECK_RESULT(CheckInstr(Opcode::LocalGet, loc));
   Result result = Result::Ok;
   Type type = Type::Any;
-  expr_loc_ = loc;
   result |= CheckLocalIndex(local_var, &type);
   result |= typechecker_.OnLocalGet(type);
   return result;
 }
 
 Result SharedValidator::OnLocalSet(const Location& loc, Var local_var) {
+  CHECK_RESULT(CheckInstr(Opcode::LocalSet, loc));
   Result result = Result::Ok;
   Type type = Type::Any;
-  expr_loc_ = loc;
   result |= CheckLocalIndex(local_var, &type);
   result |= typechecker_.OnLocalSet(type);
   return result;
 }
 
 Result SharedValidator::OnLocalTee(const Location& loc, Var local_var) {
+  CHECK_RESULT(CheckInstr(Opcode::LocalTee, loc));
   Result result = Result::Ok;
   Type type = Type::Any;
-  expr_loc_ = loc;
   result |= CheckLocalIndex(local_var, &type);
   result |= typechecker_.OnLocalTee(type);
   return result;
 }
 
 Result SharedValidator::OnLoop(const Location& loc, Type sig_type) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::Loop, loc);
   TypeVector param_types, result_types;
-  expr_loc_ = loc;
   result |= CheckBlockSignature(loc, Opcode::Loop, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnLoop(param_types, result_types);
@@ -978,9 +887,8 @@ Result SharedValidator::OnLoop(const Location& loc, Type sig_type) {
 Result SharedValidator::OnMemoryCopy(const Location& loc,
                                      Var srcmemidx,
                                      Var destmemidx) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::MemoryCopy, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(srcmemidx, &mt);
   result |= CheckMemoryIndex(destmemidx, &mt);
   result |= typechecker_.OnMemoryCopy(mt.limits);
@@ -988,18 +896,16 @@ Result SharedValidator::OnMemoryCopy(const Location& loc,
 }
 
 Result SharedValidator::OnMemoryFill(const Location& loc, Var memidx) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::MemoryFill, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= typechecker_.OnMemoryFill(mt.limits);
   return result;
 }
 
 Result SharedValidator::OnMemoryGrow(const Location& loc, Var memidx) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::MemoryGrow, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= typechecker_.OnMemoryGrow(mt.limits);
   return result;
@@ -1008,9 +914,8 @@ Result SharedValidator::OnMemoryGrow(const Location& loc, Var memidx) {
 Result SharedValidator::OnMemoryInit(const Location& loc,
                                      Var segment_var,
                                      Var memidx) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::MemoryInit, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckDataSegmentIndex(segment_var);
   result |= typechecker_.OnMemoryInit(segment_var.index(), mt.limits);
@@ -1018,51 +923,49 @@ Result SharedValidator::OnMemoryInit(const Location& loc,
 }
 
 Result SharedValidator::OnMemorySize(const Location& loc, Var memidx) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::MemorySize, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= typechecker_.OnMemorySize(mt.limits);
   return result;
 }
 
 Result SharedValidator::OnNop(const Location& loc) {
-  expr_loc_ = loc;
-  return Result::Ok;
+  Result result = CheckInstr(Opcode::Nop, loc);
+  return result;
 }
 
 Result SharedValidator::OnRefFunc(const Location& loc, Var func_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
-  result |= CheckDeclaredFunc(func_var);
-  result |= typechecker_.OnRefFuncExpr(GetFunctionTypeIndex(func_var.index()));
+  Result result = CheckInstr(Opcode::RefFunc, loc);
+  result |= CheckFuncIndex(func_var);
+  if (Succeeded(result)) {
+    check_declared_funcs_.push_back(func_var);
+    result |=
+        typechecker_.OnRefFuncExpr(GetFunctionTypeIndex(func_var.index()));
+  }
   return result;
 }
 
 Result SharedValidator::OnRefIsNull(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::RefIsNull, loc);
   result |= typechecker_.OnRefIsNullExpr();
   return result;
 }
 
 Result SharedValidator::OnRefNull(const Location& loc, Type type) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::RefNull, loc);
   result |= typechecker_.OnRefNullExpr(type);
   return result;
 }
 
 Result SharedValidator::OnRethrow(const Location& loc, Var depth) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Rethrow, loc);
   result |= typechecker_.OnRethrow(depth.index());
   return result;
 }
 
 Result SharedValidator::OnReturnCall(const Location& loc, Var func_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::ReturnCall, loc);
   FuncType func_type;
   result |= CheckFuncIndex(func_var, &func_type);
   result |= typechecker_.OnReturnCall(func_type.params, func_type.results);
@@ -1072,8 +975,7 @@ Result SharedValidator::OnReturnCall(const Location& loc, Var func_var) {
 Result SharedValidator::OnReturnCallIndirect(const Location& loc,
                                              Var sig_var,
                                              Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::CallIndirect, loc);
   result |= CheckTableIndex(table_var);
   FuncType func_type;
   result |= CheckFuncTypeIndex(sig_var, &func_type);
@@ -1083,8 +985,7 @@ Result SharedValidator::OnReturnCallIndirect(const Location& loc,
 }
 
 Result SharedValidator::OnReturn(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Return, loc);
   result |= typechecker_.OnReturn();
   return result;
 }
@@ -1092,8 +993,7 @@ Result SharedValidator::OnReturn(const Location& loc) {
 Result SharedValidator::OnSelect(const Location& loc,
                                  Index result_count,
                                  Type* result_types) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Select, loc);
   if (result_count > 1) {
     result |=
         PrintError(loc, "invalid arity in select instruction: %" PRIindex ".",
@@ -1107,8 +1007,7 @@ Result SharedValidator::OnSelect(const Location& loc,
 Result SharedValidator::OnSimdLaneOp(const Location& loc,
                                      Opcode opcode,
                                      uint64_t value) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnSimdLaneOp(opcode, value);
   return result;
 }
@@ -1117,9 +1016,8 @@ Result SharedValidator::OnSimdLoadLane(const Location& loc,
                                      Opcode opcode,
                                      Address alignment,
                                      uint64_t value) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnSimdLoadLane(opcode, mt.limits, value);
@@ -1130,9 +1028,8 @@ Result SharedValidator::OnSimdStoreLane(const Location& loc,
                                         Opcode opcode,
                                         Address alignment,
                                         uint64_t value) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(Var(0, loc), &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnSimdStoreLane(opcode, mt.limits, value);
@@ -1142,8 +1039,7 @@ Result SharedValidator::OnSimdStoreLane(const Location& loc,
 Result SharedValidator::OnSimdShuffleOp(const Location& loc,
                                         Opcode opcode,
                                         v128 value) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnSimdShuffleOp(opcode, value);
   return result;
 }
@@ -1152,9 +1048,8 @@ Result SharedValidator::OnStore(const Location& loc,
                                 Opcode opcode,
                                 Var memidx,
                                 Address alignment) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(opcode, loc);
   MemoryType mt;
-  expr_loc_ = loc;
   result |= CheckMemoryIndex(memidx, &mt);
   result |= CheckAlign(loc, alignment, opcode.GetMemorySize());
   result |= typechecker_.OnStore(opcode, mt.limits);
@@ -1164,8 +1059,7 @@ Result SharedValidator::OnStore(const Location& loc,
 Result SharedValidator::OnTableCopy(const Location& loc,
                                     Var dst_var,
                                     Var src_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableCopy, loc);
   TableType dst_table;
   TableType src_table;
   result |= CheckTableIndex(dst_var, &dst_table);
@@ -1176,8 +1070,7 @@ Result SharedValidator::OnTableCopy(const Location& loc,
 }
 
 Result SharedValidator::OnTableFill(const Location& loc, Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableFill, loc);
   TableType table_type;
   result |= CheckTableIndex(table_var, &table_type);
   result |= typechecker_.OnTableFill(table_type.element);
@@ -1185,8 +1078,7 @@ Result SharedValidator::OnTableFill(const Location& loc, Var table_var) {
 }
 
 Result SharedValidator::OnTableGet(const Location& loc, Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableGet, loc);
   TableType table_type;
   result |= CheckTableIndex(table_var, &table_type);
   result |= typechecker_.OnTableGet(table_type.element);
@@ -1194,8 +1086,7 @@ Result SharedValidator::OnTableGet(const Location& loc, Var table_var) {
 }
 
 Result SharedValidator::OnTableGrow(const Location& loc, Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableGrow, loc);
   TableType table_type;
   result |= CheckTableIndex(table_var, &table_type);
   result |= typechecker_.OnTableGrow(table_type.element);
@@ -1205,8 +1096,7 @@ Result SharedValidator::OnTableGrow(const Location& loc, Var table_var) {
 Result SharedValidator::OnTableInit(const Location& loc,
                                     Var segment_var,
                                     Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableInit, loc);
   TableType table_type;
   ElemType elem_type;
   result |= CheckTableIndex(table_var, &table_type);
@@ -1217,8 +1107,7 @@ Result SharedValidator::OnTableInit(const Location& loc,
 }
 
 Result SharedValidator::OnTableSet(const Location& loc, Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableSet, loc);
   TableType table_type;
   result |= CheckTableIndex(table_var, &table_type);
   result |= typechecker_.OnTableSet(table_type.element);
@@ -1226,23 +1115,20 @@ Result SharedValidator::OnTableSet(const Location& loc, Var table_var) {
 }
 
 Result SharedValidator::OnTableSize(const Location& loc, Var table_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::TableSize, loc);
   result |= CheckTableIndex(table_var);
   result |= typechecker_.OnTableSize();
   return result;
 }
 
 Result SharedValidator::OnTernary(const Location& loc, Opcode opcode) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnTernary(opcode);
   return result;
 }
 
 Result SharedValidator::OnThrow(const Location& loc, Var tag_var) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Throw, loc);
   TagType tag_type;
   result |= CheckTagIndex(tag_var, &tag_type);
   result |= typechecker_.OnThrow(tag_type.params);
@@ -1250,9 +1136,8 @@ Result SharedValidator::OnThrow(const Location& loc, Var tag_var) {
 }
 
 Result SharedValidator::OnTry(const Location& loc, Type sig_type) {
-  Result result = Result::Ok;
+  Result result = CheckInstr(Opcode::Try, loc);
   TypeVector param_types, result_types;
-  expr_loc_ = loc;
   result |= CheckBlockSignature(loc, Opcode::Try, sig_type, &param_types,
                                 &result_types);
   result |= typechecker_.OnTry(param_types, result_types);
@@ -1260,15 +1145,13 @@ Result SharedValidator::OnTry(const Location& loc, Type sig_type) {
 }
 
 Result SharedValidator::OnUnary(const Location& loc, Opcode opcode) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(opcode, loc);
   result |= typechecker_.OnUnary(opcode);
   return result;
 }
 
 Result SharedValidator::OnUnreachable(const Location& loc) {
-  Result result = Result::Ok;
-  expr_loc_ = loc;
+  Result result = CheckInstr(Opcode::Unreachable, loc);
   result |= typechecker_.OnUnreachable();
   return result;
 }

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -78,11 +78,6 @@ class SharedValidator {
   Result OnMemory(const Location&, const Limits&);
   Result OnGlobalImport(const Location&, Type type, bool mutable_);
   Result OnGlobal(const Location&, Type type, bool mutable_);
-  Result OnGlobalInitExpr_Const(const Location&, Type);
-  Result OnGlobalInitExpr_GlobalGet(const Location&, Var global_var);
-  Result OnGlobalInitExpr_RefNull(const Location&, Type type);
-  Result OnGlobalInitExpr_RefFunc(const Location&, Var func_var);
-  Result OnGlobalInitExpr_Other(const Location&);
   Result OnTag(const Location&, Var sig_var);
 
   Result OnExport(const Location&,
@@ -94,19 +89,15 @@ class SharedValidator {
 
   Result OnElemSegment(const Location&, Var table_var, SegmentKind);
   void OnElemSegmentElemType(Type elem_type);
-  Result OnElemSegmentInitExpr_Const(const Location&, Type);
-  Result OnElemSegmentInitExpr_GlobalGet(const Location&, Var global_var);
-  Result OnElemSegmentInitExpr_Other(const Location&);
   Result OnElemSegmentElemExpr_RefNull(const Location&, Type type);
   Result OnElemSegmentElemExpr_RefFunc(const Location&, Var func_var);
   Result OnElemSegmentElemExpr_Other(const Location&);
 
   void OnDataCount(Index count);
-
   Result OnDataSegment(const Location&, Var memory_var, SegmentKind);
-  Result OnDataSegmentInitExpr_Const(const Location&, Type);
-  Result OnDataSegmentInitExpr_GlobalGet(const Location&, Var global_var);
-  Result OnDataSegmentInitExpr_Other(const Location&);
+
+  Result BeginInitExpr(const Location&, Type type);
+  Result EndInitExpr();
 
   Result BeginFunctionBody(const Location&, Index func_index);
   Result EndFunctionBody(const Location&);
@@ -247,6 +238,7 @@ class SharedValidator {
     Index end;
   };
 
+  Result CheckInstr(Opcode opcode, const Location& loc);
   Result CheckType(const Location&,
                    Type actual,
                    Type expected,
@@ -293,6 +285,7 @@ class SharedValidator {
   TypeChecker typechecker_;  // TODO: Move into SharedValidator.
   // Cached for access by OnTypecheckerError.
   Location expr_loc_ = Location(kInvalidOffset);
+  bool in_init_expr_ = false;
 
   Index num_types_ = 0;
   std::map<Index, FuncType> func_types_;
@@ -315,7 +308,7 @@ class SharedValidator {
 
   std::set<std::string> export_names_;  // Used to check for duplicates.
   std::set<Index> declared_funcs_;      // TODO: optimize?
-  std::vector<Var> init_expr_funcs_;
+  std::vector<Var> check_declared_funcs_;
 };
 
 }  // namespace wabt

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -644,7 +644,8 @@ Result TypeChecker::OnEnd(Label* label,
 Result TypeChecker::OnEnd() {
   Result result = Result::Ok;
   static const char* s_label_type_name[] = {
-      "function", "block", "loop", "if", "if false branch", "try", "try catch"};
+      "function", "init_expr",       "block", "loop",
+      "if",       "if false branch", "try",   "try catch"};
   WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(s_label_type_name) == kLabelTypeCount);
   Label* label;
   CHECK_RESULT(TopLabel(&label));
@@ -955,6 +956,22 @@ Result TypeChecker::EndFunction() {
   CHECK_RESULT(TopLabel(&label));
   result |= CheckLabelType(label, LabelType::Func);
   result |= OnEnd(label, "implicit return", "function");
+  return result;
+}
+
+Result TypeChecker::BeginInitExpr(Type type) {
+  type_stack_.clear();
+  label_stack_.clear();
+  PushLabel(LabelType::InitExpr, TypeVector(), {type});
+  return Result::Ok;
+}
+
+Result TypeChecker::EndInitExpr() {
+  Result result = Result::Ok;
+  Label* label;
+  CHECK_RESULT(TopLabel(&label));
+  result |= CheckLabelType(label, LabelType::InitExpr);
+  result |= OnEnd(label, "constant expression", "init_expr");
   return result;
 }
 

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -129,6 +129,9 @@ class TypeChecker {
   Result OnUnreachable();
   Result EndFunction();
 
+  Result BeginInitExpr(Type type);
+  Result EndInitExpr();
+
   static Result CheckType(Type actual, Type expected);
 
  private:

--- a/test/parse/module/bad-global-invalid-expr.txt
+++ b/test/parse/module/bad-global-invalid-expr.txt
@@ -6,7 +6,7 @@
     i32.const 2
     i32.add))
 (;; STDERR ;;;
-out/test/parse/module/bad-global-invalid-expr.txt:4:4: error: invalid global initializer expression, must be a constant expression
-  (global i32 
-   ^^^^^^
+out/test/parse/module/bad-global-invalid-expr.txt:7:5: error: invalid initializer: instruction not valid in initializer expression: i32.add
+    i32.add))
+    ^^^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-26.txt
+++ b/test/regress/regress-26.txt
@@ -14,6 +14,6 @@ section(ELEM) {
   addr[end]
 }
 (;; STDERR ;;;
-out/test/regress/regress-26/regress-26.wasm:0000013: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+out/test/regress/regress-26/regress-26.wasm:0000012: error: type mismatch in constant expression, expected [i32] but got []
 0000013: error: EndElemSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-27.txt
+++ b/test/regress/regress-27.txt
@@ -14,6 +14,6 @@ section(DATA) {
   data[str("test")]
 }
 (;; STDERR ;;;
-out/test/regress/regress-27/regress-27.wasm:0000012: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+out/test/regress/regress-27/regress-27.wasm:0000011: error: type mismatch in constant expression, expected [i32] but got []
 0000012: error: EndDataSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -20,13 +20,13 @@ out/test/spec/data.wast:359: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/data.wast:378: assert_invalid passed:
-  out/test/spec/data/data.45.wasm:0000014: error: type mismatch at data segment offset. got i64, expected i32
+  out/test/spec/data/data.45.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:386: assert_invalid passed:
-  out/test/spec/data/data.46.wasm:0000014: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/data/data.46.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:394: assert_invalid passed:
-  out/test/spec/data/data.47.wasm:0000012: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/data/data.47.wasm:0000011: error: type mismatch in constant expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:402: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -38,27 +38,25 @@ out/test/spec/data.wast:419: assert_invalid passed:
   error: expected END opcode after initializer expression
   000002b: error: OnI32ConstExpr callback failed
 out/test/spec/data.wast:428: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/data/data.51.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed
 out/test/spec/data.wast:436: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/data/data.52.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/data.wast:444: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/data/data.53.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/data.wast:452: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/data/data.54.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
 out/test/spec/data.wast:466: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
-  out/test/spec/data/data.55.wasm:0000014: error: initializer expression cannot reference a mutable global
-  0000014: error: EndDataSegmentInitExpr callback failed
+  0000013: error: OnGlobalGetExpr callback failed
 out/test/spec/data.wast:474: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  out/test/spec/data/data.56.wasm:000002a: error: initializer expression cannot reference a mutable global
-  000002a: error: EndDataSegmentInitExpr callback failed
+  0000029: error: OnGlobalGetExpr callback failed
 out/test/spec/data.wast:483: assert_invalid passed:
-  out/test/spec/data/data.57.wasm:000002e: error: initializer expression cannot reference a mutable global
-  000002e: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/data/data.57.wasm:000002d: error: initializer expression cannot reference a mutable global
+  000002d: error: OnGlobalGetExpr callback failed
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -7,13 +7,13 @@ out/test/spec/elem.wast:336: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/elem.wast:346: assert_invalid passed:
-  out/test/spec/elem/elem.34.wasm:0000015: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/elem/elem.34.wasm:0000014: error: type mismatch in constant expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:354: assert_invalid passed:
-  out/test/spec/elem/elem.35.wasm:0000015: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/elem/elem.35.wasm:0000014: error: type mismatch in constant expression, expected [i32] but got [funcref]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:362: assert_invalid passed:
-  out/test/spec/elem/elem.36.wasm:0000013: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/elem/elem.36.wasm:0000012: error: type mismatch in constant expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:370: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -25,28 +25,26 @@ out/test/spec/elem.wast:387: assert_invalid passed:
   error: expected END opcode after initializer expression
   000002c: error: OnI32ConstExpr callback failed
 out/test/spec/elem.wast:397: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/elem/elem.40.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed
 out/test/spec/elem.wast:405: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/elem/elem.41.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
 out/test/spec/elem.wast:413: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/elem/elem.42.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
 out/test/spec/elem.wast:421: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
 out/test/spec/elem.wast:435: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
-  out/test/spec/elem/elem.44.wasm:0000015: error: initializer expression cannot reference a mutable global
-  0000015: error: EndElemSegmentInitExpr callback failed
+  0000014: error: OnGlobalGetExpr callback failed
 out/test/spec/elem.wast:443: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  out/test/spec/elem/elem.45.wasm:000002b: error: initializer expression cannot reference a mutable global
-  000002b: error: EndElemSegmentInitExpr callback failed
+  000002a: error: OnGlobalGetExpr callback failed
 out/test/spec/elem.wast:452: assert_invalid passed:
-  out/test/spec/elem/elem.46.wasm:000002f: error: initializer expression cannot reference a mutable global
-  000002f: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/elem/elem.46.wasm:000002e: error: initializer expression cannot reference a mutable global
+  000002e: error: OnGlobalGetExpr callback failed
 out/test/spec/elem.wast:463: assert_invalid passed:
   out/test/spec/elem/elem.47.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
   0000018: error: OnElemSegmentElemExpr_RefNull callback failed

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -10,13 +10,13 @@ out/test/spec/func_ptrs.wast:33: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:36: assert_invalid passed:
-  out/test/spec/func_ptrs/func_ptrs.3.wasm:0000015: error: invalid elem segment offset, must be a constant expression; either i32.const or global.get.
+  out/test/spec/func_ptrs/func_ptrs.3.wasm:0000014: error: type mismatch in constant expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/func_ptrs.wast:40: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/func_ptrs/func_ptrs.4.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed
 out/test/spec/func_ptrs.wast:44: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/func_ptrs/func_ptrs.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
 out/test/spec/func_ptrs.wast:48: assert_invalid passed:
   0000000: error: function type variable out of range: 42 (max 0)

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -9,34 +9,34 @@ out/test/spec/global.wast:278: assert_invalid passed:
   out/test/spec/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
   0000035: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:287: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/global/global.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
   0000013: error: OnUnaryExpr callback failed
 out/test/spec/global.wast:292: assert_invalid passed:
-  0000000: error: local variable out of range (max 0)
+  out/test/spec/global/global.6.wasm:000000f: error: invalid initializer: instruction not valid in initializer expression: local.get
   000000f: error: OnLocalGetExpr callback failed
 out/test/spec/global.wast:297: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/global/global.7.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
   0000013: error: OnUnaryExpr callback failed
 out/test/spec/global.wast:302: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/global/global.8.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: nop
   0000010: error: OnNopExpr callback failed
 out/test/spec/global.wast:307: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/global/global.9.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000010: error: OnUnaryExpr callback failed
 out/test/spec/global.wast:312: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
   000000e: error: OnNopExpr callback failed
 out/test/spec/global.wast:317: assert_invalid passed:
-  out/test/spec/global/global.11.wasm:0000013: error: type mismatch at global initializer expression. got f32, expected i32
+  out/test/spec/global/global.11.wasm:0000012: error: type mismatch in constant expression, expected [i32] but got [f32]
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:322: assert_invalid passed:
   error: expected END opcode after initializer expression
   0000011: error: OnI32ConstExpr callback failed
 out/test/spec/global.wast:327: assert_invalid passed:
-  out/test/spec/global/global.13.wasm:000000e: error: invalid global initializer expression, must be a constant expression
+  out/test/spec/global/global.13.wasm:000000d: error: type mismatch in constant expression, expected [i32] but got []
   000000e: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:332: assert_invalid passed:
-  out/test/spec/global/global.14.wasm:0000018: error: type mismatch at global initializer expression. got externref, expected funcref
+  out/test/spec/global/global.14.wasm:0000017: error: type mismatch in constant expression, expected [funcref] but got [externref]
   0000018: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:337: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -46,16 +46,16 @@ out/test/spec/global.wast:342: assert_invalid passed:
   0000027: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:347: assert_invalid passed:
   0000000: error: initializer expression can only reference an imported global
-  0000010: error: EndGlobalInitExpr callback failed
+  000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:352: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  0000010: error: EndGlobalInitExpr callback failed
+  000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:357: assert_invalid passed:
   0000000: error: global variable out of range: 2 (max 2)
-  0000026: error: EndGlobalInitExpr callback failed
+  0000025: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:362: assert_invalid passed:
-  out/test/spec/global/global.20.wasm:000002a: error: initializer expression cannot reference a mutable global
-  000002a: error: EndGlobalInitExpr callback failed
+  out/test/spec/global/global.20.wasm:0000029: error: initializer expression cannot reference a mutable global
+  0000029: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:370: assert_malformed passed:
   0000026: error: global mutability must be 0 or 1
 out/test/spec/global.wast:383: assert_malformed passed:

--- a/test/spec/multi-memory/data.txt
+++ b/test/spec/multi-memory/data.txt
@@ -21,13 +21,13 @@ out/test/spec/multi-memory/data.wast:360: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:379: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.45.wasm:0000014: error: type mismatch at data segment offset. got i64, expected i32
+  out/test/spec/multi-memory/data/data.45.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:387: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.46.wasm:0000014: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/multi-memory/data/data.46.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:395: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.47.wasm:0000012: error: invalid data segment offset, must be a constant expression; either iXX.const or global.get.
+  out/test/spec/multi-memory/data/data.47.wasm:0000011: error: type mismatch in constant expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:403: assert_invalid passed:
   error: expected END opcode after initializer expression
@@ -39,27 +39,25 @@ out/test/spec/multi-memory/data.wast:420: assert_invalid passed:
   error: expected END opcode after initializer expression
   000002b: error: OnI32ConstExpr callback failed
 out/test/spec/multi-memory/data.wast:429: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/multi-memory/data/data.51.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed
 out/test/spec/multi-memory/data.wast:437: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/multi-memory/data/data.52.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:445: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/multi-memory/data/data.53.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:453: assert_invalid passed:
-  error: Unepxected opcode in init expr
+  out/test/spec/multi-memory/data/data.54.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:467: assert_invalid passed:
   0000000: error: global variable out of range: 0 (max 0)
-  out/test/spec/multi-memory/data/data.55.wasm:0000014: error: initializer expression cannot reference a mutable global
-  0000014: error: EndDataSegmentInitExpr callback failed
+  0000013: error: OnGlobalGetExpr callback failed
 out/test/spec/multi-memory/data.wast:475: assert_invalid passed:
   0000000: error: global variable out of range: 1 (max 1)
-  out/test/spec/multi-memory/data/data.56.wasm:000002a: error: initializer expression cannot reference a mutable global
-  000002a: error: EndDataSegmentInitExpr callback failed
+  0000029: error: OnGlobalGetExpr callback failed
 out/test/spec/multi-memory/data.wast:484: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.57.wasm:000002e: error: initializer expression cannot reference a mutable global
-  000002e: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/multi-memory/data/data.57.wasm:000002d: error: initializer expression cannot reference a mutable global
+  000002d: error: OnGlobalGetExpr callback failed
 33/33 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/ref_func.txt
+++ b/test/spec/ref_func.txt
@@ -1,30 +1,32 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/ref_func.wast
 (;; STDERR ;;;
-out/test/spec/ref_func.wast:98:15: error: function is not declared in any elem sections
-    (ref.func $f1)
-              ^^^
-out/test/spec/ref_func.wast:99:15: error: function is not declared in any elem sections
-    (ref.func $f2)
-              ^^^
-out/test/spec/ref_func.wast:90:29: error: function is not declared in any elem sections
+out/test/spec/ref_func.wast:90:29: error: function 0 is not declared in any elem sections
   (global funcref (ref.func $f1))
                             ^^^
-0000000: error: function is not declared in any elem sections
-000005d: error: OnRefFuncExpr callback failed
+out/test/spec/ref_func.wast:98:15: error: function 0 is not declared in any elem sections
+    (ref.func $f1)
+              ^^^
+out/test/spec/ref_func.wast:99:15: error: function 1 is not declared in any elem sections
+    (ref.func $f2)
+              ^^^
+0000000: error: function 0 is not declared in any elem sections
+0000000: error: function 0 is not declared in any elem sections
+0000000: error: function 1 is not declared in any elem sections
+0000069: error: EndModule callback failed
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 set-g() =>
 set-f() =>
 out/test/spec/ref_func.wast:69: assert_invalid passed:
   0000000: error: function variable out of range: 7 (max 2)
-  0000027: error: EndGlobalInitExpr callback failed
+  0000026: error: OnRefFuncExpr callback failed
 out/test/spec/ref_func.wast:80: error reading module: "out/test/spec/ref_func/ref_func.3.wasm"
 out/test/spec/ref_func.wast:109: assert_invalid passed:
-  0000000: error: function is not declared in any elem sections
-  0000019: error: OnRefFuncExpr callback failed
+  0000000: error: function 0 is not declared in any elem sections
+  000001b: error: EndModule callback failed
 out/test/spec/ref_func.wast:113: assert_invalid passed:
-  0000000: error: function is not declared in any elem sections
-  000001c: error: OnRefFuncExpr callback failed
+  0000000: error: function 0 is not declared in any elem sections
+  000001e: error: EndModule callback failed
 13/13 tests passed.
 ;;; STDOUT ;;)

--- a/test/typecheck/bad-global-getglobal-type-mismatch.txt
+++ b/test/typecheck/bad-global-getglobal-type-mismatch.txt
@@ -4,7 +4,7 @@
   (import "foo" "bar" (global i32))
   (global f32 (get_global 0)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-getglobal-type-mismatch.txt:5:16: error: type mismatch at global initializer expression. got i32, expected f32
+out/test/typecheck/bad-global-getglobal-type-mismatch.txt:5:16: error: type mismatch in constant expression, expected [f32] but got [i32]
   (global f32 (get_global 0)))
                ^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-no-init-expr.txt
+++ b/test/typecheck/bad-global-no-init-expr.txt
@@ -4,10 +4,10 @@
   (global i32)
   (global (mut f32)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-no-init-expr.txt:4:4: error: invalid global initializer expression, must be a constant expression
+out/test/typecheck/bad-global-no-init-expr.txt:4:4: error: type mismatch in constant expression, expected [i32] but got []
   (global i32)
    ^^^^^^
-out/test/typecheck/bad-global-no-init-expr.txt:5:4: error: invalid global initializer expression, must be a constant expression
+out/test/typecheck/bad-global-no-init-expr.txt:5:4: error: type mismatch in constant expression, expected [f32] but got []
   (global (mut f32)))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-type-mismatch.txt
+++ b/test/typecheck/bad-global-type-mismatch.txt
@@ -3,7 +3,7 @@
 (module
   (global i32 (f32.const 1)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-type-mismatch.txt:4:16: error: type mismatch at global initializer expression. got f32, expected i32
+out/test/typecheck/bad-global-type-mismatch.txt:4:16: error: type mismatch in constant expression, expected [i32] but got [f32]
   (global i32 (f32.const 1)))
                ^^^^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
…s. NFC

Previously we has special cases for initializer expressions (constant
expressions).  This change paves the way for adding support for
extended constant expressions that support a wider range of
instructions.

This change removes twice as many lines as it adds which shows that
this simplification is probably worthwhile even without the pending
extensions.