### PR TITLE
canonicalize positive leb128

### DIFF
--- a/src/leb128.cc
+++ b/src/leb128.cc
@@ -112,7 +112,7 @@ static void WriteS32Leb128(Stream* stream, int32_t value, const char* desc) {
   if (value < 0) {
     LEB128_LOOP_UNTIL(value == -1 && (byte & 0x40));
   } else {
-    LEB128_LOOP_UNTIL(value == 0 && !(byte & 0x40));
+    LEB128_LOOP_UNTIL(value == 0 && !(byte & 0x80));
   }
 
   stream->WriteData(data, length, desc);
@@ -124,7 +124,7 @@ static void WriteS64Leb128(Stream* stream, int64_t value, const char* desc) {
   if (value < 0) {
     LEB128_LOOP_UNTIL(value == -1 && (byte & 0x40));
   } else {
-    LEB128_LOOP_UNTIL(value == 0 && !(byte & 0x40));
+    LEB128_LOOP_UNTIL(value == 0 && !(byte & 0x80));
   }
 
   stream->WriteData(data, length, desc);


### PR DESCRIPTION
https://github.com/WebAssembly/wabt/issues/1816

I had a look at the code and found a suspicious 0x40.
I don't understand what it's doing with negative ints,
but changing the line about negative leb128 caused wat2wasm to segfault.

just this change fixes the reported bug.

I couldn't get the tests to run on main, so not fully sure about this