### PR TITLE
wasm2c: Fix 8gb model, signals, memory reserve/commits, stack depth on windows

### DIFF
--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -1,16 +1,16 @@
 
 #define TRAP(x) (wasm_rt_trap(WASM_RT_TRAP_##x), 0)
 
-#if WASM_RT_MEMCHECK_SIGNAL_HANDLER
-#define FUNC_PROLOGUE
-
-#define FUNC_EPILOGUE
-#else
+#if WASM_RT_USE_STACK_DEPTH_COUNT
 #define FUNC_PROLOGUE                                            \
   if (++wasm_rt_call_stack_depth > WASM_RT_MAX_CALL_STACK_DEPTH) \
     TRAP(EXHAUSTION);
 
 #define FUNC_EPILOGUE --wasm_rt_call_stack_depth
+#else
+#define FUNC_PROLOGUE
+
+#define FUNC_EPILOGUE
 #endif
 
 #define UNREACHABLE TRAP(UNREACHABLE)


### PR DESCRIPTION
Correct handling of Wasm's 8gb model on Windows
- Uses the Windows ExceptionHandler to track access violations (segfaults)
- Fix Windows memory to reserve, but not commit memory up front
- Correct handling of return values in os_mmap functions
- Decouple stack depth handling and heap bounds checking