### PR TITLE
Adds a --no-sandbox flag.

### DIFF
--- a/include/wabt/c-writer.h
+++ b/include/wabt/c-writer.h
@@ -26,6 +26,7 @@ class Stream;
 
 struct WriteCOptions {
   std::string_view module_name;
+  bool no_sandbox;
 };
 
 Result WriteC(Stream* c_stream,

--- a/src/tools/wasm2c.cc
+++ b/src/tools/wasm2c.cc
@@ -89,6 +89,10 @@ static void ParseOptions(int argc, char** argv) {
   s_features.AddOptions(&parser);
   parser.AddOption("no-debug-names", "Ignore debug names in the binary file",
                    []() { s_read_debug_names = false; });
+  parser.AddOption("no-sandbox",
+                   "Don't generate sandboxed code but make it\n"
+                   "compatible with native code instead.\n",
+                   []() { s_write_c_options.no_sandbox = true; });
   parser.AddArgument("filename", OptionParser::ArgumentCount::One,
                      [](const char* argument) {
                        s_infile = argument;


### PR DESCRIPTION
This flag currently does not have any effect yet.  It will be used by later changes that implement no-sandbox semantics in wasm2c.