### PR TITLE
Remove use of alloca. NFC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,6 @@ endif ()
 include(CheckIncludeFile)
 include(CheckSymbolExists)
 
-check_include_file("alloca.h" HAVE_ALLOCA_H)
 check_include_file("unistd.h" HAVE_UNISTD_H)
 check_symbol_exists(snprintf "stdio.h" HAVE_SNPRINTF)
 check_symbol_exists(strcasecmp "strings.h" HAVE_STRCASECMP)

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -26,9 +26,6 @@
 
 /* TODO(binji): nice way to define these with WABT_ prefix? */
 
-/* Whether <alloca.h> is available */
-#cmakedefine01 HAVE_ALLOCA_H
-
 /* Whether <unistd.h> is available */
 #cmakedefine01 HAVE_UNISTD_H
 
@@ -54,15 +51,6 @@
 #cmakedefine01 WITH_EXCEPTIONS
 
 #define SIZEOF_SIZE_T @SIZEOF_SIZE_T@
-
-#if HAVE_ALLOCA_H
-#include <alloca.h>
-#elif COMPILER_IS_MSVC
-#include <malloc.h>
-#define alloca _alloca
-#elif defined(__MINGW32__)
-#include <malloc.h>
-#endif
 
 #if COMPILER_IS_CLANG || COMPILER_IS_GNU
 

--- a/src/literal.cc
+++ b/src/literal.cc
@@ -159,7 +159,7 @@ Result FloatParser<T>::ParseFloat(const char* s,
   // so remove them first.
   assert(s <= end);
   const size_t kBufferSize = end - s + 1;  // +1 for \0.
-  char* buffer = static_cast<char*>(alloca(kBufferSize));
+  char buffer[kBufferSize];
   auto buffer_end =
       std::copy_if(s, end, buffer, [](char c) -> bool { return c != '_'; });
   assert(buffer_end < buffer + kBufferSize);

--- a/src/option-parser.cc
+++ b/src/option-parser.cc
@@ -22,10 +22,6 @@
 
 #include "wabt/config.h"
 
-#if HAVE_ALLOCA
-#include <alloca.h>
-#endif
-
 namespace wabt {
 
 OptionParser::Option::Option(char short_name,


### PR DESCRIPTION
We can just use a variables sized array in the once place we were using it.