### PR TITLE
Fix wat parsing of function imports with type name + inline type

### DIFF
--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1505,16 +1505,11 @@ Result WastParser::ParseImportModuleField(Module* module) {
       Consume();
       ParseBindVarOpt(&name);
       auto import = MakeUnique<FuncImport>(name);
-      if (PeekMatchLpar(TokenType::Type)) {
-        import->func.decl.has_func_type = true;
-        CHECK_RESULT(ParseTypeUseOpt(&import->func.decl));
-        EXPECT(Rpar);
-      } else {
-        CHECK_RESULT(
-            ParseFuncSignature(&import->func.decl.sig, &import->func.bindings));
-        CHECK_RESULT(ErrorIfLpar({"param", "result"}));
-        EXPECT(Rpar);
-      }
+      CHECK_RESULT(ParseTypeUseOpt(&import->func.decl));
+      CHECK_RESULT(
+          ParseFuncSignature(&import->func.decl.sig, &import->func.bindings));
+      CHECK_RESULT(ErrorIfLpar({"param", "result"}));
+      EXPECT(Rpar);
       field = MakeUnique<ImportModuleField>(std::move(import), loc);
       break;
     }

--- a/test/parse/module/import-func.txt
+++ b/test/parse/module/import-func.txt
@@ -1,5 +1,7 @@
 ;;; TOOL: wat2wasm
 (module
+  (type $add_type (func (param i32 i32) (result i32)))
+
   ;; unnamed
   (import "foo" "bar" (func (param i32) (result i64)))
 
@@ -8,4 +10,11 @@
   (import "math" "add" (func $add_i32 (param i32 i32) (result i32)))
   (import "test" "f32" (func $f32 (param f32) (result f32)))
   (import "test" "f64" (func $f64 (param f64) (result f64)))
-  (import "test" "i64" (func $i64 (param i64) (result i64))))
+  (import "test" "i64" (func $i64 (param i64) (result i64)))
+
+  ;; named type
+  (import "math" "add" (func $add_i32_2 (type $add_type)))
+
+  ;; named type, with repetition of type inline
+  (import "math" "add" (func $add_i32_3 (type $add_type) (param i32 i32) (result i32)))
+)


### PR DESCRIPTION
This simplifies the code for parsing imported functions
and makes it match more closely the code for parsing
non-imported functions.

Fixes: #1806