### PR TITLE
run-tests.py: Use sys.byteorder to make code more readable. NFC

### DIFF
--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -23,7 +23,6 @@ import os
 import re
 import shlex
 import shutil
-import struct
 import subprocess
 import sys
 import threading
@@ -39,6 +38,10 @@ OUT_DIR = os.path.join(REPO_ROOT_DIR, 'out')
 DEFAULT_TIMEOUT = 120    # seconds
 SLOW_TIMEOUT_MULTIPLIER = 3
 
+if sys.byteorder == 'big':
+    wasm2c_args = ['--cflags=-DWABT_BIG_ENDIAN']
+else:
+    wasm2c_args = []
 
 # default configurations for tests
 TOOLS = {
@@ -146,10 +149,9 @@ TOOLS = {
             '%(in_file)s',
             '--bindir=%(bindir)s',
             '--no-error-cmdline',
-            '--cflags=-DWABT_BIG_ENDIAN=' + '01'[struct.pack('<h', *struct.unpack('=h', b'\x00\x01'))[0]],
             '-o',
             '%(out_dir)s',
-        ]),
+        ] + wasm2c_args),
         ('VERBOSE-ARGS', ['--print-cmd', '-v']),
     ],
     'run-wasm-decompile': [


### PR DESCRIPTION
Split out from #1843

This also avoids adding `-DWABT_BIG_ENDIAN=0` pointlessly to all build commands on little endian machines.