### PR TITLE
Implement \u{hex} escape parsing

### DIFF
--- a/test/parse/bad-string-unicode-escape-large.txt
+++ b/test/parse/bad-string-unicode-escape-large.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func) (export "foo\u{1100000}" (func 0)))
+(;; STDERR ;;;
+out/test/parse/bad-string-unicode-escape-large.txt:3:28: error: bad escape "\u{110000"
+(module (func) (export "foo\u{1100000}" (func 0)))
+                           ^^^^^^^^^
+out/test/parse/bad-string-unicode-escape-large.txt:3:24: error: unexpected token "Invalid", expected a quoted string (e.g. "foo").
+(module (func) (export "foo\u{1100000}" (func 0)))
+                       ^^^^^^^^^^^^^^^^
+out/test/parse/bad-string-unicode-escape-large.txt:3:47: error: unexpected token 0, expected ).
+(module (func) (export "foo\u{1100000}" (func 0)))
+                                              ^
+;;; STDERR ;;)

--- a/test/parse/bad-string-unicode-escape-short.txt
+++ b/test/parse/bad-string-unicode-escape-short.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func) (export "foo\u{}bar" (func 0)))
+(;; STDERR ;;;
+out/test/parse/bad-string-unicode-escape-short.txt:3:28: error: bad escape "\u{}"
+(module (func) (export "foo\u{}bar" (func 0)))
+                           ^^^^
+out/test/parse/bad-string-unicode-escape-short.txt:3:24: error: unexpected token "Invalid", expected a quoted string (e.g. "foo").
+(module (func) (export "foo\u{}bar" (func 0)))
+                       ^^^^^^^^^^^^
+out/test/parse/bad-string-unicode-escape-short.txt:3:43: error: unexpected token 0, expected ).
+(module (func) (export "foo\u{}bar" (func 0)))
+                                          ^
+;;; STDERR ;;)

--- a/test/parse/bad-string-unicode-escape-unallowed.txt
+++ b/test/parse/bad-string-unicode-escape-unallowed.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func) (export "foo\u{d900}bar" (func 0)))
+(;; STDERR ;;;
+out/test/parse/bad-string-unicode-escape-unallowed.txt:3:28: error: bad escape "\u{d900}"
+(module (func) (export "foo\u{d900}bar" (func 0)))
+                           ^^^^^^^^
+out/test/parse/bad-string-unicode-escape-unallowed.txt:3:24: error: unexpected token "Invalid", expected a quoted string (e.g. "foo").
+(module (func) (export "foo\u{d900}bar" (func 0)))
+                       ^^^^^^^^^^^^^^^^
+out/test/parse/bad-string-unicode-escape-unallowed.txt:3:47: error: unexpected token 0, expected ).
+(module (func) (export "foo\u{d900}bar" (func 0)))
+                                              ^
+;;; STDERR ;;)

--- a/test/parse/bad-string-unicode-escape-unexpected.txt
+++ b/test/parse/bad-string-unicode-escape-unexpected.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func) (export "foo\u{0x12}" (func 0)))
+(;; STDERR ;;;
+out/test/parse/bad-string-unicode-escape-unexpected.txt:3:28: error: bad escape "\u{0"
+(module (func) (export "foo\u{0x12}" (func 0)))
+                           ^^^^
+out/test/parse/bad-string-unicode-escape-unexpected.txt:3:24: error: unexpected token "Invalid", expected a quoted string (e.g. "foo").
+(module (func) (export "foo\u{0x12}" (func 0)))
+                       ^^^^^^^^^^^^^
+out/test/parse/bad-string-unicode-escape-unexpected.txt:3:44: error: unexpected token 0, expected ).
+(module (func) (export "foo\u{0x12}" (func 0)))
+                                           ^
+;;; STDERR ;;)

--- a/test/parse/bad-string-unicode-escape-unterminated.txt
+++ b/test/parse/bad-string-unicode-escape-unterminated.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func) (export "foo\u{045" (func 0)))
+(;; STDERR ;;;
+out/test/parse/bad-string-unicode-escape-unterminated.txt:3:28: error: bad escape "\u{045"
+(module (func) (export "foo\u{045" (func 0)))
+                           ^^^^^^
+out/test/parse/bad-string-unicode-escape-unterminated.txt:3:24: error: unexpected token "Invalid", expected a quoted string (e.g. "foo").
+(module (func) (export "foo\u{045" (func 0)))
+                       ^^^^^^^^^^^
+out/test/parse/bad-string-unicode-escape-unterminated.txt:3:42: error: unexpected token 0, expected ).
+(module (func) (export "foo\u{045" (func 0)))
+                                         ^
+;;; STDERR ;;)

--- a/test/parse/bad-string-unicode-escape.txt
+++ b/test/parse/bad-string-unicode-escape.txt
@@ -1,0 +1,14 @@
+;;; TOOL: wat2wasm
+;;; ERROR: 1
+(module (func) (export "foo\ubar" (func 0)))
+(;; STDERR ;;;
+out/test/parse/bad-string-unicode-escape.txt:3:28: error: bad escape "\ub"
+(module (func) (export "foo\ubar" (func 0)))
+                           ^^^
+out/test/parse/bad-string-unicode-escape.txt:3:24: error: unexpected token "Invalid", expected a quoted string (e.g. "foo").
+(module (func) (export "foo\ubar" (func 0)))
+                       ^^^^^^^^^^
+out/test/parse/bad-string-unicode-escape.txt:3:41: error: unexpected token 0, expected ).
+(module (func) (export "foo\ubar" (func 0)))
+                                        ^
+;;; STDERR ;;)

--- a/test/roundtrip/string-unicode-escape.txt
+++ b/test/roundtrip/string-unicode-escape.txt
@@ -1,0 +1,17 @@
+;;; TOOL: run-roundtrip
+;;; ARGS: --stdout
+(module
+  (func)
+  (func)
+
+  (export "a:\u{0} b:\u{00001} c:\u{7f} d:\u{80} e:\u{7ff} f:\u{800} g:\u{ffff} h:\u{10000} i:\u{10ffff}" (func 0))
+  (export "\u{48}\u{65}\u{6c}\u{6c}\u{6f}" (func 1))
+)
+(;; STDOUT ;;;
+(module
+  (type (;0;) (func))
+  (func (;0;) (type 0))
+  (func (;1;) (type 0))
+  (export "a:\00 b:\01 c:\7f d:\c2\80 e:\df\bf f:\e0\a0\80 g:\ef\bf\bf h:\f0\90\80\80 i:\f4\8f\bf\bf" (func 0))
+  (export "Hello" (func 1)))
+;;; STDOUT ;;)


### PR DESCRIPTION
Support \u{hex} escape sequences for string literals. These literals are converted to UTF-8 characters.