### PR TITLE
interp: Remove condition for performing type checks on `Value`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,6 +111,10 @@ check_type_size(size_t SIZEOF_SIZE_T)
 include(TestBigEndian)  # Note: deprecated in CMake 3.20
 test_big_endian(WABT_BIG_ENDIAN)
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  set(WABT_DEBUG 1)
+endif ()
+
 configure_file(src/config.h.in include/wabt/config.h @ONLY)
 
 

--- a/include/wabt/interp/interp.h
+++ b/include/wabt/interp/interp.h
@@ -27,6 +27,7 @@
 #include <vector>
 
 #include "wabt/cast.h"
+#include "wabt/config.h"
 #include "wabt/common.h"
 #include "wabt/feature.h"
 #include "wabt/opcode.h"
@@ -580,7 +581,7 @@ struct Value {
   };
 
  public:
-#ifndef NDEBUG
+#ifdef WABT_DEBUG
   Value() : v128_(0, 0, 0, 0), type(ValueType::Any) {}
   void SetType(ValueType t) { type = t; }
   void CheckType(ValueType t) const {

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -22,6 +22,8 @@
 
 #cmakedefine WABT_VERSION_STRING "@WABT_VERSION_STRING@"
 
+#cmakedefine WABT_DEBUG @WABT_DEBUG@
+
 /* TODO(binji): nice way to define these with WABT_ prefix? */
 
 /* Whether <alloca.h> is available */


### PR DESCRIPTION
Value's `type` field was compiled conditionally on the `NDEBUG` define. This causes problems with programs compiling against libwabt that don't define this macro, as the Value layout no longer matches.

Removing the condition entirely, assuming the performance impact of this is limited (especially if assertions are disabled).

Fixes #2069