### PR TITLE
Add GHA workflows for testing s390x and i386

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,3 +152,31 @@ jobs:
       run: cmake --build out --target run-c-api-tests
     - name: tests
       run: cmake --build out --target run-tests
+
+  build-arch:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [s390x, i386]
+    steps:
+    - uses: actions/checkout@v1
+      with:
+        submodules: true
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+      with:
+        platforms: ${{matrix.arch}}
+
+    - name: Build image
+      run: docker build --platform linux/${{matrix.arch}} -t wabt -f scripts/Dockerfile .
+
+    - name: Unit tests
+      run: docker run --rm -t wabt cmake --build build --target run-unittests
+
+    - name: C API tests
+      run: docker run --rm -t wabt cmake --build build --target run-c-api-tests
+
+    - name: Tests
+      run: docker run --rm -t wabt cmake --build build --target run-tests

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -5,11 +5,12 @@ WORKDIR /ws
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
 
-COPY . .
-
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
     echo $TZ > /etc/timezone && \
     apt-get update && \
-    apt-get install -y git g++ cmake ninja-build python3 file && \
-    cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    apt-get install -y git g++ cmake ninja-build python3 file
+
+COPY . .
+
+RUN cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release && \
     cmake --build build

--- a/scripts/Dockerfile
+++ b/scripts/Dockerfile
@@ -1,0 +1,15 @@
+FROM debian:latest
+
+WORKDIR /ws
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+COPY . .
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && \
+    echo $TZ > /etc/timezone && \
+    apt-get update && \
+    apt-get install -y git g++ cmake ninja-build python3 file && \
+    cmake -G Ninja -S . -B build -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build


### PR DESCRIPTION
The failures in these workflows on CI match what I observed locally while testing #1969.

* Opened #1972 for an s390x failure discovered by this testing.
* Opened #1973 for i386 failures discovered by this testing.

Hopefully once the failures are fixed, this will prevent future regressions.