### PR TITLE
Improve the maintenace of ObjectKind types.

### DIFF
--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -41,9 +41,12 @@ const char* GetName(ExternKind kind) {
 
 const char* GetName(ObjectKind kind) {
   static const char* kNames[] = {
-      "Null",   "Foreign", "Trap", "DefinedFunc", "HostFunc", "Table",
-      "Memory", "Global",  "Tag",  "Module",      "Instance", "Thread",
+      "Null",  "Foreign", "Trap",   "Exception", "DefinedFunc", "HostFunc",
+      "Table", "Memory",  "Global", "Tag",       "Module",      "Instance",
   };
+
+  WABT_STATIC_ASSERT(WABT_ARRAY_SIZE(kNames) == kCommandTypeCount);
+
   return kNames[int(kind)];
 }
 

--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -91,7 +91,12 @@ enum class ObjectKind {
   Tag,
   Module,
   Instance,
+
+  First = Null,
+  Last = Instance,
 };
+
+static const int kCommandTypeCount = WABT_ENUM_COUNT(ObjectKind);
 
 const char* GetName(Mutability);
 const std::string GetName(ValueType);


### PR DESCRIPTION
I have realized the Thread has not been removed and Exception has not been added to the ObjectKind as string list. This patch makes the maintenance automated. It seems this macro is used for debugging so I am not sure how to test this.