### PR TITLE
wasm2c: simplify handling of exception tags

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -922,33 +922,22 @@ void CWriter::WriteFuncTypes() {
 }
 
 void CWriter::WriteTags() {
-  if (module_->tags.empty()) {
-    Write("static void init_tags(void) ", OpenBrace(), CloseBrace(), Newline());
-    return;
+  for (auto it = module_->tags.cbegin() + module_->num_tag_imports;
+       it != module_->tags.cend(); ++it) {
+    const Tag* tag = *it;
+    Write("static u32 ", DefineGlobalScopeName(tag->name), ";", Newline());
   }
 
-  Writef("static u32 tag[%" PRIzd "];", module_->tags.size());
-  Write(Newline(), Newline());
+  Write(Newline());
 
   Write("static void init_tags(void) ", OpenBrace());
 
-  Index tag_index = 0;
-  for (const Import* import : module_->imports) {
-    if (import->kind() != ExternalKind::Tag) {
-      continue;
-    }
-
-    Write("tag[", tag_index, "] = *", MangleName(import->module_name),
-          MangleName(import->field_name), ";", Newline());
-    ++tag_index;
-  }
-
-  for (auto it = module_->tags.cbegin() + tag_index; it != module_->tags.cend();
-       ++it) {
+  for (auto it = module_->tags.cbegin() + module_->num_tag_imports;
+       it != module_->tags.cend(); ++it) {
     const Tag* tag = *it;
     const FuncDeclaration& tag_type = tag->decl;
     Index num_params = tag_type.GetNumParams();
-    Write("tag[", tag_index, "] = wasm_rt_register_tag(");
+    Write(GlobalName(tag->name), " = wasm_rt_register_tag(");
 
     if (num_params == 0) {
       Write("0");
@@ -959,7 +948,6 @@ void CWriter::WriteTags() {
     }
 
     Write(");", Newline());
-    ++tag_index;
   }
   Write(CloseBrace(), Newline());
 }
@@ -1009,7 +997,7 @@ void CWriter::WriteImports() {
 
       case ExternalKind::Tag: {
         const Tag& tag = cast<TagImport>(import)->tag;
-        Write("u32 ",
+        Write("const u32 ",
               DefineImportName(tag.name, import->module_name,
                                MangleName(import->field_name)),
               ";");
@@ -1315,7 +1303,7 @@ void CWriter::WriteExports(WriteExportsKind kind) {
         mangled_name = ExportName(MangleName(export_->name));
         internal_name = tag->name;
         if (kind != WriteExportsKind::Initializers) {
-          Write("u32 *", mangled_name, ";");
+          Write("const u32 *", mangled_name, ";");
         }
         break;
       }
@@ -1325,12 +1313,7 @@ void CWriter::WriteExports(WriteExportsKind kind) {
     }
 
     if (kind == WriteExportsKind::Initializers) {
-      if (export_->kind == ExternalKind::Tag) {
-        Write(mangled_name, " = &tag[", module_->GetTagIndex(export_->var),
-              "];");
-      } else {
-        Write(mangled_name, " = ", ExternalPtr(internal_name), ";");
-      }
+      Write(mangled_name, " = ", ExternalPtr(internal_name), ";");
     }
 
     Write(Newline());
@@ -1636,8 +1619,8 @@ void CWriter::Write(const Catch& c) {
     return;
   }
 
-  Write("if (wasm_rt_exception_tag() == tag[", module_->GetTagIndex(c.var),
-        "]) ", OpenBrace());
+  Write("if (wasm_rt_exception_tag() == ",
+        ExternalRef(module_->GetTag(c.var)->name), ") ", OpenBrace());
 
   const Tag* tag = module_->GetTag(c.var);
   const FuncDeclaration& tag_type = tag->decl;
@@ -2051,14 +2034,13 @@ void CWriter::Write(const ExprList& exprs) {
       case ExprType::Throw: {
         const Var& var = cast<ThrowExpr>(&expr)->var;
         const Tag* tag = module_->GetTag(var);
-        const Index tag_index = module_->GetTagIndex(var);
 
         Index num_params = tag->decl.GetNumParams();
         if (num_params == 0) {
-          Write("wasm_rt_load_exception(tag[", tag_index, "], 0, NULL);",
-                Newline());
+          Write("wasm_rt_load_exception(", ExternalRef(tag->name),
+                ", 0, NULL);", Newline());
         } else if (num_params == 1) {
-          Write("wasm_rt_load_exception(tag[", tag_index, "], sizeof(",
+          Write("wasm_rt_load_exception(", ExternalRef(tag->name), ", sizeof(",
                 tag->decl.GetParamType(0), "), &", StackVar(0), ");",
                 Newline());
         } else {
@@ -2069,8 +2051,8 @@ void CWriter::Write(const ExprList& exprs) {
             Write(StackVar(i), ", ");
           }
           Write("};", Newline());
-          Write("wasm_rt_load_exception(tag[", tag_index,
-                "], sizeof(tmp), &tmp);", Newline());
+          Write("wasm_rt_load_exception(", ExternalRef(tag->name),
+                ", sizeof(tmp), &tmp);", Newline());
           Write(CloseBrace(), Newline());
         }
 


### PR DESCRIPTION
Previously, the wasm2c generated code used an array to store the tag for each index, and looked up tags by index in the array at runtime. This PR changes the handling of tags to match everything else (one named symbol per tag). This is a stepping-stone on the way to #1814.