### PR TITLE
Split base-types.h and string-format.h out of common.h

### DIFF
--- a/src/base-types.h
+++ b/src/base-types.h
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_BASE_TYPES_H_
+#define WABT_BASE_TYPES_H_
+
+namespace wabt {
+
+typedef uint32_t Index;    // An index into one of the many index spaces.
+typedef uint64_t Address;  // An address or size in linear memory.
+typedef size_t Offset;     // An offset into a host's file or memory buffer.
+
+static const Address kInvalidAddress = ~0;
+static const Index kInvalidIndex = ~0;
+static const Offset kInvalidOffset = ~0;
+
+}  // namespace wabt
+
+#endif  // WABT_BASE_TYPES_H_

--- a/src/common.h
+++ b/src/common.h
@@ -32,8 +32,10 @@
 
 #include "config.h"
 
+#include "src/base-types.h"
 #include "src/make-unique.h"
 #include "src/result.h"
+#include "src/string-format.h"
 #include "src/string-view.h"
 #include "src/type.h"
 
@@ -50,30 +52,6 @@
 #define WABT_BYTES_TO_PAGES(x) ((x) >> 16)
 #define WABT_ALIGN_UP_TO_PAGE(x) \
   (((x) + WABT_PAGE_SIZE - 1) & ~(WABT_PAGE_SIZE - 1))
-
-#define PRIstringview "%.*s"
-#define WABT_PRINTF_STRING_VIEW_ARG(x) \
-  static_cast<int>((x).length()), (x).data()
-
-#define PRItypecode "%s%#x"
-#define WABT_PRINTF_TYPE_CODE(x) \
-  (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int32_t>(x))
-
-#define WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE 128
-#define WABT_SNPRINTF_ALLOCA(buffer, len, format)                          \
-  va_list args;                                                            \
-  va_list args_copy;                                                       \
-  va_start(args, format);                                                  \
-  va_copy(args_copy, args);                                                \
-  char fixed_buf[WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE];                    \
-  char* buffer = fixed_buf;                                                \
-  size_t len = wabt_vsnprintf(fixed_buf, sizeof(fixed_buf), format, args); \
-  va_end(args);                                                            \
-  if (len + 1 > sizeof(fixed_buf)) {                                       \
-    buffer = static_cast<char*>(alloca(len + 1));                          \
-    len = wabt_vsnprintf(buffer, len + 1, format, args_copy);              \
-  }                                                                        \
-  va_end(args_copy)
 
 #define WABT_ENUM_COUNT(name) \
   (static_cast<int>(name::Last) - static_cast<int>(name::First) + 1)
@@ -174,14 +152,6 @@ struct v128 {
 
 namespace wabt {
 
-typedef uint32_t Index;    // An index into one of the many index spaces.
-typedef uint64_t Address;  // An address or size in linear memory.
-typedef size_t Offset;     // An offset into a host's file or memory buffer.
-
-static const Address kInvalidAddress = ~0;
-static const Index kInvalidIndex = ~0;
-static const Offset kInvalidOffset = ~0;
-
 template <typename Dst, typename Src>
 Dst WABT_VECTORCALL Bitcast(Src&& value) {
   static_assert(sizeof(Src) == sizeof(Dst), "Bitcast sizes must match.");
@@ -206,20 +176,6 @@ void Construct(T& placement, Args&&... args) {
 template <typename T>
 void Destruct(T& placement) {
   placement.~T();
-}
-
-inline std::string WABT_PRINTF_FORMAT(1, 2)
-    StringPrintf(const char* format, ...) {
-  va_list args;
-  va_list args_copy;
-  va_start(args, format);
-  va_copy(args_copy, args);
-  size_t len = wabt_vsnprintf(nullptr, 0, format, args) + 1;  // For \0.
-  std::vector<char> buffer(len);
-  va_end(args);
-  wabt_vsnprintf(buffer.data(), len, format, args_copy);
-  va_end(args_copy);
-  return std::string(buffer.data(), len - 1);
 }
 
 enum class LabelType {

--- a/src/string-format.h
+++ b/src/string-format.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2021 WebAssembly Community Group participants
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef WABT_STRING_FORMAT_H_
+#define WABT_STRING_FORMAT_H_
+
+#include "config.h"
+
+#define PRIstringview "%.*s"
+#define WABT_PRINTF_STRING_VIEW_ARG(x) \
+  static_cast<int>((x).length()), (x).data()
+
+#define PRItypecode "%s%#x"
+#define WABT_PRINTF_TYPE_CODE(x) \
+  (static_cast<int32_t>(x) < 0 ? "-" : ""), std::abs(static_cast<int32_t>(x))
+
+#define WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE 128
+#define WABT_SNPRINTF_ALLOCA(buffer, len, format)                          \
+  va_list args;                                                            \
+  va_list args_copy;                                                       \
+  va_start(args, format);                                                  \
+  va_copy(args_copy, args);                                                \
+  char fixed_buf[WABT_DEFAULT_SNPRINTF_ALLOCA_BUFSIZE];                    \
+  char* buffer = fixed_buf;                                                \
+  size_t len = wabt_vsnprintf(fixed_buf, sizeof(fixed_buf), format, args); \
+  va_end(args);                                                            \
+  if (len + 1 > sizeof(fixed_buf)) {                                       \
+    buffer = static_cast<char*>(alloca(len + 1));                          \
+    len = wabt_vsnprintf(buffer, len + 1, format, args_copy);              \
+  }                                                                        \
+  va_end(args_copy)
+
+namespace wabt {
+
+inline std::string WABT_PRINTF_FORMAT(1, 2)
+    StringPrintf(const char* format, ...) {
+  va_list args;
+  va_list args_copy;
+  va_start(args, format);
+  va_copy(args_copy, args);
+  size_t len = wabt_vsnprintf(nullptr, 0, format, args) + 1;  // For \0.
+  std::vector<char> buffer(len);
+  va_end(args);
+  wabt_vsnprintf(buffer.data(), len, format, args_copy);
+  va_end(args_copy);
+  return std::string(buffer.data(), len - 1);
+}
+
+}  // namespace wabt
+
+#endif  // WABT_STRING_FORMAT_H_

--- a/src/type.h
+++ b/src/type.h
@@ -22,12 +22,12 @@
 #include <vector>
 
 #include "config.h"
+#include "src/base-types.h"
 
 namespace wabt {
 
 class Type;
 
-using Index = uint32_t;
 using TypeVector = std::vector<Type>;
 
 class Type {
@@ -57,8 +57,8 @@ class Type {
   };
 
   Type() = default;  // Provided so Type can be member of a union.
-  Type(int32_t code) : enum_(static_cast<Enum>(code)), index_(UINT32_MAX) {}
-  Type(Enum e) : enum_(e), index_(UINT32_MAX) {}
+  Type(int32_t code) : enum_(static_cast<Enum>(code)), index_(kInvalidIndex) {}
+  Type(Enum e) : enum_(e), index_(kInvalidIndex) {}
   Type(Enum e, Index index) : enum_(e), index_(index) {
     assert(e == Enum::Reference);
   }


### PR DESCRIPTION
This allows them to be used in headers such as `src/type.h`
which, because they are needed in common.h, cannot themselves
include `common.h`

This allows, for example, `StringPrintf` to be used in type.h
which is something I'm planning to do as a followup.