### PR TITLE
Allow Code Metadata Annotations to have arbitrary hex strings

### DIFF
--- a/src/wast-parser.h
+++ b/src/wast-parser.h
@@ -140,7 +140,7 @@ class WastParser {
   Result ParseRefKind(Type* out_type);
   Result ParseRefType(Type* out_type);
   bool ParseRefTypeOpt(Type* out_type);
-  Result ParseQuotedText(std::string* text);
+  Result ParseQuotedText(std::string* text, bool check_utf8 = true);
   bool ParseOffsetOpt(Address* offset);
   bool ParseAlignOpt(Address* align);
   Result ParseMemidx(Location loc, Var* memidx);

--- a/test/roundtrip/code-metadata.txt
+++ b/test/roundtrip/code-metadata.txt
@@ -4,5 +4,5 @@
   (func $f (param i32) (result i32)
     i32.const 1234
     local.get 0
-    (@metadata.code.test "aa\01a") i32.add
+    (@metadata.code.test "aa\01a\ff") i32.add
     return))


### PR DESCRIPTION
This PR adds support for arbitrary hex strings in code metadata annotations. Previously, the decoded strings would be checked as utf-8 strings. However, this prohibits something like `(@metadata.code.trace_inst "\FF\FF")` since 0xffff is not a valid utf-8 string.

Also modified existing roundtrip test to have a string that includes a non-utf8 character 

