### PR TITLE
wasm2c: handle duplicate names across module fields

### DIFF
--- a/include/wabt/type.h
+++ b/include/wabt/type.h
@@ -64,7 +64,7 @@ class Type {
   Type(Enum e, Index type_index) : enum_(e), type_index_(type_index) {
     assert(e == Enum::Reference);
   }
-  operator Enum() const { return enum_; }
+  constexpr operator Enum() const { return enum_; }
 
   bool IsRef() const {
     return enum_ == Type::ExternRef || enum_ == Type::FuncRef ||

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -477,7 +477,7 @@ char CWriter::MangleType(Type type) {
 constexpr char CWriter::MangleField(ModuleFieldType type) {
   assert(static_cast<std::underlying_type<ModuleFieldType>::type>(type) <
          std::numeric_limits<char>::max());
-  return static_cast<char>(type);
+  return 'a' + static_cast<char>(type);
 }
 
 // static
@@ -577,13 +577,6 @@ std::string_view StripLeadingDollar(std::string_view name) {
   return name;
 }
 
-std::string_view StripTrailingSigil(std::string_view name) {
-  if (!name.empty()) {
-    name.remove_suffix(1);
-  }
-  return name;
-}
-
 void CWriter::DefineImportName(const Import* import,
                                std::string_view module,
                                std::string_view field_name) {
@@ -625,8 +618,7 @@ void CWriter::DefineImportName(const Import* import,
 template <ModuleFieldType T>
 std::string CWriter::DefineGlobalScopeName(std::string_view name) {
   std::string mangled = std::string(name) + MangleField(T);
-  std::string unique = DefineName(
-      &global_syms_, StripTrailingSigil(StripLeadingDollar(mangled)));
+  std::string unique = DefineName(&global_syms_, StripLeadingDollar(name));
   bool success = global_sym_map_.emplace(mangled, unique).second;
   assert(success);
   return unique;

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -192,7 +192,7 @@ class CWriter {
   bool IsTopLabelUsed() const;
   void PopLabel();
 
-  static char MangleType(Type);
+  static constexpr char MangleType(Type);
   static constexpr char MangleField(ModuleFieldType);
   static std::string MangleMultivalueTypes(const TypeVector&);
   static std::string MangleTagTypes(const TypeVector&);
@@ -449,7 +449,7 @@ void CWriter::PopLabel() {
 }
 
 // static
-char CWriter::MangleType(Type type) {
+constexpr char CWriter::MangleType(Type type) {
   // clang-format off
   switch (type) {
     case Type::I32: return 'i';

--- a/test/regress/regress-2034.txt
+++ b/test/regress/regress-2034.txt
@@ -1,0 +1,17 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS: --debug-names --enable-exceptions
+(module
+ (func $x)
+ (export "func" (func $x))
+ (global $x i32 (i32.const 14))
+ (table $x (export "tab") 0 funcref)
+ (elem $x)
+ (memory $x (export "mem") 0)
+ (data $x)
+ (tag $x (export "tag"))
+)
+
+(assert_return (invoke "func"))
+(;; STDOUT ;;;
+1/1 tests passed.
+;;; STDOUT ;;)

--- a/test/regress/regress-2034.txt
+++ b/test/regress/regress-2034.txt
@@ -1,14 +1,14 @@
 ;;; TOOL: run-spec-wasm2c
 ;;; ARGS: --debug-names --enable-exceptions
 (module
- (func $x)
- (export "func" (func $x))
- (global $x i32 (i32.const 14))
- (table $x (export "tab") 0 funcref)
- (elem $x)
- (memory $x (export "mem") 0)
- (data $x)
- (tag $x (export "tag"))
+ (func $foo)
+ (export "func" (func $foo))
+ (global $foo i32 (i32.const 14))
+ (table $foo (export "tab") 0 funcref)
+ (elem $foo)
+ (memory $foo (export "mem") 0)
+ (data $foo)
+ (tag $foo (export "tag"))
 )
 
 (assert_return (invoke "func"))


### PR DESCRIPTION
This change allows wasm2c to handle duplicate names across different module fields (e.g. an elem segment and tag both named "$e0"), by tracking the field type explicitly at each definition and then reference to a GlobalName.

There may be a less intensive way to do this... am not wedded to the approach, but this does seem to fix it.

~~Also fixes an issue in the BinaryReaderIR where tag names were being bound in a different bindings hash, which was leading to a segfault in wasm2c when a named tag was exported (because it couldn't find the tag by name).~~

Adds a regression test.

Fixes #2034.