### PR TITLE
Initial implementation of extended-const proposal.

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Wabt has been compiled to JavaScript via emscripten. Some of the functionality i
 | [annotations][] | `--enable-annotations` | | | ✓ | | |
 | [memory64][] | `--enable-memory64` | | | | | |
 | [multi-memory][] | `--enable-multi-memory` | | ✓ | ✓ | ✓ | ✓ |
+| [extended-const][] | `--enable-extended-const` | | | | | |
 
 [exception handling]: https://github.com/WebAssembly/exception-handling
 [mutable globals]: https://github.com/WebAssembly/mutable-global

--- a/src/feature.def
+++ b/src/feature.def
@@ -37,3 +37,4 @@ WABT_FEATURE(annotations,         "annotations",             false,   "Custom an
 WABT_FEATURE(gc,                  "gc",                      false,   "Garbage collection")
 WABT_FEATURE(memory64,            "memory64",                false,   "64-bit memory")
 WABT_FEATURE(multi_memory,        "multi-memory",            false,   "Multi-memory")
+WABT_FEATURE(extended_const,      "extended-const",          false,   "Extended constant expressions")

--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -519,11 +519,21 @@ Result SharedValidator::CheckAtomicAlign(const Location& loc,
   return Result::Ok;
 }
 
-static bool ValidInitOpcode(Opcode opcode) {
-  return opcode == Opcode::GlobalGet || opcode == Opcode::I32Const ||
-         opcode == Opcode::I64Const || opcode == Opcode::F32Const ||
-         opcode == Opcode::F64Const || opcode == Opcode::RefFunc ||
-         opcode == Opcode::RefNull;
+bool SharedValidator::ValidInitOpcode(Opcode opcode) const {
+  if (opcode == Opcode::GlobalGet || opcode == Opcode::I32Const ||
+      opcode == Opcode::I64Const || opcode == Opcode::F32Const ||
+      opcode == Opcode::F64Const || opcode == Opcode::RefFunc ||
+      opcode == Opcode::RefNull) {
+    return true;
+  }
+  if (options_.features.extended_const_enabled()) {
+    if (opcode == Opcode::I32Mul || opcode == Opcode::I64Mul ||
+        opcode == Opcode::I32Sub || opcode == Opcode::I64Sub ||
+        opcode == Opcode::I32Add || opcode == Opcode::I64Add) {
+      return true;
+    }
+  }
+  return false;
 }
 
 Result SharedValidator::CheckInstr(Opcode opcode, const Location& loc) {

--- a/src/shared-validator.h
+++ b/src/shared-validator.h
@@ -244,6 +244,7 @@ class SharedValidator {
     Index end;
   };
 
+  bool ValidInitOpcode(Opcode opcode) const;
   Result CheckInstr(Opcode opcode, const Location& loc);
   Result CheckType(const Location&,
                    Type actual,

--- a/src/test-interp.cc
+++ b/src/test-interp.cc
@@ -680,11 +680,13 @@ TEST_F(InterpGCTest, Collect_InstanceExport) {
   });
   Instantiate();
   auto after_new = store_.object_count();
-  EXPECT_EQ(before_new + 6, after_new);  // module, instance, f, t, m, g
+  EXPECT_EQ(before_new + 7,
+            after_new);  // module, instance, f, t, m, g, g-init-func
 
-  // Instance keeps all exports alive.
+  // Instance keeps all exports alive, except the init func which can be
+  // collected once its has been run
   store_.Collect();
-  EXPECT_EQ(after_new, store_.object_count());
+  EXPECT_EQ(after_new - 1, store_.object_count());
 }
 
 // TODO: Test for Thread keeping references alive as locals/params/stack values.

--- a/test/help/spectest-interp.txt
+++ b/test/help/spectest-interp.txt
@@ -28,6 +28,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
   -V, --value-stack-size=SIZE                  Size in elements of the value stack
   -C, --call-stack-size=SIZE                   Size in elements of the call stack

--- a/test/help/wasm-interp.txt
+++ b/test/help/wasm-interp.txt
@@ -39,6 +39,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
   -V, --value-stack-size=SIZE                  Size in elements of the value stack
   -C, --call-stack-size=SIZE                   Size in elements of the call stack

--- a/test/help/wasm-opcodecnt.txt
+++ b/test/help/wasm-opcodecnt.txt
@@ -29,6 +29,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
   -o, --output=FILENAME                        Output file for the opcode counts, by default use stdout
   -c, --cutoff=N                               Cutoff for reporting counts less than N

--- a/test/help/wasm-validate.txt
+++ b/test/help/wasm-validate.txt
@@ -28,6 +28,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
       --no-debug-names                         Ignore debug names in the binary file
       --ignore-custom-section-errors           Ignore errors in custom sections

--- a/test/help/wasm2wat.txt
+++ b/test/help/wasm2wat.txt
@@ -34,6 +34,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
       --inline-exports                         Write all exports inline
       --inline-imports                         Write all imports inline

--- a/test/help/wast2json.txt
+++ b/test/help/wast2json.txt
@@ -31,6 +31,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
   -o, --output=FILE                            output JSON file
   -r, --relocatable                            Create a relocatable wasm binary (suitable for linking with e.g. lld)

--- a/test/help/wat-desugar.txt
+++ b/test/help/wat-desugar.txt
@@ -38,6 +38,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
       --generate-names                         Give auto-generated names to non-named functions, types, etc.
 ;;; STDOUT ;;)

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -38,6 +38,7 @@ options:
       --enable-gc                              Enable Garbage collection
       --enable-memory64                        Enable 64-bit memory
       --enable-multi-memory                    Enable Multi-memory
+      --enable-extended-const                  Enable Extended constant expressions
       --enable-all                             Enable all features
   -o, --output=FILE                            output wasm binary file
   -r, --relocatable                            Create a relocatable wasm binary (suitable for linking with e.g. lld)

--- a/test/spec/extended-const/data.txt
+++ b/test/spec/extended-const/data.txt
@@ -1,0 +1,63 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/data.wast
+;;; ARGS*: --enable-extended-const
+(;; STDOUT ;;;
+out/test/spec/extended-const/data.wast:325: assert_invalid passed:
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
+out/test/spec/extended-const/data.wast:333: assert_invalid passed:
+  0000000: error: memory variable out of range: 1 (max 1)
+  0000012: error: BeginDataSegment callback failed
+out/test/spec/extended-const/data.wast:346: assert_invalid passed:
+  0000000: error: memory variable out of range: 0 (max 0)
+  000000c: error: BeginDataSegment callback failed
+out/test/spec/extended-const/data.wast:357: assert_invalid passed:
+  0000000: error: memory variable out of range: 1 (max 0)
+  000000d: error: BeginDataSegment callback failed
+out/test/spec/extended-const/data.wast:369: assert_invalid passed:
+  0000000: error: memory variable out of range: 1 (max 1)
+  0000012: error: BeginDataSegment callback failed
+out/test/spec/extended-const/data.wast:391: assert_invalid passed:
+  0000000: error: memory variable out of range: 1 (max 0)
+  000000d: error: BeginDataSegment callback failed
+out/test/spec/extended-const/data.wast:410: assert_invalid passed:
+  out/test/spec/extended-const/data/data.49.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
+  0000014: error: EndDataSegmentInitExpr callback failed
+out/test/spec/extended-const/data.wast:418: assert_invalid passed:
+  out/test/spec/extended-const/data/data.50.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [funcref]
+  0000014: error: EndDataSegmentInitExpr callback failed
+out/test/spec/extended-const/data.wast:426: assert_invalid passed:
+  out/test/spec/extended-const/data/data.51.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
+  0000012: error: EndDataSegmentInitExpr callback failed
+out/test/spec/extended-const/data.wast:434: assert_invalid passed:
+  out/test/spec/extended-const/data/data.52.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000016: error: EndDataSegmentInitExpr callback failed
+out/test/spec/extended-const/data.wast:442: assert_invalid passed:
+  out/test/spec/extended-const/data/data.53.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002c: error: EndDataSegmentInitExpr callback failed
+out/test/spec/extended-const/data.wast:451: assert_invalid passed:
+  out/test/spec/extended-const/data/data.54.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002c: error: EndDataSegmentInitExpr callback failed
+out/test/spec/extended-const/data.wast:460: assert_invalid passed:
+  out/test/spec/extended-const/data/data.55.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000014: error: OnUnaryExpr callback failed
+out/test/spec/extended-const/data.wast:468: assert_invalid passed:
+  out/test/spec/extended-const/data/data.56.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000012: error: OnNopExpr callback failed
+out/test/spec/extended-const/data.wast:476: assert_invalid passed:
+  out/test/spec/extended-const/data/data.57.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000012: error: OnNopExpr callback failed
+out/test/spec/extended-const/data.wast:484: assert_invalid passed:
+  out/test/spec/extended-const/data/data.58.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000014: error: OnNopExpr callback failed
+out/test/spec/extended-const/data.wast:498: assert_invalid passed:
+  0000000: error: global variable out of range: 0 (max 0)
+  0000013: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/data.wast:506: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000029: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/data.wast:515: assert_invalid passed:
+  out/test/spec/extended-const/data/data.61.wasm:000002d: error: initializer expression cannot reference a mutable global
+  000002d: error: OnGlobalGetExpr callback failed
+33/33 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/extended-const/elem.txt
+++ b/test/spec/extended-const/elem.txt
@@ -1,0 +1,68 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/elem.wast
+;;; ARGS*: --enable-extended-const
+(;; STDOUT ;;;
+out/test/spec/extended-const/elem.wast:321: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/extended-const/elem.wast:331: assert_trap passed: out of bounds table access: table.init out of bounds
+out/test/spec/extended-const/elem.wast:336: assert_invalid passed:
+  0000000: error: table variable out of range: 0 (max 0)
+  0000016: error: BeginElemSegment callback failed
+out/test/spec/extended-const/elem.wast:346: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.34.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
+  0000015: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:354: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.35.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [funcref]
+  0000015: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:362: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.36.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
+  0000013: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:370: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.37.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000017: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:378: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.38.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002d: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:387: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.39.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002d: error: EndElemSegmentInitExpr callback failed
+out/test/spec/extended-const/elem.wast:397: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.40.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000015: error: OnUnaryExpr callback failed
+out/test/spec/extended-const/elem.wast:405: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.41.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000013: error: OnNopExpr callback failed
+out/test/spec/extended-const/elem.wast:413: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.42.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000013: error: OnNopExpr callback failed
+out/test/spec/extended-const/elem.wast:421: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000015: error: OnNopExpr callback failed
+out/test/spec/extended-const/elem.wast:435: assert_invalid passed:
+  0000000: error: global variable out of range: 0 (max 0)
+  0000014: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/elem.wast:443: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  000002a: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/elem.wast:452: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.46.wasm:000002e: error: initializer expression cannot reference a mutable global
+  000002e: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/elem.wast:463: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.47.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
+  0000018: error: OnElemSegmentElemExpr_RefNull callback failed
+out/test/spec/extended-const/elem.wast:471: assert_invalid passed:
+  0000019: error: expected END opcode after element expression
+out/test/spec/extended-const/elem.wast:479: assert_invalid passed:
+  0000017: error: expected ref.null or ref.func in passive element segment
+  0000018: error: expected END opcode after element expression
+out/test/spec/extended-const/elem.wast:487: assert_invalid passed:
+  0000017: error: expected ref.null or ref.func in passive element segment
+  0000018: error: expected END opcode after element expression
+out/test/spec/extended-const/elem.wast:495: assert_invalid passed:
+  0000022: error: expected ref.null or ref.func in passive element segment
+  0000023: error: expected END opcode after element expression
+out/test/spec/extended-const/elem.wast:504: assert_invalid passed:
+  0000022: error: expected ref.null or ref.func in passive element segment
+  0000023: error: expected END opcode after element expression
+out/test/spec/extended-const/elem.wast:562: assert_trap passed: uninitialized table element
+47/47 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/extended-const/global.txt
+++ b/test/spec/extended-const/global.txt
@@ -1,0 +1,141 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/proposals/extended-const/global.wast
+;;; ARGS*: --enable-extended-const
+(;; STDOUT ;;;
+out/test/spec/extended-const/global.wast:263: assert_trap passed: undefined table index
+out/test/spec/extended-const/global.wast:285: assert_invalid passed:
+  out/test/spec/extended-const/global/global.1.wasm:0000029: error: can't global.set on immutable global at index 0.
+  0000029: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:290: assert_invalid passed:
+  out/test/spec/extended-const/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
+  0000035: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:299: assert_invalid passed:
+  out/test/spec/extended-const/global/global.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
+  0000013: error: OnUnaryExpr callback failed
+out/test/spec/extended-const/global.wast:304: assert_invalid passed:
+  out/test/spec/extended-const/global/global.6.wasm:000000f: error: invalid initializer: instruction not valid in initializer expression: local.get
+  000000f: error: OnLocalGetExpr callback failed
+out/test/spec/extended-const/global.wast:309: assert_invalid passed:
+  out/test/spec/extended-const/global/global.7.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
+  0000013: error: OnUnaryExpr callback failed
+out/test/spec/extended-const/global.wast:314: assert_invalid passed:
+  out/test/spec/extended-const/global/global.8.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000010: error: OnNopExpr callback failed
+out/test/spec/extended-const/global.wast:319: assert_invalid passed:
+  out/test/spec/extended-const/global/global.9.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000010: error: OnUnaryExpr callback failed
+out/test/spec/extended-const/global.wast:324: assert_invalid passed:
+  out/test/spec/extended-const/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
+  000000e: error: OnNopExpr callback failed
+out/test/spec/extended-const/global.wast:329: assert_invalid passed:
+  out/test/spec/extended-const/global/global.11.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got [f32]
+  0000013: error: EndGlobalInitExpr callback failed
+out/test/spec/extended-const/global.wast:334: assert_invalid passed:
+  out/test/spec/extended-const/global/global.12.wasm:0000011: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000012: error: EndGlobalInitExpr callback failed
+out/test/spec/extended-const/global.wast:339: assert_invalid passed:
+  out/test/spec/extended-const/global/global.13.wasm:000000d: error: type mismatch in initializer expression, expected [i32] but got []
+  000000e: error: EndGlobalInitExpr callback failed
+out/test/spec/extended-const/global.wast:344: assert_invalid passed:
+  out/test/spec/extended-const/global/global.14.wasm:0000017: error: type mismatch in initializer expression, expected [funcref] but got [externref]
+  0000018: error: EndGlobalInitExpr callback failed
+out/test/spec/extended-const/global.wast:349: assert_invalid passed:
+  out/test/spec/extended-const/global/global.15.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000028: error: EndGlobalInitExpr callback failed
+out/test/spec/extended-const/global.wast:354: assert_invalid passed:
+  out/test/spec/extended-const/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000028: error: EndGlobalInitExpr callback failed
+out/test/spec/extended-const/global.wast:359: assert_invalid passed:
+  0000000: error: initializer expression can only reference an imported global
+  000000f: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:364: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  000000f: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:369: assert_invalid passed:
+  0000000: error: global variable out of range: 2 (max 2)
+  0000025: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:374: assert_invalid passed:
+  out/test/spec/extended-const/global/global.20.wasm:0000029: error: initializer expression cannot reference a mutable global
+  0000029: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:382: assert_malformed passed:
+  0000026: error: global mutability must be 0 or 1
+out/test/spec/extended-const/global.wast:395: assert_malformed passed:
+  0000026: error: global mutability must be 0 or 1
+out/test/spec/extended-const/global.wast:412: assert_malformed passed:
+  0000011: error: global mutability must be 0 or 1
+out/test/spec/extended-const/global.wast:424: assert_malformed passed:
+  0000011: error: global mutability must be 0 or 1
+out/test/spec/extended-const/global.wast:438: assert_invalid passed:
+  0000000: error: global variable out of range: 0 (max 0)
+  000001a: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:443: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000022: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:451: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000034: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:459: assert_invalid passed:
+  0000000: error: global variable out of range: 2 (max 2)
+  000003c: error: OnGlobalGetExpr callback failed
+out/test/spec/extended-const/global.wast:469: assert_invalid passed:
+  0000000: error: global variable out of range: 0 (max 0)
+  000001b: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:474: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000023: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:482: assert_invalid passed:
+  0000000: error: global variable out of range: 1 (max 1)
+  0000035: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:490: assert_invalid passed:
+  0000000: error: global variable out of range: 2 (max 2)
+  000003d: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:500: assert_invalid passed:
+  out/test/spec/extended-const/global/global.35.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
+  0000021: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:509: assert_invalid passed:
+  out/test/spec/extended-const/global/global.36.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:519: assert_invalid passed:
+  out/test/spec/extended-const/global/global.37.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:529: assert_invalid passed:
+  out/test/spec/extended-const/global/global.38.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
+  0000027: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:539: assert_invalid passed:
+  out/test/spec/extended-const/global/global.39.wasm:000002a: error: type mismatch in global.set, expected [i32] but got []
+  000002a: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:549: assert_invalid passed:
+  out/test/spec/extended-const/global/global.40.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:559: assert_invalid passed:
+  out/test/spec/extended-const/global/global.41.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:569: assert_invalid passed:
+  out/test/spec/extended-const/global/global.42.wasm:0000025: error: type mismatch in global.set, expected [i32] but got []
+  0000025: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:579: assert_invalid passed:
+  out/test/spec/extended-const/global/global.43.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
+  0000021: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:588: assert_invalid passed:
+  out/test/spec/extended-const/global/global.44.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []
+  0000021: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:597: assert_invalid passed:
+  out/test/spec/extended-const/global/global.45.wasm:0000027: error: type mismatch in global.set, expected [i32] but got []
+  0000027: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:607: assert_invalid passed:
+  out/test/spec/extended-const/global/global.46.wasm:000003e: error: type mismatch in global.set, expected [i32] but got []
+  000003e: error: OnGlobalSetExpr callback failed
+out/test/spec/extended-const/global.wast:625: assert_malformed passed:
+  out/test/spec/extended-const/global/global.47.wat:1:33: error: redefinition of global "$foo"
+  (global $foo i32 (i32.const 0))(global $foo i32 (i32.const 0))
+                                  ^^^^^^
+out/test/spec/extended-const/global.wast:629: assert_malformed passed:
+  out/test/spec/extended-const/global/global.48.wat:1:34: error: redefinition of global "$foo"
+  (import "" "" (global $foo i32))(global $foo i32 (i32.const 0))
+                                   ^^^^^^
+out/test/spec/extended-const/global.wast:633: assert_malformed passed:
+  out/test/spec/extended-const/global/global.49.wat:1:34: error: redefinition of global "$foo"
+  (import "" "" (global $foo i32))(import "" "" (global $foo i32))
+                                   ^^^^^^
+107/107 tests passed.
+;;; STDOUT ;;)

--- a/test/update-spec-tests.py
+++ b/test/update-spec-tests.py
@@ -91,7 +91,8 @@ def main(args):
     flags = {
         'memory64': '--enable-memory64',
         'multi-memory': '--enable-multi-memory',
-        'exception-handling': '--enable-exceptions'
+        'exception-handling': '--enable-exceptions',
+        'extended-const': '--enable-extended-const',
     }
 
     unimplemented = set([
@@ -100,6 +101,7 @@ def main(args):
         'function-references',
         'threads',
         'annotations',
+        'exception-handling',
         'extended-const',
     ])
 


### PR DESCRIPTION
The primary changes here are to the interpreter and how it handles
initializer expressions.  With this change we model these are normal
function that we run during module initialization.

I imagine we could optimize this further by creating one long function
and encoding the `global.set`/`memory.init`/`table.init` into the
function itself, but this change seems like a good first step to make
the current tests pass.