### PR TITLE
Updated multi-value message

### DIFF
--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -53,7 +53,7 @@ Result SharedValidator::OnFuncType(const Location& loc,
   Result result = Result::Ok;
   if (!options_.features.multi_value_enabled() && result_count > 1) {
     result |=
-        PrintError(loc, "multiple result values not currently supported.");
+        PrintError(loc, "multiple result values are not supported without multi-value enabled.");
   }
   func_types_.emplace(
       num_types_++,

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -52,8 +52,9 @@ Result SharedValidator::OnFuncType(const Location& loc,
                                    Index type_index) {
   Result result = Result::Ok;
   if (!options_.features.multi_value_enabled() && result_count > 1) {
-    result |=
-        PrintError(loc, "multiple result values are not supported without multi-value enabled.");
+    result |= PrintError(loc,
+                         "multiple result values are not supported without "
+                         "multi-value enabled.");
   }
   func_types_.emplace(
       num_types_++,


### PR DESCRIPTION
Resolves https://github.com/WebAssembly/wabt/issues/1796

To test locally:

1. Make a WAT file containing a function which returns multiple values. Example:
```
(module
    (func $mult (export "mult")
        (result f64 f64)
        f64.const 1
        f64.const 2
    )
)
```
2. Use `wat2wasm` to compile, disabling multi-value. For example:
```
sudo bin/wat2wasm --disable-multi-value examples/multi.wat -o examples/multi.wasm
```

An error should be returned by the compiler. The wording of the error should be `multiple result values are not supported without multi-value enabled.`