### PR TITLE
BinaryReaderIR: fix mis-binding of tags with debug name

### DIFF
--- a/src/binary-reader-ir.cc
+++ b/src/binary-reader-ir.cc
@@ -1495,7 +1495,7 @@ Result BinaryReaderIR::SetTagName(Index index, std::string_view name) {
   std::string dollar_name =
       GetUniqueName(&module_->tag_bindings, MakeDollarName(name));
   tag->name = dollar_name;
-  module_->global_bindings.emplace(dollar_name, Binding(index));
+  module_->tag_bindings.emplace(dollar_name, Binding(index));
   return Result::Ok;
 }
 

--- a/test/regress/regress-2039.txt
+++ b/test/regress/regress-2039.txt
@@ -1,0 +1,6 @@
+;;; TOOL: run-spec-wasm2c
+;;; ARGS: --debug-names --enable-exceptions
+(module (tag $t (export "tag")))
+(;; STDOUT ;;;
+0/0 tests passed.
+;;; STDOUT ;;)

--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -463,6 +463,7 @@ def main(args):
     parser.add_argument('--enable-multi-memory', action='store_true')
     parser.add_argument('--disable-bulk-memory', action='store_true')
     parser.add_argument('--disable-reference-types', action='store_true')
+    parser.add_argument('--debug-names', action='store_true')
     options = parser.parse_args(args)
 
     with utils.TempDirectory(options.out_dir, 'run-spec-wasm2c-') as out_dir:
@@ -476,7 +477,8 @@ def main(args):
             '--enable-exceptions': options.enable_exceptions,
             '--enable-multi-memory': options.enable_multi_memory,
             '--disable-bulk-memory': options.disable_bulk_memory,
-            '--disable-reference-types': options.disable_reference_types})
+            '--disable-reference-types': options.disable_reference_types,
+            '--debug-names': options.debug_names})
 
         json_file_path = utils.ChangeDir(
             utils.ChangeExt(options.file, '.json'), out_dir)


### PR DESCRIPTION
Fixes #2039.

Split out from #2035.