### PR TITLE
Fix architecture checks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,46 +170,22 @@ else ()
     add_definitions(-Wno-clobbered)
   endif ()
 
+  # wasm doesn't allow for x87 floating point math
   if (NOT EMSCRIPTEN)
-    # try to get the target architecture by compiling a dummy.c file and
-    # checking the architecture using the file command.
-    file(WRITE ${WABT_BINARY_DIR}/dummy.c "main(){}")
-    try_compile(
-      COMPILE_OK
-      ${WABT_BINARY_DIR}
-      ${WABT_BINARY_DIR}/dummy.c
-      COPY_FILE ${WABT_BINARY_DIR}/dummy
-    )
-    if (COMPILE_OK)
-      execute_process(
-        COMMAND file ${WABT_BINARY_DIR}/dummy
-        RESULT_VARIABLE FILE_RESULT
-        OUTPUT_VARIABLE FILE_OUTPUT
-        ERROR_QUIET
-      )
+    check_symbol_exists(__i386__ "" TARGET_IS_X86_32)
+    check_symbol_exists(__SSE2_MATH__ "" HAVE_SSE2_MATH)
 
-      if (FILE_RESULT EQUAL 0)
-        if (${FILE_OUTPUT} MATCHES "x86[-_]64")
-          set(TARGET_ARCH "x86-64")
-        elseif (${FILE_OUTPUT} MATCHES "Intel 80386")
-          set(TARGET_ARCH "i386")
-        elseif (${FILE_OUTPUT} MATCHES "ARM")
-          set(TARGET_ARCH "ARM")
-        elseif (${FILE_OUTPUT} MATCHES "IBM S/390")
-          set(TARGET_ARCH "s390x")
-        else ()
-          message(WARNING "Unknown target architecture!")
-        endif ()
+    if (TARGET_IS_X86_32 AND NOT HAVE_SSE2_MATH)
+      if (COMPILER_IS_GNU OR COMPILER_IS_CLANG)
+        add_definitions(-msse2 -mfpmath=sse)
       else ()
-        message(WARNING "Error running `file` command on dummy executable")
+        message(
+          WARNING
+          "Unknown compiler ${CMAKE_CXX_COMPILER_ID} appears to target x86_32 with x87 "
+          "math. Please add flags to use SSE2 math and set TARGET_IS_X86_32 and "
+          "HAVE_SSE2_MATH appropriately at the CMake command line."
+        )
       endif ()
-    else ()
-      message(WARNING "Error compiling dummy.c file")
-    endif ()
-
-    if (TARGET_ARCH STREQUAL "i386")
-      # wasm doesn't allow for x87 floating point math
-      add_definitions(-msse2 -mfpmath=sse)
     endif ()
   endif ()
 endif ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,6 +108,9 @@ include(CheckTypeSize)
 check_type_size(ssize_t SSIZE_T)
 check_type_size(size_t SIZEOF_SIZE_T)
 
+include(TestBigEndian)  # Note: deprecated in CMake 3.20
+test_big_endian(WABT_BIG_ENDIAN)
+
 configure_file(src/config.h.in include/wabt/config.h @ONLY)
 
 
@@ -207,9 +210,6 @@ else ()
     if (TARGET_ARCH STREQUAL "i386")
       # wasm doesn't allow for x87 floating point math
       add_definitions(-msse2 -mfpmath=sse)
-    endif ()
-    if (TARGET_ARCH STREQUAL "s390x")
-      add_definitions(-DWABT_BIG_ENDIAN=1)
     endif ()
   endif ()
 endif ()
@@ -384,6 +384,9 @@ endif ()
 IF (NOT WIN32)
   add_library(wasm-rt-impl STATIC wasm2c/wasm-rt-impl.c wasm2c/wasm-rt-impl.h)
   add_library(wabt::wasm-rt-impl ALIAS wasm-rt-impl)
+  if (WABT_BIG_ENDIAN)
+    target_compile_definitions(wasm-rt-impl PUBLIC WABT_BIG_ENDIAN=1)
+  endif ()
 
   if (WABT_INSTALL_RULES)
     install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,13 +177,14 @@ else ()
 
     if (TARGET_IS_X86_32 AND NOT HAVE_SSE2_MATH)
       if (COMPILER_IS_GNU OR COMPILER_IS_CLANG)
-        add_definitions(-msse2 -mfpmath=sse)
+        add_compile_options(-msse2 -mfpmath=sse)
       else ()
         message(
           WARNING
-          "Unknown compiler ${CMAKE_CXX_COMPILER_ID} appears to target x86_32 with x87 "
-          "math. Please add flags to use SSE2 math and set TARGET_IS_X86_32 and "
-          "HAVE_SSE2_MATH appropriately at the CMake command line."
+          "Unknown compiler ${CMAKE_CXX_COMPILER_ID} appears to target x86-32 with x87 "
+          "math. If you want wasm2c to work in a spec-compliant way, please add flags to "
+          "use SSE2 math and set TARGET_IS_X86_32 and HAVE_SSE2_MATH appropriately at the "
+          "CMake command line."
         )
       endif ()
     endif ()

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -42,6 +42,9 @@
 /* Whether ENABLE_VIRTUAL_TERMINAL_PROCESSING is defined by windows.h */
 #cmakedefine01 HAVE_WIN32_VT100
 
+/* Whether the target architecture is big endian */
+#cmakedefine01 WABT_BIG_ENDIAN
+
 #cmakedefine01 COMPILER_IS_CLANG
 #cmakedefine01 COMPILER_IS_GNU
 #cmakedefine01 COMPILER_IS_MSVC

--- a/test/run-tests.py
+++ b/test/run-tests.py
@@ -39,7 +39,7 @@ DEFAULT_TIMEOUT = 120    # seconds
 SLOW_TIMEOUT_MULTIPLIER = 3
 
 if sys.byteorder == 'big':
-    wasm2c_args = ['--cflags=-DWABT_BIG_ENDIAN']
+    wasm2c_args = ['--cflags=-DWABT_BIG_ENDIAN=1']
 else:
     wasm2c_args = []
 


### PR DESCRIPTION
This PR consists of two tightly related changes. It depends on #1968 

### 1. Fix x87 math detection

`TARGET_ARCH` was only used to determine whether to add gcc-specific SSE math flags (`-msse2 -mfpmath=sse`). The new approach simply assumes gcc compatibility with its `__i386__` and `__SSE2_MATH__` symbols, which are defined precisely when we are targeting x86-32 with SSE2 math enabled. If those macros are defined, then we conclude all is well. Otherwise, we
add the flags if we know the compiler is gcc or clang (and will thus accept them) and issue a warning if the compiler is unknown.

Fixes #1709
Fixes #1688

### 2. Use standard modules to test endianness

CMake prior to v3.20 provides a module TestBigEndian which we can use to set the `WABT_BIG_ENDIAN` define. As of 3.20, the `CMAKE_<LANG>_BYTE_ORDER` variable should be preferred. Leaving this as a note for the future.