### PR TITLE
Fix erroneous reporting of "Data reloctions outside of segments"

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -1232,9 +1232,15 @@ Result BinaryReaderObjdump::EndModule() {
     return Result::Error;
   }
 
-  if (options_->relocs) {
+  if (options_->relocs && ShouldPrintDetails()) {
     if (next_data_reloc_ != objdump_state_->data_relocations.size()) {
-      err_stream_->Writef("Data reloctions outside of segments\n");
+      err_stream_->Writef("Data reloctions outside of segments!:\n");
+      for (size_t i = next_data_reloc_;
+           i < objdump_state_->data_relocations.size(); i++) {
+        const Reloc& reloc = objdump_state_->data_relocations[i];
+        PrintRelocation(reloc, reloc.offset);
+      }
+
       return Result::Error;
     }
   }


### PR DESCRIPTION
This check should only not be done during disassembly, only
when displaying details.

Fixes: #1790