### PR TITLE
Fix javadoc-style comment formatting. NFC

### DIFF
--- a/wasm2c/wasm-rt-impl.h
+++ b/wasm2c/wasm-rt-impl.h
@@ -38,7 +38,8 @@ extern jmp_buf g_jmp_buf;
 extern uint32_t g_saved_call_stack_depth;
 #endif
 
-/** Convenience macro to use before calling a wasm function. On first execution
+/**
+ * Convenience macro to use before calling a wasm function. On first execution
  * it will return `WASM_RT_TRAP_NONE` (i.e. 0). If the function traps, it will
  * jump back and return the trap that occurred.
  *

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -43,12 +43,13 @@ extern "C" {
 #define wasm_rt_memcpy memcpy
 #endif
 
-/** Enable memory checking via a signal handler via the following definition:
+/**
+ * Enable memory checking via a signal handler via the following definition:
  *
  * #define WASM_RT_MEMCHECK_SIGNAL_HANDLER 1
  *
  * This is usually 10%-25% faster, but requires OS-specific support.
- * */
+ */
 
 /** Check whether the signal handler is supported at all. */
 #if (defined(__linux__) || defined(__unix__) || defined(__APPLE__)) && \
@@ -74,7 +75,8 @@ extern "C" {
 #define WASM_RT_MEMCHECK_SIGNAL_HANDLER 0
 #define WASM_RT_MEMCHECK_SIGNAL_HANDLER_POSIX 0
 
-/** When the signal handler is not used, stack depth is limited explicitly.
+/**
+ * When the signal handler is not used, stack depth is limited explicitly.
  * The maximum stack depth before trapping can be configured by defining
  * this symbol before including wasm-rt when building the generated c files,
  * for example:
@@ -82,7 +84,7 @@ extern "C" {
  * ```
  *   cc -c -DWASM_RT_MAX_CALL_STACK_DEPTH=100 my_module.c -o my_module.o
  * ```
- * */
+ */
 #ifndef WASM_RT_MAX_CALL_STACK_DEPTH
 #define WASM_RT_MAX_CALL_STACK_DEPTH 500
 #endif
@@ -128,9 +130,11 @@ typedef enum {
   WASM_RT_F64,
 } wasm_rt_type_t;
 
-/** A function type for all `funcref` functions in a Table. All functions are
+/**
+ * A function type for all `funcref` functions in a Table. All functions are
  * stored in this canonical form, but must be cast to their proper signature to
- * call. */
+ * call.
+ */
 typedef void (*wasm_rt_funcref_t)(void);
 
 /** A single element of a Table. */
@@ -170,10 +174,12 @@ void wasm_rt_init(void);
 /** Free the runtime's state. */
 void wasm_rt_free(void);
 
-/** Stop execution immediately and jump back to the call to `wasm_rt_try`.
- *  The result of `wasm_rt_try` will be the provided trap reason.
+/**
+ * Stop execution immediately and jump back to the call to `wasm_rt_try`.
+ * The result of `wasm_rt_try` will be the provided trap reason.
  *
- *  This is typically called by the generated code, and not the embedder. */
+ * This is typically called by the generated code, and not the embedder.
+ */
 WASM_RT_NO_RETURN void wasm_rt_trap(wasm_rt_trap_t);
 
 /**
@@ -181,7 +187,8 @@ WASM_RT_NO_RETURN void wasm_rt_trap(wasm_rt_trap_t);
  */
 const char* wasm_rt_strerror(wasm_rt_trap_t trap);
 
-/** Register a function type with the given signature. The returned function
+/**
+ * Register a function type with the given signature. The returned function
  * index is guaranteed to be the same for all calls with the same signature.
  * The following varargs must all be of type `wasm_rt_type_t`, first the
  * params` and then the `results`.
@@ -198,22 +205,26 @@ const char* wasm_rt_strerror(wasm_rt_trap_t trap);
  *    // Register (func (param i32 f32) (result i64)) again.
  *    wasm_rt_register_func_type(2, 1, WASM_RT_I32, WASM_RT_F32, WASM_RT_I64);
  *    => returns 1
- *  ``` */
+ *  ```
+ */
 uint32_t wasm_rt_register_func_type(uint32_t params, uint32_t results, ...);
 
-/** Initialize a Memory object with an initial page size of `initial_pages` and
+/**
+ * Initialize a Memory object with an initial page size of `initial_pages` and
  * a maximum page size of `max_pages`.
  *
  *  ```
  *    wasm_rt_memory_t my_memory;
  *    // 1 initial page (65536 bytes), and a maximum of 2 pages.
  *    wasm_rt_allocate_memory(&my_memory, 1, 2);
- *  ``` */
+ *  ```
+ */
 void wasm_rt_allocate_memory(wasm_rt_memory_t*,
                              uint32_t initial_pages,
                              uint32_t max_pages);
 
-/** Grow a Memory object by `pages`, and return the previous page count. If
+/**
+ * Grow a Memory object by `pages`, and return the previous page count. If
  * this new page count is greater than the maximum page count, the grow fails
  * and 0xffffffffu (UINT32_MAX) is returned instead.
  *
@@ -225,7 +236,8 @@ void wasm_rt_allocate_memory(wasm_rt_memory_t*,
  *    if (old_page_size == UINT32_MAX) {
  *      // Failed to grow memory.
  *    }
- *  ``` */
+ *  ```
+ */
 uint32_t wasm_rt_grow_memory(wasm_rt_memory_t*, uint32_t pages);
 
 /**
@@ -233,14 +245,16 @@ uint32_t wasm_rt_grow_memory(wasm_rt_memory_t*, uint32_t pages);
  */
 void wasm_rt_free_memory(wasm_rt_memory_t*);
 
-/** Initialize a Table object with an element count of `elements` and a maximum
+/**
+ * Initialize a Table object with an element count of `elements` and a maximum
  * page size of `max_elements`.
  *
  *  ```
  *    wasm_rt_table_t my_table;
  *    // 5 elemnets and a maximum of 10 elements.
  *    wasm_rt_allocate_table(&my_table, 5, 10);
- *  ``` */
+ *  ```
+ */
 void wasm_rt_allocate_table(wasm_rt_table_t*,
                             uint32_t elements,
                             uint32_t max_elements);


### PR DESCRIPTION
Multiline javadoc/doxygen comments start and end
with an empty line.