### PR TITLE
Track locations of Vars in BinaryReaderIR and BinaryReaderInterp

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -454,7 +454,7 @@ void BinaryReaderIR::SetBlockDeclaration(BlockDeclaration* decl,
                                          Type sig_type) {
   if (sig_type.IsIndex()) {
     Index type_index = sig_type.GetIndex();
-    SetFuncDeclaration(decl, Var(type_index));
+    SetFuncDeclaration(decl, Var(type_index, GetLocation()));
   } else {
     decl->has_func_type = false;
     decl->sig.param_types.clear();
@@ -796,18 +796,18 @@ Result BinaryReaderIR::OnBlockExpr(Type sig_type) {
 }
 
 Result BinaryReaderIR::OnBrExpr(Index depth) {
-  return AppendExpr(MakeUnique<BrExpr>(Var(depth)));
+  return AppendExpr(MakeUnique<BrExpr>(Var(depth, GetLocation())));
 }
 
 Result BinaryReaderIR::OnBrIfExpr(Index depth) {
-  return AppendExpr(MakeUnique<BrIfExpr>(Var(depth)));
+  return AppendExpr(MakeUnique<BrIfExpr>(Var(depth, GetLocation())));
 }
 
 Result BinaryReaderIR::OnBrTableExpr(Index num_targets,
                                      Index* target_depths,
                                      Index default_target_depth) {
   auto expr = MakeUnique<BrTableExpr>();
-  expr->default_target = Var(default_target_depth);
+  expr->default_target = Var(default_target_depth, GetLocation());
   expr->targets.resize(num_targets);
   for (Index i = 0; i < num_targets; ++i) {
     expr->targets[i] = Var(target_depths[i]);
@@ -816,13 +816,13 @@ Result BinaryReaderIR::OnBrTableExpr(Index num_targets,
 }
 
 Result BinaryReaderIR::OnCallExpr(Index func_index) {
-  return AppendExpr(MakeUnique<CallExpr>(Var(func_index)));
+  return AppendExpr(MakeUnique<CallExpr>(Var(func_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnCallIndirectExpr(Index sig_index, Index table_index) {
   auto expr = MakeUnique<CallIndirectExpr>();
   SetFuncDeclaration(&expr->decl, Var(sig_index, GetLocation()));
-  expr->table = Var(table_index);
+  expr->table = Var(table_index, GetLocation());
   return AppendExpr(std::move(expr));
 }
 
@@ -831,14 +831,14 @@ Result BinaryReaderIR::OnCallRefExpr() {
 }
 
 Result BinaryReaderIR::OnReturnCallExpr(Index func_index) {
-  return AppendExpr(MakeUnique<ReturnCallExpr>(Var(func_index)));
+  return AppendExpr(MakeUnique<ReturnCallExpr>(Var(func_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnReturnCallIndirectExpr(Index sig_index,
                                                 Index table_index) {
   auto expr = MakeUnique<ReturnCallIndirectExpr>();
   SetFuncDeclaration(&expr->decl, Var(sig_index, GetLocation()));
-  expr->table = Var(table_index);
+  expr->table = Var(table_index, GetLocation());
   return AppendExpr(std::move(expr));
 }
 
@@ -949,8 +949,8 @@ Result BinaryReaderIR::OnLoadExpr(Opcode opcode,
                                   Index memidx,
                                   Address alignment_log2,
                                   Address offset) {
-  return AppendExpr(
-      MakeUnique<LoadExpr>(opcode, Var(memidx), 1 << alignment_log2, offset));
+  return AppendExpr(MakeUnique<LoadExpr>(opcode, Var(memidx, GetLocation()),
+                                         1 << alignment_log2, offset));
 }
 
 Result BinaryReaderIR::OnLoopExpr(Type sig_type) {
@@ -963,64 +963,67 @@ Result BinaryReaderIR::OnLoopExpr(Type sig_type) {
 }
 
 Result BinaryReaderIR::OnMemoryCopyExpr(Index srcmemidx, Index destmemidx) {
-  return AppendExpr(
-      MakeUnique<MemoryCopyExpr>(Var(srcmemidx), Var(destmemidx)));
+  return AppendExpr(MakeUnique<MemoryCopyExpr>(Var(srcmemidx, GetLocation()),
+                                               Var(destmemidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnDataDropExpr(Index segment) {
-  return AppendExpr(MakeUnique<DataDropExpr>(Var(segment)));
+  return AppendExpr(MakeUnique<DataDropExpr>(Var(segment, GetLocation())));
 }
 
 Result BinaryReaderIR::OnMemoryFillExpr(Index memidx) {
-  return AppendExpr(MakeUnique<MemoryFillExpr>(Var(memidx)));
+  return AppendExpr(MakeUnique<MemoryFillExpr>(Var(memidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnMemoryGrowExpr(Index memidx) {
-  return AppendExpr(MakeUnique<MemoryGrowExpr>(Var(memidx)));
+  return AppendExpr(MakeUnique<MemoryGrowExpr>(Var(memidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnMemoryInitExpr(Index segment, Index memidx) {
-  return AppendExpr(MakeUnique<MemoryInitExpr>(Var(segment), Var(memidx)));
+  return AppendExpr(MakeUnique<MemoryInitExpr>(Var(segment, GetLocation()),
+                                               Var(memidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnMemorySizeExpr(Index memidx) {
-  return AppendExpr(MakeUnique<MemorySizeExpr>(Var(memidx)));
+  return AppendExpr(MakeUnique<MemorySizeExpr>(Var(memidx, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableCopyExpr(Index dst_index, Index src_index) {
-  return AppendExpr(MakeUnique<TableCopyExpr>(Var(dst_index), Var(src_index)));
+  return AppendExpr(MakeUnique<TableCopyExpr>(Var(dst_index, GetLocation()),
+                                              Var(src_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnElemDropExpr(Index segment) {
-  return AppendExpr(MakeUnique<ElemDropExpr>(Var(segment)));
+  return AppendExpr(MakeUnique<ElemDropExpr>(Var(segment, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableInitExpr(Index segment, Index table_index) {
-  return AppendExpr(MakeUnique<TableInitExpr>(Var(segment), Var(table_index)));
+  return AppendExpr(MakeUnique<TableInitExpr>(Var(segment, GetLocation()),
+                                              Var(table_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableGetExpr(Index table_index) {
-  return AppendExpr(MakeUnique<TableGetExpr>(Var(table_index)));
+  return AppendExpr(MakeUnique<TableGetExpr>(Var(table_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableSetExpr(Index table_index) {
-  return AppendExpr(MakeUnique<TableSetExpr>(Var(table_index)));
+  return AppendExpr(MakeUnique<TableSetExpr>(Var(table_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableGrowExpr(Index table_index) {
-  return AppendExpr(MakeUnique<TableGrowExpr>(Var(table_index)));
+  return AppendExpr(MakeUnique<TableGrowExpr>(Var(table_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableSizeExpr(Index table_index) {
-  return AppendExpr(MakeUnique<TableSizeExpr>(Var(table_index)));
+  return AppendExpr(MakeUnique<TableSizeExpr>(Var(table_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnTableFillExpr(Index table_index) {
-  return AppendExpr(MakeUnique<TableFillExpr>(Var(table_index)));
+  return AppendExpr(MakeUnique<TableFillExpr>(Var(table_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnRefFuncExpr(Index func_index) {
-  return AppendExpr(MakeUnique<RefFuncExpr>(Var(func_index)));
+  return AppendExpr(MakeUnique<RefFuncExpr>(Var(func_index, GetLocation())));
 }
 
 Result BinaryReaderIR::OnRefNullExpr(Type type) {
@@ -1062,8 +1065,8 @@ Result BinaryReaderIR::OnStoreExpr(Opcode opcode,
                                    Index memidx,
                                    Address alignment_log2,
                                    Address offset) {
-  return AppendExpr(
-      MakeUnique<StoreExpr>(opcode, Var(memidx), 1 << alignment_log2, offset));
+  return AppendExpr(MakeUnique<StoreExpr>(opcode, Var(memidx, GetLocation()),
+                                          1 << alignment_log2, offset));
 }
 
 Result BinaryReaderIR::OnThrowExpr(Index tag_index) {
@@ -1173,7 +1176,7 @@ Result BinaryReaderIR::OnSimdLoadLaneExpr(Opcode opcode,
                                           Address offset,
                                           uint64_t value) {
   return AppendExpr(MakeUnique<SimdLoadLaneExpr>(
-      opcode, Var(memidx), 1 << alignment_log2, offset, value));
+      opcode, Var(memidx, GetLocation()), 1 << alignment_log2, offset, value));
 }
 
 Result BinaryReaderIR::OnSimdStoreLaneExpr(Opcode opcode,
@@ -1182,7 +1185,7 @@ Result BinaryReaderIR::OnSimdStoreLaneExpr(Opcode opcode,
                                            Address offset,
                                            uint64_t value) {
   return AppendExpr(MakeUnique<SimdStoreLaneExpr>(
-      opcode, Var(memidx), 1 << alignment_log2, offset, value));
+      opcode, Var(memidx, GetLocation()), 1 << alignment_log2, offset, value));
 }
 
 Result BinaryReaderIR::OnSimdShuffleOpExpr(Opcode opcode, v128 value) {

--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -810,7 +810,7 @@ Result BinaryReaderIR::OnBrTableExpr(Index num_targets,
   expr->default_target = Var(default_target_depth, GetLocation());
   expr->targets.resize(num_targets);
   for (Index i = 0; i < num_targets; ++i) {
-    expr->targets[i] = Var(target_depths[i]);
+    expr->targets[i] = Var(target_depths[i], GetLocation());
   }
   return AppendExpr(std::move(expr));
 }

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -670,7 +670,7 @@ void CWriter::Write(const GotoLabel& goto_label) {
     // We've generated names for all labels, so we should only be using an
     // index when branching to the implicit function label, which can't be
     // named.
-    Write("goto ", Var(kImplicitFuncLabel), ";");
+    Write("goto ", Var(kImplicitFuncLabel, {}), ";");
   }
 }
 
@@ -1979,7 +1979,7 @@ void CWriter::Write(const ExprList& exprs) {
       case ExprType::Return:
         // Goto the function label instead; this way we can do shared function
         // cleanup code in one place.
-        Write(GotoLabel(Var(label_stack_.size() - 1)), Newline());
+        Write(GotoLabel(Var(label_stack_.size() - 1, {})), Newline());
         // Stop processing this ExprList, since the following are unreachable.
         return;
 

--- a/src/decompiler.cc
+++ b/src/decompiler.cc
@@ -671,7 +671,7 @@ struct Decompiler {
                          Index index,
                          std::string_view name) {
     // Figure out if this thing is imported, exported, or neither.
-    auto is_import = mc.module.IsImport(kind, Var(index));
+    auto is_import = mc.module.IsImport(kind, Var(index, Location()));
     // TODO: is this the best way to check for export?
     // FIXME: this doesn't work for functions that get renamed in some way,
     // as the export has the original name..

--- a/src/ir.cc
+++ b/src/ir.cc
@@ -586,17 +586,19 @@ void MakeTypeBindingReverseMapping(
   }
 }
 
+Var::Var() : Var(kInvalidIndex, Location()) {}
+
 Var::Var(Index index, const Location& loc)
     : loc(loc), type_(VarType::Index), index_(index) {}
 
 Var::Var(std::string_view name, const Location& loc)
     : loc(loc), type_(VarType::Name), name_(name) {}
 
-Var::Var(Var&& rhs) : Var(kInvalidIndex) {
+Var::Var(Var&& rhs) : Var() {
   *this = std::move(rhs);
 }
 
-Var::Var(const Var& rhs) : Var(kInvalidIndex) {
+Var::Var(const Var& rhs) : Var() {
   *this = rhs;
 }
 

--- a/src/ir.h
+++ b/src/ir.h
@@ -41,8 +41,9 @@ enum class VarType {
 };
 
 struct Var {
-  explicit Var(Index index = kInvalidIndex, const Location& loc = Location());
-  explicit Var(std::string_view name, const Location& loc = Location());
+  explicit Var();
+  explicit Var(Index index, const Location& loc);
+  explicit Var(std::string_view name, const Location& loc);
   Var(Var&&);
   Var(const Var&);
   Var& operator=(const Var&);

--- a/src/validator.cc
+++ b/src/validator.cc
@@ -280,7 +280,7 @@ Result Validator::OnCallRefExpr(CallRefExpr* expr) {
   Index function_type_index;
   result_ |= validator_.OnCallRef(expr->loc, &function_type_index);
   if (Succeeded(result_)) {
-    expr->function_type_index = Var{function_type_index};
+    expr->function_type_index = Var{function_type_index, expr->loc};
     return Result::Ok;
   }
 

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -937,7 +937,7 @@ Result WastParser::ParseValueType(Var* out_type) {
     return Result::Error;
   }
 
-  *out_type = Var(type);
+  *out_type = Var(type, GetLocation());
   return Result::Ok;
 }
 
@@ -1654,7 +1654,7 @@ Result WastParser::ParseMemoryModuleField(Module* module) {
     if (MatchLpar(TokenType::Data)) {
       auto data_segment_field = MakeUnique<DataSegmentModuleField>(loc);
       DataSegment& data_segment = data_segment_field->data_segment;
-      data_segment.memory_var = Var(module->memories.size());
+      data_segment.memory_var = Var(module->memories.size(), GetLocation());
       data_segment.offset.push_back(MakeUnique<ConstExpr>(
           field->memory.page_limits.is_64 ? Const::I64(0) : Const::I32(0)));
       data_segment.offset.back().loc = loc;
@@ -1726,7 +1726,7 @@ Result WastParser::ParseTableModuleField(Module* module) {
 
     auto elem_segment_field = MakeUnique<ElemSegmentModuleField>(loc);
     ElemSegment& elem_segment = elem_segment_field->elem_segment;
-    elem_segment.table_var = Var(module->tables.size());
+    elem_segment.table_var = Var(module->tables.size(), GetLocation());
     elem_segment.offset.push_back(MakeUnique<ConstExpr>(Const::I32(0)));
     elem_segment.offset.back().loc = loc;
     elem_segment.elem_type = elem_type;

--- a/src/wat-writer.cc
+++ b/src/wat-writer.cc
@@ -1329,7 +1329,7 @@ void WatWriter::WriteBeginFunc(const Func& func) {
     WriteCloseSpace();
   }
 
-  if (module.IsImport(ExternalKind::Func, Var(func_index_))) {
+  if (module.IsImport(ExternalKind::Func, Var(func_index_, Location()))) {
     // Imported functions can be written a few ways:
     //
     //   1. (import "module" "field" (func (type 0)))

--- a/test/spec/call.txt
+++ b/test/spec/call.txt
@@ -51,10 +51,10 @@ out/test/spec/call.wast:499: assert_invalid passed:
   out/test/spec/call/call.16.wasm:0000025: error: type mismatch in call, expected [i32, i32] but got [i32]
   0000025: error: OnCallExpr callback failed
 out/test/spec/call.wast:512: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/call/call.17.wasm:0000019: error: function variable out of range: 1 (max 1)
   0000019: error: OnCallExpr callback failed
 out/test/spec/call.wast:516: assert_invalid passed:
-  0000000: error: function variable out of range: 1012321300 (max 1)
+  out/test/spec/call/call.18.wasm:000001d: error: function variable out of range: 1012321300 (max 1)
   000001d: error: OnCallExpr callback failed
 91/91 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/call_indirect.txt
+++ b/test/spec/call_indirect.txt
@@ -85,7 +85,7 @@ out/test/spec/call_indirect.wast:776: assert_malformed passed:
   ...0 funcref)(func (result i32)  (call_indirect (type $sig) (param i32) (resu...
                                     ^^^^^^^^^^^^^
 out/test/spec/call_indirect.wast:791: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/call_indirect/call_indirect.13.wasm:000001c: error: table variable out of range: 0 (max 0)
   000001c: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:799: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.14.wasm:0000023: error: type mismatch in i32.eqz, expected [i32] but got []
@@ -142,13 +142,13 @@ out/test/spec/call_indirect.wast:977: assert_invalid passed:
   out/test/spec/call_indirect/call_indirect.31.wasm:000003d: error: type mismatch in call_indirect, expected [i32, i32] but got [i32]
   000003d: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:997: assert_invalid passed:
-  0000000: error: function type variable out of range: 1 (max 1)
+  out/test/spec/call_indirect/call_indirect.32.wasm:0000022: error: function type variable out of range: 1 (max 1)
   0000022: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:1004: assert_invalid passed:
-  0000000: error: function type variable out of range: 1012321300 (max 1)
+  out/test/spec/call_indirect/call_indirect.33.wasm:0000026: error: function type variable out of range: 1012321300 (max 1)
   0000026: error: OnCallIndirectExpr callback failed
 out/test/spec/call_indirect.wast:1015: assert_invalid passed:
-  0000000: error: function variable out of range: 0 (max 0)
+  out/test/spec/call_indirect/call_indirect.34.wasm:0000018: error: function variable out of range: 0 (max 0)
   0000018: error: OnElemSegmentElemExpr_RefFunc callback failed
 169/169 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -2,22 +2,22 @@
 ;;; STDIN_FILE: third_party/testsuite/data.wast
 (;; STDOUT ;;;
 out/test/spec/data.wast:293: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/data/data.39.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/data.wast:301: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/data/data.40.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
 out/test/spec/data.wast:314: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/data/data.41.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/data.wast:325: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 0)
+  out/test/spec/data/data.42.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/data.wast:337: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/data/data.43.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
 out/test/spec/data.wast:359: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 0)
+  out/test/spec/data/data.44.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/data.wast:378: assert_invalid passed:
   out/test/spec/data/data.45.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
@@ -50,10 +50,10 @@ out/test/spec/data.wast:452: assert_invalid passed:
   out/test/spec/data/data.54.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
 out/test/spec/data.wast:466: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/data/data.55.wasm:0000013: error: global variable out of range: 0 (max 0)
   0000013: error: OnGlobalGetExpr callback failed
 out/test/spec/data.wast:474: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/data/data.56.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnGlobalGetExpr callback failed
 out/test/spec/data.wast:483: assert_invalid passed:
   out/test/spec/data/data.57.wasm:000002d: error: initializer expression cannot reference a mutable global

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -4,7 +4,7 @@
 out/test/spec/elem.wast:321: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/elem.wast:331: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/elem.wast:336: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/elem/elem.33.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/elem.wast:346: assert_invalid passed:
   out/test/spec/elem/elem.34.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
@@ -37,10 +37,10 @@ out/test/spec/elem.wast:421: assert_invalid passed:
   out/test/spec/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
 out/test/spec/elem.wast:435: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/elem/elem.44.wasm:0000014: error: global variable out of range: 0 (max 0)
   0000014: error: OnGlobalGetExpr callback failed
 out/test/spec/elem.wast:443: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/elem/elem.45.wasm:000002a: error: global variable out of range: 1 (max 1)
   000002a: error: OnGlobalGetExpr callback failed
 out/test/spec/elem.wast:452: assert_invalid passed:
   out/test/spec/elem/elem.46.wasm:000002e: error: initializer expression cannot reference a mutable global

--- a/test/spec/exception-handling/exports.txt
+++ b/test/spec/exception-handling/exports.txt
@@ -3,13 +3,13 @@
 ;;; ARGS*: --enable-exceptions
 (;; STDOUT ;;;
 out/test/spec/exception-handling/exports.wast:39: assert_invalid passed:
-  0000000: error: function variable out of range: 0 (max 0)
+  out/test/spec/exception-handling/exports/exports.15.wasm:000000f: error: function variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:43: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.16.wasm:0000019: error: function variable out of range: 1 (max 1)
   0000019: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:47: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.17.wasm:000002e: error: function variable out of range: 1 (max 1)
   000002e: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:51: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.18.wasm:000001d: error: duplicate export "a"
@@ -30,13 +30,13 @@ out/test/spec/exception-handling/exports.wast:71: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.23.wasm:0000022: error: duplicate export "t0"
   0000022: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:100: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/exception-handling/exports/exports.36.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:104: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.37.wasm:0000017: error: global variable out of range: 1 (max 1)
   0000017: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:108: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.38.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:112: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.39.wasm:000001b: error: duplicate export "a"
@@ -54,13 +54,13 @@ out/test/spec/exception-handling/exports.wast:128: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.43.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:155: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/exception-handling/exports/exports.59.wasm:000000f: error: table variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:159: assert_invalid passed:
-  0000000: error: table variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.60.wasm:0000015: error: table variable out of range: 1 (max 1)
   0000015: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:163: assert_invalid passed:
-  0000000: error: table variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.61.wasm:0000026: error: table variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:167: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.62.wasm:0000019: error: duplicate export "a"
@@ -78,13 +78,13 @@ out/test/spec/exception-handling/exports.wast:183: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.66.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:211: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/exception-handling/exports/exports.81.wasm:000000f: error: memory variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:215: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.82.wasm:0000014: error: memory variable out of range: 1 (max 1)
   0000014: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:219: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/exports/exports.83.wasm:0000026: error: memory variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exception-handling/exports.wast:223: assert_invalid passed:
   out/test/spec/exception-handling/exports/exports.84.wasm:0000018: error: duplicate export "a"

--- a/test/spec/exception-handling/imports.txt
+++ b/test/spec/exception-handling/imports.txt
@@ -13,7 +13,7 @@ called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/exception-handling/imports.wast:100: assert_invalid passed:
-  0000000: error: function type variable out of range: 1 (max 1)
+  out/test/spec/exception-handling/imports/imports.2.wasm:000001e: error: function type variable out of range: 1 (max 1)
   000001e: error: OnImportFunc callback failed
 called host spectest.print_i32(i32:13) =>
 out/test/spec/exception-handling/imports.wast:136: assert_unlinkable passed:

--- a/test/spec/exception-handling/throw.txt
+++ b/test/spec/exception-handling/throw.txt
@@ -8,7 +8,7 @@ out/test/spec/exception-handling/throw.wast:41: assert_exception passed
 out/test/spec/exception-handling/throw.wast:42: assert_exception passed
 out/test/spec/exception-handling/throw.wast:43: assert_exception passed
 out/test/spec/exception-handling/throw.wast:47: assert_invalid passed:
-  0000000: error: tag variable out of range: 0 (max 0)
+  out/test/spec/exception-handling/throw/throw.1.wasm:0000019: error: tag variable out of range: 0 (max 0)
   0000019: error: OnThrowExpr callback failed
 out/test/spec/exception-handling/throw.wast:48: assert_invalid passed:
   out/test/spec/exception-handling/throw/throw.2.wasm:0000022: error: type mismatch in throw, expected [i32] but got []

--- a/test/spec/exports.txt
+++ b/test/spec/exports.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/exports.wast
 (;; STDOUT ;;;
 out/test/spec/exports.wast:39: assert_invalid passed:
-  0000000: error: function variable out of range: 0 (max 0)
+  out/test/spec/exports/exports.15.wasm:000000f: error: function variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exports.wast:43: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.16.wasm:0000019: error: function variable out of range: 1 (max 1)
   0000019: error: OnExport callback failed
 out/test/spec/exports.wast:47: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.17.wasm:000002e: error: function variable out of range: 1 (max 1)
   000002e: error: OnExport callback failed
 out/test/spec/exports.wast:51: assert_invalid passed:
   out/test/spec/exports/exports.18.wasm:000001d: error: duplicate export "a"
@@ -26,13 +26,13 @@ out/test/spec/exports.wast:67: assert_invalid passed:
   out/test/spec/exports/exports.22.wasm:0000022: error: duplicate export "a"
   0000022: error: OnExport callback failed
 out/test/spec/exports.wast:96: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/exports/exports.35.wasm:000000f: error: global variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exports.wast:100: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.36.wasm:0000017: error: global variable out of range: 1 (max 1)
   0000017: error: OnExport callback failed
 out/test/spec/exports.wast:104: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.37.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnExport callback failed
 out/test/spec/exports.wast:108: assert_invalid passed:
   out/test/spec/exports/exports.38.wasm:000001b: error: duplicate export "a"
@@ -50,13 +50,13 @@ out/test/spec/exports.wast:124: assert_invalid passed:
   out/test/spec/exports/exports.42.wasm:0000020: error: duplicate export "a"
   0000020: error: OnExport callback failed
 out/test/spec/exports.wast:151: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/exports/exports.58.wasm:000000f: error: table variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exports.wast:155: assert_invalid passed:
-  0000000: error: table variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.59.wasm:0000015: error: table variable out of range: 1 (max 1)
   0000015: error: OnExport callback failed
 out/test/spec/exports.wast:159: assert_invalid passed:
-  0000000: error: table variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.60.wasm:0000026: error: table variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exports.wast:163: assert_invalid passed:
   out/test/spec/exports/exports.61.wasm:0000019: error: duplicate export "a"
@@ -74,13 +74,13 @@ out/test/spec/exports.wast:179: assert_invalid passed:
   out/test/spec/exports/exports.65.wasm:000001e: error: duplicate export "a"
   000001e: error: OnExport callback failed
 out/test/spec/exports.wast:207: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/exports/exports.80.wasm:000000f: error: memory variable out of range: 0 (max 0)
   000000f: error: OnExport callback failed
 out/test/spec/exports.wast:211: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.81.wasm:0000014: error: memory variable out of range: 1 (max 1)
   0000014: error: OnExport callback failed
 out/test/spec/exports.wast:215: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/exports/exports.82.wasm:0000026: error: memory variable out of range: 1 (max 1)
   0000026: error: OnExport callback failed
 out/test/spec/exports.wast:219: assert_invalid passed:
   out/test/spec/exports/exports.83.wasm:0000018: error: duplicate export "a"

--- a/test/spec/extended-const/data.txt
+++ b/test/spec/extended-const/data.txt
@@ -3,22 +3,22 @@
 ;;; ARGS*: --enable-extended-const
 (;; STDOUT ;;;
 out/test/spec/extended-const/data.wast:325: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/extended-const/data/data.43.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/extended-const/data.wast:333: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/extended-const/data/data.44.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
 out/test/spec/extended-const/data.wast:346: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/extended-const/data/data.45.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/extended-const/data.wast:357: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 0)
+  out/test/spec/extended-const/data/data.46.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/extended-const/data.wast:369: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/extended-const/data/data.47.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
 out/test/spec/extended-const/data.wast:391: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 0)
+  out/test/spec/extended-const/data/data.48.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/extended-const/data.wast:410: assert_invalid passed:
   out/test/spec/extended-const/data/data.49.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
@@ -51,10 +51,10 @@ out/test/spec/extended-const/data.wast:484: assert_invalid passed:
   out/test/spec/extended-const/data/data.58.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
 out/test/spec/extended-const/data.wast:498: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/extended-const/data/data.59.wasm:0000013: error: global variable out of range: 0 (max 0)
   0000013: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/data.wast:506: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/data/data.60.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/data.wast:515: assert_invalid passed:
   out/test/spec/extended-const/data/data.61.wasm:000002d: error: initializer expression cannot reference a mutable global

--- a/test/spec/extended-const/elem.txt
+++ b/test/spec/extended-const/elem.txt
@@ -5,7 +5,7 @@
 out/test/spec/extended-const/elem.wast:321: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/extended-const/elem.wast:331: assert_trap passed: out of bounds table access: table.init out of bounds
 out/test/spec/extended-const/elem.wast:336: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/extended-const/elem/elem.33.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/extended-const/elem.wast:346: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.34.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
@@ -38,10 +38,10 @@ out/test/spec/extended-const/elem.wast:421: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.43.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
 out/test/spec/extended-const/elem.wast:435: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/extended-const/elem/elem.44.wasm:0000014: error: global variable out of range: 0 (max 0)
   0000014: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/elem.wast:443: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/elem/elem.45.wasm:000002a: error: global variable out of range: 1 (max 1)
   000002a: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/elem.wast:452: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.46.wasm:000002e: error: initializer expression cannot reference a mutable global

--- a/test/spec/extended-const/global.txt
+++ b/test/spec/extended-const/global.txt
@@ -46,13 +46,13 @@ out/test/spec/extended-const/global.wast:354: assert_invalid passed:
   out/test/spec/extended-const/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
 out/test/spec/extended-const/global.wast:359: assert_invalid passed:
-  0000000: error: initializer expression can only reference an imported global
+  out/test/spec/extended-const/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
   000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:364: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 1)
   000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:369: assert_invalid passed:
-  0000000: error: global variable out of range: 2 (max 2)
+  out/test/spec/extended-const/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 2)
   0000025: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:374: assert_invalid passed:
   out/test/spec/extended-const/global/global.20.wasm:0000029: error: initializer expression cannot reference a mutable global
@@ -66,28 +66,28 @@ out/test/spec/extended-const/global.wast:412: assert_malformed passed:
 out/test/spec/extended-const/global.wast:424: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
 out/test/spec/extended-const/global.wast:438: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/extended-const/global/global.27.wasm:000001a: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:443: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/global/global.28.wasm:0000022: error: global variable out of range: 1 (max 1)
   0000022: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:451: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/global/global.29.wasm:0000034: error: global variable out of range: 1 (max 1)
   0000034: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:459: assert_invalid passed:
-  0000000: error: global variable out of range: 2 (max 2)
+  out/test/spec/extended-const/global/global.30.wasm:000003c: error: global variable out of range: 2 (max 2)
   000003c: error: OnGlobalGetExpr callback failed
 out/test/spec/extended-const/global.wast:469: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/extended-const/global/global.31.wasm:000001b: error: global variable out of range: 0 (max 0)
   000001b: error: OnGlobalSetExpr callback failed
 out/test/spec/extended-const/global.wast:474: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/global/global.32.wasm:0000023: error: global variable out of range: 1 (max 1)
   0000023: error: OnGlobalSetExpr callback failed
 out/test/spec/extended-const/global.wast:482: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/extended-const/global/global.33.wasm:0000035: error: global variable out of range: 1 (max 1)
   0000035: error: OnGlobalSetExpr callback failed
 out/test/spec/extended-const/global.wast:490: assert_invalid passed:
-  0000000: error: global variable out of range: 2 (max 2)
+  out/test/spec/extended-const/global/global.34.wasm:000003d: error: global variable out of range: 2 (max 2)
   000003d: error: OnGlobalSetExpr callback failed
 out/test/spec/extended-const/global.wast:500: assert_invalid passed:
   out/test/spec/extended-const/global/global.35.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []

--- a/test/spec/func.txt
+++ b/test/spec/func.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/func.wast
 (;; STDOUT ;;;
 out/test/spec/func.wast:436: assert_invalid passed:
-  0000000: error: function type variable out of range: 2 (max 2)
+  out/test/spec/func/func.2.wasm:000001a: error: function type variable out of range: 2 (max 2)
   000001a: error: OnFunction callback failed
 out/test/spec/func.wast:448: assert_malformed passed:
   out/test/spec/func/func.3.wat:1:123: error: invalid func type index 2

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -4,10 +4,10 @@
 called host spectest.print_i32(i32:83) =>
 four(i32:83) =>
 out/test/spec/func_ptrs.wast:32: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/func_ptrs/func_ptrs.1.wasm:000000c: error: table variable out of range: 0 (max 0)
   000000c: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:33: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/func_ptrs/func_ptrs.2.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/func_ptrs.wast:36: assert_invalid passed:
   out/test/spec/func_ptrs/func_ptrs.3.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
@@ -19,10 +19,10 @@ out/test/spec/func_ptrs.wast:44: assert_invalid passed:
   out/test/spec/func_ptrs/func_ptrs.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
 out/test/spec/func_ptrs.wast:48: assert_invalid passed:
-  0000000: error: function type variable out of range: 42 (max 0)
+  out/test/spec/func_ptrs/func_ptrs.6.wasm:000000c: error: function type variable out of range: 42 (max 0)
   000000c: error: OnFunction callback failed
 out/test/spec/func_ptrs.wast:49: assert_invalid passed:
-  0000000: error: function type variable out of range: 43 (max 0)
+  out/test/spec/func_ptrs/func_ptrs.7.wasm:0000020: error: function type variable out of range: 43 (max 0)
   0000020: error: OnImportFunc callback failed
 out/test/spec/func_ptrs.wast:78: assert_trap passed: undefined table index
 out/test/spec/func_ptrs.wast:79: assert_trap passed: undefined table index

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -45,13 +45,13 @@ out/test/spec/global.wast:342: assert_invalid passed:
   out/test/spec/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
   0000028: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:347: assert_invalid passed:
-  0000000: error: initializer expression can only reference an imported global
+  out/test/spec/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
   000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:352: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/global/global.18.wasm:000000f: error: global variable out of range: 1 (max 1)
   000000f: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:357: assert_invalid passed:
-  0000000: error: global variable out of range: 2 (max 2)
+  out/test/spec/global/global.19.wasm:0000025: error: global variable out of range: 2 (max 2)
   0000025: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:362: assert_invalid passed:
   out/test/spec/global/global.20.wasm:0000029: error: initializer expression cannot reference a mutable global
@@ -65,28 +65,28 @@ out/test/spec/global.wast:400: assert_malformed passed:
 out/test/spec/global.wast:412: assert_malformed passed:
   0000011: error: global mutability must be 0 or 1
 out/test/spec/global.wast:426: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/global/global.27.wasm:000001a: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:431: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/global/global.28.wasm:0000022: error: global variable out of range: 1 (max 1)
   0000022: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:439: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/global/global.29.wasm:0000034: error: global variable out of range: 1 (max 1)
   0000034: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:447: assert_invalid passed:
-  0000000: error: global variable out of range: 2 (max 2)
+  out/test/spec/global/global.30.wasm:000003c: error: global variable out of range: 2 (max 2)
   000003c: error: OnGlobalGetExpr callback failed
 out/test/spec/global.wast:457: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/global/global.31.wasm:000001b: error: global variable out of range: 0 (max 0)
   000001b: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:462: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/global/global.32.wasm:0000023: error: global variable out of range: 1 (max 1)
   0000023: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:470: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/global/global.33.wasm:0000035: error: global variable out of range: 1 (max 1)
   0000035: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:478: assert_invalid passed:
-  0000000: error: global variable out of range: 2 (max 2)
+  out/test/spec/global/global.34.wasm:000003d: error: global variable out of range: 2 (max 2)
   000003d: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:488: assert_invalid passed:
   out/test/spec/global/global.35.wasm:0000021: error: type mismatch in global.set, expected [i32] but got []

--- a/test/spec/imports.txt
+++ b/test/spec/imports.txt
@@ -12,7 +12,7 @@ called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/imports.wast:93: assert_invalid passed:
-  0000000: error: function type variable out of range: 1 (max 1)
+  out/test/spec/imports/imports.2.wasm:000001e: error: function type variable out of range: 1 (max 1)
   000001e: error: OnImportFunc callback failed
 called host spectest.print_i32(i32:13) =>
 out/test/spec/imports.wast:129: assert_unlinkable passed:

--- a/test/spec/local_get.txt
+++ b/test/spec/local_get.txt
@@ -32,22 +32,22 @@ out/test/spec/local_get.wast:193: assert_invalid passed:
   out/test/spec/local_get/local_get.10.wasm:000001c: error: type mismatch at end of function, expected [] but got [f64]
   000001c: error: EndFunctionBody callback failed
 out/test/spec/local_get.wast:201: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_get/local_get.11.wasm:000001d: error: local variable out of range (max 2)
   000001d: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:205: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_get/local_get.12.wasm:0000020: error: local variable out of range (max 2)
   0000020: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:210: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_get/local_get.13.wasm:000001b: error: local variable out of range (max 2)
   000001b: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:214: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_get/local_get.14.wasm:000001f: error: local variable out of range (max 2)
   000001f: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:219: assert_invalid passed:
-  0000000: error: local variable out of range (max 3)
+  out/test/spec/local_get/local_get.15.wasm:000001e: error: local variable out of range (max 3)
   000001e: error: OnLocalGetExpr callback failed
 out/test/spec/local_get.wast:223: assert_invalid passed:
-  0000000: error: local variable out of range (max 3)
+  out/test/spec/local_get/local_get.16.wasm:0000021: error: local variable out of range (max 3)
   0000021: error: OnLocalGetExpr callback failed
 36/36 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/local_set.txt
+++ b/test/spec/local_set.txt
@@ -83,22 +83,22 @@ out/test/spec/local_set.wast:329: assert_invalid passed:
   out/test/spec/local_set/local_set.27.wasm:0000025: error: type mismatch in implicit return, expected [f64] but got []
   0000025: error: EndFunctionBody callback failed
 out/test/spec/local_set.wast:337: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_set/local_set.28.wasm:000001f: error: local variable out of range (max 2)
   000001f: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:341: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_set/local_set.29.wasm:0000022: error: local variable out of range (max 2)
   0000022: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:346: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_set/local_set.30.wasm:000001d: error: local variable out of range (max 2)
   000001d: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:350: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_set/local_set.31.wasm:0000021: error: local variable out of range (max 2)
   0000021: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:355: assert_invalid passed:
-  0000000: error: local variable out of range (max 3)
+  out/test/spec/local_set/local_set.32.wasm:0000020: error: local variable out of range (max 3)
   0000020: error: OnLocalSetExpr callback failed
 out/test/spec/local_set.wast:359: assert_invalid passed:
-  0000000: error: local variable out of range (max 3)
+  out/test/spec/local_set/local_set.33.wasm:0000023: error: local variable out of range (max 3)
   0000023: error: OnLocalSetExpr callback failed
 53/53 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/local_tee.txt
+++ b/test/spec/local_tee.txt
@@ -107,22 +107,22 @@ out/test/spec/local_tee.wast:607: assert_invalid passed:
   out/test/spec/local_tee/local_tee.35.wasm:0000020: error: type mismatch in local.tee, expected [f64] but got [i64]
   0000020: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:615: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_tee/local_tee.36.wasm:000001f: error: local variable out of range (max 2)
   000001f: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:619: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_tee/local_tee.37.wasm:0000022: error: local variable out of range (max 2)
   0000022: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:624: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_tee/local_tee.38.wasm:000001d: error: local variable out of range (max 2)
   000001d: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:628: assert_invalid passed:
-  0000000: error: local variable out of range (max 2)
+  out/test/spec/local_tee/local_tee.39.wasm:0000021: error: local variable out of range (max 2)
   0000021: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:633: assert_invalid passed:
-  0000000: error: local variable out of range (max 3)
+  out/test/spec/local_tee/local_tee.40.wasm:0000020: error: local variable out of range (max 3)
   0000020: error: OnLocalTeeExpr callback failed
 out/test/spec/local_tee.wast:637: assert_invalid passed:
-  0000000: error: local variable out of range (max 3)
+  out/test/spec/local_tee/local_tee.41.wasm:0000023: error: local variable out of range (max 3)
   0000023: error: OnLocalTeeExpr callback failed
 97/97 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/memory.txt
+++ b/test/spec/memory.txt
@@ -8,13 +8,13 @@ out/test/spec/memory.wast:11: assert_invalid passed:
   out/test/spec/memory/memory.7.wasm:0000023: error: only one memory block allowed
   0000023: error: OnMemory callback failed
 out/test/spec/memory.wast:20: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory/memory.11.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:21: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory/memory.12.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:22: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory/memory.13.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory.wast:25: assert_invalid passed:
   000001b: error: load/store memory 0 out of range 0
@@ -25,10 +25,10 @@ out/test/spec/memory.wast:33: assert_invalid passed:
 out/test/spec/memory.wast:37: assert_invalid passed:
   000001d: error: load/store memory 0 out of range 0
 out/test/spec/memory.wast:41: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory/memory.18.wasm:0000019: error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed
 out/test/spec/memory.wast:45: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory/memory.19.wasm:000001b: error: memory variable out of range: 0 (max 0)
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory.wast:51: assert_invalid passed:
   out/test/spec/memory/memory.20.wasm:000000e: error: max pages (0) must be >= initial pages (1)

--- a/test/spec/memory64/memory.txt
+++ b/test/spec/memory64/memory.txt
@@ -9,13 +9,13 @@ out/test/spec/memory64/memory.wast:11: assert_invalid passed:
   out/test/spec/memory64/memory/memory.7.wasm:0000023: error: only one memory block allowed
   0000023: error: OnMemory callback failed
 out/test/spec/memory64/memory.wast:20: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory/memory.11.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory.wast:21: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory/memory.12.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory.wast:22: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory/memory.13.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory.wast:25: assert_invalid passed:
   000001b: error: load/store memory 0 out of range 0
@@ -26,10 +26,10 @@ out/test/spec/memory64/memory.wast:33: assert_invalid passed:
 out/test/spec/memory64/memory.wast:37: assert_invalid passed:
   000001d: error: load/store memory 0 out of range 0
 out/test/spec/memory64/memory.wast:41: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory/memory.18.wasm:0000019: error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed
 out/test/spec/memory64/memory.wast:45: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory/memory.19.wasm:000001b: error: memory variable out of range: 0 (max 0)
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory64/memory.wast:51: assert_invalid passed:
   out/test/spec/memory64/memory/memory.20.wasm:000000e: error: max pages (0) must be >= initial pages (1)

--- a/test/spec/memory64/memory64.txt
+++ b/test/spec/memory64/memory64.txt
@@ -9,13 +9,13 @@ out/test/spec/memory64/memory64.wast:9: assert_invalid passed:
   out/test/spec/memory64/memory64/memory64.5.wasm:0000023: error: only one memory block allowed
   0000023: error: OnMemory callback failed
 out/test/spec/memory64/memory64.wast:18: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.9.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory64.wast:19: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.10.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory64.wast:20: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.11.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/memory64/memory64.wast:23: assert_invalid passed:
   000001b: error: load/store memory 0 out of range 0
@@ -26,10 +26,10 @@ out/test/spec/memory64/memory64.wast:31: assert_invalid passed:
 out/test/spec/memory64/memory64.wast:35: assert_invalid passed:
   000001d: error: load/store memory 0 out of range 0
 out/test/spec/memory64/memory64.wast:39: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.16.wasm:0000019: error: memory variable out of range: 0 (max 0)
   0000019: error: OnMemorySizeExpr callback failed
 out/test/spec/memory64/memory64.wast:43: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory64/memory64/memory64.17.wasm:000001b: error: memory variable out of range: 0 (max 0)
   out/test/spec/memory64/memory64/memory64.17.wasm:000001b: error: type mismatch in memory.grow, expected [i32] but got [i64]
   000001b: error: OnMemoryGrowExpr callback failed
 out/test/spec/memory64/memory64.wast:49: assert_invalid passed:

--- a/test/spec/memory_copy.txt
+++ b/test/spec/memory_copy.txt
@@ -21,8 +21,8 @@ out/test/spec/memory_copy.wast:3240: assert_trap passed: out of bounds memory ac
 out/test/spec/memory_copy.wast:3601: assert_trap passed: out of bounds memory access: memory.copy out of bound
 out/test/spec/memory_copy.wast:3962: assert_trap passed: out of bounds memory access: memory.copy out of bound
 out/test/spec/memory_copy.wast:4316: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory_copy/memory_copy.19.wasm:000002d: error: memory variable out of range: 0 (max 0)
+  out/test/spec/memory_copy/memory_copy.19.wasm:000002d: error: memory variable out of range: 0 (max 0)
   000002d: error: OnMemoryCopyExpr callback failed
 out/test/spec/memory_copy.wast:4322: assert_invalid passed:
   out/test/spec/memory_copy/memory_copy.20.wasm:0000036: error: type mismatch in memory.copy, expected [i32, i32, i32] but got [i32, i32, f32]

--- a/test/spec/memory_init.txt
+++ b/test/spec/memory_init.txt
@@ -8,7 +8,7 @@ test() =>
 out/test/spec/memory_init.wast:190: assert_invalid passed:
   0000023: error: data.drop requires data count section
 out/test/spec/memory_init.wast:196: assert_invalid passed:
-  0000000: error: data_segment variable out of range: 4 (max 1)
+  out/test/spec/memory_init/memory_init.5.wasm:000002c: error: data_segment variable out of range: 4 (max 1)
   000002c: error: OnDataDropExpr callback failed
 test() =>
 out/test/spec/memory_init.wast:217: assert_trap passed: out of bounds memory access: memory.init out of bounds
@@ -16,7 +16,7 @@ out/test/spec/memory_init.wast:224: assert_trap passed: out of bounds memory acc
 out/test/spec/memory_init.wast:227: assert_invalid passed:
   000002a: error: memory.init requires data count section
 out/test/spec/memory_init.wast:233: assert_invalid passed:
-  0000000: error: data_segment variable out of range: 1 (max 1)
+  out/test/spec/memory_init/memory_init.10.wasm:0000034: error: data_segment variable out of range: 1 (max 1)
   0000034: error: OnMemoryInitExpr callback failed
 test() =>
 out/test/spec/memory_init.wast:253: assert_trap passed: out of bounds memory access: memory.init out of bounds

--- a/test/spec/multi-memory/data.txt
+++ b/test/spec/multi-memory/data.txt
@@ -3,22 +3,22 @@
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
 out/test/spec/multi-memory/data.wast:294: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/multi-memory/data/data.39.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:302: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/multi-memory/data/data.40.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:315: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/multi-memory/data/data.41.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:326: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 0)
+  out/test/spec/multi-memory/data/data.42.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:338: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 1)
+  out/test/spec/multi-memory/data/data.43.wasm:0000012: error: memory variable out of range: 1 (max 1)
   0000012: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:360: assert_invalid passed:
-  0000000: error: memory variable out of range: 1 (max 0)
+  out/test/spec/multi-memory/data/data.44.wasm:000000d: error: memory variable out of range: 1 (max 0)
   000000d: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/data.wast:379: assert_invalid passed:
   out/test/spec/multi-memory/data/data.45.wasm:0000013: error: type mismatch in initializer expression, expected [i32] but got [i64]
@@ -51,10 +51,10 @@ out/test/spec/multi-memory/data.wast:453: assert_invalid passed:
   out/test/spec/multi-memory/data/data.54.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:467: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/multi-memory/data/data.55.wasm:0000013: error: global variable out of range: 0 (max 0)
   0000013: error: OnGlobalGetExpr callback failed
 out/test/spec/multi-memory/data.wast:475: assert_invalid passed:
-  0000000: error: global variable out of range: 1 (max 1)
+  out/test/spec/multi-memory/data/data.56.wasm:0000029: error: global variable out of range: 1 (max 1)
   0000029: error: OnGlobalGetExpr callback failed
 out/test/spec/multi-memory/data.wast:484: assert_invalid passed:
   out/test/spec/multi-memory/data/data.57.wasm:000002d: error: initializer expression cannot reference a mutable global

--- a/test/spec/multi-memory/imports.txt
+++ b/test/spec/multi-memory/imports.txt
@@ -13,7 +13,7 @@ called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 called host spectest.print_f64(f64:24.000000) =>
 out/test/spec/multi-memory/imports.wast:93: assert_invalid passed:
-  0000000: error: function type variable out of range: 1 (max 1)
+  out/test/spec/multi-memory/imports/imports.2.wasm:000001e: error: function type variable out of range: 1 (max 1)
   000001e: error: OnImportFunc callback failed
 called host spectest.print_i32(i32:13) =>
 out/test/spec/multi-memory/imports.wast:129: assert_unlinkable passed:

--- a/test/spec/multi-memory/memory.txt
+++ b/test/spec/multi-memory/memory.txt
@@ -3,13 +3,13 @@
 ;;; ARGS*: --enable-multi-memory
 (;; STDOUT ;;;
 out/test/spec/multi-memory/memory.wast:17: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/multi-memory/memory/memory.9.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/memory.wast:18: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/multi-memory/memory/memory.10.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/memory.wast:19: assert_invalid passed:
-  0000000: error: memory variable out of range: 0 (max 0)
+  out/test/spec/multi-memory/memory/memory.11.wasm:000000c: error: memory variable out of range: 0 (max 0)
   000000c: error: BeginDataSegment callback failed
 out/test/spec/multi-memory/memory.wast:22: assert_invalid passed:
   000001b: error: load/store memory 0 out of range 0

--- a/test/spec/ref_func.txt
+++ b/test/spec/ref_func.txt
@@ -4,13 +4,13 @@
 set-g() =>
 set-f() =>
 out/test/spec/ref_func.wast:69: assert_invalid passed:
-  0000000: error: function variable out of range: 7 (max 2)
+  out/test/spec/ref_func/ref_func.2.wasm:0000026: error: function variable out of range: 7 (max 2)
   0000026: error: OnRefFuncExpr callback failed
 out/test/spec/ref_func.wast:109: assert_invalid passed:
-  0000000: error: function 0 is not declared in any elem sections
+  out/test/spec/ref_func/ref_func.4.wasm:0000019: error: function 0 is not declared in any elem sections
   000001b: error: EndModule callback failed
 out/test/spec/ref_func.wast:113: assert_invalid passed:
-  0000000: error: function 0 is not declared in any elem sections
+  out/test/spec/ref_func/ref_func.5.wasm:000001c: error: function 0 is not declared in any elem sections
   000001e: error: EndModule callback failed
 16/16 tests passed.
 ;;; STDOUT ;;)

--- a/test/spec/simd_load.txt
+++ b/test/spec/simd_load.txt
@@ -32,7 +32,7 @@ out/test/spec/simd_load.wast:174: assert_invalid passed:
   out/test/spec/simd_load/simd_load.19.wasm:0000025: error: type mismatch at end of function, expected [] but got [v128]
   0000025: error: EndFunctionBody callback failed
 out/test/spec/simd_load.wast:182: assert_invalid passed:
-  0000000: error: local variable out of range (max 0)
+  out/test/spec/simd_load/simd_load.20.wasm:000001e: error: local variable out of range (max 0)
   000001e: error: OnLocalGetExpr callback failed
 out/test/spec/simd_load.wast:186: assert_invalid passed:
   out/test/spec/simd_load/simd_load.21.wasm:0000020: error: type mismatch in v128.load, expected [i32] but got []

--- a/test/spec/start.txt
+++ b/test/spec/start.txt
@@ -2,7 +2,7 @@
 ;;; STDIN_FILE: third_party/testsuite/start.wast
 (;; STDOUT ;;;
 out/test/spec/start.wast:2: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/start/start.0.wasm:0000015: error: function variable out of range: 1 (max 1)
   0000015: error: OnStartFunction callback failed
 out/test/spec/start.wast:7: assert_invalid passed:
   out/test/spec/start/start.1.wasm:0000016: error: start function must not return anything

--- a/test/spec/table.txt
+++ b/test/spec/table.txt
@@ -2,10 +2,10 @@
 ;;; STDIN_FILE: third_party/testsuite/table.wast
 (;; STDOUT ;;;
 out/test/spec/table.wast:14: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/table/table.9.wasm:000000c: error: table variable out of range: 0 (max 0)
   000000c: error: BeginElemSegment callback failed
 out/test/spec/table.wast:15: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
+  out/test/spec/table/table.10.wasm:0000016: error: table variable out of range: 0 (max 0)
   0000016: error: BeginElemSegment callback failed
 out/test/spec/table.wast:19: assert_invalid passed:
   out/test/spec/table/table.11.wasm:000000f: error: max elems (0) must be >= initial elems (1)

--- a/test/spec/table_init.txt
+++ b/test/spec/table_init.txt
@@ -108,18 +108,18 @@ out/test/spec/table_init.wast:375: assert_trap passed: uninitialized table eleme
 out/test/spec/table_init.wast:376: assert_trap passed: uninitialized table element
 out/test/spec/table_init.wast:377: assert_trap passed: uninitialized table element
 out/test/spec/table_init.wast:379: assert_invalid passed:
-  0000000: error: elem_segment variable out of range: 0 (max 0)
+  out/test/spec/table_init/table_init.7.wasm:0000024: error: elem_segment variable out of range: 0 (max 0)
   0000024: error: OnElemDropExpr callback failed
 out/test/spec/table_init.wast:385: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
-  0000000: error: elem_segment variable out of range: 0 (max 0)
+  out/test/spec/table_init/table_init.8.wasm:000002b: error: table variable out of range: 0 (max 0)
+  out/test/spec/table_init/table_init.8.wasm:000002b: error: elem_segment variable out of range: 0 (max 0)
   000002b: error: OnTableInitExpr callback failed
 out/test/spec/table_init.wast:391: assert_invalid passed:
-  0000000: error: elem_segment variable out of range: 4 (max 1)
+  out/test/spec/table_init/table_init.9.wasm:0000035: error: elem_segment variable out of range: 4 (max 1)
   0000035: error: OnElemDropExpr callback failed
 out/test/spec/table_init.wast:399: assert_invalid passed:
-  0000000: error: table variable out of range: 0 (max 0)
-  0000000: error: elem_segment variable out of range: 4 (max 1)
+  out/test/spec/table_init/table_init.10.wasm:000003c: error: table variable out of range: 0 (max 0)
+  out/test/spec/table_init/table_init.10.wasm:000003c: error: elem_segment variable out of range: 4 (max 1)
   000003c: error: OnTableInitExpr callback failed
 test() =>
 out/test/spec/table_init.wast:453: assert_trap passed: out of bounds table access: table.init out of bounds

--- a/test/spec/unreached-invalid.txt
+++ b/test/spec/unreached-invalid.txt
@@ -2,13 +2,13 @@
 ;;; STDIN_FILE: third_party/testsuite/unreached-invalid.wast
 (;; STDOUT ;;;
 out/test/spec/unreached-invalid.wast:4: assert_invalid passed:
-  0000000: error: local variable out of range (max 0)
+  out/test/spec/unreached-invalid/unreached-invalid.0.wasm:000001a: error: local variable out of range (max 0)
   000001a: error: OnLocalGetExpr callback failed
 out/test/spec/unreached-invalid.wast:8: assert_invalid passed:
-  0000000: error: global variable out of range: 0 (max 0)
+  out/test/spec/unreached-invalid/unreached-invalid.1.wasm:000001a: error: global variable out of range: 0 (max 0)
   000001a: error: OnGlobalGetExpr callback failed
 out/test/spec/unreached-invalid.wast:12: assert_invalid passed:
-  0000000: error: function variable out of range: 1 (max 1)
+  out/test/spec/unreached-invalid/unreached-invalid.2.wasm:000001a: error: function variable out of range: 1 (max 1)
   000001a: error: OnCallExpr callback failed
 out/test/spec/unreached-invalid.wast:16: assert_invalid passed:
   out/test/spec/unreached-invalid/unreached-invalid.3.wasm:0000018: error: invalid depth: 1 (max 0)


### PR DESCRIPTION
The BinaryReaderIR and BinaryReaderInterp were converting a lot of Indexes to Vars without tagging them with the source location, as discovered/discussed at https://github.com/WebAssembly/wabt/pull/1962#discussion_r946069037 .

The PR has the reader delegates tag each Index with the current location when converting to Var. Split out from #1962.