### PR TITLE
Fix wasm2c examples to print helpful prompts

### DIFF
--- a/wasm2c/examples/fac/main.c
+++ b/wasm2c/examples/fac/main.c
@@ -5,7 +5,10 @@
 
 int main(int argc, char** argv) {
   /* Make sure there is at least one command-line argument. */
-  if (argc < 2) return 1;
+  if (argc < 2) {
+    printf("Invalid argument. Expected '%s NUMBER'\n", argv[0]);
+    return 1;
+  }
 
   /* Convert the argument from a string to an int. We'll implicitly cast the int
   to a `u32`, which is what `fac` expects. */

--- a/wasm2c/examples/rot13/main.c
+++ b/wasm2c/examples/rot13/main.c
@@ -45,6 +45,11 @@ void Z_hostZ_buf_done(struct Z_host_instance_t* instance, u32 ptr, u32 size) {
 }
 
 int main(int argc, char** argv) {
+  /* Make sure there is at least one command-line argument. */
+  if (argc < 2) {
+    printf("Invalid argument. Expected '%s WORD'\n", argv[0]);
+    return 1;
+  }
   /* Initialize the Wasm runtime. */
   wasm_rt_init();
 


### PR DESCRIPTION
Ensure wasm2c examples print something useful when you run them