### PR TITLE
Change description of calling wat2wasm without -o flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ run `make update-gperf` to update the prebuilt C++ sources in `src/prebuilt/`.
 Some examples:
 
 ```sh
-# parse and typecheck test.wat
+# parse test.wat and write to .wasm binary file with the same name
 $ bin/wat2wasm test.wat
 
 # parse test.wat and write to binary file test.wasm

--- a/docs/doc/wat2wasm.1.html
+++ b/docs/doc/wat2wasm.1.html
@@ -84,10 +84,10 @@
 </section>
 <section class="Sh">
 <h1 class="Sh" id="EXAMPLES"><a class="permalink" href="#EXAMPLES">EXAMPLES</a></h1>
-Parse and typecheck test.wat
+Parse test.wat and write to .wasm binary file with the same name
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wat2wasm test.wat</code></div>
-<p class="Pp">parse test.wat and write to binary file test.wasm</p>
+<p class="Pp">Parse test.wat and write to binary file test.wasm</p>
 <p class="Pp"></p>
 <div class="Bd Bd-indent"><code class="Li">$ wat2wasm test.wat -o
   test.wasm</code></div>

--- a/man/wat2wasm.1
+++ b/man/wat2wasm.1
@@ -46,11 +46,11 @@ Write debug names to the generated binary file
 Don't check for invalid modules
 .El
 .Sh EXAMPLES
-Parse and typecheck test.wat
+Parse test.wat and write to .wasm binary file with the same name
 .Pp
 .Dl $ wat2wasm test.wat
 .Pp
-parse test.wat and write to binary file test.wasm
+Parse test.wat and write to binary file test.wasm
 .Pp
 .Dl $ wat2wasm test.wat -o test.wasm
 .Pp

--- a/src/tools/wat2wasm.cc
+++ b/src/tools/wat2wasm.cc
@@ -53,7 +53,7 @@ static const char s_description[] =
   convert it to the wasm binary format.
 
 examples:
-  # parse and typecheck test.wat
+  # parse test.wat and write to .wasm binary file with the same name
   $ wat2wasm test.wat
 
   # parse test.wat and write to binary file test.wasm

--- a/test/help/wat2wasm.txt
+++ b/test/help/wat2wasm.txt
@@ -7,7 +7,7 @@ usage: wat2wasm [options] filename
   convert it to the wasm binary format.
 
 examples:
-  # parse and typecheck test.wat
+  # parse test.wat and write to .wasm binary file with the same name
   $ wat2wasm test.wat
 
   # parse test.wat and write to binary file test.wasm


### PR DESCRIPTION
Fixes #1941 

I wonder if the PR would be better by changing the example of calling with the `-o` flag directly below it in many of the changed files should be changed to speciffy a non-default-named file. That would make it clear that no `-o` flag indicates default name, while `-o` allows you to explicitly set it. Something like

```bash
# parse test.wat and write to binary file module.wasm
$ bin/wat2wasm test.wat -o module.wasm
```

Signed-off-by: Mark Irish <markdirish@gmail.com>