### PR TITLE
Change Thread in interpreter to a normal object

### DIFF
--- a/src/interp/interp-inl.h
+++ b/src/interp/interp-inl.h
@@ -467,6 +467,10 @@ inline const Features& Store::features() const {
   return features_;
 }
 
+inline std::set<Thread*>& Store::threads() {
+  return threads_;
+}
+
 //// Object ////
 // static
 inline bool Object::classof(const Object* obj) {
@@ -938,16 +942,6 @@ inline std::vector<DataSegment>& Instance::datas() {
 }
 
 //// Thread ////
-// static
-inline bool Thread::classof(const Object* obj) {
-  return obj->kind() == skind;
-}
-
-// static
-inline Thread::Ptr Thread::New(Store& store, const Options& options) {
-  return store.Alloc<Thread>(store, options);
-}
-
 inline Store& Thread::store() {
   return store_;
 }

--- a/src/test-interp.cc
+++ b/src/test-interp.cc
@@ -346,7 +346,7 @@ TEST_F(InterpTest, HostFunc_PingPong_SameThread) {
       0x0b, 0x01, 0x09, 0x00, 0x20, 0x00, 0x41, 0x01, 0x6a, 0x10, 0x00, 0x0b,
   });
 
-  auto thread = Thread::New(store_, {});
+  Thread thread(store_);
 
   auto host_func =
       HostFunc::New(store_, FuncType{{ValueType::I32}, {ValueType::I32}},
@@ -369,7 +369,7 @@ TEST_F(InterpTest, HostFunc_PingPong_SameThread) {
   Values results;
   Trap::Ptr trap;
   Result result =
-      GetFuncExport(0)->Call(*thread, {Value::Make(1)}, results, &trap);
+      GetFuncExport(0)->Call(thread, {Value::Make(1)}, results, &trap);
 
   ASSERT_EQ(Result::Ok, result);
   EXPECT_EQ(1u, results.size());


### PR DESCRIPTION
Improves memory consumption since thread instances are freed without running garbage collector.