### PR TITLE
fix test/wasm2c/spec/names.txt with python 3.6

### DIFF
--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -399,7 +399,7 @@ def main(args):
         cc = utils.Executable(options.cc, *options.cflags)
         cc.verbose = options.print_cmd
 
-        with open(json_file_path) as json_file:
+        with open(json_file_path, encoding="utf-8") as json_file:
             spec_json = json.load(json_file)
 
         prefix = ''


### PR DESCRIPTION
On RHEL/CentOS 7, the system python3 is 3.6. Before python 3.7.0 (see
[3.7.0 alpha 1 changelog](https://docs.python.org/3.7/whatsnew/changelog.html#id186), [issue 28180](https://bugs.python.org/issue28180) and [PEP 538](https://www.python.org/dev/peps/pep-0538)), the default text
encoding was ascii, which fails on Unicode characters when deserializing
a json file in `json.load()`:
```
- test/wasm2c/spec/names.txt
  expected error code 0, got 1.
  STDERR MISMATCH:
  --- expected
  +++ actual
  @@ -0,0 +1,10 @@
  +Traceback (most recent call last):
  +  File "/builddir/build/BUILD/wabt-1.0.24/test/run-spec-wasm2c.py", line 437, in <module>
  +    sys.exit(main(sys.argv[1:]))
  +  File "/builddir/build/BUILD/wabt-1.0.24/test/run-spec-wasm2c.py", line 394, in main
  +    spec_json = json.load(json_file)
  +  File "/usr/lib64/python3.6/json/__init__.py", line 296, in load
  +    return loads(fp.read(),
  +  File "/usr/lib64/python3.6/encodings/ascii.py", line 26, in decode
  +    return codecs.ascii_decode(input, self.errors)[0]
  +UnicodeDecodeError: 'ascii' codec can't decode byte 0xef in position 2862: ordinal not in range(128)
  STDOUT MISMATCH:
  --- expected
  +++ actual
  @@ -1,3 +0,0 @@
  -spectest.print_i32(42)
  -spectest.print_i32(123)
  -482/482 tests passed.
```

Fixes #1704.