### PR TITLE
Fix lint CI on push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,8 @@ jobs:
         sudo apt-get install clang-format
     - run: flake8
     - run: ./scripts/clang-format-diff.sh
+      env:
+        GITHUB_EVENT_BEFORE: ${{ github.event.before }}
   build:
     name: build
     runs-on: ${{ matrix.os }}

--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -3,10 +3,10 @@
 set -o errexit
 set -o pipefail
 
-if [ -n "$GITHUB_EVENT_BEFORE" ] && [ "push" = "$GITHUB_EVENT_NAME" ]; then
-  BRANCH="$GITHUB_EVENT_BEFORE"
-elif [ -n "$1" ]; then
+if [ -n "$1" ]; then
   BRANCH="$1"
+elif [ -n "$GITHUB_EVENT_BEFORE" ] && [ "push" = "$GITHUB_EVENT_NAME" ]; then
+  BRANCH="$GITHUB_EVENT_BEFORE"
 elif [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"
 else

--- a/scripts/clang-format-diff.sh
+++ b/scripts/clang-format-diff.sh
@@ -3,7 +3,9 @@
 set -o errexit
 set -o pipefail
 
-if [ -n "$1" ]; then
+if [ -n "$GITHUB_EVENT_BEFORE" ] && [ "push" = "$GITHUB_EVENT_NAME" ]; then
+  BRANCH="$GITHUB_EVENT_BEFORE"
+elif [ -n "$1" ]; then
   BRANCH="$1"
 elif [ -n "$GITHUB_BASE_REF" ]; then
   BRANCH="origin/$GITHUB_BASE_REF"


### PR DESCRIPTION
Because clang-format-diff is designed to check only the diff, this effectively only checks the relevant commit instead of the whole repo. So it should be fine to accept PRs that don't pass lint - the lint job will fail for that commit, but following pushes should pass.

Granted this isn't so relevant for the main repo where everyone goes through PRs, but for forks/etc it makes a difference. An alternative would be to just skip clang-format-diff on push (with something like `if: github.event_name != 'push'` instead of `env: ...`) but, again: forks/etc.