### PR TITLE
wasm2c: Use GetReferenceNullValue() helper. NFC

### DIFF
--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -2660,7 +2660,8 @@ void CWriter::Write(const ExprList& exprs) {
             break;
           case Type::ExternRef:
             Write(StackVar(0, Type::I32), " = (", StackVar(0),
-                  " == wasm_rt_externref_null_value);", Newline());
+                  " == ", GetReferenceNullValue(Type::ExternRef), ");",
+                  Newline());
             break;
           default:
             WABT_UNREACHABLE;


### PR DESCRIPTION
I could do the same for FuncRef above.. but that would turn `isNull` on FuncRef from a one 1-word check to a 3-word check.  Maybe not worth it?