### PR TITLE
wasm2c: run multi-memory tests

### DIFF
--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -56,6 +56,13 @@ examples:
   $ wasm2c test.wasm --no-debug-names -o test.c
 )";
 
+static const std::string supported_features[] = {"multi-memory"};
+
+static bool IsFeatureSupported(const std::string& feature) {
+  return std::find(std::begin(supported_features), std::end(supported_features),
+                   feature) != std::end(supported_features);
+};
+
 static void ParseOptions(int argc, char** argv) {
   OptionParser parser("wasm2c", s_description);
 
@@ -80,15 +87,15 @@ static void ParseOptions(int argc, char** argv) {
                      });
   parser.Parse(argc, argv);
 
-  // TODO(binji): currently wasm2c doesn't support any non-default feature
-  // flags.
-  bool any_non_default_feature = false;
-#define WABT_FEATURE(variable, flag, default_, help) \
-  any_non_default_feature |= (s_features.variable##_enabled() != default_);
+  bool any_non_supported_feature = false;
+#define WABT_FEATURE(variable, flag, default_, help)   \
+  any_non_supported_feature |=                         \
+      (s_features.variable##_enabled() != default_) && \
+      !IsFeatureSupported(flag);
 #include "src/feature.def"
 #undef WABT_FEATURE
 
-  if (any_non_default_feature) {
+  if (any_non_supported_feature) {
     fprintf(stderr,
             "wasm2c currently only supports a fixed set of features.\n");
     exit(1);

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -377,6 +377,7 @@ def main(args):
                         help='print the commands that are run.',
                         action='store_true')
     parser.add_argument('file', help='wast file.')
+    parser.add_argument('--enable-multi-memory', action='store_true')
     options = parser.parse_args(args)
 
     with utils.TempDirectory(options.out_dir, 'run-spec-wasm2c-') as out_dir:
@@ -385,7 +386,9 @@ def main(args):
             find_exe.GetWast2JsonExecutable(options.bindir),
             error_cmdline=options.error_cmdline)
         wast2json.verbose = options.print_cmd
-        wast2json.AppendOptionalArgs({'-v': options.verbose})
+        wast2json.AppendOptionalArgs({
+            '-v': options.verbose,
+            '--enable-multi-memory': options.enable_multi_memory})
 
         json_file_path = utils.ChangeDir(
             utils.ChangeExt(options.file, '.json'), out_dir)
@@ -395,6 +398,8 @@ def main(args):
             find_exe.GetWasm2CExecutable(options.bindir),
             error_cmdline=options.error_cmdline)
         wasm2c.verbose = options.print_cmd
+        wasm2c.AppendOptionalArgs({
+            '--enable-multi-memory': options.enable_multi_memory})
 
         cc = utils.Executable(options.cc, *options.cflags)
         cc.verbose = options.print_cmd

--- a/test/wasm2c/spec/multi-memory/binary.txt
+++ b/test/wasm2c/spec/multi-memory/binary.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/binary.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+0/0 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/multi-memory/data.txt
+++ b/test/wasm2c/spec/multi-memory/data.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/data.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+14/14 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/multi-memory/memory.txt
+++ b/test/wasm2c/spec/multi-memory/memory.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/memory.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+45/45 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/multi-memory/memory_grow.txt
+++ b/test/wasm2c/spec/multi-memory/memory_grow.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/memory_grow.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+131/131 tests passed.
+;;; STDOUT ;;)

--- a/test/wasm2c/spec/multi-memory/memory_size.txt
+++ b/test/wasm2c/spec/multi-memory/memory_size.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/proposals/multi-memory/memory_size.wast
+;;; ARGS*: --enable-multi-memory
+(;; STDOUT ;;;
+40/40 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
~~This PR is sequenced behind #1810 and #1829.~~

PR #1751 added support for multi-memory and ran the multi-memory tests with `run-interp-spec`. This PR also runs (some of) the multi-memory tests under wasm2c, with `run-spec-wasm2c`. Only 5 of the 9 multi-memory tests are supported by wasm2c right now; the others require reference types, multi-table, or bulk memory.