### PR TITLE
Simplify part of type-checker. NFC

### DIFF
--- a/include/wabt/opcode.h
+++ b/include/wabt/opcode.h
@@ -69,14 +69,6 @@ struct Opcode {
   Type GetParamType(int n) const { return GetInfo().param_types[n - 1]; }
   Address GetMemorySize() const { return GetInfo().memory_size; }
 
-  // If this is a load/store op, the type depends on the memory used.
-  Type GetMemoryParam(Type param,
-                      const Limits* limits,
-                      bool has_address_operands) {
-    return limits && limits->is_64 && has_address_operands ? Type(Type::I64)
-                                                           : param;
-  }
-
   // Get the byte sequence for this opcode, including prefix.
   std::vector<uint8_t> GetBytes() const;
 

--- a/include/wabt/type-checker.h
+++ b/include/wabt/type-checker.h
@@ -171,9 +171,7 @@ class TypeChecker {
                            Type expected2,
                            Type expected3,
                            const char* desc);
-  Result CheckOpcode1(Opcode opcode,
-                      const Limits* limits = nullptr,
-                      bool has_address_operands = false);
+  Result CheckOpcode1(Opcode opcode, const Limits* limits = nullptr);
   Result CheckOpcode2(Opcode opcode, const Limits* limits = nullptr);
   Result CheckOpcode3(Opcode opcode,
                       const Limits* limits1 = nullptr,


### PR DESCRIPTION
Simplify `CheckOpcode1` by avoiding using it for memory.fill.

Simplify and move GetMemoryParam.