### PR TITLE
wasm2c: Use `static` for wasm-rt globals. NFC

### DIFF
--- a/wasm2c/wasm-rt-impl.c
+++ b/wasm2c/wasm-rt-impl.c
@@ -46,23 +46,24 @@ typedef struct FuncType {
 } FuncType;
 
 #if WASM_RT_MEMCHECK_SIGNAL_HANDLER
-bool g_signal_handler_installed = false;
-char* g_alt_stack;
+static bool g_signal_handler_installed = false;
+static char* g_alt_stack;
 #else
 uint32_t wasm_rt_call_stack_depth;
-uint32_t g_saved_call_stack_depth;
+uint32_t wasm_rt_saved_call_stack_depth;
 #endif
 
-jmp_buf g_jmp_buf;
-FuncType* g_func_types;
-uint32_t g_func_type_count;
+static FuncType* g_func_types;
+static uint32_t g_func_type_count;
+
+jmp_buf wasm_rt_jmp_buf;
 
 void wasm_rt_trap(wasm_rt_trap_t code) {
   assert(code != WASM_RT_TRAP_NONE);
 #if !WASM_RT_MEMCHECK_SIGNAL_HANDLER
-  wasm_rt_call_stack_depth = g_saved_call_stack_depth;
+  wasm_rt_call_stack_depth = wasm_rt_saved_call_stack_depth;
 #endif
-  WASM_RT_LONGJMP(g_jmp_buf, code);
+  WASM_RT_LONGJMP(wasm_rt_jmp_buf, code);
 }
 
 static bool func_types_are_equal(FuncType* a, FuncType* b) {

--- a/wasm2c/wasm-rt-impl.h
+++ b/wasm2c/wasm-rt-impl.h
@@ -26,7 +26,7 @@ extern "C" {
 #endif
 
 /** A setjmp buffer used for handling traps. */
-extern jmp_buf g_jmp_buf;
+extern jmp_buf wasm_rt_jmp_buf;
 
 #if WASM_RT_MEMCHECK_SIGNAL_HANDLER_POSIX
 #define WASM_RT_SETJMP(buf) sigsetjmp(buf, 1)
@@ -35,7 +35,7 @@ extern jmp_buf g_jmp_buf;
 #define WASM_RT_SETJMP(buf) setjmp(buf)
 #define WASM_RT_LONGJMP(buf, val) longjmp(buf, val)
 /** Saved call stack depth that will be restored in case a trap occurs. */
-extern uint32_t g_saved_call_stack_depth;
+extern uint32_t wasm_rt_saved_call_stack_depth;
 #endif
 
 /**
@@ -55,11 +55,11 @@ extern uint32_t g_saved_call_stack_depth;
  * ```
  */
 #if WASM_RT_MEMCHECK_SIGNAL_HANDLER_POSIX
-#define wasm_rt_impl_try() WASM_RT_SETJMP(g_jmp_buf)
+#define wasm_rt_impl_try() WASM_RT_SETJMP(wasm_rt_jmp_buf)
 #else
-#define wasm_rt_impl_try()                              \
-  (g_saved_call_stack_depth = wasm_rt_call_stack_depth, \
-   WASM_RT_SETJMP(g_jmp_buf))
+#define wasm_rt_impl_try()                                    \
+  (wasm_rt_saved_call_stack_depth = wasm_rt_call_stack_depth, \
+   WASM_RT_SETJMP(wasm_rt_jmp_buf))
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
And use the `wasm_rt_` prefix for the one non-static global.

While reviewing #1930 I noticed these globals could/should be static.