### PR TITLE
Honor CC environment variable in test/run-spec-wasm2c.py

### DIFF
--- a/test/run-spec-wasm2c.py
+++ b/test/run-spec-wasm2c.py
@@ -426,6 +426,7 @@ def main(args):
     default_compiler = 'cc'
     if IS_WINDOWS:
         default_compiler = 'cl.exe'
+    default_compiler = os.getenv('CC', default_compiler)
     parser = argparse.ArgumentParser()
     parser.add_argument('-o', '--out-dir', metavar='PATH',
                         help='output directory for files.')


### PR DESCRIPTION
I've been having some issues with the recent version of gcc on my system and being able to run `CC=/usr/bin/clang ./test/run-tests.py` has proved useful.