### PR TITLE
Implement a separate free list for Refs

### DIFF
--- a/src/interp/interp-inl.h
+++ b/src/interp/interp-inl.h
@@ -190,6 +190,44 @@ auto FreeList<T>::count() const -> Index {
   return list_.size() - free_.size();
 }
 
+//// FreeRefList ////
+inline FreeRefList::Index FreeRefList::New(Ref ref) {
+  if (free_head_ == 0) {
+    list_.push_back(ref);
+    return list_.size() - 1;
+  }
+
+  Index index = free_head_ - 1;
+  assert(!IsUsed(index));
+  free_head_ = list_[index].index & (freeBit - 1);
+  list_[index] = ref;
+  return index;
+}
+
+inline void FreeRefList::Delete(Index index) {
+  assert(IsUsed(index));
+  list_[index].index = free_head_ | freeBit;
+  free_head_ = index + 1;
+}
+
+inline bool FreeRefList::IsUsed(Index index) const {
+  return (list_[index].index & freeBit) == 0;
+}
+
+inline const Ref& FreeRefList::Get(Index index) const {
+  assert(IsUsed(index));
+  return list_[index];
+}
+
+inline Ref& FreeRefList::Get(Index index) {
+  assert(IsUsed(index));
+  return list_[index];
+}
+
+inline FreeRefList::Index FreeRefList::size() const {
+  return list_.size();
+}
+
 //// RefPtr ////
 template <typename T>
 RefPtr<T>::RefPtr() : obj_(nullptr), store_(nullptr), root_index_(0) {}

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -435,18 +435,42 @@ class FreeList {
   //                 1 when the payload is the index of the next free object
   //   n: the payload
   //
-  // When T is a Ref (see Store::RootList below), we'd need to store the
-  // "is_free" bit in most-significant bit instead.
-  //
   std::vector<T> list_;
   std::vector<size_t> free_;
   std::vector<bool> is_free_;
 };
 
+// TODO: After the rework of FreeList (see TODO above),
+// this class could be merged with it.
+class FreeRefList {
+ public:
+  using Index = size_t;
+
+  Index New(Ref);
+  void Delete(Index);
+
+  bool IsUsed(Index) const;
+
+  const Ref& Get(Index) const;
+  Ref& Get(Index);
+
+  Index size() const;  // 1 greater than the maximum index.
+
+ private:
+  // The value of freeBit is 0x80..0, and this bit is set
+  // for currently unused (free) items of list_ vector.
+  static const Index freeBit = (SIZE_MAX >> 1) + 1;
+
+  std::vector<Ref> list_;
+  // If free_head_ is zero, there is no free slots in list_,
+  // otherwise free_head_ - 1 represents the first free slot.
+  Index free_head_ = 0;
+};
+
 class Store {
  public:
   using ObjectList = FreeList<std::unique_ptr<Object>>;
-  using RootList = FreeList<Ref>;
+  using RootList = FreeRefList;
 
   explicit Store(const Features& = Features{});
 


### PR DESCRIPTION
Create a memory optimized free list for Refs in the interpreter.

This patch is based on a comment in the original Free List. The highest bit cannot be set for valid Ref indices, so it can be used to represent free items. If the patch is accepted, I will specialize the original free list for objects, where the lowest bit will represent unused slots.