### PR TITLE
Fix size of segment in initialization error reporting

### DIFF
--- a/test/binary/bad-data-size.txt
+++ b/test/binary/bad-data-size.txt
@@ -1,5 +1,4 @@
 ;;; TOOL: run-gen-wasm-interp
-;;; ARGS1: --disable-bulk-memory
 ;;; ERROR: 1
 magic
 version


### PR DESCRIPTION
When data of element segment init fails we were reporting the size, but
we were unconditionally calling `Drop` for active segments which meant
they always get reported as zero sized in the error message.

This mismatch was only showing up with bulk memory enabled (since
without this we do a two phase initialization).  The only test we have
for this error message was using `--disable-bulk-memory`, but not for
any good reason (most likely because of this very bug).

Also restore the comment about why we sometimes need to do a two phase
initialization for element and data segments.  This comment was lost in
PR #1330 but seem important since I don't think we have any tests for
this older behaviour.