### PR TITLE
Convert type checks to assertions in the interpreter. NFC

### DIFF
--- a/include/wabt/interp/interp.h
+++ b/include/wabt/interp/interp.h
@@ -929,7 +929,7 @@ class Global : public Extern {
   Result Get(T* out) const;
   template <typename T>
   Result WABT_VECTORCALL Set(T);
-  Result Set(Store&, Ref);
+  void Set(Store&, Ref);
 
   template <typename T>
   T WABT_VECTORCALL UnsafeGet() const;


### PR DESCRIPTION
All of these checks represent cases where a validation error would prevent the type mismatch.

When debugging #2054 this check actually worked against since it was resulting a false-positive "out-of-bound" error reports when really it was an internal type inconsistency (a bug).