### PR TITLE
Fix git describe behavior

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,12 +46,12 @@ if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
       message(WARNING "${GIT_VERSION_ERROR} Error running git describe to determine version")
     endif()
   else ()
-    set(CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION} (${GIT_VERSION})")
+    set(WABT_VERSION_STRING "${WABT_VERSION_STRING} (${GIT_VERSION})")
   endif ()
 endif ()
 
-if (NOT "${CMAKE_PROJECT_VERSION}")
-  set(CMAKE_PROJECT_VERSION ${PROJECT_VERSION})
+if (NOT "${WABT_VERSION_STRING}")
+  set(WABT_VERSION_STRING ${PROJECT_VERSION})
 endif()
 
 option(BUILD_TESTS "Build GTest-based tests" ON)
@@ -109,10 +109,7 @@ include(CheckTypeSize)
 check_type_size(ssize_t SSIZE_T)
 check_type_size(size_t SIZEOF_SIZE_T)
 
-configure_file(
-  ${WABT_SOURCE_DIR}/src/config.h.in
-  ${WABT_BINARY_DIR}/config.h
-)
+configure_file(src/config.h.in config.h @ONLY)
 
 include_directories(${WABT_SOURCE_DIR} ${WABT_BINARY_DIR})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,32 +27,31 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 # Check if wabt is being used directly or via add_subdirectory, FetchContent, etc
 string(COMPARE EQUAL "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_SOURCE_DIR}" PROJECT_IS_TOP_LEVEL)
 
+# By default use the project version as the version string
+set(WABT_VERSION_STRING "${PROJECT_VERSION}")
+
 # For git users, attempt to generate a more useful version string
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
-  find_package(Git QUIET REQUIRED)
-  execute_process(COMMAND
-          "${GIT_EXECUTABLE}" --git-dir=${CMAKE_CURRENT_SOURCE_DIR}/.git describe --tags
-          RESULT_VARIABLE
-              GIT_VERSION_RESULT
-          ERROR_VARIABLE
-              GIT_VERSION_ERROR
-          OUTPUT_VARIABLE
-              GIT_VERSION
-          OUTPUT_STRIP_TRAILING_WHITESPACE)
-  if (${GIT_VERSION_RESULT})
-    # Don't issue warning if we aren't the top-level project;
-    # just assume that whoever included us knows the version they are getting
-    if (PROJECT_IS_TOP_LEVEL)
-      message(WARNING "${GIT_VERSION_ERROR} Error running git describe to determine version")
-    endif()
-  else ()
-    set(WABT_VERSION_STRING "${WABT_VERSION_STRING} (${GIT_VERSION})")
+  find_package(Git)
+  if (Git_FOUND)
+    execute_process(
+      COMMAND "${GIT_EXECUTABLE}" -C "${WABT_SOURCE_DIR}" describe --tags
+      RESULT_VARIABLE GIT_VERSION_RESULT
+      ERROR_VARIABLE GIT_VERSION_ERROR
+      ERROR_STRIP_TRAILING_WHITESPACE
+      OUTPUT_VARIABLE GIT_VERSION
+      OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
+    if (GIT_VERSION_RESULT EQUAL 0)
+      # If we're actually on the tag for this version, don't add the commit description
+      if (NOT GIT_VERSION STREQUAL "${WABT_VERSION_STRING}")
+        string(APPEND WABT_VERSION_STRING " (git~${GIT_VERSION})")
+      endif ()
+    elseif (PROJECT_IS_TOP_LEVEL)
+      message(NOTICE "git: ${GIT_VERSION_ERROR}\n  ** Did you forget to run `git fetch --tags`?")
+    endif ()
   endif ()
 endif ()
-
-if (NOT "${WABT_VERSION_STRING}")
-  set(WABT_VERSION_STRING ${PROJECT_VERSION})
-endif()
 
 option(BUILD_TESTS "Build GTest-based tests" ON)
 option(USE_SYSTEM_GTEST "Use system GTest, instead of building" OFF)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -20,7 +20,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#cmakedefine CMAKE_PROJECT_VERSION "${CMAKE_PROJECT_VERSION}"
+#cmakedefine WABT_VERSION_STRING "@WABT_VERSION_STRING@"
 
 /* TODO(binji): nice way to define these with WABT_ prefix? */
 

--- a/src/option-parser.cc
+++ b/src/option-parser.cc
@@ -56,7 +56,7 @@ OptionParser::OptionParser(const char* program_name, const char* description)
     exit(0);
   });
   AddOption("version", "Print version information", []() {
-    printf("%s\n", CMAKE_PROJECT_VERSION);
+    printf("%s\n", WABT_VERSION_STRING);
     exit(0);
   });
 }


### PR DESCRIPTION
Before this commit, the attempt to add the output of `git describe` to the version string printed by `$wasm-tool --version` was bugged. It would always print the three-part version number (like 1.0.29).

After this commit, the output of `git describe --tags` is used to append a description to the version number in the form of: `ver (git~desc)`. For example:

    $ ./wasm2c --version
    1.0.29 (git~1.0.29-27-gf63184ef)

If this command returns a tag equal in name to the current version, nothing is appended.

If this command fails, a NOTICE (rather than a WARNING) is printed (only if the project is top-level), and only the bare version number is used. If the source code is not living in the git repository then, again, only the bare number is used, but no warning is printed.

Fixes #1977
Fixes #1978