### PR TITLE
Install wasm2c source files as data

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -393,8 +393,13 @@ IF (NOT WIN32)
       INCLUDES DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
     )
     install(
-      FILES "wasm2c/wasm-rt-impl.h" "wasm2c/wasm-rt.h"
+      FILES "wasm2c/wasm-rt.h"
       TYPE INCLUDE
+      COMPONENT wabt-development
+    )
+    install(
+      FILES "wasm2c/wasm-rt-impl.h" "wasm2c/wasm-rt-impl.c"
+      DESTINATION "${CMAKE_INSTALL_DATADIR}/wabt/wasm2c"
       COMPONENT wabt-development
     )
   endif ()


### PR DESCRIPTION
Toolchains using wasm2c depend on the wasm-rt files to build the generated programs. Using a packaged binary wasm-rt library is not enough for toolchains that do e.g. cross-compilation, and they need to copy and use the source files instead. Therefore, package the required wasm-rt source files as data for toolchains to use.

Even though some files are already installed in `include`, I deliberately chose to install all the required headers and source files in the data dir, to ensure it's clear these belong together as data for toolchains. I believe it is unusual and confusing that a toolchain should copy some data from the platform's `include` dir and assume it is platform-independent, as this dir should only contain platform-specific headers used for compiling software for the host platform. This is also consistent with e.g. the [Debian package](https://packages.debian.org/sid/amd64/wabt/filelist), which also packages the wasm-rt source files together (in addition to the headers being present in the `include` dir, for tools that use the packaged binary wasm-rt library instead).

Closes #2057.