### PR TITLE
wast2json: write binary modules verbatim

### DIFF
--- a/src/binary-writer-spec.cc
+++ b/src/binary-writer-spec.cc
@@ -126,6 +126,7 @@ void BinaryWriterSpec::WriteEscapedString(std::string_view s) {
 void BinaryWriterSpec::WriteCommandType(const Command& command) {
   static const char* s_command_names[] = {
       "module",
+      "module",
       "action",
       "register",
       "assert_malformed",
@@ -472,6 +473,25 @@ void BinaryWriterSpec::WriteCommands() {
         WriteKey("filename");
         WriteEscapedString(GetBasename(filename));
         WriteModule(filename, module);
+        num_modules_++;
+        last_module_index = i;
+        break;
+      }
+
+      case CommandType::ScriptModule: {
+        auto* script_module_command = cast<ScriptModuleCommand>(command);
+        const auto& module = script_module_command->module;
+        std::string filename = GetModuleFilename(kWasmExtension);
+        WriteLocation(module.loc);
+        WriteSeparator();
+        if (!module.name.empty()) {
+          WriteKey("name");
+          WriteEscapedString(module.name);
+          WriteSeparator();
+        }
+        WriteKey("filename");
+        WriteEscapedString(GetBasename(filename));
+        WriteScriptModule(filename, *script_module_command->script_module);
         num_modules_++;
         last_module_index = i;
         break;

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -565,8 +565,13 @@ const Module* Script::GetModule(const Var& var) const {
   if (index >= commands.size()) {
     return nullptr;
   }
-  auto* command = cast<ModuleCommand>(commands[index].get());
-  return &command->module;
+  auto* command = commands[index].get();
+  if (isa<ModuleCommand>(command)) {
+    return &cast<ModuleCommand>(command)->module;
+  } else if (isa<ScriptModuleCommand>(command)) {
+    return &cast<ScriptModuleCommand>(command)->module;
+  }
+  return nullptr;
 }
 
 void MakeTypeBindingReverseMapping(

--- a/src/ir.h
+++ b/src/ir.h
@@ -1321,6 +1321,7 @@ class InvokeAction : public ActionMixin<ActionType::Invoke> {
 
 enum class CommandType {
   Module,
+  ScriptModule,
   Action,
   Register,
   AssertMalformed,
@@ -1359,6 +1360,15 @@ class CommandMixin : public Command {
 class ModuleCommand : public CommandMixin<CommandType::Module> {
  public:
   Module module;
+};
+
+class ScriptModuleCommand : public CommandMixin<CommandType::ScriptModule> {
+ public:
+  // Both the module and the script_module need to be stored since the module
+  // has the parsed information about the module, but the script_module has the
+  // original contents (binary or quoted).
+  Module module;
+  std::unique_ptr<ScriptModule> script_module;
 };
 
 template <CommandType TypeEnum>

--- a/src/resolve-names.cc
+++ b/src/resolve-names.cc
@@ -577,6 +577,10 @@ void NameResolver::VisitCommand(Command* command) {
       VisitModule(&cast<ModuleCommand>(command)->module);
       break;
 
+    case CommandType::ScriptModule:
+      VisitModule(&cast<ScriptModuleCommand>(command)->module);
+      break;
+
     case CommandType::Action:
     case CommandType::AssertReturn:
     case CommandType::AssertTrap:

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -1274,6 +1274,7 @@ wabt::Result CommandRunner::Run(const Script& script) {
   for (const CommandPtr& command : script.commands) {
     switch (command->type) {
       case CommandType::Module:
+      case CommandType::ScriptModule:
         TallyCommand(OnModuleCommand(cast<ModuleCommand>(command.get())));
         break;
 

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -958,6 +958,13 @@ void ScriptValidator::CheckCommand(const Command* command) {
       break;
     }
 
+    case CommandType::ScriptModule: {
+      Validator module_validator(
+          errors_, &cast<ScriptModuleCommand>(command)->module, options_);
+      module_validator.CheckModule();
+      break;
+    }
+
     case CommandType::Action:
       // Ignore result type.
       CheckAction(cast<ActionCommand>(command)->action.get());

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -3309,15 +3309,20 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
   std::unique_ptr<ScriptModule> script_module;
   CHECK_RESULT(ParseScriptModule(&script_module));
 
-  auto command = MakeUnique<ModuleCommand>();
-  Module& module = command->module;
+  Module* module = nullptr;
 
   switch (script_module->type()) {
-    case ScriptModuleType::Text:
-      module = std::move(cast<TextScriptModule>(script_module.get())->module);
+    case ScriptModuleType::Text: {
+      auto command = MakeUnique<ModuleCommand>();
+      module = &command->module;
+      *module = std::move(cast<TextScriptModule>(script_module.get())->module);
+      *out_command = std::move(command);
       break;
+    }
 
     case ScriptModuleType::Binary: {
+      auto command = MakeUnique<ScriptModuleCommand>();
+      module = &command->module;
       auto* bsm = cast<BinaryScriptModule>(script_module.get());
       ReadBinaryOptions options;
 #if WABT_TRACING
@@ -3328,9 +3333,9 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
       Errors errors;
       const char* filename = "<text>";
       ReadBinaryIr(filename, bsm->data.data(), bsm->data.size(), options,
-                   &errors, &module);
-      module.name = bsm->name;
-      module.loc = bsm->loc;
+                   &errors, module);
+      module->name = bsm->name;
+      module->loc = bsm->loc;
       for (const auto& error : errors) {
         assert(error.error_level == ErrorLevel::Error);
         if (error.loc.offset == kInvalidOffset) {
@@ -3340,6 +3345,9 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
                 error.loc.offset, error.message.c_str());
         }
       }
+
+      command->script_module = std::move(script_module);
+      *out_command = std::move(command);
       break;
     }
 
@@ -3351,15 +3359,14 @@ Result WastParser::ParseModuleCommand(Script* script, CommandPtr* out_command) {
   if (script) {
     Index command_index = script->commands.size();
 
-    if (!module.name.empty()) {
-      script->module_bindings.emplace(module.name,
-                                      Binding(module.loc, command_index));
+    if (!module->name.empty()) {
+      script->module_bindings.emplace(module->name,
+                                      Binding(module->loc, command_index));
     }
 
     last_module_index_ = command_index;
   }
 
-  *out_command = std::move(command);
   return Result::Ok;
 }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -1159,8 +1159,14 @@ Result WastParser::ParseModule(std::unique_ptr<Module>* out_module) {
     // modules.
     CommandPtr command;
     CHECK_RESULT(ParseModuleCommand(nullptr, &command));
-    auto module_command = cast<ModuleCommand>(std::move(command));
-    *module = std::move(module_command->module);
+    if (isa<ModuleCommand>(command.get())) {
+      auto module_command = cast<ModuleCommand>(std::move(command));
+      *module = std::move(module_command->module);
+    } else {
+      assert(isa<ScriptModuleCommand>(command.get()));
+      auto module_command = cast<ScriptModuleCommand>(std::move(command));
+      *module = std::move(module_command->module);
+    }
   } else if (IsModuleField(PeekPair())) {
     // Parse an inline module (i.e. one with no surrounding (module)).
     CHECK_RESULT(ParseModuleFieldList(module.get()));

--- a/test/wast2json/module-binary.txt
+++ b/test/wast2json/module-binary.txt
@@ -1,0 +1,15 @@
+;;; TOOL: wast2json
+;;; ARGS: -v
+(module binary
+  "\00asm" "\01\00\00\00"
+  "\04\04\01"                          ;; Table section with 1 entry
+  "\70\00\00"                          ;; no max, minimum 0, funcref
+  "\09\09\01"                          ;; Element section with 1 entry
+  "\02"                                ;; Element with explicit table index
+  "\80\00"                             ;; Table index 0, encoded with 2 bytes
+  "\41\00\0b\00\00"                    ;; (i32.const 0) with no elements
+)
+(;; STDERR ;;;
+0000000: 0061 736d 0100 0000 0404 0170 0000 0909 
+0000010: 0102 8000 4100 0b00 00                    ; 
+;;; STDERR ;;)


### PR DESCRIPTION
Previously any top-level module defined in a .wast file would be parsed
and converted to a `Module` and stored in a `ModuleCommand`, since it
may be used later by the script (e.g. via an `invoke` command). This
means that when it was written out later it may have been changed, which
is undesirable for binary and quoted modules.

This change adds a new `ScriptModuleCommand`, which stores both a
`Module` and a `ScriptModule`. The `Module` contains the parsed
information, and the `ScriptModule` contains the original contents of
the binary or quoted data.

This fixes issue #1927.