### PR TITLE
Switch from `typedef` to using `using` in C++ code. NFC

### DIFF
--- a/include/wabt/base-types.h
+++ b/include/wabt/base-types.h
@@ -22,9 +22,9 @@
 
 namespace wabt {
 
-typedef uint32_t Index;    // An index into one of the many index spaces.
-typedef uint64_t Address;  // An address or size in linear memory.
-typedef size_t Offset;     // An offset into a host's file or memory buffer.
+using Index = uint32_t;    // An index into one of the many index spaces.
+using Address = uint64_t;  // An address or size in linear memory.
+using Offset = size_t;     // An offset into a host's file or memory buffer.
 
 static const Address kInvalidAddress = ~0;
 static const Index kInvalidIndex = ~0;

--- a/include/wabt/binary-reader-opcnt.h
+++ b/include/wabt/binary-reader-opcnt.h
@@ -84,7 +84,7 @@ bool operator<=(const OpcodeInfo&, const OpcodeInfo&);
 bool operator>(const OpcodeInfo&, const OpcodeInfo&);
 bool operator>=(const OpcodeInfo&, const OpcodeInfo&);
 
-typedef std::map<OpcodeInfo, size_t> OpcodeInfoCounts;
+using OpcodeInfoCounts = std::map<OpcodeInfo, size_t>;
 
 Result ReadBinaryOpcnt(const void* data,
                        size_t size,

--- a/include/wabt/binary-writer-spec.h
+++ b/include/wabt/binary-writer-spec.h
@@ -35,8 +35,8 @@ struct FilenameMemoryStreamPair {
   std::unique_ptr<MemoryStream> stream;
 };
 
-typedef std::function<Stream*(std::string_view filename)>
-    WriteBinarySpecStreamFactory;
+using WriteBinarySpecStreamFactory =
+    std::function<Stream*(std::string_view filename)>;
 
 Result WriteBinarySpecScript(Stream* json_stream,
                              WriteBinarySpecStreamFactory module_stream_factory,

--- a/include/wabt/binding-hash.h
+++ b/include/wabt/binding-hash.h
@@ -42,8 +42,8 @@ struct Binding {
 // object through a pointer to std::unordered_multimap.
 class BindingHash : public std::unordered_multimap<std::string, Binding> {
  public:
-  typedef std::function<void(const value_type&, const value_type&)>
-      DuplicateCallback;
+  using DuplicateCallback =
+      std::function<void(const value_type&, const value_type&)>;
 
   void FindDuplicates(DuplicateCallback callback) const;
 
@@ -59,7 +59,7 @@ class BindingHash : public std::unordered_multimap<std::string, Binding> {
   }
 
  private:
-  typedef std::vector<const value_type*> ValueTypeVector;
+  using ValueTypeVector = std::vector<const value_type*>;
 
   void CreateDuplicatesVector(ValueTypeVector* out_duplicates) const;
   void SortDuplicatesVectorByLocation(ValueTypeVector* duplicates) const;

--- a/include/wabt/circular-array.h
+++ b/include/wabt/circular-array.h
@@ -29,11 +29,11 @@ namespace wabt {
 template <class T, size_t kCapacity>
 class CircularArray {
  public:
-  typedef T value_type;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
-  typedef size_t size_type;
-  typedef ptrdiff_t difference_type;
+  using value_type = T;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using size_type = size_t;
+  using difference_type = ptrdiff_t;
 
   CircularArray() {
     static_assert(kCapacity && ((kCapacity & (kCapacity - 1)) == 0),

--- a/include/wabt/intrusive-list.h
+++ b/include/wabt/intrusive-list.h
@@ -53,15 +53,15 @@ template <typename T>
 class intrusive_list {
  public:
   // types:
-  typedef T value_type;
-  typedef value_type& reference;
-  typedef const value_type& const_reference;
+  using value_type = T;
+  using reference = value_type&;
+  using const_reference = const value_type&;
   class iterator;
   class const_iterator;
-  typedef std::size_t size_type;
-  typedef std::ptrdiff_t difference_type;
-  typedef std::reverse_iterator<iterator> reverse_iterator;
-  typedef std::reverse_iterator<const_iterator> const_reverse_iterator;
+  using size_type = std::size_t;
+  using difference_type = std::ptrdiff_t;
+  using reverse_iterator = std::reverse_iterator<iterator>;
+  using const_reverse_iterator = std::reverse_iterator<const_iterator>;
 
   // construct/copy/destroy:
   intrusive_list();
@@ -142,11 +142,11 @@ class intrusive_list {
 template <typename T>
 class intrusive_list<T>::iterator {
  public:
-  typedef std::ptrdiff_t difference_type;
-  typedef std::bidirectional_iterator_tag iterator_category;
-  typedef T value_type;
-  typedef T* pointer;
-  typedef T& reference;
+  using difference_type = std::ptrdiff_t;
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = T;
+  using pointer = T*;
+  using reference = T&;
 
   iterator(const intrusive_list<T>& list, T* node)
       : list_(&list), node_(node) {}
@@ -205,11 +205,11 @@ class intrusive_list<T>::iterator {
 template <typename T>
 class intrusive_list<T>::const_iterator {
  public:
-  typedef std::ptrdiff_t difference_type;
-  typedef std::bidirectional_iterator_tag iterator_category;
-  typedef T value_type;
-  typedef const T* pointer;
-  typedef const T& reference;
+  using difference_type = std::ptrdiff_t;
+  using iterator_category = std::bidirectional_iterator_tag;
+  using value_type = T;
+  using pointer = const T*;
+  using reference = const T&;
 
   const_iterator(const intrusive_list<T>& list, T* node)
       : list_(&list), node_(node) {}

--- a/include/wabt/ir.h
+++ b/include/wabt/ir.h
@@ -78,7 +78,7 @@ struct Var {
     std::string name_;
   };
 };
-typedef std::vector<Var> VarVector;
+using VarVector = std::vector<Var>;
 
 struct Const {
   static constexpr uintptr_t kRefNullBits = ~uintptr_t(0);
@@ -200,7 +200,7 @@ struct Const {
   v128 data_;
   ExpectedNan nan_[4];
 };
-typedef std::vector<Const> ConstVector;
+using ConstVector = std::vector<Const>;
 
 struct FuncSignature {
   TypeVector param_types;
@@ -377,9 +377,9 @@ enum class ExprType {
 const char* GetExprTypeName(ExprType type);
 
 class Expr;
-typedef intrusive_list<Expr> ExprList;
+using ExprList = intrusive_list<Expr>;
 
-typedef FuncDeclaration BlockDeclaration;
+using BlockDeclaration = FuncDeclaration;
 
 struct Block {
   Block() = default;
@@ -402,7 +402,7 @@ struct Catch {
     return var.is_index() && var.index() == kInvalidIndex;
   }
 };
-typedef std::vector<Catch> CatchVector;
+using CatchVector = std::vector<Catch>;
 
 enum class TryKind { Plain, Catch, Delegate };
 
@@ -456,16 +456,16 @@ class MemoryBinaryExpr : public ExprMixin<TypeEnum> {
   Var destmemidx;
 };
 
-typedef ExprMixin<ExprType::Drop> DropExpr;
-typedef ExprMixin<ExprType::Nop> NopExpr;
-typedef ExprMixin<ExprType::Return> ReturnExpr;
-typedef ExprMixin<ExprType::Unreachable> UnreachableExpr;
+using DropExpr = ExprMixin<ExprType::Drop>;
+using NopExpr = ExprMixin<ExprType::Nop>;
+using ReturnExpr = ExprMixin<ExprType::Return>;
+using UnreachableExpr = ExprMixin<ExprType::Unreachable>;
 
-typedef MemoryExpr<ExprType::MemoryGrow> MemoryGrowExpr;
-typedef MemoryExpr<ExprType::MemorySize> MemorySizeExpr;
-typedef MemoryExpr<ExprType::MemoryFill> MemoryFillExpr;
+using MemoryGrowExpr = MemoryExpr<ExprType::MemoryGrow>;
+using MemorySizeExpr = MemoryExpr<ExprType::MemorySize>;
+using MemoryFillExpr = MemoryExpr<ExprType::MemoryFill>;
 
-typedef MemoryBinaryExpr<ExprType::MemoryCopy> MemoryCopyExpr;
+using MemoryCopyExpr = MemoryBinaryExpr<ExprType::MemoryCopy>;
 
 template <ExprType TypeEnum>
 class RefTypeExpr : public ExprMixin<TypeEnum> {
@@ -476,8 +476,8 @@ class RefTypeExpr : public ExprMixin<TypeEnum> {
   Type type;
 };
 
-typedef RefTypeExpr<ExprType::RefNull> RefNullExpr;
-typedef ExprMixin<ExprType::RefIsNull> RefIsNullExpr;
+using RefNullExpr = RefTypeExpr<ExprType::RefNull>;
+using RefIsNullExpr = ExprMixin<ExprType::RefIsNull>;
 
 template <ExprType TypeEnum>
 class OpcodeExpr : public ExprMixin<TypeEnum> {
@@ -488,11 +488,11 @@ class OpcodeExpr : public ExprMixin<TypeEnum> {
   Opcode opcode;
 };
 
-typedef OpcodeExpr<ExprType::Binary> BinaryExpr;
-typedef OpcodeExpr<ExprType::Compare> CompareExpr;
-typedef OpcodeExpr<ExprType::Convert> ConvertExpr;
-typedef OpcodeExpr<ExprType::Unary> UnaryExpr;
-typedef OpcodeExpr<ExprType::Ternary> TernaryExpr;
+using BinaryExpr = OpcodeExpr<ExprType::Binary>;
+using CompareExpr = OpcodeExpr<ExprType::Compare>;
+using ConvertExpr = OpcodeExpr<ExprType::Convert>;
+using UnaryExpr = OpcodeExpr<ExprType::Unary>;
+using TernaryExpr = OpcodeExpr<ExprType::Ternary>;
 
 class SimdLaneOpExpr : public ExprMixin<ExprType::SimdLaneOp> {
  public:
@@ -570,28 +570,28 @@ class MemoryVarExpr : public MemoryExpr<TypeEnum> {
   Var var;
 };
 
-typedef VarExpr<ExprType::Br> BrExpr;
-typedef VarExpr<ExprType::BrIf> BrIfExpr;
-typedef VarExpr<ExprType::Call> CallExpr;
-typedef VarExpr<ExprType::RefFunc> RefFuncExpr;
-typedef VarExpr<ExprType::GlobalGet> GlobalGetExpr;
-typedef VarExpr<ExprType::GlobalSet> GlobalSetExpr;
-typedef VarExpr<ExprType::LocalGet> LocalGetExpr;
-typedef VarExpr<ExprType::LocalSet> LocalSetExpr;
-typedef VarExpr<ExprType::LocalTee> LocalTeeExpr;
-typedef VarExpr<ExprType::ReturnCall> ReturnCallExpr;
-typedef VarExpr<ExprType::Throw> ThrowExpr;
-typedef VarExpr<ExprType::Rethrow> RethrowExpr;
+using BrExpr = VarExpr<ExprType::Br>;
+using BrIfExpr = VarExpr<ExprType::BrIf>;
+using CallExpr = VarExpr<ExprType::Call>;
+using RefFuncExpr = VarExpr<ExprType::RefFunc>;
+using GlobalGetExpr = VarExpr<ExprType::GlobalGet>;
+using GlobalSetExpr = VarExpr<ExprType::GlobalSet>;
+using LocalGetExpr = VarExpr<ExprType::LocalGet>;
+using LocalSetExpr = VarExpr<ExprType::LocalSet>;
+using LocalTeeExpr = VarExpr<ExprType::LocalTee>;
+using ReturnCallExpr = VarExpr<ExprType::ReturnCall>;
+using ThrowExpr = VarExpr<ExprType::Throw>;
+using RethrowExpr = VarExpr<ExprType::Rethrow>;
 
-typedef VarExpr<ExprType::DataDrop> DataDropExpr;
-typedef VarExpr<ExprType::ElemDrop> ElemDropExpr;
-typedef VarExpr<ExprType::TableGet> TableGetExpr;
-typedef VarExpr<ExprType::TableSet> TableSetExpr;
-typedef VarExpr<ExprType::TableGrow> TableGrowExpr;
-typedef VarExpr<ExprType::TableSize> TableSizeExpr;
-typedef VarExpr<ExprType::TableFill> TableFillExpr;
+using DataDropExpr = VarExpr<ExprType::DataDrop>;
+using ElemDropExpr = VarExpr<ExprType::ElemDrop>;
+using TableGetExpr = VarExpr<ExprType::TableGet>;
+using TableSetExpr = VarExpr<ExprType::TableSet>;
+using TableGrowExpr = VarExpr<ExprType::TableGrow>;
+using TableSizeExpr = VarExpr<ExprType::TableSize>;
+using TableFillExpr = VarExpr<ExprType::TableFill>;
 
-typedef MemoryVarExpr<ExprType::MemoryInit> MemoryInitExpr;
+using MemoryInitExpr = MemoryVarExpr<ExprType::MemoryInit>;
 
 class SelectExpr : public ExprMixin<ExprType::Select> {
  public:
@@ -674,8 +674,8 @@ class BlockExprBase : public ExprMixin<TypeEnum> {
   Block block;
 };
 
-typedef BlockExprBase<ExprType::Block> BlockExpr;
-typedef BlockExprBase<ExprType::Loop> LoopExpr;
+using BlockExpr = BlockExprBase<ExprType::Block>;
+using LoopExpr = BlockExprBase<ExprType::Loop>;
 
 class IfExpr : public ExprMixin<ExprType::If> {
  public:
@@ -734,17 +734,17 @@ class LoadStoreExpr : public MemoryExpr<TypeEnum> {
   Address offset;
 };
 
-typedef LoadStoreExpr<ExprType::Load> LoadExpr;
-typedef LoadStoreExpr<ExprType::Store> StoreExpr;
+using LoadExpr = LoadStoreExpr<ExprType::Load>;
+using StoreExpr = LoadStoreExpr<ExprType::Store>;
 
-typedef LoadStoreExpr<ExprType::AtomicLoad> AtomicLoadExpr;
-typedef LoadStoreExpr<ExprType::AtomicStore> AtomicStoreExpr;
-typedef LoadStoreExpr<ExprType::AtomicRmw> AtomicRmwExpr;
-typedef LoadStoreExpr<ExprType::AtomicRmwCmpxchg> AtomicRmwCmpxchgExpr;
-typedef LoadStoreExpr<ExprType::AtomicWait> AtomicWaitExpr;
-typedef LoadStoreExpr<ExprType::AtomicNotify> AtomicNotifyExpr;
-typedef LoadStoreExpr<ExprType::LoadSplat> LoadSplatExpr;
-typedef LoadStoreExpr<ExprType::LoadZero> LoadZeroExpr;
+using AtomicLoadExpr = LoadStoreExpr<ExprType::AtomicLoad>;
+using AtomicStoreExpr = LoadStoreExpr<ExprType::AtomicStore>;
+using AtomicRmwExpr = LoadStoreExpr<ExprType::AtomicRmw>;
+using AtomicRmwCmpxchgExpr = LoadStoreExpr<ExprType::AtomicRmwCmpxchg>;
+using AtomicWaitExpr = LoadStoreExpr<ExprType::AtomicWait>;
+using AtomicNotifyExpr = LoadStoreExpr<ExprType::AtomicNotify>;
+using LoadSplatExpr = LoadStoreExpr<ExprType::LoadSplat>;
+using LoadZeroExpr = LoadStoreExpr<ExprType::LoadZero>;
 
 class AtomicFenceExpr : public ExprMixin<ExprType::AtomicFence> {
  public:
@@ -765,8 +765,8 @@ struct Tag {
 
 class LocalTypes {
  public:
-  typedef std::pair<Type, Index> Decl;
-  typedef std::vector<Decl> Decls;
+  using Decl = std::pair<Type, Index>;
+  using Decls = std::vector<Decl>;
 
   struct const_iterator {
     const_iterator(Decls::const_iterator decl, Index index)
@@ -865,7 +865,7 @@ struct Table {
   Type elem_type;
 };
 
-typedef std::vector<ExprList> ExprListVector;
+using ExprListVector = std::vector<ExprList>;
 
 struct ElemSegment {
   explicit ElemSegment(std::string_view name) : name(name) {}
@@ -1001,7 +1001,7 @@ class ModuleField : public intrusive_list_base<ModuleField> {
   ModuleFieldType type_;
 };
 
-typedef intrusive_list<ModuleField> ModuleFieldList;
+using ModuleFieldList = intrusive_list<ModuleField>;
 
 template <ModuleFieldType TypeEnum>
 class ModuleFieldMixin : public ModuleField {
@@ -1249,8 +1249,8 @@ class DataScriptModule : public ScriptModuleMixin<TypeEnum> {
   std::vector<uint8_t> data;
 };
 
-typedef DataScriptModule<ScriptModuleType::Binary> BinaryScriptModule;
-typedef DataScriptModule<ScriptModuleType::Quoted> QuotedScriptModule;
+using BinaryScriptModule = DataScriptModule<ScriptModuleType::Binary>;
+using QuotedScriptModule = DataScriptModule<ScriptModuleType::Quoted>;
 
 enum class ActionType {
   Invoke,
@@ -1276,7 +1276,7 @@ class Action {
   ActionType type_;
 };
 
-typedef std::unique_ptr<Action> ActionPtr;
+using ActionPtr = std::unique_ptr<Action>;
 
 template <ActionType TypeEnum>
 class ActionMixin : public Action {
@@ -1361,7 +1361,7 @@ class ActionCommandBase : public CommandMixin<TypeEnum> {
   ActionPtr action;
 };
 
-typedef ActionCommandBase<CommandType::Action> ActionCommand;
+using ActionCommand = ActionCommandBase<CommandType::Action>;
 
 class RegisterCommand : public CommandMixin<CommandType::Register> {
  public:
@@ -1385,9 +1385,9 @@ class AssertTrapCommandBase : public CommandMixin<TypeEnum> {
   std::string text;
 };
 
-typedef AssertTrapCommandBase<CommandType::AssertTrap> AssertTrapCommand;
-typedef AssertTrapCommandBase<CommandType::AssertExhaustion>
-    AssertExhaustionCommand;
+using AssertTrapCommand = AssertTrapCommandBase<CommandType::AssertTrap>;
+using AssertExhaustionCommand =
+    AssertTrapCommandBase<CommandType::AssertExhaustion>;
 
 template <CommandType TypeEnum>
 class AssertModuleCommand : public CommandMixin<TypeEnum> {
@@ -1396,13 +1396,13 @@ class AssertModuleCommand : public CommandMixin<TypeEnum> {
   std::string text;
 };
 
-typedef AssertModuleCommand<CommandType::AssertMalformed>
-    AssertMalformedCommand;
-typedef AssertModuleCommand<CommandType::AssertInvalid> AssertInvalidCommand;
-typedef AssertModuleCommand<CommandType::AssertUnlinkable>
-    AssertUnlinkableCommand;
-typedef AssertModuleCommand<CommandType::AssertUninstantiable>
-    AssertUninstantiableCommand;
+using AssertMalformedCommand =
+    AssertModuleCommand<CommandType::AssertMalformed>;
+using AssertInvalidCommand = AssertModuleCommand<CommandType::AssertInvalid>;
+using AssertUnlinkableCommand =
+    AssertModuleCommand<CommandType::AssertUnlinkable>;
+using AssertUninstantiableCommand =
+    AssertModuleCommand<CommandType::AssertUninstantiable>;
 
 class AssertExceptionCommand
     : public CommandMixin<CommandType::AssertException> {
@@ -1410,8 +1410,8 @@ class AssertExceptionCommand
   ActionPtr action;
 };
 
-typedef std::unique_ptr<Command> CommandPtr;
-typedef std::vector<CommandPtr> CommandPtrVector;
+using CommandPtr = std::unique_ptr<Command>;
+using CommandPtrVector = std::vector<CommandPtr>;
 
 struct Script {
   WABT_DISALLOW_COPY_AND_ASSIGN(Script);

--- a/include/wabt/option-parser.h
+++ b/include/wabt/option-parser.h
@@ -31,8 +31,8 @@ class OptionParser {
   enum class ArgumentCount { One, OneOrMore, ZeroOrMore };
 
   struct Option;
-  typedef std::function<void(const char*)> Callback;
-  typedef std::function<void()> NullCallback;
+  using Callback = std::function<void(const char*)>;
+  using NullCallback = std::function<void()>;
 
   struct Option {
     Option(char short_name,

--- a/include/wabt/range.h
+++ b/include/wabt/range.h
@@ -29,8 +29,8 @@ struct Range {
   T size() const { return end - start; }
 };
 
-typedef Range<Offset> OffsetRange;
-typedef Range<int> ColumnRange;
+using OffsetRange = Range<Offset>;
+using ColumnRange = Range<int>;
 
 }  // namespace wabt
 

--- a/include/wabt/type-checker.h
+++ b/include/wabt/type-checker.h
@@ -28,7 +28,7 @@ namespace wabt {
 
 class TypeChecker {
  public:
-  typedef std::function<void(const char* msg)> ErrorCallback;
+  using ErrorCallback = std::function<void(const char* msg)>;
 
   struct Label {
     Label(LabelType,

--- a/include/wabt/wast-parser.h
+++ b/include/wabt/wast-parser.h
@@ -36,7 +36,7 @@ struct WastParseOptions {
   bool debug_parsing = false;
 };
 
-typedef std::array<TokenType, 2> TokenTypePair;
+using TokenTypePair = std::array<TokenType, 2>;
 
 class WastParser {
  public:
@@ -114,7 +114,7 @@ class WastParser {
   // token (used for printing better error messages).
   void ConsumeIfLpar() { Match(TokenType::Lpar); }
 
-  typedef bool SynchronizeFunc(TokenTypePair pair);
+  using SynchronizeFunc = bool(*)(TokenTypePair pair);
 
   // Attempt to synchronize the token stream by dropping tokens until the
   // SynchronizeFunc returns true, or until a token limit is reached. This

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -370,8 +370,8 @@ struct FuncCodeMetadata {
 struct CodeMetadataSection {
   std::vector<FuncCodeMetadata> entries;
 };
-typedef std::unordered_map<std::string_view, CodeMetadataSection>
-    CodeMetadataSections;
+using CodeMetadataSections =
+    std::unordered_map<std::string_view, CodeMetadataSection>;
 
 class BinaryWriter {
   WABT_DISALLOW_COPY_AND_ASSIGN(BinaryWriter);

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -73,12 +73,12 @@ struct Name {
   const std::string& name;
 };
 
-typedef Name<0> LocalName;
-typedef Name<1> GlobalName;
-typedef Name<2> ExternalPtr;
-typedef Name<3> ExternalRef;
-typedef Name<4> ExternalInstancePtr;
-typedef Name<5> ExternalInstanceRef;
+using LocalName = Name<0>;
+using GlobalName = Name<1>;
+using ExternalPtr = Name<2>;
+using ExternalRef = Name<3>;
+using ExternalInstancePtr = Name<4>;
+using ExternalInstanceRef = Name<5>;
 
 struct GotoLabel {
   explicit GotoLabel(const Var& var) : var(var) {}
@@ -153,10 +153,10 @@ class CWriter {
   Result WriteModule(const Module&);
 
  private:
-  typedef std::set<std::string> SymbolSet;
-  typedef std::map<std::string, std::string> SymbolMap;
-  typedef std::pair<Index, Type> StackTypePair;
-  typedef std::map<StackTypePair, std::string> StackVarSymbolMap;
+  using SymbolSet = std::set<std::string>;
+  using SymbolMap = std::map<std::string, std::string>;
+  using StackTypePair = std::pair<Index, Type>;
+  using StackVarSymbolMap = std::map<StackTypePair, std::string>;
 
   void WriteCHeader();
   void WriteCSource();

--- a/src/emscripten-helpers.cc
+++ b/src/emscripten-helpers.cc
@@ -42,9 +42,9 @@
 #include "wabt/wast-parser.h"
 #include "wabt/wat-writer.h"
 
-typedef std::unique_ptr<wabt::OutputBuffer> WabtOutputBufferPtr;
-typedef std::pair<std::string, WabtOutputBufferPtr>
-    WabtFilenameOutputBufferPair;
+using WabtOutputBufferPtr = std::unique_ptr<wabt::OutputBuffer>;
+using WabtFilenameOutputBufferPair =
+    std::pair<std::string, WabtOutputBufferPtr>;
 
 struct WabtParseWatResult {
   wabt::Result result;

--- a/src/interp/interp-wasi.cc
+++ b/src/interp/interp-wasi.cc
@@ -49,45 +49,45 @@ namespace {
 
 // BEGIN: wasi.h types from wasi-libc
 
-typedef uint32_t __wasi_size_t;
-typedef uint32_t __wasi_ptr_t;
+using __wasi_size_t = uint32_t;
+using __wasi_ptr_t = uint32_t;
 
 static_assert(sizeof(__wasi_size_t) == 4, "witx calculated size");
 static_assert(alignof(__wasi_size_t) == 4, "witx calculated align");
 static_assert(sizeof(__wasi_ptr_t) == 4, "witx calculated size");
 static_assert(alignof(__wasi_ptr_t) == 4, "witx calculated align");
 
-typedef struct __wasi_prestat_dir_t {
+struct __wasi_prestat_dir_t {
   __wasi_size_t pr_name_len;
-} __wasi_prestat_dir_t;
+};
 
-typedef uint8_t __wasi_preopentype_t;
-typedef uint64_t __wasi_rights_t;
-typedef uint16_t __wasi_fdflags_t;
-typedef uint8_t __wasi_filetype_t;
-typedef uint16_t __wasi_oflags_t;
-typedef uint32_t __wasi_lookupflags_t;
-typedef uint32_t __wasi_fd_t;
-typedef uint64_t __wasi_timestamp_t;
-typedef uint8_t __wasi_whence_t;
-typedef int64_t __wasi_filedelta_t;
-typedef uint64_t __wasi_filesize_t;
+using __wasi_preopentype_t = uint8_t;
+using __wasi_rights_t = uint64_t;
+using __wasi_fdflags_t = uint16_t;
+using __wasi_filetype_t = uint8_t;
+using __wasi_oflags_t = uint16_t;
+using __wasi_lookupflags_t = uint32_t;
+using __wasi_fd_t = uint32_t;
+using __wasi_timestamp_t = uint64_t;
+using __wasi_whence_t = uint8_t;
+using __wasi_filedelta_t = int64_t;
+using __wasi_filesize_t = uint64_t;
 
-typedef union __wasi_prestat_u_t {
+union __wasi_prestat_u_t {
   __wasi_prestat_dir_t dir;
-} __wasi_prestat_u_t;
+};
 
 struct __wasi_prestat_t {
   __wasi_preopentype_t tag;
   __wasi_prestat_u_t u;
 };
 
-typedef struct __wasi_fdstat_t {
+struct __wasi_fdstat_t {
   __wasi_filetype_t fs_filetype;
   __wasi_fdflags_t fs_flags;
   __wasi_rights_t fs_rights_base;
   __wasi_rights_t fs_rights_inheriting;
-} __wasi_fdstat_t;
+};
 
 static_assert(sizeof(__wasi_fdstat_t) == 24, "witx calculated size");
 static_assert(alignof(__wasi_fdstat_t) == 8, "witx calculated align");
@@ -110,22 +110,22 @@ static_assert(alignof(__wasi_iovec_t) == 4, "witx calculated align");
 static_assert(offsetof(__wasi_iovec_t, buf) == 0, "witx calculated offset");
 static_assert(offsetof(__wasi_iovec_t, buf_len) == 4, "witx calculated offset");
 
-typedef uint64_t __wasi_device_t;
+using __wasi_device_t = uint64_t;
 
 static_assert(sizeof(__wasi_device_t) == 8, "witx calculated size");
 static_assert(alignof(__wasi_device_t) == 8, "witx calculated align");
 
-typedef uint64_t __wasi_inode_t;
+using __wasi_inode_t = uint64_t;
 
 static_assert(sizeof(__wasi_inode_t) == 8, "witx calculated size");
 static_assert(alignof(__wasi_inode_t) == 8, "witx calculated align");
 
-typedef uint64_t __wasi_linkcount_t;
+using __wasi_linkcount_t = uint64_t;
 
 static_assert(sizeof(__wasi_linkcount_t) == 8, "witx calculated size");
 static_assert(alignof(__wasi_linkcount_t) == 8, "witx calculated align");
 
-typedef struct __wasi_filestat_t {
+struct __wasi_filestat_t {
   __wasi_device_t dev;
   __wasi_inode_t ino;
   __wasi_filetype_t filetype;
@@ -134,7 +134,7 @@ typedef struct __wasi_filestat_t {
   __wasi_timestamp_t atim;
   __wasi_timestamp_t mtim;
   __wasi_timestamp_t ctim;
-} __wasi_filestat_t;
+};
 
 static_assert(sizeof(__wasi_filestat_t) == 64, "witx calculated size");
 static_assert(alignof(__wasi_filestat_t) == 8, "witx calculated align");

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -37,7 +37,7 @@ struct FloatTraitsBase {};
 
 template <>
 struct FloatTraitsBase<float> {
-  typedef uint32_t Uint;
+  using Uint = uint32_t;
   static constexpr int kBits = sizeof(Uint) * 8;
   static constexpr int kSigBits = 23;
   static constexpr float kHugeVal = HUGE_VALF;
@@ -48,7 +48,7 @@ struct FloatTraitsBase<float> {
 
 template <>
 struct FloatTraitsBase<double> {
-  typedef uint64_t Uint;
+  using Uint = uint64_t;
   static constexpr int kBits = sizeof(Uint) * 8;
   static constexpr int kSigBits = 52;
   static constexpr float kHugeVal = HUGE_VAL;
@@ -61,7 +61,7 @@ struct FloatTraitsBase<double> {
 
 template <typename T>
 struct FloatTraits : FloatTraitsBase<T> {
-  typedef typename FloatTraitsBase<T>::Uint Uint;
+  using Uint = typename FloatTraitsBase<T>::Uint;
   using FloatTraitsBase<T>::kBits;
   using FloatTraitsBase<T>::kSigBits;
 
@@ -80,9 +80,9 @@ struct FloatTraits : FloatTraitsBase<T> {
 template <typename T>
 class FloatParser {
  public:
-  typedef FloatTraits<T> Traits;
-  typedef typename Traits::Uint Uint;
-  typedef T Float;
+  using Traits = FloatTraits<T>;
+  using Uint = typename Traits::Uint;
+  using Float = T;
 
   static Result Parse(LiteralType,
                       const char* s,
@@ -107,8 +107,8 @@ class FloatParser {
 template <typename T>
 class FloatWriter {
  public:
-  typedef FloatTraits<T> Traits;
-  typedef typename Traits::Uint Uint;
+  using Traits = FloatTraits<T>;
+  using Uint = typename Traits::Uint;
 
   static void WriteHex(char* out, size_t size, Uint bits);
 };
@@ -719,7 +719,7 @@ Result ParseInt(const char* s,
                 const char* end,
                 U* out,
                 ParseIntType parse_type) {
-  typedef typename std::make_signed<U>::type S;
+  using S = typename std::make_signed<U>::type;
   uint64_t value;
   bool has_sign = false;
   if (*s == '-' || *s == '+') {

--- a/src/test-intrusive-list.cc
+++ b/src/test-intrusive-list.cc
@@ -63,7 +63,7 @@ struct TestObject : intrusive_list_base<TestObject> {
 // static
 int TestObject::creation_count = 0;
 
-typedef intrusive_list<TestObject> TestObjectList;
+using TestObjectList = intrusive_list<TestObject>;
 
 class IntrusiveListTest : public ::testing::Test {
  protected:

--- a/src/tools/spectest-interp.cc
+++ b/src/tools/spectest-interp.cc
@@ -99,8 +99,8 @@ static void ParseOptions(int argc, char** argv) {
 namespace spectest {
 
 class Command;
-typedef std::unique_ptr<Command> CommandPtr;
-typedef std::vector<CommandPtr> CommandPtrVector;
+using CommandPtr = std::unique_ptr<Command>;
+using CommandPtrVector = std::vector<CommandPtr>;
 
 class Script {
  public:
@@ -155,7 +155,7 @@ class ActionCommandBase : public CommandMixin<TypeEnum> {
   Action action;
 };
 
-typedef ActionCommandBase<CommandType::Action> ActionCommand;
+using ActionCommand = ActionCommandBase<CommandType::Action>;
 
 class RegisterCommand : public CommandMixin<CommandType::Register> {
  public:
@@ -289,9 +289,9 @@ class AssertTrapCommandBase : public CommandMixin<TypeEnum> {
   std::string text;
 };
 
-typedef AssertTrapCommandBase<CommandType::AssertTrap> AssertTrapCommand;
-typedef AssertTrapCommandBase<CommandType::AssertExhaustion>
-    AssertExhaustionCommand;
+using AssertTrapCommand = AssertTrapCommandBase<CommandType::AssertTrap>;
+using AssertExhaustionCommand =
+    AssertTrapCommandBase<CommandType::AssertExhaustion>;
 
 template <CommandType TypeEnum>
 class AssertModuleCommand : public CommandMixin<TypeEnum> {
@@ -301,13 +301,13 @@ class AssertModuleCommand : public CommandMixin<TypeEnum> {
   std::string text;
 };
 
-typedef AssertModuleCommand<CommandType::AssertMalformed>
-    AssertMalformedCommand;
-typedef AssertModuleCommand<CommandType::AssertInvalid> AssertInvalidCommand;
-typedef AssertModuleCommand<CommandType::AssertUnlinkable>
-    AssertUnlinkableCommand;
-typedef AssertModuleCommand<CommandType::AssertUninstantiable>
-    AssertUninstantiableCommand;
+using AssertMalformedCommand =
+    AssertModuleCommand<CommandType::AssertMalformed>;
+using AssertInvalidCommand = AssertModuleCommand<CommandType::AssertInvalid>;
+using AssertUnlinkableCommand =
+    AssertModuleCommand<CommandType::AssertUnlinkable>;
+using AssertUninstantiableCommand =
+    AssertModuleCommand<CommandType::AssertUninstantiable>;
 
 class AssertExceptionCommand
     : public CommandMixin<CommandType::AssertException> {

--- a/src/tools/wasm-opcodecnt.cc
+++ b/src/tools/wasm-opcodecnt.cc
@@ -98,7 +98,7 @@ static size_t SumCounts(const OpcodeInfoCounts& info_counts) {
 }
 
 void WriteCounts(Stream& stream, const OpcodeInfoCounts& info_counts) {
-  typedef std::pair<Opcode, size_t> OpcodeCountPair;
+  using OpcodeCountPair = std::pair<Opcode, size_t>;
 
   std::map<Opcode, size_t> counts;
   for (auto& [info, count] : info_counts) {
@@ -122,9 +122,9 @@ void WriteCounts(Stream& stream, const OpcodeInfoCounts& info_counts) {
 
 void WriteCountsWithImmediates(Stream& stream, const OpcodeInfoCounts& counts) {
   // Remove const from the key type so we can sort below.
-  typedef std::pair<std::remove_const<OpcodeInfoCounts::key_type>::type,
-                    OpcodeInfoCounts::mapped_type>
-      OpcodeInfoCountPair;
+  using OpcodeInfoCountPair =
+      std::pair<std::remove_const<OpcodeInfoCounts::key_type>::type,
+                OpcodeInfoCounts::mapped_type>;
 
   std::vector<OpcodeInfoCountPair> sorted;
   std::copy_if(counts.begin(), counts.end(), std::back_inserter(sorted),

--- a/src/wast-parser.cc
+++ b/src/wast-parser.cc
@@ -142,7 +142,7 @@ void RemoveEscapes(std::string_view text, OutputIter dest) {
   }
 }
 
-typedef std::vector<std::string_view> TextVector;
+using TextVector = std::vector<std::string_view>;
 
 template <typename OutputIter>
 void RemoveEscapes(const TextVector& texts, OutputIter out) {


### PR DESCRIPTION
This is more modern and (IMHO) easier to read than that old C typedef syntax.