### PR TITLE
Build fixes for FetchContent users

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,10 +25,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 # Check if wabt is being used directly or via add_subdirectory, FetchContent, etc
-set(WABT_MASTER_PROJECT OFF)
-if (CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
-  set(WABT_MASTER_PROJECT ON)
-endif()
+string(COMPARE EQUAL "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}" PROJECT_IS_TOP_LEVEL)
 
 # For git users, attempt to generate a more useful version string
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
@@ -43,9 +40,9 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
               GIT_VERSION
           OUTPUT_STRIP_TRAILING_WHITESPACE)
   if (${GIT_VERSION_RESULT})
-    # Don't issue warning if we aren't the master project;
+    # Don't issue warning if we aren't the top-level project;
     # just assume that whoever included us knows the version they are getting
-    if (WABT_MASTER_PROJECT)
+    if (PROJECT_IS_TOP_LEVEL)
       message(WARNING "${GIT_VERSION_ERROR} Error running git describe to determine version")
     endif()
   else ()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,10 +359,14 @@ add_library(wabt STATIC ${WABT_LIBRARY_SRC})
 IF (NOT WIN32)
   add_library(wasm-rt-impl STATIC wasm2c/wasm-rt-impl.c wasm2c/wasm-rt-impl.h)
   if (WABT_INSTALL_RULES)
-    install(TARGETS wasm-rt-impl)
     install(
-      FILES wasm2c/wasm-rt.h wasm2c/wasm-rt-impl.h
+      TARGETS wasm-rt-impl
+      COMPONENT wabt-development
+    )
+    install(
+      FILES "wasm2c/wasm-rt-impl.h" "wasm2c/wasm-rt.h"
       TYPE INCLUDE
+      COMPONENT wabt-development
     )
   endif ()
 endif ()
@@ -693,15 +697,17 @@ endif ()
 
 # install
 if (WABT_INSTALL_RULES AND (BUILD_TOOLS OR BUILD_TESTS))
-  install(TARGETS ${WABT_EXECUTABLES})
+  install(
+    TARGETS ${WABT_EXECUTABLES}
+    COMPONENT wabt-runtime
+  )
   if (UNIX)
-    file(GLOB MAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/man/*.1")
-    foreach(MAN_FILE ${MAN_FILES})
-      install(
-        FILES ${MAN_FILE}
-        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/
-      )
-    endforeach()
+    install(
+      DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}/man/"
+      DESTINATION ${CMAKE_INSTALL_MANDIR}/man1
+      COMPONENT wabt-documentation
+      FILES_MATCHING PATTERN "*.1"
+    )
   endif ()
 endif ()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,7 @@ option(USE_UBSAN "Use undefined behavior sanitizer" OFF)
 option(CODE_COVERAGE "Build with code coverage enabled" OFF)
 option(WITH_EXCEPTIONS "Build with exceptions enabled" OFF)
 option(WERROR "Build with warnings as errors" OFF)
+option(WABT_INSTALL_RULES "Include WABT's install() rules" "${PROJECT_IS_TOP_LEVEL}")
 # WASI support is still a work in progress.
 # Only a handful of syscalls are supported at this point.
 option(WITH_WASI "Build WASI support via uvwasi" OFF)
@@ -357,8 +358,10 @@ add_library(wabt STATIC ${WABT_LIBRARY_SRC})
 
 IF (NOT WIN32)
   add_library(wasm-rt-impl STATIC wasm2c/wasm-rt-impl.c wasm2c/wasm-rt-impl.h)
-  install(TARGETS wasm-rt-impl DESTINATION ${CMAKE_INSTALL_LIBDIR})
-  install(FILES wasm2c/wasm-rt.h wasm2c/wasm-rt-impl.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  if (WABT_INSTALL_RULES)
+    install(TARGETS wasm-rt-impl DESTINATION ${CMAKE_INSTALL_LIBDIR})
+    install(FILES wasm2c/wasm-rt.h wasm2c/wasm-rt-impl.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+  endif ()
 endif ()
 
 if (BUILD_FUZZ_TOOLS)
@@ -686,12 +689,9 @@ if (BUILD_TESTS)
 endif ()
 
 # install
-if (BUILD_TOOLS OR BUILD_TESTS)
+if (WABT_INSTALL_RULES AND (BUILD_TOOLS OR BUILD_TESTS))
   install(TARGETS ${WABT_EXECUTABLES} DESTINATION bin)
   if (UNIX)
-    if (NOT CMAKE_INSTALL_MANDIR)
-      include(GNUInstallDirs)
-    endif ()
     file(GLOB MAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/man/*.1")
     foreach(MAN_FILE ${MAN_FILES})
       install(FILES ${MAN_FILE}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -359,8 +359,11 @@ add_library(wabt STATIC ${WABT_LIBRARY_SRC})
 IF (NOT WIN32)
   add_library(wasm-rt-impl STATIC wasm2c/wasm-rt-impl.c wasm2c/wasm-rt-impl.h)
   if (WABT_INSTALL_RULES)
-    install(TARGETS wasm-rt-impl DESTINATION ${CMAKE_INSTALL_LIBDIR})
-    install(FILES wasm2c/wasm-rt.h wasm2c/wasm-rt-impl.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+    install(TARGETS wasm-rt-impl)
+    install(
+      FILES wasm2c/wasm-rt.h wasm2c/wasm-rt-impl.h
+      TYPE INCLUDE
+    )
   endif ()
 endif ()
 
@@ -690,12 +693,14 @@ endif ()
 
 # install
 if (WABT_INSTALL_RULES AND (BUILD_TOOLS OR BUILD_TESTS))
-  install(TARGETS ${WABT_EXECUTABLES} DESTINATION bin)
+  install(TARGETS ${WABT_EXECUTABLES})
   if (UNIX)
     file(GLOB MAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/man/*.1")
     foreach(MAN_FILE ${MAN_FILES})
-      install(FILES ${MAN_FILE}
-        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/)
+      install(
+        FILES ${MAN_FILE}
+        DESTINATION ${CMAKE_INSTALL_MANDIR}/man1/
+      )
     endforeach()
   endif ()
 endif ()

--- a/cmake/README.md
+++ b/cmake/README.md
@@ -1,3 +1,0 @@
-FindRE2C.cmake is copied from the [CMakeXFind
-repository](https://github.com/julp/CMakeXFind). This makes it more convenient
-to build for users who can't/won't run `git submodule update --init`.


### PR DESCRIPTION
This PR makes two important fixes for FetchContent users.

### 1. Add WABT_INSTALL_RULES option

This option is enabled by default when WABT is the top-level project and disabled by default when it is not. It is used (and should continue to be used) to guard uses of the install() command.

This fixes an issue where FetchContent users were forced to install parts of WABT. This most notably included the wasm-rt-impl library and its associated headers.

### 2. Add components to install() rules

By default, CMake assigns every install() rule to an "Unspecified" component. By adding COMPONENT annotations, users become empowered to install only the parts of WABT that they need. WABT now provides three components:

1. `wabt-runtime` - the executables in WABT_EXECUTABLES
2. `wabt-development` - the wasm-rt static library and headers
3. `wabt-documentation` - the man pages, on UNIX only

Users can access this functionality using, e.g.:
```
cmake --install build --component wabt-development
```
**When a user specifies no component, all are installed.**

FetchContent users benefit as well. If they enable WABT's install rules, they can build accurate packaging dependencies around these components.

---

There are also a handful of small drive-by fixes: (1) rename `WABT_MASTER_PROJECT` to [`PROJECT_IS_TOP_LEVEL`](https://cmake.org/cmake/help/latest/variable/PROJECT_IS_TOP_LEVEL.html?)for easier CMake upgrades down the line. (2) drop arguments to `install()` rules that match defaults as of CMake 3.14+. (3) delete the top-level `cmake/` folder that doesn't have anything useful in it.