### PR TITLE
wasm2c/README.md: document runtime symbols needed for exceptions

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1553,9 +1553,9 @@ void CWriter::Write(const Block& block) {
 size_t CWriter::BeginTry(const TryExpr& tryexpr) {
   Write(OpenBrace()); /* beginning of try-catch */
   const std::string tlabel = DefineLocalScopeName(tryexpr.block.label);
-  Write("jmp_buf *", tlabel, "_outer_target = wasm_rt_get_unwind_target();",
-        Newline());
-  Write("jmp_buf ", tlabel, "_unwind_target;", Newline());
+  Write("WASM_RT_UNWIND_TARGET *", tlabel,
+        "_outer_target = wasm_rt_get_unwind_target();", Newline());
+  Write("WASM_RT_UNWIND_TARGET ", tlabel, "_unwind_target;", Newline());
   Write("if (!wasm_rt_try(", tlabel, "_unwind_target)) ");
   Write(OpenBrace()); /* beginning of try block */
   DropTypes(tryexpr.block.decl.GetNumParams());

--- a/wasm2c/wasm-rt.h
+++ b/wasm2c/wasm-rt.h
@@ -227,14 +227,19 @@ void wasm_rt_load_exception(uint32_t tag, uint32_t size, const void* values);
 WASM_RT_NO_RETURN void wasm_rt_throw(void);
 
 /**
+ * The type of an unwind target if an exception is thrown and caught.
+ */
+#define WASM_RT_UNWIND_TARGET jmp_buf
+
+/**
  * Get the current unwind target if an exception is thrown.
  */
-jmp_buf* wasm_rt_get_unwind_target(void);
+WASM_RT_UNWIND_TARGET* wasm_rt_get_unwind_target(void);
 
 /**
  * Set the unwind target if an exception is thrown.
  */
-void wasm_rt_set_unwind_target(jmp_buf* target);
+void wasm_rt_set_unwind_target(WASM_RT_UNWIND_TARGET* target);
 
 /**
  * Tag of the active exception.


### PR DESCRIPTION
wasm2c's README omitted the symbols that the runtime must implement to support wasm2c output (when wasm2c is run with exceptions support enabled). Closes #1949.