### PR TITLE
Fix type names for function references

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -80,7 +80,7 @@ void BinaryReaderLogging::LogType(Type type) {
   if (type.IsIndex()) {
     LOGF_NOINDENT("typeidx[%d]", type.GetIndex());
   } else {
-    LOGF_NOINDENT("%s", type.GetName());
+    LOGF_NOINDENT("%s", type.GetName().c_str());
   }
 }
 
@@ -208,7 +208,7 @@ Result BinaryReaderLogging::OnImportTable(Index import_index,
   SPrintLimits(buf, sizeof(buf), elem_limits);
   LOGF("OnImportTable(import_index: %" PRIindex ", table_index: %" PRIindex
        ", elem_type: %s, %s)\n",
-       import_index, table_index, elem_type.GetName(), buf);
+       import_index, table_index, elem_type.GetName().c_str(), buf);
   return reader_->OnImportTable(import_index, module_name, field_name,
                                 table_index, elem_type, elem_limits);
 }
@@ -236,7 +236,8 @@ Result BinaryReaderLogging::OnImportGlobal(Index import_index,
   LOGF("OnImportGlobal(import_index: %" PRIindex ", global_index: %" PRIindex
        ", type: %s, mutable: "
        "%s)\n",
-       import_index, global_index, type.GetName(), mutable_ ? "true" : "false");
+       import_index, global_index, type.GetName().c_str(),
+       mutable_ ? "true" : "false");
   return reader_->OnImportGlobal(import_index, module_name, field_name,
                                  global_index, type, mutable_);
 }
@@ -259,7 +260,7 @@ Result BinaryReaderLogging::OnTable(Index index,
   char buf[100];
   SPrintLimits(buf, sizeof(buf), elem_limits);
   LOGF("OnTable(index: %" PRIindex ", elem_type: %s, %s)\n", index,
-       elem_type.GetName(), buf);
+       elem_type.GetName().c_str(), buf);
   return reader_->OnTable(index, elem_type, elem_limits);
 }
 
@@ -272,7 +273,7 @@ Result BinaryReaderLogging::OnMemory(Index index, const Limits* page_limits) {
 
 Result BinaryReaderLogging::BeginGlobal(Index index, Type type, bool mutable_) {
   LOGF("BeginGlobal(index: %" PRIindex ", type: %s, mutable: %s)\n", index,
-       type.GetName(), mutable_ ? "true" : "false");
+       type.GetName().c_str(), mutable_ ? "true" : "false");
   return reader_->BeginGlobal(index, type, mutable_);
 }
 
@@ -295,7 +296,7 @@ Result BinaryReaderLogging::OnLocalDecl(Index decl_index,
                                         Index count,
                                         Type type) {
   LOGF("OnLocalDecl(index: %" PRIindex ", count: %" PRIindex ", type: %s)\n",
-       decl_index, count, type.GetName());
+       decl_index, count, type.GetName().c_str());
   return reader_->OnLocalDecl(decl_index, count, type);
 }
 
@@ -412,7 +413,7 @@ Result BinaryReaderLogging::BeginElemSegment(Index index,
 
 Result BinaryReaderLogging::OnElemSegmentElemType(Index index, Type elem_type) {
   LOGF("OnElemSegmentElemType(index: %" PRIindex ", type: %s)\n", index,
-       elem_type.GetName());
+       elem_type.GetName().c_str());
   return reader_->OnElemSegmentElemType(index, elem_type);
 }
 
@@ -657,10 +658,10 @@ Result BinaryReaderLogging::OnComdatEntry(ComdatType kind, Index index) {
     return reader_->name(value);                  \
   }
 
-#define DEFINE_TYPE(name)                       \
-  Result BinaryReaderLogging::name(Type type) { \
-    LOGF(#name "(%s)\n", type.GetName());       \
-    return reader_->name(type);                 \
+#define DEFINE_TYPE(name)                         \
+  Result BinaryReaderLogging::name(Type type) {   \
+    LOGF(#name "(%s)\n", type.GetName().c_str()); \
+    return reader_->name(type);                   \
   }
 
 #define DEFINE_INDEX_DESC(name, desc)                 \
@@ -669,10 +670,11 @@ Result BinaryReaderLogging::OnComdatEntry(ComdatType kind, Index index) {
     return reader_->name(value);                      \
   }
 
-#define DEFINE_INDEX_TYPE(name)                                              \
-  Result BinaryReaderLogging::name(Index value, Type type) {                 \
-    LOGF(#name "(index: %" PRIindex ", type: %s)\n", value, type.GetName()); \
-    return reader_->name(value, type);                                       \
+#define DEFINE_INDEX_TYPE(name)                              \
+  Result BinaryReaderLogging::name(Index value, Type type) { \
+    LOGF(#name "(index: %" PRIindex ", type: %s)\n", value,  \
+         type.GetName().c_str());                            \
+    return reader_->name(value, type);                       \
   }
 
 #define DEFINE_INDEX_INDEX(name, desc0, desc1)                           \

--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -575,7 +575,7 @@ Result BinaryReaderObjdumpDisassemble::OnLocalDecl(Index decl_index,
   }
   local_index_ += count;
 
-  printf("] type=%s\n", type.GetName());
+  printf("] type=%s\n", type.GetName().c_str());
 
   last_opcode_end = current_opcode_offset + data_size;
   current_opcode_offset = last_opcode_end;
@@ -783,7 +783,7 @@ Result BinaryReaderObjdumpDisassemble::OnOpcodeType(Type type) {
     return Result::Ok;
   }
   if (current_opcode == Opcode::SelectT) {
-    LogOpcode(type.GetName());
+    LogOpcode(type.GetName().c_str());
   } else {
     LogOpcode(type.GetRefKindName());
   }
@@ -1257,7 +1257,7 @@ Result BinaryReaderObjdump::OnFuncType(Index index,
     if (i != 0) {
       printf(", ");
     }
-    printf("%s", param_types[i].GetName());
+    printf("%s", param_types[i].GetName().c_str());
   }
   printf(") -> ");
   switch (result_count) {
@@ -1265,7 +1265,7 @@ Result BinaryReaderObjdump::OnFuncType(Index index,
       printf("nil");
       break;
     case 1:
-      printf("%s", result_types[0].GetName());
+      printf("%s", result_types[0].GetName().c_str());
       break;
     default:
       printf("(");
@@ -1273,7 +1273,7 @@ Result BinaryReaderObjdump::OnFuncType(Index index,
         if (i != 0) {
           printf(", ");
         }
-        printf("%s", result_types[i].GetName());
+        printf("%s", result_types[i].GetName().c_str());
       }
       printf(")");
       break;
@@ -1293,7 +1293,7 @@ Result BinaryReaderObjdump::OnStructType(Index index,
     if (fields[i].mutable_) {
       printf(" (mut");
     }
-    printf(" %s", fields[i].type.GetName());
+    printf(" %s", fields[i].type.GetName().c_str());
     if (fields[i].mutable_) {
       printf(")");
     }
@@ -1310,7 +1310,7 @@ Result BinaryReaderObjdump::OnArrayType(Index index, TypeMut field) {
   if (field.mutable_) {
     printf(" (mut");
   }
-  printf(" %s", field.type.GetName());
+  printf(" %s", field.type.GetName().c_str());
   if (field.mutable_) {
     printf(")");
   }
@@ -1396,7 +1396,7 @@ Result BinaryReaderObjdump::OnImportTable(Index import_index,
                                           Type elem_type,
                                           const Limits* elem_limits) {
   PrintDetails(" - table[%" PRIindex "] type=%s initial=%" PRId64, table_index,
-               elem_type.GetName(), elem_limits->initial);
+               elem_type.GetName().c_str(), elem_limits->initial);
   if (elem_limits->has_max) {
     PrintDetails(" max=%" PRId64, elem_limits->max);
   }
@@ -1435,7 +1435,7 @@ Result BinaryReaderObjdump::OnImportGlobal(Index import_index,
                                            Type type,
                                            bool mutable_) {
   PrintDetails(" - global[%" PRIindex "] %s mutable=%d", global_index,
-               type.GetName(), mutable_);
+               type.GetName().c_str(), mutable_);
   PrintDetails(" <- " PRIstringview "." PRIstringview "\n",
                WABT_PRINTF_STRING_VIEW_ARG(module_name),
                WABT_PRINTF_STRING_VIEW_ARG(field_name));
@@ -1486,7 +1486,7 @@ Result BinaryReaderObjdump::OnTable(Index index,
                                     Type elem_type,
                                     const Limits* elem_limits) {
   PrintDetails(" - table[%" PRIindex "] type=%s initial=%" PRId64, index,
-               elem_type.GetName(), elem_limits->initial);
+               elem_type.GetName().c_str(), elem_limits->initial);
   if (elem_limits->has_max) {
     PrintDetails(" max=%" PRId64, elem_limits->max);
   }
@@ -1522,7 +1522,7 @@ Result BinaryReaderObjdump::OnExport(Index index,
 Result BinaryReaderObjdump::OnElemSegmentElemExpr_RefNull(Index segment_index,
                                                           Type type) {
   PrintDetails("  - elem[%" PRIzd "] = ref.null %s\n",
-               elem_offset_ + elem_index_, type.GetName());
+               elem_offset_ + elem_index_, type.GetName().c_str());
   elem_index_++;
   return Result::Ok;
 }
@@ -1576,8 +1576,8 @@ Result BinaryReaderObjdump::OnGlobalCount(Index count) {
 }
 
 Result BinaryReaderObjdump::BeginGlobal(Index index, Type type, bool mutable_) {
-  PrintDetails(" - global[%" PRIindex "] %s mutable=%d", index, type.GetName(),
-               mutable_);
+  PrintDetails(" - global[%" PRIindex "] %s mutable=%d", index,
+               type.GetName().c_str(), mutable_);
   string_view name = GetGlobalName(index);
   if (!name.empty()) {
     PrintDetails(" <" PRIstringview ">", WABT_PRINTF_STRING_VIEW_ARG(name));

--- a/src/binary-reader-opcnt.cc
+++ b/src/binary-reader-opcnt.cc
@@ -139,7 +139,7 @@ void OpcodeInfo::Write(Stream& stream) {
       if (type.IsIndex()) {
         stream.Writef(" type:%d", type.GetIndex());
       } else if (type != Type::Void) {
-        stream.Writef(" %s", type.GetName());
+        stream.Writef(" %s", type.GetName().c_str());
       }
       break;
     }

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2569,7 +2569,7 @@ Result BinaryReader::ReadElemSection(Offset section_size) {
         CHECK_RESULT(ReadExternalKind(&kind, "export kind"));
         ERROR_UNLESS(kind == ExternalKind::Func,
                      "segment elem type must be func (%s)",
-                     elem_type.GetName());
+                     elem_type.GetName().c_str());
         elem_type = Type::FuncRef;
       }
     }

--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -160,7 +160,7 @@ void BinaryWriterSpec::WriteVar(const Var& var) {
 void BinaryWriterSpec::WriteTypeObject(Type type) {
   json_stream_->Writef("{");
   WriteKey("type");
-  WriteString(type.GetName());
+  WriteString(type.GetName().c_str());
   json_stream_->Writef("}");
 }
 
@@ -259,7 +259,7 @@ void BinaryWriterSpec::WriteConst(const Const& const_) {
       WriteString("v128");
       WriteSeparator();
       WriteKey("lane_type");
-      WriteString(const_.lane_type().GetName());
+      WriteString(const_.lane_type().GetName().c_str());
       WriteSeparator();
       WriteKey("value");
       json_stream_->Writef("[");

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -56,10 +56,10 @@ void WriteOpcode(Stream* stream, Opcode opcode) {
 }
 
 void WriteType(Stream* stream, Type type, const char* desc) {
-  WriteS32Leb128(stream, type, desc ? desc : type.GetName());
+  WriteS32Leb128(stream, type, desc ? desc : type.GetName().c_str());
   if (type.IsReferenceWithIndex()) {
     WriteS32Leb128(stream, type.GetReferenceIndex(),
-                   desc ? desc : type.GetName());
+                   desc ? desc : type.GetName().c_str());
   }
 }
 

--- a/src/interp/interp-wasm-c-api.cc
+++ b/src/interp/interp-wasm-c-api.cc
@@ -537,21 +537,21 @@ static void print_sig(const FuncType& sig) {
 #ifndef NDEBUG
   fprintf(stderr, "(");
   bool first = true;
-  for (auto Type : sig.params) {
+  for (auto type : sig.params) {
     if (!first) {
       fprintf(stderr, ", ");
     }
     first = false;
-    fprintf(stderr, "%s", Type.GetName());
+    fprintf(stderr, "%s", type.GetName().c_str());
   }
   fprintf(stderr, ") -> (");
   first = true;
-  for (auto Type : sig.results) {
+  for (auto type : sig.results) {
     if (!first) {
       fprintf(stderr, ", ");
     }
     first = false;
-    fprintf(stderr, "%s", Type.GetName());
+    fprintf(stderr, "%s", type.GetName().c_str());
   }
   fprintf(stderr, ")\n");
 #endif

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -31,7 +31,7 @@ const char* GetName(Mutability mut) {
   return kNames[int(mut)];
 }
 
-const char* GetName(ValueType type) {
+const std::string GetName(ValueType type) {
   return type.GetName();
 }
 
@@ -105,9 +105,9 @@ Result Match(const TableType& expected,
              const TableType& actual,
              std::string* out_msg) {
   if (expected.element != actual.element) {
-    *out_msg =
-        StringPrintf("type mismatch in imported table, expected %s but got %s.",
-                     GetName(expected.element), GetName(actual.element));
+    *out_msg = StringPrintf(
+        "type mismatch in imported table, expected %s but got %s.",
+        GetName(expected.element).c_str(), GetName(actual.element).c_str());
     return Result::Error;
   }
 
@@ -149,7 +149,7 @@ Result Match(const GlobalType& expected,
        !TypesMatch(expected.type, actual.type))) {
     *out_msg = StringPrintf(
         "type mismatch in imported global, expected %s but got %s.",
-        GetName(expected.type), GetName(actual.type));
+        GetName(expected.type).c_str(), GetName(actual.type).c_str());
     return Result::Error;
   }
 

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -91,7 +91,7 @@ enum class ObjectKind {
 };
 
 const char* GetName(Mutability);
-const char* GetName(ValueType);
+const std::string GetName(ValueType);
 const char* GetName(ExternKind);
 const char* GetName(ObjectKind);
 

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -178,7 +178,7 @@ Result SharedValidator::CheckType(const Location& loc,
                                   const char* desc) {
   if (Failed(TypeChecker::CheckType(actual, expected))) {
     PrintError(loc, "type mismatch at %s. got %s, expected %s", desc,
-               actual.GetName(), expected.GetName());
+               actual.GetName().c_str(), expected.GetName().c_str());
     return Result::Error;
   }
   return Result::Ok;

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -762,7 +762,7 @@ wabt::Result JSONParser::ParseLaneConstValue(Type lane_type,
     }
 
     default:
-      PrintError("unknown concrete type: \"%s\"", lane_type.GetName());
+      PrintError("unknown concrete type: \"%s\"", lane_type.GetName().c_str());
       return wabt::Result::Error;
   }
 
@@ -834,7 +834,7 @@ wabt::Result JSONParser::ParseConstValue(Type type,
       break;
 
     default:
-      PrintError("unknown concrete type: \"%s\"", type.GetName());
+      PrintError("unknown concrete type: \"%s\"", type.GetName().c_str());
       return wabt::Result::Error;
   }
 
@@ -1657,10 +1657,12 @@ static std::string ExpectedValueToString(const ExpectedValue& ev) {
           return TypedValueToString(ev.value);
 
         case ExpectedNan::Arithmetic:
-          return StringPrintf("%s:nan:arithmetic", ev.value.type.GetName());
+          return StringPrintf("%s:nan:arithmetic",
+                              ev.value.type.GetName().c_str());
 
         case ExpectedNan::Canonical:
-          return StringPrintf("%s:nan:canonical", ev.value.type.GetName());
+          return StringPrintf("%s:nan:canonical",
+                              ev.value.type.GetName().c_str());
       }
       break;
 

--- a/src/type.h
+++ b/src/type.h
@@ -23,6 +23,7 @@
 
 #include "config.h"
 #include "src/base-types.h"
+#include "src/string-format.h"
 
 namespace wabt {
 
@@ -57,9 +58,10 @@ class Type {
   };
 
   Type() = default;  // Provided so Type can be member of a union.
-  Type(int32_t code) : enum_(static_cast<Enum>(code)), index_(kInvalidIndex) {}
-  Type(Enum e) : enum_(e), index_(kInvalidIndex) {}
-  Type(Enum e, Index index) : enum_(e), index_(index) {
+  Type(int32_t code)
+      : enum_(static_cast<Enum>(code)), type_index_(kInvalidIndex) {}
+  Type(Enum e) : enum_(e), type_index_(kInvalidIndex) {}
+  Type(Enum e, Index type_index) : enum_(e), type_index_(type_index) {
     assert(e == Enum::Reference);
   }
   operator Enum() const { return enum_; }
@@ -76,7 +78,7 @@ class Type {
     return IsRef();
   }
 
-  const char* GetName() const {
+  std::string GetName() const {
     switch (enum_) {
       case Type::I32:       return "i32";
       case Type::I64:       return "i64";
@@ -90,11 +92,10 @@ class Type {
       case Type::Void:      return "void";
       case Type::Any:       return "any";
       case Type::ExternRef: return "externref";
-
-      // TODO(dbezhetskov): add index for reference type.
       case Type::Reference:
-        return "reference";
-      default:              return "<type_index>";
+        return StringPrintf("(ref %d)", type_index_);
+      default:
+        return StringPrintf("<type_index[%d]>", enum_);
     }
   }
 
@@ -129,7 +130,7 @@ class Type {
 
   Index GetReferenceIndex() const {
     assert(enum_ == Enum::Reference);
-    return index_;
+    return type_index_;
   }
 
   TypeVector GetInlineVector() const {
@@ -155,7 +156,7 @@ class Type {
 
  private:
   Enum enum_;
-  Index index_;
+  Index type_index_;  // Only used for for Type::Reference
 };
 
 }  // namespace wabt

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -186,7 +186,8 @@ void ScriptValidator::CheckTypeIndex(const Location* loc,
   if (Failed(TypeChecker::CheckType(actual, expected))) {
     PrintError(loc,
                "type mismatch for %s %" PRIindex " of %s. got %s, expected %s",
-               index_kind, index, desc, actual.GetName(), expected.GetName());
+               index_kind, index, desc, actual.GetName().c_str(),
+               expected.GetName().c_str());
   }
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -322,11 +322,12 @@ Result CheckTypeIndex(const Location& loc,
                       Errors* errors) {
   // Types must match exactly; no subtyping should be allowed.
   if (actual != expected) {
-    errors->emplace_back(ErrorLevel::Error, loc,
-                         StringPrintf("type mismatch for %s %" PRIindex
-                                      " of %s. got %s, expected %s",
-                                      index_kind, index, desc, actual.GetName(),
-                                      expected.GetName()));
+    errors->emplace_back(
+        ErrorLevel::Error, loc,
+        StringPrintf("type mismatch for %s %" PRIindex
+                     " of %s. got %s, expected %s",
+                     index_kind, index, desc, actual.GetName().c_str(),
+                     expected.GetName().c_str()));
     return Result::Error;
   }
   return Result::Ok;
@@ -877,7 +878,7 @@ Result WastParser::ParseValueType(Var* out_type) {
   }
 
   if (!is_enabled) {
-    Error(token.loc, "value type not allowed: %s", type.GetName());
+    Error(token.loc, "value type not allowed: %s", type.GetName().c_str());
     return Result::Error;
   }
 
@@ -923,7 +924,7 @@ Result WastParser::ParseRefKind(Type* out_type) {
        !options_->features.reference_types_enabled()) ||
       ((type == Type::Struct || type == Type::Array) &&
        !options_->features.gc_enabled())) {
-    Error(token.loc, "value type not allowed: %s", type.GetName());
+    Error(token.loc, "value type not allowed: %s", type.GetName().c_str());
     return Result::Error;
   }
 
@@ -941,7 +942,7 @@ Result WastParser::ParseRefType(Type* out_type) {
   Type type = token.type();
   if (type == Type::ExternRef &&
       !options_->features.reference_types_enabled()) {
-    Error(token.loc, "value type not allowed: %s", type.GetName());
+    Error(token.loc, "value type not allowed: %s", type.GetName().c_str());
     return Result::Error;
   }
 

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -421,9 +421,7 @@ void WatWriter::WriteRefKind(Type type, NextChar next_char) {
 }
 
 void WatWriter::WriteType(Type type, NextChar next_char) {
-  const char* type_name = type.GetName();
-  assert(type_name);
-  WritePuts(type_name, next_char);
+  WritePuts(type.GetName().c_str(), next_char);
 }
 
 void WatWriter::WriteTypes(const TypeVector& types, const char* name) {

--- a/test/dump/typed_func_refs_params.txt
+++ b/test/dump/typed_func_refs_params.txt
@@ -44,8 +44,8 @@
 ; func type 1
 0000010: 60                                        ; func
 0000011: 03                                        ; num params
-0000012: 6b                                        ; reference
-0000013: 00                                        ; reference
+0000012: 6b                                        ; (ref 0)
+0000013: 00                                        ; (ref 0)
 0000014: 7d                                        ; f32
 0000015: 7d                                        ; f32
 0000016: 01                                        ; num results

--- a/test/dump/typed_func_refs_results.txt
+++ b/test/dump/typed_func_refs_results.txt
@@ -58,14 +58,14 @@
 ; func type 1
 0000010: 60                                        ; func
 0000011: 03                                        ; num params
-0000012: 6b                                        ; reference
-0000013: 00                                        ; reference
-0000014: 6b                                        ; reference
-0000015: 00                                        ; reference
+0000012: 6b                                        ; (ref 0)
+0000013: 00                                        ; (ref 0)
+0000014: 6b                                        ; (ref 0)
+0000015: 00                                        ; (ref 0)
 0000016: 7f                                        ; i32
 0000017: 01                                        ; num results
-0000018: 6b                                        ; reference
-0000019: 00                                        ; reference
+0000018: 6b                                        ; (ref 0)
+0000019: 00                                        ; (ref 0)
 ; func type 2
 000001a: 60                                        ; func
 000001b: 00                                        ; num params
@@ -114,8 +114,8 @@
 000003f: 01                                        ; i32 literal
 0000040: 46                                        ; i32.eq
 0000041: 04                                        ; if
-0000042: 6b                                        ; reference
-0000043: 00                                        ; reference
+0000042: 6b                                        ; (ref 0)
+0000043: 00                                        ; (ref 0)
 0000044: 20                                        ; local.get
 0000045: 00                                        ; local index
 0000046: 05                                        ; else
@@ -172,7 +172,7 @@ Code Disassembly:
  00003c: 20 02                      | local.get 2
  00003e: 41 01                      | i32.const 1
  000040: 46                         | i32.eq
- 000041: 04 6b 00                   | if reference
+ 000041: 04 6b 00                   | if (ref 0)
  000044: 20 00                      |   local.get 0
  000046: 05                         | else
  000047: 20 01                      |   local.get 1

--- a/test/roundtrip/fold-function-references.txt
+++ b/test/roundtrip/fold-function-references.txt
@@ -53,10 +53,10 @@
 (;; STDOUT ;;;
 (module
   (type (;0;) (func (param f32) (result f32)))
-  (type (;1;) (func (param reference f32 f32) (result f32)))
-  (type (;2;) (func (param reference reference i32) (result reference)))
+  (type (;1;) (func (param (ref 0) f32 f32) (result f32)))
+  (type (;2;) (func (param (ref 0) (ref 0) i32) (result (ref 0))))
   (type (;3;) (func (result f32)))
-  (func (;0;) (type 1) (param reference f32 f32) (result f32)
+  (func (;0;) (type 1) (param (ref 0) f32 f32) (result f32)
     (f32.div
       (f32.sub
         (f32.add
@@ -67,8 +67,8 @@
           (local.get 1)
           (local.get 0)))
       (local.get 2)))
-  (func (;1;) (type 2) (param reference reference i32) (result reference)
-    (if (result reference)  ;; label = @1
+  (func (;1;) (type 2) (param (ref 0) (ref 0) i32) (result (ref 0))
+    (if (result (ref 0))  ;; label = @1
       (i32.eq
         (local.get 2)
         (i32.const 1))

--- a/test/typecheck/bad-callref-wrong-signature.txt
+++ b/test/typecheck/bad-callref-wrong-signature.txt
@@ -21,7 +21,7 @@
 )
 
 (;; STDERR ;;;
-out/test/typecheck/bad-callref-wrong-signature.txt:17:6: error: type mismatch in call, expected [reference] but got [reference]
+out/test/typecheck/bad-callref-wrong-signature.txt:17:6: error: type mismatch in call, expected [(ref 0)] but got [(ref 2)]
     (call $foo (ref.func $mul))
      ^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
This requires `Type::GetName` to return to be dynamicllay created and
return `std::string` rather then a `const char*`

As this diff shows this type name is only used in textual output and
error messages so should this change should not have a effect of binary
parse time or the interpreter.