### PR TITLE
Prefer `constexpr` over `static const`. NFC

### DIFF
--- a/include/wabt/base-types.h
+++ b/include/wabt/base-types.h
@@ -26,9 +26,9 @@ typedef uint32_t Index;    // An index into one of the many index spaces.
 typedef uint64_t Address;  // An address or size in linear memory.
 typedef size_t Offset;     // An offset into a host's file or memory buffer.
 
-static const Address kInvalidAddress = ~0;
-static const Index kInvalidIndex = ~0;
-static const Offset kInvalidOffset = ~0;
+constexpr Address kInvalidAddress = ~0;
+constexpr Index kInvalidIndex = ~0;
+constexpr Offset kInvalidOffset = ~0;
 
 }  // namespace wabt
 

--- a/include/wabt/binary.h
+++ b/include/wabt/binary.h
@@ -65,7 +65,7 @@ enum class BinarySection {
   Last = Tag,
 };
 /* clang-format on */
-static const int kBinarySectionCount = WABT_ENUM_COUNT(BinarySection);
+constexpr int kBinarySectionCount = WABT_ENUM_COUNT(BinarySection);
 
 enum class BinarySectionOrder {
 #define V(Name, name, code) Name,

--- a/include/wabt/circular-array.h
+++ b/include/wabt/circular-array.h
@@ -103,7 +103,7 @@ class CircularArray {
   }
 
  private:
-  static const size_type kMask = kCapacity - 1;
+  static constexpr size_type kMask = kCapacity - 1;
 
   size_t position(size_t index) const { return (front_ + index) & kMask; }
 

--- a/include/wabt/common.h
+++ b/include/wabt/common.h
@@ -204,7 +204,7 @@ enum class LabelType {
   First = Func,
   Last = Catch,
 };
-static const int kLabelTypeCount = WABT_ENUM_COUNT(LabelType);
+constexpr int kLabelTypeCount = WABT_ENUM_COUNT(LabelType);
 
 struct Location {
   enum class Type {
@@ -291,7 +291,7 @@ enum class RelocType {
   First = FuncIndexLEB,
   Last = MemoryAddressTLSI32,
 };
-static const int kRelocTypeCount = WABT_ENUM_COUNT(RelocType);
+constexpr int kRelocTypeCount = WABT_ENUM_COUNT(RelocType);
 
 struct Reloc {
   Reloc(RelocType, size_t offset, Index index, int32_t addend = 0);
@@ -365,7 +365,7 @@ enum class ExternalKind {
   First = Func,
   Last = Tag,
 };
-static const int kExternalKindCount = WABT_ENUM_COUNT(ExternalKind);
+constexpr int kExternalKindCount = WABT_ENUM_COUNT(ExternalKind);
 
 struct Limits {
   Limits() = default;

--- a/include/wabt/interp/interp.h
+++ b/include/wabt/interp/interp.h
@@ -96,7 +96,7 @@ enum class ObjectKind {
   Last = Instance,
 };
 
-static const int kCommandTypeCount = WABT_ENUM_COUNT(ObjectKind);
+constexpr int kCommandTypeCount = WABT_ENUM_COUNT(ObjectKind);
 
 const char* GetName(Mutability);
 const std::string GetName(ValueType);
@@ -119,7 +119,7 @@ using RefVec = std::vector<Ref>;
 template <typename T, u8 L>
 struct Simd {
   using LaneType = T;
-  static const u8 lanes = L;
+  static constexpr u8 lanes = L;
 
   T v[L];
 
@@ -1086,8 +1086,8 @@ enum class RunResult {
 class Thread {
  public:
   struct Options {
-    static const u32 kDefaultValueStackSize = 64 * 1024 / sizeof(Value);
-    static const u32 kDefaultCallStackSize = 64 * 1024 / sizeof(Frame);
+    static constexpr u32 kDefaultValueStackSize = 64 * 1024 / sizeof(Value);
+    static constexpr u32 kDefaultCallStackSize = 64 * 1024 / sizeof(Frame);
 
     u32 value_stack_size = kDefaultValueStackSize;
     u32 call_stack_size = kDefaultCallStackSize;

--- a/include/wabt/interp/istream.h
+++ b/include/wabt/interp/istream.h
@@ -95,7 +95,7 @@ class Istream {
  public:
   using SerializedOpcode = u32;  // TODO: change to u16
   using Offset = u32;
-  static const Offset kInvalidOffset = ~0;
+  static constexpr Offset kInvalidOffset = ~0;
   // Each br_table entry is made up of three instructions:
   //
   //   interp_drop_keep $drop $keep
@@ -103,7 +103,7 @@ class Istream {
   //   br $label
   //
   // Each opcode is a SerializedOpcode, and each immediate is a u32.
-  static const Offset kBrTableEntrySize =
+  static constexpr Offset kBrTableEntrySize =
       sizeof(SerializedOpcode) * 3 + 4 * sizeof(u32);
 
   // Emit API.

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -1320,7 +1320,7 @@ enum class CommandType {
   First = Module,
   Last = AssertException,
 };
-static const int kCommandTypeCount = WABT_ENUM_COUNT(CommandType);
+constexpr int kCommandTypeCount = WABT_ENUM_COUNT(CommandType);
 
 class Command {
  public:

--- a/include/wabt/opcode.h
+++ b/include/wabt/opcode.h
@@ -91,9 +91,9 @@ struct Opcode {
   bool IsInvalid() const { return enum_ >= Invalid; }
 
  private:
-  static const uint32_t kMathPrefix = 0xfc;
-  static const uint32_t kThreadsPrefix = 0xfe;
-  static const uint32_t kSimdPrefix = 0xfd;
+  static constexpr uint32_t kMathPrefix = 0xfc;
+  static constexpr uint32_t kThreadsPrefix = 0xfe;
+  static constexpr uint32_t kSimdPrefix = 0xfd;
 
   struct Info {
     const char* name;

--- a/include/wabt/wast-lexer.h
+++ b/include/wabt/wast-lexer.h
@@ -56,7 +56,7 @@ class WastLexer {
   }
 
  private:
-  static const int kEof = -1;
+  static constexpr int kEof = -1;
   enum class CharClass { IdChar = 1, Keyword = 2, HexDigit = 4, Digit = 8 };
 
   Location GetLocation();

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -96,7 +96,7 @@ namespace {
 
 /* TODO(binji): better leb size guess. Some sections we know will only be 1
  byte, but others we can be fairly certain will be larger. */
-static const size_t LEB_SECTION_SIZE_GUESS = 1;
+constexpr size_t LEB_SECTION_SIZE_GUESS = 1;
 
 #define ALLOC_FAILURE \
   fprintf(stderr, "%s:%d: allocation failed\n", __FILE__, __LINE__)

--- a/src/test-hexfloat.cc
+++ b/src/test-hexfloat.cc
@@ -67,7 +67,7 @@ static bool is_infinity_or_nan(uint64_t double_bits) {
 
 class ThreadedTest : public ::testing::Test {
  protected:
-  static const int kDefaultNumThreads = 2;
+  static constexpr int kDefaultNumThreads = 2;
 
   virtual void SetUp() {
     num_threads_ = std::thread::hardware_concurrency();


### PR DESCRIPTION
IIUC this is prefered in modern C++ and expresses indent better.