### PR TITLE
Add base64 encoding support to wat2wasm demo

### DIFF
--- a/docs/demo/wat2wasm/index.html
+++ b/docs/demo/wat2wasm/index.html
@@ -68,7 +68,10 @@
         </div>
         <div id="top-right" class="split split-horizontal">
           <pre id="output" class="output"></pre>
-          <div class="toolbar">BUILD LOG</div>
+          <div class="toolbar">
+            <button class="btn disabled" type="button" id="buildLog" style="text-decoration: underline">BUILD LOG</button>
+            <button class="btn disabled" type="button" id="base64">BASE64</button>
+          </div>
         </div>
       </div>
       <div id="bottom-row" class="split-vertical">


### PR DESCRIPTION
A new button is added for base64 encoding of the wasm binary. This allows getting the binary without downloading it.