### PR TITLE
Fix location in config.h in source list

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,11 @@ jobs:
     - name: mkdir
       run: mkdir -p out
     - name: cmake
-      run: cmake .. -G Ninja -DWERROR=ON
+      run: cmake .. -G Ninja -DWERROR=ON -Werror=dev
       working-directory: out
       if: matrix.os != 'windows-latest'
     - name: cmake (windows)
-      run: cmake .. -DWERROR=ON
+      run: cmake .. -DWERROR=ON -Werror=dev
       working-directory: out
       if: matrix.os == 'windows-latest'
     - name: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,6 +256,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${WABT_SOURCE_DIR}/cmake)
 add_custom_target(everything)
 
 set(WABT_LIBRARY_SRC
+  ${WABT_BINARY_DIR}/config.h
+
   src/apply-names.h
   src/apply-names.cc
   src/binary.h
@@ -276,7 +278,7 @@ set(WABT_LIBRARY_SRC
   src/color.cc
   src/common.h
   src/common.cc
-  src/config.h
+  src/config.h.in
   src/config.cc
   src/decompiler.h
   src/decompiler-ast.h


### PR DESCRIPTION
The wrong name here was causing a cmake warning because
it was finding `config.h.in` instead and this behaviour is
deprecated.