### PR TITLE
Fix checking of ref.func index declarations

### DIFF
--- a/src/shared-validator.cc
+++ b/src/shared-validator.cc
@@ -952,12 +952,12 @@ Result SharedValidator::OnRefFunc(const Location& loc, Var func_var) {
   Result result = CheckInstr(Opcode::RefFunc, loc);
   result |= CheckFuncIndex(func_var);
   if (Succeeded(result)) {
-    // Reference declarations aren't needed for uses in global sections, and
-    // the use in a global itself counts as a declaration.
-    if (!in_init_expr_) {
-      check_declared_funcs_.push_back(func_var);
-    } else {
+    // References in initializer expressions are considered declarations, as
+    // opposed to references in function bodies that are considered usages.
+    if (in_init_expr_) {
       declared_funcs_.insert(func_var.index());
+    } else {
+      check_declared_funcs_.push_back(func_var);
     }
     Index func_type = GetFunctionTypeIndex(func_var.index());
     result |= typechecker_.OnRefFuncExpr(func_type);

--- a/test/spec/ref_func.txt
+++ b/test/spec/ref_func.txt
@@ -1,19 +1,6 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/ref_func.wast
 (;; STDERR ;;;
-out/test/spec/ref_func.wast:90:29: error: function 0 is not declared in any elem sections
-  (global funcref (ref.func $f1))
-                            ^^^
-out/test/spec/ref_func.wast:98:15: error: function 0 is not declared in any elem sections
-    (ref.func $f1)
-              ^^^
-out/test/spec/ref_func.wast:99:15: error: function 1 is not declared in any elem sections
-    (ref.func $f2)
-              ^^^
-0000000: error: function 0 is not declared in any elem sections
-0000000: error: function 0 is not declared in any elem sections
-0000000: error: function 1 is not declared in any elem sections
-0000069: error: EndModule callback failed
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 set-g() =>
@@ -21,7 +8,6 @@ set-f() =>
 out/test/spec/ref_func.wast:69: assert_invalid passed:
   0000000: error: function variable out of range: 7 (max 2)
   0000026: error: OnRefFuncExpr callback failed
-out/test/spec/ref_func.wast:80: error reading module: "out/test/spec/ref_func/ref_func.3.wasm"
 out/test/spec/ref_func.wast:109: assert_invalid passed:
   0000000: error: function 0 is not declared in any elem sections
   000001b: error: EndModule callback failed


### PR DESCRIPTION
The validation was overly strict for ref.func index uses. In the spec, the ref index just needs to appear in

> the set of function indices occurring in the module, except in its functions or start function.

(https://webassembly.github.io/spec/core/valid/modules.html#valid-module)

which includes uses in the global and export sections. There were some test failures in the spec tests that were fixed by this, so the PR also changes test expectations.

Fixes issue #1893