### PR TITLE
CI: Move emscripten build to official Docker image (emsdk:latest)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,7 +74,7 @@ jobs:
         submodules: true
     - name: build
       run: |
-        docker run -di --name emscripten -v $(pwd):/src trzeci/emscripten:1.39.10-upstream bash
+        docker run -di --name emscripten -v $(pwd):/src emscripten/emsdk:latest bash
         docker exec emscripten emcc -v
         docker exec emscripten emcmake cmake .
         docker exec emscripten make -j 2 VERBOSE=1


### PR DESCRIPTION
The `trzeci/emscripten` images are now described as deprecated (https://hub.docker.com/r/trzeci/emscripten/). emsdk:latest is pretty fast moving which is a bit of a risk, but in principle not that different from the depenency on ubuntu-latest and windows-latest (and previously macos-latest).