### PR TITLE
Fix function body start/end locations in wasm-validate

### DIFF
--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -461,6 +461,7 @@ Result SharedValidator::BeginFunctionBody(const Location& loc,
 }
 
 Result SharedValidator::EndFunctionBody(const Location& loc) {
+  expr_loc_ = loc;
   return typechecker_.EndFunction();
 }
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -816,16 +816,18 @@ Result Validator::CheckModule() {
   Index func_index = module->num_func_imports;
   for (const ModuleField& field : module->fields) {
     if (auto* f = dyn_cast<FuncModuleField>(&field)) {
-      result_ |= validator_.BeginFunctionBody(field.loc, func_index++);
+      const Location& body_start = f->func.loc;
+      const Location& body_end =
+          f->func.exprs.empty() ? body_start : f->func.exprs.back().loc;
+      result_ |= validator_.BeginFunctionBody(body_start, func_index++);
 
       for (auto&& decl : f->func.local_types.decls()) {
-        // TODO: Better location?
-        result_ |= validator_.OnLocalDecl(field.loc, decl.second, decl.first);
+        result_ |= validator_.OnLocalDecl(body_start, decl.second, decl.first);
       }
 
       ExprVisitor visitor(this);
       result_ |= visitor.VisitExprList(const_cast<ExprList&>(f->func.exprs));
-      result_ |= validator_.EndFunctionBody(field.loc);
+      result_ |= validator_.EndFunctionBody(body_end);
     }
   }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1361,6 +1361,7 @@ Result WastParser::ParseFuncModuleField(Module* module) {
   } else {
     auto field = MakeUnique<FuncModuleField>(loc, name);
     Func& func = field->func;
+    func.loc = GetLocation();
     CHECK_RESULT(ParseTypeUseOpt(&func.decl));
     CHECK_RESULT(ParseFuncSignature(&func.decl.sig, &func.bindings));
     TypeVector local_types;

--- a/test/parse/expr/bad-select-multi.txt
+++ b/test/parse/expr/bad-select-multi.txt
@@ -14,7 +14,7 @@
 out/test/parse/expr/bad-select-multi.txt:10:5: error: invalid arity in select instruction: 2.
     select (result i32 i32)
     ^^^^^^
-out/test/parse/expr/bad-select-multi.txt:10:5: error: type mismatch at end of function, expected [] but got [... i32, i32, i32, i32]
-    select (result i32 i32)
-    ^^^^^^
+out/test/parse/expr/bad-select-multi.txt:11:5: error: type mismatch at end of function, expected [] but got [... i32, i32, i32, i32]
+    unreachable
+    ^^^^^^^^^^^
 ;;; STDERR ;;)

--- a/test/regress/regress-28.txt
+++ b/test/regress/regress-28.txt
@@ -15,6 +15,6 @@ section(CODE) {
   }
 }
 (;; STDERR ;;;
-out/test/regress/regress-28/regress-28.wasm:000001b: error: type mismatch at end of function, expected [] but got [any]
+out/test/regress/regress-28/regress-28.wasm:000001c: error: type mismatch at end of function, expected [] but got [any]
 000001c: error: EndFunctionBody callback failed
 ;;; STDERR ;;)

--- a/test/spec/block.txt
+++ b/test/spec/block.txt
@@ -52,16 +52,16 @@ out/test/spec/block.wast:497: assert_invalid passed:
   out/test/spec/block/block.12.wasm:000001c: error: type mismatch at end of block, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/block.wast:505: assert_invalid passed:
-  out/test/spec/block/block.13.wasm:000001b: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/block/block.13.wasm:000001c: error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:509: assert_invalid passed:
-  out/test/spec/block/block.14.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/block/block.14.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:513: assert_invalid passed:
-  out/test/spec/block/block.15.wasm:000001b: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/block/block.15.wasm:000001c: error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:517: assert_invalid passed:
-  out/test/spec/block/block.16.wasm:000001b: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/block/block.16.wasm:000001c: error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/block.wast:522: assert_invalid passed:
   out/test/spec/block/block.17.wasm:000001c: error: type mismatch at end of block, expected [] but got [i32]
@@ -163,40 +163,40 @@ out/test/spec/block.wast:725: assert_invalid passed:
   out/test/spec/block/block.49.wasm:000001f: error: type mismatch at end of block, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/block.wast:732: assert_invalid passed:
-  out/test/spec/block/block.50.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/block/block.50.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:738: assert_invalid passed:
-  out/test/spec/block/block.51.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/block/block.51.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:744: assert_invalid passed:
-  out/test/spec/block/block.52.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [f64]
+  out/test/spec/block/block.52.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [f64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:750: assert_invalid passed:
-  out/test/spec/block/block.53.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/block/block.53.wasm:0000020: error: type mismatch in implicit return, expected [i64] but got [i32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:756: assert_invalid passed:
-  out/test/spec/block/block.54.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [f32]
+  out/test/spec/block/block.54.wasm:0000020: error: type mismatch in implicit return, expected [i64] but got [f32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:762: assert_invalid passed:
-  out/test/spec/block/block.55.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [f64]
+  out/test/spec/block/block.55.wasm:0000020: error: type mismatch in implicit return, expected [i64] but got [f64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:768: assert_invalid passed:
-  out/test/spec/block/block.56.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/block/block.56.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:774: assert_invalid passed:
-  out/test/spec/block/block.57.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i64]
+  out/test/spec/block/block.57.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:780: assert_invalid passed:
-  out/test/spec/block/block.58.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [f64]
+  out/test/spec/block/block.58.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got [f64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:786: assert_invalid passed:
-  out/test/spec/block/block.59.wasm:000001f: error: type mismatch in implicit return, expected [f64] but got [i32]
+  out/test/spec/block/block.59.wasm:0000020: error: type mismatch in implicit return, expected [f64] but got [i32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:792: assert_invalid passed:
-  out/test/spec/block/block.60.wasm:000001f: error: type mismatch in implicit return, expected [f64] but got [i64]
+  out/test/spec/block/block.60.wasm:0000020: error: type mismatch in implicit return, expected [f64] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:798: assert_invalid passed:
-  out/test/spec/block/block.61.wasm:000001f: error: type mismatch in implicit return, expected [f64] but got [f32]
+  out/test/spec/block/block.61.wasm:0000020: error: type mismatch in implicit return, expected [f64] but got [f32]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/block.wast:805: assert_invalid passed:
   out/test/spec/block/block.62.wasm:000001c: error: type mismatch in br, expected [i32] but got []
@@ -337,19 +337,19 @@ out/test/spec/block.wast:1080: assert_invalid passed:
   out/test/spec/block/block.107.wasm:000001f: error: type mismatch in br, expected [i32, i32] but got [i32]
   000001f: error: OnBrExpr callback failed
 out/test/spec/block.wast:1087: assert_invalid passed:
-  out/test/spec/block/block.108.wasm:0000023: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/block/block.108.wasm:0000024: error: type mismatch at end of function, expected [] but got [i32]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1093: assert_invalid passed:
-  out/test/spec/block/block.109.wasm:0000023: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/block/block.109.wasm:0000024: error: type mismatch at end of function, expected [] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1099: assert_invalid passed:
-  out/test/spec/block/block.110.wasm:0000026: error: type mismatch at end of function, expected [] but got [f32]
+  out/test/spec/block/block.110.wasm:0000027: error: type mismatch at end of function, expected [] but got [f32]
   0000027: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1105: assert_invalid passed:
-  out/test/spec/block/block.111.wasm:000002a: error: type mismatch at end of function, expected [] but got [f64]
+  out/test/spec/block/block.111.wasm:000002b: error: type mismatch at end of function, expected [] but got [f64]
   000002b: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1111: assert_invalid passed:
-  out/test/spec/block/block.112.wasm:000002a: error: type mismatch at end of function, expected [] but got [i32, i32]
+  out/test/spec/block/block.112.wasm:000002b: error: type mismatch at end of function, expected [] but got [i32, i32]
   000002b: error: EndFunctionBody callback failed
 out/test/spec/block.wast:1118: assert_invalid passed:
   out/test/spec/block/block.113.wasm:000001e: error: type mismatch in br, expected [i32] but got []

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -15,10 +15,10 @@ out/test/spec/call.wast:403: assert_invalid passed:
   out/test/spec/call/call.4.wasm:000001f: error: type mismatch in call, expected [f64, i32] but got []
   000001f: error: OnCallExpr callback failed
 out/test/spec/call.wast:410: assert_invalid passed:
-  out/test/spec/call/call.5.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/call/call.5.wasm:000001d: error: type mismatch at end of function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/call.wast:417: assert_invalid passed:
-  out/test/spec/call/call.6.wasm:0000025: error: type mismatch at end of function, expected [] but got [f64, i32]
+  out/test/spec/call/call.6.wasm:0000026: error: type mismatch at end of function, expected [] but got [f64, i32]
   0000026: error: EndFunctionBody callback failed
 out/test/spec/call.wast:425: assert_invalid passed:
   out/test/spec/call/call.7.wasm:0000022: error: type mismatch in call, expected [i32, i32] but got [i32]

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -100,10 +100,10 @@ out/test/spec/call_indirect.wast:824: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.17.wasm:0000027: error: type mismatch in call_indirect, expected [f64, i32] but got []
   0000027: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:832: assert_invalid passed:
-  out/test/spec/call_indirect/call_indirect.18.wasm:0000024: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/call_indirect/call_indirect.18.wasm:0000025: error: type mismatch at end of function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/call_indirect.wast:840: assert_invalid passed:
-  out/test/spec/call_indirect/call_indirect.19.wasm:000002d: error: type mismatch at end of function, expected [] but got [f64, i32]
+  out/test/spec/call_indirect/call_indirect.19.wasm:000002e: error: type mismatch at end of function, expected [] but got [f64, i32]
   000002e: error: EndFunctionBody callback failed
 out/test/spec/call_indirect.wast:851: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.20.wasm:0000027: error: type mismatch in call_indirect, expected [i32] but got []

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -52,7 +52,7 @@ out/test/spec/func.wast:623: assert_malformed passed:
   ...unc (param i32 i32) (result i32)))(func (type $sig) (param i32) (result i3...
                                         ^^^^
 out/test/spec/func.wast:634: assert_invalid passed:
-  out/test/spec/func/func.16.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/func/func.16.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/func.wast:638: assert_invalid passed:
   out/test/spec/func/func.17.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got [f32]
@@ -61,7 +61,7 @@ out/test/spec/func.wast:642: assert_invalid passed:
   out/test/spec/func/func.18.wasm:000001e: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001e: error: OnUnaryExpr callback failed
 out/test/spec/func.wast:650: assert_invalid passed:
-  out/test/spec/func/func.19.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/func/func.19.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/func.wast:654: assert_invalid passed:
   out/test/spec/func/func.20.wasm:000001b: error: type mismatch in i32.eqz, expected [i32] but got [f32]
@@ -70,40 +70,40 @@ out/test/spec/func.wast:658: assert_invalid passed:
   out/test/spec/func/func.21.wasm:000001c: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001c: error: OnUnaryExpr callback failed
 out/test/spec/func.wast:666: assert_invalid passed:
-  out/test/spec/func/func.22.wasm:0000017: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/func/func.22.wasm:0000019: error: type mismatch in implicit return, expected [i32] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:670: assert_invalid passed:
-  out/test/spec/func/func.23.wasm:0000017: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/func/func.23.wasm:0000019: error: type mismatch in implicit return, expected [i64] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:674: assert_invalid passed:
-  out/test/spec/func/func.24.wasm:0000017: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/func/func.24.wasm:0000019: error: type mismatch in implicit return, expected [f32] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:678: assert_invalid passed:
-  out/test/spec/func/func.25.wasm:0000017: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/func/func.25.wasm:0000019: error: type mismatch in implicit return, expected [f64] but got []
   0000019: error: EndFunctionBody callback failed
 out/test/spec/func.wast:682: assert_invalid passed:
-  out/test/spec/func/func.26.wasm:0000018: error: type mismatch in implicit return, expected [f64, i32] but got []
+  out/test/spec/func/func.26.wasm:000001a: error: type mismatch in implicit return, expected [f64, i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:687: assert_invalid passed:
-  out/test/spec/func/func.27.wasm:0000019: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/func/func.27.wasm:000001a: error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:693: assert_invalid passed:
-  out/test/spec/func/func.28.wasm:000001a: error: type mismatch in implicit return, expected [i32, i32] but got []
+  out/test/spec/func/func.28.wasm:000001b: error: type mismatch in implicit return, expected [i32, i32] but got []
   000001b: error: EndFunctionBody callback failed
 out/test/spec/func.wast:699: assert_invalid passed:
-  out/test/spec/func/func.29.wasm:0000019: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/func/func.29.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/func.wast:705: assert_invalid passed:
-  out/test/spec/func/func.30.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32, i64]
+  out/test/spec/func/func.30.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32, i64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/func.wast:711: assert_invalid passed:
-  out/test/spec/func/func.31.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/func/func.31.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [f32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/func.wast:717: assert_invalid passed:
-  out/test/spec/func/func.32.wasm:000001e: error: type mismatch in implicit return, expected [f32, f32] but got [f32]
+  out/test/spec/func/func.32.wasm:000001f: error: type mismatch in implicit return, expected [f32, f32] but got [f32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/func.wast:723: assert_invalid passed:
-  out/test/spec/func/func.33.wasm:0000022: error: type mismatch at end of function, expected [] but got [f32]
+  out/test/spec/func/func.33.wasm:0000023: error: type mismatch at end of function, expected [] but got [f32]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/func.wast:730: assert_invalid passed:
   out/test/spec/func/func.34.wasm:0000019: error: type mismatch in return, expected [i32] but got []

--- a/test/spec/if.txt
+++ b/test/spec/if.txt
@@ -68,31 +68,31 @@ out/test/spec/if.wast:816: assert_malformed passed:
   ...))(func (i32.const 0) (i32.const 1)  (if (type $sig) (param i32) (result i...
                                           ^
 out/test/spec/if.wast:826: assert_invalid passed:
-  out/test/spec/if/if.12.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/if/if.12.wasm:000001f: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/if.wast:834: assert_invalid passed:
-  out/test/spec/if/if.13.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/if/if.13.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:838: assert_invalid passed:
-  out/test/spec/if/if.14.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/if/if.14.wasm:000001e: error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:842: assert_invalid passed:
-  out/test/spec/if/if.15.wasm:000001d: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/if/if.15.wasm:000001e: error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:846: assert_invalid passed:
-  out/test/spec/if/if.16.wasm:000001d: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/if/if.16.wasm:000001e: error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:851: assert_invalid passed:
-  out/test/spec/if/if.17.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/if/if.17.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:855: assert_invalid passed:
-  out/test/spec/if/if.18.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/if/if.18.wasm:000001e: error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:859: assert_invalid passed:
-  out/test/spec/if/if.19.wasm:000001d: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/if/if.19.wasm:000001e: error: type mismatch in implicit return, expected [f32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:863: assert_invalid passed:
-  out/test/spec/if/if.20.wasm:000001d: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/if/if.20.wasm:000001e: error: type mismatch in implicit return, expected [f64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/if.wast:868: assert_invalid passed:
   out/test/spec/if/if.21.wasm:000001e: error: type mismatch at end of `if true` branch, expected [] but got [i32]
@@ -203,13 +203,13 @@ out/test/spec/if.wast:1092: assert_invalid passed:
   out/test/spec/if/if.56.wasm:0000023: error: type mismatch at end of `if true` branch, expected [] but got [i32]
   0000024: error: OnElseExpr callback failed
 out/test/spec/if.wast:1099: assert_invalid passed:
-  out/test/spec/if/if.57.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/if/if.57.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/if.wast:1109: assert_invalid passed:
-  out/test/spec/if/if.58.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/if/if.58.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/if.wast:1119: assert_invalid passed:
-  out/test/spec/if/if.59.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/if/if.59.wasm:0000027: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000027: error: EndFunctionBody callback failed
 out/test/spec/if.wast:1130: assert_invalid passed:
   out/test/spec/if/if.60.wasm:000001e: error: type mismatch in br, expected [i32] but got []

--- a/test/spec/load.txt
+++ b/test/spec/load.txt
@@ -54,46 +54,46 @@ out/test/spec/load.wast:301: assert_malformed passed:
   (memory 1)(func (param i32) (result f64) (f64.load64 (local.get 0)))
                                             ^^^^^^^^^^
 out/test/spec/load.wast:312: assert_invalid passed:
-  out/test/spec/load/load.14.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/load/load.14.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:316: assert_invalid passed:
-  out/test/spec/load/load.15.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/load/load.15.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:320: assert_invalid passed:
-  out/test/spec/load/load.16.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/load/load.16.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:324: assert_invalid passed:
-  out/test/spec/load/load.17.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/load/load.17.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:328: assert_invalid passed:
-  out/test/spec/load/load.18.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/load/load.18.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:332: assert_invalid passed:
-  out/test/spec/load/load.19.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.19.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:336: assert_invalid passed:
-  out/test/spec/load/load.20.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.20.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:340: assert_invalid passed:
-  out/test/spec/load/load.21.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.21.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:344: assert_invalid passed:
-  out/test/spec/load/load.22.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.22.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:348: assert_invalid passed:
-  out/test/spec/load/load.23.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.23.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:352: assert_invalid passed:
-  out/test/spec/load/load.24.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.24.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:356: assert_invalid passed:
-  out/test/spec/load/load.25.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/load/load.25.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:360: assert_invalid passed:
-  out/test/spec/load/load.26.wasm:0000021: error: type mismatch at end of function, expected [] but got [f32]
+  out/test/spec/load/load.26.wasm:0000022: error: type mismatch at end of function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:364: assert_invalid passed:
-  out/test/spec/load/load.27.wasm:0000021: error: type mismatch at end of function, expected [] but got [f64]
+  out/test/spec/load/load.27.wasm:0000022: error: type mismatch at end of function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/load.wast:371: assert_invalid passed:
   out/test/spec/load/load.28.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got [f32]

--- a/test/spec/local_get.txt
+++ b/test/spec/local_get.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/local_get.wast
 (;; STDOUT ;;;
 out/test/spec/local_get.wast:149: assert_invalid passed:
-  out/test/spec/local_get/local_get.1.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_get/local_get.1.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:153: assert_invalid passed:
   out/test/spec/local_get/local_get.2.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got [f32]
@@ -11,7 +11,7 @@ out/test/spec/local_get.wast:157: assert_invalid passed:
   out/test/spec/local_get/local_get.3.wasm:000001f: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001f: error: OnUnaryExpr callback failed
 out/test/spec/local_get.wast:165: assert_invalid passed:
-  out/test/spec/local_get/local_get.4.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_get/local_get.4.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:169: assert_invalid passed:
   out/test/spec/local_get/local_get.5.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got [f32]
@@ -20,16 +20,16 @@ out/test/spec/local_get.wast:173: assert_invalid passed:
   out/test/spec/local_get/local_get.6.wasm:000001d: error: type mismatch in f64.neg, expected [f64] but got [i64]
   000001d: error: OnUnaryExpr callback failed
 out/test/spec/local_get.wast:181: assert_invalid passed:
-  out/test/spec/local_get/local_get.7.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/local_get/local_get.7.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:185: assert_invalid passed:
-  out/test/spec/local_get/local_get.8.wasm:000001b: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/local_get/local_get.8.wasm:000001c: error: type mismatch at end of function, expected [] but got [i64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:189: assert_invalid passed:
-  out/test/spec/local_get/local_get.9.wasm:000001b: error: type mismatch at end of function, expected [] but got [f32]
+  out/test/spec/local_get/local_get.9.wasm:000001c: error: type mismatch at end of function, expected [] but got [f32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:193: assert_invalid passed:
-  out/test/spec/local_get/local_get.10.wasm:000001b: error: type mismatch at end of function, expected [] but got [f64]
+  out/test/spec/local_get/local_get.10.wasm:000001c: error: type mismatch at end of function, expected [] but got [f64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:201: assert_invalid passed:
   0000000: error: local variable out of range (max 2)

--- a/test/spec/local_set.txt
+++ b/test/spec/local_set.txt
@@ -71,16 +71,16 @@ out/test/spec/local_set.wast:309: assert_invalid passed:
   out/test/spec/local_set/local_set.23.wasm:0000020: error: type mismatch in local.set, expected [f64] but got [i64]
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:317: assert_invalid passed:
-  out/test/spec/local_set/local_set.24.wasm:000001d: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/local_set/local_set.24.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:321: assert_invalid passed:
-  out/test/spec/local_set/local_set.25.wasm:000001d: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/local_set/local_set.25.wasm:000001e: error: type mismatch in implicit return, expected [i64] but got []
   000001e: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:325: assert_invalid passed:
-  out/test/spec/local_set/local_set.26.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/local_set/local_set.26.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got []
   0000021: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:329: assert_invalid passed:
-  out/test/spec/local_set/local_set.27.wasm:0000024: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/local_set/local_set.27.wasm:0000025: error: type mismatch in implicit return, expected [f64] but got []
   0000025: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:337: assert_invalid passed:
   0000000: error: local variable out of range (max 2)

--- a/test/spec/local_tee.txt
+++ b/test/spec/local_tee.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/local_tee.wast
 (;; STDOUT ;;;
 out/test/spec/local_tee.wast:371: assert_invalid passed:
-  out/test/spec/local_tee/local_tee.1.wasm:000001e: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_tee/local_tee.1.wasm:000001f: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/local_tee.wast:375: assert_invalid passed:
   out/test/spec/local_tee/local_tee.2.wasm:0000021: error: type mismatch in i32.eqz, expected [i32] but got [f32]
@@ -23,7 +23,7 @@ out/test/spec/local_tee.wast:396: assert_invalid passed:
   out/test/spec/local_tee/local_tee.7.wasm:0000026: error: type mismatch in local.tee, expected [i64] but got [f64]
   0000026: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:404: assert_invalid passed:
-  out/test/spec/local_tee/local_tee.8.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got [i32]
+  out/test/spec/local_tee/local_tee.8.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_tee.wast:408: assert_invalid passed:
   out/test/spec/local_tee/local_tee.9.wasm:000001b: error: type mismatch in i32.eqz, expected [i32] but got [f32]

--- a/test/spec/loop.txt
+++ b/test/spec/loop.txt
@@ -52,16 +52,16 @@ out/test/spec/loop.wast:601: assert_invalid passed:
   out/test/spec/loop/loop.12.wasm:000001c: error: type mismatch at end of loop, expected [] but got [i32]
   000001c: error: OnEndExpr callback failed
 out/test/spec/loop.wast:609: assert_invalid passed:
-  out/test/spec/loop/loop.13.wasm:000001b: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/loop/loop.13.wasm:000001c: error: type mismatch in implicit return, expected [i32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:613: assert_invalid passed:
-  out/test/spec/loop/loop.14.wasm:000001b: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/loop/loop.14.wasm:000001c: error: type mismatch in implicit return, expected [i64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:617: assert_invalid passed:
-  out/test/spec/loop/loop.15.wasm:000001b: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/loop/loop.15.wasm:000001c: error: type mismatch in implicit return, expected [f32] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:621: assert_invalid passed:
-  out/test/spec/loop/loop.16.wasm:000001b: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/loop/loop.16.wasm:000001c: error: type mismatch in implicit return, expected [f64] but got []
   000001c: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:626: assert_invalid passed:
   out/test/spec/loop/loop.17.wasm:000001c: error: type mismatch at end of loop, expected [] but got [i32]
@@ -94,7 +94,7 @@ out/test/spec/loop.wast:680: assert_invalid passed:
   out/test/spec/loop/loop.26.wasm:000001f: error: type mismatch at end of loop, expected [] but got [i32]
   000001f: error: OnEndExpr callback failed
 out/test/spec/loop.wast:686: assert_invalid passed:
-  out/test/spec/loop/loop.27.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/loop/loop.27.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 out/test/spec/loop.wast:693: assert_invalid passed:
   out/test/spec/loop/loop.28.wasm:000001e: error: type mismatch in loop, expected [i32] but got []

--- a/test/spec/memory64/load64.txt
+++ b/test/spec/memory64/load64.txt
@@ -55,46 +55,46 @@ out/test/spec/memory64/load64.wast:301: assert_malformed passed:
   (memory i64 1)(func (param i64) (result f64) (f64.load64 (local.get 0)))
                                                 ^^^^^^^^^^
 out/test/spec/memory64/load64.wast:312: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.14.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.14.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:316: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.15.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.15.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:320: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.16.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.16.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:324: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.17.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.17.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:328: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.18.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory64/load64/load64.18.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:332: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.19.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.19.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:336: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.20.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.20.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:340: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.21.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.21.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:344: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.22.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.22.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:348: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.23.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.23.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:352: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.24.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.24.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:356: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.25.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/memory64/load64/load64.25.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:360: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.26.wasm:0000021: error: type mismatch at end of function, expected [] but got [f32]
+  out/test/spec/memory64/load64/load64.26.wasm:0000022: error: type mismatch at end of function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:364: assert_invalid passed:
-  out/test/spec/memory64/load64/load64.27.wasm:0000021: error: type mismatch at end of function, expected [] but got [f64]
+  out/test/spec/memory64/load64/load64.27.wasm:0000022: error: type mismatch at end of function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/memory64/load64.wast:371: assert_invalid passed:
   out/test/spec/memory64/load64/load64.28.wasm:0000025: error: type mismatch in i32.load, expected [i64] but got [f32]

--- a/test/spec/memory_grow.txt
+++ b/test/spec/memory_grow.txt
@@ -25,10 +25,10 @@ out/test/spec/memory_grow.wast:353: assert_invalid passed:
   out/test/spec/memory_grow/memory_grow.9.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory_grow.wast:363: assert_invalid passed:
-  out/test/spec/memory_grow/memory_grow.10.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory_grow/memory_grow.10.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/memory_grow.wast:372: assert_invalid passed:
-  out/test/spec/memory_grow/memory_grow.11.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/memory_grow/memory_grow.11.wasm:0000022: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000022: error: EndFunctionBody callback failed
 91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory_size.txt
+++ b/test/spec/memory_size.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/memory_size.wast
 (;; STDOUT ;;;
 out/test/spec/memory_size.wast:69: assert_invalid passed:
-  out/test/spec/memory_size/memory_size.4.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/memory_size/memory_size.4.wasm:000001f: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/memory_size.wast:78: assert_invalid passed:
-  out/test/spec/memory_size/memory_size.5.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/memory_size/memory_size.5.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
 38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/load.txt
+++ b/test/spec/multi-memory/load.txt
@@ -55,46 +55,46 @@ out/test/spec/multi-memory/load.wast:365: assert_malformed passed:
   (memory 1)(func (param i32) (result f64) (f64.load64 (local.get 0)))
                                             ^^^^^^^^^^
 out/test/spec/multi-memory/load.wast:376: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.17.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.17.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:380: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.18.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.18.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:384: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.19.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.19.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:388: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.20.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.20.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:392: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.21.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/load/load.21.wasm:0000022: error: type mismatch at end of function, expected [] but got [i32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:396: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.22.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.22.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:400: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.23.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.23.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:404: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.24.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.24.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:408: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.25.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.25.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:412: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.26.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.26.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:416: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.27.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.27.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:420: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.28.wasm:0000021: error: type mismatch at end of function, expected [] but got [i64]
+  out/test/spec/multi-memory/load/load.28.wasm:0000022: error: type mismatch at end of function, expected [] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:424: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.29.wasm:0000021: error: type mismatch at end of function, expected [] but got [f32]
+  out/test/spec/multi-memory/load/load.29.wasm:0000022: error: type mismatch at end of function, expected [] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:428: assert_invalid passed:
-  out/test/spec/multi-memory/load/load.30.wasm:0000021: error: type mismatch at end of function, expected [] but got [f64]
+  out/test/spec/multi-memory/load/load.30.wasm:0000022: error: type mismatch at end of function, expected [] but got [f64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/load.wast:435: assert_invalid passed:
   out/test/spec/multi-memory/load/load.31.wasm:0000025: error: type mismatch in i32.load, expected [i32] but got [f32]

--- a/test/spec/multi-memory/memory_grow.txt
+++ b/test/spec/multi-memory/memory_grow.txt
@@ -25,16 +25,16 @@ out/test/spec/multi-memory/memory_grow.wast:469: assert_invalid passed:
   out/test/spec/multi-memory/memory_grow/memory_grow.12.wasm:0000025: error: type mismatch in memory.grow, expected [i32] but got []
   0000025: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:480: assert_invalid passed:
-  out/test/spec/multi-memory/memory_grow/memory_grow.13.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.13.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_grow.wast:489: assert_invalid passed:
   out/test/spec/multi-memory/memory_grow/memory_grow.14.wasm:0000024: error: type mismatch in memory.grow, expected [i32] but got [f32]
   0000024: error: OnMemoryGrowExpr callback failed
 out/test/spec/multi-memory/memory_grow.wast:499: assert_invalid passed:
-  out/test/spec/multi-memory/memory_grow/memory_grow.15.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.15.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_grow.wast:508: assert_invalid passed:
-  out/test/spec/multi-memory/memory_grow/memory_grow.16.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/multi-memory/memory_grow/memory_grow.16.wasm:0000022: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000022: error: EndFunctionBody callback failed
 140/140 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/memory_size.txt
+++ b/test/spec/multi-memory/memory_size.txt
@@ -3,10 +3,10 @@
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
 out/test/spec/multi-memory/memory_size.wast:95: assert_invalid passed:
-  out/test/spec/multi-memory/memory_size/memory_size.6.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/multi-memory/memory_size/memory_size.6.wasm:000001f: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/memory_size.wast:104: assert_invalid passed:
-  out/test/spec/multi-memory/memory_size/memory_size.7.wasm:000001f: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/multi-memory/memory_size/memory_size.7.wasm:0000020: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000020: error: EndFunctionBody callback failed
 42/42 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/multi-memory/store.txt
+++ b/test/spec/multi-memory/store.txt
@@ -39,31 +39,31 @@ out/test/spec/multi-memory/store.wast:251: assert_malformed passed:
   (memory 1)(func (param i32) (f64.store64 (local.get 0) (f64.const 0)))
                                ^^^^^^^^^^^
 out/test/spec/multi-memory/store.wast:260: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.14.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/multi-memory/store/store.14.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:264: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.15.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.15.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:268: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.16.wasm:0000028: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/multi-memory/store/store.16.wasm:0000029: error: type mismatch in implicit return, expected [f32] but got []
   0000029: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:272: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.17.wasm:000002c: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/multi-memory/store/store.17.wasm:000002d: error: type mismatch in implicit return, expected [f64] but got []
   000002d: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:276: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.18.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/multi-memory/store/store.18.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:280: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.19.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/multi-memory/store/store.19.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:284: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.20.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.20.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:288: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.21.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.21.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:292: assert_invalid passed:
-  out/test/spec/multi-memory/store/store.22.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/multi-memory/store/store.22.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/multi-memory/store.wast:298: assert_invalid passed:
   out/test/spec/multi-memory/store/store.23.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []

--- a/test/spec/nop.txt
+++ b/test/spec/nop.txt
@@ -2,16 +2,16 @@
 ;;; STDIN_FILE: third_party/testsuite/nop.wast
 (;; STDOUT ;;;
 out/test/spec/nop.wast:412: assert_invalid passed:
-  out/test/spec/nop/nop.1.wasm:0000019: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/nop/nop.1.wasm:000001a: error: type mismatch in implicit return, expected [i32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/nop.wast:416: assert_invalid passed:
-  out/test/spec/nop/nop.2.wasm:0000019: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/nop/nop.2.wasm:000001a: error: type mismatch in implicit return, expected [i64] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/nop.wast:420: assert_invalid passed:
-  out/test/spec/nop/nop.3.wasm:0000019: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/nop/nop.3.wasm:000001a: error: type mismatch in implicit return, expected [f32] but got []
   000001a: error: EndFunctionBody callback failed
 out/test/spec/nop.wast:424: assert_invalid passed:
-  out/test/spec/nop/nop.4.wasm:0000019: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/nop/nop.4.wasm:000001a: error: type mismatch in implicit return, expected [f64] but got []
   000001a: error: EndFunctionBody callback failed
 87/87 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/select.txt
+++ b/test/spec/select.txt
@@ -85,7 +85,7 @@ out/test/spec/select.wast:504: assert_invalid passed:
   out/test/spec/select/select.27.wasm:0000025: error: type mismatch in select, expected [i32, i32, i32] but got [i32, i32, f64]
   0000025: error: OnSelectExpr callback failed
 out/test/spec/select.wast:511: assert_invalid passed:
-  out/test/spec/select/select.28.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/select/select.28.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000020: error: EndFunctionBody callback failed
 146/146 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load.txt
+++ b/test/spec/simd_load.txt
@@ -29,7 +29,7 @@ out/test/spec/simd_load.wast:170: assert_invalid passed:
   out/test/spec/simd_load/simd_load.18.wasm:0000028: error: type mismatch in br_if, expected [i32] but got [v128]
   0000028: error: OnBrIfExpr callback failed
 out/test/spec/simd_load.wast:174: assert_invalid passed:
-  out/test/spec/simd_load/simd_load.19.wasm:0000024: error: type mismatch at end of function, expected [] but got [v128]
+  out/test/spec/simd_load/simd_load.19.wasm:0000025: error: type mismatch at end of function, expected [] but got [v128]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/simd_load.wast:182: assert_invalid passed:
   0000000: error: local variable out of range (max 0)

--- a/test/spec/simd_store.txt
+++ b/test/spec/simd_store.txt
@@ -20,7 +20,7 @@ out/test/spec/simd_store.wast:132: assert_invalid passed:
   out/test/spec/simd_store/simd_store.6.wasm:0000024: error: type mismatch in v128.store, expected [i32, v128] but got []
   0000024: error: OnStoreExpr callback failed
 out/test/spec/simd_store.wast:136: assert_invalid passed:
-  out/test/spec/simd_store/simd_store.7.wasm:0000035: error: type mismatch in implicit return, expected [v128] but got []
+  out/test/spec/simd_store/simd_store.7.wasm:0000036: error: type mismatch in implicit return, expected [v128] but got []
   0000036: error: EndFunctionBody callback failed
 out/test/spec/simd_store.wast:144: assert_invalid passed:
   out/test/spec/simd_store/simd_store.8.wasm:0000032: error: type mismatch in v128.store, expected [i32, v128] but got [v128]

--- a/test/spec/store.txt
+++ b/test/spec/store.txt
@@ -30,31 +30,31 @@ out/test/spec/store.wast:103: assert_malformed passed:
   (memory 1)(func (param i32) (f64.store64 (local.get 0) (f64.const 0)))
                                ^^^^^^^^^^^
 out/test/spec/store.wast:112: assert_invalid passed:
-  out/test/spec/store/store.8.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/store/store.8.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:116: assert_invalid passed:
-  out/test/spec/store/store.9.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.9.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:120: assert_invalid passed:
-  out/test/spec/store/store.10.wasm:0000028: error: type mismatch in implicit return, expected [f32] but got []
+  out/test/spec/store/store.10.wasm:0000029: error: type mismatch in implicit return, expected [f32] but got []
   0000029: error: EndFunctionBody callback failed
 out/test/spec/store.wast:124: assert_invalid passed:
-  out/test/spec/store/store.11.wasm:000002c: error: type mismatch in implicit return, expected [f64] but got []
+  out/test/spec/store/store.11.wasm:000002d: error: type mismatch in implicit return, expected [f64] but got []
   000002d: error: EndFunctionBody callback failed
 out/test/spec/store.wast:128: assert_invalid passed:
-  out/test/spec/store/store.12.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/store/store.12.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:132: assert_invalid passed:
-  out/test/spec/store/store.13.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/store/store.13.wasm:0000026: error: type mismatch in implicit return, expected [i32] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:136: assert_invalid passed:
-  out/test/spec/store/store.14.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.14.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:140: assert_invalid passed:
-  out/test/spec/store/store.15.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.15.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:144: assert_invalid passed:
-  out/test/spec/store/store.16.wasm:0000025: error: type mismatch in implicit return, expected [i64] but got []
+  out/test/spec/store/store.16.wasm:0000026: error: type mismatch in implicit return, expected [i64] but got []
   0000026: error: EndFunctionBody callback failed
 out/test/spec/store.wast:150: assert_invalid passed:
   out/test/spec/store/store.17.wasm:000001f: error: type mismatch in i32.store, expected [i32, i32] but got []

--- a/test/spec/table_fill.txt
+++ b/test/spec/table_fill.txt
@@ -29,7 +29,7 @@ out/test/spec/table_fill.wast:135: assert_invalid passed:
   out/test/spec/table_fill/table_fill.8.wasm:000002a: error: type mismatch in table.fill, expected [i32, funcref, i32] but got [i32, externref, i32]
   000002a: error: OnTableFillExpr callback failed
 out/test/spec/table_fill.wast:146: assert_invalid passed:
-  out/test/spec/table_fill/table_fill.9.wasm:0000027: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/table_fill/table_fill.9.wasm:0000028: error: type mismatch in implicit return, expected [i32] but got []
   0000028: error: EndFunctionBody callback failed
 44/44 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_get.txt
+++ b/test/spec/table_get.txt
@@ -13,13 +13,13 @@ out/test/spec/table_get.wast:51: assert_invalid passed:
   out/test/spec/table_get/table_get.2.wasm:0000025: error: type mismatch in table.get, expected [i32] but got [f32]
   0000025: error: OnTableGetExpr callback failed
 out/test/spec/table_get.wast:61: assert_invalid passed:
-  out/test/spec/table_get/table_get.3.wasm:0000021: error: type mismatch at end of function, expected [] but got [externref]
+  out/test/spec/table_get/table_get.3.wasm:0000022: error: type mismatch at end of function, expected [] but got [externref]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/table_get.wast:70: assert_invalid passed:
-  out/test/spec/table_get/table_get.4.wasm:0000022: error: type mismatch in implicit return, expected [funcref] but got [externref]
+  out/test/spec/table_get/table_get.4.wasm:0000023: error: type mismatch in implicit return, expected [funcref] but got [externref]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/table_get.wast:80: assert_invalid passed:
-  out/test/spec/table_get/table_get.5.wasm:0000025: error: type mismatch in implicit return, expected [funcref] but got [externref]
+  out/test/spec/table_get/table_get.5.wasm:0000026: error: type mismatch in implicit return, expected [funcref] but got [externref]
   0000026: error: EndFunctionBody callback failed
 15/15 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_grow.txt
+++ b/test/spec/table_grow.txt
@@ -23,10 +23,10 @@ out/test/spec/table_grow.wast:147: assert_invalid passed:
   out/test/spec/table_grow/table_grow.9.wasm:0000026: error: type mismatch in table.grow, expected [funcref, i32] but got [externref, i32]
   0000026: error: OnTableGrowExpr callback failed
 out/test/spec/table_grow.wast:157: assert_invalid passed:
-  out/test/spec/table_grow/table_grow.10.wasm:0000024: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/table_grow/table_grow.10.wasm:0000025: error: type mismatch at end of function, expected [] but got [i32]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/table_grow.wast:166: assert_invalid passed:
-  out/test/spec/table_grow/table_grow.11.wasm:0000025: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/table_grow/table_grow.11.wasm:0000026: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000026: error: EndFunctionBody callback failed
 45/45 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_set.txt
+++ b/test/spec/table_set.txt
@@ -28,7 +28,7 @@ out/test/spec/table_set.wast:101: assert_invalid passed:
   out/test/spec/table_set/table_set.6.wasm:0000027: error: type mismatch in table.set, expected [i32, funcref] but got [i32, externref]
   0000027: error: OnTableSetExpr callback failed
 out/test/spec/table_set.wast:112: assert_invalid passed:
-  out/test/spec/table_set/table_set.7.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/table_set/table_set.7.wasm:0000025: error: type mismatch in implicit return, expected [i32] but got []
   0000025: error: EndFunctionBody callback failed
 25/25 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/table_size.txt
+++ b/test/spec/table_size.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/table_size.wast
 (;; STDOUT ;;;
 out/test/spec/table_size.wast:70: assert_invalid passed:
-  out/test/spec/table_size/table_size.1.wasm:0000020: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/table_size/table_size.1.wasm:0000021: error: type mismatch at end of function, expected [] but got [i32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/table_size.wast:79: assert_invalid passed:
-  out/test/spec/table_size/table_size.2.wasm:0000021: error: type mismatch in implicit return, expected [f32] but got [i32]
+  out/test/spec/table_size/table_size.2.wasm:0000022: error: type mismatch in implicit return, expected [f32] but got [i32]
   0000022: error: EndFunctionBody callback failed
 38/38 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -17,28 +17,28 @@ out/test/spec/unreached-invalid.wast:21: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.4.wasm:000001b: error: type mismatch in i64.eqz, expected [i64] but got [i32]
   000001b: error: OnConvertExpr callback failed
 out/test/spec/unreached-invalid.wast:27: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.5.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.5.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:33: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.6.wasm:0000023: error: type mismatch in select, expected [i32, i32, i32] but got [i64, i32, i32]
   0000023: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:42: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.7.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.7.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:46: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.8.wasm:0000019: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.8.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:50: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.9.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.9.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:56: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.10.wasm:0000019: error: type mismatch at end of function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.10.wasm:000001a: error: type mismatch at end of function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:60: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.11.wasm:000001b: error: type mismatch at end of function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.11.wasm:000001c: error: type mismatch at end of function, expected [] but got [any]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:64: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.12.wasm:000001d: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.12.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:71: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.13.wasm:000001f: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -65,10 +65,10 @@ out/test/spec/unreached-invalid.wast:113: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.20.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:119: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.21.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.21.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:125: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.22.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.22.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:132: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.23.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -95,10 +95,10 @@ out/test/spec/unreached-invalid.wast:174: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.30.wasm:0000023: error: type mismatch in loop, expected [i32] but got [f32]
   0000023: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:180: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.31.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.31.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:186: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.32.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.32.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000021: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:193: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.33.wasm:000001c: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -131,10 +131,10 @@ out/test/spec/unreached-invalid.wast:247: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.42.wasm:0000021: error: type mismatch in loop, expected [i32] but got [f32]
   0000021: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:253: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.43.wasm:000001a: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.43.wasm:000001b: error: type mismatch at end of function, expected [] but got [i32]
   000001b: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:259: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.44.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.44.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [f32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:265: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.45.wasm:000001e: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -171,10 +171,10 @@ out/test/spec/unreached-invalid.wast:327: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.55.wasm:0000024: error: type mismatch in loop, expected [i32] but got [f32]
   0000024: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:334: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.56.wasm:000001d: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.56.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
   000001e: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:340: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.57.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.57.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:348: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.58.wasm:0000020: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -202,10 +202,10 @@ out/test/spec/unreached-invalid.wast:390: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.65.wasm:0000025: error: type mismatch in loop, expected [i32] but got [f32]
   0000025: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:396: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.66.wasm:000001e: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.66.wasm:000001f: error: type mismatch at end of function, expected [] but got [i32]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:402: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.67.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [f32]
+  out/test/spec/unreached-invalid/unreached-invalid.67.wasm:0000023: error: type mismatch in implicit return, expected [i32] but got [f32]
   0000023: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:409: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.68.wasm:000001d: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -268,10 +268,10 @@ out/test/spec/unreached-invalid.wast:540: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.87.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:546: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.88.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.88.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:552: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.89.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.89.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:558: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.90.wasm:0000023: error: type mismatch at end of block, expected [] but got [i32]
@@ -301,10 +301,10 @@ out/test/spec/unreached-invalid.wast:611: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.98.wasm:0000020: error: type mismatch at end of block, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:617: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.99.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.99.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got []
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:623: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.100.wasm:0000023: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.100.wasm:0000024: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000024: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:629: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.101.wasm:0000025: error: type mismatch at end of block, expected [] but got [i32]
@@ -313,19 +313,19 @@ out/test/spec/unreached-invalid.wast:637: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.102.wasm:0000020: error: type mismatch at end of loop, expected [] but got [i32]
   0000020: error: OnEndExpr callback failed
 out/test/spec/unreached-invalid.wast:643: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.103.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.103.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:649: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.104.wasm:0000021: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.104.wasm:0000022: error: type mismatch in implicit return, expected [i32] but got [i64]
   0000022: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:656: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.105.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.105.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:662: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.106.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got []
+  out/test/spec/unreached-invalid/unreached-invalid.106.wasm:0000020: error: type mismatch in implicit return, expected [i32] but got []
   0000020: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:669: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.107.wasm:000001c: error: type mismatch at end of function, expected [] but got [i32]
+  out/test/spec/unreached-invalid/unreached-invalid.107.wasm:000001d: error: type mismatch at end of function, expected [] but got [i32]
   000001d: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:676: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.108.wasm:0000022: error: type mismatch at end of block, expected [] but got [i32]
@@ -349,10 +349,10 @@ out/test/spec/unreached-invalid.wast:720: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.114.wasm:000001b: error: type mismatch in select, expected [any, any, i32] but got [i64]
   000001b: error: OnSelectExpr callback failed
 out/test/spec/unreached-invalid.wast:726: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.115.wasm:000001e: error: type mismatch in implicit return, expected [i32] but got [i64]
+  out/test/spec/unreached-invalid/unreached-invalid.115.wasm:000001f: error: type mismatch in implicit return, expected [i32] but got [i64]
   000001f: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:733: assert_invalid passed:
-  out/test/spec/unreached-invalid/unreached-invalid.116.wasm:0000019: error: type mismatch at end of function, expected [] but got [any]
+  out/test/spec/unreached-invalid/unreached-invalid.116.wasm:000001a: error: type mismatch at end of function, expected [] but got [any]
   000001a: error: EndFunctionBody callback failed
 out/test/spec/unreached-invalid.wast:738: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.117.wasm:0000026: error: type mismatch in br_table, expected [i32] but got [externref]

--- a/test/typecheck/bad-nested-br.txt
+++ b/test/typecheck/bad-nested-br.txt
@@ -19,7 +19,7 @@
     ;; return statement here, or a value returned from (br $outer).
   ))
 (;; STDERR ;;;
-out/test/typecheck/bad-nested-br.txt:17:5: error: type mismatch in implicit return, expected [i32] but got []
-    end
-    ^^^
+out/test/typecheck/bad-nested-br.txt:5:5: error: type mismatch in implicit return, expected [i32] but got []
+    block $outer
+    ^^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value0.txt
+++ b/test/typecheck/bad-select-value0.txt
@@ -11,7 +11,7 @@
 out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch in select, expected [f64, f64, i32] but got [i32, f64, f32]
     select
     ^^^^^^
-out/test/typecheck/bad-select-value0.txt:8:5: error: type mismatch at end of function, expected [] but got [f64]
-    select
-    ^^^^^^
+out/test/typecheck/bad-select-value0.txt:9:5: error: type mismatch at end of function, expected [] but got [f64]
+    drop))
+    ^^^^
 ;;; STDERR ;;)

--- a/test/typecheck/bad-select-value1.txt
+++ b/test/typecheck/bad-select-value1.txt
@@ -11,7 +11,7 @@
 out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch in select, expected [i64, i64, i32] but got [i32, i64, f32]
     select
     ^^^^^^
-out/test/typecheck/bad-select-value1.txt:8:5: error: type mismatch at end of function, expected [] but got [i64]
-    select
-    ^^^^^^
+out/test/typecheck/bad-select-value1.txt:9:5: error: type mismatch at end of function, expected [] but got [i64]
+    drop))
+    ^^^^
 ;;; STDERR ;;)


### PR DESCRIPTION
For text validation, this means the error is always corretly reported on
he final expression in the function.

For binary validation, this means that we report the byte after the last
instrution in the function as the failure location.  This is in line
with other binary validation reports.  For example, for `type mismatch
in i32.add` we report the validtion error at the byte *after* the add
instruction.