### PR TITLE
Finish updating testsuite

### DIFF
--- a/include/wabt/wast-lexer.h
+++ b/include/wabt/wast-lexer.h
@@ -54,7 +54,7 @@ class WastLexer {
 
  private:
   static const int kEof = -1;
-  enum class CharClass { Reserved = 1, Keyword = 2, HexDigit = 4, Digit = 8 };
+  enum class CharClass { IdChar = 1, Keyword = 2, HexDigit = 4, Digit = 8 };
 
   Location GetLocation();
   std::string_view GetText(size_t offset = 0);
@@ -76,12 +76,16 @@ class WastLexer {
   static bool IsDigit(int c) { return IsCharClass(c, CharClass::Digit); }
   static bool IsHexDigit(int c) { return IsCharClass(c, CharClass::HexDigit); }
   static bool IsKeyword(int c) { return IsCharClass(c, CharClass::Keyword); }
-  static bool IsReserved(int c) { return IsCharClass(c, CharClass::Reserved); }
+  static bool IsIdChar(int c) { return IsCharClass(c, CharClass::IdChar); }
 
   bool ReadNum();
   bool ReadHexNum();
-  int ReadReservedChars();
-  bool NoTrailingReservedChars() { return ReadReservedChars() == 0; }
+
+  enum class ReservedChars { None, Some, Id };
+  ReservedChars ReadReservedChars();
+  bool NoTrailingReservedChars() {
+    return ReadReservedChars() == ReservedChars::None;
+  }
   void ReadSign();
   Token GetStringToken(WastParser*);
   Token GetNumberToken(TokenType);

--- a/test/spec/tokens.txt
+++ b/test/spec/tokens.txt
@@ -1,2 +1,113 @@
 ;;; TOOL: run-interp-spec
 ;;; STDIN_FILE: third_party/testsuite/tokens.wast
+(;; STDOUT ;;;
+out/test/spec/tokens.wast:74: assert_malformed passed:
+  out/test/spec/tokens/tokens.17.wat:1:41: error: unexpected token "0$l", expected a var (e.g. 12 or $foo).
+  (func (block $l (i32.const 0) (br_table 0$l)))
+                                          ^^^
+out/test/spec/tokens.wast:84: assert_malformed passed:
+  out/test/spec/tokens/tokens.19.wat:1:41: error: undefined label variable "$l0"
+  (func (block $l (i32.const 0) (br_table $l0)))
+                                          ^^^
+out/test/spec/tokens.wast:94: assert_malformed passed:
+  out/test/spec/tokens/tokens.21.wat:1:41: error: undefined label variable "$l$l"
+  (func (block $l (i32.const 0) (br_table $l$l)))
+                                          ^^^^
+out/test/spec/tokens.wast:114: assert_malformed passed:
+  out/test/spec/tokens/tokens.25.wat:1:2: error: unexpected token "data"a"", expected a module field or a module.
+  (data"a")
+   ^^^^^^^
+  out/test/spec/tokens/tokens.25.wat:1:9: error: unexpected token ), expected EOF.
+  (data"a")
+          ^
+out/test/spec/tokens.wast:124: assert_malformed passed:
+  out/test/spec/tokens/tokens.27.wat:1:7: error: unexpected token $l"a", expected ).
+  (data $l"a")
+        ^^^^^
+out/test/spec/tokens.wast:134: assert_malformed passed:
+  out/test/spec/tokens/tokens.29.wat:1:7: error: unexpected token $l" a", expected ).
+  (data $l" a")
+        ^^^^^^
+out/test/spec/tokens.wast:144: assert_malformed passed:
+  out/test/spec/tokens/tokens.31.wat:1:7: error: unexpected token $l"a ", expected ).
+  (data $l"a ")
+        ^^^^^^
+out/test/spec/tokens.wast:154: assert_malformed passed:
+  out/test/spec/tokens/tokens.33.wat:1:7: error: unexpected token $l"a ""b", expected ).
+  (data $l"a ""b")
+        ^^^^^^^^^
+out/test/spec/tokens.wast:164: assert_malformed passed:
+  out/test/spec/tokens/tokens.35.wat:1:7: error: unexpected token $l"", expected ).
+  (data $l"")
+        ^^^^^^^^^^
+out/test/spec/tokens.wast:174: assert_malformed passed:
+  out/test/spec/tokens/tokens.37.wat:1:7: error: unexpected token $l" ", expected ).
+  (data $l" ")
+        ^^^^^^^^^^^
+out/test/spec/tokens.wast:184: assert_malformed passed:
+  out/test/spec/tokens/tokens.39.wat:1:7: error: unexpected token $l" ", expected ).
+  (data $l" ")
+        ^^^^^^^^^^^
+out/test/spec/tokens.wast:194: assert_malformed passed:
+  out/test/spec/tokens/tokens.41.wat:1:7: error: invalid string token
+  (data "a""b")
+        ^^^
+  out/test/spec/tokens/tokens.41.wat:1:7: error: unexpected token Invalid, expected ).
+  (data "a""b")
+        ^^^
+out/test/spec/tokens.wast:204: assert_malformed passed:
+  out/test/spec/tokens/tokens.43.wat:1:7: error: invalid string token
+  (data "a"" b")
+        ^^^
+  out/test/spec/tokens/tokens.43.wat:1:7: error: unexpected token Invalid, expected ).
+  (data "a"" b")
+        ^^^
+out/test/spec/tokens.wast:214: assert_malformed passed:
+  out/test/spec/tokens/tokens.45.wat:1:7: error: invalid string token
+  (data "a ""b")
+        ^^^^
+  out/test/spec/tokens/tokens.45.wat:1:7: error: unexpected token Invalid, expected ).
+  (data "a ""b")
+        ^^^^
+out/test/spec/tokens.wast:224: assert_malformed passed:
+  out/test/spec/tokens/tokens.47.wat:1:7: error: invalid string token
+  (data """")
+        ^^^^^^^^
+  out/test/spec/tokens/tokens.47.wat:1:7: error: unexpected token Invalid, expected ).
+  (data """")
+        ^^^^^^^^
+out/test/spec/tokens.wast:234: assert_malformed passed:
+  out/test/spec/tokens/tokens.49.wat:1:7: error: invalid string token
+  (data """ ")
+        ^^^^^^^^
+  out/test/spec/tokens/tokens.49.wat:1:7: error: unexpected token Invalid, expected ).
+  (data """ ")
+        ^^^^^^^^
+out/test/spec/tokens.wast:244: assert_malformed passed:
+  out/test/spec/tokens/tokens.51.wat:1:7: error: invalid string token
+  (data " """)
+        ^^^^^^^^^
+  out/test/spec/tokens/tokens.51.wat:1:7: error: unexpected token Invalid, expected ).
+  (data " """)
+        ^^^^^^^^^
+out/test/spec/tokens.wast:252: assert_malformed passed:
+  out/test/spec/tokens/tokens.52.wat:1:7: error: unexpected token "a", expected ).
+  (func "a"x)
+        ^^^
+  out/test/spec/tokens/tokens.52.wat:1:10: error: unexpected token x.
+  (func "a"x)
+           ^
+out/test/spec/tokens.wast:258: assert_malformed passed:
+  out/test/spec/tokens/tokens.53.wat:1:7: error: unexpected token "a", expected ).
+  (func "a"0)
+        ^^^
+out/test/spec/tokens.wast:264: assert_malformed passed:
+  out/test/spec/tokens/tokens.54.wat:1:7: error: unexpected token 0"a", expected ).
+  (func 0"a")
+        ^^^^
+out/test/spec/tokens.wast:270: assert_malformed passed:
+  out/test/spec/tokens/tokens.55.wat:1:7: error: unexpected token "a", expected ).
+  (func "a"$x)
+        ^^^
+56/56 tests passed.
+;;; STDOUT ;;)

--- a/test/spec/tokens.txt
+++ b/test/spec/tokens.txt
@@ -1,0 +1,2 @@
+;;; TOOL: run-interp-spec
+;;; STDIN_FILE: third_party/testsuite/tokens.wast

--- a/test/wasm2c/spec/tokens.txt
+++ b/test/wasm2c/spec/tokens.txt
@@ -1,0 +1,5 @@
+;;; TOOL: run-spec-wasm2c
+;;; STDIN_FILE: third_party/testsuite/tokens.wast
+(;; STDOUT ;;;
+0/0 tests passed.
+;;; STDOUT ;;)


### PR DESCRIPTION
The testsuite was already updated in https://github.com/WebAssembly/wabt/pull/2003, so this just runs `update-spec-tests.py` to bring in the new `tokens.wast` test. The Wast lexer changes are necessary because of https://github.com/WebAssembly/spec/pull/1499 . There may be a more elegant way to make this change, though...