### PR TITLE
wasm2c CI: run asan and ubsan tests on clang 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,9 +81,10 @@ jobs:
 
   build-asan:
     name: asan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       USE_NINJA: "1"
+      CC: "clang" # used by the wasm2c tests
       WASM2C_CFLAGS: "-fsanitize=address"
     steps:
     - uses: actions/setup-python@v1
@@ -100,9 +101,10 @@ jobs:
 
   build-ubsan:
     name: ubsan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     env:
       USE_NINJA: "1"
+      CC: "clang" # used by the wasm2c tests
       WASM2C_CFLAGS: "-fsanitize=undefined"
     steps:
     - uses: actions/setup-python@v1


### PR DESCRIPTION
Move the GitHub CI tests for "asan" and "ubsan" over to using clang as the wasm2c compiler (in addition to using clang to compile wasm2c and the rest of WABT itself). Prerequisite for #2077.

This could probably be done in a more principled way (by modifying the Makefile for "clang-xxx-asan" and "clang-xxx-ubsan") but this matches the current practice in setting WASM2C_CFLAGS explicitly in the GitHub workflow (and is easier).