### PR TITLE
Raise minimum CMake version to 3.16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,3 +116,35 @@ jobs:
     - run: make clang-release-ubsan
     - run: make test-clang-debug-ubsan
     - run: make test-clang-release-ubsan
+
+  build-min-cmake:
+    name: min-cmake
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+    - uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install Ninja
+      run: sudo apt-get install ninja-build
+    - name: Detect minimum CMake version
+      run: >
+        awk 'match($0, /cmake_minimum_required\(VERSION *([0-9]+\.[0-9]+)\)/, a)
+        { print "WABT_CMAKE_VER=" a[1] }' CMakeLists.txt | tee $GITHUB_ENV
+    - name: Install minimum CMake
+      run: |
+        python -m pip install -U setuptools wheel pip
+        python -m pip install "cmake==${WABT_CMAKE_VER}.*"
+        cmake --version
+    - name: Configure WABT
+      run: cmake -G Ninja -S . -B out -DCMAKE_BUILD_TYPE=Release
+    - name: build
+      run: cmake --build out
+    - name: unittests
+      run: cmake --build out --target run-unittests
+    - name: c-api-tests
+      run: cmake --build out --target run-c-api-tests
+    - name: tests
+      run: cmake --build out --target run-tests

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,16 +14,13 @@
 # limitations under the License.
 #
 
-cmake_minimum_required(VERSION 3.1.0)
+cmake_minimum_required(VERSION 3.16)
 project(WABT LANGUAGES C CXX VERSION 1.0.29)
+
 include(GNUInstallDirs)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-
-if (POLICY CMP0077)
-  cmake_policy(SET CMP0077 NEW)
-endif (POLICY CMP0077)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -631,10 +628,6 @@ if (BUILD_TESTS)
     LIBS gtest_main gtest ${CMAKE_THREAD_LIBS_INIT}
   )
 
-  if (NOT CMAKE_VERSION VERSION_LESS "3.2")
-    set(USES_TERMINAL USES_TERMINAL)
-  endif ()
-
   # test running
   set(RUN_TESTS_PY ${WABT_SOURCE_DIR}/test/run-tests.py)
 
@@ -642,20 +635,20 @@ if (BUILD_TESTS)
     COMMAND ${PYTHON_EXECUTABLE} ${RUN_TESTS_PY} --bindir $<TARGET_FILE_DIR:wat2wasm>
     DEPENDS ${WABT_EXECUTABLES}
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-    ${USES_TERMINAL}
+    USES_TERMINAL
   )
 
   add_custom_target(run-unittests
     COMMAND $<TARGET_FILE:wabt-unittests>
     DEPENDS wabt-unittests
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-    ${USES_TERMINAL}
+    USES_TERMINAL
   )
 
   add_custom_target(run-c-api-tests
     COMMAND ${PYTHON_EXECUTABLE} ${WABT_SOURCE_DIR}/test/run-c-api-examples.py --bindir $<TARGET_FILE_DIR:wat2wasm>
     WORKING_DIRECTORY ${WABT_SOURCE_DIR}
-    ${USES_TERMINAL}
+    USES_TERMINAL
   )
 
   add_custom_target(check DEPENDS run-unittests run-tests run-c-api-tests)


### PR DESCRIPTION
The stated minimum, 3.1, was released on Dec 17, 2014 and did not support a value of 17 for `CMAKE_CXX_STANDARD`. The first version to do so was 3.8. In fact, attempting to build with CMake 3.7 fails with errors like:

```
CMake Error in CMakeLists.txt:
  Target "wasm-strip" requires the language dialect "CXX17" , but CMake does
  not know the compile flags to use to enable it.
```

So we might as well take this chance to raise the minimum to something more recent. I propose 3.16 here because of the following features:

* CMP0077 (v3.13) makes the lives of `FetchContent` users easier by allowing `option()` to be overridden.
* CMP0082 (v3.14) corrects the semantics of `install()` rules, which is relevant for `FetchContent` users.
* CMake 3.12 allows the namelink of a shared library on Linux to be installed separately (i.e. in a dev package)
* CMake 3.14 integrates the standard install destination variables from `GNUInstallDirs` with the `install()` command.
* CMake 3.15 introduced the `CMAKE_MSVC_RUNTIME_LIBRARY` variable for controlling the selection of the runtime library from the outside.
* CMake 3.16 gained support for generator expressions in RPATH properties, which will make it easier to ship shared libraries.

This version is quite conservative and I would even suggest upgrading further. Windows and macOS users enjoy frequent updates from Homebrew and Microsoft Visual Studio. Ubuntu Linux 20.04 LTS ships 3.16 and the newest LTS ships 3.22. Linux users can always install the latest version through PIP, even on ARM, PowerPC, and s390x, and even without sudo.

I have also added a GHA job to the CI workflow to test that WABT builds under its stated minimum version. This should prevent unintentional compatibility issues from creeping in. The other workflows can use newer CMake versions to catch issues there.

Fixes #1568