### PR TITLE
Remove check from binary-reader-interp.cc that the validator already catches. NFC

### DIFF
--- a/src/interp/binary-reader-interp.cc
+++ b/src/interp/binary-reader-interp.cc
@@ -301,7 +301,6 @@ class BinaryReaderInterp : public BinaryReaderNop {
                                     Index* out_keep_count);
   Result BeginInitExpr(Type type);
   Result EndInitExpr();
-  Result CheckEmptyInitExpr();
 
   void EmitBr(Index depth,
               Index drop_count,
@@ -641,15 +640,6 @@ Result BinaryReaderInterp::BeginInitExpr(Type type) {
   reading_init_expr_ = true;
   init_expr_.kind = InitExprKind::None;
   CHECK_RESULT(validator_.BeginInitExpr(GetLocation(), type));
-  return Result::Ok;
-}
-
-Result BinaryReaderInterp::CheckEmptyInitExpr() {
-  assert(reading_init_expr_);
-  if (init_expr_.kind != InitExprKind::None) {
-    PrintError("expected END opcode after initializer expression");
-    return Result::Error;
-  }
   return Result::Ok;
 }
 
@@ -1192,7 +1182,6 @@ Result BinaryReaderInterp::OnDropExpr() {
 Result BinaryReaderInterp::OnI32ConstExpr(uint32_t value) {
   CHECK_RESULT(validator_.OnConst(GetLocation(), Type::I32));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::I32;
     init_expr_.i32_ = value;
     return Result::Ok;
@@ -1204,7 +1193,6 @@ Result BinaryReaderInterp::OnI32ConstExpr(uint32_t value) {
 Result BinaryReaderInterp::OnI64ConstExpr(uint64_t value) {
   CHECK_RESULT(validator_.OnConst(GetLocation(), Type::I64));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::I64;
     init_expr_.i64_ = value;
     return Result::Ok;
@@ -1216,7 +1204,6 @@ Result BinaryReaderInterp::OnI64ConstExpr(uint64_t value) {
 Result BinaryReaderInterp::OnF32ConstExpr(uint32_t value_bits) {
   CHECK_RESULT(validator_.OnConst(GetLocation(), Type::F32));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::F32;
     init_expr_.f32_ = Bitcast<f32>(value_bits);
     return Result::Ok;
@@ -1228,7 +1215,6 @@ Result BinaryReaderInterp::OnF32ConstExpr(uint32_t value_bits) {
 Result BinaryReaderInterp::OnF64ConstExpr(uint64_t value_bits) {
   CHECK_RESULT(validator_.OnConst(GetLocation(), Type::F64));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::F64;
     init_expr_.f64_ = Bitcast<f64>(value_bits);
     return Result::Ok;
@@ -1240,7 +1226,6 @@ Result BinaryReaderInterp::OnF64ConstExpr(uint64_t value_bits) {
 Result BinaryReaderInterp::OnV128ConstExpr(v128 value_bits) {
   CHECK_RESULT(validator_.OnConst(GetLocation(), Type::V128));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::V128;
     init_expr_.v128_ = Bitcast<v128>(value_bits);
     return Result::Ok;
@@ -1252,7 +1237,6 @@ Result BinaryReaderInterp::OnV128ConstExpr(v128 value_bits) {
 Result BinaryReaderInterp::OnGlobalGetExpr(Index global_index) {
   CHECK_RESULT(validator_.OnGlobalGet(GetLocation(), Var(global_index)));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::GlobalGet;
     init_expr_.index_ = global_index;
     return Result::Ok;
@@ -1349,7 +1333,6 @@ Result BinaryReaderInterp::OnTableFillExpr(Index table_index) {
 Result BinaryReaderInterp::OnRefFuncExpr(Index func_index) {
   CHECK_RESULT(validator_.OnRefFunc(GetLocation(), Var(func_index)));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::RefFunc;
     init_expr_.index_ = func_index;
     return Result::Ok;
@@ -1361,7 +1344,6 @@ Result BinaryReaderInterp::OnRefFuncExpr(Index func_index) {
 Result BinaryReaderInterp::OnRefNullExpr(Type type) {
   CHECK_RESULT(validator_.OnRefNull(GetLocation(), type));
   if (reading_init_expr_) {
-    CHECK_RESULT(CheckEmptyInitExpr());
     init_expr_.kind = InitExprKind::RefNull;
     init_expr_.type_ = type;
     return Result::Ok;

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -180,11 +180,14 @@ class TypeChecker {
     // Minor optimization, check result before constructing the vector to pass
     // to the other overload of PrintStackIfFailed.
     if (Failed(result)) {
-      PrintStackIfFailed(result, desc, {args...});
+      PrintStackIfFailedV(result, desc, {args...}, /*is_end=*/false);
     }
   }
 
-  void PrintStackIfFailed(Result, const char* desc, const TypeVector&);
+  void PrintStackIfFailedV(Result,
+                           const char* desc,
+                           const TypeVector&,
+                           bool is_end);
 
   ErrorCallback error_callback_;
   TypeVector type_stack_;

--- a/test/binary/bad-typecheck-missing-drop.txt
+++ b/test/binary/bad-typecheck-missing-drop.txt
@@ -13,6 +13,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
-out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
+out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
+out/test/binary/bad-typecheck-missing-drop/bad-typecheck-missing-drop.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-binary-one-expr.txt
+++ b/test/parse/expr/bad-binary-one-expr.txt
@@ -7,7 +7,7 @@
 out/test/parse/expr/bad-binary-one-expr.txt:5:4: error: type mismatch in i32.add, expected [i32, i32] but got [i32]
    i32.add))
    ^^^^^^^
-out/test/parse/expr/bad-binary-one-expr.txt:5:4: error: type mismatch in function, expected [] but got [i32]
+out/test/parse/expr/bad-binary-one-expr.txt:5:4: error: type mismatch at end of function, expected [] but got [i32]
    i32.add))
    ^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-compare-one-expr.txt
+++ b/test/parse/expr/bad-compare-one-expr.txt
@@ -7,7 +7,7 @@
 out/test/parse/expr/bad-compare-one-expr.txt:5:11: error: type mismatch in i32.lt_s, expected [i32, i32] but got [i32]
           i32.lt_s))
           ^^^^^^^^
-out/test/parse/expr/bad-compare-one-expr.txt:5:11: error: type mismatch in function, expected [] but got [i32]
+out/test/parse/expr/bad-compare-one-expr.txt:5:11: error: type mismatch at end of function, expected [] but got [i32]
           i32.lt_s))
           ^^^^^^^^
 ;;; STDERR ;;)

--- a/test/parse/expr/bad-select-multi.txt
+++ b/test/parse/expr/bad-select-multi.txt
@@ -14,7 +14,7 @@
 out/test/parse/expr/bad-select-multi.txt:10:5: error: invalid arity in select instruction: 2.
     select (result i32 i32)
     ^^^^^^
-out/test/parse/expr/bad-select-multi.txt:10:5: error: type mismatch in function, expected [] but got [... i32, i32, i32, i32]
+out/test/parse/expr/bad-select-multi.txt:10:5: error: type mismatch at end of function, expected [] but got [... i32, i32, i32, i32]
     select (result i32 i32)
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-10.txt
+++ b/test/regress/regress-10.txt
@@ -8,7 +8,7 @@
       tee_local 0
     end))
 (;; STDERR ;;;
-out/test/regress/regress-10.txt:9:5: error: type mismatch in block, expected [] but got [i32]
+out/test/regress/regress-10.txt:9:5: error: type mismatch at end of block, expected [] but got [i32]
     end))
     ^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-11.txt
+++ b/test/regress/regress-11.txt
@@ -10,7 +10,7 @@
       i32.const 1
     end))
 (;; STDERR ;;;
-out/test/regress/regress-11.txt:9:7: error: type mismatch in block, expected [] but got [i32]
+out/test/regress/regress-11.txt:9:7: error: type mismatch at end of block, expected [] but got [i32]
       end
       ^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-23.txt
+++ b/test/regress/regress-23.txt
@@ -56,16 +56,16 @@
   )
 )
 (;; STDERR ;;;
-out/test/regress/regress-23.txt:13:5: error: type mismatch in if true branch, expected [i32] but got []
+out/test/regress/regress-23.txt:13:5: error: type mismatch in `if true` branch, expected [i32] but got []
     )
     ^
-out/test/regress/regress-23.txt:25:7: error: type mismatch in if true branch, expected [i32] but got []
+out/test/regress/regress-23.txt:25:7: error: type mismatch in `if true` branch, expected [i32] but got []
       )
       ^
-out/test/regress/regress-23.txt:41:3: error: type mismatch in if false branch, expected [i32] but got []
+out/test/regress/regress-23.txt:41:3: error: type mismatch in `if false` branch, expected [i32] but got []
   )
   ^
-out/test/regress/regress-23.txt:56:3: error: type mismatch in if false branch, expected [i32] but got []
+out/test/regress/regress-23.txt:56:3: error: type mismatch in `if false` branch, expected [i32] but got []
   )
   ^
 ;;; STDERR ;;)

--- a/test/regress/regress-26.txt
+++ b/test/regress/regress-26.txt
@@ -14,6 +14,6 @@ section(ELEM) {
   addr[end]
 }
 (;; STDERR ;;;
-out/test/regress/regress-26/regress-26.wasm:0000012: error: type mismatch in constant expression, expected [i32] but got []
+out/test/regress/regress-26/regress-26.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
 0000013: error: EndElemSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-27.txt
+++ b/test/regress/regress-27.txt
@@ -14,6 +14,6 @@ section(DATA) {
   data[str("test")]
 }
 (;; STDERR ;;;
-out/test/regress/regress-27/regress-27.wasm:0000011: error: type mismatch in constant expression, expected [i32] but got []
+out/test/regress/regress-27/regress-27.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
 0000012: error: EndDataSegmentInitExpr callback failed
 ;;; STDERR ;;)

--- a/test/regress/regress-28.txt
+++ b/test/regress/regress-28.txt
@@ -15,6 +15,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-out/test/regress/regress-28/regress-28.wasm:000001b: error: type mismatch in function, expected [] but got [any]
+out/test/regress/regress-28/regress-28.wasm:000001b: error: type mismatch at end of function, expected [] but got [any]
 000001c: error: EndFunctionBody callback failed
 ;;; STDERR ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -49,7 +49,7 @@ out/test/spec/block.wast:489: assert_malformed passed:
   ...2) (result i32)))(func (i32.const 0) (block (type $sig) (param i32) (resul...
                                           ^
 out/test/spec/block.wast:497: assert_invalid passed:
-  out/test/spec/block/block.12.wasm:000001c: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/block/block.12.wasm:000001c: error: type mismatch at end of block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:505: assert_invalid passed:
   out/test/spec/block/block.13.wasm:000001b: error: type mismatch in implicit return, expected [i32] but got []
@@ -64,19 +64,19 @@ out/test/spec/block.wast:517: assert_invalid passed:
   out/test/spec/block/block.16.wasm:000001b: error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:522: assert_invalid passed:
-  out/test/spec/block/block.17.wasm:000001c: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/block/block.17.wasm:000001c: error: type mismatch at end of block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:528: assert_invalid passed:
-  out/test/spec/block/block.18.wasm:000001c: error: type mismatch in block, expected [] but got [i64]
+  out/test/spec/block/block.18.wasm:000001c: error: type mismatch at end of block, expected [] but got [i64]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:534: assert_invalid passed:
-  out/test/spec/block/block.19.wasm:000001f: error: type mismatch in block, expected [] but got [f32]
+  out/test/spec/block/block.19.wasm:000001f: error: type mismatch at end of block, expected [] but got [f32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/block.wast:540: assert_invalid passed:
-  out/test/spec/block/block.20.wasm:0000023: error: type mismatch in block, expected [] but got [f64]
+  out/test/spec/block/block.20.wasm:0000023: error: type mismatch at end of block, expected [] but got [f64]
   0000023: error: OnEndExpr callback failed
 out/test/spec/block.wast:546: assert_invalid passed:
-  out/test/spec/block/block.21.wasm:000001e: error: type mismatch in block, expected [] but got [i32, i32]
+  out/test/spec/block/block.21.wasm:000001e: error: type mismatch at end of block, expected [] but got [i32, i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/block.wast:552: assert_invalid passed:
   out/test/spec/block/block.22.wasm:000001b: error: type mismatch in block, expected [i32] but got []
@@ -160,7 +160,7 @@ out/test/spec/block.wast:719: assert_invalid passed:
   out/test/spec/block/block.48.wasm:0000020: error: type mismatch in block, expected [i32, i32] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/block.wast:725: assert_invalid passed:
-  out/test/spec/block/block.49.wasm:000001f: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/block/block.49.wasm:000001f: error: type mismatch at end of block, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/block.wast:732: assert_invalid passed:
   out/test/spec/block/block.50.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
@@ -337,19 +337,19 @@ out/test/spec/block.wast:1080: assert_invalid passed:
   out/test/spec/block/block.107.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1087: assert_invalid passed:
-  out/test/spec/block/block.108.wasm:0000023: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/block/block.108.wasm:0000023: error: type mismatch at end of function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1093: assert_invalid passed:
-  out/test/spec/block/block.109.wasm:0000023: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/block/block.109.wasm:0000023: error: type mismatch at end of function, expected [] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1099: assert_invalid passed:
-  out/test/spec/block/block.110.wasm:0000026: error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/block/block.110.wasm:0000026: error: type mismatch at end of function, expected [] but got [f32]
   0000027: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1105: assert_invalid passed:
-  out/test/spec/block/block.111.wasm:000002a: error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/block/block.111.wasm:000002a: error: type mismatch at end of function, expected [] but got [f64]
   000002b: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1111: assert_invalid passed:
-  out/test/spec/block/block.112.wasm:000002a: error: type mismatch in function, expected [] but got [i32, i32]
+  out/test/spec/block/block.112.wasm:000002a: error: type mismatch at end of function, expected [] but got [i32, i32]
   000002b: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1118: assert_invalid passed:
   out/test/spec/block/block.113.wasm:000001e: error: type mismatch in br, expected [i32] but got []

--- a/test/spec/br_if.txt
+++ b/test/spec/br_if.txt
@@ -32,10 +32,10 @@ out/test/spec/br_if.wast:521: assert_invalid passed:
   out/test/spec/br_if/br_if.10.wasm:000001e: error: type mismatch in br_if, expected [i32] but got []
   000001e: error: OnBrIfExpr callback failed
 out/test/spec/br_if.wast:527: assert_invalid passed:
-  out/test/spec/br_if/br_if.11.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_if/br_if.11.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/br_if.wast:533: assert_invalid passed:
-  out/test/spec/br_if/br_if.12.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_if/br_if.12.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/br_if.wast:540: assert_invalid passed:
   out/test/spec/br_if/br_if.13.wasm:000001f: error: type mismatch in br_if, expected [i32] but got []

--- a/test/spec/br_table.txt
+++ b/test/spec/br_table.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/br_table.wast
 (;; STDOUT ;;;
 out/test/spec/br_table.wast:1442: assert_invalid passed:
-  out/test/spec/br_table/br_table.1.wasm:0000022: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_table/br_table.1.wasm:0000022: error: type mismatch at end of block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/br_table.wast:1449: assert_invalid passed:
   out/test/spec/br_table/br_table.2.wasm:000001d: error: type mismatch in br_table, expected [i32] but got []
@@ -35,7 +35,7 @@ out/test/spec/br_table.wast:1516: assert_invalid passed:
   out/test/spec/br_table/br_table.11.wasm:0000022: error: type mismatch in br_table, expected [i32] but got [... i64]
   0000022: error: OnBrTableExpr callback failed
 out/test/spec/br_table.wast:1525: assert_invalid passed:
-  out/test/spec/br_table/br_table.12.wasm:0000022: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/br_table/br_table.12.wasm:0000022: error: type mismatch at end of block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/br_table.wast:1532: assert_invalid passed:
   out/test/spec/br_table/br_table.13.wasm:0000022: error: type mismatch in br_table, expected [i32] but got []

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -15,10 +15,10 @@ out/test/spec/call.wast:403: assert_invalid passed:
   out/test/spec/call/call.4.wasm:000001f: error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
 out/test/spec/call.wast:410: assert_invalid passed:
-  out/test/spec/call/call.5.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/call/call.5.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/call.wast:417: assert_invalid passed:
-  out/test/spec/call/call.6.wasm:0000025: error: type mismatch in function, expected [] but got [f64, i32]
+  out/test/spec/call/call.6.wasm:0000025: error: type mismatch at end of function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
 out/test/spec/call.wast:425: assert_invalid passed:
   out/test/spec/call/call.7.wasm:0000022: error: type mismatch in call, expected [i32, i32] but got [i32]

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -100,10 +100,10 @@ out/test/spec/call_indirect.wast:824: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.17.wasm:0000027: error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:832: assert_invalid passed:
-  out/test/spec/call_indirect/call_indirect.18.wasm:0000024: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/call_indirect/call_indirect.18.wasm:0000024: error: type mismatch at end of function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/call_indirect.wast:840: assert_invalid passed:
-  out/test/spec/call_indirect/call_indirect.19.wasm:000002d: error: type mismatch in function, expected [] but got [f64, i32]
+  out/test/spec/call_indirect/call_indirect.19.wasm:000002d: error: type mismatch at end of function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
 out/test/spec/call_indirect.wast:851: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.20.wasm:0000027: error: type mismatch in call_indirect, expected [i32] but got []

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -20,23 +20,23 @@ out/test/spec/data.wast:359: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/data.wast:378: assert_invalid passed:
-  out/test/spec/data/data.45.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [i64]
+  out/test/spec/data/data.45.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:386: assert_invalid passed:
-  out/test/spec/data/data.46.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [funcref]
+  out/test/spec/data/data.46.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:394: assert_invalid passed:
-  out/test/spec/data/data.47.wasm:0000011: error: type mismatch in constant expression, expected [i32] but got []
+  out/test/spec/data/data.47.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:402: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  0000015: error: OnI32ConstExpr callback failed
+  out/test/spec/data/data.48.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000016: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:410: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  000002b: error: OnGlobalGetExpr callback failed
+  out/test/spec/data/data.49.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002c: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:419: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  000002b: error: OnI32ConstExpr callback failed
+  out/test/spec/data/data.50.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002c: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:428: assert_invalid passed:
   out/test/spec/data/data.51.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -7,23 +7,23 @@ out/test/spec/elem.wast:336: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/elem.wast:346: assert_invalid passed:
-  out/test/spec/elem/elem.34.wasm:0000014: error: type mismatch in constant expression, expected [i32] but got [i64]
+  out/test/spec/elem/elem.34.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:354: assert_invalid passed:
-  out/test/spec/elem/elem.35.wasm:0000014: error: type mismatch in constant expression, expected [i32] but got [funcref]
+  out/test/spec/elem/elem.35.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:362: assert_invalid passed:
-  out/test/spec/elem/elem.36.wasm:0000012: error: type mismatch in constant expression, expected [i32] but got []
+  out/test/spec/elem/elem.36.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:370: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  0000016: error: OnI32ConstExpr callback failed
+  out/test/spec/elem/elem.37.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000017: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:378: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  000002c: error: OnGlobalGetExpr callback failed
+  out/test/spec/elem/elem.38.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002d: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:387: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  000002c: error: OnI32ConstExpr callback failed
+  out/test/spec/elem/elem.39.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002d: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:397: assert_invalid passed:
   out/test/spec/elem/elem.40.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000015: error: OnUnaryExpr callback failed

--- a/test/spec/exception-handling/try_catch.txt
+++ b/test/spec/exception-handling/try_catch.txt
@@ -25,13 +25,13 @@ out/test/spec/exception-handling/try_catch.wast:232: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.7.wasm:000001d: error: type mismatch in try, expected [i32] but got [i64]
   000001d: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:234: assert_invalid passed:
-  out/test/spec/exception-handling/try_catch/try_catch.8.wasm:0000023: error: type mismatch in try catch, expected [] but got [i32]
+  out/test/spec/exception-handling/try_catch/try_catch.8.wasm:0000023: error: type mismatch at end of try catch, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:236: assert_invalid passed:
   out/test/spec/exception-handling/try_catch/try_catch.9.wasm:0000028: error: type mismatch in try catch, expected [i32] but got [i64]
   0000028: error: OnEndExpr callback failed
 out/test/spec/exception-handling/try_catch.wast:241: assert_invalid passed:
-  out/test/spec/exception-handling/try_catch/try_catch.10.wasm:000001d: error: type mismatch in try catch, expected [] but got [i32]
+  out/test/spec/exception-handling/try_catch/try_catch.10.wasm:000001d: error: type mismatch at end of try catch, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 35/35 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -91,10 +91,10 @@ out/test/spec/func.wast:693: assert_invalid passed:
   out/test/spec/func/func.28.wasm:000001a: error: type mismatch in implicit return, expected [i32, i32] but got []
   000001b: error: EndFunctionBody callback failed
 out/test/spec/func.wast:699: assert_invalid passed:
-  out/test/spec/func/func.29.wasm:0000019: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/func/func.29.wasm:0000019: error: type mismatch at end of function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:705: assert_invalid passed:
-  out/test/spec/func/func.30.wasm:000001b: error: type mismatch in function, expected [] but got [i32, i64]
+  out/test/spec/func/func.30.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32, i64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/func.wast:711: assert_invalid passed:
   out/test/spec/func/func.31.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got [f32]
@@ -103,7 +103,7 @@ out/test/spec/func.wast:717: assert_invalid passed:
   out/test/spec/func/func.32.wasm:000001e: error: type mismatch in implicit return, expected [f32, f32] but got [f32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/func.wast:723: assert_invalid passed:
-  out/test/spec/func/func.33.wasm:0000022: error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/func/func.33.wasm:0000022: error: type mismatch at end of function, expected [] but got [f32]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/func.wast:730: assert_invalid passed:
   out/test/spec/func/func.34.wasm:0000019: error: type mismatch in return, expected [i32] but got []

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -10,7 +10,7 @@ out/test/spec/func_ptrs.wast:33: assert_invalid passed:
   0000000: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:36: assert_invalid passed:
-  out/test/spec/func_ptrs/func_ptrs.3.wasm:0000014: error: type mismatch in constant expression, expected [i32] but got [i64]
+  out/test/spec/func_ptrs/func_ptrs.3.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/func_ptrs.wast:40: assert_invalid passed:
   out/test/spec/func_ptrs/func_ptrs.4.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -27,23 +27,23 @@ out/test/spec/global.wast:312: assert_invalid passed:
   out/test/spec/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
   000000e: error: OnNopExpr callback failed
 out/test/spec/global.wast:317: assert_invalid passed:
-  out/test/spec/global/global.11.wasm:0000012: error: type mismatch in constant expression, expected [i32] but got [f32]
+  out/test/spec/global/global.11.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got [f32]
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:322: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  0000011: error: OnI32ConstExpr callback failed
+  out/test/spec/global/global.12.wasm:0000011: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000012: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:327: assert_invalid passed:
-  out/test/spec/global/global.13.wasm:000000d: error: type mismatch in constant expression, expected [i32] but got []
+  out/test/spec/global/global.13.wasm:000000d: error: type mismatch in initializer expression, expected [i32] but got []
   000000e: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:332: assert_invalid passed:
-  out/test/spec/global/global.14.wasm:0000017: error: type mismatch in constant expression, expected [funcref] but got [externref]
+  out/test/spec/global/global.14.wasm:0000017: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000018: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:337: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  0000027: error: OnGlobalGetExpr callback failed
+  out/test/spec/global/global.15.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000028: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:342: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  0000027: error: OnGlobalGetExpr callback failed
+  out/test/spec/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000028: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:347: assert_invalid passed:
   0000000: error: initializer expression can only reference an imported global
   000000f: error: OnGlobalGetExpr callback failed

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -68,7 +68,7 @@ out/test/spec/if.wast:816: assert_malformed passed:
   ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (result i...
                                           ^
 out/test/spec/if.wast:826: assert_invalid passed:
-  out/test/spec/if/if.12.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/if/if.12.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/if.wast:834: assert_invalid passed:
   out/test/spec/if/if.13.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
@@ -95,112 +95,112 @@ out/test/spec/if.wast:863: assert_invalid passed:
   out/test/spec/if/if.20.wasm:000001d: error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:868: assert_invalid passed:
-  out/test/spec/if/if.21.wasm:000001e: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.21.wasm:000001e: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:874: assert_invalid passed:
-  out/test/spec/if/if.22.wasm:000001e: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.22.wasm:000001e: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:880: assert_invalid passed:
-  out/test/spec/if/if.23.wasm:000001f: error: type mismatch in if false branch, expected [] but got [i32]
+  out/test/spec/if/if.23.wasm:000001f: error: type mismatch at end of `if false` branch, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:886: assert_invalid passed:
-  out/test/spec/if/if.24.wasm:000001d: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.24.wasm:000001d: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:893: assert_invalid passed:
-  out/test/spec/if/if.25.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.25.wasm:0000020: error: type mismatch at end of `if true` branch, expected [] but got [i32, i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/if.wast:899: assert_invalid passed:
-  out/test/spec/if/if.26.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.26.wasm:0000020: error: type mismatch at end of `if true` branch, expected [] but got [i32, i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/if.wast:905: assert_invalid passed:
-  out/test/spec/if/if.27.wasm:0000021: error: type mismatch in if false branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.27.wasm:0000021: error: type mismatch at end of `if false` branch, expected [] but got [i32, i32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/if.wast:911: assert_invalid passed:
-  out/test/spec/if/if.28.wasm:000001f: error: type mismatch in if true branch, expected [] but got [i32, i32]
+  out/test/spec/if/if.28.wasm:000001f: error: type mismatch at end of `if true` branch, expected [] but got [i32, i32]
   0000020: error: OnElseExpr callback failed
 out/test/spec/if.wast:918: assert_invalid passed:
-  out/test/spec/if/if.29.wasm:000001c: error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.29.wasm:000001c: error: type mismatch in `if true` branch, expected [i32] but got []
   000001d: error: OnElseExpr callback failed
 out/test/spec/if.wast:924: assert_invalid passed:
-  out/test/spec/if/if.30.wasm:000001f: error: type mismatch in if false branch, expected [i32] but got []
+  out/test/spec/if/if.30.wasm:000001f: error: type mismatch in `if false` branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:930: assert_invalid passed:
-  out/test/spec/if/if.31.wasm:000001d: error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.31.wasm:000001d: error: type mismatch in `if true` branch, expected [i32] but got []
   000001d: error: OnEndExpr callback failed
 out/test/spec/if.wast:937: assert_invalid passed:
-  out/test/spec/if/if.32.wasm:000001d: error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.32.wasm:000001d: error: type mismatch in `if true` branch, expected [i32, i32] but got []
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:943: assert_invalid passed:
-  out/test/spec/if/if.33.wasm:0000022: error: type mismatch in if false branch, expected [i32, i32] but got []
+  out/test/spec/if/if.33.wasm:0000022: error: type mismatch in `if false` branch, expected [i32, i32] but got []
   0000022: error: OnEndExpr callback failed
 out/test/spec/if.wast:949: assert_invalid passed:
-  out/test/spec/if/if.34.wasm:000001e: error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.34.wasm:000001e: error: type mismatch in `if true` branch, expected [i32, i32] but got []
   000001e: error: OnEndExpr callback failed
 out/test/spec/if.wast:956: assert_invalid passed:
-  out/test/spec/if/if.35.wasm:000001f: error: type mismatch in if false branch, expected [i32] but got []
+  out/test/spec/if/if.35.wasm:000001f: error: type mismatch in `if false` branch, expected [i32] but got []
   000001f: error: OnEndExpr callback failed
 out/test/spec/if.wast:962: assert_invalid passed:
-  out/test/spec/if/if.36.wasm:0000022: error: type mismatch in if false branch, expected [i32, i32] but got []
+  out/test/spec/if/if.36.wasm:0000022: error: type mismatch in `if false` branch, expected [i32, i32] but got []
   0000022: error: OnEndExpr callback failed
 out/test/spec/if.wast:969: assert_invalid passed:
-  out/test/spec/if/if.37.wasm:000001d: error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.37.wasm:000001d: error: type mismatch in `if true` branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:975: assert_invalid passed:
-  out/test/spec/if/if.38.wasm:0000021: error: type mismatch in if false branch, expected [i32] but got []
+  out/test/spec/if/if.38.wasm:0000021: error: type mismatch in `if false` branch, expected [i32] but got []
   0000021: error: OnEndExpr callback failed
 out/test/spec/if.wast:981: assert_invalid passed:
-  out/test/spec/if/if.39.wasm:000001d: error: type mismatch in if true branch, expected [i32] but got []
+  out/test/spec/if/if.39.wasm:000001d: error: type mismatch in `if true` branch, expected [i32] but got []
   000001e: error: OnElseExpr callback failed
 out/test/spec/if.wast:988: assert_invalid passed:
-  out/test/spec/if/if.40.wasm:000001e: error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.40.wasm:000001e: error: type mismatch in `if true` branch, expected [i32, i32] but got []
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:994: assert_invalid passed:
-  out/test/spec/if/if.41.wasm:0000024: error: type mismatch in if false branch, expected [i32, i32] but got []
+  out/test/spec/if/if.41.wasm:0000024: error: type mismatch in `if false` branch, expected [i32, i32] but got []
   0000024: error: OnEndExpr callback failed
 out/test/spec/if.wast:1000: assert_invalid passed:
-  out/test/spec/if/if.42.wasm:000001e: error: type mismatch in if true branch, expected [i32, i32] but got []
+  out/test/spec/if/if.42.wasm:000001e: error: type mismatch in `if true` branch, expected [i32, i32] but got []
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1007: assert_invalid passed:
-  out/test/spec/if/if.43.wasm:000001e: error: type mismatch in if true branch, expected [i32] but got [i64]
+  out/test/spec/if/if.43.wasm:000001e: error: type mismatch in `if true` branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1013: assert_invalid passed:
-  out/test/spec/if/if.44.wasm:0000022: error: type mismatch in if false branch, expected [i32] but got [i64]
+  out/test/spec/if/if.44.wasm:0000022: error: type mismatch in `if false` branch, expected [i32] but got [i64]
   0000022: error: OnEndExpr callback failed
 out/test/spec/if.wast:1019: assert_invalid passed:
-  out/test/spec/if/if.45.wasm:000001e: error: type mismatch in if true branch, expected [i32] but got [i64]
+  out/test/spec/if/if.45.wasm:000001e: error: type mismatch in `if true` branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1026: assert_invalid passed:
-  out/test/spec/if/if.46.wasm:000001f: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.46.wasm:000001f: error: type mismatch in `if true` branch, expected [i32, i32] but got [i32]
   0000020: error: OnElseExpr callback failed
 out/test/spec/if.wast:1032: assert_invalid passed:
-  out/test/spec/if/if.47.wasm:0000025: error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.47.wasm:0000025: error: type mismatch in `if false` branch, expected [i32, i32] but got [i32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/if.wast:1038: assert_invalid passed:
-  out/test/spec/if/if.48.wasm:000001f: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.48.wasm:000001f: error: type mismatch in `if true` branch, expected [i32, i32] but got [i32]
   0000020: error: OnElseExpr callback failed
 out/test/spec/if.wast:1045: assert_invalid passed:
-  out/test/spec/if/if.49.wasm:0000021: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.49.wasm:0000021: error: type mismatch in `if true` branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
 out/test/spec/if.wast:1052: assert_invalid passed:
-  out/test/spec/if/if.50.wasm:0000027: error: type mismatch in if false branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.50.wasm:0000027: error: type mismatch in `if false` branch, expected [i32, i32] but got [i32]
   0000027: error: OnEndExpr callback failed
 out/test/spec/if.wast:1059: assert_invalid passed:
-  out/test/spec/if/if.51.wasm:0000021: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.51.wasm:0000021: error: type mismatch in `if true` branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
 out/test/spec/if.wast:1067: assert_invalid passed:
-  out/test/spec/if/if.52.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.52.wasm:0000020: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   0000021: error: OnElseExpr callback failed
 out/test/spec/if.wast:1073: assert_invalid passed:
-  out/test/spec/if/if.53.wasm:0000024: error: type mismatch in if false branch, expected [] but got [i32]
+  out/test/spec/if/if.53.wasm:0000024: error: type mismatch at end of `if false` branch, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/if.wast:1079: assert_invalid passed:
-  out/test/spec/if/if.54.wasm:0000020: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.54.wasm:0000020: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   0000021: error: OnElseExpr callback failed
 out/test/spec/if.wast:1086: assert_invalid passed:
-  out/test/spec/if/if.55.wasm:000001e: error: type mismatch in if true branch, expected [i32] but got [i64]
+  out/test/spec/if/if.55.wasm:000001e: error: type mismatch in `if true` branch, expected [i32] but got [i64]
   000001f: error: OnElseExpr callback failed
 out/test/spec/if.wast:1092: assert_invalid passed:
-  out/test/spec/if/if.56.wasm:0000023: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/if/if.56.wasm:0000023: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   0000024: error: OnElseExpr callback failed
 out/test/spec/if.wast:1099: assert_invalid passed:
   out/test/spec/if/if.57.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got [i64]
@@ -263,7 +263,7 @@ out/test/spec/if.wast:1265: assert_invalid passed:
   out/test/spec/if/if.76.wasm:0000023: error: type mismatch in br, expected [i32, i32] but got [i64]
   0000023: error: OnBrExpr callback failed
 out/test/spec/if.wast:1275: assert_invalid passed:
-  out/test/spec/if/if.77.wasm:0000021: error: type mismatch in if true branch, expected [i32, i32] but got [i32]
+  out/test/spec/if/if.77.wasm:0000021: error: type mismatch in `if true` branch, expected [i32, i32] but got [i32]
   0000022: error: OnElseExpr callback failed
 out/test/spec/if.wast:1286: assert_invalid passed:
   out/test/spec/if/if.78.wasm:0000019: error: type mismatch in if, expected [i32] but got []

--- a/test/spec/labels.txt
+++ b/test/spec/labels.txt
@@ -5,10 +5,10 @@ out/test/spec/labels.wast:318: assert_invalid passed:
   out/test/spec/labels/labels.1.wasm:000001e: error: type mismatch in f32.neg, expected [f32] but got []
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/labels.wast:322: assert_invalid passed:
-  out/test/spec/labels/labels.2.wasm:0000023: error: type mismatch in block, expected [] but got [f32]
+  out/test/spec/labels/labels.2.wasm:0000023: error: type mismatch at end of block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/labels.wast:326: assert_invalid passed:
-  out/test/spec/labels/labels.3.wasm:0000023: error: type mismatch in block, expected [] but got [f32]
+  out/test/spec/labels/labels.3.wasm:0000023: error: type mismatch at end of block, expected [] but got [f32]
   0000023: error: OnEndExpr callback failed
 28/28 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/load.txt
+++ b/test/spec/load.txt
@@ -54,46 +54,46 @@ out/test/spec/load.wast:301: assert_malformed passed:
   (memory 1)(func (param i32) (result f64) (f64.load64 (local.get 0)))
                                             ^^^^^^^^^^
 out/test/spec/load.wast:312: assert_invalid passed:
-  out/test/spec/load/load.14.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.14.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:316: assert_invalid passed:
-  out/test/spec/load/load.15.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.15.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:320: assert_invalid passed:
-  out/test/spec/load/load.16.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.16.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:324: assert_invalid passed:
-  out/test/spec/load/load.17.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.17.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:328: assert_invalid passed:
-  out/test/spec/load/load.18.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/load/load.18.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:332: assert_invalid passed:
-  out/test/spec/load/load.19.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.19.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:336: assert_invalid passed:
-  out/test/spec/load/load.20.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.20.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:340: assert_invalid passed:
-  out/test/spec/load/load.21.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.21.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:344: assert_invalid passed:
-  out/test/spec/load/load.22.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.22.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:348: assert_invalid passed:
-  out/test/spec/load/load.23.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.23.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:352: assert_invalid passed:
-  out/test/spec/load/load.24.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.24.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:356: assert_invalid passed:
-  out/test/spec/load/load.25.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/load/load.25.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:360: assert_invalid passed:
-  out/test/spec/load/load.26.wasm:0000021: error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/load/load.26.wasm:0000021: error: type mismatch at end of function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:364: assert_invalid passed:
-  out/test/spec/load/load.27.wasm:0000021: error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/load/load.27.wasm:0000021: error: type mismatch at end of function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:371: assert_invalid passed:
   out/test/spec/load/load.28.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got [f32]

--- a/test/spec/local_get.txt
+++ b/test/spec/local_get.txt
@@ -20,16 +20,16 @@ out/test/spec/local_get.wast:173: assert_invalid passed:
   out/test/spec/local_get/local_get.6.wasm:000001d: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/local_get.wast:181: assert_invalid passed:
-  out/test/spec/local_get/local_get.7.wasm:000001b: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/local_get/local_get.7.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:185: assert_invalid passed:
-  out/test/spec/local_get/local_get.8.wasm:000001b: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/local_get/local_get.8.wasm:000001b: error: type mismatch at end of function, expected [] but got [i64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:189: assert_invalid passed:
-  out/test/spec/local_get/local_get.9.wasm:000001b: error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/local_get/local_get.9.wasm:000001b: error: type mismatch at end of function, expected [] but got [f32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:193: assert_invalid passed:
-  out/test/spec/local_get/local_get.10.wasm:000001b: error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/local_get/local_get.10.wasm:000001b: error: type mismatch at end of function, expected [] but got [f64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:201: assert_invalid passed:
   0000000: error: local variable out of range (max 2)

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -49,7 +49,7 @@ out/test/spec/loop.wast:593: assert_malformed passed:
   ...2) (result i32)))(func (i32.const 0) (loop (type $sig) (param i32) (result...
                                           ^
 out/test/spec/loop.wast:601: assert_invalid passed:
-  out/test/spec/loop/loop.12.wasm:000001c: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/loop/loop.12.wasm:000001c: error: type mismatch at end of loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:609: assert_invalid passed:
   out/test/spec/loop/loop.13.wasm:000001b: error: type mismatch in implicit return, expected [i32] but got []
@@ -64,10 +64,10 @@ out/test/spec/loop.wast:621: assert_invalid passed:
   out/test/spec/loop/loop.16.wasm:000001b: error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:626: assert_invalid passed:
-  out/test/spec/loop/loop.17.wasm:000001c: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/loop/loop.17.wasm:000001c: error: type mismatch at end of loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:632: assert_invalid passed:
-  out/test/spec/loop/loop.18.wasm:000001e: error: type mismatch in loop, expected [] but got [i32, i32]
+  out/test/spec/loop/loop.18.wasm:000001e: error: type mismatch at end of loop, expected [] but got [i32, i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/loop.wast:638: assert_invalid passed:
   out/test/spec/loop/loop.19.wasm:000001b: error: type mismatch in loop, expected [i32] but got []
@@ -91,7 +91,7 @@ out/test/spec/loop.wast:674: assert_invalid passed:
   out/test/spec/loop/loop.25.wasm:0000020: error: type mismatch in loop, expected [i32, i32] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/loop.wast:680: assert_invalid passed:
-  out/test/spec/loop/loop.26.wasm:000001f: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/loop/loop.26.wasm:000001f: error: type mismatch at end of loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/loop.wast:686: assert_invalid passed:
   out/test/spec/loop/loop.27.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]

--- a/test/spec/memory64/load64.txt
+++ b/test/spec/memory64/load64.txt
@@ -55,46 +55,46 @@ out/test/spec/memory64/load64.wast:301: assert_malformed passed:
   (memory i64 1)(func (param i64) (result f64) (f64.load64 (local.get 0)))
                                                 ^^^^^^^^^^
 out/test/spec/memory64/load64.wast:312: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.14.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.14.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:316: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.15.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.15.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:320: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.16.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.16.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:324: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.17.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.17.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:328: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.18.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.18.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:332: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.19.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.19.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:336: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.20.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.20.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:340: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.21.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.21.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:344: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.22.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.22.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:348: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.23.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.23.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:352: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.24.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.24.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:356: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.25.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.25.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:360: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.26.wasm:0000021: error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/memory64/load64/load64.26.wasm:0000021: error: type mismatch at end of function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:364: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.27.wasm:0000021: error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/memory64/load64/load64.27.wasm:0000021: error: type mismatch at end of function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:371: assert_invalid passed:
   out/test/spec/memory64/load64/load64.28.wasm:0000025: error: type mismatch in i32.load, expected [i64] but got [f32]

--- a/test/spec/memory_grow.txt
+++ b/test/spec/memory_grow.txt
@@ -25,7 +25,7 @@ out/test/spec/memory_grow.wast:353: assert_invalid passed:
   out/test/spec/memory_grow/memory_grow.9.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:363: assert_invalid passed:
-  out/test/spec/memory_grow/memory_grow.10.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory_grow/memory_grow.10.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/memory_grow.wast:372: assert_invalid passed:
   out/test/spec/memory_grow/memory_grow.11.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]

--- a/test/spec/memory_size.txt
+++ b/test/spec/memory_size.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/memory_size.wast
 (;; STDOUT ;;;
 out/test/spec/memory_size.wast:69: assert_invalid passed:
-  out/test/spec/memory_size/memory_size.4.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/memory_size/memory_size.4.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/memory_size.wast:78: assert_invalid passed:
   out/test/spec/memory_size/memory_size.5.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]

--- a/test/spec/multi-memory/data.txt
+++ b/test/spec/multi-memory/data.txt
@@ -21,23 +21,23 @@ out/test/spec/multi-memory/data.wast:360: assert_invalid passed:
   0000000: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:379: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.45.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [i64]
+  out/test/spec/multi-memory/data/data.45.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:387: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.46.wasm:0000013: error: type mismatch in constant expression, expected [i32] but got [funcref]
+  out/test/spec/multi-memory/data/data.46.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [funcref]
   0000014: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:395: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.47.wasm:0000011: error: type mismatch in constant expression, expected [i32] but got []
+  out/test/spec/multi-memory/data/data.47.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:403: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  0000015: error: OnI32ConstExpr callback failed
+  out/test/spec/multi-memory/data/data.48.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000016: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:411: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  000002b: error: OnGlobalGetExpr callback failed
+  out/test/spec/multi-memory/data/data.49.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002c: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:420: assert_invalid passed:
-  error: expected END opcode after initializer expression
-  000002b: error: OnI32ConstExpr callback failed
+  out/test/spec/multi-memory/data/data.50.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002c: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:429: assert_invalid passed:
   out/test/spec/multi-memory/data/data.51.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
   0000014: error: OnUnaryExpr callback failed

--- a/test/spec/multi-memory/load.txt
+++ b/test/spec/multi-memory/load.txt
@@ -55,46 +55,46 @@ out/test/spec/multi-memory/load.wast:365: assert_malformed passed:
   (memory 1)(func (param i32) (result f64) (f64.load64 (local.get 0)))
                                             ^^^^^^^^^^
 out/test/spec/multi-memory/load.wast:376: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.17.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.17.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:380: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.18.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.18.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:384: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.19.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.19.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:388: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.20.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.20.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:392: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.21.wasm:0000021: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.21.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:396: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.22.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.22.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:400: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.23.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.23.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:404: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.24.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.24.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:408: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.25.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.25.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:412: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.26.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.26.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:416: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.27.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.27.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:420: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.28.wasm:0000021: error: type mismatch in function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.28.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:424: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.29.wasm:0000021: error: type mismatch in function, expected [] but got [f32]
+  out/test/spec/multi-memory/load/load.29.wasm:0000021: error: type mismatch at end of function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:428: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.30.wasm:0000021: error: type mismatch in function, expected [] but got [f64]
+  out/test/spec/multi-memory/load/load.30.wasm:0000021: error: type mismatch at end of function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:435: assert_invalid passed:
   out/test/spec/multi-memory/load/load.31.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got [f32]

--- a/test/spec/multi-memory/memory_grow.txt
+++ b/test/spec/multi-memory/memory_grow.txt
@@ -25,13 +25,13 @@ out/test/spec/multi-memory/memory_grow.wast:469: assert_invalid passed:
   out/test/spec/multi-memory/memory_grow/memory_grow.12.wasm:0000025: error: type mismatch in memory.grow, expected [i32] but got []
   0000025: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:480: assert_invalid passed:
-  out/test/spec/multi-memory/memory_grow/memory_grow.13.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.13.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_grow.wast:489: assert_invalid passed:
   out/test/spec/multi-memory/memory_grow/memory_grow.14.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:499: assert_invalid passed:
-  out/test/spec/multi-memory/memory_grow/memory_grow.15.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.15.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_grow.wast:508: assert_invalid passed:
   out/test/spec/multi-memory/memory_grow/memory_grow.16.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]

--- a/test/spec/multi-memory/memory_size.txt
+++ b/test/spec/multi-memory/memory_size.txt
@@ -3,7 +3,7 @@
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
 out/test/spec/multi-memory/memory_size.wast:95: assert_invalid passed:
-  out/test/spec/multi-memory/memory_size/memory_size.6.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_size/memory_size.6.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_size.wast:104: assert_invalid passed:
   out/test/spec/multi-memory/memory_size/memory_size.7.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]

--- a/test/spec/simd_load.txt
+++ b/test/spec/simd_load.txt
@@ -29,7 +29,7 @@ out/test/spec/simd_load.wast:170: assert_invalid passed:
   out/test/spec/simd_load/simd_load.18.wasm:0000028: error: type mismatch in br_if, expected [i32] but got [v128]
   0000028: error: OnBrIfExpr callback failed
 out/test/spec/simd_load.wast:174: assert_invalid passed:
-  out/test/spec/simd_load/simd_load.19.wasm:0000024: error: type mismatch in function, expected [] but got [v128]
+  out/test/spec/simd_load/simd_load.19.wasm:0000024: error: type mismatch at end of function, expected [] but got [v128]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/simd_load.wast:182: assert_invalid passed:
   0000000: error: local variable out of range (max 0)

--- a/test/spec/table_get.txt
+++ b/test/spec/table_get.txt
@@ -13,7 +13,7 @@ out/test/spec/table_get.wast:51: assert_invalid passed:
   out/test/spec/table_get/table_get.2.wasm:0000025: error: type mismatch in table.get, expected [i32] but got [f32]
   0000025: error: OnTableGetExpr callback failed
 out/test/spec/table_get.wast:61: assert_invalid passed:
-  out/test/spec/table_get/table_get.3.wasm:0000021: error: type mismatch in function, expected [] but got [externref]
+  out/test/spec/table_get/table_get.3.wasm:0000021: error: type mismatch at end of function, expected [] but got [externref]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/table_get.wast:70: assert_invalid passed:
   out/test/spec/table_get/table_get.4.wasm:0000022: error: type mismatch in implicit return, expected [funcref] but got [externref]

--- a/test/spec/table_grow.txt
+++ b/test/spec/table_grow.txt
@@ -23,7 +23,7 @@ out/test/spec/table_grow.wast:147: assert_invalid passed:
   out/test/spec/table_grow/table_grow.9.wasm:0000026: error: type mismatch in table.grow, expected [funcref, i32] but got [externref, i32]
   0000026: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:157: assert_invalid passed:
-  out/test/spec/table_grow/table_grow.10.wasm:0000024: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/table_grow/table_grow.10.wasm:0000024: error: type mismatch at end of function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/table_grow.wast:166: assert_invalid passed:
   out/test/spec/table_grow/table_grow.11.wasm:0000025: error: type mismatch in implicit return, expected [f32] but got [i32]

--- a/test/spec/table_size.txt
+++ b/test/spec/table_size.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/table_size.wast
 (;; STDOUT ;;;
 out/test/spec/table_size.wast:70: assert_invalid passed:
-  out/test/spec/table_size/table_size.1.wasm:0000020: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/table_size/table_size.1.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/table_size.wast:79: assert_invalid passed:
   out/test/spec/table_size/table_size.2.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -23,22 +23,22 @@ out/test/spec/unreached-invalid.wast:33: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.6.wasm:0000023: error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
   0000023: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:42: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.7.wasm:000001a: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.7.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:46: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.8.wasm:0000019: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.8.wasm:0000019: error: type mismatch at end of function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:50: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.9.wasm:000001b: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.9.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:56: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.10.wasm:0000019: error: type mismatch in function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.10.wasm:0000019: error: type mismatch at end of function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:60: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.11.wasm:000001b: error: type mismatch in function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.11.wasm:000001b: error: type mismatch at end of function, expected [] but got [any]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:64: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.12.wasm:000001d: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.12.wasm:000001d: error: type mismatch at end of function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:71: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.13.wasm:000001f: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -53,19 +53,19 @@ out/test/spec/unreached-invalid.wast:89: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.16.wasm:0000023: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:95: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.17.wasm:000001e: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.17.wasm:000001e: error: type mismatch at end of block, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:101: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.18.wasm:0000024: error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:107: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.19.wasm:0000020: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.19.wasm:0000020: error: type mismatch at end of loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:113: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.20.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:119: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.21.wasm:000001b: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.21.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:125: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.22.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
@@ -83,19 +83,19 @@ out/test/spec/unreached-invalid.wast:150: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.26.wasm:0000020: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:156: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.27.wasm:000001d: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.27.wasm:000001d: error: type mismatch at end of block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:162: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.28.wasm:0000025: error: type mismatch in block, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:168: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.29.wasm:000001f: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.29.wasm:000001f: error: type mismatch at end of loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:174: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.30.wasm:0000023: error: type mismatch in loop, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:180: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.31.wasm:000001a: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.31.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:186: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.32.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [f32]
@@ -119,19 +119,19 @@ out/test/spec/unreached-invalid.wast:223: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.38.wasm:0000020: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000020: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:229: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.39.wasm:000001d: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.39.wasm:000001d: error: type mismatch at end of block, expected [] but got [i32]
   000001d: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:235: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.40.wasm:0000023: error: type mismatch in block, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:241: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.41.wasm:000001f: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.41.wasm:000001f: error: type mismatch at end of loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:247: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.42.wasm:0000021: error: type mismatch in loop, expected [i32] but got [f32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:253: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.43.wasm:000001a: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.43.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:259: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.44.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [f32]
@@ -158,20 +158,20 @@ out/test/spec/unreached-invalid.wast:302: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.51.wasm:0000023: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:308: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.52.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.52.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:314: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.53.wasm:0000026: error: type mismatch in block, expected [i32] but got [... f32]
-  out/test/spec/unreached-invalid/unreached-invalid.53.wasm:0000026: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.53.wasm:0000026: error: type mismatch at end of block, expected [] but got [i32]
   0000026: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:321: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.54.wasm:0000022: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.54.wasm:0000022: error: type mismatch at end of loop, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:327: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.55.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:334: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.56.wasm:000001d: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.56.wasm:000001d: error: type mismatch at end of function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:340: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.57.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
@@ -189,20 +189,20 @@ out/test/spec/unreached-invalid.wast:366: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.61.wasm:0000024: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000024: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:372: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.62.wasm:0000021: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.62.wasm:0000021: error: type mismatch at end of block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:378: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.63.wasm:0000027: error: type mismatch in block, expected [i32] but got [... f32]
-  out/test/spec/unreached-invalid/unreached-invalid.63.wasm:0000027: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.63.wasm:0000027: error: type mismatch at end of block, expected [] but got [i32]
   0000027: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:384: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.64.wasm:0000023: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.64.wasm:0000023: error: type mismatch at end of loop, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:390: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.65.wasm:0000025: error: type mismatch in loop, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:396: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.66.wasm:000001e: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.66.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:402: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.67.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [f32]
@@ -220,19 +220,19 @@ out/test/spec/unreached-invalid.wast:427: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.71.wasm:0000023: error: type mismatch in f32.eq, expected [f32, f32] but got [i32, f32]
   0000023: error: OnCompareExpr callback failed
 out/test/spec/unreached-invalid.wast:433: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.72.wasm:000001e: error: type mismatch in if true branch, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.72.wasm:000001e: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   000001e: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:439: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.73.wasm:0000022: error: type mismatch in if true branch, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.73.wasm:0000022: error: type mismatch in `if true` branch, expected [i32] but got [f32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:445: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.74.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.74.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:451: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.75.wasm:0000024: error: type mismatch in block, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:457: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.76.wasm:0000020: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.76.wasm:0000020: error: type mismatch at end of loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:463: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.77.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
@@ -247,13 +247,13 @@ out/test/spec/unreached-invalid.wast:484: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.80.wasm:0000021: error: type mismatch in br_if, expected [i32] but got [f32]
   0000021: error: OnBrIfExpr callback failed
 out/test/spec/unreached-invalid.wast:490: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.81.wasm:0000024: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.81.wasm:0000024: error: type mismatch at end of block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:498: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.82.wasm:0000024: error: type mismatch in block, expected [f32] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:507: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.83.wasm:0000024: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.83.wasm:0000024: error: type mismatch at end of block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:515: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.84.wasm:0000022: error: type mismatch in br_table, expected [i32] but got [f32]
@@ -265,7 +265,7 @@ out/test/spec/unreached-invalid.wast:527: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.86.wasm:0000023: error: br_table labels have inconsistent types: expected [f32], got []
   0000023: error: OnBrTableExpr callback failed
 out/test/spec/unreached-invalid.wast:540: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.87.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.87.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:546: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.88.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
@@ -274,10 +274,10 @@ out/test/spec/unreached-invalid.wast:552: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.89.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:558: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.90.wasm:0000023: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.90.wasm:0000023: error: type mismatch at end of block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:565: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.91.wasm:0000021: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.91.wasm:0000021: error: type mismatch at end of block, expected [] but got [i32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:571: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.92.wasm:0000022: error: type mismatch in block, expected [i32] but got []
@@ -286,7 +286,7 @@ out/test/spec/unreached-invalid.wast:577: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.93.wasm:0000024: error: type mismatch in block, expected [i32] but got [i64]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:584: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.94.wasm:0000023: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.94.wasm:0000023: error: type mismatch at end of block, expected [] but got [i32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:590: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.95.wasm:0000025: error: type mismatch in block, expected [i32] but got []
@@ -295,10 +295,10 @@ out/test/spec/unreached-invalid.wast:596: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.96.wasm:0000027: error: type mismatch in block, expected [i32] but got [i64]
   0000027: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:604: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.97.wasm:0000024: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.97.wasm:0000024: error: type mismatch at end of block, expected [] but got [i32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:611: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.98.wasm:0000020: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.98.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:617: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.99.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got []
@@ -307,10 +307,10 @@ out/test/spec/unreached-invalid.wast:623: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.100.wasm:0000023: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:629: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.101.wasm:0000025: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.101.wasm:0000025: error: type mismatch at end of block, expected [] but got [i32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:637: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.102.wasm:0000020: error: type mismatch in loop, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.102.wasm:0000020: error: type mismatch at end of loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:643: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.103.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
@@ -325,10 +325,10 @@ out/test/spec/unreached-invalid.wast:662: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.106.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:669: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.107.wasm:000001c: error: type mismatch in function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.107.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:676: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.108.wasm:0000022: error: type mismatch in block, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.108.wasm:0000022: error: type mismatch at end of block, expected [] but got [i32]
   0000022: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:687: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.109.wasm:000001c: error: type mismatch in i64.extend_i32_u, expected [i32] but got [i64]
@@ -352,7 +352,7 @@ out/test/spec/unreached-invalid.wast:726: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.115.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:733: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.116.wasm:0000019: error: type mismatch in function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.116.wasm:0000019: error: type mismatch at end of function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:738: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.117.wasm:0000026: error: type mismatch in br_table, expected [i32] but got [externref]

--- a/test/typecheck/bad-block-multi-mismatch.txt
+++ b/test/typecheck/bad-block-multi-mismatch.txt
@@ -42,7 +42,7 @@
 out/test/typecheck/bad-block-multi-mismatch.txt:8:5: error: type mismatch in block, expected [i32, i32] but got [i32]
     end
     ^^^
-out/test/typecheck/bad-block-multi-mismatch.txt:17:5: error: type mismatch in block, expected [] but got [i32]
+out/test/typecheck/bad-block-multi-mismatch.txt:17:5: error: type mismatch at end of block, expected [] but got [i32]
     end
     ^^^
 out/test/typecheck/bad-block-multi-mismatch.txt:25:5: error: type mismatch in block, expected [f32, i32] but got [i32, i32]

--- a/test/typecheck/bad-call-result-mismatch.txt
+++ b/test/typecheck/bad-call-result-mismatch.txt
@@ -27,19 +27,19 @@
 out/test/typecheck/bad-call-result-mismatch.txt:10:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:11:7: error: type mismatch in if true branch, expected [] but got [i64]
+out/test/typecheck/bad-call-result-mismatch.txt:11:7: error: type mismatch at end of `if true` branch, expected [] but got [i64]
       call $direct
       ^^^^
 out/test/typecheck/bad-call-result-mismatch.txt:15:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:16:7: error: type mismatch in if true branch, expected [] but got [f32]
+out/test/typecheck/bad-call-result-mismatch.txt:16:7: error: type mismatch at end of `if true` branch, expected [] but got [f32]
       call $import
       ^^^^
 out/test/typecheck/bad-call-result-mismatch.txt:20:5: error: type mismatch in if, expected [i32] but got []
     if
     ^^
-out/test/typecheck/bad-call-result-mismatch.txt:22:7: error: type mismatch in if true branch, expected [] but got [i64]
+out/test/typecheck/bad-call-result-mismatch.txt:22:7: error: type mismatch at end of `if true` branch, expected [] but got [i64]
       call_indirect (type $indirect)
       ^^^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-empty-catch.txt
+++ b/test/typecheck/bad-empty-catch.txt
@@ -9,7 +9,7 @@
     end
   ))
 (;; STDERR ;;;
-out/test/typecheck/bad-empty-catch.txt:9:5: error: type mismatch in try catch, expected [] but got [i32]
+out/test/typecheck/bad-empty-catch.txt:9:5: error: type mismatch at end of try catch, expected [] but got [i32]
     end
     ^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-getglobal-type-mismatch.txt
+++ b/test/typecheck/bad-global-getglobal-type-mismatch.txt
@@ -4,7 +4,7 @@
   (import "foo" "bar" (global i32))
   (global f32 (get_global 0)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-getglobal-type-mismatch.txt:5:16: error: type mismatch in constant expression, expected [f32] but got [i32]
+out/test/typecheck/bad-global-getglobal-type-mismatch.txt:5:16: error: type mismatch in initializer expression, expected [f32] but got [i32]
   (global f32 (get_global 0)))
                ^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-no-init-expr.txt
+++ b/test/typecheck/bad-global-no-init-expr.txt
@@ -4,10 +4,10 @@
   (global i32)
   (global (mut f32)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-no-init-expr.txt:4:4: error: type mismatch in constant expression, expected [i32] but got []
+out/test/typecheck/bad-global-no-init-expr.txt:4:4: error: type mismatch in initializer expression, expected [i32] but got []
   (global i32)
    ^^^^^^
-out/test/typecheck/bad-global-no-init-expr.txt:5:4: error: type mismatch in constant expression, expected [f32] but got []
+out/test/typecheck/bad-global-no-init-expr.txt:5:4: error: type mismatch in initializer expression, expected [f32] but got []
   (global (mut f32)))
    ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-global-type-mismatch.txt
+++ b/test/typecheck/bad-global-type-mismatch.txt
@@ -3,7 +3,7 @@
 (module
   (global i32 (f32.const 1)))
 (;; STDERR ;;;
-out/test/typecheck/bad-global-type-mismatch.txt:4:16: error: type mismatch in constant expression, expected [i32] but got [f32]
+out/test/typecheck/bad-global-type-mismatch.txt:4:16: error: type mismatch in initializer expression, expected [i32] but got [f32]
   (global i32 (f32.const 1)))
                ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-multi-mismatch.txt
+++ b/test/typecheck/bad-if-multi-mismatch.txt
@@ -57,22 +57,22 @@
     end)
 )
 (;; STDERR ;;;
-out/test/typecheck/bad-if-multi-mismatch.txt:10:7: error: type mismatch in if true branch, expected [] but got [i32]
+out/test/typecheck/bad-if-multi-mismatch.txt:10:7: error: type mismatch at end of `if true` branch, expected [] but got [i32]
       i64.const 0
       ^^^^^^^^^
-out/test/typecheck/bad-if-multi-mismatch.txt:15:5: error: type mismatch in if false branch, expected [] but got [i32]
+out/test/typecheck/bad-if-multi-mismatch.txt:15:5: error: type mismatch at end of `if false` branch, expected [] but got [i32]
     end
     ^^^
-out/test/typecheck/bad-if-multi-mismatch.txt:22:7: error: type mismatch in if true branch, expected [i32, f64] but got [f64]
+out/test/typecheck/bad-if-multi-mismatch.txt:22:7: error: type mismatch in `if true` branch, expected [i32, f64] but got [f64]
       f64.const 0
       ^^^^^^^^^
-out/test/typecheck/bad-if-multi-mismatch.txt:25:5: error: type mismatch in if false branch, expected [i32, f64] but got [f64]
+out/test/typecheck/bad-if-multi-mismatch.txt:25:5: error: type mismatch in `if false` branch, expected [i32, f64] but got [f64]
     end
     ^^^
-out/test/typecheck/bad-if-multi-mismatch.txt:33:7: error: type mismatch in if true branch, expected [i32, f64] but got [f32, f64]
+out/test/typecheck/bad-if-multi-mismatch.txt:33:7: error: type mismatch in `if true` branch, expected [i32, f64] but got [f32, f64]
       f64.const 0
       ^^^^^^^^^
-out/test/typecheck/bad-if-multi-mismatch.txt:37:5: error: type mismatch in if false branch, expected [i32, f64] but got [f32, f64]
+out/test/typecheck/bad-if-multi-mismatch.txt:37:5: error: type mismatch in `if false` branch, expected [i32, f64] but got [f32, f64]
     end
     ^^^
 out/test/typecheck/bad-if-multi-mismatch.txt:43:5: error: type mismatch in if, expected [i32] but got []

--- a/test/typecheck/bad-if-type-mismatch.txt
+++ b/test/typecheck/bad-if-type-mismatch.txt
@@ -10,7 +10,7 @@
     end
     drop))
 (;; STDERR ;;;
-out/test/typecheck/bad-if-type-mismatch.txt:7:7: error: type mismatch in if true branch, expected [i32] but got [f32]
+out/test/typecheck/bad-if-type-mismatch.txt:7:7: error: type mismatch in `if true` branch, expected [i32] but got [f32]
       f32.const 0
       ^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-if-value-void.txt
+++ b/test/typecheck/bad-if-value-void.txt
@@ -12,7 +12,7 @@
       drop
     end))
 (;; STDERR ;;;
-out/test/typecheck/bad-if-value-void.txt:8:9: error: type mismatch in if true branch, expected [f32] but got []
+out/test/typecheck/bad-if-value-void.txt:8:9: error: type mismatch in `if true` branch, expected [f32] but got []
         nop
         ^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-loop-multi-mismatch.txt
+++ b/test/typecheck/bad-loop-multi-mismatch.txt
@@ -42,7 +42,7 @@
 out/test/typecheck/bad-loop-multi-mismatch.txt:8:5: error: type mismatch in loop, expected [i32, i32] but got [i32]
     end
     ^^^
-out/test/typecheck/bad-loop-multi-mismatch.txt:17:5: error: type mismatch in loop, expected [] but got [i32]
+out/test/typecheck/bad-loop-multi-mismatch.txt:17:5: error: type mismatch at end of loop, expected [] but got [i32]
     end
     ^^^
 out/test/typecheck/bad-loop-multi-mismatch.txt:25:5: error: type mismatch in loop, expected [f32, i32] but got [i32, i32]

--- a/test/typecheck/bad-select-value0.txt
+++ b/test/typecheck/bad-select-value0.txt
@@ -11,7 +11,7 @@
 out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, f32]
     select
     ^^^^^^
-out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in function, expected [] but got [f64]
+out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch at end of function, expected [] but got [f64]
     select
     ^^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value1.txt
+++ b/test/typecheck/bad-select-value1.txt
@@ -11,7 +11,7 @@
 out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, f32]
     select
     ^^^^^^
-out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in function, expected [] but got [i64]
+out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch at end of function, expected [] but got [i64]
     select
     ^^^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
If you leave stuff on the stack at the end of an initializer
expression use the same mechanism to report the error as we
do for functions etc.

In addition, improve such errors so its more obvious what is
going on when the validations fails in this way.