### PR TITLE
Fix param naming for `OnFuncRefExpr` (See #1768). NFC

### DIFF
--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -940,8 +940,8 @@ Result SharedValidator::OnRefFunc(const Location& loc, Var func_var) {
   result |= CheckFuncIndex(func_var);
   if (Succeeded(result)) {
     check_declared_funcs_.push_back(func_var);
-    result |=
-        typechecker_.OnRefFuncExpr(GetFunctionTypeIndex(func_var.index()));
+    Index func_type = GetFunctionTypeIndex(func_var.index());
+    result |= typechecker_.OnRefFuncExpr(func_type);
   }
   return result;
 }

--- a/src/type-checker.cc
+++ b/src/type-checker.cc
@@ -770,9 +770,9 @@ Result TypeChecker::OnTableFill(Type elem_type) {
   return PopAndCheck3Types(Type::I32, elem_type, Type::I32, "table.fill");
 }
 
-Result TypeChecker::OnRefFuncExpr(Index func_index) {
+Result TypeChecker::OnRefFuncExpr(Index func_type) {
   if (features_.function_references_enabled()) {
-    PushType(Type(Type::Reference, func_index));
+    PushType(Type(Type::Reference, func_type));
   } else {
     PushType(Type::FuncRef);
   }

--- a/src/type-checker.h
+++ b/src/type-checker.h
@@ -111,7 +111,7 @@ class TypeChecker {
   Result OnTableGrow(Type elem_type);
   Result OnTableSize();
   Result OnTableFill(Type elem_type);
-  Result OnRefFuncExpr(Index func_index);
+  Result OnRefFuncExpr(Index func_type);
   Result OnRefNullExpr(Type type);
   Result OnRefIsNullExpr();
   Result OnRethrow(Index depth);


### PR DESCRIPTION
In #1768, I renamed the parameter to `OnFuncRefExpr` without realizing
that there are two distinct methods in the codebase with this name.  On
is the `BinaryReader` callback which takes a function index and one is
the `TypeChecker` callback which takes a function *type* (a type index).