### PR TITLE
Use inline keyword over WABT_INLINE. NFC

### DIFF
--- a/include/wabt/common.h
+++ b/include/wabt/common.h
@@ -391,7 +391,7 @@ void InitStdio();
 
 extern const char* g_kind_name[];
 
-static WABT_INLINE const char* GetKindName(ExternalKind kind) {
+static inline const char* GetKindName(ExternalKind kind) {
   return static_cast<size_t>(kind) < kExternalKindCount
              ? g_kind_name[static_cast<size_t>(kind)]
              : "<error_kind>";
@@ -401,7 +401,7 @@ static WABT_INLINE const char* GetKindName(ExternalKind kind) {
 
 extern const char* g_reloc_type_name[];
 
-static WABT_INLINE const char* GetRelocTypeName(RelocType reloc) {
+static inline const char* GetRelocTypeName(RelocType reloc) {
   return static_cast<size_t>(reloc) < kRelocTypeCount
              ? g_reloc_type_name[static_cast<size_t>(reloc)]
              : "<error_reloc_type>";
@@ -409,7 +409,7 @@ static WABT_INLINE const char* GetRelocTypeName(RelocType reloc) {
 
 /* symbol */
 
-static WABT_INLINE const char* GetSymbolTypeName(SymbolType type) {
+static inline const char* GetSymbolTypeName(SymbolType type) {
   switch (type) {
     case SymbolType::Function:
       return "func";

--- a/include/wabt/error.h
+++ b/include/wabt/error.h
@@ -30,7 +30,7 @@ enum class ErrorLevel {
   Error,
 };
 
-static WABT_INLINE const char* GetErrorLevelName(ErrorLevel error_level) {
+static inline const char* GetErrorLevelName(ErrorLevel error_level) {
   switch (error_level) {
     case ErrorLevel::Warning:
       return "warning";

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -66,7 +66,6 @@
 
 #if COMPILER_IS_CLANG || COMPILER_IS_GNU
 
-#define WABT_INLINE inline
 #define WABT_UNLIKELY(x) __builtin_expect(!!(x), 0)
 #define WABT_LIKELY(x) __builtin_expect(!!(x), 1)
 
@@ -94,7 +93,6 @@
 #include <intrin.h>
 #include <string.h>
 
-#define WABT_INLINE __inline
 #define WABT_STATIC_ASSERT(x) _STATIC_ASSERT(x)
 #define WABT_UNLIKELY(x) (x)
 #define WABT_LIKELY(x) (x)


### PR DESCRIPTION
I'm not sure this was ever needed.  `__inline` and `inline` are identical under msvc:
https://learn.microsoft.com/en-us/cpp/cpp/inline-functions-cpp?view=msvc-170 "The __inline keyword is equivalent to inline"