### PR TITLE
wasm2c: allow externref initialization when externref type is not void*

### DIFF
--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -494,9 +494,8 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
   }
 }
 
-// Currently we only support initializing externref tables with ref.null.
+// Currently Wasm only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
-                                        const wasm_rt_externref_t* src,
                                         u32 src_size,
                                         u32 dest_addr,
                                         u32 src_addr,
@@ -506,8 +505,7 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
   if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
     TRAP(OOB);
   for (u32 i = 0; i < n; i++) {
-    const wasm_rt_externref_t* src_expr = &src[src_addr + i];
-    dest->data[dest_addr + i] = *src_expr;
+    dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
 }
 

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -557,9 +557,8 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
   }
 }
 
-// Currently we only support initializing externref tables with ref.null.
+// Currently Wasm only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
-                                        const wasm_rt_externref_t* src,
                                         u32 src_size,
                                         u32 dest_addr,
                                         u32 src_addr,
@@ -569,8 +568,7 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
   if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
     TRAP(OOB);
   for (u32 i = 0; i < n; i++) {
-    const wasm_rt_externref_t* src_expr = &src[src_addr + i];
-    dest->data[dest_addr + i] = *src_expr;
+    dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
 }
 

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -587,9 +587,8 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
   }
 }
 
-// Currently we only support initializing externref tables with ref.null.
+// Currently Wasm only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
-                                        const wasm_rt_externref_t* src,
                                         u32 src_size,
                                         u32 dest_addr,
                                         u32 src_addr,
@@ -599,8 +598,7 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
   if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
     TRAP(OOB);
   for (u32 i = 0; i < n; i++) {
-    const wasm_rt_externref_t* src_expr = &src[src_addr + i];
-    dest->data[dest_addr + i] = *src_expr;
+    dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
 }
 

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -551,9 +551,8 @@ static inline void funcref_table_init(wasm_rt_funcref_table_t* dest,
   }
 }
 
-// Currently we only support initializing externref tables with ref.null.
+// Currently Wasm only supports initializing externref tables with ref.null.
 static inline void externref_table_init(wasm_rt_externref_table_t* dest,
-                                        const wasm_rt_externref_t* src,
                                         u32 src_size,
                                         u32 dest_addr,
                                         u32 src_addr,
@@ -563,8 +562,7 @@ static inline void externref_table_init(wasm_rt_externref_table_t* dest,
   if (UNLIKELY(dest_addr + (uint64_t)n > dest->size))
     TRAP(OOB);
   for (u32 i = 0; i < n; i++) {
-    const wasm_rt_externref_t* src_expr = &src[src_addr + i];
-    dest->data[dest_addr + i] = *src_expr;
+    dest->data[dest_addr + i] = wasm_rt_externref_null_value;
   }
 }
 


### PR DESCRIPTION
Here's one approach to keep externref initializers agnostic to the type of externref while keeping MSVC happy about only using constant expressions in the initializers. (We use `wasm_rt_externref_t` typedef'd to a non-pointer type, so `NULL` doesn't typecheck in that setting.)

An alternative could be to change `wasm_rt_externref_null_value` to a `#define` (instead of a `static const`) but this seems maybe preferable...?