### PR TITLE
objdump: Consider params when printing local decl index

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -240,6 +240,15 @@ class BinaryReaderObjdumpPrepass : public BinaryReaderObjdumpBase {
     return Result::Ok;
   }
 
+  Result OnFuncType(Index index,
+                    Index param_count,
+                    Type* param_types,
+                    Index result_count,
+                    Type* result_types) override {
+    objdump_state_->function_param_counts[index] = param_count;
+    return Result::Ok;
+  }
+
   Result OnNameEntry(NameSectionSubsection type,
                      Index index,
                      string_view name) override {
@@ -548,7 +557,6 @@ Result BinaryReaderObjdumpDisassemble::OnLocalDeclCount(Index count) {
   if (!in_function_body) {
     return Result::Ok;
   }
-  local_index_ = 0;
   current_opcode_offset = state->offset;
   return Result::Ok;
 }
@@ -845,6 +853,7 @@ Result BinaryReaderObjdumpDisassemble::BeginFunctionBody(Index index,
 
   last_opcode_end = 0;
   in_function_body = true;
+  local_index_ = objdump_state_->function_param_counts[index];
   return Result::Ok;
 }
 

--- a/src/binary-reader-objdump.h
+++ b/src/binary-reader-objdump.h
@@ -76,6 +76,7 @@ struct ObjdumpState {
   ObjdumpNames segment_names;
   ObjdumpNames table_names;
   std::vector<ObjdumpSymbol> symtab;
+  std::map<Index, Index> function_param_counts;
 };
 
 Result ReadBinaryObjdump(const uint8_t* data,

--- a/test/dump/debug-names.txt
+++ b/test/dump/debug-names.txt
@@ -148,8 +148,8 @@ Custom:
 Code Disassembly:
 
 00001d func[0] <F1>:
- 00001e: 01 7d                      | local[0] type=f32
- 000020: 02 7f                      | local[1..2] type=i32
+ 00001e: 01 7d                      | local[1] type=f32
+ 000020: 02 7f                      | local[2..3] type=i32
  000022: 0b                         | end
 000024 func[1]:
  000025: 0b                         | end

--- a/test/dump/localget-param.txt
+++ b/test/dump/localget-param.txt
@@ -79,10 +79,10 @@ localget-param.wasm:	file format wasm 0x1
 Code Disassembly:
 
 000018 func[0]:
- 000019: 01 7e                      | local[0] type=i64
- 00001b: 01 7d                      | local[1] type=f32
- 00001d: 01 7f                      | local[2] type=i32
- 00001f: 01 7d                      | local[3] type=f32
+ 000019: 01 7e                      | local[2] type=i64
+ 00001b: 01 7d                      | local[3] type=f32
+ 00001d: 01 7f                      | local[4] type=i32
+ 00001f: 01 7d                      | local[5] type=f32
  000021: 20 00                      | local.get 0
  000023: 1a                         | drop
  000024: 20 01                      | local.get 1

--- a/test/dump/localset-param.txt
+++ b/test/dump/localset-param.txt
@@ -89,10 +89,10 @@ localset-param.wasm:	file format wasm 0x1
 Code Disassembly:
 
 000018 func[0]:
- 000019: 01 7e                      | local[0] type=i64
- 00001b: 01 7d                      | local[1] type=f32
- 00001d: 01 7f                      | local[2] type=i32
- 00001f: 01 7d                      | local[3] type=f32
+ 000019: 01 7e                      | local[2] type=i64
+ 00001b: 01 7d                      | local[3] type=f32
+ 00001d: 01 7f                      | local[4] type=i32
+ 00001f: 01 7d                      | local[5] type=f32
  000021: 41 00                      | i32.const 0
  000023: 21 00                      | local.set 0
  000025: 43 00 00 00 00             | f32.const 0x0p+0


### PR DESCRIPTION
Currently, objdump -d will start at index 0 when printing local declarations e.g. `local[0] type=i64`, regardless of whether the function has any params. To me, it feels like starting the index at the param count to match the index used in opcodes and elsewhere would be less confusing.