### PR TITLE
Fix Store object assignment.

### DIFF
--- a/src/interp/interp.h
+++ b/src/interp/interp.h
@@ -453,6 +453,10 @@ class Store {
 
   explicit Store(const Features& = Features{});
 
+  Store(const Store&) = delete;
+  Store& operator=(const Store&) = delete;
+  Store& operator=(const Store&&) = delete;
+
   bool IsValid(Ref) const;
   bool HasValueType(Ref, ValueType) const;
   template <typename T>


### PR DESCRIPTION
When a new store object is assigned to a value, its FreeList is copied without duplicating the referenced objects, so these objects are destroyed twice.