### PR TITLE
Make wasm2c output UBSAN-clean (and run w2c CI w/ UBSAN)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
     env:
       USE_NINJA: "1"
       CC: "clang" # used by the wasm2c tests
-      WASM2C_CFLAGS: "-fsanitize=undefined"
+      WASM2C_CFLAGS: "-fno-sanitize-recover=undefined"
     steps:
     - uses: actions/setup-python@v1
       with:

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1527,9 +1527,9 @@ void CWriter::WriteDataInitializers() {
           ExternalInstanceRef(ModuleFieldType::Memory, memory->name), ", ");
     WriteInitExpr(data_segment->offset);
     if (data_segment->data.empty()) {
-      Write(", true, NULL, 0");
+      Write(", NULL, 0");
     } else {
-      Write(", false, data_segment_data_",
+      Write(", data_segment_data_",
             GlobalName(ModuleFieldType::DataSegment, data_segment->name), ", ",
             data_segment->data.size());
     }
@@ -2669,9 +2669,9 @@ void CWriter::Write(const ExprList& exprs) {
               ExternalInstancePtr(ModuleFieldType::Memory, dest_memory->name),
               ", ");
         if (src_data->data.empty()) {
-          Write("true, NULL, 0");
+          Write("NULL, 0");
         } else {
-          Write("false, data_segment_data_",
+          Write("data_segment_data_",
                 GlobalName(ModuleFieldType::DataSegment, src_data->name), ", ");
           if (is_droppable(src_data)) {
             Write("(", "instance->data_segment_dropped_",

--- a/src/c-writer.cc
+++ b/src/c-writer.cc
@@ -1527,9 +1527,9 @@ void CWriter::WriteDataInitializers() {
           ExternalInstanceRef(ModuleFieldType::Memory, memory->name), ", ");
     WriteInitExpr(data_segment->offset);
     if (data_segment->data.empty()) {
-      Write(", NULL, 0");
+      Write(", true, NULL, 0");
     } else {
-      Write(", data_segment_data_",
+      Write(", false, data_segment_data_",
             GlobalName(ModuleFieldType::DataSegment, data_segment->name), ", ",
             data_segment->data.size());
     }
@@ -2669,9 +2669,9 @@ void CWriter::Write(const ExprList& exprs) {
               ExternalInstancePtr(ModuleFieldType::Memory, dest_memory->name),
               ", ");
         if (src_data->data.empty()) {
-          Write("NULL, 0");
+          Write("true, NULL, 0");
         } else {
-          Write("data_segment_data_",
+          Write("false, data_segment_data_",
                 GlobalName(ModuleFieldType::DataSegment, src_data->name), ", ");
           if (is_droppable(src_data)) {
             Write("(", "instance->data_segment_dropped_",

--- a/src/template/wasm2c.declarations.c
+++ b/src/template/wasm2c.declarations.c
@@ -55,6 +55,9 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   size_t i = 0;
   u8* dest_chars = dest;
   memcpy(dest, src, n);
@@ -64,12 +67,10 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, check_only, i, s)         \
-  do {                                            \
-    RANGE_CHECK((&m), m.size - o - s, s);         \
-    if (!check_only) {                            \
-      load_data(&(m.data[m.size - o - s]), i, s); \
-    }                                             \
+#define LOAD_DATA(m, o, i, s)                   \
+  do {                                          \
+    RANGE_CHECK((&m), m.size - o - s, s);       \
+    load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -90,14 +91,15 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #else
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, check_only, i, s) \
-  do {                                    \
-    RANGE_CHECK((&m), o, s);              \
-    if (!check_only) {                    \
-      load_data(&(m.data[o]), i, s);      \
-    }                                     \
+#define LOAD_DATA(m, o, i, s)      \
+  do {                             \
+    RANGE_CHECK((&m), o, s);       \
+    load_data(&(m.data[o]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -430,7 +432,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~((uint32_t)1 << 31);
+    tmp = tmp & ~(1UL << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -441,7 +443,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~((uint64_t)1 << 63);
+    tmp = tmp & ~(1ULL << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -478,7 +480,6 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
-                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -486,7 +487,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
 typedef struct {

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -128,10 +128,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, i, s)                   \
-  do {                                          \
-    RANGE_CHECK((&m), m.size - o - s, s);       \
-    load_data(&(m.data[m.size - o - s]), i, s); \
+#define LOAD_DATA(m, o, check_only, i, s)         \
+  do {                                            \
+    RANGE_CHECK((&m), m.size - o - s, s);         \
+    if (!check_only) {                            \
+      load_data(&(m.data[m.size - o - s]), i, s); \
+    }                                             \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -154,10 +156,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, i, s)      \
-  do {                             \
-    RANGE_CHECK((&m), o, s);       \
-    load_data(&(m.data[o]), i, s); \
+#define LOAD_DATA(m, o, check_only, i, s) \
+  do {                                    \
+    RANGE_CHECK((&m), o, s);              \
+    if (!check_only) {                    \
+      load_data(&(m.data[o]), i, s);      \
+    }                                     \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -490,7 +494,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~(1 << 31);
+    tmp = tmp & ~((uint32_t)1 << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -501,7 +505,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~(1ll << 63);
+    tmp = tmp & ~((uint64_t)1 << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -538,6 +542,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
+                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -545,7 +550,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
 }
 
 typedef struct {

--- a/test/wasm2c/add.txt
+++ b/test/wasm2c/add.txt
@@ -119,6 +119,9 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   size_t i = 0;
   u8* dest_chars = dest;
   memcpy(dest, src, n);
@@ -128,12 +131,10 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, check_only, i, s)         \
-  do {                                            \
-    RANGE_CHECK((&m), m.size - o - s, s);         \
-    if (!check_only) {                            \
-      load_data(&(m.data[m.size - o - s]), i, s); \
-    }                                             \
+#define LOAD_DATA(m, o, i, s)                   \
+  do {                                          \
+    RANGE_CHECK((&m), m.size - o - s, s);       \
+    load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -154,14 +155,15 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #else
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, check_only, i, s) \
-  do {                                    \
-    RANGE_CHECK((&m), o, s);              \
-    if (!check_only) {                    \
-      load_data(&(m.data[o]), i, s);      \
-    }                                     \
+#define LOAD_DATA(m, o, i, s)      \
+  do {                             \
+    RANGE_CHECK((&m), o, s);       \
+    load_data(&(m.data[o]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -494,7 +496,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~((uint32_t)1 << 31);
+    tmp = tmp & ~(1UL << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -505,7 +507,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~((uint64_t)1 << 63);
+    tmp = tmp & ~(1ULL << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -542,7 +544,6 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
-                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -550,7 +551,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
 typedef struct {

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -149,6 +149,9 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   size_t i = 0;
   u8* dest_chars = dest;
   memcpy(dest, src, n);
@@ -158,12 +161,10 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, check_only, i, s)         \
-  do {                                            \
-    RANGE_CHECK((&m), m.size - o - s, s);         \
-    if (!check_only) {                            \
-      load_data(&(m.data[m.size - o - s]), i, s); \
-    }                                             \
+#define LOAD_DATA(m, o, i, s)                   \
+  do {                                          \
+    RANGE_CHECK((&m), m.size - o - s, s);       \
+    load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -184,14 +185,15 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #else
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, check_only, i, s) \
-  do {                                    \
-    RANGE_CHECK((&m), o, s);              \
-    if (!check_only) {                    \
-      load_data(&(m.data[o]), i, s);      \
-    }                                     \
+#define LOAD_DATA(m, o, i, s)      \
+  do {                             \
+    RANGE_CHECK((&m), o, s);       \
+    load_data(&(m.data[o]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -524,7 +526,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~((uint32_t)1 << 31);
+    tmp = tmp & ~(1UL << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -535,7 +537,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~((uint64_t)1 << 63);
+    tmp = tmp & ~(1ULL << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -572,7 +574,6 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
-                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -580,7 +581,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
 typedef struct {
@@ -694,7 +695,7 @@ static const u8 data_segment_data_w2c_d0[] = {
 
 static void init_memories(Z_test_instance_t* instance) {
   wasm_rt_allocate_memory(&instance->w2c_memory, 1, 65536, 0);
-  LOAD_DATA(instance->w2c_memory, 8u, false, data_segment_data_w2c_d0, 14);
+  LOAD_DATA(instance->w2c_memory, 8u, data_segment_data_w2c_d0, 14);
 }
 
 static void init_data_instances(Z_test_instance_t *instance) {

--- a/test/wasm2c/hello.txt
+++ b/test/wasm2c/hello.txt
@@ -158,10 +158,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, i, s)                   \
-  do {                                          \
-    RANGE_CHECK((&m), m.size - o - s, s);       \
-    load_data(&(m.data[m.size - o - s]), i, s); \
+#define LOAD_DATA(m, o, check_only, i, s)         \
+  do {                                            \
+    RANGE_CHECK((&m), m.size - o - s, s);         \
+    if (!check_only) {                            \
+      load_data(&(m.data[m.size - o - s]), i, s); \
+    }                                             \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -184,10 +186,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, i, s)      \
-  do {                             \
-    RANGE_CHECK((&m), o, s);       \
-    load_data(&(m.data[o]), i, s); \
+#define LOAD_DATA(m, o, check_only, i, s) \
+  do {                                    \
+    RANGE_CHECK((&m), o, s);              \
+    if (!check_only) {                    \
+      load_data(&(m.data[o]), i, s);      \
+    }                                     \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -520,7 +524,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~(1 << 31);
+    tmp = tmp & ~((uint32_t)1 << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -531,7 +535,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~(1ll << 63);
+    tmp = tmp & ~((uint64_t)1 << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -568,6 +572,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
+                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -575,7 +580,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
 }
 
 typedef struct {
@@ -689,7 +694,7 @@ static const u8 data_segment_data_w2c_d0[] = {
 
 static void init_memories(Z_test_instance_t* instance) {
   wasm_rt_allocate_memory(&instance->w2c_memory, 1, 65536, 0);
-  LOAD_DATA(instance->w2c_memory, 8u, data_segment_data_w2c_d0, 14);
+  LOAD_DATA(instance->w2c_memory, 8u, false, data_segment_data_w2c_d0, 14);
 }
 
 static void init_data_instances(Z_test_instance_t *instance) {

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -122,10 +122,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, i, s)                   \
-  do {                                          \
-    RANGE_CHECK((&m), m.size - o - s, s);       \
-    load_data(&(m.data[m.size - o - s]), i, s); \
+#define LOAD_DATA(m, o, check_only, i, s)         \
+  do {                                            \
+    RANGE_CHECK((&m), m.size - o - s, s);         \
+    if (!check_only) {                            \
+      load_data(&(m.data[m.size - o - s]), i, s); \
+    }                                             \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -148,10 +150,12 @@ static inline void load_data(void* dest, const void* src, size_t n) {
 static inline void load_data(void* dest, const void* src, size_t n) {
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, i, s)      \
-  do {                             \
-    RANGE_CHECK((&m), o, s);       \
-    load_data(&(m.data[o]), i, s); \
+#define LOAD_DATA(m, o, check_only, i, s) \
+  do {                                    \
+    RANGE_CHECK((&m), o, s);              \
+    if (!check_only) {                    \
+      load_data(&(m.data[o]), i, s);      \
+    }                                     \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -484,7 +488,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~(1 << 31);
+    tmp = tmp & ~((uint32_t)1 << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -495,7 +499,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~(1ll << 63);
+    tmp = tmp & ~((uint64_t)1 << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -532,6 +536,7 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
+                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -539,7 +544,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
 }
 
 typedef struct {

--- a/test/wasm2c/minimal.txt
+++ b/test/wasm2c/minimal.txt
@@ -113,6 +113,9 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   size_t i = 0;
   u8* dest_chars = dest;
   memcpy(dest, src, n);
@@ -122,12 +125,10 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, check_only, i, s)         \
-  do {                                            \
-    RANGE_CHECK((&m), m.size - o - s, s);         \
-    if (!check_only) {                            \
-      load_data(&(m.data[m.size - o - s]), i, s); \
-    }                                             \
+#define LOAD_DATA(m, o, i, s)                   \
+  do {                                          \
+    RANGE_CHECK((&m), m.size - o - s, s);       \
+    load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -148,14 +149,15 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #else
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, check_only, i, s) \
-  do {                                    \
-    RANGE_CHECK((&m), o, s);              \
-    if (!check_only) {                    \
-      load_data(&(m.data[o]), i, s);      \
-    }                                     \
+#define LOAD_DATA(m, o, i, s)      \
+  do {                             \
+    RANGE_CHECK((&m), o, s);       \
+    load_data(&(m.data[o]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -488,7 +490,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~((uint32_t)1 << 31);
+    tmp = tmp & ~(1UL << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -499,7 +501,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~((uint64_t)1 << 63);
+    tmp = tmp & ~(1ULL << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -536,7 +538,6 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
-                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -544,7 +545,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
 typedef struct {

--- a/wasm2c/examples/fac/fac.c
+++ b/wasm2c/examples/fac/fac.c
@@ -70,6 +70,9 @@ static inline bool func_types_eq(const wasm_rt_func_type_t a,
 
 #if WABT_BIG_ENDIAN
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   size_t i = 0;
   u8* dest_chars = dest;
   memcpy(dest, src, n);
@@ -79,12 +82,10 @@ static inline void load_data(void* dest, const void* src, size_t n) {
     dest_chars[n - i - 1] = cursor;
   }
 }
-#define LOAD_DATA(m, o, check_only, i, s)         \
-  do {                                            \
-    RANGE_CHECK((&m), m.size - o - s, s);         \
-    if (!check_only) {                            \
-      load_data(&(m.data[m.size - o - s]), i, s); \
-    }                                             \
+#define LOAD_DATA(m, o, i, s)                   \
+  do {                                          \
+    RANGE_CHECK((&m), m.size - o - s, s);       \
+    load_data(&(m.data[m.size - o - s]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                                  \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) {             \
@@ -105,14 +106,15 @@ static inline void load_data(void* dest, const void* src, size_t n) {
   }
 #else
 static inline void load_data(void* dest, const void* src, size_t n) {
+  if (!n) {
+    return;
+  }
   memcpy(dest, src, n);
 }
-#define LOAD_DATA(m, o, check_only, i, s) \
-  do {                                    \
-    RANGE_CHECK((&m), o, s);              \
-    if (!check_only) {                    \
-      load_data(&(m.data[o]), i, s);      \
-    }                                     \
+#define LOAD_DATA(m, o, i, s)      \
+  do {                             \
+    RANGE_CHECK((&m), o, s);       \
+    load_data(&(m.data[o]), i, s); \
   } while (0)
 #define DEFINE_LOAD(name, t1, t2, t3)                      \
   static inline t3 name(wasm_rt_memory_t* mem, u64 addr) { \
@@ -445,7 +447,7 @@ static float wasm_fabsf(float x) {
   if (UNLIKELY(isnan(x))) {
     uint32_t tmp;
     memcpy(&tmp, &x, 4);
-    tmp = tmp & ~((uint32_t)1 << 31);
+    tmp = tmp & ~(1UL << 31);
     memcpy(&x, &tmp, 4);
     return x;
   }
@@ -456,7 +458,7 @@ static double wasm_fabs(double x) {
   if (UNLIKELY(isnan(x))) {
     uint64_t tmp;
     memcpy(&tmp, &x, 8);
-    tmp = tmp & ~((uint64_t)1 << 63);
+    tmp = tmp & ~(1ULL << 63);
     memcpy(&x, &tmp, 8);
     return x;
   }
@@ -493,7 +495,6 @@ static inline void memory_copy(wasm_rt_memory_t* dest,
 }
 
 static inline void memory_init(wasm_rt_memory_t* dest,
-                               bool check_only,
                                const u8* src,
                                u32 src_size,
                                u32 dest_addr,
@@ -501,7 +502,7 @@ static inline void memory_init(wasm_rt_memory_t* dest,
                                u32 n) {
   if (UNLIKELY(src_addr + (uint64_t)n > src_size))
     TRAP(OOB);
-  LOAD_DATA((*dest), dest_addr, check_only, src + src_addr, n);
+  LOAD_DATA((*dest), dest_addr, src + src_addr, n);
 }
 
 typedef struct {


### PR DESCRIPTION
We had been running the GitHub UBSAN wasm2c tests with -fsanitize=undefined but without -fno-sanitize-recover, meaning some of the spec tests were printing UBSAN error messages but still returning 0, so we weren't seeing the test failures.

The two issues that UBSAN was flagging were:
- fabs and fabsf left-shifting signed literals by 31 or 63 (switched to making them unsigned)
- calling memcpy with a zero length but NULL src (switched to adding an explicit `check_only` parameter to `memory_init` and `LOAD_DATA` that makes them skip the actual memcpy but still enforce the bounds-check, which is required)

Once we reach convergence on #2080/#2081/#2134, I think we're ready to merge #2119 (SIMD).