### PR TITLE
[WIP] Use length-prefixed init expressions

### DIFF
--- a/include/wabt/opcode.def
+++ b/include/wabt/opcode.def
@@ -219,11 +219,14 @@ WABT_OPCODE(F32,  I32,  ___,  ___,  0,  0,    0xbe, F32ReinterpretI32, "f32.rein
 WABT_OPCODE(F64,  I64,  ___,  ___,  0,  0,    0xbf, F64ReinterpretI64, "f64.reinterpret_i64", "")
 
 /* Sign-extension opcodes (--enable-sign-extension) */
-WABT_OPCODE(I32,  I32,  ___,  ___,  0,  0,    0xC0, I32Extend8S, "i32.extend8_s", "")
-WABT_OPCODE(I32,  I32,  ___,  ___,  0,  0,    0xC1, I32Extend16S, "i32.extend16_s", "")
-WABT_OPCODE(I64,  I64,  ___,  ___,  0,  0,    0xC2, I64Extend8S, "i64.extend8_s", "")
-WABT_OPCODE(I64,  I64,  ___,  ___,  0,  0,    0xC3, I64Extend16S, "i64.extend16_s", "")
-WABT_OPCODE(I64,  I64,  ___,  ___,  0,  0,    0xC4, I64Extend32S, "i64.extend32_s", "")
+WABT_OPCODE(I32,  I32,  ___,  ___,  0,  0,    0xc0, I32Extend8S, "i32.extend8_s", "")
+WABT_OPCODE(I32,  I32,  ___,  ___,  0,  0,    0xc1, I32Extend16S, "i32.extend16_s", "")
+WABT_OPCODE(I64,  I64,  ___,  ___,  0,  0,    0xc2, I64Extend8S, "i64.extend8_s", "")
+WABT_OPCODE(I64,  I64,  ___,  ___,  0,  0,    0xc3, I64Extend16S, "i64.extend16_s", "")
+WABT_OPCODE(I64,  I64,  ___,  ___,  0,  0,    0xc4, I64Extend32S, "i64.extend32_s", "")
+
+/* Extended const expressions */
+WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xc5, ConstExprLen, "const_expr.len", "")
 
 /* Interpreter-only opcodes */
 WABT_OPCODE(___,  ___,  ___,  ___,  0,  0,    0xe0, InterpAlloca, "alloca", "")

--- a/src/binary-writer.cc
+++ b/src/binary-writer.cc
@@ -1130,8 +1130,20 @@ void BinaryWriter::WriteExprList(const Func* func, const ExprList& exprs) {
 }
 
 void BinaryWriter::WriteInitExpr(const ExprList& expr) {
+  /* TODO(binji): better guess of the size of the const expr body */
+  const Offset leb_size_guess = 1;
+  Offset size_offset;
+  if (expr.size() > 1) {
+    WriteOpcode(stream_, Opcode::ConstExprLen);
+    size_offset =
+        WriteU32Leb128Space(leb_size_guess, "init expr body size (guess)");
+  }
   WriteExprList(nullptr, expr);
   WriteOpcode(stream_, Opcode::End);
+  if (expr.size() > 1) {
+    WriteFixupU32Leb128Size(size_offset, leb_size_guess,
+                            "FIXUP init expr size");
+  }
 }
 
 void BinaryWriter::WriteFuncLocals(const Func* func,

--- a/src/interp/interp.cc
+++ b/src/interp/interp.cc
@@ -1896,6 +1896,7 @@ RunResult Thread::StepInternal(Trap::Ptr* out_trap) {
     case O::End:
     case O::ReturnCall:
     case O::SelectT:
+    case O::ConstExprLen:
 
     case O::CallRef:
     case O::Try:

--- a/src/interp/istream.cc
+++ b/src/interp/istream.cc
@@ -774,6 +774,7 @@ Instr Istream::Read(Offset* offset) const {
     case Opcode::Loop:
     case Opcode::Try:
     case Opcode::ReturnCall:
+    case Opcode::ConstExprLen:
       // Not used.
       break;
   }

--- a/test/dump/extended-const.txt
+++ b/test/dump/extended-const.txt
@@ -70,92 +70,101 @@
 0000032: 02                                        ; num globals
 0000033: 7f                                        ; i32
 0000034: 01                                        ; global mutability
-0000035: 41                                        ; i32.const
-0000036: 2c                                        ; i32 literal
+0000035: c5                                        ; const_expr.len
+0000036: 00                                        ; init expr body size (guess)
 0000037: 41                                        ; i32.const
-0000038: 03                                        ; i32 literal
-0000039: 6b                                        ; i32.sub
-000003a: 0b                                        ; end
-000003b: 7f                                        ; i32
-000003c: 00                                        ; global mutability
-000003d: 41                                        ; i32.const
-000003e: 2d                                        ; i32 literal
-000003f: 0b                                        ; end
-0000031: 0e                                        ; FIXUP section size
+0000038: 2c                                        ; i32 literal
+0000039: 41                                        ; i32.const
+000003a: 03                                        ; i32 literal
+000003b: 6b                                        ; i32.sub
+000003c: 0b                                        ; end
+0000036: 06                                        ; FIXUP init expr size
+000003d: 7f                                        ; i32
+000003e: 00                                        ; global mutability
+000003f: 41                                        ; i32.const
+0000040: 2d                                        ; i32 literal
+0000041: 0b                                        ; end
+0000031: 10                                        ; FIXUP section size
 ; section "Elem" (9)
-0000040: 09                                        ; section code
-0000041: 00                                        ; section size (guess)
-0000042: 01                                        ; num elem segments
+0000042: 09                                        ; section code
+0000043: 00                                        ; section size (guess)
+0000044: 01                                        ; num elem segments
 ; elem segment header 0
-0000043: 00                                        ; segment flags
-0000044: 41                                        ; i32.const
-0000045: 04                                        ; i32 literal
-0000046: 23                                        ; global.get
-0000047: 00                                        ; global index
-0000048: 6c                                        ; i32.mul
-0000049: 0b                                        ; end
-000004a: 01                                        ; num elems
-000004b: 00                                        ; elem function index
-0000041: 0a                                        ; FIXUP section size
+0000045: 00                                        ; segment flags
+0000046: c5                                        ; const_expr.len
+0000047: 00                                        ; init expr body size (guess)
+0000048: 41                                        ; i32.const
+0000049: 04                                        ; i32 literal
+000004a: 23                                        ; global.get
+000004b: 00                                        ; global index
+000004c: 6c                                        ; i32.mul
+000004d: 0b                                        ; end
+0000047: 06                                        ; FIXUP init expr size
+000004e: 01                                        ; num elems
+000004f: 00                                        ; elem function index
+0000043: 0c                                        ; FIXUP section size
 ; section "DataCount" (12)
-000004c: 0c                                        ; section code
-000004d: 00                                        ; section size (guess)
-000004e: 01                                        ; data count
-000004d: 01                                        ; FIXUP section size
+0000050: 0c                                        ; section code
+0000051: 00                                        ; section size (guess)
+0000052: 01                                        ; data count
+0000051: 01                                        ; FIXUP section size
 ; section "Code" (10)
-000004f: 0a                                        ; section code
-0000050: 00                                        ; section size (guess)
-0000051: 01                                        ; num functions
+0000053: 0a                                        ; section code
+0000054: 00                                        ; section size (guess)
+0000055: 01                                        ; num functions
 ; function body 0
-0000052: 00                                        ; func body size (guess)
-0000053: 00                                        ; local decl count
-0000054: 0b                                        ; end
-0000052: 02                                        ; FIXUP func body size
-0000050: 04                                        ; FIXUP section size
-; move data: [4f, 55) -> [4c, 52)
-; truncate to 82 (0x52)
+0000056: 00                                        ; func body size (guess)
+0000057: 00                                        ; local decl count
+0000058: 0b                                        ; end
+0000056: 02                                        ; FIXUP func body size
+0000054: 04                                        ; FIXUP section size
+; move data: [53, 59) -> [50, 56)
+; truncate to 86 (0x56)
 ; section "Data" (11)
-0000052: 0b                                        ; section code
-0000053: 00                                        ; section size (guess)
-0000054: 01                                        ; num data segments
+0000056: 0b                                        ; section code
+0000057: 00                                        ; section size (guess)
+0000058: 01                                        ; num data segments
 ; data segment header 0
-0000055: 00                                        ; segment flags
-0000056: 23                                        ; global.get
-0000057: 00                                        ; global index
-0000058: 41                                        ; i32.const
-0000059: 2a                                        ; i32 literal
-000005a: 6a                                        ; i32.add
-000005b: 0b                                        ; end
-000005c: 05                                        ; data segment size
+0000059: 00                                        ; segment flags
+000005a: c5                                        ; const_expr.len
+000005b: 00                                        ; init expr body size (guess)
+000005c: 23                                        ; global.get
+000005d: 00                                        ; global index
+000005e: 41                                        ; i32.const
+000005f: 2a                                        ; i32 literal
+0000060: 6a                                        ; i32.add
+0000061: 0b                                        ; end
+000005b: 06                                        ; FIXUP init expr size
+0000062: 05                                        ; data segment size
 ; data segment data 0
-000005d: 6865 6c6c 6f                              ; data segment data
-0000053: 0e                                        ; FIXUP section size
+0000063: 6865 6c6c 6f                              ; data segment data
+0000057: 10                                        ; FIXUP section size
 ; section "name"
-0000062: 00                                        ; section code
-0000063: 00                                        ; section size (guess)
-0000064: 04                                        ; string length
-0000065: 6e61 6d65                                name  ; custom section name
-0000069: 02                                        ; local name type
-000006a: 00                                        ; subsection size (guess)
-000006b: 01                                        ; num functions
-000006c: 00                                        ; function index
-000006d: 00                                        ; num locals
-000006a: 03                                        ; FIXUP subsection size
-000006e: 04                                        ; name subsection type
-000006f: 00                                        ; subsection size (guess)
-0000070: 01                                        ; num names
-0000071: 00                                        ; elem index
-0000072: 05                                        ; string length
-0000073: 7479 7065 31                             type1  ; elem name 0
-000006f: 08                                        ; FIXUP subsection size
-0000078: 07                                        ; name subsection type
-0000079: 00                                        ; subsection size (guess)
-000007a: 01                                        ; num names
-000007b: 00                                        ; elem index
-000007c: 08                                        ; string length
-000007d: 675f 696d 706f 7274                      g_import  ; elem name 0
-0000079: 0b                                        ; FIXUP subsection size
-0000063: 21                                        ; FIXUP section size
+0000068: 00                                        ; section code
+0000069: 00                                        ; section size (guess)
+000006a: 04                                        ; string length
+000006b: 6e61 6d65                                name  ; custom section name
+000006f: 02                                        ; local name type
+0000070: 00                                        ; subsection size (guess)
+0000071: 01                                        ; num functions
+0000072: 00                                        ; function index
+0000073: 00                                        ; num locals
+0000070: 03                                        ; FIXUP subsection size
+0000074: 04                                        ; name subsection type
+0000075: 00                                        ; subsection size (guess)
+0000076: 01                                        ; num names
+0000077: 00                                        ; elem index
+0000078: 05                                        ; string length
+0000079: 7479 7065 31                             type1  ; elem name 0
+0000075: 08                                        ; FIXUP subsection size
+000007e: 07                                        ; name subsection type
+000007f: 00                                        ; subsection size (guess)
+0000080: 01                                        ; num names
+0000081: 00                                        ; elem index
+0000082: 08                                        ; string length
+0000083: 675f 696d 706f 7274                      g_import  ; elem name 0
+000007f: 0b                                        ; FIXUP subsection size
+0000069: 21                                        ; FIXUP section size
 ;;; STDERR ;;)
 (;; STDOUT ;;;
 
@@ -192,6 +201,6 @@ Custom:
 
 Code Disassembly:
 
-000050 func[0]:
- 000051: 0b                         | end
+000054 func[0]:
+ 000055: 0b                         | end
 ;;; STDOUT ;;)

--- a/test/dump/invalid-data-segment-offset.txt
+++ b/test/dump/invalid-data-segment-offset.txt
@@ -26,14 +26,17 @@
 000000f: 01                                        ; num data segments
 ; data segment header 0
 0000010: 00                                        ; segment flags
-0000011: 41                                        ; i32.const
-0000012: 01                                        ; i32 literal
+0000011: c5                                        ; const_expr.len
+0000012: 00                                        ; init expr body size (guess)
 0000013: 41                                        ; i32.const
-0000014: 02                                        ; i32 literal
-0000015: 6a                                        ; i32.add
-0000016: 0b                                        ; end
-0000017: 03                                        ; data segment size
+0000014: 01                                        ; i32 literal
+0000015: 41                                        ; i32.const
+0000016: 02                                        ; i32 literal
+0000017: 6a                                        ; i32.add
+0000018: 0b                                        ; end
+0000012: 06                                        ; FIXUP init expr size
+0000019: 03                                        ; data segment size
 ; data segment data 0
-0000018: 666f 6f                                   ; data segment data
-000000e: 0c                                        ; FIXUP section size
+000001a: 666f 6f                                   ; data segment data
+000000e: 0e                                        ; FIXUP section size
 ;;; STDERR ;;)

--- a/test/dump/invalid-elem-segment-offset.txt
+++ b/test/dump/invalid-elem-segment-offset.txt
@@ -37,21 +37,24 @@
 000001a: 01                                        ; num elem segments
 ; elem segment header 0
 000001b: 00                                        ; segment flags
-000001c: 41                                        ; i32.const
-000001d: 01                                        ; i32 literal
-000001e: 45                                        ; i32.eqz
-000001f: 0b                                        ; end
-0000020: 01                                        ; num elems
-0000021: 00                                        ; elem function index
-0000019: 08                                        ; FIXUP section size
+000001c: c5                                        ; const_expr.len
+000001d: 00                                        ; init expr body size (guess)
+000001e: 41                                        ; i32.const
+000001f: 01                                        ; i32 literal
+0000020: 45                                        ; i32.eqz
+0000021: 0b                                        ; end
+000001d: 04                                        ; FIXUP init expr size
+0000022: 01                                        ; num elems
+0000023: 00                                        ; elem function index
+0000019: 0a                                        ; FIXUP section size
 ; section "Code" (10)
-0000022: 0a                                        ; section code
-0000023: 00                                        ; section size (guess)
-0000024: 01                                        ; num functions
+0000024: 0a                                        ; section code
+0000025: 00                                        ; section size (guess)
+0000026: 01                                        ; num functions
 ; function body 0
-0000025: 00                                        ; func body size (guess)
-0000026: 00                                        ; local decl count
-0000027: 0b                                        ; end
-0000025: 02                                        ; FIXUP func body size
-0000023: 04                                        ; FIXUP section size
+0000027: 00                                        ; func body size (guess)
+0000028: 00                                        ; local decl count
+0000029: 0b                                        ; end
+0000027: 02                                        ; FIXUP func body size
+0000025: 04                                        ; FIXUP section size
 ;;; STDERR ;;)

--- a/test/spec/data.txt
+++ b/test/spec/data.txt
@@ -35,26 +35,26 @@ out/test/spec/data.wast:400: assert_invalid passed:
   out/test/spec/data/data.49.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:408: assert_invalid passed:
-  out/test/spec/data/data.50.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000016: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/data/data.50.wasm:0000017: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000018: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:416: assert_invalid passed:
-  out/test/spec/data/data.51.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002c: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/data/data.51.wasm:000002d: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002e: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:425: assert_invalid passed:
-  out/test/spec/data/data.52.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002c: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/data/data.52.wasm:000002d: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002e: error: EndDataSegmentInitExpr callback failed
 out/test/spec/data.wast:434: assert_invalid passed:
-  out/test/spec/data/data.53.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000014: error: OnUnaryExpr callback failed
+  out/test/spec/data/data.53.wasm:0000016: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000016: error: OnUnaryExpr callback failed
 out/test/spec/data.wast:442: assert_invalid passed:
   out/test/spec/data/data.54.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/data.wast:450: assert_invalid passed:
-  out/test/spec/data/data.55.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000012: error: OnNopExpr callback failed
-out/test/spec/data.wast:458: assert_invalid passed:
-  out/test/spec/data/data.56.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
+  out/test/spec/data/data.55.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
+out/test/spec/data.wast:458: assert_invalid passed:
+  out/test/spec/data/data.56.wasm:0000016: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000016: error: OnNopExpr callback failed
 out/test/spec/data.wast:466: assert_invalid passed:
   out/test/spec/data/data.57.wasm:0000020: error: initializer expression cannot reference a mutable global
   0000020: error: OnGlobalGetExpr callback failed

--- a/test/spec/elem.txt
+++ b/test/spec/elem.txt
@@ -22,26 +22,26 @@ out/test/spec/elem.wast:372: assert_invalid passed:
   out/test/spec/elem/elem.38.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:380: assert_invalid passed:
-  out/test/spec/elem/elem.39.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000017: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/elem/elem.39.wasm:0000018: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000019: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:388: assert_invalid passed:
-  out/test/spec/elem/elem.40.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002d: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/elem/elem.40.wasm:000002e: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002f: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:397: assert_invalid passed:
-  out/test/spec/elem/elem.41.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002d: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/elem/elem.41.wasm:000002e: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002f: error: EndElemSegmentInitExpr callback failed
 out/test/spec/elem.wast:407: assert_invalid passed:
-  out/test/spec/elem/elem.42.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000015: error: OnUnaryExpr callback failed
+  out/test/spec/elem/elem.42.wasm:0000017: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000017: error: OnUnaryExpr callback failed
 out/test/spec/elem.wast:415: assert_invalid passed:
   out/test/spec/elem/elem.43.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
 out/test/spec/elem.wast:423: assert_invalid passed:
-  out/test/spec/elem/elem.44.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000013: error: OnNopExpr callback failed
-out/test/spec/elem.wast:431: assert_invalid passed:
-  out/test/spec/elem/elem.45.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
+  out/test/spec/elem/elem.44.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
+out/test/spec/elem.wast:431: assert_invalid passed:
+  out/test/spec/elem/elem.45.wasm:0000017: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000017: error: OnNopExpr callback failed
 out/test/spec/elem.wast:439: assert_invalid passed:
   out/test/spec/elem/elem.46.wasm:0000021: error: initializer expression cannot reference a mutable global
   0000021: error: OnGlobalGetExpr callback failed
@@ -58,7 +58,7 @@ out/test/spec/elem.wast:476: assert_invalid passed:
   out/test/spec/elem/elem.50.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
   0000018: error: OnElemSegmentElemExpr_RefNull callback failed
 out/test/spec/elem.wast:484: assert_invalid passed:
-  0000019: error: expected END opcode after element expression
+  000001b: error: expected END opcode after element expression
 out/test/spec/elem.wast:492: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression
@@ -69,8 +69,8 @@ out/test/spec/elem.wast:508: assert_invalid passed:
   0000022: error: expected ref.null or ref.func in passive element segment
   0000023: error: expected END opcode after element expression
 out/test/spec/elem.wast:517: assert_invalid passed:
-  0000017: error: expected ref.null or ref.func in passive element segment
-  0000018: error: expected END opcode after element expression
+  0000019: error: expected ref.null or ref.func in passive element segment
+  000001a: error: expected END opcode after element expression
 out/test/spec/elem.wast:574: assert_trap passed: uninitialized table element
 out/test/spec/elem.wast:607: assert_invalid passed:
   out/test/spec/elem/elem.61.wasm:000001f: error: type mismatch at elem segment. got externref, expected funcref

--- a/test/spec/extended-const/data.txt
+++ b/test/spec/extended-const/data.txt
@@ -36,26 +36,26 @@ out/test/spec/extended-const/data.wast:432: assert_invalid passed:
   out/test/spec/extended-const/data/data.53.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/extended-const/data.wast:440: assert_invalid passed:
-  out/test/spec/extended-const/data/data.54.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000016: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/extended-const/data/data.54.wasm:0000017: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000018: error: EndDataSegmentInitExpr callback failed
 out/test/spec/extended-const/data.wast:448: assert_invalid passed:
-  out/test/spec/extended-const/data/data.55.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002c: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/extended-const/data/data.55.wasm:000002d: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002e: error: EndDataSegmentInitExpr callback failed
 out/test/spec/extended-const/data.wast:457: assert_invalid passed:
-  out/test/spec/extended-const/data/data.56.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002c: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/extended-const/data/data.56.wasm:000002d: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002e: error: EndDataSegmentInitExpr callback failed
 out/test/spec/extended-const/data.wast:466: assert_invalid passed:
-  out/test/spec/extended-const/data/data.57.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000014: error: OnUnaryExpr callback failed
+  out/test/spec/extended-const/data/data.57.wasm:0000016: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000016: error: OnUnaryExpr callback failed
 out/test/spec/extended-const/data.wast:474: assert_invalid passed:
   out/test/spec/extended-const/data/data.58.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/extended-const/data.wast:482: assert_invalid passed:
-  out/test/spec/extended-const/data/data.59.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000012: error: OnNopExpr callback failed
-out/test/spec/extended-const/data.wast:490: assert_invalid passed:
-  out/test/spec/extended-const/data/data.60.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
+  out/test/spec/extended-const/data/data.59.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
+out/test/spec/extended-const/data.wast:490: assert_invalid passed:
+  out/test/spec/extended-const/data/data.60.wasm:0000016: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000016: error: OnNopExpr callback failed
 out/test/spec/extended-const/data.wast:498: assert_invalid passed:
   out/test/spec/extended-const/data/data.61.wasm:0000020: error: initializer expression cannot reference a mutable global
   0000020: error: OnGlobalGetExpr callback failed

--- a/test/spec/extended-const/elem.txt
+++ b/test/spec/extended-const/elem.txt
@@ -23,26 +23,26 @@ out/test/spec/extended-const/elem.wast:372: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.38.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got []
   0000013: error: EndElemSegmentInitExpr callback failed
 out/test/spec/extended-const/elem.wast:380: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.39.wasm:0000016: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000017: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/extended-const/elem/elem.39.wasm:0000018: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000019: error: EndElemSegmentInitExpr callback failed
 out/test/spec/extended-const/elem.wast:388: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.40.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002d: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/extended-const/elem/elem.40.wasm:000002e: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002f: error: EndElemSegmentInitExpr callback failed
 out/test/spec/extended-const/elem.wast:397: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.41.wasm:000002c: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002d: error: EndElemSegmentInitExpr callback failed
+  out/test/spec/extended-const/elem/elem.41.wasm:000002e: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002f: error: EndElemSegmentInitExpr callback failed
 out/test/spec/extended-const/elem.wast:407: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.42.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000015: error: OnUnaryExpr callback failed
+  out/test/spec/extended-const/elem/elem.42.wasm:0000017: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000017: error: OnUnaryExpr callback failed
 out/test/spec/extended-const/elem.wast:415: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.43.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed
 out/test/spec/extended-const/elem.wast:423: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.44.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000013: error: OnNopExpr callback failed
-out/test/spec/extended-const/elem.wast:431: assert_invalid passed:
-  out/test/spec/extended-const/elem/elem.45.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
+  out/test/spec/extended-const/elem/elem.44.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: nop
   0000015: error: OnNopExpr callback failed
+out/test/spec/extended-const/elem.wast:431: assert_invalid passed:
+  out/test/spec/extended-const/elem/elem.45.wasm:0000017: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000017: error: OnNopExpr callback failed
 out/test/spec/extended-const/elem.wast:439: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.46.wasm:0000021: error: initializer expression cannot reference a mutable global
   0000021: error: OnGlobalGetExpr callback failed
@@ -59,7 +59,7 @@ out/test/spec/extended-const/elem.wast:476: assert_invalid passed:
   out/test/spec/extended-const/elem/elem.50.wasm:0000018: error: type mismatch at elem expression. got externref, expected funcref
   0000018: error: OnElemSegmentElemExpr_RefNull callback failed
 out/test/spec/extended-const/elem.wast:484: assert_invalid passed:
-  0000019: error: expected END opcode after element expression
+  000001b: error: expected END opcode after element expression
 out/test/spec/extended-const/elem.wast:492: assert_invalid passed:
   0000017: error: expected ref.null or ref.func in passive element segment
   0000018: error: expected END opcode after element expression

--- a/test/spec/extended-const/global.txt
+++ b/test/spec/extended-const/global.txt
@@ -10,20 +10,20 @@ out/test/spec/extended-const/global.wast:290: assert_invalid passed:
   out/test/spec/extended-const/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
   0000035: error: OnGlobalSetExpr callback failed
 out/test/spec/extended-const/global.wast:299: assert_invalid passed:
-  out/test/spec/extended-const/global/global.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
-  0000013: error: OnUnaryExpr callback failed
+  out/test/spec/extended-const/global/global.5.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: f32.neg
+  0000015: error: OnUnaryExpr callback failed
 out/test/spec/extended-const/global.wast:304: assert_invalid passed:
   out/test/spec/extended-const/global/global.6.wasm:000000f: error: invalid initializer: instruction not valid in initializer expression: local.get
   000000f: error: OnLocalGetExpr callback failed
 out/test/spec/extended-const/global.wast:309: assert_invalid passed:
-  out/test/spec/extended-const/global/global.7.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
-  0000013: error: OnUnaryExpr callback failed
+  out/test/spec/extended-const/global/global.7.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: f32.neg
+  0000015: error: OnUnaryExpr callback failed
 out/test/spec/extended-const/global.wast:314: assert_invalid passed:
-  out/test/spec/extended-const/global/global.8.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000010: error: OnNopExpr callback failed
+  out/test/spec/extended-const/global/global.8.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000012: error: OnNopExpr callback failed
 out/test/spec/extended-const/global.wast:319: assert_invalid passed:
-  out/test/spec/extended-const/global/global.9.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000010: error: OnUnaryExpr callback failed
+  out/test/spec/extended-const/global/global.9.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000012: error: OnUnaryExpr callback failed
 out/test/spec/extended-const/global.wast:324: assert_invalid passed:
   out/test/spec/extended-const/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
   000000e: error: OnNopExpr callback failed
@@ -31,8 +31,8 @@ out/test/spec/extended-const/global.wast:329: assert_invalid passed:
   out/test/spec/extended-const/global/global.11.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got [f32]
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/extended-const/global.wast:334: assert_invalid passed:
-  out/test/spec/extended-const/global/global.12.wasm:0000011: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000012: error: EndGlobalInitExpr callback failed
+  out/test/spec/extended-const/global/global.12.wasm:0000013: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000014: error: EndGlobalInitExpr callback failed
 out/test/spec/extended-const/global.wast:339: assert_invalid passed:
   out/test/spec/extended-const/global/global.13.wasm:000000d: error: type mismatch in initializer expression, expected [i32] but got []
   000000e: error: EndGlobalInitExpr callback failed
@@ -40,11 +40,11 @@ out/test/spec/extended-const/global.wast:344: assert_invalid passed:
   out/test/spec/extended-const/global/global.14.wasm:0000017: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000018: error: EndGlobalInitExpr callback failed
 out/test/spec/extended-const/global.wast:349: assert_invalid passed:
-  out/test/spec/extended-const/global/global.15.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000028: error: EndGlobalInitExpr callback failed
+  out/test/spec/extended-const/global/global.15.wasm:0000029: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002a: error: EndGlobalInitExpr callback failed
 out/test/spec/extended-const/global.wast:354: assert_invalid passed:
-  out/test/spec/extended-const/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000028: error: EndGlobalInitExpr callback failed
+  out/test/spec/extended-const/global/global.16.wasm:0000029: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002a: error: EndGlobalInitExpr callback failed
 out/test/spec/extended-const/global.wast:359: assert_invalid passed:
   out/test/spec/extended-const/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
   000000f: error: OnGlobalGetExpr callback failed

--- a/test/spec/func_ptrs.txt
+++ b/test/spec/func_ptrs.txt
@@ -13,8 +13,8 @@ out/test/spec/func_ptrs.wast:36: assert_invalid passed:
   out/test/spec/func_ptrs/func_ptrs.3.wasm:0000014: error: type mismatch in initializer expression, expected [i32] but got [i64]
   0000015: error: EndElemSegmentInitExpr callback failed
 out/test/spec/func_ptrs.wast:40: assert_invalid passed:
-  out/test/spec/func_ptrs/func_ptrs.4.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000015: error: OnUnaryExpr callback failed
+  out/test/spec/func_ptrs/func_ptrs.4.wasm:0000017: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000017: error: OnUnaryExpr callback failed
 out/test/spec/func_ptrs.wast:44: assert_invalid passed:
   out/test/spec/func_ptrs/func_ptrs.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: nop
   0000013: error: OnNopExpr callback failed

--- a/test/spec/global.txt
+++ b/test/spec/global.txt
@@ -9,20 +9,20 @@ out/test/spec/global.wast:278: assert_invalid passed:
   out/test/spec/global/global.2.wasm:0000035: error: can't global.set on immutable global at index 0.
   0000035: error: OnGlobalSetExpr callback failed
 out/test/spec/global.wast:287: assert_invalid passed:
-  out/test/spec/global/global.5.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
-  0000013: error: OnUnaryExpr callback failed
+  out/test/spec/global/global.5.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: f32.neg
+  0000015: error: OnUnaryExpr callback failed
 out/test/spec/global.wast:292: assert_invalid passed:
   out/test/spec/global/global.6.wasm:000000f: error: invalid initializer: instruction not valid in initializer expression: local.get
   000000f: error: OnLocalGetExpr callback failed
 out/test/spec/global.wast:297: assert_invalid passed:
-  out/test/spec/global/global.7.wasm:0000013: error: invalid initializer: instruction not valid in initializer expression: f32.neg
-  0000013: error: OnUnaryExpr callback failed
+  out/test/spec/global/global.7.wasm:0000015: error: invalid initializer: instruction not valid in initializer expression: f32.neg
+  0000015: error: OnUnaryExpr callback failed
 out/test/spec/global.wast:302: assert_invalid passed:
-  out/test/spec/global/global.8.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000010: error: OnNopExpr callback failed
+  out/test/spec/global/global.8.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000012: error: OnNopExpr callback failed
 out/test/spec/global.wast:307: assert_invalid passed:
-  out/test/spec/global/global.9.wasm:0000010: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000010: error: OnUnaryExpr callback failed
+  out/test/spec/global/global.9.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000012: error: OnUnaryExpr callback failed
 out/test/spec/global.wast:312: assert_invalid passed:
   out/test/spec/global/global.10.wasm:000000e: error: invalid initializer: instruction not valid in initializer expression: nop
   000000e: error: OnNopExpr callback failed
@@ -30,8 +30,8 @@ out/test/spec/global.wast:317: assert_invalid passed:
   out/test/spec/global/global.11.wasm:0000012: error: type mismatch in initializer expression, expected [i32] but got [f32]
   0000013: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:322: assert_invalid passed:
-  out/test/spec/global/global.12.wasm:0000011: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000012: error: EndGlobalInitExpr callback failed
+  out/test/spec/global/global.12.wasm:0000013: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000014: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:327: assert_invalid passed:
   out/test/spec/global/global.13.wasm:000000d: error: type mismatch in initializer expression, expected [i32] but got []
   000000e: error: EndGlobalInitExpr callback failed
@@ -39,11 +39,11 @@ out/test/spec/global.wast:332: assert_invalid passed:
   out/test/spec/global/global.14.wasm:0000017: error: type mismatch in initializer expression, expected [funcref] but got [externref]
   0000018: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:337: assert_invalid passed:
-  out/test/spec/global/global.15.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000028: error: EndGlobalInitExpr callback failed
+  out/test/spec/global/global.15.wasm:0000029: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002a: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:342: assert_invalid passed:
-  out/test/spec/global/global.16.wasm:0000027: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000028: error: EndGlobalInitExpr callback failed
+  out/test/spec/global/global.16.wasm:0000029: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002a: error: EndGlobalInitExpr callback failed
 out/test/spec/global.wast:347: assert_invalid passed:
   out/test/spec/global/global.17.wasm:000000f: error: initializer expression can only reference an imported global
   000000f: error: OnGlobalGetExpr callback failed

--- a/test/spec/multi-memory/data.txt
+++ b/test/spec/multi-memory/data.txt
@@ -36,26 +36,26 @@ out/test/spec/multi-memory/data.wast:401: assert_invalid passed:
   out/test/spec/multi-memory/data/data.49.wasm:0000011: error: type mismatch in initializer expression, expected [i32] but got []
   0000012: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:409: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.50.wasm:0000015: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  0000016: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/multi-memory/data/data.50.wasm:0000017: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  0000018: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:417: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.51.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002c: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/multi-memory/data/data.51.wasm:000002d: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002e: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:426: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.52.wasm:000002b: error: type mismatch at end of initializer expression, expected [] but got [i32]
-  000002c: error: EndDataSegmentInitExpr callback failed
+  out/test/spec/multi-memory/data/data.52.wasm:000002d: error: type mismatch at end of initializer expression, expected [] but got [i32]
+  000002e: error: EndDataSegmentInitExpr callback failed
 out/test/spec/multi-memory/data.wast:435: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.53.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
-  0000014: error: OnUnaryExpr callback failed
+  out/test/spec/multi-memory/data/data.53.wasm:0000016: error: invalid initializer: instruction not valid in initializer expression: i32.ctz
+  0000016: error: OnUnaryExpr callback failed
 out/test/spec/multi-memory/data.wast:443: assert_invalid passed:
   out/test/spec/multi-memory/data/data.54.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
   0000012: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:451: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.55.wasm:0000012: error: invalid initializer: instruction not valid in initializer expression: nop
-  0000012: error: OnNopExpr callback failed
-out/test/spec/multi-memory/data.wast:459: assert_invalid passed:
-  out/test/spec/multi-memory/data/data.56.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
+  out/test/spec/multi-memory/data/data.55.wasm:0000014: error: invalid initializer: instruction not valid in initializer expression: nop
   0000014: error: OnNopExpr callback failed
+out/test/spec/multi-memory/data.wast:459: assert_invalid passed:
+  out/test/spec/multi-memory/data/data.56.wasm:0000016: error: invalid initializer: instruction not valid in initializer expression: nop
+  0000016: error: OnNopExpr callback failed
 out/test/spec/multi-memory/data.wast:467: assert_invalid passed:
   out/test/spec/multi-memory/data/data.57.wasm:0000020: error: initializer expression cannot reference a mutable global
   0000020: error: OnGlobalGetExpr callback failed


### PR DESCRIPTION
This change reserves a new byte in (0xc5) in the opcode space for encoding the
size of a const expression.   When this byte is the first instruction in a const
expression the leb that follows is the length in bytes of the entire expression.

See https://github.com/WebAssembly/extended-const/issues/9