### PR TITLE
Allow binary reader to skip function bodies. NFC

### DIFF
--- a/src/binary-reader-objdump.cc
+++ b/src/binary-reader-objdump.cc
@@ -2354,6 +2354,7 @@ Result ReadBinaryObjdump(const uint8_t* data,
 
   switch (options->mode) {
     case ObjdumpMode::Prepass: {
+      read_options.skip_function_bodies = true;
       BinaryReaderObjdumpPrepass reader(data, size, options, state);
       return ReadBinary(data, size, &reader, read_options);
     }
@@ -2362,6 +2363,7 @@ Result ReadBinaryObjdump(const uint8_t* data,
       return ReadBinary(data, size, &reader, read_options);
     }
     default: {
+      read_options.skip_function_bodies = true;
       BinaryReaderObjdump reader(data, size, options, state);
       return ReadBinary(data, size, &reader, read_options);
     }

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -2717,7 +2717,11 @@ Result BinaryReader::ReadCodeSection(Offset section_size) {
       CALLBACK(OnLocalDecl, k, num_local_types, local_type);
     }
 
-    CHECK_RESULT(ReadFunctionBody(end_offset));
+    if (options_.skip_function_bodies) {
+      state_.offset = end_offset;
+    } else {
+      CHECK_RESULT(ReadFunctionBody(end_offset));
+    }
 
     CALLBACK(EndFunctionBody, func_index);
   }

--- a/src/binary-reader.h
+++ b/src/binary-reader.h
@@ -49,6 +49,7 @@ struct ReadBinaryOptions {
   bool read_debug_names = false;
   bool stop_on_first_error = true;
   bool fail_on_custom_section_error = true;
+  bool skip_function_bodies = false;
 };
 
 // TODO: Move somewhere else?

--- a/test/binary/bad-opcode-prefix.txt
+++ b/test/binary/bad-opcode-prefix.txt
@@ -1,5 +1,4 @@
-;;; TOOL: run-objdump-gen-wasm
-;;; ERROR: 1
+;;; TOOL: run-gen-wasm-bad
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }
@@ -13,12 +12,5 @@ section(CODE) {
 }
 (;; STDERR ;;;
 000001a: error: unexpected opcode: 0xfe 0x7f
+000001a: error: unexpected opcode: 0xfe 0x7f
 ;;; STDERR ;;)
-(;; STDOUT ;;;
-
-bad-opcode-prefix.wasm:	file format wasm 0x1
-
-Code Disassembly:
-
-000017 func[0]:
-;;; STDOUT ;;)

--- a/test/binary/bad-opcode.txt
+++ b/test/binary/bad-opcode.txt
@@ -1,6 +1,4 @@
-;;; TOOL: run-objdump-gen-wasm
-;;; ARGS: -x
-;;; ERROR: 1
+;;; TOOL: run-gen-wasm-bad
 magic
 version
 section(TYPE) { count[1] function params[0] results[1] i32 }
@@ -14,21 +12,5 @@ section(CODE) {
 }
 (;; STDERR ;;;
 0000019: error: unexpected opcode: 0xff
+0000019: error: unexpected opcode: 0xff
 ;;; STDERR ;;)
-(;; STDOUT ;;;
-
-bad-opcode.wasm:	file format wasm 0x1
-
-Section Details:
-
-Type[1]:
- - type[0] () -> i32
-Function[1]:
- - func[0] sig=0
-Code[1]:
- - func[0] size=3
-
-Code Disassembly:
-
-000017 func[0]:
-;;; STDOUT ;;)


### PR DESCRIPTION
This is purely a performance optimization for wasm-objdump since it
doesn't always need to decode function bodies.

For a very large wasm file that I was testing this takes the time taken
for `wasm-objdump -h` from 8.6s to 1.5s.