### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,9 @@
+# This file contains a list of commits that are not likely what you
+# are looking for in a blame, such as mass reformatting or renaming.
+# You can set this file as a default ignore file for blame by running
+# the following command.
+#
+# $ git config blame.ignoreRevsFile .git-blame-ignore-revs
+
+# Clang-format codebase
+e59cf9369004a521814222afbc05ae6b59446cd5


### PR DESCRIPTION
This adds a `.git-blame-ignore-revs` file, which was supported since version 2.23 (Aug 2019), which lets `git blame` ignore specified revisions. Usage examples:
https://github.com/llvm/llvm-project/blob/main/.git-blame-ignore-revs https://github.com/WebAssembly/binaryen/blob/main/.git-blame-ignore-revs

This currently contains a clang-format commit (#1684).