### PR TITLE
Module loading is now implemented

### DIFF
--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -465,7 +465,6 @@ static Result ReadAndRunModule(const char* module_filename) {
     return Result::Error;
 #endif
   } else {
-    // PopulateImports(module, &imports);
     BindImports(module, imports);
   }
 

--- a/src/tools/wasm-interp.cc
+++ b/src/tools/wasm-interp.cc
@@ -194,7 +194,7 @@ static Ref GenerateHostPrint(const ImportDesc &import) {
         WriteCall(stream, import_name, func_type, params, results, *trap);
         return Result::Ok;
       });
-  
+
   return host_func.ref();
 }
 
@@ -481,6 +481,11 @@ static Result ReadAndRunModule(const char* module_filename) {
         WasiRunStart(instance, &uvwasi, s_stderr_stream.get(), s_trace_stream));
   }
 #endif
+
+  for (auto &pair : s_registry) {
+    pair.second.clear();
+  }
+  s_registry.clear();
 
   return Result::Ok;
 }


### PR DESCRIPTION
#2005 feature is finally implemented.
Modules can be loaded via `-m --module=NAME:PATH`
Maybe I will expand it in the future to accept dll/so/dylib/bundle as well. I am open for suggestions.
`-N --native=mod:lib.so` would be nice, or make `--module` more dynamic? \*
'@' will override the module name
'$' is reserved to prefer prefer the debug name if provided in the name section.
providing no NAME use the file-name. again reserved for the future is to use the debug name given in the name section

\* note that native libraries either need some witx glue, or ffi or an API to bind against.