### PR TITLE
Include CWriter in libwabt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,6 +228,25 @@ endif ()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${WABT_SOURCE_DIR}/cmake)
 
+# CWriter code templates
+set(TEMPLATE_CMAKE ${WABT_SOURCE_DIR}/scripts/gen-wasm2c-templates.cmake)
+
+add_custom_command(
+  OUTPUT wasm2c_header_top.cc wasm2c_header_bottom.cc wasm2c_source_includes.cc wasm2c_source_declarations.cc
+
+  COMMAND ${CMAKE_COMMAND} -D out="wasm2c_header_top.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.top.h" -D symbol="s_header_top" -P ${TEMPLATE_CMAKE}
+  COMMAND ${CMAKE_COMMAND} -D out="wasm2c_header_bottom.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.bottom.h" -D symbol="s_header_bottom" -P ${TEMPLATE_CMAKE}
+  COMMAND ${CMAKE_COMMAND} -D out="wasm2c_source_includes.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.includes.c" -D symbol="s_source_includes" -P ${TEMPLATE_CMAKE}
+  COMMAND ${CMAKE_COMMAND} -D out="wasm2c_source_declarations.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.declarations.c" -D symbol="s_source_declarations" -P ${TEMPLATE_CMAKE}
+
+  DEPENDS ${WABT_SOURCE_DIR}/src/template/wasm2c.top.h
+  ${WABT_SOURCE_DIR}/src/template/wasm2c.bottom.h
+  ${WABT_SOURCE_DIR}/src/template/wasm2c.includes.c
+  ${WABT_SOURCE_DIR}/src/template/wasm2c.declarations.c
+)
+
+set(CWRITER_TEMPLATE_SRC wasm2c_header_top.cc wasm2c_header_bottom.cc wasm2c_source_includes.cc wasm2c_source_declarations.cc)
+
 add_custom_target(everything)
 
 set(WABT_LIBRARY_CC
@@ -269,6 +288,8 @@ set(WABT_LIBRARY_CC
   src/wast-lexer.cc
   src/wast-parser.cc
   src/wat-writer.cc
+  src/c-writer.cc
+  ${CWRITER_TEMPLATE_SRC}
 
   # TODO(binji): Move this into its own library?
   src/interp/binary-reader-interp.cc
@@ -480,28 +501,9 @@ if (BUILD_TOOLS)
   )
 
   # wasm2c
-  set(TEMPLATE_CMAKE ${WABT_SOURCE_DIR}/scripts/gen-wasm2c-templates.cmake)
-
-  # wasm2c generated code templates
-  add_custom_command(
-    OUTPUT wasm2c_header_top.cc wasm2c_header_bottom.cc wasm2c_source_includes.cc wasm2c_source_declarations.cc
-
-    COMMAND ${CMAKE_COMMAND} -D out="wasm2c_header_top.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.top.h" -D symbol="s_header_top" -P ${TEMPLATE_CMAKE}
-    COMMAND ${CMAKE_COMMAND} -D out="wasm2c_header_bottom.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.bottom.h" -D symbol="s_header_bottom" -P ${TEMPLATE_CMAKE}
-    COMMAND ${CMAKE_COMMAND} -D out="wasm2c_source_includes.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.includes.c" -D symbol="s_source_includes" -P ${TEMPLATE_CMAKE}
-    COMMAND ${CMAKE_COMMAND} -D out="wasm2c_source_declarations.cc" -D in="${WABT_SOURCE_DIR}/src/template/wasm2c.declarations.c" -D symbol="s_source_declarations" -P ${TEMPLATE_CMAKE}
-
-    DEPENDS ${WABT_SOURCE_DIR}/src/template/wasm2c.top.h
-    ${WABT_SOURCE_DIR}/src/template/wasm2c.bottom.h
-    ${WABT_SOURCE_DIR}/src/template/wasm2c.includes.c
-    ${WABT_SOURCE_DIR}/src/template/wasm2c.declarations.c
-  )
-
-  set(CWRITER_TEMPLATE_SRC wasm2c_header_top.cc wasm2c_header_bottom.cc wasm2c_source_includes.cc wasm2c_source_declarations.cc)
-
   wabt_executable(
     NAME wasm2c
-    SOURCES src/tools/wasm2c.cc src/c-writer.cc ${CWRITER_TEMPLATE_SRC}
+    SOURCES src/tools/wasm2c.cc
     INSTALL
   )
 


### PR DESCRIPTION
This allows programs linking with `libwabt` to use `CWriter`. (Currently, `c-writer.cc` and the source templates are only linked into the `wasm2c` executable.)