### PR TITLE
add wasm2wat offset in verbose mode

### DIFF
--- a/src/binary-reader-logging.cc
+++ b/src/binary-reader-logging.cc
@@ -28,6 +28,7 @@ namespace wabt {
 
 #define LOGF(...)               \
   do {                          \
+    WriteOffset();              \
     WriteIndent();              \
     LOGF_NOINDENT(__VA_ARGS__); \
   } while (0)
@@ -49,8 +50,9 @@ void SPrintLimits(char* dst, size_t size, const Limits* limits) {
 }  // end anonymous namespace
 
 BinaryReaderLogging::BinaryReaderLogging(Stream* stream,
-                                         BinaryReaderDelegate* forward)
-    : stream_(stream), reader_(forward), indent_(0) {}
+                                         BinaryReaderDelegate* forward,
+                                         Offset* offset)
+    : stream_(stream), reader_(forward), offset_(offset), indent_(0) {}
 
 void BinaryReaderLogging::Indent() {
   indent_ += INDENT_SIZE;
@@ -59,6 +61,17 @@ void BinaryReaderLogging::Indent() {
 void BinaryReaderLogging::Dedent() {
   indent_ -= INDENT_SIZE;
   assert(indent_ >= 0);
+}
+
+void BinaryReaderLogging::WriteOffset() {
+  char dst[100];
+  int result;
+  if (offset_) {
+    result = wabt_snprintf(dst, sizeof(dst), "0x%lx", *offset_);
+    WABT_USE(result);
+    assert(static_cast<size_t>(result) < sizeof(dst));
+    stream_->WriteData(dst, static_cast<size_t>(result));
+  }
 }
 
 void BinaryReaderLogging::WriteIndent() {

--- a/src/binary-reader-logging.h
+++ b/src/binary-reader-logging.h
@@ -25,7 +25,7 @@ class Stream;
 
 class BinaryReaderLogging : public BinaryReaderDelegate {
  public:
-  BinaryReaderLogging(Stream*, BinaryReaderDelegate* forward);
+  BinaryReaderLogging(Stream*, BinaryReaderDelegate* forward, Offset*);
 
   bool OnError(const Error&) override;
   void OnSetState(const State* s) override;
@@ -396,6 +396,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
  private:
   void Indent();
   void Dedent();
+  void WriteOffset();
   void WriteIndent();
   void LogType(Type type);
   void LogTypes(Index type_count, Type* types);
@@ -404,6 +405,7 @@ class BinaryReaderLogging : public BinaryReaderDelegate {
 
   Stream* stream_;
   BinaryReaderDelegate* reader_;
+  Offset* offset_;
   int indent_;
 };
 

--- a/src/binary-reader.cc
+++ b/src/binary-reader.cc
@@ -200,7 +200,7 @@ BinaryReader::BinaryReader(const void* data,
                            const ReadBinaryOptions& options)
     : read_end_(size),
       state_(static_cast<const uint8_t*>(data), size),
-      logging_delegate_(options.log_stream, delegate),
+      logging_delegate_(options.log_stream, delegate, &state_.offset),
       delegate_(options.log_stream ? &logging_delegate_ : delegate),
       options_(options),
       last_known_section_(BinarySection::Invalid) {


### PR DESCRIPTION
in wasmtime, we sometimes only get the offset information. to be able to collect more information, we need to the offset information.