### PR TITLE
Silence gtest and uvwasi warnings on GCC 11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -534,6 +534,10 @@ if (BUILD_TOOLS)
     add_definitions(-DWITH_WASI)
     set(INTERP_LIBS uvwasi_a)
     set(EXTRA_INTERP_SRC src/interp/interp-wasi.cc)
+
+    if (COMPILER_IS_GNU)
+      target_compile_options(uv_a PRIVATE "-Wno-sign-compare")
+    endif ()
   endif()
 
   # wasm-interp
@@ -618,6 +622,10 @@ if (BUILD_TESTS)
     add_library(gtest_main STATIC
       third_party/gtest/googletest/src/gtest_main.cc
     )
+
+    if (COMPILER_IS_GNU)
+      target_compile_options(gtest PRIVATE "-Wno-maybe-uninitialized")
+    endif ()
   endif ()
 
   # hexfloat-test


### PR DESCRIPTION
GitHub is starting to phase in ubuntu-22.04 runners for "ubuntu-latest" workflows, and these use GCC 11 which has some new warnings that break WABT's build of gtest and uvwasi, so we are starting to get nondeterministic failures in the CI. This silences the warnings just for gtest and uvwasi.

~~I left the CI workflow as "ubuntu-latest" so this might be tested with GCC 9 (ubuntu-22.04) or GCC 11 (ubuntu-22.04) depending on the luck of the draw. We could hardcode it as ubuntu-22.04 in build.yml if we want to get rid of the nondeterminism.~~ (Edit: based on https://github.blog/changelog/2022-11-09-github-actions-ubuntu-latest-workflows-will-use-ubuntu-22-04/, it looks like the period of nondeterminism/cutover is basically over.)